### PR TITLE
build: set the Python import package name in the generator config

### DIFF
--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -13,10 +13,12 @@ cd "$(dirname "$0")/../sdk"
 npx --yes "fern-api@${FERN_CLI_VERSION}" check
 
 if [ "$#" -ge 1 ]; then
-    npx --yes "fern-api@${FERN_CLI_VERSION}" generate --local --group "$1"
+    rm -rf "generated/$1"
+    npx --yes "fern-api@${FERN_CLI_VERSION}" generate --force --local --group "$1"
     exit 0
 fi
 
 for group in go python typescript; do
-    npx --yes "fern-api@${FERN_CLI_VERSION}" generate --local --group "$group"
+    rm -rf "generated/${group}"
+    npx --yes "fern-api@${FERN_CLI_VERSION}" generate --force --local --group "$group"
 done

--- a/sdk/fern/generators.yml
+++ b/sdk/fern/generators.yml
@@ -21,6 +21,7 @@ groups:
         version: 5.28.0
         config:
           client_class_name: LoonFS
+          package_name: loonfs_sdk
         output:
           location: local-file-system
           path: ../generated/python


### PR DESCRIPTION
Two fixes from review of the Python SDK repository.

Commit 1: adds `package_name: loonfs_sdk` to the Python generator config. PR #663 set the client class name but not the import package, so generated examples, error hints, and tests referenced `loonfs` while the repository packages the code as `loonfs_sdk`. Running pytest in a fresh environment failed on the missing `loonfs` module. With this key, a clean regeneration references `loonfs_sdk` everywhere (44 references checked, zero bare `loonfs` imports remain). The runtime aiohttp hint now reads `pip install loonfs_sdk[aiohttp]`, which pip resolves to the `loonfs-sdk` distribution.

Commit 2: `scripts/generate-sdks.sh` now removes each group's output directory before generating and passes `--force`. Without this, `fern generate` can stop on an interactive overwrite prompt when the output directory is not empty, which hangs unattended runs.

Verified: `scripts/generate-sdks.sh python` runs end to end with this config, `fern check` passes, and the regenerated output is what the Python SDK repository pull request now contains (verified there with install, import, and pytest in a fresh virtualenv).