### PR TITLE
api: rename the health tag to system

### DIFF
--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -396,7 +396,7 @@ async fn method_not_allowed() -> ApiResponseError {
         get,
         operation_id = "health",
         path = "/health",
-        tag = "health",
+        tag = "system",
         summary = "Check health",
         description = "Returns `ok` when the server is running and can accept requests.",
         security(()),
@@ -416,7 +416,7 @@ async fn health() -> &'static str {
         get,
         operation_id = "readiness",
         path = "/readiness",
-        tag = "health",
+        tag = "system",
         summary = "Check readiness",
         description = "Returns `ready` while the server admits new work. Once shutdown \
                        begins and publisher admission closes, answers 503 `shutting_down` \
@@ -454,7 +454,7 @@ const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
         get,
         operation_id = "get_metrics",
         path = "/metrics",
-        tag = "health",
+        tag = "system",
         summary = "Scrape metrics",
         description = "Returns this process's metrics in Prometheus text exposition format \
                        0.0.4. Unlike `/health` and `/readiness`, the route requires the \

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -174,7 +174,7 @@ pub fn openapi_document() -> utoipa::openapi::OpenApi {
     security(("bearer_auth" = [])),
     modifiers(&BearerAuth),
     tags(
-        (name = "health", description = "Server health"),
+        (name = "system", description = "Server health"),
         (name = "capabilities", description = "Capability discovery"),
         (name = "namespaces", description = "Namespace lifecycle and status"),
         (name = "filesystem", description = "Path-oriented filesystem APIs"),

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -174,7 +174,7 @@ pub fn openapi_document() -> utoipa::openapi::OpenApi {
     security(("bearer_auth" = [])),
     modifiers(&BearerAuth),
     tags(
-        (name = "system", description = "Server health"),
+        (name = "system", description = "Server health, readiness, and metrics"),
         (name = "capabilities", description = "Capability discovery"),
         (name = "namespaces", description = "Namespace lifecycle and status"),
         (name = "filesystem", description = "Path-oriented filesystem APIs"),

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -13,7 +13,7 @@
     "/health": {
       "get": {
         "tags": [
-          "health"
+          "system"
         ],
         "summary": "Check health",
         "description": "Returns `ok` when the server is running and can accept requests.",
@@ -42,7 +42,7 @@
     "/metrics": {
       "get": {
         "tags": [
-          "health"
+          "system"
         ],
         "summary": "Scrape metrics",
         "description": "Returns this process's metrics in Prometheus text exposition format 0.0.4. Unlike `/health` and `/readiness`, the route requires the deployment's bearer token.",
@@ -78,7 +78,7 @@
     "/readiness": {
       "get": {
         "tags": [
-          "health"
+          "system"
         ],
         "summary": "Check readiness",
         "description": "Returns `ready` while the server admits new work. Once shutdown begins and publisher admission closes, answers 503 `shutting_down` so load balancers can drain the instance. `/health` stays the liveness probe: it only reports that the process is up.",
@@ -7051,7 +7051,7 @@
   ],
   "tags": [
     {
-      "name": "health",
+      "name": "system",
       "description": "Server health"
     },
     {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -7052,7 +7052,7 @@
   "tags": [
     {
       "name": "system",
-      "description": "Server health"
+      "description": "Server health, readiness, and metrics"
     },
     {
       "name": "capabilities",


### PR DESCRIPTION
Renames the OpenAPI `health` tag to `system` so it no longer collides with the `health` operation name in generated clients. The tag groups health, readiness, and metrics.

Operation IDs, paths, and schemas are unchanged. The generated OpenAPI document is refreshed with the new tag.
