### PR TITLE
build: set the SDK class and package names in the generator config

### DIFF
--- a/sdk/fern/generators.yml
+++ b/sdk/fern/generators.yml
@@ -11,6 +11,7 @@ groups:
         config:
           module:
             path: github.com/loonfs/loonfs-sdk-go
+          packageName: loonfs
         output:
           location: local-file-system
           path: ../generated/go
@@ -18,6 +19,8 @@ groups:
     generators:
       - name: fernapi/fern-python-sdk
         version: 5.28.0
+        config:
+          client_class_name: LoonFS
         output:
           location: local-file-system
           path: ../generated/python
@@ -25,6 +28,8 @@ groups:
     generators:
       - name: fernapi/fern-typescript-sdk
         version: 3.88.0
+        config:
+          namespaceExport: LoonFS
         output:
           location: local-file-system
           path: ../generated/typescript


### PR DESCRIPTION
Adds three keys to fern/generators.yml so the generated SDKs use the agreed names:

- Go: `packageName: loonfs`. The package identifier is `loonfs`.
- Python: `client_class_name: LoonFS`. The client classes are `LoonFS` and `AsyncLoonFS`.
- TypeScript: `namespaceExport: LoonFS`. The exports are `LoonFSClient`, the `LoonFS` type namespace, and `LoonFSError`.

Without these keys the generators fall back to names derived from the Fern organization field: `LoonfsApi` in Python and no `LoonFS` export in TypeScript.

Verified by generating all three SDKs locally with the pinned generator versions and this exact config. The initial SDK repository pull requests contain that output. `fern check` passes.