### PR TITLE
api: mark the cursor list operations for SDK pagination

### DIFF
--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -1381,8 +1381,6 @@ mod tests {
                 }
             }
         }));
-        let original = document.clone();
-
         let error = add_pagination_metadata(&mut document)
             .expect_err("unregistered cursor operation should fail generation");
         assert!(matches!(
@@ -1390,130 +1388,6 @@ mod tests {
             OpenapiPostprocessError::MissingPaginationMetadata { operation_id }
                 if operation_id == "future_list"
         ));
-        assert_eq!(document, original);
-    }
-
-    #[test]
-    fn pagination_operation_without_cursor_returns_a_named_error() {
-        let mut document = list_checkpoints_document(
-            serde_json::json!([]),
-            serde_json::json!({
-                "next_cursor": {"type": ["string", "null"]},
-                "checkpoints": {"type": "array", "items": {}}
-            }),
-        );
-
-        let error = add_pagination_metadata(&mut document)
-            .expect_err("pagination operation without cursor should fail generation");
-        assert!(matches!(
-            error,
-            OpenapiPostprocessError::MissingPaginationCursorParameter { operation_id }
-                if operation_id == "list_checkpoints"
-        ));
-    }
-
-    #[test]
-    fn pagination_operation_without_response_component_returns_a_named_error() {
-        let mut document = list_checkpoints_document(
-            serde_json::json!([{"name": "cursor", "in": "query"}]),
-            serde_json::json!({
-                "next_cursor": {"type": ["string", "null"]},
-                "checkpoints": {"type": "array", "items": {}}
-            }),
-        );
-        document
-            .as_object_mut()
-            .expect("document object")
-            .get_mut("components")
-            .and_then(Value::as_object_mut)
-            .and_then(|components| components.get_mut("schemas"))
-            .and_then(Value::as_object_mut)
-            .expect("schemas object")
-            .clear();
-
-        let error = add_pagination_metadata(&mut document)
-            .expect_err("missing response component should fail generation");
-        assert!(matches!(
-            error,
-            OpenapiPostprocessError::MissingPaginationResponseSchema { operation_id }
-                if operation_id == "list_checkpoints"
-        ));
-    }
-
-    #[test]
-    fn pagination_response_without_next_cursor_returns_a_named_error() {
-        let mut document = list_checkpoints_document(
-            serde_json::json!([{"name": "cursor", "in": "query"}]),
-            serde_json::json!({
-                "checkpoints": {"type": "array", "items": {}}
-            }),
-        );
-
-        let error = add_pagination_metadata(&mut document)
-            .expect_err("response without next_cursor should fail generation");
-        assert!(matches!(
-            error,
-            OpenapiPostprocessError::MissingPaginationResponseProperty {
-                operation_id,
-                property
-            } if operation_id == "list_checkpoints" && property == "next_cursor"
-        ));
-    }
-
-    #[test]
-    fn pagination_results_field_without_array_returns_a_named_error() {
-        let mut document = list_checkpoints_document(
-            serde_json::json!([{"name": "cursor", "in": "query"}]),
-            serde_json::json!({
-                "next_cursor": {"type": ["string", "null"]},
-                "checkpoints": {"type": "object"}
-            }),
-        );
-
-        let error = add_pagination_metadata(&mut document)
-            .expect_err("non-array results field should fail generation");
-        assert!(matches!(
-            error,
-            OpenapiPostprocessError::PaginationResultsNotArray {
-                operation_id,
-                results_field
-            } if operation_id == "list_checkpoints" && results_field == "checkpoints"
-        ));
-    }
-
-    fn list_checkpoints_document(
-        parameters: serde_json::Value,
-        properties: serde_json::Value,
-    ) -> Value {
-        ordered(serde_json::json!({
-            "components": {
-                "schemas": {
-                    "ListCheckpointsResponse": {
-                        "type": "object",
-                        "properties": properties
-                    }
-                }
-            },
-            "paths": {
-                "/checkpoints": {
-                    "get": {
-                        "operationId": "list_checkpoints",
-                        "parameters": parameters,
-                        "responses": {
-                            "200": {
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "$ref": "#/components/schemas/ListCheckpointsResponse"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }))
     }
 
     #[test]

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -91,6 +91,41 @@ pub(crate) enum RetryClass {
     NewAttempt,
 }
 
+/// Pagination fields for cursor list operations. Keep this table sorted.
+///
+/// `grep` stores its cursor in the request body. The pinned generators do not
+/// wire request-body cursors. `gc_grep_index` resumes a maintenance pass across
+/// calls and does not paginate results. `list_changes` is sequence-keyed by
+/// design through `after_seq` and `next_after_seq`, not an opaque cursor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PaginationOperation {
+    pub(crate) operation_id: &'static str,
+    pub(crate) results_field: &'static str,
+}
+
+pub(crate) const PAGINATION_OPERATIONS: &[PaginationOperation] = &[
+    PaginationOperation {
+        operation_id: "list_checkpoints",
+        results_field: "checkpoints",
+    },
+    PaginationOperation {
+        operation_id: "list_file_revisions",
+        results_field: "revisions",
+    },
+    PaginationOperation {
+        operation_id: "list_file_revisions_by_inode",
+        results_field: "revisions",
+    },
+    PaginationOperation {
+        operation_id: "list_path_entries",
+        results_field: "entries",
+    },
+    PaginationOperation {
+        operation_id: "list_trash",
+        results_field: "entries",
+    },
+];
+
 impl RetryClass {
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
@@ -107,6 +142,34 @@ pub(crate) enum OpenapiPostprocessError {
     Json(#[from] serde_json::Error),
     #[error("OpenAPI operation `{operation_id}` has no retry classification")]
     MissingRetryClassification { operation_id: String },
+    #[error("OpenAPI pagination operation `{operation_id}` does not appear in the document")]
+    MissingPaginationOperation { operation_id: String },
+    #[error("OpenAPI pagination operation `{operation_id}` has no `cursor` query parameter")]
+    MissingPaginationCursorParameter { operation_id: String },
+    #[error("OpenAPI pagination operation `{operation_id}` has no 200 response component schema")]
+    MissingPaginationResponseSchema { operation_id: String },
+    #[error("OpenAPI pagination operation `{operation_id}` response has no `{property}` property")]
+    MissingPaginationResponseProperty {
+        operation_id: String,
+        property: String,
+    },
+    #[error(
+        "OpenAPI pagination operation `{operation_id}` response property `{results_field}` is not an array"
+    )]
+    PaginationResultsNotArray {
+        operation_id: String,
+        results_field: String,
+    },
+    #[error(
+        "OpenAPI operation `{operation_id}` has a `cursor` query parameter but no pagination metadata entry"
+    )]
+    MissingPaginationMetadata { operation_id: String },
+    #[error("OpenAPI pagination metadata cannot read `{location}`")]
+    InvalidPaginationDocument { location: &'static str },
+    #[error("OpenAPI path item `{path}` is not an object")]
+    InvalidPaginationPathItem { path: String },
+    #[error("OpenAPI operation `{method} {path}` is not an object or has no operation ID")]
+    InvalidPaginationOperation { method: &'static str, path: String },
     #[error("OpenAPI union variant `{schema_name}` conflicts with an existing component schema")]
     UnionVariantSchemaCollision { schema_name: String },
     #[error("proxy operation `{operation_id}` does not appear in the full OpenAPI document")]
@@ -208,6 +271,7 @@ pub(crate) fn openapi_json_pretty(
     add_union_discriminators(&mut document);
     extract_union_variants(&mut document)?;
     add_operation_retry_classes(&mut document)?;
+    add_pagination_metadata(&mut document)?;
     Ok(serde_json::to_string_pretty(&document)?)
 }
 
@@ -573,6 +637,198 @@ fn add_operation_retry_classes(document: &mut Value) -> Result<(), OpenapiPostpr
             );
         }
     }
+    Ok(())
+}
+
+/// Adds `x-fern-pagination` to each cursor list operation.
+fn add_pagination_metadata(document: &mut Value) -> Result<(), OpenapiPostprocessError> {
+    validate_pagination_metadata(document)?;
+
+    let paths = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("paths"))
+        .and_then(Value::as_object_mut)
+        .ok_or(OpenapiPostprocessError::InvalidPaginationDocument { location: "paths" })?;
+
+    for (path, path_item) in paths {
+        let path_item = path_item.as_object_mut().ok_or_else(|| {
+            OpenapiPostprocessError::InvalidPaginationPathItem { path: path.clone() }
+        })?;
+        for &method in HTTP_METHODS {
+            let Some(operation) = path_item.get_mut(method) else {
+                continue;
+            };
+            let operation = operation.as_object_mut().ok_or_else(|| {
+                OpenapiPostprocessError::InvalidPaginationOperation {
+                    method,
+                    path: path.clone(),
+                }
+            })?;
+            let operation_id = operation
+                .get("operationId")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| OpenapiPostprocessError::InvalidPaginationOperation {
+                    method,
+                    path: path.clone(),
+                })?;
+            let Some(metadata) = pagination_operation(&operation_id) else {
+                continue;
+            };
+
+            let mut extension = Map::new();
+            extension.insert(
+                "cursor".to_owned(),
+                Value::String("$request.cursor".to_owned()),
+            );
+            extension.insert(
+                "next_cursor".to_owned(),
+                Value::String("$response.next_cursor".to_owned()),
+            );
+            extension.insert(
+                "results".to_owned(),
+                Value::String(format!("$response.{}", metadata.results_field)),
+            );
+            operation.insert("x-fern-pagination".to_owned(), Value::Object(extension));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_pagination_metadata(document: &Value) -> Result<(), OpenapiPostprocessError> {
+    let schemas = document
+        .get("components")
+        .and_then(|components| components.get("schemas"))
+        .and_then(Value::as_object)
+        .ok_or(OpenapiPostprocessError::InvalidPaginationDocument {
+            location: "components.schemas",
+        })?;
+    let paths = document
+        .get("paths")
+        .and_then(Value::as_object)
+        .ok_or(OpenapiPostprocessError::InvalidPaginationDocument { location: "paths" })?;
+    let mut found_operations = BTreeSet::new();
+
+    for (path, path_item) in paths {
+        let path_item = path_item.as_object().ok_or_else(|| {
+            OpenapiPostprocessError::InvalidPaginationPathItem { path: path.clone() }
+        })?;
+        for &method in HTTP_METHODS {
+            let Some(operation) = path_item.get(method) else {
+                continue;
+            };
+            let operation = operation.as_object().ok_or_else(|| {
+                OpenapiPostprocessError::InvalidPaginationOperation {
+                    method,
+                    path: path.clone(),
+                }
+            })?;
+            let operation_id = operation
+                .get("operationId")
+                .and_then(Value::as_str)
+                .ok_or_else(|| OpenapiPostprocessError::InvalidPaginationOperation {
+                    method,
+                    path: path.clone(),
+                })?;
+            let has_cursor = has_query_parameter(operation, "cursor");
+            let Some(metadata) = pagination_operation(operation_id) else {
+                if has_cursor {
+                    return Err(OpenapiPostprocessError::MissingPaginationMetadata {
+                        operation_id: operation_id.to_owned(),
+                    });
+                }
+                continue;
+            };
+            found_operations.insert(metadata.operation_id);
+
+            if !has_cursor {
+                return Err(OpenapiPostprocessError::MissingPaginationCursorParameter {
+                    operation_id: operation_id.to_owned(),
+                });
+            }
+            validate_pagination_response(schemas, operation, metadata)?;
+        }
+    }
+
+    for metadata in PAGINATION_OPERATIONS {
+        if !found_operations.contains(metadata.operation_id) {
+            return Err(OpenapiPostprocessError::MissingPaginationOperation {
+                operation_id: metadata.operation_id.to_owned(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn pagination_operation(operation_id: &str) -> Option<&'static PaginationOperation> {
+    PAGINATION_OPERATIONS
+        .iter()
+        .find(|metadata| metadata.operation_id == operation_id)
+}
+
+fn has_query_parameter(operation: &Map, parameter_name: &str) -> bool {
+    operation
+        .get("parameters")
+        .and_then(Value::as_array)
+        .is_some_and(|parameters| {
+            parameters.iter().any(|parameter| {
+                parameter.get("in").and_then(Value::as_str) == Some("query")
+                    && parameter.get("name").and_then(Value::as_str) == Some(parameter_name)
+            })
+        })
+}
+
+fn validate_pagination_response(
+    schemas: &Map,
+    operation: &Map,
+    metadata: &PaginationOperation,
+) -> Result<(), OpenapiPostprocessError> {
+    let response_schema = operation
+        .get("responses")
+        .and_then(|responses| responses.get("200"))
+        .and_then(|response| response.get("content"))
+        .and_then(|content| content.get("application/json"))
+        .and_then(|content| content.get("schema"))
+        .and_then(|schema| schema.get("$ref"))
+        .and_then(Value::as_str)
+        .and_then(|reference| component_schema_for_reference(schemas, reference))
+        .and_then(Value::as_object)
+        .ok_or_else(
+            || OpenapiPostprocessError::MissingPaginationResponseSchema {
+                operation_id: metadata.operation_id.to_owned(),
+            },
+        )?;
+    let properties = response_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .ok_or_else(
+            || OpenapiPostprocessError::MissingPaginationResponseSchema {
+                operation_id: metadata.operation_id.to_owned(),
+            },
+        )?;
+
+    for property in ["next_cursor", metadata.results_field] {
+        if !properties.contains_key(property) {
+            return Err(OpenapiPostprocessError::MissingPaginationResponseProperty {
+                operation_id: metadata.operation_id.to_owned(),
+                property: property.to_owned(),
+            });
+        }
+    }
+    if properties
+        .get(metadata.results_field)
+        .and_then(|property| property.get("type"))
+        .and_then(Value::as_str)
+        != Some("array")
+    {
+        return Err(OpenapiPostprocessError::PaginationResultsNotArray {
+            operation_id: metadata.operation_id.to_owned(),
+            results_field: metadata.results_field.to_owned(),
+        });
+    }
+
     Ok(())
 }
 
@@ -1094,6 +1350,170 @@ mod tests {
             OpenapiPostprocessError::MissingRetryClassification { operation_id }
                 if operation_id == "future_operation"
         ));
+    }
+
+    #[test]
+    fn missing_pagination_operation_returns_a_named_error() {
+        let mut document = ordered(serde_json::json!({
+            "components": {"schemas": {}},
+            "paths": {}
+        }));
+
+        let error = add_pagination_metadata(&mut document)
+            .expect_err("missing pagination operation should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::MissingPaginationOperation { operation_id }
+                if operation_id == "list_checkpoints"
+        ));
+    }
+
+    #[test]
+    fn unregistered_cursor_operation_returns_a_named_error() {
+        let mut document = ordered(serde_json::json!({
+            "components": {"schemas": {}},
+            "paths": {
+                "/future": {
+                    "get": {
+                        "operationId": "future_list",
+                        "parameters": [{"name": "cursor", "in": "query"}]
+                    }
+                }
+            }
+        }));
+        let original = document.clone();
+
+        let error = add_pagination_metadata(&mut document)
+            .expect_err("unregistered cursor operation should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::MissingPaginationMetadata { operation_id }
+                if operation_id == "future_list"
+        ));
+        assert_eq!(document, original);
+    }
+
+    #[test]
+    fn pagination_operation_without_cursor_returns_a_named_error() {
+        let mut document = list_checkpoints_document(
+            serde_json::json!([]),
+            serde_json::json!({
+                "next_cursor": {"type": ["string", "null"]},
+                "checkpoints": {"type": "array", "items": {}}
+            }),
+        );
+
+        let error = add_pagination_metadata(&mut document)
+            .expect_err("pagination operation without cursor should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::MissingPaginationCursorParameter { operation_id }
+                if operation_id == "list_checkpoints"
+        ));
+    }
+
+    #[test]
+    fn pagination_operation_without_response_component_returns_a_named_error() {
+        let mut document = list_checkpoints_document(
+            serde_json::json!([{"name": "cursor", "in": "query"}]),
+            serde_json::json!({
+                "next_cursor": {"type": ["string", "null"]},
+                "checkpoints": {"type": "array", "items": {}}
+            }),
+        );
+        document
+            .as_object_mut()
+            .expect("document object")
+            .get_mut("components")
+            .and_then(Value::as_object_mut)
+            .and_then(|components| components.get_mut("schemas"))
+            .and_then(Value::as_object_mut)
+            .expect("schemas object")
+            .clear();
+
+        let error = add_pagination_metadata(&mut document)
+            .expect_err("missing response component should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::MissingPaginationResponseSchema { operation_id }
+                if operation_id == "list_checkpoints"
+        ));
+    }
+
+    #[test]
+    fn pagination_response_without_next_cursor_returns_a_named_error() {
+        let mut document = list_checkpoints_document(
+            serde_json::json!([{"name": "cursor", "in": "query"}]),
+            serde_json::json!({
+                "checkpoints": {"type": "array", "items": {}}
+            }),
+        );
+
+        let error = add_pagination_metadata(&mut document)
+            .expect_err("response without next_cursor should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::MissingPaginationResponseProperty {
+                operation_id,
+                property
+            } if operation_id == "list_checkpoints" && property == "next_cursor"
+        ));
+    }
+
+    #[test]
+    fn pagination_results_field_without_array_returns_a_named_error() {
+        let mut document = list_checkpoints_document(
+            serde_json::json!([{"name": "cursor", "in": "query"}]),
+            serde_json::json!({
+                "next_cursor": {"type": ["string", "null"]},
+                "checkpoints": {"type": "object"}
+            }),
+        );
+
+        let error = add_pagination_metadata(&mut document)
+            .expect_err("non-array results field should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::PaginationResultsNotArray {
+                operation_id,
+                results_field
+            } if operation_id == "list_checkpoints" && results_field == "checkpoints"
+        ));
+    }
+
+    fn list_checkpoints_document(
+        parameters: serde_json::Value,
+        properties: serde_json::Value,
+    ) -> Value {
+        ordered(serde_json::json!({
+            "components": {
+                "schemas": {
+                    "ListCheckpointsResponse": {
+                        "type": "object",
+                        "properties": properties
+                    }
+                }
+            },
+            "paths": {
+                "/checkpoints": {
+                    "get": {
+                        "operationId": "list_checkpoints",
+                        "parameters": parameters,
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/ListCheckpointsResponse"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }))
     }
 
     #[test]

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -93,35 +93,56 @@ pub(crate) enum RetryClass {
 
 /// Pagination fields for cursor list operations. Keep this table sorted.
 ///
+/// Most entries page through the opaque `cursor` and `next_cursor` pair.
+/// `list_changes` pages through its sequence fields: `next_after_seq` is
+/// absent on the final page, so a pager stops at the snapshot head.
+///
 /// `grep` stores its cursor in the request body. The pinned generators do not
 /// wire request-body cursors. `gc_grep_index` resumes a maintenance pass across
-/// calls and does not paginate results. `list_changes` is sequence-keyed by
-/// design through `after_seq` and `next_after_seq`, not an opaque cursor.
+/// calls and does not paginate results.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct PaginationOperation {
     pub(crate) operation_id: &'static str,
+    pub(crate) cursor_parameter: &'static str,
+    pub(crate) next_field: &'static str,
     pub(crate) results_field: &'static str,
 }
 
 pub(crate) const PAGINATION_OPERATIONS: &[PaginationOperation] = &[
     PaginationOperation {
+        operation_id: "list_changes",
+        cursor_parameter: "after_seq",
+        next_field: "next_after_seq",
+        results_field: "changes",
+    },
+    PaginationOperation {
         operation_id: "list_checkpoints",
+        cursor_parameter: "cursor",
+        next_field: "next_cursor",
         results_field: "checkpoints",
     },
     PaginationOperation {
         operation_id: "list_file_revisions",
+        cursor_parameter: "cursor",
+        next_field: "next_cursor",
         results_field: "revisions",
     },
     PaginationOperation {
         operation_id: "list_file_revisions_by_inode",
+        cursor_parameter: "cursor",
+        next_field: "next_cursor",
         results_field: "revisions",
     },
     PaginationOperation {
         operation_id: "list_path_entries",
+        cursor_parameter: "cursor",
+        next_field: "next_cursor",
         results_field: "entries",
     },
     PaginationOperation {
         operation_id: "list_trash",
+        cursor_parameter: "cursor",
+        next_field: "next_cursor",
         results_field: "entries",
     },
 ];
@@ -144,8 +165,11 @@ pub(crate) enum OpenapiPostprocessError {
     MissingRetryClassification { operation_id: String },
     #[error("OpenAPI pagination operation `{operation_id}` does not appear in the document")]
     MissingPaginationOperation { operation_id: String },
-    #[error("OpenAPI pagination operation `{operation_id}` has no `cursor` query parameter")]
-    MissingPaginationCursorParameter { operation_id: String },
+    #[error("OpenAPI pagination operation `{operation_id}` has no `{parameter}` query parameter")]
+    MissingPaginationCursorParameter {
+        operation_id: String,
+        parameter: &'static str,
+    },
     #[error("OpenAPI pagination operation `{operation_id}` has no 200 response component schema")]
     MissingPaginationResponseSchema { operation_id: String },
     #[error("OpenAPI pagination operation `{operation_id}` response has no `{property}` property")]
@@ -161,9 +185,12 @@ pub(crate) enum OpenapiPostprocessError {
         results_field: String,
     },
     #[error(
-        "OpenAPI operation `{operation_id}` has a `cursor` query parameter but no pagination metadata entry"
+        "OpenAPI operation `{operation_id}` has a `{parameter}` pagination query parameter but no pagination metadata entry"
     )]
-    MissingPaginationMetadata { operation_id: String },
+    MissingPaginationMetadata {
+        operation_id: String,
+        parameter: String,
+    },
     #[error("OpenAPI pagination metadata cannot read `{location}`")]
     InvalidPaginationDocument { location: &'static str },
     #[error("OpenAPI path item `{path}` is not an object")]
@@ -679,11 +706,11 @@ fn add_pagination_metadata(document: &mut Value) -> Result<(), OpenapiPostproces
             let mut extension = Map::new();
             extension.insert(
                 "cursor".to_owned(),
-                Value::String("$request.cursor".to_owned()),
+                Value::String(format!("$request.{}", metadata.cursor_parameter)),
             );
             extension.insert(
                 "next_cursor".to_owned(),
-                Value::String("$response.next_cursor".to_owned()),
+                Value::String(format!("$response.{}", metadata.next_field)),
             );
             extension.insert(
                 "results".to_owned(),
@@ -731,20 +758,24 @@ fn validate_pagination_metadata(document: &Value) -> Result<(), OpenapiPostproce
                     method,
                     path: path.clone(),
                 })?;
-            let has_cursor = has_query_parameter(operation, "cursor");
+            let pagination_parameter = ["cursor", "after_seq"]
+                .into_iter()
+                .find(|name| has_query_parameter(operation, name));
             let Some(metadata) = pagination_operation(operation_id) else {
-                if has_cursor {
+                if let Some(parameter) = pagination_parameter {
                     return Err(OpenapiPostprocessError::MissingPaginationMetadata {
                         operation_id: operation_id.to_owned(),
+                        parameter: parameter.to_owned(),
                     });
                 }
                 continue;
             };
             found_operations.insert(metadata.operation_id);
 
-            if !has_cursor {
+            if !has_query_parameter(operation, metadata.cursor_parameter) {
                 return Err(OpenapiPostprocessError::MissingPaginationCursorParameter {
                     operation_id: operation_id.to_owned(),
+                    parameter: metadata.cursor_parameter,
                 });
             }
             validate_pagination_response(schemas, operation, metadata)?;
@@ -809,7 +840,7 @@ fn validate_pagination_response(
             },
         )?;
 
-    for property in ["next_cursor", metadata.results_field] {
+    for property in [metadata.next_field, metadata.results_field] {
         if !properties.contains_key(property) {
             return Err(OpenapiPostprocessError::MissingPaginationResponseProperty {
                 operation_id: metadata.operation_id.to_owned(),
@@ -1364,7 +1395,7 @@ mod tests {
         assert!(matches!(
             error,
             OpenapiPostprocessError::MissingPaginationOperation { operation_id }
-                if operation_id == "list_checkpoints"
+                if operation_id == "list_changes"
         ));
     }
 
@@ -1385,8 +1416,10 @@ mod tests {
             .expect_err("unregistered cursor operation should fail generation");
         assert!(matches!(
             error,
-            OpenapiPostprocessError::MissingPaginationMetadata { operation_id }
-                if operation_id == "future_list"
+            OpenapiPostprocessError::MissingPaginationMetadata {
+                operation_id,
+                parameter,
+            } if operation_id == "future_list" && parameter == "cursor"
         ));
     }
 

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -646,6 +646,153 @@ fn every_registered_operation_publishes_its_retry_class() {
 }
 
 #[test]
+fn cursor_list_operations_publish_the_registered_pagination_metadata() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let published = operations_by_id(&spec)
+        .into_iter()
+        .filter_map(|(operation_id, operation)| {
+            operation
+                .get("x-fern-pagination")
+                .cloned()
+                .map(|extension| (operation_id, extension))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let expected = openapi_postprocess::PAGINATION_OPERATIONS
+        .iter()
+        .map(|metadata| {
+            (
+                metadata.operation_id,
+                serde_json::json!({
+                    "cursor": "$request.cursor",
+                    "next_cursor": "$response.next_cursor",
+                    "results": format!("$response.{}", metadata.results_field),
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(published, expected);
+}
+
+#[test]
+fn every_cursor_query_operation_publishes_pagination_metadata() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+
+    for (operation_id, operation) in operations_by_id(&spec) {
+        if !operation_has_query_parameter(operation, "cursor") {
+            continue;
+        }
+        assert!(
+            operation.get("x-fern-pagination").is_some(),
+            "cursor query operation `{operation_id}` has no x-fern-pagination extension"
+        );
+    }
+}
+
+#[test]
+fn pagination_response_components_publish_cursor_and_result_fields() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let operations = operations_by_id(&spec);
+    let schemas = spec
+        .get("components")
+        .and_then(|components| components.get("schemas"))
+        .and_then(Value::as_object)
+        .expect("openapi schemas object");
+
+    for metadata in openapi_postprocess::PAGINATION_OPERATIONS {
+        let operation = operations
+            .get(metadata.operation_id)
+            .unwrap_or_else(|| panic!("missing operation `{}`", metadata.operation_id));
+        let response_reference = operation
+            .pointer("/responses/200/content/application~1json/schema/$ref")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| {
+                panic!(
+                    "pagination operation `{}` has no 200 response schema reference",
+                    metadata.operation_id
+                )
+            });
+        let response_schema = component_schema_for_ref(schemas, response_reference)
+            .unwrap_or_else(|| panic!("missing response component `{response_reference}`"));
+        let properties = response_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| {
+                panic!(
+                    "pagination operation `{}` response has no properties",
+                    metadata.operation_id
+                )
+            });
+
+        assert!(
+            properties.contains_key("next_cursor"),
+            "pagination operation `{}` response has no next_cursor property",
+            metadata.operation_id
+        );
+        assert_eq!(
+            properties
+                .get(metadata.results_field)
+                .and_then(|property| property.get("type"))
+                .and_then(Value::as_str),
+            Some("array"),
+            "pagination operation `{}` response field `{}` is not an array",
+            metadata.operation_id,
+            metadata.results_field
+        );
+    }
+}
+
+#[test]
+fn proxy_cursor_list_operations_keep_pagination_metadata() {
+    let full: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let proxy: Value = serde_json::from_str(
+        &std::fs::read_to_string(PROXY_OPENAPI_JSON_PATH).expect("read static proxy openapi json"),
+    )
+    .expect("parse proxy openapi json");
+    let full_operations = operations_by_id(&full);
+    let proxy_operations = operations_by_id(&proxy);
+    let table_operation_ids = openapi_postprocess::PAGINATION_OPERATIONS
+        .iter()
+        .map(|metadata| metadata.operation_id)
+        .collect::<BTreeSet<_>>();
+    let expected_proxy_operations = openapi_postprocess::PROXY_OPERATIONS
+        .iter()
+        .map(|(operation_id, _)| *operation_id)
+        .filter(|operation_id| table_operation_ids.contains(operation_id))
+        .collect::<BTreeSet<_>>();
+    let mut actual_proxy_operations = BTreeSet::new();
+
+    for (operation_id, proxy_operation) in proxy_operations {
+        if !table_operation_ids.contains(operation_id) {
+            continue;
+        }
+        let full_operation = full_operations
+            .get(operation_id)
+            .unwrap_or_else(|| panic!("missing full operation `{operation_id}`"));
+        assert_eq!(
+            proxy_operation.get("x-fern-pagination"),
+            full_operation.get("x-fern-pagination"),
+            "proxy pagination metadata differs for `{operation_id}`"
+        );
+        actual_proxy_operations.insert(operation_id);
+    }
+
+    assert_eq!(actual_proxy_operations, expected_proxy_operations);
+}
+
+#[test]
 fn openapi_publishes_namespace_diagnostics_in_the_admin_plane() {
     let spec: Value = serde_json::from_str(
         &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
@@ -1476,6 +1623,45 @@ fn required_fields(schema: &Value) -> BTreeSet<&str> {
         .flatten()
         .filter_map(Value::as_str)
         .collect()
+}
+
+fn operations_by_id(spec: &Value) -> BTreeMap<&str, &Value> {
+    let paths = spec
+        .get("paths")
+        .and_then(Value::as_object)
+        .expect("openapi paths object");
+    let mut operations = BTreeMap::new();
+
+    for path_item in paths.values() {
+        let path_item = path_item.as_object().expect("openapi path item object");
+        for method in ["get", "post", "put", "delete", "patch"] {
+            let Some(operation) = path_item.get(method) else {
+                continue;
+            };
+            let operation_id = operation
+                .get("operationId")
+                .and_then(Value::as_str)
+                .expect("OpenAPI operation has an operationId");
+            assert!(
+                operations.insert(operation_id, operation).is_none(),
+                "duplicate operationId `{operation_id}`"
+            );
+        }
+    }
+
+    operations
+}
+
+fn operation_has_query_parameter(operation: &Value, parameter_name: &str) -> bool {
+    operation
+        .get("parameters")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .any(|parameter| {
+            parameter.get("in").and_then(Value::as_str) == Some("query")
+                && parameter.get("name").and_then(Value::as_str) == Some(parameter_name)
+        })
 }
 
 fn component_schema_for_ref<'a>(

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -666,8 +666,8 @@ fn cursor_list_operations_publish_the_registered_pagination_metadata() {
             (
                 metadata.operation_id,
                 serde_json::json!({
-                    "cursor": "$request.cursor",
-                    "next_cursor": "$response.next_cursor",
+                    "cursor": format!("$request.{}", metadata.cursor_parameter),
+                    "next_cursor": format!("$response.{}", metadata.next_field),
                     "results": format!("$response.{}", metadata.results_field),
                 }),
             )

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -678,80 +678,6 @@ fn cursor_list_operations_publish_the_registered_pagination_metadata() {
 }
 
 #[test]
-fn every_cursor_query_operation_publishes_pagination_metadata() {
-    let spec: Value = serde_json::from_str(
-        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
-    )
-    .expect("parse openapi json");
-
-    for (operation_id, operation) in operations_by_id(&spec) {
-        if !operation_has_query_parameter(operation, "cursor") {
-            continue;
-        }
-        assert!(
-            operation.get("x-fern-pagination").is_some(),
-            "cursor query operation `{operation_id}` has no x-fern-pagination extension"
-        );
-    }
-}
-
-#[test]
-fn pagination_response_components_publish_cursor_and_result_fields() {
-    let spec: Value = serde_json::from_str(
-        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
-    )
-    .expect("parse openapi json");
-    let operations = operations_by_id(&spec);
-    let schemas = spec
-        .get("components")
-        .and_then(|components| components.get("schemas"))
-        .and_then(Value::as_object)
-        .expect("openapi schemas object");
-
-    for metadata in openapi_postprocess::PAGINATION_OPERATIONS {
-        let operation = operations
-            .get(metadata.operation_id)
-            .unwrap_or_else(|| panic!("missing operation `{}`", metadata.operation_id));
-        let response_reference = operation
-            .pointer("/responses/200/content/application~1json/schema/$ref")
-            .and_then(Value::as_str)
-            .unwrap_or_else(|| {
-                panic!(
-                    "pagination operation `{}` has no 200 response schema reference",
-                    metadata.operation_id
-                )
-            });
-        let response_schema = component_schema_for_ref(schemas, response_reference)
-            .unwrap_or_else(|| panic!("missing response component `{response_reference}`"));
-        let properties = response_schema
-            .get("properties")
-            .and_then(Value::as_object)
-            .unwrap_or_else(|| {
-                panic!(
-                    "pagination operation `{}` response has no properties",
-                    metadata.operation_id
-                )
-            });
-
-        assert!(
-            properties.contains_key("next_cursor"),
-            "pagination operation `{}` response has no next_cursor property",
-            metadata.operation_id
-        );
-        assert_eq!(
-            properties
-                .get(metadata.results_field)
-                .and_then(|property| property.get("type"))
-                .and_then(Value::as_str),
-            Some("array"),
-            "pagination operation `{}` response field `{}` is not an array",
-            metadata.operation_id,
-            metadata.results_field
-        );
-    }
-}
-
-#[test]
 fn proxy_cursor_list_operations_keep_pagination_metadata() {
     let full: Value = serde_json::from_str(
         &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
@@ -1650,18 +1576,6 @@ fn operations_by_id(spec: &Value) -> BTreeMap<&str, &Value> {
     }
 
     operations
-}
-
-fn operation_has_query_parameter(operation: &Value, parameter_name: &str) -> bool {
-    operation
-        .get("parameters")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .any(|parameter| {
-            parameter.get("in").and_then(Value::as_str) == Some("query")
-                && parameter.get("name").and_then(Value::as_str) == Some(parameter_name)
-        })
 }
 
 fn component_schema_for_ref<'a>(

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -581,7 +581,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.entries"
+        }
       }
     },
     "/v0/mounts/{mount}/filesystem/revisions": {
@@ -689,7 +694,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.revisions"
+        }
       }
     },
     "/v0/mounts/{mount}/filesystem/stat": {
@@ -874,7 +884,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.entries"
+        }
       }
     },
     "/v0/mounts/{mount}/query/grep": {

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -142,7 +142,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.after_seq",
+          "next_cursor": "$response.next_after_seq",
+          "results": "$response.changes"
+        }
       }
     },
     "/v0/mounts/{mount}/commits": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1339,7 +1339,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.after_seq",
+          "next_cursor": "$response.next_after_seq",
+          "results": "$response.changes"
+        }
       }
     },
     "/v0/namespaces/{namespace_id}/commits": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -200,7 +200,12 @@
             "$ref": "#/components/responses/DeadlineExceededResponse"
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.checkpoints"
+        }
       },
       "post": {
         "tags": [
@@ -1773,7 +1778,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.entries"
+        }
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/revisions": {
@@ -1881,7 +1891,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.revisions"
+        }
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/stat": {
@@ -2066,7 +2081,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.entries"
+        }
       }
     },
     "/v0/namespaces/{namespace_id}/forks": {
@@ -2381,7 +2401,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.revisions"
+        }
       }
     },
     "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content": {


### PR DESCRIPTION
Adds `x-fern-pagination` metadata to the five cursor-based list operations. The generated Go and TypeScript SDKs use this metadata to provide pagers while keeping the full response available for fields such as `head_seq`.

A small table maps each operation to its result array. The OpenAPI postprocessor verifies that every registered operation exists, accepts a `cursor` query parameter, and returns `next_cursor` with an array of results. It also rejects cursor-based operations that are missing from the table. The browser proxy document retains the same metadata.

Grep is not included because its cursor is currently in the request body, which the pinned generators do not support for pagination. Grep index garbage collection uses a continuation token for maintenance work rather than result pagination. The change feed uses `after_seq` and `next_after_seq` instead of an opaque cursor.

Tests verify the emitted metadata, both directions of the registration guard, and preservation in the proxy document.