### PR TITLE
test(sdk): run the conformance corpus through the generated Go SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,33 @@ jobs:
       - run: cargo test --all --locked
       - run: cargo test -p loonfs-server --features openapi --locked openapi
 
+  sdk-conformance-go:
+    name: SDK conformance (Go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+          cache: false
+      - run: scripts/generate-sdks.sh go
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-sdk-conformance-${{ hashFiles('sdk/generated/go/go.sum', 'sdk/conformance/go/go.mod') }}
+          restore-keys: ${{ runner.os }}-go-sdk-conformance-
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-sdk-conformance-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-sdk-conformance-
+      - run: scripts/run-sdk-conformance.sh go
+
   # Checks the declared minimum supported Rust version actually builds the
   # workspace. Keep the toolchain here in sync with `rust-version` in the
   # workspace Cargo.toml.

--- a/crates/loonfs-conformance/Cargo.toml
+++ b/crates/loonfs-conformance/Cargo.toml
@@ -10,22 +10,22 @@ publish = false
 readme = "README.md"
 
 [dependencies]
-serde.workspace = true
-serde_json.workspace = true
-thiserror.workspace = true
-
-[dev-dependencies]
 async-trait.workspace = true
 axum.workspace = true
 bytes.workspace = true
 futures.workspace = true
 loonfs-api.workspace = true
-loonfs-client.workspace = true
 loonfs-objectstore.workspace = true
 loonfs-server = { path = "../loonfs-server", features = ["test-support"] }
-reqwest = { workspace = true, features = ["json"] }
+serde.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
+
+[dev-dependencies]
+loonfs-client.workspace = true
+reqwest = { workspace = true, features = ["json"] }
 
 [lints]
 workspace = true

--- a/crates/loonfs-conformance/src/bin/conformance-server.rs
+++ b/crates/loonfs-conformance/src/bin/conformance-server.rs
@@ -1,0 +1,25 @@
+use loonfs_conformance::server::start_server;
+use serde::Serialize;
+use std::io::{Read, Write};
+
+#[derive(Serialize)]
+struct ServerInfo<'a> {
+    base_url: &'a str,
+    token: &'a str,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let server = start_server().await?;
+    let info = ServerInfo {
+        base_url: &server.base_url,
+        token: server.token,
+    };
+    let mut stdout = std::io::stdout().lock();
+    serde_json::to_writer(&mut stdout, &info)?;
+    writeln!(stdout)?;
+    stdout.flush()?;
+
+    std::io::stdin().read_to_end(&mut Vec::new())?;
+    Ok(())
+}

--- a/crates/loonfs-conformance/src/lib.rs
+++ b/crates/loonfs-conformance/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! The integration harness is in `tests/reference.rs`.
 
+pub mod server;
+
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashSet;

--- a/crates/loonfs-conformance/src/lib.rs
+++ b/crates/loonfs-conformance/src/lib.rs
@@ -1,6 +1,6 @@
-//! Loads shared SDK test cases and checks behavior that does not need a server.
+//! Shared cases and server support for SDK conformance tests.
 //!
-//! The integration harness is in `tests/reference.rs`.
+//! Each client harness loads the same cases from `cases/`.
 
 pub mod server;
 

--- a/crates/loonfs-conformance/src/server.rs
+++ b/crates/loonfs-conformance/src/server.rs
@@ -1,0 +1,470 @@
+//! Local server infrastructure for SDK conformance tests.
+
+use async_trait::async_trait;
+use axum::extract::{Path as AxumPath, State};
+use axum::http::header::{ETAG, RANGE};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, put};
+use axum::Router;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs_api::{Checksum, ChecksumAlgorithm};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::presign::{
+    DirectGetIssuer, DirectMultipartIssuer, DirectPutIssuer, DirectTransferIssuers,
+    PresignedGetRequest, PresignedPartRequest, PresignedPutRequest, PresignedUrl,
+};
+use loonfs_objectstore::{
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
+    ObjectStore, ObjectStoreError, PutMode, SharedObjectStore, StoredObjectChecksum,
+};
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::task::JoinHandle;
+
+/// Bearer token accepted by the conformance server.
+pub const AUTH_TOKEN: &str = "conformance-test-token";
+
+const DIRECT_PUT_MAX_BYTES: u64 = 64 * 1024 * 1024;
+
+/// A running conformance API and transfer service.
+#[derive(Debug)]
+pub struct ConformanceServer {
+    /// Base URL for the HTTP API.
+    pub base_url: String,
+    /// Bearer token accepted by the HTTP API.
+    pub token: &'static str,
+    server_task: JoinHandle<()>,
+    provider_task: JoinHandle<()>,
+    _temp_dir: TempDir,
+}
+
+impl Drop for ConformanceServer {
+    fn drop(&mut self) {
+        self.server_task.abort();
+        self.provider_task.abort();
+    }
+}
+
+/// Starts a conformance API and its loopback transfer service.
+pub async fn start_server() -> Result<ConformanceServer, Box<dyn std::error::Error + Send + Sync>> {
+    let api_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let provider_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let api_address = api_listener.local_addr()?;
+    let provider_address = provider_listener.local_addr()?;
+
+    let temp_dir = tempfile::tempdir()?;
+    let store_root = temp_dir.path().join("store");
+    let store = Arc::new(ConformanceStore::new(&store_root)?);
+    let shared_store: SharedObjectStore = store.clone();
+
+    let provider_router = transfer_router(store);
+    let provider_task = tokio::spawn(async move {
+        axum::serve(provider_listener, provider_router)
+            .await
+            .expect("serve conformance transfers");
+    });
+    let issuer = Arc::new(LoopbackIssuer {
+        base_url: format!("http://{provider_address}"),
+    });
+    let transfers = DirectTransferIssuers::read_only(issuer.clone())
+        .with_put(issuer.clone())
+        .with_multipart(issuer);
+
+    let config_path = temp_dir.path().join("loonfs-server.toml");
+    write_server_config(&config_path, &store_root)?;
+    let config = loonfs_server::load_server_config(&config_path)?;
+    let api_router =
+        loonfs_server::app_with_test_transfers(config, shared_store, transfers).await?;
+    let server_task = tokio::spawn(async move {
+        axum::serve(api_listener, api_router)
+            .await
+            .expect("serve conformance API");
+    });
+
+    health_check(api_address).await?;
+
+    Ok(ConformanceServer {
+        base_url: format!("http://{api_address}"),
+        token: AUTH_TOKEN,
+        server_task,
+        provider_task,
+        _temp_dir: temp_dir,
+    })
+}
+
+async fn health_check(address: std::net::SocketAddr) -> io::Result<()> {
+    let mut stream = tokio::net::TcpStream::connect(address).await?;
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+        .await?;
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).await?;
+    if response.starts_with(b"HTTP/1.1 200 ") {
+        return Ok(());
+    }
+    Err(io::Error::other("conformance server health check failed"))
+}
+
+fn write_server_config(path: &Path, store_root: &Path) -> io::Result<()> {
+    let contents = format!(
+        r#"bind = "127.0.0.1:0"
+auth_token = "{AUTH_TOKEN}"
+content_token_secret = "conformance-content-token-secret"
+writer_id = "loonfs-conformance"
+
+[store]
+kind = "local-fs"
+root = "{}"
+"#,
+        store_root.display()
+    );
+    fs::write(path, contents)
+}
+
+#[derive(Debug)]
+struct LoopbackIssuer {
+    base_url: String,
+}
+
+impl DirectGetIssuer for LoopbackIssuer {
+    fn presign_get(
+        &self,
+        request: PresignedGetRequest<'_>,
+        _now: SystemTime,
+    ) -> Result<PresignedUrl, ObjectStoreError> {
+        Ok(PresignedUrl {
+            method: "GET".to_owned(),
+            url: format!("{}/objects/{}", self.base_url, request.object_key),
+            headers: BTreeMap::new(),
+            expires_at_ms: u64::MAX,
+        })
+    }
+}
+
+impl DirectPutIssuer for LoopbackIssuer {
+    fn checksum_algorithm(&self) -> ChecksumAlgorithm {
+        ChecksumAlgorithm::Sha256
+    }
+
+    fn max_content_bytes(&self) -> u64 {
+        DIRECT_PUT_MAX_BYTES
+    }
+
+    fn presign_put(
+        &self,
+        request: PresignedPutRequest<'_>,
+        _now: SystemTime,
+    ) -> Result<PresignedUrl, ObjectStoreError> {
+        Ok(PresignedUrl {
+            method: "PUT".to_owned(),
+            url: format!("{}/objects/{}", self.base_url, request.object_key),
+            headers: BTreeMap::new(),
+            expires_at_ms: u64::MAX,
+        })
+    }
+}
+
+impl DirectMultipartIssuer for LoopbackIssuer {
+    fn presign_multipart_part(
+        &self,
+        request: PresignedPartRequest<'_>,
+        _now: SystemTime,
+    ) -> Result<PresignedUrl, ObjectStoreError> {
+        Ok(PresignedUrl {
+            method: "PUT".to_owned(),
+            url: format!(
+                "{}/multipart/{}/{}",
+                self.base_url, request.provider_upload_id, request.part_number
+            ),
+            headers: BTreeMap::new(),
+            expires_at_ms: u64::MAX,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ConformanceStore {
+    inner: LocalFsStore,
+    next_upload_id: AtomicU64,
+    multipart: Mutex<HashMap<String, MultipartState>>,
+    stored_checksums: Mutex<HashMap<String, Checksum>>,
+}
+
+#[derive(Debug)]
+struct MultipartState {
+    object_key: String,
+    parts: HashMap<u32, StoredPart>,
+}
+
+#[derive(Debug)]
+struct StoredPart {
+    bytes: Bytes,
+    etag: String,
+}
+
+impl ConformanceStore {
+    fn new(root: &Path) -> Result<Self, ObjectStoreError> {
+        Ok(Self {
+            inner: LocalFsStore::new(root)?,
+            next_upload_id: AtomicU64::new(1),
+            multipart: Mutex::new(HashMap::new()),
+            stored_checksums: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn put_part(
+        &self,
+        upload_id: &str,
+        part_number: u32,
+        bytes: Bytes,
+    ) -> Result<String, ObjectStoreError> {
+        let mut uploads = self.multipart.lock().expect("multipart lock");
+        let upload = uploads
+            .get_mut(upload_id)
+            .ok_or_else(|| ObjectStoreError::NotFound {
+                object_key: upload_id.to_owned(),
+            })?;
+        let etag = format!("\"{upload_id}-{part_number}-{}\"", bytes.len());
+        upload.parts.insert(
+            part_number,
+            StoredPart {
+                bytes,
+                etag: etag.clone(),
+            },
+        );
+        Ok(etag)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ConformanceStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn head_stored_checksum(
+        &self,
+        key: &str,
+    ) -> Result<Option<StoredObjectChecksum>, ObjectStoreError> {
+        let multipart_checksum = self
+            .stored_checksums
+            .lock()
+            .expect("stored checksum lock")
+            .get(key)
+            .cloned();
+        if let Some(checksum) = multipart_checksum {
+            let size_bytes = self
+                .inner
+                .head(key)
+                .await?
+                .ok_or_else(|| ObjectStoreError::NotFound {
+                    object_key: key.to_owned(),
+                })?
+                .size_bytes;
+            return Ok(Some(StoredObjectChecksum {
+                size_bytes,
+                checksum,
+            }));
+        }
+        self.inner.head_stored_checksum(key).await
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
+        let number = self.next_upload_id.fetch_add(1, Ordering::Relaxed);
+        let upload_id = format!("conformance-multipart-{number}");
+        self.multipart.lock().expect("multipart lock").insert(
+            upload_id.clone(),
+            MultipartState {
+                object_key: key.to_owned(),
+                parts: HashMap::new(),
+            },
+        );
+        Ok(upload_id)
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion, ObjectStoreError> {
+        let upload = self
+            .multipart
+            .lock()
+            .expect("multipart lock")
+            .remove(provider_upload_id);
+        let Some(upload) = upload else {
+            return Ok(MultipartCompletion::UnknownUpload);
+        };
+        if upload.object_key != key {
+            return Err(ObjectStoreError::transport(
+                key,
+                "multipart completion named a different object",
+            ));
+        }
+
+        let mut assembled = Vec::new();
+        for requested in parts {
+            let stored = upload.parts.get(&requested.part_number).ok_or_else(|| {
+                ObjectStoreError::transport(
+                    key,
+                    format!("multipart part {} is absent", requested.part_number),
+                )
+            })?;
+            if stored.etag != requested.etag
+                || Checksum::compute(requested.checksum.algorithm, &stored.bytes)
+                    != requested.checksum
+            {
+                return Err(ObjectStoreError::transport(
+                    key,
+                    format!("multipart part {} did not match", requested.part_number),
+                ));
+            }
+            assembled.extend_from_slice(&stored.bytes);
+        }
+        if Checksum::compute(checksum.algorithm, &assembled) != *checksum {
+            return Err(ObjectStoreError::transport(
+                key,
+                "assembled multipart checksum did not match",
+            ));
+        }
+        self.inner
+            .put(key, Bytes::from(assembled), PutMode::CreateIfAbsent)
+            .await?;
+        self.stored_checksums
+            .lock()
+            .expect("stored checksum lock")
+            .insert(key.to_owned(), checksum.clone());
+        Ok(MultipartCompletion::Assembled)
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        _key: &str,
+        provider_upload_id: &str,
+    ) -> Result<(), ObjectStoreError> {
+        self.multipart
+            .lock()
+            .expect("multipart lock")
+            .remove(provider_upload_id);
+        Ok(())
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn put_streamed(
+        &self,
+        key: &str,
+        body: ByteStream,
+        mode: PutMode,
+    ) -> Result<u64, ObjectStoreError> {
+        self.inner.put_streamed(key, body, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_from_stream(prefix, start_after)
+    }
+}
+
+fn transfer_router(store: Arc<ConformanceStore>) -> Router {
+    Router::new()
+        .route("/objects/{*key}", get(get_object).put(put_object))
+        .route("/multipart/{upload_id}/{part_number}", put(put_part))
+        .layer(axum::extract::DefaultBodyLimit::disable())
+        .with_state(store)
+}
+
+async fn get_object(
+    State(store): State<Arc<ConformanceStore>>,
+    AxumPath(key): AxumPath<String>,
+    headers: HeaderMap,
+) -> Response {
+    match store.get(&key, None).await {
+        Ok(Some(bytes)) => {
+            if let Some(start) = range_start(&headers) {
+                let Ok(start) = usize::try_from(start) else {
+                    return StatusCode::RANGE_NOT_SATISFIABLE.into_response();
+                };
+                if start > bytes.len() {
+                    return StatusCode::RANGE_NOT_SATISFIABLE.into_response();
+                }
+                return (StatusCode::PARTIAL_CONTENT, bytes.slice(start..)).into_response();
+            }
+            (StatusCode::OK, bytes).into_response()
+        }
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
+}
+
+fn range_start(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get(RANGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("bytes="))
+        .and_then(|value| value.strip_suffix('-'))
+        .and_then(|value| value.parse().ok())
+}
+
+async fn put_object(
+    State(store): State<Arc<ConformanceStore>>,
+    AxumPath(key): AxumPath<String>,
+    body: Bytes,
+) -> Response {
+    match store.put_if_absent(&key, body).await {
+        Ok(_) => StatusCode::OK.into_response(),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => {
+            StatusCode::PRECONDITION_FAILED.into_response()
+        }
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
+}
+
+async fn put_part(
+    State(store): State<Arc<ConformanceStore>>,
+    AxumPath((upload_id, part_number)): AxumPath<(String, u32)>,
+    body: Bytes,
+) -> Response {
+    match store.put_part(&upload_id, part_number, body) {
+        Ok(etag) => (StatusCode::OK, [(ETAG, etag)]).into_response(),
+        Err(ObjectStoreError::NotFound { .. }) => StatusCode::NOT_FOUND.into_response(),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
+}

--- a/crates/loonfs-conformance/src/server.rs
+++ b/crates/loonfs-conformance/src/server.rs
@@ -1,4 +1,4 @@
-//! Local server infrastructure for SDK conformance tests.
+//! Starts a local LoonFS server for SDK conformance tests.
 
 use async_trait::async_trait;
 use axum::extract::{Path as AxumPath, State};

--- a/crates/loonfs-conformance/tests/reference.rs
+++ b/crates/loonfs-conformance/tests/reference.rs
@@ -2,52 +2,25 @@
 
 #![allow(clippy::panic, clippy::unwrap_used)]
 
-use async_trait::async_trait;
-use axum::extract::{Path as AxumPath, State};
-use axum::http::header::{ETAG, RANGE};
-use axum::http::{HeaderMap, StatusCode};
-use axum::response::{IntoResponse, Response};
-use axum::routing::{get, put};
-use axum::Router;
 use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, CompleteMultipartUploadRequest, CompleteUploadRequest,
     DirectMultipartUploadOptions, FilesystemChange, UploadContentClaim, UploadPartChecksumClaim,
     UploadSessionStatus,
 };
 use loonfs_api::{
-    ActorRef, ApiError, ChangeSeq, Checksum, ChecksumAlgorithm, CommitId, CommitRequest,
-    FilesystemOperation, NamespaceId,
+    ActorRef, ApiError, ChangeSeq, Checksum, CommitId, CommitRequest, FilesystemOperation,
+    NamespaceId,
 };
 use loonfs_client::{
     Client, ClientConfig, ClientError, CommitOptions, CreateDirectoryOptions, DeleteOptions,
     ListPathEntriesOptions, MoveOptions, NamespacePath, PutFileOptions, StatPathOptions,
 };
+use loonfs_conformance::server::{start_server, ConformanceServer, AUTH_TOKEN};
 use loonfs_conformance::{byte_pattern, load_cases, validate_page_walk, Case, CaseFamily};
-use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::presign::{
-    DirectGetIssuer, DirectMultipartIssuer, DirectPutIssuer, DirectTransferIssuers,
-    PresignedGetRequest, PresignedPartRequest, PresignedPutRequest, PresignedUrl,
-};
-use loonfs_objectstore::{
-    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
-    ObjectStore, ObjectStoreError, PutMode, SharedObjectStore, StoredObjectChecksum,
-};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::{BTreeMap, HashMap};
-use std::fs;
-use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
-use tempfile::TempDir;
-use tokio::task::JoinHandle;
-
-const AUTH_TOKEN: &str = "conformance-test-token";
-const DIRECT_PUT_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 #[test]
 fn every_family_specific_fixture_shape_parses_without_a_server() {
@@ -109,75 +82,23 @@ struct Harness {
     unauthenticated_client: Client,
     raw_client: reqwest::Client,
     server_url: String,
-    server_task: JoinHandle<()>,
-    provider_task: JoinHandle<()>,
-    _temp_dir: TempDir,
+    _server: ConformanceServer,
 }
 
 impl Harness {
     async fn start() -> Self {
-        let api_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind conformance API listener");
-        let provider_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind conformance transfer listener");
-        let api_address = api_listener.local_addr().expect("API listener address");
-        let provider_address = provider_listener
-            .local_addr()
-            .expect("transfer listener address");
-
-        let temp_dir = tempfile::tempdir().expect("conformance temp directory");
-        let store_root = temp_dir.path().join("store");
-        let store = Arc::new(ConformanceStore::new(&store_root));
-        let shared_store: SharedObjectStore = store.clone();
-
-        let provider_router = transfer_router(store);
-        let provider_task = tokio::spawn(async move {
-            axum::serve(provider_listener, provider_router)
-                .await
-                .expect("serve conformance transfers");
-        });
-        let issuer = Arc::new(LoopbackIssuer {
-            base_url: format!("http://{provider_address}"),
-        });
-        let transfers = DirectTransferIssuers::read_only(issuer.clone())
-            .with_put(issuer.clone())
-            .with_multipart(issuer);
-
-        let config_path = temp_dir.path().join("loonfs-server.toml");
-        write_server_config(&config_path, &store_root);
-        let config = loonfs_server::load_server_config(&config_path).expect("load server config");
-        let api_router = loonfs_server::app_with_test_transfers(config, shared_store, transfers)
-            .await
-            .expect("build conformance server");
-        let server_task = tokio::spawn(async move {
-            axum::serve(api_listener, api_router)
-                .await
-                .expect("serve conformance API");
-        });
-
-        let server_url = format!("http://{api_address}");
+        let server = start_server().await.expect("start conformance server");
+        let server_url = server.base_url.clone();
         let client = configured_client(&server_url, Some(AUTH_TOKEN));
         let unauthenticated_client = configured_client(&server_url, None);
-        client.health().await.expect("conformance server health");
 
         Self {
             client,
             unauthenticated_client,
             raw_client: reqwest::Client::new(),
             server_url,
-            server_task,
-            provider_task,
-            _temp_dir: temp_dir,
+            _server: server,
         }
-    }
-}
-
-impl Drop for Harness {
-    fn drop(&mut self) {
-        self.server_task.abort();
-        self.provider_task.abort();
     }
 }
 
@@ -190,361 +111,6 @@ fn configured_client(server_url: &str, auth_token: Option<&str>) -> Client {
         ca_cert_path: None,
     })
     .expect("valid conformance client")
-}
-
-fn write_server_config(path: &Path, store_root: &Path) {
-    let contents = format!(
-        r#"bind = "127.0.0.1:0"
-auth_token = "{AUTH_TOKEN}"
-content_token_secret = "conformance-content-token-secret"
-writer_id = "loonfs-conformance"
-
-[store]
-kind = "local-fs"
-root = "{}"
-"#,
-        store_root.display()
-    );
-    fs::write(path, contents).expect("write conformance server config");
-}
-
-#[derive(Debug)]
-struct LoopbackIssuer {
-    base_url: String,
-}
-
-impl DirectGetIssuer for LoopbackIssuer {
-    fn presign_get(
-        &self,
-        request: PresignedGetRequest<'_>,
-        _now: SystemTime,
-    ) -> Result<PresignedUrl, ObjectStoreError> {
-        Ok(PresignedUrl {
-            method: "GET".to_owned(),
-            url: format!("{}/objects/{}", self.base_url, request.object_key),
-            headers: BTreeMap::new(),
-            expires_at_ms: u64::MAX,
-        })
-    }
-}
-
-impl DirectPutIssuer for LoopbackIssuer {
-    fn checksum_algorithm(&self) -> ChecksumAlgorithm {
-        ChecksumAlgorithm::Sha256
-    }
-
-    fn max_content_bytes(&self) -> u64 {
-        DIRECT_PUT_MAX_BYTES
-    }
-
-    fn presign_put(
-        &self,
-        request: PresignedPutRequest<'_>,
-        _now: SystemTime,
-    ) -> Result<PresignedUrl, ObjectStoreError> {
-        Ok(PresignedUrl {
-            method: "PUT".to_owned(),
-            url: format!("{}/objects/{}", self.base_url, request.object_key),
-            headers: BTreeMap::new(),
-            expires_at_ms: u64::MAX,
-        })
-    }
-}
-
-impl DirectMultipartIssuer for LoopbackIssuer {
-    fn presign_multipart_part(
-        &self,
-        request: PresignedPartRequest<'_>,
-        _now: SystemTime,
-    ) -> Result<PresignedUrl, ObjectStoreError> {
-        Ok(PresignedUrl {
-            method: "PUT".to_owned(),
-            url: format!(
-                "{}/multipart/{}/{}",
-                self.base_url, request.provider_upload_id, request.part_number
-            ),
-            headers: BTreeMap::new(),
-            expires_at_ms: u64::MAX,
-        })
-    }
-}
-
-#[derive(Debug)]
-struct ConformanceStore {
-    inner: LocalFsStore,
-    next_upload_id: AtomicU64,
-    multipart: Mutex<HashMap<String, MultipartState>>,
-    stored_checksums: Mutex<HashMap<String, Checksum>>,
-}
-
-#[derive(Debug)]
-struct MultipartState {
-    object_key: String,
-    parts: HashMap<u32, StoredPart>,
-}
-
-#[derive(Debug)]
-struct StoredPart {
-    bytes: Bytes,
-    etag: String,
-}
-
-impl ConformanceStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            next_upload_id: AtomicU64::new(1),
-            multipart: Mutex::new(HashMap::new()),
-            stored_checksums: Mutex::new(HashMap::new()),
-        }
-    }
-
-    fn put_part(
-        &self,
-        upload_id: &str,
-        part_number: u32,
-        bytes: Bytes,
-    ) -> Result<String, ObjectStoreError> {
-        let mut uploads = self.multipart.lock().expect("multipart lock");
-        let upload = uploads
-            .get_mut(upload_id)
-            .ok_or_else(|| ObjectStoreError::NotFound {
-                object_key: upload_id.to_owned(),
-            })?;
-        let etag = format!("\"{upload_id}-{part_number}-{}\"", bytes.len());
-        upload.parts.insert(
-            part_number,
-            StoredPart {
-                bytes,
-                etag: etag.clone(),
-            },
-        );
-        Ok(etag)
-    }
-}
-
-#[async_trait]
-impl ObjectStore for ConformanceStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn head_stored_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<StoredObjectChecksum>, ObjectStoreError> {
-        let multipart_checksum = self
-            .stored_checksums
-            .lock()
-            .expect("stored checksum lock")
-            .get(key)
-            .cloned();
-        if let Some(checksum) = multipart_checksum {
-            let size_bytes = self
-                .inner
-                .head(key)
-                .await?
-                .ok_or_else(|| ObjectStoreError::NotFound {
-                    object_key: key.to_owned(),
-                })?
-                .size_bytes;
-            return Ok(Some(StoredObjectChecksum {
-                size_bytes,
-                checksum,
-            }));
-        }
-        self.inner.head_stored_checksum(key).await
-    }
-
-    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
-        let number = self.next_upload_id.fetch_add(1, Ordering::Relaxed);
-        let upload_id = format!("conformance-multipart-{number}");
-        self.multipart.lock().expect("multipart lock").insert(
-            upload_id.clone(),
-            MultipartState {
-                object_key: key.to_owned(),
-                parts: HashMap::new(),
-            },
-        );
-        Ok(upload_id)
-    }
-
-    async fn complete_multipart_upload(
-        &self,
-        key: &str,
-        provider_upload_id: &str,
-        parts: &[MultipartPart],
-        checksum: &Checksum,
-    ) -> Result<MultipartCompletion, ObjectStoreError> {
-        let upload = self
-            .multipart
-            .lock()
-            .expect("multipart lock")
-            .remove(provider_upload_id);
-        let Some(upload) = upload else {
-            return Ok(MultipartCompletion::UnknownUpload);
-        };
-        if upload.object_key != key {
-            return Err(ObjectStoreError::transport(
-                key,
-                "multipart completion named a different object",
-            ));
-        }
-
-        let mut assembled = Vec::new();
-        for requested in parts {
-            let stored = upload.parts.get(&requested.part_number).ok_or_else(|| {
-                ObjectStoreError::transport(
-                    key,
-                    format!("multipart part {} is absent", requested.part_number),
-                )
-            })?;
-            if stored.etag != requested.etag
-                || Checksum::compute(requested.checksum.algorithm, &stored.bytes)
-                    != requested.checksum
-            {
-                return Err(ObjectStoreError::transport(
-                    key,
-                    format!("multipart part {} did not match", requested.part_number),
-                ));
-            }
-            assembled.extend_from_slice(&stored.bytes);
-        }
-        if Checksum::compute(checksum.algorithm, &assembled) != *checksum {
-            return Err(ObjectStoreError::transport(
-                key,
-                "assembled multipart checksum did not match",
-            ));
-        }
-        self.inner
-            .put(key, Bytes::from(assembled), PutMode::CreateIfAbsent)
-            .await?;
-        self.stored_checksums
-            .lock()
-            .expect("stored checksum lock")
-            .insert(key.to_owned(), checksum.clone());
-        Ok(MultipartCompletion::Assembled)
-    }
-
-    async fn abort_multipart_upload(
-        &self,
-        _key: &str,
-        provider_upload_id: &str,
-    ) -> Result<(), ObjectStoreError> {
-        self.multipart
-            .lock()
-            .expect("multipart lock")
-            .remove(provider_upload_id);
-        Ok(())
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn put_streamed(
-        &self,
-        key: &str,
-        body: ByteStream,
-        mode: PutMode,
-    ) -> Result<u64, ObjectStoreError> {
-        self.inner.put_streamed(key, body, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_from_stream(
-        &self,
-        prefix: &str,
-        start_after: Option<&str>,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_from_stream(prefix, start_after)
-    }
-}
-
-fn transfer_router(store: Arc<ConformanceStore>) -> Router {
-    Router::new()
-        .route("/objects/{*key}", get(get_object).put(put_object))
-        .route("/multipart/{upload_id}/{part_number}", put(put_part))
-        .layer(axum::extract::DefaultBodyLimit::disable())
-        .with_state(store)
-}
-
-async fn get_object(
-    State(store): State<Arc<ConformanceStore>>,
-    AxumPath(key): AxumPath<String>,
-    headers: HeaderMap,
-) -> Response {
-    match store.get(&key, None).await {
-        Ok(Some(bytes)) => {
-            if let Some(start) = range_start(&headers) {
-                let Ok(start) = usize::try_from(start) else {
-                    return StatusCode::RANGE_NOT_SATISFIABLE.into_response();
-                };
-                if start > bytes.len() {
-                    return StatusCode::RANGE_NOT_SATISFIABLE.into_response();
-                }
-                return (StatusCode::PARTIAL_CONTENT, bytes.slice(start..)).into_response();
-            }
-            (StatusCode::OK, bytes).into_response()
-        }
-        Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
-    }
-}
-
-fn range_start(headers: &HeaderMap) -> Option<u64> {
-    headers
-        .get(RANGE)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.strip_prefix("bytes="))
-        .and_then(|value| value.strip_suffix('-'))
-        .and_then(|value| value.parse().ok())
-}
-
-async fn put_object(
-    State(store): State<Arc<ConformanceStore>>,
-    AxumPath(key): AxumPath<String>,
-    body: Bytes,
-) -> Response {
-    match store.put_if_absent(&key, body).await {
-        Ok(_) => StatusCode::OK.into_response(),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => {
-            StatusCode::PRECONDITION_FAILED.into_response()
-        }
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
-    }
-}
-
-async fn put_part(
-    State(store): State<Arc<ConformanceStore>>,
-    AxumPath((upload_id, part_number)): AxumPath<(String, u32)>,
-    body: Bytes,
-) -> Response {
-    match store.put_part(&upload_id, part_number, body) {
-        Ok(etag) => (StatusCode::OK, [(ETAG, etag)]).into_response(),
-        Err(ObjectStoreError::NotFound { .. }) => StatusCode::NOT_FOUND.into_response(),
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
-    }
 }
 
 fn parse_values<R, E>(case: &Case) -> (R, E)

--- a/scripts/run-sdk-conformance.sh
+++ b/scripts/run-sdk-conformance.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Runs one generated SDK against the shared conformance server and cases.
+# Runs a generated SDK against a local server using the shared test cases.
 #
 # Usage: scripts/run-sdk-conformance.sh <go|python|typescript>
 

--- a/scripts/run-sdk-conformance.sh
+++ b/scripts/run-sdk-conformance.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Runs one generated SDK against the shared conformance server and cases.
+#
+# Usage: scripts/run-sdk-conformance.sh <go|python|typescript>
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: scripts/run-sdk-conformance.sh <go|python|typescript>" >&2
+    exit 2
+fi
+
+LANGUAGE="$1"
+case "$LANGUAGE" in
+    go|python|typescript) ;;
+    *)
+        echo "usage: scripts/run-sdk-conformance.sh <go|python|typescript>" >&2
+        exit 2
+        ;;
+esac
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+if [ ! -d "$REPO_ROOT/sdk/generated/$LANGUAGE" ]; then
+    "$REPO_ROOT/scripts/generate-sdks.sh" "$LANGUAGE"
+fi
+
+cd "$REPO_ROOT"
+cargo build -p loonfs-conformance --bin conformance-server
+
+RUN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/loonfs-conformance.XXXXXX")
+SERVER_INPUT="$RUN_DIR/server-input"
+SERVER_OUTPUT="$RUN_DIR/server-output"
+mkfifo "$SERVER_INPUT" "$SERVER_OUTPUT"
+
+SERVER_PID=
+cleanup() {
+    status=$?
+    trap - 0
+    if [ -n "$SERVER_PID" ]; then
+        exec 3>&-
+        attempts=0
+        while kill -0 "$SERVER_PID" 2>/dev/null && [ "$attempts" -lt 50 ]; do
+            sleep 0.1
+            attempts=$((attempts + 1))
+        done
+        if kill -0 "$SERVER_PID" 2>/dev/null; then
+            kill "$SERVER_PID" 2>/dev/null || :
+        fi
+        wait "$SERVER_PID" 2>/dev/null || :
+    fi
+    rm -r "$RUN_DIR"
+    exit "$status"
+}
+trap cleanup 0
+
+exec 3<>"$SERVER_INPUT"
+"$REPO_ROOT/target/debug/conformance-server" \
+    <"$SERVER_INPUT" >"$SERVER_OUTPUT" 3>&- &
+SERVER_PID=$!
+IFS= read -r SERVER_LINE <"$SERVER_OUTPUT"
+
+LOONFS_CONFORMANCE_URL=$(printf '%s\n' "$SERVER_LINE" | \
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["base_url"])')
+LOONFS_CONFORMANCE_TOKEN=$(printf '%s\n' "$SERVER_LINE" | \
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["token"])')
+LOONFS_CONFORMANCE_CASES="$REPO_ROOT/crates/loonfs-conformance/cases"
+export LOONFS_CONFORMANCE_URL LOONFS_CONFORMANCE_TOKEN LOONFS_CONFORMANCE_CASES
+
+case "$LANGUAGE" in
+    go)
+        if (cd "$REPO_ROOT/sdk/conformance/go" && go test ./...); then
+            HARNESS_STATUS=0
+        else
+            HARNESS_STATUS=$?
+        fi
+        ;;
+    python|typescript)
+        echo "harness not present yet" >&2
+        HARNESS_STATUS=1
+        ;;
+esac
+
+exit "$HARNESS_STATUS"

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -48,8 +47,6 @@ var expectedCases = []struct {
 }
 
 type harness struct {
-	baseURL         string
-	token           string
 	client          *client.Client
 	unauthenticated *client.Client
 }
@@ -73,8 +70,6 @@ func TestSDKConformance(t *testing.T) {
 		t.Fatalf("load conformance cases: %v", err)
 	}
 	h := &harness{
-		baseURL: baseURL,
-		token:   token,
 		client: client.NewClient(
 			option.WithBaseURL(baseURL),
 			option.WithToken(token),
@@ -245,68 +240,6 @@ func runErrorContract(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 	if unauthorized.Body.RequestID == nil {
 		t.Error("unauthenticated error has no request_id")
-	}
-
-	malformedRequest, err := http.NewRequestWithContext(
-		context.Background(),
-		http.MethodPost,
-		fmt.Sprintf("%s/v0/namespaces/%s/commits", h.baseURL, request.NamespaceID),
-		bytes.NewReader(request.MalformedBody),
-	)
-	if err != nil {
-		t.Fatalf("build malformed-body request: %v", err)
-	}
-	malformedRequest.Header.Set("Authorization", "Bearer "+h.token)
-	malformedRequest.Header.Set("Content-Type", "application/json")
-	malformed := sendRawRequest(t, malformedRequest)
-	assertRawError(t, malformed, expected.MalformedBody)
-
-	invalidRequest, err := http.NewRequestWithContext(
-		context.Background(),
-		http.MethodGet,
-		fmt.Sprintf(
-			"%s/v0/namespaces/%s/changes?after_seq=%s",
-			h.baseURL,
-			request.NamespaceID,
-			request.InvalidAfterSeq,
-		),
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("build invalid-query request: %v", err)
-	}
-	invalidRequest.Header.Set("Authorization", "Bearer "+h.token)
-	invalidQuery := sendRawRequest(t, invalidRequest)
-	assertRawError(t, invalidQuery, expected.InvalidQuery)
-}
-
-func sendRawRequest(t *testing.T, request *http.Request) *http.Response {
-	t.Helper()
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatalf("send raw request: %v", err)
-	}
-	return response
-}
-
-func assertRawError(t *testing.T, response *http.Response, expected errorOutcome) {
-	t.Helper()
-	defer response.Body.Close()
-	if response.StatusCode != expected.Status {
-		t.Errorf("status = %d, want %d", response.StatusCode, expected.Status)
-	}
-	var apiError loonfs.APIError
-	if err := json.NewDecoder(response.Body).Decode(&apiError); err != nil {
-		t.Fatalf("decode API error envelope: %v", err)
-	}
-	if apiError.Code != expected.Code {
-		t.Errorf("code = %q, want %q", apiError.Code, expected.Code)
-	}
-	if apiError.Param == nil || *apiError.Param != expected.Param {
-		t.Errorf("param = %v, want %q", apiError.Param, expected.Param)
-	}
-	if apiError.RequestID == nil {
-		t.Error("error has no request_id")
 	}
 }
 

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -21,7 +21,7 @@ import (
 
 const fixtureVersion = 1
 
-const transferSkip = "needs transfer orchestration; covered by the Rust reference harness"
+const transferSkip = "file transfer cases are not implemented in the Go harness yet"
 
 type conformanceCase struct {
 	Version  int             `json:"version"`
@@ -130,7 +130,7 @@ func loadCases(directory string) ([]conformanceCase, error) {
 		return cases[i].Name < cases[j].Name
 	})
 	if len(cases) != len(expectedCases) {
-		return nil, fmt.Errorf("version one requires %d cases, found %d", len(expectedCases), len(cases))
+		return nil, fmt.Errorf("fixture version 1 requires %d cases, found %d", len(expectedCases), len(cases))
 	}
 	for index, expected := range expectedCases {
 		if cases[index].Name != expected.name || cases[index].Family != expected.family {
@@ -152,16 +152,16 @@ func validateCase(path string, testCase *conformanceCase) error {
 	}
 	stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	if testCase.Name != stem {
-		return fmt.Errorf("invalid fixture %s: name %q must match the JSON file stem", path, testCase.Name)
+		return fmt.Errorf("invalid fixture %s: name is %q, expected %q", path, testCase.Name, stem)
 	}
 	if strings.TrimSpace(testCase.Intent) == "" {
 		return fmt.Errorf("invalid fixture %s: intent must not be empty", path)
 	}
 	if !isJSONObject(testCase.Request) {
-		return fmt.Errorf("invalid fixture %s: request must be a JSON object", path)
+		return fmt.Errorf("invalid fixture %s: request field must be a JSON object", path)
 	}
 	if !isJSONObject(testCase.Expected) {
-		return fmt.Errorf("invalid fixture %s: expected must be a JSON object", path)
+		return fmt.Errorf("invalid fixture %s: expected field must be a JSON object", path)
 	}
 	return nil
 }
@@ -191,11 +191,11 @@ func decodeCaseValues[R, E any](t *testing.T, testCase conformanceCase) (R, E) {
 	t.Helper()
 	request, err := decodeStrict[R](testCase.Request)
 	if err != nil {
-		t.Fatalf("%s request did not parse: %v", testCase.Name, err)
+		t.Fatalf("decode %s request: %v", testCase.Name, err)
 	}
 	expected, err := decodeStrict[E](testCase.Expected)
 	if err != nil {
-		t.Fatalf("%s expected values did not parse: %v", testCase.Name, err)
+		t.Fatalf("decode %s expected values: %v", testCase.Name, err)
 	}
 	return request, expected
 }
@@ -441,10 +441,10 @@ func runPagination(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Error("final cursor is not nil")
 	}
 	if savedCursor == nil {
-		t.Fatal("saved mid-walk cursor is nil")
+		t.Fatal("resume cursor was not recorded")
 	}
 	if resumeOffset < 0 {
-		t.Fatal("saved mid-walk offset is absent")
+		t.Fatal("resume position was not recorded")
 	}
 
 	resumed := make([]string, 0, len(request.EntryNames)-resumeOffset)
@@ -489,18 +489,18 @@ func validatePageWalk(expected, observed []string, resumeOffset int, resumed []s
 	seen := make(map[string]struct{}, len(observed))
 	for _, name := range observed {
 		if _, exists := seen[name]; exists {
-			return fmt.Errorf("full pagination walk repeated %q", name)
+			return fmt.Errorf("pagination returned %q more than once", name)
 		}
 		seen[name] = struct{}{}
 	}
 	if !equalStrings(observed, expected) {
-		return errors.New("full pagination walk did not match the expected entries")
+		return errors.New("pagination returned unexpected entries")
 	}
 	if resumeOffset > len(expected) {
 		return fmt.Errorf("pagination resume offset %d exceeds %d entries", resumeOffset, len(expected))
 	}
 	if !equalStrings(resumed, expected[resumeOffset:]) {
-		return errors.New("resumed pagination walk did not match the expected suffix")
+		return errors.New("resumed pagination returned unexpected entries")
 	}
 	return nil
 }

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -1,0 +1,636 @@
+package conformance_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	loonfs "github.com/loonfs/loonfs-sdk-go"
+	"github.com/loonfs/loonfs-sdk-go/client"
+	"github.com/loonfs/loonfs-sdk-go/option"
+)
+
+const fixtureVersion = 1
+
+const transferSkip = "needs transfer orchestration; covered by the Rust reference harness"
+
+type conformanceCase struct {
+	Version  int             `json:"version"`
+	Name     string          `json:"name"`
+	Intent   string          `json:"intent"`
+	Family   string          `json:"family"`
+	Request  json.RawMessage `json:"request"`
+	Expected json.RawMessage `json:"expected"`
+}
+
+var expectedCases = []struct {
+	name   string
+	family string
+}{
+	{name: "changes", family: "changes"},
+	{name: "commit_replay", family: "commit_replay"},
+	{name: "download", family: "download"},
+	{name: "end_to_end", family: "end_to_end"},
+	{name: "error_contract", family: "error_contract"},
+	{name: "pagination", family: "pagination"},
+	{name: "upload_abort", family: "upload_abort"},
+	{name: "upload_direct_put", family: "upload_direct_put"},
+	{name: "upload_multipart", family: "upload_multipart"},
+}
+
+type harness struct {
+	baseURL         string
+	token           string
+	client          *client.Client
+	unauthenticated *client.Client
+}
+
+func TestSDKConformance(t *testing.T) {
+	baseURL := os.Getenv("LOONFS_CONFORMANCE_URL")
+	if baseURL == "" {
+		t.Skip("run scripts/run-sdk-conformance.sh go")
+	}
+	token := os.Getenv("LOONFS_CONFORMANCE_TOKEN")
+	if token == "" {
+		t.Fatal("LOONFS_CONFORMANCE_TOKEN is not set")
+	}
+	casesDirectory := os.Getenv("LOONFS_CONFORMANCE_CASES")
+	if casesDirectory == "" {
+		t.Fatal("LOONFS_CONFORMANCE_CASES is not set")
+	}
+
+	cases, err := loadCases(casesDirectory)
+	if err != nil {
+		t.Fatalf("load conformance cases: %v", err)
+	}
+	h := &harness{
+		baseURL: baseURL,
+		token:   token,
+		client: client.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithToken(token),
+		),
+		unauthenticated: client.NewClient(option.WithBaseURL(baseURL)),
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			switch testCase.Family {
+			case "error_contract":
+				runErrorContract(t, h, testCase)
+			case "commit_replay":
+				runCommitReplay(t, h, testCase)
+			case "pagination":
+				runPagination(t, h, testCase)
+			case "changes":
+				runChanges(t, h, testCase)
+			case "upload_direct_put", "upload_multipart", "upload_abort", "download", "end_to_end":
+				t.Skip(transferSkip)
+			default:
+				t.Fatalf("unknown case family %q", testCase.Family)
+			}
+		})
+	}
+}
+
+func loadCases(directory string) ([]conformanceCase, error) {
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+	cases := make([]conformanceCase, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(directory, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		testCase, err := decodeStrict[conformanceCase](data)
+		if err != nil {
+			return nil, fmt.Errorf("decode %s: %w", path, err)
+		}
+		if err := validateCase(path, &testCase); err != nil {
+			return nil, err
+		}
+		cases = append(cases, testCase)
+	}
+	sort.Slice(cases, func(i, j int) bool {
+		return cases[i].Name < cases[j].Name
+	})
+	if len(cases) != len(expectedCases) {
+		return nil, fmt.Errorf("version one requires %d cases, found %d", len(expectedCases), len(cases))
+	}
+	for index, expected := range expectedCases {
+		if cases[index].Name != expected.name || cases[index].Family != expected.family {
+			return nil, fmt.Errorf(
+				"expected %q with family %q, found %q with family %q",
+				expected.name,
+				expected.family,
+				cases[index].Name,
+				cases[index].Family,
+			)
+		}
+	}
+	return cases, nil
+}
+
+func validateCase(path string, testCase *conformanceCase) error {
+	if testCase.Version != fixtureVersion {
+		return fmt.Errorf("invalid fixture %s: version must be %d, found %d", path, fixtureVersion, testCase.Version)
+	}
+	stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	if testCase.Name != stem {
+		return fmt.Errorf("invalid fixture %s: name %q must match the JSON file stem", path, testCase.Name)
+	}
+	if strings.TrimSpace(testCase.Intent) == "" {
+		return fmt.Errorf("invalid fixture %s: intent must not be empty", path)
+	}
+	if !isJSONObject(testCase.Request) {
+		return fmt.Errorf("invalid fixture %s: request must be a JSON object", path)
+	}
+	if !isJSONObject(testCase.Expected) {
+		return fmt.Errorf("invalid fixture %s: expected must be a JSON object", path)
+	}
+	return nil
+}
+
+func isJSONObject(data []byte) bool {
+	var object map[string]json.RawMessage
+	return json.Unmarshal(data, &object) == nil && object != nil
+}
+
+func decodeStrict[T any](data []byte) (T, error) {
+	var value T
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&value); err != nil {
+		return value, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return value, errors.New("JSON contains a second value")
+		}
+		return value, err
+	}
+	return value, nil
+}
+
+func decodeCaseValues[R, E any](t *testing.T, testCase conformanceCase) (R, E) {
+	t.Helper()
+	request, err := decodeStrict[R](testCase.Request)
+	if err != nil {
+		t.Fatalf("%s request did not parse: %v", testCase.Name, err)
+	}
+	expected, err := decodeStrict[E](testCase.Expected)
+	if err != nil {
+		t.Fatalf("%s expected values did not parse: %v", testCase.Name, err)
+	}
+	return request, expected
+}
+
+type errorContractRequest struct {
+	NamespaceID     string          `json:"namespace_id"`
+	MalformedBody   json.RawMessage `json:"malformed_body"`
+	InvalidAfterSeq string          `json:"invalid_after_seq"`
+}
+
+type errorContractExpected struct {
+	Unauthenticated errorStatusExpected `json:"unauthenticated"`
+	MalformedBody   errorOutcome        `json:"malformed_body"`
+	InvalidQuery    errorOutcome        `json:"invalid_query"`
+}
+
+type errorStatusExpected struct {
+	Status int    `json:"status"`
+	Code   string `json:"code"`
+}
+
+type errorOutcome struct {
+	Status int    `json:"status"`
+	Code   string `json:"code"`
+	Param  string `json:"param"`
+}
+
+func runErrorContract(t *testing.T, h *harness, testCase conformanceCase) {
+	t.Helper()
+	request, expected := decodeCaseValues[errorContractRequest, errorContractExpected](t, testCase)
+	_, err := h.unauthenticated.Namespaces.GetNamespace(
+		context.Background(),
+		&loonfs.GetNamespaceRequest{NamespaceID: request.NamespaceID},
+	)
+	var unauthorized *loonfs.UnauthorizedError
+	if !errors.As(err, &unauthorized) {
+		t.Fatalf("expected UnauthorizedError, found %T: %v", err, err)
+	}
+	if unauthorized.StatusCode != expected.Unauthenticated.Status {
+		t.Errorf("unauthenticated status = %d, want %d", unauthorized.StatusCode, expected.Unauthenticated.Status)
+	}
+	if unauthorized.Body == nil {
+		t.Fatal("unauthenticated error has no body")
+	}
+	if unauthorized.Body.Code != expected.Unauthenticated.Code {
+		t.Errorf("unauthenticated code = %q, want %q", unauthorized.Body.Code, expected.Unauthenticated.Code)
+	}
+	if unauthorized.Body.RequestID == nil {
+		t.Error("unauthenticated error has no request_id")
+	}
+
+	malformedRequest, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		fmt.Sprintf("%s/v0/namespaces/%s/commits", h.baseURL, request.NamespaceID),
+		bytes.NewReader(request.MalformedBody),
+	)
+	if err != nil {
+		t.Fatalf("build malformed-body request: %v", err)
+	}
+	malformedRequest.Header.Set("Authorization", "Bearer "+h.token)
+	malformedRequest.Header.Set("Content-Type", "application/json")
+	malformed := sendRawRequest(t, malformedRequest)
+	assertRawError(t, malformed, expected.MalformedBody)
+
+	invalidRequest, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		fmt.Sprintf(
+			"%s/v0/namespaces/%s/changes?after_seq=%s",
+			h.baseURL,
+			request.NamespaceID,
+			request.InvalidAfterSeq,
+		),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("build invalid-query request: %v", err)
+	}
+	invalidRequest.Header.Set("Authorization", "Bearer "+h.token)
+	invalidQuery := sendRawRequest(t, invalidRequest)
+	assertRawError(t, invalidQuery, expected.InvalidQuery)
+}
+
+func sendRawRequest(t *testing.T, request *http.Request) *http.Response {
+	t.Helper()
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("send raw request: %v", err)
+	}
+	return response
+}
+
+func assertRawError(t *testing.T, response *http.Response, expected errorOutcome) {
+	t.Helper()
+	defer response.Body.Close()
+	if response.StatusCode != expected.Status {
+		t.Errorf("status = %d, want %d", response.StatusCode, expected.Status)
+	}
+	var apiError loonfs.APIError
+	if err := json.NewDecoder(response.Body).Decode(&apiError); err != nil {
+		t.Fatalf("decode API error envelope: %v", err)
+	}
+	if apiError.Code != expected.Code {
+		t.Errorf("code = %q, want %q", apiError.Code, expected.Code)
+	}
+	if apiError.Param == nil || *apiError.Param != expected.Param {
+		t.Errorf("param = %v, want %q", apiError.Param, expected.Param)
+	}
+	if apiError.RequestID == nil {
+		t.Error("error has no request_id")
+	}
+}
+
+type commitReplayRequest struct {
+	NamespaceID string          `json:"namespace_id"`
+	CommitID    string          `json:"commit_id"`
+	Actor       loonfs.ActorRef `json:"actor"`
+	Message     string          `json:"message"`
+	Path        string          `json:"path"`
+}
+
+type commitReplayExpected struct {
+	CommittedSeq int64 `json:"committed_seq"`
+}
+
+func runCommitReplay(t *testing.T, h *harness, testCase conformanceCase) {
+	t.Helper()
+	request, expected := decodeCaseValues[commitReplayRequest, commitReplayExpected](t, testCase)
+	createNamespace(t, h.client, request.NamespaceID)
+	commit := createDirectoryCommit(
+		request.NamespaceID,
+		request.CommitID,
+		&request.Actor,
+		request.Path,
+		&request.Message,
+	)
+	first, err := h.client.Filesystem.ApplyCommit(context.Background(), commit)
+	if err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+	replayed, err := h.client.Filesystem.ApplyCommit(context.Background(), commit)
+	if err != nil {
+		t.Fatalf("replayed commit: %v", err)
+	}
+
+	if int64(first.CommittedSeq) != expected.CommittedSeq {
+		t.Errorf("first committed_seq = %d, want %d", first.CommittedSeq, expected.CommittedSeq)
+	}
+	if string(first.CommitID) != request.CommitID {
+		t.Errorf("first commit_id = %q, want %q", first.CommitID, request.CommitID)
+	}
+	if replayed.CommittedSeq != first.CommittedSeq {
+		t.Errorf("replayed committed_seq = %d, want %d", replayed.CommittedSeq, first.CommittedSeq)
+	}
+	if replayed.CommitID != first.CommitID ||
+		replayed.CommittedSeq != first.CommittedSeq ||
+		replayed.NamespaceID != first.NamespaceID {
+		t.Errorf("replayed commit = %#v, want %#v", replayed, first)
+	}
+}
+
+type paginationRequest struct {
+	NamespaceID     string          `json:"namespace_id"`
+	Directory       string          `json:"directory"`
+	Actor           loonfs.ActorRef `json:"actor"`
+	EntryNames      []string        `json:"entry_names"`
+	PageSize        int             `json:"page_size"`
+	ResumeAfterPage int             `json:"resume_after_page"`
+}
+
+type paginationExpected struct {
+	EntryCount       int   `json:"entry_count"`
+	MinimumPageCount int   `json:"minimum_page_count"`
+	HeadSeq          int64 `json:"head_seq"`
+}
+
+func runPagination(t *testing.T, h *harness, testCase conformanceCase) {
+	t.Helper()
+	request, expected := decodeCaseValues[paginationRequest, paginationExpected](t, testCase)
+	createNamespace(t, h.client, request.NamespaceID)
+	applyCreateDirectory(
+		t,
+		h.client,
+		request.NamespaceID,
+		"conf-pagination-directory",
+		&request.Actor,
+		request.Directory,
+	)
+	for index, name := range request.EntryNames {
+		applyCreateDirectory(
+			t,
+			h.client,
+			request.NamespaceID,
+			fmt.Sprintf("conf-pagination-entry-%02d", index),
+			&request.Actor,
+			request.Directory+"/"+name,
+		)
+	}
+
+	observed := make([]string, 0, len(request.EntryNames))
+	var cursor *string
+	pageCount := 0
+	var savedCursor *string
+	resumeOffset := -1
+	for {
+		page, err := h.client.Filesystem.ListPathEntries(
+			context.Background(),
+			&loonfs.ListPathEntriesRequest{
+				NamespaceID: request.NamespaceID,
+				Path:        request.Directory,
+				Limit:       &request.PageSize,
+				Cursor:      cursor,
+			},
+		)
+		if err != nil {
+			t.Fatalf("list pagination page: %v", err)
+		}
+		pageCount++
+		if int64(page.HeadSeq) != expected.HeadSeq {
+			t.Errorf("page %d head_seq = %d, want %d", pageCount, page.HeadSeq, expected.HeadSeq)
+		}
+		observed = append(observed, listedNames(t, page.Entries)...)
+		cursor = page.NextCursor
+		if pageCount == request.ResumeAfterPage {
+			if cursor != nil {
+				value := *cursor
+				savedCursor = &value
+			}
+			resumeOffset = len(observed)
+		}
+		if cursor == nil {
+			break
+		}
+	}
+	if len(observed) != expected.EntryCount {
+		t.Errorf("entry count = %d, want %d", len(observed), expected.EntryCount)
+	}
+	if pageCount < expected.MinimumPageCount {
+		t.Errorf("page count = %d, want at least %d", pageCount, expected.MinimumPageCount)
+	}
+	if cursor != nil {
+		t.Error("final cursor is not nil")
+	}
+	if savedCursor == nil {
+		t.Fatal("saved mid-walk cursor is nil")
+	}
+	if resumeOffset < 0 {
+		t.Fatal("saved mid-walk offset is absent")
+	}
+
+	resumed := make([]string, 0, len(request.EntryNames)-resumeOffset)
+	cursor = savedCursor
+	for {
+		page, err := h.client.Filesystem.ListPathEntries(
+			context.Background(),
+			&loonfs.ListPathEntriesRequest{
+				NamespaceID: request.NamespaceID,
+				Path:        request.Directory,
+				Limit:       &request.PageSize,
+				Cursor:      cursor,
+			},
+		)
+		if err != nil {
+			t.Fatalf("resume pagination page: %v", err)
+		}
+		resumed = append(resumed, listedNames(t, page.Entries)...)
+		cursor = page.NextCursor
+		if cursor == nil {
+			break
+		}
+	}
+	if err := validatePageWalk(request.EntryNames, observed, resumeOffset, resumed); err != nil {
+		t.Fatalf("pagination invariants: %v", err)
+	}
+}
+
+func listedNames(t *testing.T, entries []*loonfs.AuthoritativePathEntry) []string {
+	t.Helper()
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.DisplayName == nil {
+			t.Fatal("listed entry has no display_name")
+		}
+		names = append(names, string(*entry.DisplayName))
+	}
+	return names
+}
+
+func validatePageWalk(expected, observed []string, resumeOffset int, resumed []string) error {
+	seen := make(map[string]struct{}, len(observed))
+	for _, name := range observed {
+		if _, exists := seen[name]; exists {
+			return fmt.Errorf("full pagination walk repeated %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	if !equalStrings(observed, expected) {
+		return errors.New("full pagination walk did not match the expected entries")
+	}
+	if resumeOffset > len(expected) {
+		return fmt.Errorf("pagination resume offset %d exceeds %d entries", resumeOffset, len(expected))
+	}
+	if !equalStrings(resumed, expected[resumeOffset:]) {
+		return errors.New("resumed pagination walk did not match the expected suffix")
+	}
+	return nil
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+type changesRequest struct {
+	NamespaceID string          `json:"namespace_id"`
+	Path        string          `json:"path"`
+	CommitID    string          `json:"commit_id"`
+	Actor       loonfs.ActorRef `json:"actor"`
+	AfterSeq    int64           `json:"after_seq"`
+}
+
+type changesExpected struct {
+	CommittedSeq int64  `json:"committed_seq"`
+	ChangeCount  int    `json:"change_count"`
+	EventKind    string `json:"event_kind"`
+}
+
+func runChanges(t *testing.T, h *harness, testCase conformanceCase) {
+	t.Helper()
+	request, expected := decodeCaseValues[changesRequest, changesExpected](t, testCase)
+	createNamespace(t, h.client, request.NamespaceID)
+	commit := createDirectoryCommit(
+		request.NamespaceID,
+		request.CommitID,
+		&request.Actor,
+		request.Path,
+		nil,
+	)
+	committed, err := h.client.Filesystem.ApplyCommit(context.Background(), commit)
+	if err != nil {
+		t.Fatalf("commit change: %v", err)
+	}
+	if int64(committed.CommittedSeq) != expected.CommittedSeq {
+		t.Errorf("committed_seq = %d, want %d", committed.CommittedSeq, expected.CommittedSeq)
+	}
+	feed, err := h.client.Filesystem.ListChanges(
+		context.Background(),
+		&loonfs.ListChangesRequest{
+			NamespaceID: request.NamespaceID,
+			AfterSeq:    loonfs.ChangeSeq(request.AfterSeq),
+		},
+	)
+	if err != nil {
+		t.Fatalf("list changes: %v", err)
+	}
+	if len(feed.Changes) != expected.ChangeCount {
+		t.Fatalf("change count = %d, want %d", len(feed.Changes), expected.ChangeCount)
+	}
+	if len(feed.Changes) == 0 {
+		t.Fatal("change feed is empty")
+	}
+	change := feed.Changes[0]
+	if string(change.CommitID) != request.CommitID {
+		t.Errorf("change commit_id = %q, want %q", change.CommitID, request.CommitID)
+	}
+	if change.CommittedBy == nil ||
+		change.CommittedBy.ID != request.Actor.ID ||
+		change.CommittedBy.Kind != request.Actor.Kind {
+		t.Errorf("change committed_by = %#v, want %#v", change.CommittedBy, request.Actor)
+	}
+	if expected.EventKind != "directory_created" {
+		t.Errorf("expected event kind = %q, want %q", expected.EventKind, "directory_created")
+	}
+	if len(change.Events) != 1 || change.Events[0] == nil || change.Events[0].DirectoryCreated == nil {
+		t.Errorf("change events = %#v, want one directory_created event", change.Events)
+	}
+}
+
+func createNamespace(t *testing.T, sdk *client.Client, namespaceID string) {
+	t.Helper()
+	_, err := sdk.Namespaces.CreateNamespace(
+		context.Background(),
+		&loonfs.CreateNamespaceRequest{NamespaceID: loonfs.NamespaceID(namespaceID)},
+	)
+	if err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+}
+
+func applyCreateDirectory(
+	t *testing.T,
+	sdk *client.Client,
+	namespaceID string,
+	commitID string,
+	actor *loonfs.ActorRef,
+	path string,
+) {
+	t.Helper()
+	_, err := sdk.Filesystem.ApplyCommit(
+		context.Background(),
+		createDirectoryCommit(namespaceID, commitID, actor, path, nil),
+	)
+	if err != nil {
+		t.Fatalf("create directory %s: %v", path, err)
+	}
+}
+
+func createDirectoryCommit(
+	namespaceID string,
+	commitID string,
+	actor *loonfs.ActorRef,
+	path string,
+	message *string,
+) *loonfs.CommitRequest {
+	parents := false
+	return &loonfs.CommitRequest{
+		NamespaceID: namespaceID,
+		Actor:       actor,
+		CommitID:    loonfs.CommitID(commitID),
+		Message:     message,
+		Operations: []*loonfs.FilesystemOperation{
+			{
+				CreateDirectory: &loonfs.FsOpCreateDirectory{
+					Parents: &parents,
+					Path:    loonfs.AbsolutePath(path),
+				},
+			},
+		},
+	}
+}

--- a/sdk/conformance/go/go.mod
+++ b/sdk/conformance/go/go.mod
@@ -1,0 +1,7 @@
+module github.com/loonfs/loonfs/sdk/conformance/go
+
+go 1.21
+
+require github.com/loonfs/loonfs-sdk-go v0.0.0
+
+replace github.com/loonfs/loonfs-sdk-go => ../../generated/go

--- a/sdk/conformance/go/go.mod
+++ b/sdk/conformance/go/go.mod
@@ -4,4 +4,6 @@ go 1.21
 
 require github.com/loonfs/loonfs-sdk-go v0.0.0
 
+require github.com/google/uuid v1.6.0 // indirect
+
 replace github.com/loonfs/loonfs-sdk-go => ../../generated/go

--- a/sdk/conformance/go/go.sum
+++ b/sdk/conformance/go/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Adds a Go conformance harness that runs the generated SDK against a local LoonFS server. It uses the shared JSON cases to test typed authentication errors, commit replay, cursor pagination, and change feed responses. File transfer cases remain skipped until the Go harness supports them.

Moves the local server setup from the Rust reference test into shared conformance support so the Rust and generated SDK harnesses run against the same API and object transfer behavior. A small server binary reports its URL and token, then remains active for the lifetime of the test runner.

Adds a runner script that starts the server, provides the cases and credentials to the selected harness, and stops the server on exit. CI generates the Go SDK and runs the harness on every change.