### PR TITLE
api: declare retry semantics for every operation

### DIFF
--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -76,6 +76,7 @@ impl Client {
     /// name is a label, not a key. This is a maintenance operation, not a
     /// file mutation. The record is a garbage-collection root until released
     /// or expired.
+    /// Retrying this request starts a distinct attempt.
     pub async fn create_checkpoint(
         &self,
         namespace_id: &NamespaceId,
@@ -85,7 +86,7 @@ impl Client {
             "{}/v0/admin/namespaces/{namespace_id}/checkpoints",
             self.base_url
         );
-        self.request_json(self.post(&url), Some(request)).await
+        self.request_json_once(self.post(&url), Some(request)).await
     }
 
     /// Creates a checkpoint pager beginning at `cursor` (admin plane).
@@ -142,6 +143,7 @@ impl Client {
     /// The request selects the actions by naming them, and a request that
     /// names none is rejected. Absent overrides inside a selected action use
     /// the server's defaults.
+    /// Retrying this request starts a distinct attempt.
     pub async fn maintenance_step(
         &self,
         namespace_id: &NamespaceId,
@@ -151,7 +153,7 @@ impl Client {
             "{}/v0/admin/namespaces/{namespace_id}/maintenance/step",
             self.base_url
         );
-        self.request_json(self.post(&url), Some(request)).await
+        self.request_json_once(self.post(&url), Some(request)).await
     }
 
     /// Proves the server's backing store honours the object-store contract
@@ -161,9 +163,10 @@ impl Client {
     /// runs only when asked. A store that fails a check answers with that
     /// check reported failed rather than with an error: the probe ran, and
     /// the answer is that the store is wrong.
+    /// Retrying this request starts a distinct attempt.
     pub async fn probe_store(&self, request: &StoreProbeRequest) -> Result<StoreProbeResponse> {
         let url = format!("{}/v0/admin/store/probe", self.base_url);
-        self.request_json(self.post(&url), Some(request)).await
+        self.request_json_once(self.post(&url), Some(request)).await
     }
 
     /// Content search over the namespace's grep index (query plane).
@@ -225,6 +228,7 @@ impl Client {
     ///
     /// `max_objects` bounds the reads the pass spends; when keys remain the
     /// response carries a `next_cursor` to resume from.
+    /// Retrying this request starts a distinct attempt.
     pub async fn gc_grep_index(
         &self,
         namespace_id: &NamespaceId,
@@ -234,6 +238,6 @@ impl Client {
             "{}/v0/admin/namespaces/{namespace_id}/grep/index/gc",
             self.base_url
         );
-        self.request_json(self.post(&url), Some(request)).await
+        self.request_json_once(self.post(&url), Some(request)).await
     }
 }

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -669,6 +669,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn retry_policy_matches_admin_operation_classes() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        let (transport, client) = single_attempt_probe();
+        assert_single_attempt(
+            client
+                .create_checkpoint(
+                    &namespace_id,
+                    &CreateCheckpointRequest {
+                        name: "backup".to_owned(),
+                        ttl_ms: None,
+                    },
+                )
+                .await,
+            &transport,
+        );
+        drop(transport);
+
+        let response = NamespaceDiagnostics {
+            namespace_id: namespace_id.clone(),
+            head_seq: ChangeSeq(3),
+            retention_floor_seq: ChangeSeq(1),
+            current_manifest_id: None,
+            wal_tail_segments: 2,
+        };
+        let transport = crate::transport::test_transport::failure_then_success(
+            serde_json::to_vec(&response).expect("serialize response"),
+        );
+        let client = retry_policy_client();
+
+        let actual = client
+            .get_namespace_diagnostics(&namespace_id)
+            .await
+            .expect("safe admin read should retry");
+        assert_eq!(actual, response);
+        assert_eq!(transport.attempts(), 2);
+    }
+
+    #[tokio::test]
     async fn retry_policy_commit_id_filesystem_mutation_retries() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let commit_id =

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -15,8 +15,7 @@ enum Value {
     Object(Map),
 }
 
-/// Public operation IDs are stable because generated SDKs use them as method
-/// names. Keep this registry sorted so changes are easy to review.
+/// Generated SDKs use operation IDs as method names. Keep this list sorted.
 pub(crate) const OPENAPI_OPERATION_IDS: &[&str] = &[
     "abort_upload",
     "apply_commit",
@@ -57,7 +56,7 @@ pub(crate) const OPENAPI_OPERATION_IDS: &[&str] = &[
     "upload_content",
 ];
 
-/// Retry behavior published for generated SDKs.
+/// Retry behavior for generated SDKs.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RetryClass {
     Safe,
@@ -77,7 +76,7 @@ impl RetryClass {
     }
 }
 
-/// One retry classification for every public operation ID.
+/// Retry class for each public operation.
 pub(crate) const OPERATION_RETRY_CLASSES: &[(&str, RetryClass)] = &[
     ("abort_upload", RetryClass::Safe),
     ("apply_commit", RetryClass::Replay),
@@ -164,12 +163,12 @@ pub(crate) fn openapi_json_pretty(
     serde_json::to_string_pretty(&document)
 }
 
-/// Publishes the retry rule associated with each stable operation ID.
+/// Adds `x-loonfs-retry` to every OpenAPI operation.
 fn add_operation_retry_classes(document: &mut Value) {
     assert_eq!(
         OPENAPI_OPERATION_IDS.len(),
         OPERATION_RETRY_CLASSES.len(),
-        "the operation ID registry and retry classification table differ in length"
+        "operation IDs and retry classes must have the same length"
     );
     for (registered, (classified, _)) in OPENAPI_OPERATION_IDS
         .iter()
@@ -177,7 +176,7 @@ fn add_operation_retry_classes(document: &mut Value) {
     {
         assert_eq!(
             registered, classified,
-            "the operation ID registry and retry classification table differ"
+            "operation IDs and retry classes must use the same order"
         );
     }
 

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -15,6 +15,109 @@ enum Value {
     Object(Map),
 }
 
+/// Public operation IDs are stable because generated SDKs use them as method
+/// names. Keep this registry sorted so changes are easy to review.
+pub(crate) const OPENAPI_OPERATION_IDS: &[&str] = &[
+    "abort_upload",
+    "apply_commit",
+    "begin_download",
+    "begin_download_by_inode",
+    "begin_upload",
+    "capabilities",
+    "complete_upload",
+    "create_checkpoint",
+    "create_namespace",
+    "delete_namespace",
+    "disable_grep_index",
+    "enable_grep_index",
+    "fork_namespace",
+    "gc_grep_index",
+    "get_file_bytes",
+    "get_file_revision_bytes_by_inode",
+    "get_grep_index_status",
+    "get_metrics",
+    "get_namespace",
+    "get_namespace_diagnostics",
+    "get_upload_status",
+    "grep",
+    "health",
+    "list_changes",
+    "list_checkpoints",
+    "list_file_revisions",
+    "list_file_revisions_by_inode",
+    "list_path_entries",
+    "list_trash",
+    "maintenance_step",
+    "probe_store",
+    "readiness",
+    "release_checkpoint",
+    "sign_upload_parts",
+    "stat_inode",
+    "stat_path",
+    "upload_content",
+];
+
+/// Retry behavior published for generated SDKs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RetryClass {
+    Safe,
+    Replay,
+    Verify,
+    NewAttempt,
+}
+
+impl RetryClass {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Safe => "safe",
+            Self::Replay => "replay",
+            Self::Verify => "verify",
+            Self::NewAttempt => "new_attempt",
+        }
+    }
+}
+
+/// One retry classification for every public operation ID.
+pub(crate) const OPERATION_RETRY_CLASSES: &[(&str, RetryClass)] = &[
+    ("abort_upload", RetryClass::Safe),
+    ("apply_commit", RetryClass::Replay),
+    ("begin_download", RetryClass::Safe),
+    ("begin_download_by_inode", RetryClass::Safe),
+    ("begin_upload", RetryClass::NewAttempt),
+    ("capabilities", RetryClass::Safe),
+    ("complete_upload", RetryClass::Verify),
+    ("create_checkpoint", RetryClass::NewAttempt),
+    ("create_namespace", RetryClass::NewAttempt),
+    ("delete_namespace", RetryClass::NewAttempt),
+    ("disable_grep_index", RetryClass::Safe),
+    ("enable_grep_index", RetryClass::Safe),
+    ("fork_namespace", RetryClass::NewAttempt),
+    ("gc_grep_index", RetryClass::NewAttempt),
+    ("get_file_bytes", RetryClass::Safe),
+    ("get_file_revision_bytes_by_inode", RetryClass::Safe),
+    ("get_grep_index_status", RetryClass::Safe),
+    ("get_metrics", RetryClass::Safe),
+    ("get_namespace", RetryClass::Safe),
+    ("get_namespace_diagnostics", RetryClass::Safe),
+    ("get_upload_status", RetryClass::Safe),
+    ("grep", RetryClass::Safe),
+    ("health", RetryClass::Safe),
+    ("list_changes", RetryClass::Safe),
+    ("list_checkpoints", RetryClass::Safe),
+    ("list_file_revisions", RetryClass::Safe),
+    ("list_file_revisions_by_inode", RetryClass::Safe),
+    ("list_path_entries", RetryClass::Safe),
+    ("list_trash", RetryClass::Safe),
+    ("maintenance_step", RetryClass::NewAttempt),
+    ("probe_store", RetryClass::NewAttempt),
+    ("readiness", RetryClass::Safe),
+    ("release_checkpoint", RetryClass::Safe),
+    ("sign_upload_parts", RetryClass::Safe),
+    ("stat_inode", RetryClass::Safe),
+    ("stat_path", RetryClass::Safe),
+    ("upload_content", RetryClass::Safe),
+];
+
 impl Value {
     fn get(&self, name: &str) -> Option<&Self> {
         self.as_object()?.get(name)
@@ -57,7 +160,62 @@ pub(crate) fn openapi_json_pretty(
     let mut document = serde_json::from_str(&derived)?;
     normalize_optional_schemas(&mut document);
     add_union_discriminators(&mut document);
+    add_operation_retry_classes(&mut document);
     serde_json::to_string_pretty(&document)
+}
+
+/// Publishes the retry rule associated with each stable operation ID.
+fn add_operation_retry_classes(document: &mut Value) {
+    assert_eq!(
+        OPENAPI_OPERATION_IDS.len(),
+        OPERATION_RETRY_CLASSES.len(),
+        "the operation ID registry and retry classification table differ in length"
+    );
+    for (registered, (classified, _)) in OPENAPI_OPERATION_IDS
+        .iter()
+        .zip(OPERATION_RETRY_CLASSES.iter())
+    {
+        assert_eq!(
+            registered, classified,
+            "the operation ID registry and retry classification table differ"
+        );
+    }
+
+    let paths = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("paths"))
+        .and_then(Value::as_object_mut)
+        .expect("OpenAPI document has no paths object");
+
+    for path_item in paths.values_mut() {
+        let path_item = path_item
+            .as_object_mut()
+            .expect("OpenAPI path item is not an object");
+        for method in ["get", "post", "put", "delete", "patch"] {
+            let Some(operation) = path_item.get_mut(method) else {
+                continue;
+            };
+            let operation = operation
+                .as_object_mut()
+                .expect("OpenAPI operation is not an object");
+            let operation_id = operation
+                .get("operationId")
+                .and_then(Value::as_str)
+                .expect("OpenAPI operation has no operationId");
+            let retry_class = OPERATION_RETRY_CLASSES
+                .iter()
+                .find_map(|(candidate, retry_class)| {
+                    (*candidate == operation_id).then_some(*retry_class)
+                })
+                .unwrap_or_else(|| {
+                    panic!("OpenAPI operation `{operation_id}` has no retry classification")
+                });
+            operation.insert(
+                "x-loonfs-retry".to_owned(),
+                Value::String(retry_class.as_str().to_owned()),
+            );
+        }
+    }
 }
 
 /// Removes `null` from schemas for values that are omitted when absent.

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -61,7 +61,6 @@ pub(crate) const OPENAPI_OPERATION_IDS: &[&str] = &[
 pub(crate) enum RetryClass {
     Safe,
     Replay,
-    Verify,
     NewAttempt,
 }
 
@@ -70,10 +69,17 @@ impl RetryClass {
         match self {
             Self::Safe => "safe",
             Self::Replay => "replay",
-            Self::Verify => "verify",
             Self::NewAttempt => "new_attempt",
         }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OpenapiPostprocessError {
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("OpenAPI operation `{operation_id}` has no retry classification")]
+    MissingRetryClassification { operation_id: String },
 }
 
 /// Retry class for each public operation.
@@ -84,7 +90,7 @@ pub(crate) const OPERATION_RETRY_CLASSES: &[(&str, RetryClass)] = &[
     ("begin_download_by_inode", RetryClass::Safe),
     ("begin_upload", RetryClass::NewAttempt),
     ("capabilities", RetryClass::Safe),
-    ("complete_upload", RetryClass::Verify),
+    ("complete_upload", RetryClass::Replay),
     ("create_checkpoint", RetryClass::NewAttempt),
     ("create_namespace", RetryClass::NewAttempt),
     ("delete_namespace", RetryClass::NewAttempt),
@@ -154,17 +160,17 @@ impl Value {
 /// Generates OpenAPI JSON, applies schema fixes, and preserves field order.
 pub(crate) fn openapi_json_pretty(
     document: &(impl Serialize + ?Sized),
-) -> Result<String, serde_json::Error> {
+) -> Result<String, OpenapiPostprocessError> {
     let derived = serde_json::to_string(document)?;
     let mut document = serde_json::from_str(&derived)?;
     normalize_optional_schemas(&mut document);
     add_union_discriminators(&mut document);
-    add_operation_retry_classes(&mut document);
-    serde_json::to_string_pretty(&document)
+    add_operation_retry_classes(&mut document)?;
+    Ok(serde_json::to_string_pretty(&document)?)
 }
 
 /// Adds `x-loonfs-retry` to every OpenAPI operation.
-fn add_operation_retry_classes(document: &mut Value) {
+fn add_operation_retry_classes(document: &mut Value) -> Result<(), OpenapiPostprocessError> {
     assert_eq!(
         OPENAPI_OPERATION_IDS.len(),
         OPERATION_RETRY_CLASSES.len(),
@@ -206,15 +212,16 @@ fn add_operation_retry_classes(document: &mut Value) {
                 .find_map(|(candidate, retry_class)| {
                     (*candidate == operation_id).then_some(*retry_class)
                 })
-                .unwrap_or_else(|| {
-                    panic!("OpenAPI operation `{operation_id}` has no retry classification")
-                });
+                .ok_or_else(|| OpenapiPostprocessError::MissingRetryClassification {
+                    operation_id: operation_id.to_owned(),
+                })?;
             operation.insert(
                 "x-loonfs-retry".to_owned(),
                 Value::String(retry_class.as_str().to_owned()),
             );
         }
     }
+    Ok(())
 }
 
 /// Removes `null` from schemas for values that are omitted when absent.
@@ -486,6 +493,25 @@ mod tests {
         let once = document.clone();
         add_union_discriminators(&mut document);
         assert_eq!(document, once);
+    }
+
+    #[test]
+    fn missing_retry_classification_returns_a_named_error() {
+        let mut document = ordered(serde_json::json!({
+            "paths": {
+                "/future": {
+                    "post": {"operationId": "future_operation"}
+                }
+            }
+        }));
+
+        let error = add_operation_retry_classes(&mut document)
+            .expect_err("unknown operation should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::MissingRetryClassification { operation_id }
+                if operation_id == "future_operation"
+        ));
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -110,6 +110,7 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "max_wal_tail_segments",
     "name_key",
     "namespace_id",
+    "new_attempt",
     "new_namespace_id",
     "next_after_seq",
     "next_cursor",

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::panic)]
 
 use serde_json::Value;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[path = "../../src/bin/loonfs-openapi/openapi_postprocess.rs"]
 mod openapi_postprocess;
@@ -314,7 +314,7 @@ fn openapi_documents_current_server_paths() {
 
 #[test]
 fn openapi_operation_ids_match_the_public_registry() {
-    const REGISTRY_MESSAGE: &str = "operation IDs define generated SDK method names; update crates/loonfs-server/tests/it/openapi.rs::openapi_operation_ids_match_the_public_registry only for a deliberate public rename";
+    const REGISTRY_MESSAGE: &str = "operation IDs define generated SDK method names; update crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs::OPENAPI_OPERATION_IDS only for a deliberate public rename";
 
     let spec: Value = serde_json::from_str(
         &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
@@ -366,47 +366,66 @@ fn openapi_operation_ids_match_the_public_registry() {
     operation_ids.sort_unstable();
     assert_eq!(
         operation_ids,
-        [
-            "abort_upload",
-            "apply_commit",
-            "begin_download",
-            "begin_download_by_inode",
-            "begin_upload",
-            "capabilities",
-            "complete_upload",
-            "create_checkpoint",
-            "create_namespace",
-            "delete_namespace",
-            "disable_grep_index",
-            "enable_grep_index",
-            "fork_namespace",
-            "gc_grep_index",
-            "get_file_bytes",
-            "get_file_revision_bytes_by_inode",
-            "get_grep_index_status",
-            "get_metrics",
-            "get_namespace",
-            "get_namespace_diagnostics",
-            "get_upload_status",
-            "grep",
-            "health",
-            "list_changes",
-            "list_checkpoints",
-            "list_file_revisions",
-            "list_file_revisions_by_inode",
-            "list_path_entries",
-            "list_trash",
-            "maintenance_step",
-            "probe_store",
-            "readiness",
-            "release_checkpoint",
-            "sign_upload_parts",
-            "stat_inode",
-            "stat_path",
-            "upload_content",
-        ],
+        openapi_postprocess::OPENAPI_OPERATION_IDS,
         "operationIds changed; {REGISTRY_MESSAGE}"
     );
+}
+
+#[test]
+fn every_registered_operation_publishes_its_retry_class() {
+    let registered = openapi_postprocess::OPENAPI_OPERATION_IDS
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let classified = openapi_postprocess::OPERATION_RETRY_CLASSES
+        .iter()
+        .map(|(operation_id, _)| *operation_id)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        openapi_postprocess::OPENAPI_OPERATION_IDS.len(),
+        registered.len(),
+        "the operation ID registry contains a duplicate"
+    );
+    assert_eq!(
+        openapi_postprocess::OPERATION_RETRY_CLASSES.len(),
+        classified.len(),
+        "an operation has more than one retry classification"
+    );
+    assert_eq!(classified, registered);
+
+    let generated = openapi_postprocess::openapi_json_pretty(&loonfs_server::openapi_document())
+        .expect("generate openapi json");
+    let spec: Value = serde_json::from_str(&generated).expect("parse generated openapi json");
+    let paths = spec
+        .get("paths")
+        .and_then(Value::as_object)
+        .expect("openapi paths object");
+    let mut published = BTreeMap::new();
+    for path_item in paths.values().filter_map(Value::as_object) {
+        for method in ["get", "post", "put", "delete", "patch"] {
+            let Some(operation) = path_item.get(method) else {
+                continue;
+            };
+            let operation_id = operation
+                .get("operationId")
+                .and_then(Value::as_str)
+                .expect("OpenAPI operation has an operationId");
+            let retry_class = operation
+                .get("x-loonfs-retry")
+                .and_then(Value::as_str)
+                .expect("OpenAPI operation has an x-loonfs-retry extension");
+            assert!(
+                published.insert(operation_id, retry_class).is_none(),
+                "duplicate operationId `{operation_id}`"
+            );
+        }
+    }
+
+    let expected = openapi_postprocess::OPERATION_RETRY_CLASSES
+        .iter()
+        .map(|(operation_id, retry_class)| (*operation_id, retry_class.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(published, expected);
 }
 
 #[test]

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -314,7 +314,7 @@ fn openapi_documents_current_server_paths() {
 
 #[test]
 fn openapi_operation_ids_match_the_public_registry() {
-    const REGISTRY_MESSAGE: &str = "operation IDs define generated SDK method names; update crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs::OPENAPI_OPERATION_IDS only for a deliberate public rename";
+    const REGISTRY_MESSAGE: &str = "operation IDs define generated SDK method names; update OPENAPI_OPERATION_IDS only when renaming a public method";
 
     let spec: Value = serde_json::from_str(
         &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
@@ -384,12 +384,12 @@ fn every_registered_operation_publishes_its_retry_class() {
     assert_eq!(
         openapi_postprocess::OPENAPI_OPERATION_IDS.len(),
         registered.len(),
-        "the operation ID registry contains a duplicate"
+        "operation IDs must be unique"
     );
     assert_eq!(
         openapi_postprocess::OPERATION_RETRY_CLASSES.len(),
         classified.len(),
-        "an operation has more than one retry classification"
+        "each operation must have one retry class"
     );
     assert_eq!(classified, registered);
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -610,10 +610,11 @@ commit-status lookup: after `commit_outcome_unknown`, a transport failure, or
 a process restart, resubmit the same request with the same `commit_id` and
 read the definitive answer from the response.
 
-The blocking Rust client automatically retries reads, commits,
-replay-safe upload stages, and idempotent maintenance calls, but makes one
-attempt for namespace create, fork, and delete, upload-session begin, and
-presigned direct PUT.
+The blocking Rust client automatically retries reads, commits, replay-safe
+upload stages, upload completion, and idempotent maintenance calls. It makes
+one attempt for every `new_attempt` operation: namespace create, fork, and
+delete; upload-session begin; checkpoint create; maintenance step; grep-index
+collection; and store probe. Presigned direct PUT also makes one attempt.
 
 Commits record a durable receipt binding the `commit_id` to its
 `committed_seq`; replay reads that receipt, and a reuse conflict reports the
@@ -686,7 +687,6 @@ Every operation includes an `x-loonfs-retry` value for generated SDKs:
 
 - `safe`: the operation is read-only, or resending the same request is harmless.
 - `replay`: resend the same request to receive the original result.
-- `verify`: read the operation status after an unclear failure before retrying.
 - `new_attempt`: another request starts new work or returns a final conflict.
 
 The table below lists the retry class for every v0 operation.
@@ -712,7 +712,7 @@ The table below lists the retry class for every v0 operation.
 | Start an upload | `begin_upload` | `new_attempt` | `POST /v0/namespaces/{ns}/uploads` |
 | Upload content through the server | `upload_content` | `safe` | `PUT /v0/namespaces/{ns}/uploads/{upload_id}/content` |
 | Create multipart upload URLs | `sign_upload_parts` | `safe` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/parts` |
-| Complete an upload | `complete_upload` | `verify` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
+| Complete an upload | `complete_upload` | `replay` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
 | Read upload status | `get_upload_status` | `safe` | `GET /v0/namespaces/{ns}/uploads/{upload_id}`; completed sessions return a fresh `content_token` |
 | Abort an upload session | `abort_upload` | `safe` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/abort` (terminal and repeatable; a completed session is refused) |
 | Read committed changes | `list_changes` | `safe` | `GET /v0/namespaces/{ns}/changes?after_seq=123&limit=100` |
@@ -1225,12 +1225,16 @@ object, and returns failure. The client must start a new session. If assembly
 or the metadata read fails before a comparison can be made, the server returns
 `server_error` and keeps the session open so completion can be retried.
 
-If completion fails without a clear response, read the upload status before
-retrying:
+If completion fails without a clear response, resend the same completion
+request:
 
-- `completed`: use the result and its fresh receipt.
-- `open`: resend the same completion request.
-- `aborted`: do not retry.
+- a completed session returns its stored result and a fresh `content_token`
+  while the minting window remains open;
+- an open session continues completion;
+- an aborted session is terminal; do not retry.
+
+A caller that cannot resend the same request reads the upload status instead;
+a completed status returns the same stored result.
 
 When an `open` multipart upload no longer exists at the provider, the server
 checks whether the completed object matches the request. A match completes the

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -682,21 +682,22 @@ by anyone who can read the connection. Serve `https` for any deployment
 reachable beyond localhost — either terminated by the server itself or by a
 proxy in front of it.
 
-Every operation publishes one `x-loonfs-retry` value for generated SDKs.
-The vocabulary is closed: `safe` means that the operation changes no state
-or an identical resend is harmless, `replay` means that a declared request
-identity returns the original outcome, `verify` means that the client reads
-the outcome after an ambiguous failure before it retries, and `new_attempt`
-means that another request starts distinct work or returns a terminal
-conflict. The complete v0 binding is shown below.
+Every operation includes an `x-loonfs-retry` value for generated SDKs:
+
+- `safe`: the operation is read-only, or resending the same request is harmless.
+- `replay`: resend the same request to receive the original result.
+- `verify`: read the operation status after an unclear failure before retrying.
+- `new_attempt`: another request starts new work or returns a final conflict.
+
+The table below lists the retry class for every v0 operation.
 
 | Purpose | Operation ID | Retry class | Representative HTTP shape |
 | --- | --- | --- | --- |
-| Check process health | `health` | `safe` | `GET /health` |
-| Check request admission | `readiness` | `safe` | `GET /readiness` |
+| Check server health | `health` | `safe` | `GET /health` |
+| Check server readiness | `readiness` | `safe` | `GET /readiness` |
 | Read deployment capabilities | `capabilities` | `safe` | `GET /v0/capabilities` |
 | Create a namespace | `create_namespace` | `new_attempt` | `POST /v0/namespaces` |
-| Read one namespace's core state | `get_namespace` | `safe` | `GET /v0/namespaces/{ns}` |
+| Read a namespace | `get_namespace` | `safe` | `GET /v0/namespaces/{ns}` |
 | Stat a path | `stat_path` | `safe` | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt&include_attributes=false` (the parameter is optional and defaults to `true`) |
 | Stat an inode | `stat_inode` | `safe` | `GET /v0/namespaces/{ns}/inodes/{inode_id}?include_attributes=false` (the parameter is optional and defaults to `true`) |
 | List a path | `list_path_entries` | `safe` | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs&limit=100&cursor=...&include_attributes=true` (the parameter is optional and defaults to `false`) |
@@ -704,30 +705,30 @@ conflict. The complete v0 binding is shown below.
 | List file revisions by inode | `list_file_revisions_by_inode` | `safe` | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions?limit=100&cursor=...` |
 | Read current or prior file content by path | `get_file_bytes` | `safe` | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt&revision_no=3` (`revision_no` is optional) |
 | Read prior file content by inode | `get_file_revision_bytes_by_inode` | `safe` | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/content` |
-| Take a download grant for one file | `begin_download` | `safe` | `POST /v0/namespaces/{ns}/filesystem/downloads` |
-| Take a download grant by inode | `begin_download_by_inode` | `safe` | `POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads` with strict empty body `{}` |
+| Start a download by path | `begin_download` | `safe` | `POST /v0/namespaces/{ns}/filesystem/downloads` |
+| Start a download by inode | `begin_download_by_inode` | `safe` | `POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads` with body `{}` |
 | List recoverable deletions | `list_trash` | `safe` | `GET /v0/namespaces/{ns}/filesystem/trash?limit=100&cursor=...` |
 | Apply a commit | `apply_commit` | `replay` | `POST /v0/namespaces/{ns}/commits` |
-| Begin or prepare upload | `begin_upload` | `new_attempt` | `POST /v0/namespaces/{ns}/uploads` |
-| Upload full staged content | `upload_content` | `safe` | `PUT /v0/namespaces/{ns}/uploads/{upload_id}/content` |
-| Sign staged upload parts | `sign_upload_parts` | `safe` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/parts` |
-| Complete staged upload | `complete_upload` | `verify` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
-| Read an upload session | `get_upload_status` | `safe` | `GET /v0/namespaces/{ns}/uploads/{upload_id}` (a completed session answers with a freshly minted `content_token`) |
+| Start an upload | `begin_upload` | `new_attempt` | `POST /v0/namespaces/{ns}/uploads` |
+| Upload content through the server | `upload_content` | `safe` | `PUT /v0/namespaces/{ns}/uploads/{upload_id}/content` |
+| Create multipart upload URLs | `sign_upload_parts` | `safe` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/parts` |
+| Complete an upload | `complete_upload` | `verify` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
+| Read upload status | `get_upload_status` | `safe` | `GET /v0/namespaces/{ns}/uploads/{upload_id}`; completed sessions return a fresh `content_token` |
 | Abort an upload session | `abort_upload` | `safe` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/abort` (terminal and repeatable; a completed session is refused) |
 | Read committed changes | `list_changes` | `safe` | `GET /v0/namespaces/{ns}/changes?after_seq=123&limit=100` |
 | Fork a namespace | `fork_namespace` | `new_attempt` | `POST /v0/namespaces/{source_ns}/forks` |
 | Delete a namespace | `delete_namespace` | `new_attempt` | `DELETE /v0/namespaces/{ns}?expected_head_seq=418` (feature `core.namespaces.delete`; the precondition is optional) |
-| Read namespace storage diagnostics | `get_namespace_diagnostics` | `safe` | `GET /v0/admin/namespaces/{ns}/diagnostics` |
-| Create a checkpoint | `create_checkpoint` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/checkpoints` (body carries the required `name` and optional `ttl_ms`; every call mints a new user-owned record under a new id, and that record is a GC root until it is released) |
-| List checkpoints | `list_checkpoints` | `safe` | `GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` (one bounded page of active records in ascending checkpoint-id order, with the id the release route takes; see below) |
+| Read namespace diagnostics | `get_namespace_diagnostics` | `safe` | `GET /v0/admin/namespaces/{ns}/diagnostics` |
+| Create a checkpoint | `create_checkpoint` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/checkpoints`; requires `name` and accepts `ttl_ms` |
+| List checkpoints | `list_checkpoints` | `safe` | `GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` |
 | Release a checkpoint | `release_checkpoint` | `safe` | `POST /v0/admin/namespaces/{ns}/checkpoints/{checkpoint_id}/release` (idempotent and one-way; fork-owned records are rejected) |
-| Run a maintenance step | `maintenance_step` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/maintenance/step` (the one maintenance entry point; see below) |
-| Content search | `grep` | `safe` | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires a materialized active grep root) |
-| Read the grep index's lifecycle | `get_grep_index_status` | `safe` | `GET /v0/admin/namespaces/{ns}/grep/index` (feature `admin.grep.index`; one grep root read, no side effects) |
-| Enable the grep index | `enable_grep_index` | `safe` | `POST /v0/admin/namespaces/{ns}/grep/index/enable` (feature `admin.grep.index`; CAS-publishes the independent grep root into checkpointed backfill and nudges the deployment's maintenance runner; idempotent) |
-| Disable the grep index | `disable_grep_index` | `safe` | `POST /v0/admin/namespaces/{ns}/grep/index/disable` (feature `admin.grep.index`; CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
-| Collect grep-index garbage | `gc_grep_index` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (feature `admin.grep.index`; one explicit pass over only that namespace's grep extension; the body may be absent for the default request; `max_objects` bounds the reads it spends and defaults to 1024 when omitted, returning a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
-| Probe the store contract | `probe_store` | `new_attempt` | `POST /v0/admin/store/probe` (the one admin route whose subject is the store rather than a namespace; body carries no options today and `{}` is the request; see below) |
+| Run maintenance | `maintenance_step` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/maintenance/step` |
+| Search file contents | `grep` | `safe` | `POST /v0/namespaces/{ns}/query/grep`; requires the `query.grep` feature and an active index |
+| Read grep index status | `get_grep_index_status` | `safe` | `GET /v0/admin/namespaces/{ns}/grep/index` |
+| Enable the grep index | `enable_grep_index` | `safe` | `POST /v0/admin/namespaces/{ns}/grep/index/enable`; idempotent |
+| Disable the grep index | `disable_grep_index` | `safe` | `POST /v0/admin/namespaces/{ns}/grep/index/disable`; idempotent |
+| Collect grep index garbage | `gc_grep_index` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/grep/index/gc`; supports `max_objects` and `next_cursor` |
+| Test object storage | `probe_store` | `new_attempt` | `POST /v0/admin/store/probe` with body `{}` |
 | Scrape metrics | `get_metrics` | `safe` | `GET /metrics` (Prometheus text exposition; authorized, unlike the liveness routes — see below) |
 
 The status, enable, and disable routes all return one flat grep-index object:
@@ -1224,14 +1225,17 @@ object, and returns failure. The client must start a new session. If assembly
 or the metadata read fails before a comparison can be made, the server returns
 `server_error` and keeps the session open so completion can be retried.
 
-After an ambiguous completion failure, the client reads the upload session
-before retrying. A `completed` session is the original result, with a freshly
-minted receipt. An `open` session permits the identical completion request to
-be retried. During that retry, if the provider has no such upload, the object
-at the key is read back and verified; if it is the promised object, completion
-is recorded. If neither an upload nor a matching object exists, the session is
-aborted and completion fails. An `aborted` status is terminal and is not
-retried.
+If completion fails without a clear response, read the upload status before
+retrying:
+
+- `completed`: use the result and its fresh receipt.
+- `open`: resend the same completion request.
+- `aborted`: do not retry.
+
+When an `open` multipart upload no longer exists at the provider, the server
+checks whether the completed object matches the request. A match completes the
+session. If the upload and a matching object are both missing, the server
+aborts the session and returns an error.
 
 **Cleanup.** The session record carries the provider's upload id, so a
 session that is aborted — by the client, by a failed verification, or by

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -682,46 +682,53 @@ by anyone who can read the connection. Serve `https` for any deployment
 reachable beyond localhost — either terminated by the server itself or by a
 proxy in front of it.
 
-A representative v0 binding is shown below.
+Every operation publishes one `x-loonfs-retry` value for generated SDKs.
+The vocabulary is closed: `safe` means that the operation changes no state
+or an identical resend is harmless, `replay` means that a declared request
+identity returns the original outcome, `verify` means that the client reads
+the outcome after an ambiguous failure before it retries, and `new_attempt`
+means that another request starts distinct work or returns a terminal
+conflict. The complete v0 binding is shown below.
 
-| Purpose | Representative HTTP shape |
-| --- | --- |
-| Read deployment capabilities | `GET /v0/capabilities` |
-| Create a namespace | `POST /v0/namespaces` |
-| Read one namespace's core state | `GET /v0/namespaces/{ns}` |
-| Stat a path | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt&include_attributes=false` (the parameter is optional and defaults to `true`) |
-| Stat an inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}?include_attributes=false` (the parameter is optional and defaults to `true`) |
-| List a path | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs&limit=100&cursor=...&include_attributes=true` (the parameter is optional and defaults to `false`) |
-| List file revisions by path | `GET /v0/namespaces/{ns}/filesystem/revisions?path=/docs/report.txt&limit=100&cursor=...` |
-| List file revisions by inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions?limit=100&cursor=...` |
-| Read file content | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt` |
-| Read prior file content by path | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt&revision_no=3` |
-| Read prior file content by inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/content` |
-| Take a download grant for one file | `POST /v0/namespaces/{ns}/filesystem/downloads` |
-| Take a download grant by inode | `POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads` with strict empty body `{}` |
-| List recoverable deletions | `GET /v0/namespaces/{ns}/filesystem/trash?limit=100&cursor=...` |
-| Apply a commit | `POST /v0/namespaces/{ns}/commits` |
-| Begin or prepare upload | `POST /v0/namespaces/{ns}/uploads` |
-| Upload full staged content | `PUT /v0/namespaces/{ns}/uploads/{upload_id}/content` |
-| Sign staged upload parts | `POST /v0/namespaces/{ns}/uploads/{upload_id}/parts` |
-| Complete staged upload | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
-| Read an upload session | `GET /v0/namespaces/{ns}/uploads/{upload_id}` (a completed session answers with a freshly minted `content_token`) |
-| Abort an upload session | `POST /v0/namespaces/{ns}/uploads/{upload_id}/abort` (terminal and repeatable; a completed session is refused) |
-| Read committed changes | `GET /v0/namespaces/{ns}/changes?after_seq=123&limit=100` |
-| Fork a namespace | `POST /v0/namespaces/{source_ns}/forks` |
-| Delete a namespace | `DELETE /v0/namespaces/{ns}?expected_head_seq=418` (feature `core.namespaces.delete`; the precondition is optional) |
-| Read namespace storage diagnostics | `GET /v0/admin/namespaces/{ns}/diagnostics` |
-| Create a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoints` (body carries the required `name` and optional `ttl_ms`; every call mints a new user-owned record under a new id, and that record is a GC root until it is released) |
-| List checkpoints | `GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` (one bounded page of active records in ascending checkpoint-id order, with the id the release route takes; see below) |
-| Release a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoints/{checkpoint_id}/release` (idempotent and one-way; fork-owned records are rejected) |
-| Run a maintenance step | `POST /v0/admin/namespaces/{ns}/maintenance/step` (the one maintenance entry point; see below) |
-| Content search | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires a materialized active grep root) |
-| Read the grep index's lifecycle | `GET /v0/admin/namespaces/{ns}/grep/index` (feature `admin.grep.index`; one grep root read, no side effects) |
-| Enable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/enable` (feature `admin.grep.index`; CAS-publishes the independent grep root into checkpointed backfill and nudges the deployment's maintenance runner; idempotent) |
-| Disable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/disable` (feature `admin.grep.index`; CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
-| Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (feature `admin.grep.index`; one explicit pass over only that namespace's grep extension; the body may be absent for the default request; `max_objects` bounds the reads it spends and defaults to 1024 when omitted, returning a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
-| Probe the store contract | `POST /v0/admin/store/probe` (the one admin route whose subject is the store rather than a namespace; body carries no options today and `{}` is the request; see below) |
-| Scrape metrics | `GET /metrics` (Prometheus text exposition; authorized, unlike the liveness routes — see below) |
+| Purpose | Operation ID | Retry class | Representative HTTP shape |
+| --- | --- | --- | --- |
+| Check process health | `health` | `safe` | `GET /health` |
+| Check request admission | `readiness` | `safe` | `GET /readiness` |
+| Read deployment capabilities | `capabilities` | `safe` | `GET /v0/capabilities` |
+| Create a namespace | `create_namespace` | `new_attempt` | `POST /v0/namespaces` |
+| Read one namespace's core state | `get_namespace` | `safe` | `GET /v0/namespaces/{ns}` |
+| Stat a path | `stat_path` | `safe` | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt&include_attributes=false` (the parameter is optional and defaults to `true`) |
+| Stat an inode | `stat_inode` | `safe` | `GET /v0/namespaces/{ns}/inodes/{inode_id}?include_attributes=false` (the parameter is optional and defaults to `true`) |
+| List a path | `list_path_entries` | `safe` | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs&limit=100&cursor=...&include_attributes=true` (the parameter is optional and defaults to `false`) |
+| List file revisions by path | `list_file_revisions` | `safe` | `GET /v0/namespaces/{ns}/filesystem/revisions?path=/docs/report.txt&limit=100&cursor=...` |
+| List file revisions by inode | `list_file_revisions_by_inode` | `safe` | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions?limit=100&cursor=...` |
+| Read current or prior file content by path | `get_file_bytes` | `safe` | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt&revision_no=3` (`revision_no` is optional) |
+| Read prior file content by inode | `get_file_revision_bytes_by_inode` | `safe` | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/content` |
+| Take a download grant for one file | `begin_download` | `safe` | `POST /v0/namespaces/{ns}/filesystem/downloads` |
+| Take a download grant by inode | `begin_download_by_inode` | `safe` | `POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads` with strict empty body `{}` |
+| List recoverable deletions | `list_trash` | `safe` | `GET /v0/namespaces/{ns}/filesystem/trash?limit=100&cursor=...` |
+| Apply a commit | `apply_commit` | `replay` | `POST /v0/namespaces/{ns}/commits` |
+| Begin or prepare upload | `begin_upload` | `new_attempt` | `POST /v0/namespaces/{ns}/uploads` |
+| Upload full staged content | `upload_content` | `safe` | `PUT /v0/namespaces/{ns}/uploads/{upload_id}/content` |
+| Sign staged upload parts | `sign_upload_parts` | `safe` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/parts` |
+| Complete staged upload | `complete_upload` | `verify` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
+| Read an upload session | `get_upload_status` | `safe` | `GET /v0/namespaces/{ns}/uploads/{upload_id}` (a completed session answers with a freshly minted `content_token`) |
+| Abort an upload session | `abort_upload` | `safe` | `POST /v0/namespaces/{ns}/uploads/{upload_id}/abort` (terminal and repeatable; a completed session is refused) |
+| Read committed changes | `list_changes` | `safe` | `GET /v0/namespaces/{ns}/changes?after_seq=123&limit=100` |
+| Fork a namespace | `fork_namespace` | `new_attempt` | `POST /v0/namespaces/{source_ns}/forks` |
+| Delete a namespace | `delete_namespace` | `new_attempt` | `DELETE /v0/namespaces/{ns}?expected_head_seq=418` (feature `core.namespaces.delete`; the precondition is optional) |
+| Read namespace storage diagnostics | `get_namespace_diagnostics` | `safe` | `GET /v0/admin/namespaces/{ns}/diagnostics` |
+| Create a checkpoint | `create_checkpoint` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/checkpoints` (body carries the required `name` and optional `ttl_ms`; every call mints a new user-owned record under a new id, and that record is a GC root until it is released) |
+| List checkpoints | `list_checkpoints` | `safe` | `GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` (one bounded page of active records in ascending checkpoint-id order, with the id the release route takes; see below) |
+| Release a checkpoint | `release_checkpoint` | `safe` | `POST /v0/admin/namespaces/{ns}/checkpoints/{checkpoint_id}/release` (idempotent and one-way; fork-owned records are rejected) |
+| Run a maintenance step | `maintenance_step` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/maintenance/step` (the one maintenance entry point; see below) |
+| Content search | `grep` | `safe` | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires a materialized active grep root) |
+| Read the grep index's lifecycle | `get_grep_index_status` | `safe` | `GET /v0/admin/namespaces/{ns}/grep/index` (feature `admin.grep.index`; one grep root read, no side effects) |
+| Enable the grep index | `enable_grep_index` | `safe` | `POST /v0/admin/namespaces/{ns}/grep/index/enable` (feature `admin.grep.index`; CAS-publishes the independent grep root into checkpointed backfill and nudges the deployment's maintenance runner; idempotent) |
+| Disable the grep index | `disable_grep_index` | `safe` | `POST /v0/admin/namespaces/{ns}/grep/index/disable` (feature `admin.grep.index`; CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
+| Collect grep-index garbage | `gc_grep_index` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (feature `admin.grep.index`; one explicit pass over only that namespace's grep extension; the body may be absent for the default request; `max_objects` bounds the reads it spends and defaults to 1024 when omitted, returning a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
+| Probe the store contract | `probe_store` | `new_attempt` | `POST /v0/admin/store/probe` (the one admin route whose subject is the store rather than a namespace; body carries no options today and `{}` is the request; see below) |
+| Scrape metrics | `get_metrics` | `safe` | `GET /metrics` (Prometheus text exposition; authorized, unlike the liveness routes — see below) |
 
 The status, enable, and disable routes all return one flat grep-index object:
 `namespace_id`, lifecycle fields tagged by `status`, `next_run_ordinal`, and
@@ -1217,16 +1224,14 @@ object, and returns failure. The client must start a new session. If assembly
 or the metadata read fails before a comparison can be made, the server returns
 `server_error` and keeps the session open so completion can be retried.
 
-If the completion response is lost, the client calls `complete` again. The
-server resolves the result from durable state:
-
-- the session is already `completed` → the original result replays, with a
-  freshly minted receipt;
-- the session is still `open` and the provider has no such upload → the
-  object at the key is read back and verified; if it is the promised object,
-  the completion is recorded as if the first attempt's response had arrived;
-- neither an upload nor a matching object exists → the session is aborted and
-  completion fails.
+After an ambiguous completion failure, the client reads the upload session
+before retrying. A `completed` session is the original result, with a freshly
+minted receipt. An `open` session permits the identical completion request to
+be retried. During that retry, if the provider has no such upload, the object
+at the key is read back and verified; if it is the promised object, completion
+is recorded. If neither an upload nor a matching object exists, the session is
+aborted and completion fails. An `aborted` status is terminal and is not
+retried.
 
 **Cleanup.** The session record carries the provider's upload id, so a
 session that is aborted — by the client, by a failed verification, or by

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -35,7 +35,8 @@
         },
         "security": [
           {}
-        ]
+        ],
+        "x-loonfs-retry": "safe"
       }
     },
     "/metrics": {
@@ -70,7 +71,8 @@
           "408": {
             "$ref": "#/components/responses/DeadlineExceededResponse"
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/readiness": {
@@ -108,7 +110,8 @@
         },
         "security": [
           {}
-        ]
+        ],
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/checkpoints": {
@@ -196,7 +199,8 @@
           "408": {
             "$ref": "#/components/responses/DeadlineExceededResponse"
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       },
       "post": {
         "tags": [
@@ -291,7 +295,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "new_attempt"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release": {
@@ -366,7 +371,8 @@
           "408": {
             "$ref": "#/components/responses/DeadlineExceededResponse"
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/diagnostics": {
@@ -442,7 +448,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/grep/index": {
@@ -518,7 +525,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/grep/index/disable": {
@@ -614,7 +622,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/grep/index/enable": {
@@ -710,7 +719,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/grep/index/gc": {
@@ -802,7 +812,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "new_attempt"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/maintenance/step": {
@@ -886,7 +897,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "new_attempt"
       }
     },
     "/v0/admin/store/probe": {
@@ -939,7 +951,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "new_attempt"
       }
     },
     "/v0/capabilities": {
@@ -974,7 +987,8 @@
           "408": {
             "$ref": "#/components/responses/DeadlineExceededResponse"
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces": {
@@ -1049,7 +1063,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "new_attempt"
       }
     },
     "/v0/namespaces/{namespace_id}": {
@@ -1125,7 +1140,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       },
       "delete": {
         "tags": [
@@ -1218,7 +1234,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "new_attempt"
       }
     },
     "/v0/namespaces/{namespace_id}/changes": {
@@ -1316,7 +1333,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/commits": {
@@ -1422,7 +1440,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "replay"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/content": {
@@ -1538,7 +1557,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/downloads": {
@@ -1634,7 +1654,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/list": {
@@ -1751,7 +1772,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/revisions": {
@@ -1858,7 +1880,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/stat": {
@@ -1953,7 +1976,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/trash": {
@@ -2041,7 +2065,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/forks": {
@@ -2137,7 +2162,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "new_attempt"
       }
     },
     "/v0/namespaces/{namespace_id}/inodes/{inode_id}": {
@@ -2234,7 +2260,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions": {
@@ -2353,7 +2380,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content": {
@@ -2481,7 +2509,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads": {
@@ -2607,7 +2636,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/query/grep": {
@@ -2733,7 +2763,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads": {
@@ -2839,7 +2870,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "new_attempt"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}": {
@@ -2924,7 +2956,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/abort": {
@@ -3019,7 +3052,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete": {
@@ -3135,7 +3169,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "verify"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content": {
@@ -3262,7 +3297,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/parts": {
@@ -3387,7 +3423,8 @@
               }
             }
           }
-        }
+        },
+        "x-loonfs-retry": "safe"
       }
     }
   },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3170,7 +3170,7 @@
             }
           }
         },
-        "x-loonfs-retry": "verify"
+        "x-loonfs-retry": "replay"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content": {


### PR DESCRIPTION
Adds `x-loonfs-retry` to all 37 OpenAPI operations. The value tells generated clients whether resending a request is safe, the server can replay the original result, the client should check status first, or another call starts new work.

A typed table maps each public operation ID to its retry class. OpenAPI generation fails when an operation is missing a classification, and tests verify that the registry, table, and generated document stay in sync.

The API guide defines the four retry classes, lists the class for every operation, and explains how to handle an upload completion whose result is unclear. This PR changes OpenAPI metadata and documentation; it does not change server behavior.
