### PR TITLE
api: derive the proxy profile document

### DIFF
--- a/crates/loonfs-server/src/bin/loonfs-openapi.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi.rs
@@ -1,4 +1,4 @@
-//! Writes the full and proxy OpenAPI documents.
+//! Writes the full OpenAPI document and the browser proxy document.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};

--- a/crates/loonfs-server/src/bin/loonfs-openapi.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi.rs
@@ -1,23 +1,72 @@
-//! Writes the generated OpenAPI document to `docs/specs/openapi.json`.
+//! Writes the full and proxy OpenAPI documents.
 
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
 #[path = "loonfs-openapi/openapi_postprocess.rs"]
 mod openapi_postprocess;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let path = std::env::args_os()
-        .nth(1)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("docs/specs/openapi.json"));
+    let (full_path, proxy_path) = output_paths(std::env::args_os().skip(1))?;
+    let (full, proxy) =
+        openapi_postprocess::openapi_documents_pretty(&loonfs_server::openapi_document())?;
+    write_json(&full_path, full)?;
+    write_json(&proxy_path, proxy)?;
+    Ok(())
+}
 
+fn output_paths(
+    arguments: impl IntoIterator<Item = OsString>,
+) -> Result<(PathBuf, PathBuf), std::io::Error> {
+    let mut full_path = None;
+    let mut proxy_path = None;
+    let mut arguments = arguments.into_iter();
+
+    while let Some(argument) = arguments.next() {
+        if argument == "--proxy-output" {
+            let value = arguments
+                .next()
+                .ok_or_else(|| invalid_input("--proxy-output requires an output path"))?;
+            if proxy_path.replace(PathBuf::from(value)).is_some() {
+                return Err(invalid_input("--proxy-output may be set only once"));
+            }
+        } else if argument.to_string_lossy().starts_with('-') {
+            return Err(invalid_input(format!(
+                "unknown argument `{}`",
+                argument.to_string_lossy()
+            )));
+        } else if full_path.replace(PathBuf::from(argument)).is_some() {
+            return Err(invalid_input(
+                "only one full-document output path is accepted",
+            ));
+        }
+    }
+
+    let full_path = full_path.unwrap_or_else(|| PathBuf::from("docs/specs/openapi.json"));
+    let proxy_path = proxy_path.unwrap_or_else(|| default_proxy_path(&full_path));
+    if full_path == proxy_path {
+        return Err(invalid_input(
+            "the full and proxy documents require different output paths",
+        ));
+    }
+    Ok((full_path, proxy_path))
+}
+
+fn default_proxy_path(full_path: &Path) -> PathBuf {
+    full_path.with_file_name("openapi-proxy.json")
+}
+
+fn invalid_input(message: impl Into<String>) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, message.into())
+}
+
+fn write_json(path: &Path, mut json: String) -> Result<(), std::io::Error> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent)?;
         }
     }
 
-    let mut json = openapi_postprocess::openapi_json_pretty(&loonfs_server::openapi_document())?;
     json.push('\n');
     std::fs::write(path, json)?;
     Ok(())

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -56,14 +56,14 @@ pub(crate) const OPENAPI_OPERATION_IDS: &[&str] = &[
     "upload_content",
 ];
 
-/// How a proxy operation is addressed.
+/// Whether a proxy operation uses a mount path.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ProxyOperationScope {
     Unscoped,
     Mount,
 }
 
-/// Operations published by the LoonFS Proxy profile. Keep this table sorted.
+/// Operations included in the browser proxy document. Keep this table sorted.
 pub(crate) const PROXY_OPERATIONS: &[(&str, ProxyOperationScope)] = &[
     ("abort_upload", ProxyOperationScope::Mount),
     ("apply_commit", ProxyOperationScope::Mount),
@@ -211,7 +211,7 @@ pub(crate) fn openapi_json_pretty(
     Ok(serde_json::to_string_pretty(&document)?)
 }
 
-/// Generates the full document and derives the proxy profile from its JSON.
+/// Generates the full OpenAPI document and the browser proxy document.
 pub(crate) fn openapi_documents_pretty(
     document: &(impl Serialize + ?Sized),
 ) -> Result<(String, String), OpenapiPostprocessError> {
@@ -220,11 +220,12 @@ pub(crate) fn openapi_documents_pretty(
     Ok((full, proxy))
 }
 
-/// Derives the LoonFS Proxy profile from a generated full OpenAPI document.
+/// Builds the browser proxy document from the full OpenAPI JSON.
 pub(crate) fn proxy_openapi_json_pretty(
     full_document: &str,
 ) -> Result<String, OpenapiPostprocessError> {
     let mut document = serde_json::from_str(full_document)?;
+    describe_proxy_document(&mut document);
     derive_proxy_paths(&mut document)?;
     remove_proxy_security(&mut document);
     remove_trusted_tags(&mut document);
@@ -235,6 +236,24 @@ pub(crate) fn proxy_openapi_json_pretty(
 const HTTP_METHODS: &[&str] = &["get", "post", "put", "delete", "patch"];
 const NAMESPACE_PATH_PREFIX: &str = "/v0/namespaces/{namespace_id}";
 const MOUNT_PATH_PREFIX: &str = "/v0/mounts/{mount}";
+
+fn describe_proxy_document(document: &mut Value) {
+    let info = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("info"))
+        .and_then(Value::as_object_mut)
+        .expect("OpenAPI document has no info object");
+    info.insert(
+        "title".to_owned(),
+        Value::String("LoonFS Browser Proxy API".to_owned()),
+    );
+    info.insert(
+        "description".to_owned(),
+        Value::String(
+            "API for browser clients that access namespaces through application mounts.".to_owned(),
+        ),
+    );
+}
 
 fn derive_proxy_paths(document: &mut Value) -> Result<(), OpenapiPostprocessError> {
     let paths = document
@@ -357,7 +376,7 @@ fn rewrite_namespace_parameters(operation: &mut Value) -> usize {
         parameter.insert("name".to_owned(), Value::String("mount".to_owned()));
         parameter.insert(
             "description".to_owned(),
-            Value::String("Application mount label".to_owned()),
+            Value::String("Application mount name".to_owned()),
         );
         parameter.insert(
             "schema".to_owned(),

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -228,7 +228,7 @@ pub(crate) fn proxy_openapi_json_pretty(
     describe_proxy_document(&mut document);
     derive_proxy_paths(&mut document)?;
     remove_proxy_security(&mut document);
-    remove_trusted_tags(&mut document);
+    retain_referenced_tags(&mut document);
     prune_proxy_components(&mut document)?;
     Ok(serde_json::to_string_pretty(&document)?)
 }
@@ -403,7 +403,30 @@ fn remove_proxy_security(document: &mut Value) {
     }
 }
 
-fn remove_trusted_tags(document: &mut Value) {
+/// Retains only tag definitions that a retained operation references, so a
+/// tag whose operations were all pruned does not survive as a dead entry.
+fn retain_referenced_tags(document: &mut Value) {
+    let mut referenced = BTreeSet::new();
+    if let Some(paths) = document.get("paths").and_then(Value::as_object) {
+        for path_item in paths.values() {
+            let Some(path_item) = path_item.as_object() else {
+                continue;
+            };
+            for (field, operation) in path_item {
+                if !HTTP_METHODS.contains(&field.as_str()) {
+                    continue;
+                }
+                let Some(tags) = operation.get("tags").and_then(Value::as_array) else {
+                    continue;
+                };
+                for tag in tags {
+                    if let Some(tag) = tag.as_str() {
+                        referenced.insert(tag.to_owned());
+                    }
+                }
+            }
+        }
+    }
     let Some(tags) = document
         .as_object_mut()
         .and_then(|document| document.get_mut("tags"))
@@ -415,10 +438,9 @@ fn remove_trusted_tags(document: &mut Value) {
         return;
     };
     tags.retain(|tag| {
-        !matches!(
-            tag.get("name").and_then(Value::as_str),
-            Some("system" | "admin")
-        )
+        tag.get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|name| referenced.contains(name))
     });
 }
 

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -56,6 +56,33 @@ pub(crate) const OPENAPI_OPERATION_IDS: &[&str] = &[
     "upload_content",
 ];
 
+/// How a proxy operation is addressed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ProxyOperationScope {
+    Unscoped,
+    Mount,
+}
+
+/// Operations published by the LoonFS Proxy profile. Keep this table sorted.
+pub(crate) const PROXY_OPERATIONS: &[(&str, ProxyOperationScope)] = &[
+    ("abort_upload", ProxyOperationScope::Mount),
+    ("apply_commit", ProxyOperationScope::Mount),
+    ("begin_download", ProxyOperationScope::Mount),
+    ("begin_upload", ProxyOperationScope::Mount),
+    ("capabilities", ProxyOperationScope::Unscoped),
+    ("complete_upload", ProxyOperationScope::Mount),
+    ("get_file_bytes", ProxyOperationScope::Mount),
+    ("get_upload_status", ProxyOperationScope::Mount),
+    ("grep", ProxyOperationScope::Mount),
+    ("list_changes", ProxyOperationScope::Mount),
+    ("list_file_revisions", ProxyOperationScope::Mount),
+    ("list_path_entries", ProxyOperationScope::Mount),
+    ("list_trash", ProxyOperationScope::Mount),
+    ("sign_upload_parts", ProxyOperationScope::Mount),
+    ("stat_path", ProxyOperationScope::Mount),
+    ("upload_content", ProxyOperationScope::Mount),
+];
+
 /// Retry behavior for generated SDKs.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RetryClass {
@@ -82,6 +109,18 @@ pub(crate) enum OpenapiPostprocessError {
     MissingRetryClassification { operation_id: String },
     #[error("OpenAPI union variant `{schema_name}` conflicts with an existing component schema")]
     UnionVariantSchemaCollision { schema_name: String },
+    #[error("proxy operation `{operation_id}` does not appear in the full OpenAPI document")]
+    MissingProxyOperation { operation_id: String },
+    #[error(
+        "proxy operation `{operation_id}` appears more than once in the full OpenAPI document"
+    )]
+    DuplicateProxyOperation { operation_id: String },
+    #[error("proxy operation `{operation_id}` has an unexpected path `{path}`")]
+    UnexpectedProxyPath { operation_id: String, path: String },
+    #[error("proxy operation `{operation_id}` has no `namespace_id` path parameter")]
+    MissingProxyNamespaceParameter { operation_id: String },
+    #[error("proxy document references a missing OpenAPI component `{reference}`")]
+    MissingProxyComponent { reference: String },
 }
 
 /// Retry class for each public operation.
@@ -170,6 +209,275 @@ pub(crate) fn openapi_json_pretty(
     extract_union_variants(&mut document)?;
     add_operation_retry_classes(&mut document)?;
     Ok(serde_json::to_string_pretty(&document)?)
+}
+
+/// Generates the full document and derives the proxy profile from its JSON.
+pub(crate) fn openapi_documents_pretty(
+    document: &(impl Serialize + ?Sized),
+) -> Result<(String, String), OpenapiPostprocessError> {
+    let full = openapi_json_pretty(document)?;
+    let proxy = proxy_openapi_json_pretty(&full)?;
+    Ok((full, proxy))
+}
+
+/// Derives the LoonFS Proxy profile from a generated full OpenAPI document.
+pub(crate) fn proxy_openapi_json_pretty(
+    full_document: &str,
+) -> Result<String, OpenapiPostprocessError> {
+    let mut document = serde_json::from_str(full_document)?;
+    derive_proxy_paths(&mut document)?;
+    remove_proxy_security(&mut document);
+    remove_trusted_tags(&mut document);
+    prune_proxy_components(&mut document)?;
+    Ok(serde_json::to_string_pretty(&document)?)
+}
+
+const HTTP_METHODS: &[&str] = &["get", "post", "put", "delete", "patch"];
+const NAMESPACE_PATH_PREFIX: &str = "/v0/namespaces/{namespace_id}";
+const MOUNT_PATH_PREFIX: &str = "/v0/mounts/{mount}";
+
+fn derive_proxy_paths(document: &mut Value) -> Result<(), OpenapiPostprocessError> {
+    let paths = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("paths"))
+        .and_then(Value::as_object_mut)
+        .expect("OpenAPI document has no paths object");
+    let mut derived_paths = Map::new();
+    let mut found_operations = BTreeSet::new();
+
+    for (path, path_item) in paths.iter() {
+        let path_item = path_item
+            .as_object()
+            .expect("OpenAPI path item is not an object");
+        let mut derived_path_item = Map::new();
+        let mut derived_path = None;
+
+        for (field, value) in path_item {
+            if !HTTP_METHODS.contains(&field.as_str()) {
+                derived_path_item.insert(field.clone(), value.clone());
+                continue;
+            }
+
+            let operation_id = value
+                .get("operationId")
+                .and_then(Value::as_str)
+                .expect("OpenAPI operation has no operationId");
+            let Some((_, scope)) = PROXY_OPERATIONS
+                .iter()
+                .find(|(candidate, _)| *candidate == operation_id)
+            else {
+                continue;
+            };
+            if !found_operations.insert(operation_id.to_owned()) {
+                return Err(OpenapiPostprocessError::DuplicateProxyOperation {
+                    operation_id: operation_id.to_owned(),
+                });
+            }
+
+            let operation_path = proxy_path(operation_id, path, *scope)?;
+            if let Some(existing) = &derived_path {
+                assert_eq!(
+                    existing, &operation_path,
+                    "one path item changed proxy scope"
+                );
+            } else {
+                derived_path = Some(operation_path);
+            }
+
+            let mut operation = value.clone();
+            operation
+                .as_object_mut()
+                .expect("OpenAPI operation is not an object")
+                .shift_remove("security");
+            if *scope == ProxyOperationScope::Mount
+                && rewrite_namespace_parameters(&mut operation) == 0
+            {
+                return Err(OpenapiPostprocessError::MissingProxyNamespaceParameter {
+                    operation_id: operation_id.to_owned(),
+                });
+            }
+            derived_path_item.insert(field.clone(), operation);
+        }
+
+        if let Some(derived_path) = derived_path {
+            derived_paths.insert(derived_path, Value::Object(derived_path_item));
+        }
+    }
+
+    for (operation_id, _) in PROXY_OPERATIONS {
+        if !found_operations.contains(*operation_id) {
+            return Err(OpenapiPostprocessError::MissingProxyOperation {
+                operation_id: (*operation_id).to_owned(),
+            });
+        }
+    }
+    *paths = derived_paths;
+    Ok(())
+}
+
+fn proxy_path(
+    operation_id: &str,
+    path: &str,
+    scope: ProxyOperationScope,
+) -> Result<String, OpenapiPostprocessError> {
+    match scope {
+        ProxyOperationScope::Unscoped => Ok(path.to_owned()),
+        ProxyOperationScope::Mount => path
+            .strip_prefix(NAMESPACE_PATH_PREFIX)
+            .map(|suffix| format!("{MOUNT_PATH_PREFIX}{suffix}"))
+            .ok_or_else(|| OpenapiPostprocessError::UnexpectedProxyPath {
+                operation_id: operation_id.to_owned(),
+                path: path.to_owned(),
+            }),
+    }
+}
+
+fn rewrite_namespace_parameters(operation: &mut Value) -> usize {
+    let Some(parameters) = operation
+        .as_object_mut()
+        .and_then(|operation| operation.get_mut("parameters"))
+        .and_then(|parameters| match parameters {
+            Value::Array(parameters) => Some(parameters),
+            _ => None,
+        })
+    else {
+        return 0;
+    };
+    let mut rewritten = 0;
+
+    for parameter in parameters {
+        let Some(parameter) = parameter.as_object_mut() else {
+            continue;
+        };
+        if parameter.get("in").and_then(Value::as_str) != Some("path")
+            || parameter.get("name").and_then(Value::as_str) != Some("namespace_id")
+        {
+            continue;
+        }
+        parameter.insert("name".to_owned(), Value::String("mount".to_owned()));
+        parameter.insert(
+            "description".to_owned(),
+            Value::String("Application mount label".to_owned()),
+        );
+        parameter.insert(
+            "schema".to_owned(),
+            Value::Object(IndexMap::from([(
+                "type".to_owned(),
+                Value::String("string".to_owned()),
+            )])),
+        );
+        rewritten += 1;
+    }
+    rewritten
+}
+
+fn remove_proxy_security(document: &mut Value) {
+    let document = document
+        .as_object_mut()
+        .expect("OpenAPI document is not an object");
+    document.shift_remove("security");
+    if let Some(components) = document
+        .get_mut("components")
+        .and_then(Value::as_object_mut)
+    {
+        components.shift_remove("securitySchemes");
+    }
+}
+
+fn remove_trusted_tags(document: &mut Value) {
+    let Some(tags) = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("tags"))
+        .and_then(|tags| match tags {
+            Value::Array(tags) => Some(tags),
+            _ => None,
+        })
+    else {
+        return;
+    };
+    tags.retain(|tag| {
+        !matches!(
+            tag.get("name").and_then(Value::as_str),
+            Some("system" | "admin")
+        )
+    });
+}
+
+fn prune_proxy_components(document: &mut Value) -> Result<(), OpenapiPostprocessError> {
+    let mut pending = Vec::new();
+    collect_component_references(
+        document
+            .get("paths")
+            .expect("OpenAPI document has no paths object"),
+        &mut pending,
+    );
+    let mut referenced = BTreeSet::new();
+
+    while let Some(reference) = pending.pop() {
+        let Some((component_type, component_name)) = component_reference_parts(&reference) else {
+            continue;
+        };
+        if !referenced.insert((component_type.clone(), component_name.clone())) {
+            continue;
+        }
+        let component = document
+            .get("components")
+            .and_then(|components| components.get(&component_type))
+            .and_then(Value::as_object)
+            .and_then(|components| components.get(&component_name))
+            .ok_or_else(|| OpenapiPostprocessError::MissingProxyComponent {
+                reference: reference.clone(),
+            })?;
+        collect_component_references(component, &mut pending);
+    }
+
+    let components = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("components"))
+        .and_then(Value::as_object_mut)
+        .expect("OpenAPI document has no components object");
+    components.retain(|component_type, entries| {
+        let Some(entries) = entries.as_object_mut() else {
+            return false;
+        };
+        entries.retain(|component_name, _| {
+            referenced.contains(&(component_type.clone(), component_name.clone()))
+        });
+        !entries.is_empty()
+    });
+    Ok(())
+}
+
+fn collect_component_references(value: &Value, references: &mut Vec<String>) {
+    match value {
+        Value::String(value) => {
+            if value.starts_with("#/components/") {
+                references.push(value.clone());
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_component_references(value, references);
+            }
+        }
+        Value::Object(object) => {
+            for value in object.values() {
+                collect_component_references(value, references);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn component_reference_parts(reference: &str) -> Option<(String, String)> {
+    let mut parts = reference.strip_prefix("#/components/")?.split('/');
+    let component_type = decode_json_pointer_segment(parts.next()?);
+    let component_name = decode_json_pointer_segment(parts.next()?);
+    Some((component_type, component_name))
+}
+
+fn decode_json_pointer_segment(segment: &str) -> String {
+    segment.replace("~1", "/").replace("~0", "~")
 }
 
 /// Adds `x-loonfs-retry` to every OpenAPI operation.

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -460,6 +460,11 @@ fn proxy_paths_use_mounts_and_declare_no_security() {
         &std::fs::read_to_string(PROXY_OPENAPI_JSON_PATH).expect("read static proxy openapi json"),
     )
     .expect("parse proxy openapi json");
+    assert_eq!(spec["info"]["title"], "LoonFS Browser Proxy API");
+    assert_eq!(
+        spec["info"]["description"],
+        "API for browser clients that access namespaces through application mounts."
+    );
     assert!(spec.get("security").is_none());
     assert!(spec.pointer("/components/securitySchemes").is_none());
     assert!(values_named(&spec, "security").next().is_none());
@@ -510,7 +515,7 @@ fn proxy_paths_use_mounts_and_declare_no_security() {
                         .iter()
                         .find(|parameter| parameter["in"] == "path" && parameter["name"] == "mount")
                         .expect("proxy operation mount parameter");
-                    assert_eq!(mount["description"], "Application mount label");
+                    assert_eq!(mount["description"], "Application mount name");
                     assert_eq!(mount["schema"], serde_json::json!({"type": "string"}));
                 }
             }
@@ -533,7 +538,9 @@ fn proxy_components_are_exactly_the_referenced_closure() {
         .flat_map(|(component_type, entries)| {
             entries
                 .as_object()
-                .unwrap_or_else(|| panic!("proxy component group `{component_type}` is an object"))
+                .unwrap_or_else(|| {
+                    panic!("proxy component group `{component_type}` must be an object")
+                })
                 .keys()
                 .map(move |component_name| (component_type.clone(), component_name.clone()))
         })

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -8,6 +8,10 @@ mod openapi_postprocess;
 
 const OPENAPI_JSON_PATH: &str =
     concat!(env!("CARGO_MANIFEST_DIR"), "/../../docs/specs/openapi.json");
+const PROXY_OPENAPI_JSON_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/specs/openapi-proxy.json"
+);
 const OPENAPI_PATH_SOURCES: &[&str] = &[
     include_str!("../../src/http/mod.rs"),
     include_str!("../../src/http/handlers_downloads.rs"),
@@ -20,16 +24,23 @@ const OPENAPI_PATH_SOURCES: &[&str] = &[
 ];
 
 #[test]
-fn openapi_static_file_is_current() {
-    let mut generated =
-        openapi_postprocess::openapi_json_pretty(&loonfs_server::openapi_document())
-            .expect("generate openapi json");
-    generated.push('\n');
-    let committed = std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json");
+fn openapi_static_files_are_current() {
+    let (mut full, mut proxy) =
+        openapi_postprocess::openapi_documents_pretty(&loonfs_server::openapi_document())
+            .expect("generate full and proxy OpenAPI JSON");
+    full.push('\n');
+    proxy.push('\n');
 
     assert_eq!(
-        generated, committed,
-        "docs/specs/openapi.json is stale; rerun `cargo run -p loonfs-server --features openapi --bin loonfs-openapi -- docs/specs/openapi.json`"
+        full,
+        std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+        "docs/specs/openapi.json is stale; rerun `cargo run -p loonfs-server --features openapi --bin loonfs-openapi -- --proxy-output docs/specs/openapi-proxy.json docs/specs/openapi.json`"
+    );
+    assert_eq!(
+        proxy,
+        std::fs::read_to_string(PROXY_OPENAPI_JSON_PATH)
+            .expect("read static proxy openapi json"),
+        "docs/specs/openapi-proxy.json is stale; rerun `cargo run -p loonfs-server --features openapi --bin loonfs-openapi -- --proxy-output docs/specs/openapi-proxy.json docs/specs/openapi.json`"
     );
 }
 
@@ -391,6 +402,170 @@ fn openapi_operation_ids_match_the_public_registry() {
         operation_ids,
         openapi_postprocess::OPENAPI_OPERATION_IDS,
         "operationIds changed; {REGISTRY_MESSAGE}"
+    );
+}
+
+#[test]
+fn proxy_operation_ids_match_the_allowlist() {
+    let registered = openapi_postprocess::OPENAPI_OPERATION_IDS
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let allowlisted = openapi_postprocess::PROXY_OPERATIONS
+        .iter()
+        .map(|(operation_id, _)| *operation_id)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        allowlisted.len(),
+        openapi_postprocess::PROXY_OPERATIONS.len(),
+        "proxy operation IDs must be unique"
+    );
+    assert!(
+        allowlisted.is_subset(&registered),
+        "proxy operation IDs must be registered public operations"
+    );
+    assert!(
+        openapi_postprocess::PROXY_OPERATIONS
+            .windows(2)
+            .all(|pair| pair[0].0 < pair[1].0),
+        "proxy operations must stay sorted"
+    );
+
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(PROXY_OPENAPI_JSON_PATH).expect("read static proxy openapi json"),
+    )
+    .expect("parse proxy openapi json");
+    let published = spec["paths"]
+        .as_object()
+        .expect("proxy openapi paths object")
+        .values()
+        .filter_map(Value::as_object)
+        .flat_map(|path_item| {
+            ["get", "post", "put", "delete", "patch"]
+                .into_iter()
+                .filter_map(|method| path_item.get(method))
+        })
+        .map(|operation| {
+            operation["operationId"]
+                .as_str()
+                .expect("proxy operation has an operation ID")
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(published, allowlisted);
+}
+
+#[test]
+fn proxy_paths_use_mounts_and_declare_no_security() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(PROXY_OPENAPI_JSON_PATH).expect("read static proxy openapi json"),
+    )
+    .expect("parse proxy openapi json");
+    assert!(spec.get("security").is_none());
+    assert!(spec.pointer("/components/securitySchemes").is_none());
+    assert!(values_named(&spec, "security").next().is_none());
+
+    let tag_names = spec["tags"]
+        .as_array()
+        .expect("proxy tags array")
+        .iter()
+        .filter_map(|tag| tag["name"].as_str())
+        .collect::<BTreeSet<_>>();
+    assert!(!tag_names.contains("system"));
+    assert!(!tag_names.contains("admin"));
+
+    let paths = spec["paths"]
+        .as_object()
+        .expect("proxy openapi paths object");
+    for (path, path_item) in paths {
+        assert!(
+            !path.contains("namespace_id"),
+            "proxy path contains namespace_id: `{path}`"
+        );
+        assert!(!path.starts_with("/v0/admin/"));
+        assert!(!matches!(
+            path.as_str(),
+            "/health" | "/readiness" | "/metrics"
+        ));
+
+        for operation in ["get", "post", "put", "delete", "patch"]
+            .into_iter()
+            .filter_map(|method| path_item.get(method))
+        {
+            let operation_id = operation["operationId"]
+                .as_str()
+                .expect("proxy operation ID");
+            let scope = openapi_postprocess::PROXY_OPERATIONS
+                .iter()
+                .find_map(|(candidate, scope)| (*candidate == operation_id).then_some(*scope))
+                .expect("published proxy operation is allowlisted");
+            match scope {
+                openapi_postprocess::ProxyOperationScope::Unscoped => {
+                    assert_eq!(path, "/v0/capabilities");
+                }
+                openapi_postprocess::ProxyOperationScope::Mount => {
+                    assert!(path.starts_with("/v0/mounts/{mount}/"));
+                    let mount = operation["parameters"]
+                        .as_array()
+                        .expect("proxy operation parameters")
+                        .iter()
+                        .find(|parameter| parameter["in"] == "path" && parameter["name"] == "mount")
+                        .expect("proxy operation mount parameter");
+                    assert_eq!(mount["description"], "Application mount label");
+                    assert_eq!(mount["schema"], serde_json::json!({"type": "string"}));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn proxy_components_are_exactly_the_referenced_closure() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(PROXY_OPENAPI_JSON_PATH).expect("read static proxy openapi json"),
+    )
+    .expect("parse proxy openapi json");
+    let components = spec["components"]
+        .as_object()
+        .expect("proxy components object");
+    let referenced = referenced_components(&spec);
+    let published = components
+        .iter()
+        .flat_map(|(component_type, entries)| {
+            entries
+                .as_object()
+                .unwrap_or_else(|| panic!("proxy component group `{component_type}` is an object"))
+                .keys()
+                .map(move |component_name| (component_type.clone(), component_name.clone()))
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(published, referenced);
+
+    let schemas = components["schemas"]
+        .as_object()
+        .expect("proxy schemas object");
+    for reference in string_values(&spec)
+        .filter_map(Value::as_str)
+        .filter_map(|reference| reference.strip_prefix("#/components/schemas/"))
+    {
+        let schema_name = decode_json_pointer_segment(reference);
+        assert!(
+            schemas.contains_key(&schema_name),
+            "proxy schema reference is missing: `{schema_name}`"
+        );
+    }
+}
+
+#[test]
+fn openapi_document_generation_is_byte_stable() {
+    let first = openapi_postprocess::openapi_documents_pretty(&loonfs_server::openapi_document())
+        .expect("generate full and proxy OpenAPI JSON");
+    let second = openapi_postprocess::openapi_documents_pretty(&loonfs_server::openapi_document())
+        .expect("generate full and proxy OpenAPI JSON again");
+    assert_eq!(first, second);
+    assert_eq!(
+        openapi_postprocess::proxy_openapi_json_pretty(&first.0)
+            .expect("derive proxy OpenAPI JSON again"),
+        first.1
     );
 }
 
@@ -1196,6 +1371,60 @@ fn values_named<'a>(value: &'a Value, name: &'a str) -> Box<dyn Iterator<Item = 
         ),
         _ => Box::new(std::iter::empty()),
     }
+}
+
+fn string_values(value: &Value) -> Box<dyn Iterator<Item = &Value> + '_> {
+    match value {
+        Value::String(_) => Box::new(std::iter::once(value)),
+        Value::Object(object) => Box::new(object.values().flat_map(string_values)),
+        Value::Array(values) => Box::new(values.iter().flat_map(string_values)),
+        _ => Box::new(std::iter::empty()),
+    }
+}
+
+fn referenced_components(spec: &Value) -> BTreeSet<(String, String)> {
+    let components = spec["components"]
+        .as_object()
+        .expect("proxy components object");
+    let mut pending = string_values(&spec["paths"])
+        .filter_map(Value::as_str)
+        .filter(|value| value.starts_with("#/components/"))
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let mut referenced = BTreeSet::new();
+
+    while let Some(reference) = pending.pop() {
+        let Some((component_type, component_name)) = component_reference_parts(&reference) else {
+            continue;
+        };
+        if !referenced.insert((component_type.clone(), component_name.clone())) {
+            continue;
+        }
+        let component = components
+            .get(&component_type)
+            .and_then(Value::as_object)
+            .and_then(|entries| entries.get(&component_name))
+            .unwrap_or_else(|| panic!("missing proxy component reference `{reference}`"));
+        pending.extend(
+            string_values(component)
+                .filter_map(Value::as_str)
+                .filter(|value| value.starts_with("#/components/"))
+                .map(str::to_owned),
+        );
+    }
+    referenced
+}
+
+fn component_reference_parts(reference: &str) -> Option<(String, String)> {
+    let mut parts = reference.strip_prefix("#/components/")?.split('/');
+    Some((
+        decode_json_pointer_segment(parts.next()?),
+        decode_json_pointer_segment(parts.next()?),
+    ))
+}
+
+fn decode_json_pointer_segment(segment: &str) -> String {
+    segment.replace("~1", "/").replace("~0", "~")
 }
 
 fn collect_one_of_objects<'a>(

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -477,6 +477,18 @@ fn proxy_paths_use_mounts_and_declare_no_security() {
         .collect::<BTreeSet<_>>();
     assert!(!tag_names.contains("system"));
     assert!(!tag_names.contains("admin"));
+    let referenced_tags = spec["paths"]
+        .as_object()
+        .expect("proxy openapi paths object")
+        .values()
+        .flat_map(|path_item| path_item.as_object().expect("proxy path item").values())
+        .flat_map(|operation| operation["tags"].as_array().into_iter().flatten())
+        .filter_map(|tag| tag.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        tag_names, referenced_tags,
+        "every declared proxy tag must be referenced by a retained operation"
+    );
 
     let paths = spec["paths"]
         .as_object()

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -31,7 +31,7 @@ The specification lives in this folder:
 | `architecture.md` | Orientation | How the durable pieces and the runtime fit together. |
 | `object-storage-providers.md` | Non-normative reference | Provider limits and performance data points that inform the design. |
 | `openapi.json` | Generated reference | Static OpenAPI document for the current v0 HTTP API. |
-| `openapi-proxy.json` | Generated reference | Derived browser proxy profile with application mount paths and no trusted server surfaces. |
+| `openapi-proxy.json` | Generated reference | OpenAPI document for browser clients that access namespaces through application mounts. |
 
 When something new needs a home: if other implementations must understand it to read or write a store correctly, it belongs in `format.md`. If it is an operation clients call, it belongs in `api.md`. How an implementation organizes its internal work — queues, schedulers, caches — is not specified at all.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -31,6 +31,7 @@ The specification lives in this folder:
 | `architecture.md` | Orientation | How the durable pieces and the runtime fit together. |
 | `object-storage-providers.md` | Non-normative reference | Provider limits and performance data points that inform the design. |
 | `openapi.json` | Generated reference | Static OpenAPI document for the current v0 HTTP API. |
+| `openapi-proxy.json` | Generated reference | Derived browser proxy profile with application mount paths and no trusted server surfaces. |
 
 When something new needs a home: if other implementations must understand it to read or write a store correctly, it belongs in `format.md`. If it is an operation clients call, it belongs in `api.md`. How an implementation organizes its internal work — queues, schedulers, caches — is not specified at all.
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2111,7 +2111,7 @@ Representative content-upload response:
 Representative complete-upload request:
 
 ```json
-{}
+{ "mode": "service_proxied" }
 ```
 
 Representative complete-upload response:

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -1,0 +1,4125 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "LoonFS HTTP API",
+    "description": "Static OpenAPI document for the LoonFS v0 HTTP API.",
+    "license": {
+      "name": "Apache-2.0",
+      "identifier": "Apache-2.0"
+    },
+    "version": "0.2.1"
+  },
+  "paths": {
+    "/v0/capabilities": {
+      "get": {
+        "tags": [
+          "capabilities"
+        ],
+        "summary": "Get capabilities",
+        "description": "Returns a summary of supported features and limits.",
+        "operationId": "capabilities",
+        "responses": {
+          "200": {
+            "description": "Capability document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CapabilityDocument"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/changes": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "List changes after a sequence",
+        "description": "Returns committed changes from the write-ahead log. Callers can use this feed to keep another projection synchronized with WAL history.",
+        "operationId": "list_changes",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "after_seq",
+            "in": "query",
+            "description": "Return committed changes after this sequence",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ChangeSeq"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Committed changes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid change cursor or limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/commits": {
+      "post": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "Apply a commit",
+        "description": "Applies one commit: an ordered, non-empty list of path operations that commit together as one logical commit, under one commit id that makes retries idempotent. A single-operation call is the one-element case. The first operation that fails aborts the whole request, and a request carrying more than one operation names that operation's position in `details.operation_index`.",
+        "operationId": "apply_commit",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Commit applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid commit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or path not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "409": {
+            "description": "Operation conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Commit unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "replay"
+      }
+    },
+    "/v0/mounts/{mount}/filesystem/content": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "Read file",
+        "description": "Returns file bytes for the current revision at a path, or for a specific retained revision when `revision_no` is provided.",
+        "operationId": "get_file_bytes",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Absolute file path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "revision_no",
+            "in": "query",
+            "description": "Optional prior revision number",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RevisionNo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File bytes",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path or revision",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace, path, or revision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Content exceeds the advertised `download.max_content_bytes` limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The server is at its concurrent content-read limit; retry shortly",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/filesystem/downloads": {
+      "post": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "Begin download",
+        "description": "Authorizes one direct read of a file's content object and returns a short-lived presigned GET capability, the resolved revision, and the content reference the client checks the arriving bytes against. `Range` is outside the signature, so one grant serves ranged, resumed, and parallel reads. Deployments that cannot presign answer 501 `not_supported`; the proxied `GET /filesystem/content` route stays available and is capped by `download.max_content_bytes`.",
+        "operationId": "begin_download",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeginDownloadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Download authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeginDownloadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path or revision",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace, path, or revision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Direct download is unsupported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/filesystem/list": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "List directory",
+        "description": "Lists a directory at the current namespace head.",
+        "operationId": "list_path_entries",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Absolute filesystem path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque directory-list page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include_attributes",
+            "in": "query",
+            "description": "Project each entry's attribute map and revision (`true` or `false`). Defaults to `false`: a page holds many entries and each map may be 64 KiB, so a listing does not carry them unless asked.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Directory listing page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListPathEntriesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path, limit, cursor, or include_attributes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or path not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/filesystem/revisions": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "List file revisions",
+        "description": "Resolves the current path to a file inode and returns revisions for that file. If the file could be renamed, use the inode revision API for stable identity.",
+        "operationId": "list_file_revisions",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Absolute file path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque file-revisions page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File revisions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFileRevisionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or path not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/filesystem/stat": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "Stat path",
+        "description": "Returns the current metadata for a path, including inode identity, kind, display name, file content metadata, and the inode's attributes.",
+        "operationId": "stat_path",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Absolute filesystem path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include_attributes",
+            "in": "query",
+            "description": "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`: a stat answers for one path and a map is capped at 64 KiB.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authoritative path entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthoritativePathEntry"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path or include_attributes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or path not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/filesystem/trash": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "List recoverable deletions",
+        "description": "Returns the namespace's recoverable deletions, oldest deletion first. Entries never age out at the retention floor; each carries the inode id and deletion sequence undelete needs, plus the deleted name when the delete recorded one.",
+        "operationId": "list_trash",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque trash page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recoverable deletions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTrashResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/query/grep": {
+      "post": {
+        "tags": [
+          "query"
+        ],
+        "summary": "Content search",
+        "description": "Searches file content with a regular expression, accelerated by the namespace's grep index. Matches are verified against the real pattern and returned in ascending `(inode_id, byte_offset)` order; revisions committed after the index watermark are scanned exhaustively unless `allow_stale` skips them. Requires this deployment to serve grep and the namespace to carry a materialized active grep root.",
+        "operationId": "grep",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrepRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "One page of matches",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GrepResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid pattern, cursor, or an unindexable pattern without allow_scan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "This deployment does not serve grep queries, the grep index is not enabled, or its backfill has not completed on this namespace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The index trails the head past the scan budget",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/uploads": {
+      "post": {
+        "tags": [
+          "uploads"
+        ],
+        "summary": "Begin upload",
+        "description": "Starts an upload session for content that may later be attached to a file. Service-proxied uploads send bytes through the server; direct-put uploads return object-store presigned credentials.",
+        "operationId": "begin_upload",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeginUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Upload session started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeginUploadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid upload request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Body exceeds the 1 MiB upload-control limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Requested upload mode is unsupported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "new_attempt"
+      }
+    },
+    "/v0/mounts/{mount}/uploads/{upload_id}": {
+      "get": {
+        "tags": [
+          "uploads"
+        ],
+        "summary": "Get upload session",
+        "description": "Returns an upload session. A completed session includes a new content token so the client can retry the commit without uploading the content again.",
+        "operationId": "get_upload_status",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "upload_id",
+            "in": "path",
+            "description": "Upload session id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Upload session state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid upload id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or upload not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/uploads/{upload_id}/abort": {
+      "post": {
+        "tags": [
+          "uploads"
+        ],
+        "summary": "Abort upload",
+        "description": "Ends an upload session without selecting content and deletes the object it was writing. Repeating it succeeds; a session that already completed cannot be aborted.",
+        "operationId": "abort_upload",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "upload_id",
+            "in": "path",
+            "description": "Upload session id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Upload aborted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid upload id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or upload not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "409": {
+            "description": "Upload already completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/uploads/{upload_id}/complete": {
+      "post": {
+        "tags": [
+          "uploads"
+        ],
+        "summary": "Complete upload",
+        "description": "Completes an upload. The request mode must match the mode used to start the session. Direct-multipart requests also include the content claim and completed parts.",
+        "operationId": "complete_upload",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "upload_id",
+            "in": "path",
+            "description": "Upload session id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request mode must match the upload session.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Upload completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid completion request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or upload not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "409": {
+            "description": "Upload completion conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Completion body exceeds the advertised `upload.completion_max_body_bytes` limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "replay"
+      }
+    },
+    "/v0/mounts/{mount}/uploads/{upload_id}/content": {
+      "put": {
+        "tags": [
+          "uploads"
+        ],
+        "summary": "Upload content",
+        "description": "Uploads bytes into a service-proxied upload session and returns the content reference for the stored object.",
+        "operationId": "upload_content",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "upload_id",
+            "in": "path",
+            "description": "Upload session id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Upload content accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadContentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid upload content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or upload not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Upload content conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Body exceeds the advertised `upload.max_content_bytes` limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The server is at its concurrent proxied-upload limit; retry shortly",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    },
+    "/v0/mounts/{mount}/uploads/{upload_id}/parts": {
+      "post": {
+        "tags": [
+          "uploads"
+        ],
+        "summary": "Sign multipart parts",
+        "description": "Returns one short-lived, checksum-bound upload capability per requested part of an open direct_multipart session. Asking again for a part is how a client retries it.",
+        "operationId": "sign_upload_parts",
+        "parameters": [
+          {
+            "name": "mount",
+            "in": "path",
+            "description": "Application mount label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "upload_id",
+            "in": "path",
+            "description": "Upload session id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignUploadPartsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Part capabilities issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignUploadPartsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid part request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or upload not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "409": {
+            "description": "Upload already completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Body exceeds the 1 MiB upload-control limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Direct multipart upload is unsupported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-loonfs-retry": "safe"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AbsolutePath": {
+        "type": "string",
+        "description": "Validated complete absolute namespace path, serialized as a plain string.",
+        "example": "/docs/report.txt"
+      },
+      "ActorId": {
+        "type": "string",
+        "description": "Opaque hosting-platform actor id: non-empty, at most 256 UTF-8 bytes, without leading or trailing whitespace or control characters.",
+        "example": "usr_8f3c"
+      },
+      "ActorKind": {
+        "type": "string",
+        "description": "The type of actor responsible for a commit.",
+        "enum": [
+          "user",
+          "service",
+          "system"
+        ]
+      },
+      "ActorRef": {
+        "type": "object",
+        "description": "Identifies the user, service, or system responsible for a commit.\n\nLoonFS stores this value as provided. It does not authenticate the actor or\nlook up profile information.",
+        "required": [
+          "kind",
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ActorId",
+            "description": "A stable identifier supplied by the application."
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ActorKind",
+            "description": "The type of actor."
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApiError": {
+        "type": "object",
+        "description": "HTTP error body used by LoonFS APIs.",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
+          },
+          "details": {
+            "$ref": "#/components/schemas/ErrorDetails",
+            "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
+          },
+          "feature": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "param": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
+          },
+          "request_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
+          }
+        }
+      },
+      "AttributeKey": {
+        "type": "string",
+        "description": "Validated name of one inode attribute.\n\nA key is 1 to 128 UTF-8 bytes and carries no Unicode control\ncharacter, which is also what rejects NUL. Keys are compared exactly:\nnothing case-folds or normalizes them, so two spellings that differ in\nany byte name two different attributes.\n\nThe `loonfs.` prefix is reserved for system-owned attributes. This\ntype accepts a reserved key, because a durable row has to be able to\ncarry a system attribute. The write operation is where a caller's\nattempt to write a reserved key is rejected.",
+        "example": "owner"
+      },
+      "AttributeRevisionNo": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Revision number for an inode's attributes. It starts at 0 and increases whenever the attribute map changes.",
+        "maximum": 9007199254740991,
+        "minimum": 0
+      },
+      "AttributeValue": {
+        "type": "string",
+        "description": "One validated attribute value.\n\nA value is at most [`MAX_ATTRIBUTE_VALUE_BYTES`] UTF-8 bytes. It is\notherwise free text: control characters and the empty string are legal.\nEmpty is a stored value, not a tombstone; only an explicit remove\noperation deletes an attribute.",
+        "example": "platform"
+      },
+      "Attributes": {
+        "type": "object",
+        "description": "A validated attribute map for one inode.\n\nConstruction and decoding both enforce the same limits: a map holds at\nmost [`MAX_ATTRIBUTE_ENTRIES`] entries, each value is at most\n[`MAX_ATTRIBUTE_VALUE_BYTES`] UTF-8 bytes, and the whole map is at most\n[`MAX_ATTRIBUTES_TOTAL_BYTES`] logical UTF-8 bytes. The total counts key\nbytes and value bytes and nothing else, so it does not depend on the\nencoding the map is written in. Durable state that breaks a limit fails to\ndecode rather than decoding to something smaller.\n\nAn empty map is valid. It is the cleared state, and clearing an inode's\nattributes is a real update with its own revision.",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/AttributeValue"
+        },
+        "propertyNames": {
+          "type": "string"
+        }
+      },
+      "AttributesProjection": {
+        "type": "object",
+        "description": "One inode's structurally complete attribute projection.",
+        "required": [
+          "attributes_revision_no",
+          "attributes"
+        ],
+        "properties": {
+          "attributes": {
+            "$ref": "#/components/schemas/Attributes",
+            "description": "The complete attribute map at `attributes_revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
+          },
+          "attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "The attribute revision this projection represents."
+          },
+          "attributes_updated_at_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
+            "minimum": 0
+          },
+          "attributes_updated_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the latest attribute update. This is `None` for\nthe initial empty state at revision 0."
+          }
+        }
+      },
+      "AuthoritativePathEntry": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AuthoritativePathEntryKind",
+            "description": "File-or-directory classification and its kind-specific payload."
+          },
+          {
+            "$ref": "#/components/schemas/AttributesProjection",
+            "description": "The inode's attribute projection, when requested."
+          },
+          {
+            "type": "object",
+            "required": [
+              "namespace_id",
+              "path",
+              "inode_id",
+              "created_by",
+              "created_at_ms",
+              "head_seq"
+            ],
+            "properties": {
+              "created_at_ms": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Time the inode was created, in Unix milliseconds. Sequence numbers\ndetermine order.",
+                "minimum": 0
+              },
+              "created_by": {
+                "$ref": "#/components/schemas/ActorRef",
+                "description": "Actor that created this inode, as supplied by the application."
+              },
+              "display_name": {
+                "$ref": "#/components/schemas/DisplayName",
+                "description": "Stored display name for this path component, absent for the nameless root."
+              },
+              "head_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Namespace head sequence this answer was read from."
+              },
+              "inode_id": {
+                "type": "string",
+                "description": "Stable inode ID within a namespace",
+                "example": "ino_123",
+                "pattern": "^ino_[1-9][0-9]*$"
+              },
+              "namespace_id": {
+                "$ref": "#/components/schemas/NamespaceId",
+                "description": "Namespace that was read."
+              },
+              "parent_inode_id": {
+                "type": "string",
+                "description": "Stable inode ID within a namespace",
+                "example": "ino_123",
+                "pattern": "^ino_[1-9][0-9]*$"
+              },
+              "path": {
+                "$ref": "#/components/schemas/AbsolutePath",
+                "description": "Absolute path as rendered from stored display names."
+              }
+            }
+          }
+        ],
+        "description": "Authoritative metadata for one visible path.\n\nThis is the result shape for stat/list style reads. The entry kind carries\nthe file-only revision and content summary, so a directory cannot carry a\npartial file payload. Attributes are likewise projected as one value or\nomitted as one value, while serializing as prefixed sibling fields.\nThe attribute revision is read independently — clients feed it to\n`expected_attributes_revision_no` on the next write without touching the\nvalues — so this is a prefixed-sibling projection rather than a value\nconsumed as one nested unit."
+      },
+      "AuthoritativePathEntryKind": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AuthoritativePathEntryDirectory"
+          },
+          {
+            "$ref": "#/components/schemas/AuthoritativePathEntryFile"
+          }
+        ],
+        "description": "Kind-specific metadata for an authoritative path entry.",
+        "discriminator": {
+          "propertyName": "inode_kind",
+          "mapping": {
+            "dir": "#/components/schemas/AuthoritativePathEntryDirectory",
+            "file": "#/components/schemas/AuthoritativePathEntryFile"
+          }
+        }
+      },
+      "BeginDownloadRequest": {
+        "type": "object",
+        "description": "What a client names when it asks to read a file directly.\n\nA path and, optionally, the revision it wants — the same two things the\nproxied content read takes, so a caller switching transports changes\nnothing about what it is asking for.",
+        "required": [
+          "path"
+        ],
+        "properties": {
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path of the file to read."
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Revision to read, or `None` for the path's current revision."
+          }
+        },
+        "additionalProperties": false
+      },
+      "BeginDownloadResponse": {
+        "type": "object",
+        "description": "A short-lived capability to read one file's content object, plus\neverything the reader needs to check what arrives.\n\nThe raw object key is deliberately not here, exactly as it is not in a\n`direct_put` grant: a client learns a URL that expires, not an address it\ncan revisit.\n\nThe grant names one immutable content object, so it does not go stale\nwhen the path moves on. A commit that replaces the file writes a new\nobject and leaves this one alone; what the capability reads is what the\nrequested revision held when the grant was issued, and the reference\nsays which bytes those are.",
+        "required": [
+          "namespace_id",
+          "path",
+          "revision_no",
+          "content_ref",
+          "access"
+        ],
+        "properties": {
+          "access": {
+            "$ref": "#/components/schemas/ObjectTransferAccess",
+            "description": "Short-lived read capability the client uses without learning the raw object key."
+          },
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Identity, byte length, and checksum evidence for the object the\ncapability reads. A reader checks the bytes it receives against\n`size_bytes` and recomputes `checksum.algorithm` over the complete\npayload."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path as rendered from stored display names."
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Revision the capability reads, resolved from the request."
+          }
+        }
+      },
+      "BeginUploadRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BeginUploadServiceProxied"
+          },
+          {
+            "$ref": "#/components/schemas/BeginUploadDirectPut"
+          },
+          {
+            "$ref": "#/components/schemas/BeginUploadDirectMultipart"
+          }
+        ],
+        "description": "Request to start an upload session, tagged by transport mode.\n\nEach variant contains only fields valid for that transport, so invalid\ncombinations are rejected during decoding. The `mode` field is required.",
+        "discriminator": {
+          "propertyName": "mode",
+          "mapping": {
+            "service_proxied": "#/components/schemas/BeginUploadServiceProxied",
+            "direct_put": "#/components/schemas/BeginUploadDirectPut",
+            "direct_multipart": "#/components/schemas/BeginUploadDirectMultipart"
+          }
+        }
+      },
+      "BeginUploadResponse": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BeginUploadResponseServiceProxied"
+          },
+          {
+            "$ref": "#/components/schemas/BeginUploadResponseDirectPut"
+          },
+          {
+            "$ref": "#/components/schemas/BeginUploadResponseDirectMultipart"
+          }
+        ],
+        "description": "Response to starting an upload session, tagged by transport mode.\n\nEach variant contains only the fields needed by that transport. Unknown\nresponse fields are accepted for forward compatibility.",
+        "discriminator": {
+          "propertyName": "mode",
+          "mapping": {
+            "service_proxied": "#/components/schemas/BeginUploadResponseServiceProxied",
+            "direct_put": "#/components/schemas/BeginUploadResponseDirectPut",
+            "direct_multipart": "#/components/schemas/BeginUploadResponseDirectMultipart"
+          }
+        }
+      },
+      "CapabilityDocument": {
+        "type": "object",
+        "description": "A deployment's self-description (API spec, \"Capability discovery\").\n\nA remote client fetches this from `GET /v0/capabilities` and caches it; an\nembedded engine exposes the same document as a constant. SDK gating logic\nis therefore identical for both backends: check [`supports`] or\n[`has_profile`], and treat a `not_supported` error as authoritative when\nthe two disagree.\n\n[`supports`]: CapabilityDocument::supports\n[`has_profile`]: CapabilityDocument::has_profile",
+        "required": [
+          "protocol_version",
+          "profiles"
+        ],
+        "properties": {
+          "features": {
+            "type": "object",
+            "description": "Named features and whether this deployment supports them. An absent\nkey means unsupported.",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "limits": {
+            "type": "object",
+            "description": "Advisory numeric limits clients may use to pre-validate requests.",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Advertised profiles, each `plane/version`. All-or-nothing: every\nrequired op of an advertised profile is implemented."
+          },
+          "protocol_version": {
+            "type": "string",
+            "description": "The protocol generation, currently `v0`."
+          }
+        }
+      },
+      "ChangeSeq": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Sequence number assigned to a namespace commit. It determines the order in which commits become visible.",
+        "maximum": 9007199254740991,
+        "minimum": 0
+      },
+      "ChangesResponse": {
+        "type": "object",
+        "description": "Change-feed response after a cursor.",
+        "required": [
+          "namespace_id",
+          "after_seq",
+          "through_seq",
+          "changes"
+        ],
+        "properties": {
+          "after_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Exclusive cursor supplied by the caller, or the endpoint's initial position."
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommittedChange"
+            },
+            "description": "Logical commits after `after_seq`, ordered by ascending namespace sequence."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace whose ordered commit stream was read."
+          },
+          "next_after_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Cursor to request when another page remains, or `None` at `through_seq`."
+          },
+          "through_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Snapshot head through which this page was evaluated."
+          }
+        }
+      },
+      "Checksum": {
+        "type": "object",
+        "description": "An algorithm and its canonical lowercase-hex checksum value.\n\nThe enclosing value defines which bytes the checksum covers.",
+        "required": [
+          "algorithm",
+          "value"
+        ],
+        "properties": {
+          "algorithm": {
+            "$ref": "#/components/schemas/ChecksumAlgorithm",
+            "description": "Algorithm that produced `value`."
+          },
+          "value": {
+            "type": "string",
+            "description": "Lowercase hex of the raw checksum bytes.\n\nThe algorithm is its own field, so the value carries no prefix.\nProvider APIs that report base64 are converted at the adapter."
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChecksumAlgorithm": {
+        "type": "string",
+        "description": "Supported checksum algorithms.\n\nThe enclosing value defines which bytes a checksum covers. Unknown\nalgorithms fail to decode because every in-memory `ChecksumAlgorithm` must\nbe recomputable by this build. Adding a variant also requires adding its\nimplementation.",
+        "enum": [
+          "sha256",
+          "crc64nvme",
+          "crc32c"
+        ]
+      },
+      "CommitId": {
+        "type": "string",
+        "description": "Client-supplied idempotency key for one logical commit.\n\nReuse the same `CommitId` when retrying the same request. The accepted\ngrammar is 1 to 128 lowercase ASCII letters, digits, dots, underscores,\nor hyphens, starting with a letter or digit. [`CommitId::generate`] returns\n`c_<32 lowercase hex>`, but callers may supply any value in that grammar.",
+        "example": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
+        "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+      },
+      "CommitRequest": {
+        "type": "object",
+        "description": "A request to commit one or more filesystem operations.\n\nOperations run in order and either all succeed or none are committed. A\nrequest with one operation uses the same fingerprint rules as a batch.\n\nUnknown fields are rejected here for the same reason they are on\n[`FilesystemOperation`]: the fields a typo can hide are the ones that\ndecide whether the commit is guarded at all.",
+        "required": [
+          "commit_id",
+          "actor",
+          "operations"
+        ],
+        "properties": {
+          "actor": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the commit, as supplied by the application."
+          },
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Caller-supplied idempotency key for the whole request."
+          },
+          "content_tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentToken"
+            },
+            "description": "Proofs for any new external content refs introduced by this request.\nOne proof covers every operation that names its content ref."
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Caller annotation recorded on the commit and reported by the change\nfeed. Part of the commit's identity: reusing `commit_id` with a\ndifferent message is a `commit_id_reuse_conflict`, exactly as it is\nfor an explicit commit."
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilesystemOperation"
+            },
+            "description": "Ordered operations to apply. Must be non-empty; they commit all\ntogether or not at all."
+          }
+        },
+        "additionalProperties": false
+      },
+      "CommitResponse": {
+        "type": "object",
+        "description": "Result of one commit.\n\nEvery commit resolves to this envelope — path-oriented operations and\nexplicit commits, embedded or remote. The commit id is the caller's\nreconciliation handle: resubmitting the same request with the same id\nreplays this result instead of committing twice.",
+        "required": [
+          "namespace_id",
+          "commit_id",
+          "committed_seq"
+        ],
+        "properties": {
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Idempotency key the commit landed under: caller-supplied, or\ngenerated on the caller's behalf when the request carried none."
+          },
+          "committed_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Sequence number where the commit became visible."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that changed."
+          }
+        }
+      },
+      "CommittedChange": {
+        "type": "object",
+        "description": "One committed change in namespace order.",
+        "required": [
+          "committed_seq",
+          "commit_id",
+          "committed_by",
+          "committed_at_ms",
+          "events"
+        ],
+        "properties": {
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Client idempotency key for this logical commit."
+          },
+          "committed_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Wall-clock stamp of the commit, in Unix milliseconds.\nObservational: `committed_seq` is the order.",
+            "minimum": 0
+          },
+          "committed_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the commit, as supplied by the application."
+          },
+          "committed_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace sequence for this logical commit."
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilesystemChange"
+            },
+            "description": "Semantic filesystem events for this commit, in the order the commit\napplied them. One request operation may produce more than one event\n(see [`FilesystemChange`])."
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Caller annotation, omitted when absent and carrying no filesystem semantics."
+          }
+        }
+      },
+      "CompleteUploadRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CompleteUploadServiceProxied"
+          },
+          {
+            "$ref": "#/components/schemas/CompleteUploadDirectPut"
+          },
+          {
+            "$ref": "#/components/schemas/CompleteUploadDirectMultipart"
+          }
+        ],
+        "description": "Request to complete an upload session.\n\n`mode` must match the mode used to start the session. Service-proxied and\ndirect-PUT uploads need no other fields. Direct multipart uploads also\ninclude the completed parts and the expected content details.",
+        "discriminator": {
+          "propertyName": "mode",
+          "mapping": {
+            "service_proxied": "#/components/schemas/CompleteUploadServiceProxied",
+            "direct_put": "#/components/schemas/CompleteUploadDirectPut",
+            "direct_multipart": "#/components/schemas/CompleteUploadDirectMultipart"
+          }
+        }
+      },
+      "CompletedUploadPart": {
+        "type": "object",
+        "description": "One uploaded part, as the client observed the provider accept it.\n\nThe server keeps no durable record of any part. Part bookkeeping is the\nclient's, exactly as it is in the provider's own multipart API, and this\nis where the client hands it back.",
+        "required": [
+          "part_number",
+          "etag",
+          "checksum"
+        ],
+        "properties": {
+          "checksum": {
+            "$ref": "#/components/schemas/Checksum",
+            "description": "Checksum the part was signed and accepted with."
+          },
+          "etag": {
+            "type": "string",
+            "description": "Entity tag the provider returned for the accepted part."
+          },
+          "part_number": {
+            "type": "integer",
+            "format": "int32",
+            "description": "One-based part number.",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContentId": {
+        "type": "string",
+        "description": "Durable identity of one immutable content object.\n\nThe body is 128 fully random bits, with no time component: content\nobject keys shard on the id's leading characters, and a clock-derived\nprefix would put every upload in one window into one shard. The id\nnames *which object*, never what it contains — integrity evidence\nrides [`crate::ContentRef`] beside it.",
+        "example": "con_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41",
+        "pattern": "^con_[0-9a-f]{32}$"
+      },
+      "ContentRef": {
+        "type": "object",
+        "description": "Pointer to one immutable content object.\n\n`content_id` is identity — *which* object — and the checksum is\nevidence about its bytes. Separating the two is what lets the final\nobject key exist before the first byte is read.\n\nA `ContentRef` is safe to publish only after the referenced bytes are\ndurable in the namespace's content store.",
+        "required": [
+          "kind",
+          "content_id",
+          "size_bytes",
+          "checksum"
+        ],
+        "properties": {
+          "checksum": {
+            "$ref": "#/components/schemas/Checksum",
+            "description": "Mandatory checksum over the complete object."
+          },
+          "content_id": {
+            "$ref": "#/components/schemas/ContentId",
+            "description": "Immutable identity of the referenced object."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Content strategy used by the referenced object."
+          },
+          "size_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Complete byte length of the referenced content.",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContentToken": {
+        "type": "object",
+        "description": "Proof that a specific `content_ref` may be used in a later commit.",
+        "required": [
+          "content_ref",
+          "token"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Content authorized by this token."
+          },
+          "token": {
+            "type": "string",
+            "description": "Opaque, server-signed token. Clients must not parse it."
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteDirectoryBehavior": {
+        "type": "string",
+        "description": "Directory delete behavior for path-oriented deletes.",
+        "enum": [
+          "non_recursive",
+          "recursive"
+        ]
+      },
+      "DeletedDirentry": {
+        "type": "object",
+        "description": "Directory entry removed by a delete operation.",
+        "required": [
+          "parent_inode_id",
+          "name_key",
+          "display_name"
+        ],
+        "properties": {
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "Name shown to users."
+          },
+          "name_key": {
+            "$ref": "#/components/schemas/NameKey",
+            "description": "Name used to look up the entry."
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          }
+        }
+      },
+      "DestinationBehavior": {
+        "type": "string",
+        "description": "Destination-conflict behavior for path-oriented puts, moves, and copies.",
+        "enum": [
+          "no_replace",
+          "replace"
+        ]
+      },
+      "DirectMultipartUpload": {
+        "type": "object",
+        "description": "Part geometry returned for a direct multipart upload.\n\nThe begin response does not include a content reference or part count\nbecause the final payload is not known yet. The server owns the provider\nupload id and returns the content reference only after completion.",
+        "required": [
+          "part_size_bytes",
+          "checksum_algorithm"
+        ],
+        "properties": {
+          "checksum_algorithm": {
+            "$ref": "#/components/schemas/ChecksumAlgorithm",
+            "description": "Checksum algorithm every part and the complete assembled payload must\nuse for this session."
+          },
+          "part_size_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Byte length of every part except the last. At most 10,000 parts may\nbe uploaded, so this bounds the object at `part_size_bytes × 10_000`.",
+            "minimum": 0
+          }
+        }
+      },
+      "DirectMultipartUploadOptions": {
+        "type": "object",
+        "description": "What a `direct_multipart` client asks for when it opens a session.\n\nA begin request declares no length and no digest: the session exists to\nreceive bytes whose length may not be known yet. All it settles is the\ngeometry the client cuts to.",
+        "properties": {
+          "part_size_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Byte length of every part except the last, or `None` for the\nserver's default.\n\nThe value bounds the object: a provider accepts at most 10,000\nparts, so this session can carry at most `part_size_bytes × 10_000`\nbytes. A client that knows its payload is very large asks for a\nlarger part size; one that does not know its length at all takes the\ndefault and keeps asking for part URLs until its stream ends.",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "DirectPutUpload": {
+        "type": "object",
+        "description": "Presigned direct_put upload details. The raw object key is intentionally not public.",
+        "required": [
+          "content_ref",
+          "access"
+        ],
+        "properties": {
+          "access": {
+            "$ref": "#/components/schemas/ObjectTransferAccess",
+            "description": "Short-lived write capability the client uses without learning the raw object key."
+          },
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Immutable object identity the server minted, plus the byte length and\nchecksum covered by the signed request. Completion and the later\ncommit both name exactly this reference."
+          }
+        }
+      },
+      "DisplayName": {
+        "type": "string",
+        "description": "User-facing spelling of one path component.",
+        "example": "report.txt"
+      },
+      "ErrorDetails": {
+        "type": "object",
+        "description": "Optional machine-readable details for an [`ApiError`].\n\nClients make retry decisions from the error code and use these fields for\nrelevant identifiers such as commit ids, writer epochs, and revisions.\nFields may be absent and clients must ignore fields they do not use.",
+        "properties": {
+          "active_acquired_at_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix milliseconds at which the current epoch's acquirer took it, when\nthe head recorded one. Writer ids are process labels, so two runs on\none machine can share one; the stamp is what tells them apart.",
+            "minimum": 0
+          },
+          "active_deletion_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Deletion generation actually active for the inode."
+          },
+          "active_writer": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Writer id recorded by the current epoch's acquirer, when the head\nrecorded one."
+          },
+          "active_writer_epoch": {
+            "$ref": "#/components/schemas/WriterEpoch",
+            "description": "Epoch that currently owns the namespace."
+          },
+          "actual_attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "Attribute revision that is actually current for the inode."
+          },
+          "actual_head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Head sequence the namespace was actually at, which is what a caller\nthat still means to delete it retries against."
+          },
+          "actual_revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Revision that is actually current; absent when the inode has none."
+          },
+          "after_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Change-feed cursor the request asked to resume after."
+          },
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Idempotency key of the commit the error concerns."
+          },
+          "committed_fingerprint": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Semantic identity of the mutation that already landed under that\ncommit id, from the same receipt as `committed_seq` and present\nexactly when it is. A retry recomputes this value from the request it\njust made — see\n[`put_retry_fingerprint`](crate::put_retry_fingerprint) — and equality\nis what proves the two are the same request."
+          },
+          "committed_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Sequence at which that commit id already landed. Present when the\nfailure was decided against a durable commit receipt, which is what\nholds the sequence; absent when nothing has committed under the id\nyet and two live requests are simply claiming it at once."
+          },
+          "expected_attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "Attribute revision the request expected to be current."
+          },
+          "expected_head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Head sequence a namespace delete required the namespace to still be\nat."
+          },
+          "expected_revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Revision the request expected to be current."
+          },
+          "fenced_epoch": {
+            "$ref": "#/components/schemas/WriterEpoch",
+            "description": "Epoch the failing writer session held when it was displaced."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "operation_index": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Position, in the request's operation list, of the operation that\nfailed. A commit applies all of its operations or none of them, so\nthis names the one that stopped the whole request.",
+            "minimum": 0
+          },
+          "requested_deletion_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Deletion generation an undelete asked to recover."
+          },
+          "retention_floor_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Oldest sequence still promised for incremental replay."
+          }
+        }
+      },
+      "FileRevision": {
+        "type": "object",
+        "description": "One immutable file revision.",
+        "required": [
+          "inode_id",
+          "revision_no",
+          "committed_seq",
+          "commit_id",
+          "committed_at_ms",
+          "committed_by",
+          "content_ref"
+        ],
+        "properties": {
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Commit ID for this revision."
+          },
+          "committed_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Wall-clock stamp of the commit that created this revision, in Unix\nmilliseconds. Observational: `committed_seq` is the order.",
+            "minimum": 0
+          },
+          "committed_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for this revision, as supplied by the application."
+          },
+          "committed_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace sequence that created this revision."
+          },
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Content stored for this revision."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Revision number within the file inode."
+          }
+        }
+      },
+      "FilesystemChange": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FilesystemChangeDirectoryCreated"
+          },
+          {
+            "$ref": "#/components/schemas/FilesystemChangeFileCreated"
+          },
+          {
+            "$ref": "#/components/schemas/FilesystemChangeContentChanged"
+          },
+          {
+            "$ref": "#/components/schemas/FilesystemChangeMoved"
+          },
+          {
+            "$ref": "#/components/schemas/FilesystemChangeDeleted"
+          },
+          {
+            "$ref": "#/components/schemas/FilesystemChangeUndeleted"
+          },
+          {
+            "$ref": "#/components/schemas/FilesystemChangeAttributesChanged"
+          }
+        ],
+        "description": "One semantic filesystem change inside a commit.\n\nA commit's events are the operations it applied, in the order it applied\nthem. One request operation can apply several: creating missing parent\ndirectories, or replacing a file by moving over it, each produce an event\nper directory created or file replaced. So a request with three\noperations may report more than three events, and the events stay in\nrequest order. Events name inodes and their parent-directory bindings\nrather than full paths; a consumer that needs paths can stat the inode or\nmaintain its own binding projection from this feed.",
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "directory_created": "#/components/schemas/FilesystemChangeDirectoryCreated",
+            "file_created": "#/components/schemas/FilesystemChangeFileCreated",
+            "content_changed": "#/components/schemas/FilesystemChangeContentChanged",
+            "moved": "#/components/schemas/FilesystemChangeMoved",
+            "deleted": "#/components/schemas/FilesystemChangeDeleted",
+            "undeleted": "#/components/schemas/FilesystemChangeUndeleted",
+            "attributes_changed": "#/components/schemas/FilesystemChangeAttributesChanged"
+          }
+        }
+      },
+      "FilesystemOperation": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FsOpCreateDirectory"
+          },
+          {
+            "$ref": "#/components/schemas/FsOpPutFile"
+          },
+          {
+            "$ref": "#/components/schemas/FsOpDeletePath"
+          },
+          {
+            "$ref": "#/components/schemas/FsOpMovePath"
+          },
+          {
+            "$ref": "#/components/schemas/FsOpCopyPath"
+          },
+          {
+            "$ref": "#/components/schemas/FsOpUndelete"
+          },
+          {
+            "$ref": "#/components/schemas/FsOpRestoreRevision"
+          },
+          {
+            "$ref": "#/components/schemas/FsOpUpdateAttributes"
+          }
+        ],
+        "description": "One path-oriented filesystem operation.\n\nUnknown fields are rejected because concurrency guards are optional. A\nmisspelled guard must fail decoding instead of silently becoming `None`\nand allowing an unguarded write. Any future fieldless variant must use\nempty braces so serde also rejects unexpected fields for that variant.",
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "create_directory": "#/components/schemas/FsOpCreateDirectory",
+            "put_file": "#/components/schemas/FsOpPutFile",
+            "delete_path": "#/components/schemas/FsOpDeletePath",
+            "move_path": "#/components/schemas/FsOpMovePath",
+            "copy_path": "#/components/schemas/FsOpCopyPath",
+            "undelete": "#/components/schemas/FsOpUndelete",
+            "restore_revision": "#/components/schemas/FsOpRestoreRevision",
+            "update_attributes": "#/components/schemas/FsOpUpdateAttributes"
+          }
+        }
+      },
+      "GrepMatch": {
+        "type": "object",
+        "description": "One line-oriented match.",
+        "required": [
+          "path",
+          "inode_id",
+          "revision_no",
+          "line_number",
+          "byte_offset",
+          "line"
+        ],
+        "properties": {
+          "byte_offset": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Byte offset of the match within the file.",
+            "minimum": 0
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "line": {
+            "type": "string",
+            "description": "The matching line, truncated to the server's line cap."
+          },
+          "line_number": {
+            "type": "integer",
+            "format": "int64",
+            "description": "One-based line number of the match.",
+            "minimum": 0
+          },
+          "line_truncated": {
+            "type": "boolean",
+            "description": "True when `line` was truncated."
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "The file's absolute path, derived at the snapshot."
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "The matched revision (the newest visible one at the snapshot)."
+          }
+        }
+      },
+      "GrepRequest": {
+        "type": "object",
+        "description": "One content-search request.\n\nEvery field but `pattern` is optional, and each one selects results. A\nmisspelled `case_insensitive` or `path_prefix` would decode to the default\nand answer a different search than the caller asked for, with no sign that\nanything was dropped, so unknown fields are rejected.",
+        "required": [
+          "pattern"
+        ],
+        "properties": {
+          "allow_scan": {
+            "type": "boolean",
+            "description": "Permit a capped exhaustive scan when the pattern yields no required\ngrams. Refused beyond the server's scan budget."
+          },
+          "allow_stale": {
+            "type": "boolean",
+            "description": "When the unindexed tail exceeds the scan budget, return\nindexed-only results (reported via `tail_scanned: false`) instead\nof failing with `index_lagging`."
+          },
+          "case_insensitive": {
+            "type": "boolean",
+            "description": "Match case-insensitively. Verification is exact; the index remains\nconsulted through its case-folded grams."
+          },
+          "cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Resume cursor from a previous page. The cursor resumes strictly\nafter the last candidate the issuing page finished scanning and is\nbound to that page's request; each page is evaluated against the\nnamespace head at page time."
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Maximum matches per page.",
+            "minimum": 0
+          },
+          "path_prefix": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Restrict matches to files under this complete absolute path, resolved\nto a directory inode before candidates are filtered."
+          },
+          "pattern": {
+            "type": "string",
+            "description": "The pattern, in the Rust `regex` crate's dialect (no backreferences\nor lookaround). Patterns that require no literal bytes are rejected\nwith `query_unindexable` unless `allow_scan` is set."
+          }
+        },
+        "additionalProperties": false
+      },
+      "GrepResponse": {
+        "type": "object",
+        "description": "One content-search page.",
+        "required": [
+          "namespace_id",
+          "head_seq",
+          "built_through_seq",
+          "tail_scanned",
+          "matches"
+        ],
+        "properties": {
+          "built_through_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Commits at or below this sequence were answered from the index."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Sequence this page was evaluated at. Pages are evaluated against\nthe namespace head at page time; the cursor is an ordering resume,\nnot a snapshot pin."
+          },
+          "matches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GrepMatch"
+            },
+            "description": "Matches in ascending `(inode_id, byte_offset)` order. A page may\nreturn fewer matches than its limit and still carry a cursor: the\nper-page verified-candidate budget bounds how much content one\nrequest reads, whatever the plan's false-positive rate."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace searched."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Present when another page follows."
+          },
+          "tail_scanned": {
+            "type": "boolean",
+            "description": "True when revisions after `built_through_seq` were scanned\nexhaustively; false only when `allow_stale` skipped them."
+          }
+        }
+      },
+      "ListFileRevisionsResponse": {
+        "type": "object",
+        "description": "Response for listing file revisions.",
+        "required": [
+          "namespace_id",
+          "inode_id",
+          "head_seq",
+          "revisions"
+        ],
+        "properties": {
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence used for the read."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque cursor for the next page, if more revisions are available."
+          },
+          "revisions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileRevision"
+            },
+            "description": "Retained revisions in order."
+          }
+        }
+      },
+      "ListPathEntriesResponse": {
+        "type": "object",
+        "description": "One directory listing and the namespace head it was answered at.\n\nThe envelope names the listing target and head so an empty directory\nstill tells the caller which state it observed, and so the response can\ngrow without reshaping `entries`.",
+        "required": [
+          "namespace_id",
+          "path",
+          "head_seq",
+          "entries"
+        ],
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuthoritativePathEntry"
+            },
+            "description": "Directory entries for this page.\n\nEntries are returned in canonical name-key order. Higher-level display\nsurfaces may sort entries separately for presentation."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence this listing was read from."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor for the next page, if more entries remain."
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path of the listed directory."
+          }
+        }
+      },
+      "ListTrashResponse": {
+        "type": "object",
+        "description": "One trash listing page: the namespace's recoverable deletions.",
+        "required": [
+          "namespace_id",
+          "head_seq",
+          "entries"
+        ],
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrashEntry"
+            },
+            "description": "Recoverable deletions, oldest deletion first."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Head sequence this page was evaluated at."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Present when another page follows."
+          }
+        }
+      },
+      "NameKey": {
+        "type": "string",
+        "description": "Name-policy-derived directory entry key.\n\nUse this for exact name preconditions. Keep user-facing spelling in\n`DisplayName`.",
+        "example": "report.txt"
+      },
+      "NamespaceId": {
+        "type": "string",
+        "description": "Durable id for one namespace.\n\nA namespace is one filesystem history. This id is not a display name and\nshould not be reused after destruction. Its serialized form is 1 to 128\nlowercase ASCII letters, digits, dots, underscores, or hyphens, starting\nwith a letter or digit; the `loonfs-` prefix is reserved for system use.",
+        "example": "demo",
+        "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+      },
+      "ObjectTransferAccess": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ObjectTransferAccessPresignedUrl"
+          }
+        ],
+        "description": "Client-facing direct transfer capability.",
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "presigned_url": "#/components/schemas/ObjectTransferAccessPresignedUrl"
+          }
+        }
+      },
+      "RevisionNo": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Revision number for a file's content. It increases whenever the content is replaced or restored.",
+        "maximum": 9007199254740991,
+        "minimum": 0
+      },
+      "SignUploadPartsRequest": {
+        "type": "object",
+        "description": "Request for part-upload capabilities on an open multipart session.",
+        "required": [
+          "parts"
+        ],
+        "properties": {
+          "parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UploadPartChecksumClaim"
+            },
+            "description": "Parts to authorize, each with the checksum the provider will enforce\non it. Asking again for a part already uploaded is how a client\nretries one: a repeated part is last-write-wins at the provider."
+          }
+        },
+        "additionalProperties": false
+      },
+      "SignUploadPartsResponse": {
+        "type": "object",
+        "description": "Response carrying one capability per requested part.",
+        "required": [
+          "namespace_id",
+          "upload_id",
+          "parts"
+        ],
+        "properties": {
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that owns the upload session."
+          },
+          "parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SignedUploadPart"
+            },
+            "description": "Capabilities in the order the request asked for them."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Session the parts belong to."
+          }
+        }
+      },
+      "SignedUploadPart": {
+        "type": "object",
+        "description": "One authorized part upload.",
+        "required": [
+          "part_number",
+          "access"
+        ],
+        "properties": {
+          "access": {
+            "$ref": "#/components/schemas/ObjectTransferAccess",
+            "description": "Short-lived write capability for that part."
+          },
+          "part_number": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Part number this capability writes.",
+            "minimum": 0
+          }
+        }
+      },
+      "TrashEntry": {
+        "type": "object",
+        "description": "One deletion that can still be restored.\n\n`inode_id` and `deletion_seq` are sufficient to restore it. The original\nparent and name are included when they were recorded.",
+        "required": [
+          "inode_id",
+          "deletion_seq",
+          "deleted_at_ms",
+          "deleted_by"
+        ],
+        "properties": {
+          "deleted_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time of the deletion, in Unix milliseconds.",
+            "minimum": 0
+          },
+          "deleted_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the deletion."
+          },
+          "deletion_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Commit sequence that identifies this deletion."
+          },
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "User-facing spelling of the deleted binding, when recorded."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "name_key": {
+            "$ref": "#/components/schemas/NameKey",
+            "description": "Canonical key of the deleted binding, when recorded."
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          }
+        }
+      },
+      "UploadContentClaim": {
+        "type": "object",
+        "description": "What an upload client claims about a complete payload.\n\nThe server mints the content object's identity — a client cannot name a\nkey it has not been given — so a direct upload declares only what it can\nknow about its own bytes. Direct PUT binds the claim into the provider\nwrite; multipart verifies it against the assembled object at completion.\n\nThe digest names its own algorithm because providers do not agree on one:\neach binds into a presigned write whatever its API can enforce. The\ndeployment advertises which it is, and a claim in any other algorithm is\nrefused at begin rather than signed into a write the provider would\nreject.",
+        "required": [
+          "size_bytes",
+          "checksum"
+        ],
+        "properties": {
+          "checksum": {
+            "$ref": "#/components/schemas/Checksum",
+            "description": "Whole-payload checksum in the algorithm required by this operation."
+          },
+          "size_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Complete byte length the client will write.",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "UploadContentResponse": {
+        "type": "object",
+        "description": "Response after uploading bytes into a session.",
+        "required": [
+          "namespace_id",
+          "upload_id",
+          "content_ref"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Digest and byte length computed from the accepted body."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that owns the upload session."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Session into which the service staged these bytes."
+          }
+        }
+      },
+      "UploadId": {
+        "type": "string",
+        "description": "Durable id for one upload session.",
+        "example": "upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c",
+        "pattern": "^upl_[0-9a-f]{32}$"
+      },
+      "UploadMode": {
+        "type": "string",
+        "description": "Upload transport mode.",
+        "enum": [
+          "service_proxied",
+          "direct_put",
+          "direct_multipart"
+        ]
+      },
+      "UploadPartChecksumClaim": {
+        "type": "object",
+        "description": "One part's checksum, supplied by the client so the server can sign it\ninto that part's upload URL.",
+        "required": [
+          "part_number",
+          "checksum"
+        ],
+        "properties": {
+          "checksum": {
+            "$ref": "#/components/schemas/Checksum",
+            "description": "Checksum over this part's bytes."
+          },
+          "part_number": {
+            "type": "integer",
+            "format": "int32",
+            "description": "One-based part number, at most the provider's 10,000-part limit.",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "UploadSessionResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UploadSessionStatus",
+            "description": "The session's lifecycle and state-specific fields. Completed HTTP\nresponses carry a fresh receipt while the minting window remains open."
+          },
+          {
+            "type": "object",
+            "required": [
+              "namespace_id",
+              "upload_id",
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "$ref": "#/components/schemas/UploadMode",
+                "description": "Transport selected when the session began."
+              },
+              "namespace_id": {
+                "$ref": "#/components/schemas/NamespaceId",
+                "description": "Namespace that owns the session."
+              },
+              "upload_id": {
+                "$ref": "#/components/schemas/UploadId",
+                "description": "Session represented by this view."
+              }
+            }
+          }
+        ],
+        "description": "Current view of one upload session."
+      },
+      "UploadSessionStatus": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/UploadSessionStatusOpen"
+          },
+          {
+            "$ref": "#/components/schemas/UploadSessionStatusCompleted"
+          },
+          {
+            "$ref": "#/components/schemas/UploadSessionStatusAborted"
+          }
+        ],
+        "description": "Observed state of an upload session.\n\nA session starts as `Open` and ends as either `Completed` or `Aborted`.\nBoth final states are permanent. Reading a completed session issues a new\nreceipt for the durable content, so a lost commit response does not require\nthe content to be uploaded again.",
+        "discriminator": {
+          "propertyName": "status",
+          "mapping": {
+            "open": "#/components/schemas/UploadSessionStatusOpen",
+            "completed": "#/components/schemas/UploadSessionStatusCompleted",
+            "aborted": "#/components/schemas/UploadSessionStatusAborted"
+          }
+        }
+      },
+      "WriterEpoch": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Counter used to reject writes from an older writer.",
+        "maximum": 9007199254740991,
+        "minimum": 0
+      },
+      "AuthoritativePathEntryDirectory": {
+        "type": "object",
+        "description": "A directory, which has no revision payload in v0.\n\nThe entry tag reuses [`InodeKind`]'s wire vocabulary.",
+        "required": [
+          "inode_kind"
+        ],
+        "properties": {
+          "inode_kind": {
+            "type": "string",
+            "enum": [
+              "dir"
+            ]
+          }
+        }
+      },
+      "AuthoritativePathEntryFile": {
+        "type": "object",
+        "description": "A file and its current revision summary.",
+        "required": [
+          "revision_no",
+          "size_bytes",
+          "content_ref",
+          "revision_committed_by",
+          "revision_committed_at_ms",
+          "inode_kind"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Current content reference."
+          },
+          "inode_kind": {
+            "type": "string",
+            "enum": [
+              "file"
+            ]
+          },
+          "revision_committed_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time of the current revision, in Unix milliseconds. Revision\nsequences determine order.",
+            "minimum": 0
+          },
+          "revision_committed_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the current revision."
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Current file revision number."
+          },
+          "size_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Current file size in bytes.\n\nThis remains explicit even though `content_ref` also carries the\nlength because callers sort directory listings by this field.",
+            "minimum": 0
+          }
+        }
+      },
+      "BeginUploadServiceProxied": {
+        "type": "object",
+        "description": "Send the bytes to the service, which writes the content object.",
+        "required": [
+          "mode"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "service_proxied"
+            ]
+          }
+        }
+      },
+      "BeginUploadDirectPut": {
+        "type": "object",
+        "description": "Write the whole object through one presigned request. The server\nsigns exactly these bytes into the write it authorizes, so the claim\nis required.",
+        "required": [
+          "content",
+          "mode"
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/UploadContentClaim",
+            "description": "Byte length and digest of the payload about to be written."
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_put"
+            ]
+          }
+        }
+      },
+      "BeginUploadDirectMultipart": {
+        "type": "object",
+        "description": "Write the object in parts through presigned part uploads.",
+        "required": [
+          "mode"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_multipart"
+            ]
+          },
+          "multipart": {
+            "$ref": "#/components/schemas/DirectMultipartUploadOptions",
+            "description": "Selects the part geometry; absent takes the server's default.\nA multipart upload claims its content at completion, so nothing\nabout the payload is declared here."
+          }
+        }
+      },
+      "BeginUploadResponseServiceProxied": {
+        "type": "object",
+        "description": "The service will receive the bytes and write the content object.",
+        "required": [
+          "namespace_id",
+          "upload_id",
+          "mode"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "service_proxied"
+            ]
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace authorized to consume the eventual staged content."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Durable session identity used by subsequent append and completion\ncalls."
+          }
+        }
+      },
+      "BeginUploadResponseDirectPut": {
+        "type": "object",
+        "description": "One presigned request writes the whole object.",
+        "required": [
+          "namespace_id",
+          "upload_id",
+          "direct_put",
+          "mode"
+        ],
+        "properties": {
+          "direct_put": {
+            "$ref": "#/components/schemas/DirectPutUpload",
+            "description": "The object this session writes, and the capability to write it."
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_put"
+            ]
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace authorized to consume the eventual staged content."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Durable session identity used by subsequent completion calls."
+          }
+        }
+      },
+      "BeginUploadResponseDirectMultipart": {
+        "type": "object",
+        "description": "Presigned part uploads assemble the object.",
+        "required": [
+          "namespace_id",
+          "upload_id",
+          "direct_multipart",
+          "mode"
+        ],
+        "properties": {
+          "direct_multipart": {
+            "$ref": "#/components/schemas/DirectMultipartUpload",
+            "description": "The geometry the client cuts its payload to."
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_multipart"
+            ]
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace authorized to consume the eventual staged content."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Durable session identity used by subsequent part-signing and\ncompletion calls."
+          }
+        }
+      },
+      "CompleteUploadServiceProxied": {
+        "type": "object",
+        "description": "Complete a service-proxied upload.",
+        "required": [
+          "mode"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "service_proxied"
+            ]
+          }
+        }
+      },
+      "CompleteUploadDirectPut": {
+        "type": "object",
+        "description": "Complete a direct-PUT upload.",
+        "required": [
+          "mode"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_put"
+            ]
+          }
+        }
+      },
+      "CompleteUploadDirectMultipart": {
+        "type": "object",
+        "description": "Complete a direct multipart upload.",
+        "required": [
+          "content",
+          "parts",
+          "mode"
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/UploadContentClaim",
+            "description": "Expected length and checksum of the assembled object."
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_multipart"
+            ]
+          },
+          "parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompletedUploadPart"
+            },
+            "description": "Uploaded parts in ascending part order."
+          }
+        }
+      },
+      "FilesystemChangeDirectoryCreated": {
+        "type": "object",
+        "description": "A directory was created.",
+        "required": [
+          "inode_id",
+          "parent_inode_id",
+          "display_name",
+          "kind"
+        ],
+        "properties": {
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "User-facing spelling of the new entry."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "directory_created"
+            ]
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          }
+        }
+      },
+      "FilesystemChangeFileCreated": {
+        "type": "object",
+        "description": "A file and its first revision were created.",
+        "required": [
+          "inode_id",
+          "parent_inode_id",
+          "display_name",
+          "revision_no",
+          "content_ref",
+          "kind"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Content of the first revision."
+          },
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "User-facing spelling of the new entry."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "file_created"
+            ]
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "First revision number."
+          }
+        }
+      },
+      "FilesystemChangeContentChanged": {
+        "type": "object",
+        "description": "A file received a new current revision — a put over an existing\nfile, or a revision restore (one durable fact for both).",
+        "required": [
+          "inode_id",
+          "revision_no",
+          "content_ref",
+          "kind"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Immutable content published by the revision."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "content_changed"
+            ]
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "New monotonic position in that file's revision history."
+          }
+        }
+      },
+      "FilesystemChangeMoved": {
+        "type": "object",
+        "description": "An inode moved to a new parent directory or name.",
+        "required": [
+          "inode_id",
+          "from_parent_inode_id",
+          "from_display_name",
+          "to_parent_inode_id",
+          "to_display_name",
+          "kind"
+        ],
+        "properties": {
+          "from_display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "Spelling of the old binding."
+          },
+          "from_parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "moved"
+            ]
+          },
+          "to_display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "Spelling of the new binding."
+          },
+          "to_parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          }
+        }
+      },
+      "FilesystemChangeDeleted": {
+        "type": "object",
+        "description": "A file or directory subtree was deleted. Use the enclosing change's\n`committed_seq` as `deletion_seq` when restoring it.",
+        "required": [
+          "inode_id",
+          "kind"
+        ],
+        "properties": {
+          "deleted_direntry": {
+            "$ref": "#/components/schemas/DeletedDirentry",
+            "description": "Directory binding removed by the deletion, when the delete\nrecorded one."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "deleted"
+            ]
+          }
+        }
+      },
+      "FilesystemChangeUndeleted": {
+        "type": "object",
+        "description": "A deleted inode was recovered and re-bound.",
+        "required": [
+          "inode_id",
+          "parent_inode_id",
+          "display_name",
+          "kind"
+        ],
+        "properties": {
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "Spelling of the recovered binding."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "undeleted"
+            ]
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          }
+        }
+      },
+      "FilesystemChangeAttributesChanged": {
+        "type": "object",
+        "description": "An inode's attributes changed.",
+        "required": [
+          "inode_id",
+          "attributes_revision_no",
+          "attributes",
+          "kind"
+        ],
+        "properties": {
+          "attributes": {
+            "$ref": "#/components/schemas/Attributes",
+            "description": "The inode's complete attribute map after the update, so a consumer\nprojects it without reading anything back. An empty map is the\ncleared state."
+          },
+          "attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "New attribute revision for that inode."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "attributes_changed"
+            ]
+          }
+        }
+      },
+      "FsOpCreateDirectory": {
+        "type": "object",
+        "description": "Create one directory.",
+        "required": [
+          "path",
+          "kind"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "create_directory"
+            ]
+          },
+          "parents": {
+            "type": "boolean",
+            "description": "Also create missing ancestor directories (the same auto-create\n`put_file` performs). The final component must still be new."
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute destination path, rejected when invalid or already bound."
+          }
+        }
+      },
+      "FsOpPutFile": {
+        "type": "object",
+        "description": "Create or replace one file with an already-durable content ref.",
+        "required": [
+          "path",
+          "content_ref",
+          "kind"
+        ],
+        "properties": {
+          "behavior": {
+            "$ref": "#/components/schemas/DestinationBehavior",
+            "description": "Whether an existing file may receive a new revision instead of causing a conflict."
+          },
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Immutable bytes that must be covered by a valid preparation proof."
+          },
+          "expected_revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "When set (with `replace` behavior), the put applies only while\nthe file's current revision is still this one; a raced write\nfails the request instead of silently stacking on it, and a\nmissing file answers `path_not_found`."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "put_file"
+            ]
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute destination path; missing ancestors are created automatically."
+          }
+        }
+      },
+      "FsOpDeletePath": {
+        "type": "object",
+        "description": "Delete one path.",
+        "required": [
+          "path",
+          "kind"
+        ],
+        "properties": {
+          "behavior": {
+            "$ref": "#/components/schemas/DeleteDirectoryBehavior",
+            "description": "Whether a non-empty directory may be tombstoned recursively."
+          },
+          "expected_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "delete_path"
+            ]
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path that must resolve to a visible inode."
+          }
+        }
+      },
+      "FsOpMovePath": {
+        "type": "object",
+        "description": "Move one path to another path.",
+        "required": [
+          "from_path",
+          "to_path",
+          "kind"
+        ],
+        "properties": {
+          "behavior": {
+            "$ref": "#/components/schemas/DestinationBehavior",
+            "description": "Whether an existing destination file may be replaced."
+          },
+          "from_path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute source path that must resolve to a visible inode."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "move_path"
+            ]
+          },
+          "to_path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute destination whose parent must be visible and writable."
+          }
+        }
+      },
+      "FsOpCopyPath": {
+        "type": "object",
+        "description": "Copy one file path to another path.",
+        "required": [
+          "from_path",
+          "to_path",
+          "kind"
+        ],
+        "properties": {
+          "behavior": {
+            "$ref": "#/components/schemas/DestinationBehavior",
+            "description": "Whether an existing destination file may receive a copied revision."
+          },
+          "from_path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute source path that must resolve to a visible file."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "copy_path"
+            ]
+          },
+          "to_path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute destination whose parent must be visible and writable."
+          }
+        }
+      },
+      "FsOpUndelete": {
+        "type": "object",
+        "description": "Restore a deleted file or subtree.\n\n`inode_id` and `deletion_seq` identify one exact deletion. A stale\nsequence returns `not_deleted` and cannot undo a later deletion.",
+        "required": [
+          "inode_id",
+          "deletion_seq",
+          "kind"
+        ],
+        "properties": {
+          "deletion_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Observed deletion sequence, which prevents cancelling a newer tombstone generation."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "undelete"
+            ]
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Optional destination for the restored inode.\n\nWhen absent, the inode is rebound to the parent and name recorded by the\ndeletion. Parent identity, rather than an old path string, keeps this\ncorrect after ancestor renames. An explicit path is required when the\ndeletion recorded no binding."
+          }
+        }
+      },
+      "FsOpRestoreRevision": {
+        "type": "object",
+        "description": "Restore an older revision as the current revision for a path.",
+        "required": [
+          "path",
+          "source_revision_no",
+          "kind"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "restore_revision"
+            ]
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path that must resolve to a visible file."
+          },
+          "source_revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Existing historical revision whose content will be copied into a new current revision."
+          }
+        }
+      },
+      "FsOpUpdateAttributes": {
+        "type": "object",
+        "description": "Write and remove attributes on the inode one path resolves to.",
+        "required": [
+          "path",
+          "kind"
+        ],
+        "properties": {
+          "expected_attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "When set, the update applies only while the inode's attribute\nrevision is still this one. Absent means the update is applied\nover whatever revision is current; either way the write carries\nits own revision guard, so a concurrent update never merges\nsilently."
+          },
+          "expected_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "update_attributes"
+            ]
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path that must resolve to a visible file or directory."
+          },
+          "remove": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AttributeKey"
+            },
+            "description": "Attribute keys to remove.\n\nA list preserves duplicate entries so validation can report them instead\nof silently deduplicating the request."
+          },
+          "set": {
+            "type": "object",
+            "description": "Attributes to write. Each key replaces whatever the inode\ncurrently holds under it; keys the inode holds and this map does\nnot name are left alone.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AttributeValue"
+            },
+            "propertyNames": {
+              "type": "string",
+              "description": "Validated name of one inode attribute.\n\nA key is 1 to 128 UTF-8 bytes and carries no Unicode control\ncharacter, which is also what rejects NUL. Keys are compared exactly:\nnothing case-folds or normalizes them, so two spellings that differ in\nany byte name two different attributes.\n\nThe `loonfs.` prefix is reserved for system-owned attributes. This\ntype accepts a reserved key, because a durable row has to be able to\ncarry a system attribute. The write operation is where a caller's\nattempt to write a reserved key is rejected.",
+              "example": "owner"
+            }
+          }
+        }
+      },
+      "ObjectTransferAccessPresignedUrl": {
+        "type": "object",
+        "description": "Short-lived URL plus required headers for one object-store write.",
+        "required": [
+          "method",
+          "url",
+          "expires_at_ms",
+          "kind"
+        ],
+        "properties": {
+          "expires_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Expiration timestamp in Unix milliseconds.",
+            "minimum": 0
+          },
+          "headers": {
+            "type": "object",
+            "description": "Headers that are covered by the signature and must be sent.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "presigned_url"
+            ]
+          },
+          "method": {
+            "type": "string",
+            "description": "HTTP method the client must use."
+          },
+          "url": {
+            "type": "string",
+            "description": "Full presigned URL."
+          }
+        }
+      },
+      "UploadSessionStatusOpen": {
+        "type": "object",
+        "description": "Accepting content until its lease passes.",
+        "required": [
+          "expires_at_ms",
+          "status"
+        ],
+        "properties": {
+          "expires_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix-millisecond instant after which the session is abandoned and\nmay be aborted by server-side cleanup.",
+            "minimum": 0
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open"
+            ]
+          }
+        }
+      },
+      "UploadSessionStatusCompleted": {
+        "type": "object",
+        "description": "Final: the content is durable and verified.",
+        "required": [
+          "completed_at_ms",
+          "content_ref",
+          "status"
+        ],
+        "properties": {
+          "completed_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix-millisecond stamp of the completion.",
+            "minimum": 0
+          },
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Verified content selected by this session."
+          },
+          "content_token": {
+            "$ref": "#/components/schemas/ContentToken",
+            "description": "Fresh proof for a later commit. This is absent after the token\nminting window closes, while `content_ref` remains available."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          }
+        }
+      },
+      "UploadSessionStatusAborted": {
+        "type": "object",
+        "description": "Final: the session selected no content and its object is gone.",
+        "required": [
+          "aborted_at_ms",
+          "status"
+        ],
+        "properties": {
+          "aborted_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix-millisecond stamp of the abort.",
+            "minimum": 0
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "aborted"
+            ]
+          }
+        }
+      }
+    },
+    "responses": {
+      "DeadlineExceededResponse": {
+        "description": "The request exceeded `request_deadline_ms`. A timed-out mutation may still complete, so clients must determine its outcome before retrying.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "HTTP error body used by LoonFS APIs.",
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
+                },
+                "details": {
+                  "$ref": "#/components/schemas/ErrorDetails",
+                  "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
+                },
+                "feature": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
+                },
+                "message": {
+                  "type": "string",
+                  "description": "Human-readable error message."
+                },
+                "param": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
+                },
+                "request_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "capabilities",
+      "description": "Capability discovery"
+    },
+    {
+      "name": "namespaces",
+      "description": "Namespace lifecycle and status"
+    },
+    {
+      "name": "filesystem",
+      "description": "Path-oriented filesystem APIs"
+    },
+    {
+      "name": "inodes",
+      "description": "Identity-oriented inode read APIs"
+    },
+    {
+      "name": "uploads",
+      "description": "Upload session APIs"
+    },
+    {
+      "name": "query",
+      "description": "Derived-index query APIs"
+    }
+  ]
+}

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -4102,16 +4102,8 @@
       "description": "Capability discovery"
     },
     {
-      "name": "namespaces",
-      "description": "Namespace lifecycle and status"
-    },
-    {
       "name": "filesystem",
       "description": "Path-oriented filesystem APIs"
-    },
-    {
-      "name": "inodes",
-      "description": "Identity-oriented inode read APIs"
     },
     {
       "name": "uploads",

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "LoonFS HTTP API",
-    "description": "Static OpenAPI document for the LoonFS v0 HTTP API.",
+    "title": "LoonFS Browser Proxy API",
+    "description": "API for browser clients that access namespaces through application mounts.",
     "license": {
       "name": "Apache-2.0",
       "identifier": "Apache-2.0"
@@ -58,7 +58,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -157,7 +157,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -264,7 +264,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -381,7 +381,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -478,7 +478,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -596,7 +596,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -704,7 +704,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -800,7 +800,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -889,7 +889,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -1016,7 +1016,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -1123,7 +1123,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -1209,7 +1209,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -1305,7 +1305,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -1422,7 +1422,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"
@@ -1550,7 +1550,7 @@
           {
             "name": "mount",
             "in": "path",
-            "description": "Application mount label",
+            "description": "Application mount name",
             "required": true,
             "schema": {
               "type": "string"

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -7,13 +7,15 @@ usage() {
 Usage: prepare-release.sh --version <version>
 
 Updates the workspace version references, regenerates the OpenAPI
-specification, and refreshes Cargo.lock. It then runs the version and
+documents, and refreshes Cargo.lock. It then runs the version and
 OpenAPI checks used by the release workflow:
 
   Cargo.toml               workspace.package.version and the pinned
                            versions of the published workspace crates
   Chart.yaml               version and appVersion of the server chart
   docs/specs/openapi.json  regenerated from the server
+  docs/specs/openapi-proxy.json
+                           derived from the full OpenAPI document
   Cargo.lock               refreshed by the regeneration build
 
 Run it on a clean branch based on main after CI passes. Commit the result
@@ -61,6 +63,7 @@ cd "$repo_root"
 
 chart="crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml"
 spec="docs/specs/openapi.json"
+proxy_spec="docs/specs/openapi-proxy.json"
 
 git diff --quiet && git diff --cached --quiet \
     || die "the working tree has changes; prepare a release from a clean checkout"
@@ -96,9 +99,10 @@ sed "s/^version: .*\$/version: $version/
     "$chart" > "$chart.tmp"
 mv "$chart.tmp" "$chart"
 
-# Regenerate the specification because it includes the release version.
+# Regenerate both documents because they include the release version.
 # Cargo also refreshes Cargo.lock while building the OpenAPI generator.
-cargo run -p loonfs-server --features openapi --bin loonfs-openapi -- "$spec"
+cargo run -p loonfs-server --features openapi --bin loonfs-openapi -- \
+    --proxy-output "$proxy_spec" "$spec"
 
 # Run the version checks used by the release workflow.
 resolved=$(cargo pkgid -p loonfs-cli | sed 's/.*#//')
@@ -114,6 +118,8 @@ app_version=$(sed -n 's/^appVersion: *//p' "$chart" | tr -d '"')
 
 grep -q "\"version\": \"$version\"" "$spec" \
     || die "regenerated spec does not carry version $version"
+grep -q "\"version\": \"$version\"" "$proxy_spec" \
+    || die "regenerated proxy spec does not carry version $version"
 
 # Run the OpenAPI specification test with the same options used in CI.
 cargo test -p loonfs-server --features openapi --locked openapi


### PR DESCRIPTION
Generates `docs/specs/openapi-proxy.json` from the full OpenAPI document. This browser profile contains 16 end-user operations, changes namespace paths to `/v0/mounts/{mount}/...`, removes server authentication metadata and trusted-only tags, and keeps only referenced components.

The allowlist lives beside the operation and retry metadata. Tests verify operation coverage, mount paths, security removal, component references, and reproducible output. The OpenAPI generator and release script now refresh both documents together.

This PR defines the browser-facing API contract. It does not add a proxy server or handler.
