### PR TITLE
api: serve grep over GET and page it like the list operations

### DIFF
--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -16,8 +16,9 @@ use xxhash_rust::xxh64::xxh64;
 #[serde(deny_unknown_fields)]
 pub struct GrepRequest {
     /// The pattern, in the Rust `regex` crate's dialect (no backreferences
-    /// or lookaround). Patterns that require no literal bytes are rejected
-    /// with `query_unindexable` unless `allow_scan` is set.
+    /// or lookaround). Its UTF-8 encoding must be at most 1024 bytes.
+    /// Patterns that require no literal bytes are rejected with
+    /// `query_unindexable` unless `allow_scan` is set.
     pub pattern: String,
     /// Match case-insensitively. Verification is exact; the index remains
     /// consulted through its case-folded grams.

--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -1,7 +1,7 @@
 //! Checkpoints, maintenance, store probes, and grep administration.
 
 use super::*;
-use crate::transport::append_optional_pagination_query;
+use crate::transport::{append_optional_pagination_query, append_query_param};
 
 /// Fetches active-checkpoint pages as needed.
 #[must_use]
@@ -178,8 +178,42 @@ impl Client {
         namespace_id: &NamespaceId,
         request: &GrepRequest,
     ) -> Result<GrepResponse> {
-        let url = format!("{}/v0/namespaces/{namespace_id}/query/grep", self.base_url);
-        self.request_json(self.post(&url), Some(request)).await
+        let mut url = format!("{}/v0/namespaces/{namespace_id}/query/grep", self.base_url);
+        let mut has_query = false;
+        append_query_param(&mut url, &mut has_query, "pattern", &request.pattern);
+        append_query_param(
+            &mut url,
+            &mut has_query,
+            "case_insensitive",
+            &request.case_insensitive.to_string(),
+        );
+        if let Some(path_prefix) = &request.path_prefix {
+            append_query_param(
+                &mut url,
+                &mut has_query,
+                "path_prefix",
+                path_prefix.as_str(),
+            );
+        }
+        append_query_param(
+            &mut url,
+            &mut has_query,
+            "allow_scan",
+            &request.allow_scan.to_string(),
+        );
+        append_query_param(
+            &mut url,
+            &mut has_query,
+            "allow_stale",
+            &request.allow_stale.to_string(),
+        );
+        append_optional_pagination_query(
+            &mut url,
+            &mut has_query,
+            request.limit,
+            request.cursor.as_deref(),
+        );
+        self.request_json::<(), _>(self.get(&url), None).await
     }
 
     /// Returns whether the namespace's grep index is disabled, being built,

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -54,7 +54,7 @@ impl GrepHost {
         }
     }
 
-    /// The query the server's `POST .../query/grep` performs: this host's
+    /// The query the server's `GET .../query/grep` performs: this host's
     /// service and store for grep's own segments, its reader for the
     /// filesystem.
     pub(crate) async fn grep(

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -97,8 +97,7 @@ pub(crate) enum RetryClass {
 /// `list_changes` pages through its sequence fields: `next_after_seq` is
 /// absent on the final page, so a pager stops at the snapshot head.
 ///
-/// `grep` stores its cursor in the request body. The pinned generators do not
-/// wire request-body cursors. `gc_grep_index` resumes a maintenance pass across
+/// `gc_grep_index` is excluded: its cursor resumes a maintenance pass across
 /// calls and does not paginate results.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct PaginationOperation {
@@ -109,6 +108,12 @@ pub(crate) struct PaginationOperation {
 }
 
 pub(crate) const PAGINATION_OPERATIONS: &[PaginationOperation] = &[
+    PaginationOperation {
+        operation_id: "grep",
+        cursor_parameter: "cursor",
+        next_field: "next_cursor",
+        results_field: "matches",
+    },
     PaginationOperation {
         operation_id: "list_changes",
         cursor_parameter: "after_seq",
@@ -1392,10 +1397,11 @@ mod tests {
 
         let error = add_pagination_metadata(&mut document)
             .expect_err("missing pagination operation should fail generation");
+        let expected_operation_id = PAGINATION_OPERATIONS[0].operation_id;
         assert!(matches!(
             error,
             OpenapiPostprocessError::MissingPaginationOperation { operation_id }
-                if operation_id == "list_changes"
+                if operation_id == expected_operation_id
         ));
     }
 

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -93,61 +93,39 @@ pub(crate) enum RetryClass {
 
 /// Pagination fields for cursor list operations. Keep this table sorted.
 ///
-/// Most entries page through the opaque `cursor` and `next_cursor` pair.
-/// `list_changes` pages through its sequence fields: `next_after_seq` is
-/// absent on the final page, so a pager stops at the snapshot head.
-///
-/// `gc_grep_index` is excluded: its cursor resumes a maintenance pass across
-/// calls and does not paginate results.
+/// `list_changes` is excluded because the pinned Go generator cannot combine
+/// its required `after_seq` request value with its optional `next_after_seq`
+/// response value. `gc_grep_index` is excluded because its cursor resumes a
+/// maintenance pass rather than paginating results.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct PaginationOperation {
     pub(crate) operation_id: &'static str,
-    pub(crate) cursor_parameter: &'static str,
-    pub(crate) next_field: &'static str,
     pub(crate) results_field: &'static str,
 }
 
 pub(crate) const PAGINATION_OPERATIONS: &[PaginationOperation] = &[
     PaginationOperation {
         operation_id: "grep",
-        cursor_parameter: "cursor",
-        next_field: "next_cursor",
         results_field: "matches",
     },
     PaginationOperation {
-        operation_id: "list_changes",
-        cursor_parameter: "after_seq",
-        next_field: "next_after_seq",
-        results_field: "changes",
-    },
-    PaginationOperation {
         operation_id: "list_checkpoints",
-        cursor_parameter: "cursor",
-        next_field: "next_cursor",
         results_field: "checkpoints",
     },
     PaginationOperation {
         operation_id: "list_file_revisions",
-        cursor_parameter: "cursor",
-        next_field: "next_cursor",
         results_field: "revisions",
     },
     PaginationOperation {
         operation_id: "list_file_revisions_by_inode",
-        cursor_parameter: "cursor",
-        next_field: "next_cursor",
         results_field: "revisions",
     },
     PaginationOperation {
         operation_id: "list_path_entries",
-        cursor_parameter: "cursor",
-        next_field: "next_cursor",
         results_field: "entries",
     },
     PaginationOperation {
         operation_id: "list_trash",
-        cursor_parameter: "cursor",
-        next_field: "next_cursor",
         results_field: "entries",
     },
 ];
@@ -170,11 +148,8 @@ pub(crate) enum OpenapiPostprocessError {
     MissingRetryClassification { operation_id: String },
     #[error("OpenAPI pagination operation `{operation_id}` does not appear in the document")]
     MissingPaginationOperation { operation_id: String },
-    #[error("OpenAPI pagination operation `{operation_id}` has no `{parameter}` query parameter")]
-    MissingPaginationCursorParameter {
-        operation_id: String,
-        parameter: &'static str,
-    },
+    #[error("OpenAPI pagination operation `{operation_id}` has no `cursor` query parameter")]
+    MissingPaginationCursorParameter { operation_id: String },
     #[error("OpenAPI pagination operation `{operation_id}` has no 200 response component schema")]
     MissingPaginationResponseSchema { operation_id: String },
     #[error("OpenAPI pagination operation `{operation_id}` response has no `{property}` property")]
@@ -190,12 +165,9 @@ pub(crate) enum OpenapiPostprocessError {
         results_field: String,
     },
     #[error(
-        "OpenAPI operation `{operation_id}` has a `{parameter}` pagination query parameter but no pagination metadata entry"
+        "OpenAPI operation `{operation_id}` has a `cursor` query parameter but no pagination metadata entry"
     )]
-    MissingPaginationMetadata {
-        operation_id: String,
-        parameter: String,
-    },
+    MissingPaginationMetadata { operation_id: String },
     #[error("OpenAPI pagination metadata cannot read `{location}`")]
     InvalidPaginationDocument { location: &'static str },
     #[error("OpenAPI path item `{path}` is not an object")]
@@ -711,11 +683,11 @@ fn add_pagination_metadata(document: &mut Value) -> Result<(), OpenapiPostproces
             let mut extension = Map::new();
             extension.insert(
                 "cursor".to_owned(),
-                Value::String(format!("$request.{}", metadata.cursor_parameter)),
+                Value::String("$request.cursor".to_owned()),
             );
             extension.insert(
                 "next_cursor".to_owned(),
-                Value::String(format!("$response.{}", metadata.next_field)),
+                Value::String("$response.next_cursor".to_owned()),
             );
             extension.insert(
                 "results".to_owned(),
@@ -763,24 +735,20 @@ fn validate_pagination_metadata(document: &Value) -> Result<(), OpenapiPostproce
                     method,
                     path: path.clone(),
                 })?;
-            let pagination_parameter = ["cursor", "after_seq"]
-                .into_iter()
-                .find(|name| has_query_parameter(operation, name));
+            let has_cursor = has_query_parameter(operation, "cursor");
             let Some(metadata) = pagination_operation(operation_id) else {
-                if let Some(parameter) = pagination_parameter {
+                if has_cursor {
                     return Err(OpenapiPostprocessError::MissingPaginationMetadata {
                         operation_id: operation_id.to_owned(),
-                        parameter: parameter.to_owned(),
                     });
                 }
                 continue;
             };
             found_operations.insert(metadata.operation_id);
 
-            if !has_query_parameter(operation, metadata.cursor_parameter) {
+            if !has_cursor {
                 return Err(OpenapiPostprocessError::MissingPaginationCursorParameter {
                     operation_id: operation_id.to_owned(),
-                    parameter: metadata.cursor_parameter,
                 });
             }
             validate_pagination_response(schemas, operation, metadata)?;
@@ -845,7 +813,7 @@ fn validate_pagination_response(
             },
         )?;
 
-    for property in [metadata.next_field, metadata.results_field] {
+    for property in ["next_cursor", metadata.results_field] {
         if !properties.contains_key(property) {
             return Err(OpenapiPostprocessError::MissingPaginationResponseProperty {
                 operation_id: metadata.operation_id.to_owned(),
@@ -1422,10 +1390,8 @@ mod tests {
             .expect_err("unregistered cursor operation should fail generation");
         assert!(matches!(
             error,
-            OpenapiPostprocessError::MissingPaginationMetadata {
-                operation_id,
-                parameter,
-            } if operation_id == "future_list" && parameter == "cursor"
+            OpenapiPostprocessError::MissingPaginationMetadata { operation_id }
+                if operation_id == "future_list"
         ));
     }
 

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -293,6 +293,9 @@ where
     }
 }
 
+/// Maximum UTF-8 byte length accepted for a grep pattern query parameter.
+pub(super) const MAX_GREP_PATTERN_BYTES: usize = 1024;
+
 /// Maximum body size for starting an upload or signing multipart parts.
 /// A request with 1,000 part claims is at most 131,011 bytes, so 1 MiB leaves
 /// ample room for every valid request.

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -604,7 +604,10 @@ fn parse_after_seq(value: &str) -> Result<loonfs_api::ChangeSeq, ApiResponseErro
     parse_public_ordinal("after_seq", value, loonfs_api::ChangeSeq::parse)
 }
 
-fn required_query_param(value: Option<String>, name: &str) -> Result<String, ApiResponseError> {
+pub(super) fn required_query_param(
+    value: Option<String>,
+    name: &str,
+) -> Result<String, ApiResponseError> {
     value.ok_or_else(|| {
         ApiResponseError::new(
             StatusCode::BAD_REQUEST,
@@ -616,15 +619,19 @@ fn required_query_param(value: Option<String>, name: &str) -> Result<String, Api
 }
 
 pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {
+    parse_boolean_query_param(value, "include_attributes")
+}
+
+pub(super) fn parse_boolean_query_param(value: &str, name: &str) -> Result<bool, ApiResponseError> {
     match value {
         "true" => Ok(true),
         "false" => Ok(false),
         other => Err(ApiResponseError::new(
             StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
-            &format!("invalid include_attributes `{other}`: expected `true` or `false`"),
+            &format!("invalid {name} `{other}`: expected `true` or `false`"),
         )
-        .with_param("include_attributes")),
+        .with_param(name)),
     }
 }
 

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -1,10 +1,16 @@
 //! The `query/v0` plane: derived-index reads.
 
+#[cfg(feature = "openapi")]
+use super::handlers_filesystem::{OpenApiDefaultFalseBoolean, OpenApiPageLimit};
 use super::handlers_uploads::current_unix_ms;
-use super::{authorize, AppJson, AppState, NamespaceIdPath, OptionalAppJson};
+use super::{
+    authorize,
+    handlers_filesystem::{parse_boolean_query_param, required_query_param, resolve_page_limit},
+    AppQuery, AppState, NamespaceIdPath, OptionalAppJson, MAX_GREP_PATTERN_BYTES,
+};
 use crate::http::error::{status_for_core_error_code, ApiResponseError};
 use axum::extract::State;
-use axum::http::HeaderMap;
+use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use loonfs_api::v0::{GrepGcRequest, GrepGcResponse, GrepIndexStatusResponse};
 #[cfg(feature = "openapi")]
@@ -14,17 +20,36 @@ use loonfs_api::{
 };
 use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError, NamespaceReads};
 
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct GrepQuery {
+    pattern: Option<String>,
+    case_insensitive: Option<String>,
+    path_prefix: Option<String>,
+    allow_scan: Option<String>,
+    allow_stale: Option<String>,
+    limit: Option<String>,
+    cursor: Option<String>,
+}
+
 #[cfg_attr(
     feature = "openapi",
     utoipa::path(
-        post,
+        get,
         operation_id = "grep",
         path = "/v0/namespaces/{namespace_id}/query/grep",
         tag = "query",
         summary = "Content search",
         description = "Searches file content with a regular expression, accelerated by the namespace's grep index. Matches are verified against the real pattern and returned in ascending `(inode_id, byte_offset)` order; revisions committed after the index watermark are scanned exhaustively unless `allow_stale` skips them. Requires this deployment to serve grep and the namespace to carry a materialized active grep root.",
-        params(("namespace_id" = String, Path, description = "Namespace id")),
-        request_body = GrepRequest,
+        params(
+            ("namespace_id" = String, Path, description = "Namespace id"),
+            ("pattern" = String, Query, description = "Pattern in the Rust `regex` crate's dialect. Its UTF-8 encoding must be at most 1024 bytes."),
+            ("case_insensitive" = inline(Option<OpenApiDefaultFalseBoolean>), Query, description = "Match case-insensitively (`true` or `false`). Defaults to `false`."),
+            ("path_prefix" = Option<String>, Query, description = "Complete absolute path used to restrict matches."),
+            ("allow_scan" = inline(Option<OpenApiDefaultFalseBoolean>), Query, description = "Permit a capped exhaustive scan when the pattern has no required grams (`true` or `false`). Defaults to `false`."),
+            ("allow_stale" = inline(Option<OpenApiDefaultFalseBoolean>), Query, description = "Return indexed-only results when the unindexed tail exceeds the scan budget (`true` or `false`). Defaults to `false`."),
+            ("limit" = inline(Option<OpenApiPageLimit>), Query, description = "Maximum matches per page"),
+            ("cursor" = Option<String>, Query, description = "Opaque grep page cursor")
+        ),
         responses(
             (status = 200, description = "One page of matches", body = GrepResponse),
             (status = 400, description = "Invalid pattern, cursor, or an unindexable pattern without allow_scan", body = ApiError),
@@ -42,9 +67,12 @@ use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError, NamespaceRea
 pub(super) async fn grep(
     State(state): State<AppState>,
     namespace_id_path: NamespaceIdPath,
-    AppJson(request): AppJson<GrepRequest>,
+    headers: HeaderMap,
+    query: AppQuery<GrepQuery>,
 ) -> Result<Json<GrepResponse>, ApiResponseError> {
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
+    let request = grep_request(query.into_params()?)?;
     // First touch: on a deployment that maintains this index, a search is
     // also the hint that someone cares about this namespace again — after a
     // restart, nothing else has said so.
@@ -62,6 +90,54 @@ pub(super) async fn grep(
         .await
         .map_err(|error| map_grep_error(&namespace_id, error))?;
     Ok(Json(response))
+}
+
+fn grep_request(query: GrepQuery) -> Result<GrepRequest, ApiResponseError> {
+    let pattern = required_query_param(query.pattern, "pattern")?;
+    if pattern.len() > MAX_GREP_PATTERN_BYTES {
+        return Err(ApiResponseError::new(
+            StatusCode::BAD_REQUEST,
+            loonfs_api::ErrorCode::InvalidRequest,
+            &format!(
+                "grep pattern is {} bytes; the maximum is {MAX_GREP_PATTERN_BYTES} bytes",
+                pattern.len()
+            ),
+        )
+        .with_param("pattern"));
+    }
+    let path_prefix = query
+        .path_prefix
+        .map(|value| {
+            loonfs_api::AbsolutePath::parse(&value).map_err(|error| {
+                ApiResponseError::new(
+                    StatusCode::BAD_REQUEST,
+                    loonfs_api::ErrorCode::InvalidRequest,
+                    &error.to_string(),
+                )
+                .with_param("path_prefix")
+            })
+        })
+        .transpose()?;
+    let limit = query
+        .limit
+        .map(|value| resolve_page_limit(Some(value)).map(|limit| limit.get()))
+        .transpose()?;
+    Ok(GrepRequest {
+        pattern,
+        case_insensitive: parse_optional_boolean(query.case_insensitive, "case_insensitive")?,
+        path_prefix,
+        cursor: query.cursor,
+        limit,
+        allow_stale: parse_optional_boolean(query.allow_stale, "allow_stale")?,
+        allow_scan: parse_optional_boolean(query.allow_scan, "allow_scan")?,
+    })
+}
+
+fn parse_optional_boolean(value: Option<String>, name: &str) -> Result<bool, ApiResponseError> {
+    value
+        .as_deref()
+        .map(|value| parse_boolean_query_param(value, name))
+        .unwrap_or(Ok(false))
 }
 
 /// Absent-capability response where this deployment answers no searches.
@@ -299,7 +375,7 @@ fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> A
             );
             let response = ApiResponseError::runtime_for_namespace(namespace_id, error);
             if cursor_is_invalid {
-                response.with_param("/cursor")
+                response.with_param("cursor")
             } else {
                 response
             }

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -34,7 +34,7 @@ use self::error::ApiResponseError;
 use self::extractors::{
     authorize, server_busy_error, AppJson, AppPath, AppQuery, NamespaceIdPath, OptionalAppJson,
     UploadBodyBytes, UploadBodyStream, UploadControlJson, MAX_COMPLETION_BODY_BYTES,
-    MAX_UPLOAD_CONTROL_BODY_BYTES,
+    MAX_GREP_PATTERN_BYTES, MAX_UPLOAD_CONTROL_BODY_BYTES,
 };
 use self::handlers_downloads::{begin_download, begin_download_by_inode};
 use self::handlers_filesystem::{
@@ -195,9 +195,9 @@ fn router(state: AppState) -> Router {
     let serves_grep = state.config.grep.mode.serves_grep();
     let maintains_index = state.config.grep.mode.maintains_index();
     let grep_route = if serves_grep {
-        post(grep)
+        get(grep)
     } else {
-        post(grep_queries_not_served)
+        get(grep_queries_not_served)
     };
     let enable_grep_route = if maintains_index {
         post(enable_grep_index)

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2029,28 +2029,22 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
     }
 
     // Invalid grep path prefixes return invalid_request after authentication.
-    let grep_url = format!("http://{addr}/v0/namespaces/demo/query/grep");
-    let invalid_grep = r#"{"pattern":"needle","path_prefix":"relative"}"#;
+    let grep_url =
+        format!("http://{addr}/v0/namespaces/demo/query/grep?pattern=needle&path_prefix=relative");
     let body = expect_enveloped(
         || {
             raw_agent()
-                .post(&grep_url)
+                .get(&grep_url)
                 .set("authorization", "Bearer test-token")
-                .set("content-type", "application/json")
-                .send_string(invalid_grep)
+                .call()
         },
         "invalid grep path should answer 400",
         400,
         "invalid_request",
     );
-    assert_eq!(body["param"], "/path_prefix");
+    assert_eq!(body["param"], "path_prefix");
     expect_enveloped(
-        || {
-            raw_agent()
-                .post(&grep_url)
-                .set("content-type", "application/json")
-                .send_string(invalid_grep)
-        },
+        || raw_agent().get(&grep_url).call(),
         "authorization should precede grep path decoding",
         401,
         "unauthorized",

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -9,11 +9,10 @@ use loonfs::{CreateNamespaceOptions, FsWriter, PutFileOptions};
 use loonfs::{FsAdmin, FsReader};
 use loonfs_api::v0::{GrepGcResponse, GrepIndexLifecycle, GrepIndexStatusResponse};
 use loonfs_api::{
-    ApiError, CapabilityDocument, ChangeSeq, GrepRequest, GrepResponse, NamespaceId,
-    FEATURE_ADMIN_GREP_INDEX, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_QUERY_GREP,
-    FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_QUERY_GREP_DEFAULT,
-    LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
-    PROFILE_QUERY_V0,
+    ApiError, CapabilityDocument, ChangeSeq, GrepResponse, NamespaceId, FEATURE_ADMIN_GREP_INDEX,
+    FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_MULTIPART,
+    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX,
+    LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES, PROFILE_QUERY_V0,
 };
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
 use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker, GREP_INDEX_JOB};
@@ -55,7 +54,7 @@ async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
     // the key whose absence the client just read.
     assert_not_supported(
         &router,
-        Method::POST,
+        Method::GET,
         &query_path(&namespace_id),
         None,
         FEATURE_QUERY_GREP,
@@ -72,6 +71,74 @@ async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
         FEATURE_ADMIN_GREP_INDEX,
     )
     .await;
+    server.shutdown().await.expect("settle the server writer");
+}
+
+#[tokio::test]
+async fn grep_get_query_parameters_use_the_list_route_grammar() {
+    let temp_dir = tempdir().expect("store tempdir");
+    let (_store, _writer, namespace_id) = seed_namespace(temp_dir.path(), "query-grammar").await;
+    let (router, server, _local_cache) = app(test_config(temp_dir.path(), GrepMode::ServeOnly))
+        .await
+        .expect("build app");
+    let path = query_path(&namespace_id);
+
+    let response = send(&router, Method::GET, &path, None).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error: ApiError = response_json(response).await;
+    assert_eq!(error.code, "invalid_request");
+    assert_eq!(error.param.as_deref(), Some("pattern"));
+
+    for name in ["case_insensitive", "allow_scan", "allow_stale"] {
+        for value in ["yes", "1", "TRUE", ""] {
+            let response = send(
+                &router,
+                Method::GET,
+                &format!("{path}?pattern=needle&{name}={value}"),
+                None,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let error: ApiError = response_json(response).await;
+            assert_eq!(error.code, "invalid_request");
+            assert_eq!(error.param.as_deref(), Some(name));
+        }
+        for value in ["true", "false"] {
+            let response = send(
+                &router,
+                Method::GET,
+                &format!("{path}?pattern=needle&{name}={value}"),
+                None,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+        }
+    }
+
+    let at_bound = "n".repeat(1024);
+    let response = send(
+        &router,
+        Method::GET,
+        &format!("{path}?pattern={at_bound}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+
+    let over_bound = "n".repeat(1025);
+    let response = send(
+        &router,
+        Method::GET,
+        &format!("{path}?pattern={over_bound}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error: ApiError = response_json(response).await;
+    assert_eq!(error.code, "invalid_request");
+    assert_eq!(error.param.as_deref(), Some("pattern"));
+    assert!(error.message.contains("maximum is 1024 bytes"));
+
     server.shutdown().await.expect("settle the server writer");
 }
 
@@ -326,12 +393,9 @@ async fn first_query_after_restart_resumes_stale_and_mid_backfill_namespaces() {
 
     let not_materialized = send(
         &router,
-        Method::POST,
-        &format!("/v0/namespaces/{backfill}/query/grep"),
-        Some(
-            serde_json::to_vec(&grep_request("mid-backfill needle"))
-                .expect("serialize grep request"),
-        ),
+        Method::GET,
+        &query_path_with_pattern(&backfill, "mid-backfill needle"),
+        None,
     )
     .await;
     assert!(
@@ -449,9 +513,9 @@ async fn maintain_only_keeps_the_index_built_without_serving_searches() {
     );
     let error = assert_not_supported(
         &router,
-        Method::POST,
+        Method::GET,
         &query_path(&namespace_id),
-        Some(serde_json::to_vec(&grep_request("needle")).expect("serialize grep request")),
+        None,
         FEATURE_QUERY_GREP,
     )
     .await;
@@ -665,6 +729,14 @@ fn query_path(namespace_id: &NamespaceId) -> String {
     format!("/v0/namespaces/{namespace_id}/query/grep")
 }
 
+fn query_path_with_pattern(namespace_id: &NamespaceId, pattern: &str) -> String {
+    format!(
+        "{}?pattern={}",
+        query_path(namespace_id),
+        pattern.replace(' ', "%20")
+    )
+}
+
 fn admin_grep_paths(namespace_id: &NamespaceId) -> Vec<String> {
     ["enable", "disable", "gc"]
         .into_iter()
@@ -706,29 +778,16 @@ async fn disable_grep(router: &Router, namespace_id: &NamespaceId) -> GrepIndexS
 }
 
 async fn grep(router: &Router, namespace_id: &NamespaceId, pattern: &str) -> GrepResponse {
-    let request = grep_request(pattern);
     response_json(
         send(
             router,
-            Method::POST,
-            &format!("/v0/namespaces/{namespace_id}/query/grep"),
-            Some(serde_json::to_vec(&request).expect("serialize grep request")),
+            Method::GET,
+            &query_path_with_pattern(namespace_id, pattern),
+            None,
         )
         .await,
     )
     .await
-}
-
-fn grep_request(pattern: &str) -> GrepRequest {
-    GrepRequest {
-        pattern: pattern.to_owned(),
-        case_insensitive: false,
-        path_prefix: None,
-        cursor: None,
-        limit: None,
-        allow_stale: false,
-        allow_scan: false,
-    }
 }
 
 async fn drive_worker_to_current(

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -754,6 +754,7 @@ fn openapi_query_parameters_publish_the_runtime_grammar() {
         ("/v0/namespaces/{namespace_id}/filesystem/trash", "get"),
         ("/v0/admin/namespaces/{namespace_id}/checkpoints", "get"),
         ("/v0/namespaces/{namespace_id}/changes", "get"),
+        ("/v0/namespaces/{namespace_id}/query/grep", "get"),
     ] {
         let parameter = query_parameter(paths, path, method, "limit");
         assert_eq!(parameter.get("required"), Some(&Value::Bool(false)));
@@ -779,6 +780,21 @@ fn openapi_query_parameters_publish_the_runtime_grammar() {
             Some(default)
         );
     }
+
+    let grep_path = "/v0/namespaces/{namespace_id}/query/grep";
+    for name in ["case_insensitive", "allow_scan", "allow_stale"] {
+        let parameter = query_parameter(paths, grep_path, "get", name);
+        assert_eq!(parameter.get("required"), Some(&Value::Bool(false)));
+        let schema = parameter.get("schema").expect("grep boolean schema");
+        assert_eq!(schema.get("type").and_then(Value::as_str), Some("boolean"));
+        assert_eq!(schema.get("default").and_then(Value::as_bool), Some(false));
+    }
+    let pattern = query_parameter(paths, grep_path, "get", "pattern");
+    assert_eq!(pattern.get("required"), Some(&Value::Bool(true)));
+    assert!(pattern
+        .get("description")
+        .and_then(Value::as_str)
+        .is_some_and(|description| description.contains("1024 bytes")));
 
     for (path, method, parameter_name, schema_name, required) in [
         (

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -666,8 +666,8 @@ fn cursor_list_operations_publish_the_registered_pagination_metadata() {
             (
                 metadata.operation_id,
                 serde_json::json!({
-                    "cursor": format!("$request.{}", metadata.cursor_parameter),
-                    "next_cursor": format!("$response.{}", metadata.next_field),
+                    "cursor": "$request.cursor",
+                    "next_cursor": "$response.next_cursor",
                     "results": format!("$response.{}", metadata.results_field),
                 }),
             )

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -319,7 +319,7 @@ feature, and the namespace's verified grep root shows the index
 materialized for the data being served. Missing either half is
 the existing `not_supported` response with the feature named.
 
-The endpoint is `POST /v0/namespaces/{ns}/query/grep`. The
+The endpoint is `GET /v0/namespaces/{ns}/query/grep`. The
 request carries the pattern, a case-insensitivity flag, an
 optional path prefix to scope the search, a page cursor, and
 limits. The pattern dialect is the Rust `regex` crate's — no

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -26,7 +26,7 @@ within a plane is expressed as **named features** (section 2).
 | --- | --- | --- | --- |
 | `core/v0` | Data plane | Path and inode reads (stat, list, content, revisions), path mutations, staged uploads, the change feed, namespace state by id, `GET /v0/capabilities`, and the standard error contract. Namespace `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
 | `admin/v0` | Maintenance plane | Read namespace storage diagnostics; create and release checkpoints; run one-shot maintenance steps that select any of metadata upkeep (WAL flush plus reorganization), retention-floor advancement, and garbage collection. Maintenance triggers for derived indexes arrive as features in this plane: grep-index administration is the `admin.grep.index` **feature**. | Optional |
-| `query/v0` | Query plane | Content search over derived indexes (`POST /v0/namespaces/{namespace_id}/query/grep`). Grep-index search is the `query.grep` **feature** within this profile; using it also requires a materialized active grep root for the namespace. | Optional |
+| `query/v0` | Query plane | Content search over derived indexes (`GET /v0/namespaces/{namespace_id}/query/grep`). Grep-index search is the `query.grep` **feature** within this profile; using it also requires a materialized active grep root for the namespace. | Optional |
 | `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. Clients must tolerate unknown error codes, so authorization errors can land with this plane without breaking anyone. |
 
 Notes:
@@ -161,7 +161,7 @@ hoc.
 | `core.uploads.direct_put.checksum.<algorithm>` | Nothing on its own; it names the whole-object checksum a `direct_put` claim must carry. | Exactly one is advertised, alongside `core.uploads.direct_put`, and only ever `true`. Registered algorithms are `sha256`, `crc64nvme`, and `crc32c`, matching the `checksum.algorithm` spellings. Providers do not agree on what they can bind into a presigned write, so the deployment names it and the client folds that digest while staging; a claim in any other algorithm answers `invalid_request` at begin. |
 | `core.uploads.direct_multipart` | Starting presigned `direct_multipart` upload sessions (`POST /v0/namespaces/{ns}/uploads`) and signing their parts (`POST /v0/namespaces/{ns}/uploads/{upload_id}/parts`). | The server opens the provider's multipart upload and returns one short-lived, checksum-bound capability per part. It needs an S3-style multipart API on top of the signing the other keys need, so a provider without one advertises this key alone as absent. |
 | `core.downloads.direct_get` | Taking path or inode download grants (`POST /v0/namespaces/{ns}/filesystem/downloads` and `POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads`). | The server returns a short-lived presigned GET capability for the selected content object. Any deployment that offers a direct write advertises this too, because one that lets a client create an object larger than `download.max_content_bytes` must be able to hand that object back. Raw object keys are not part of this feature. |
-| `query.grep` | Content search (`POST /v0/namespaces/{ns}/query/grep`). | The serving half of a data-dependent capability: the request also requires a materialized active grep root, and a namespace without one answers `not_supported` whatever this key advertises. |
+| `query.grep` | Content search (`GET /v0/namespaces/{ns}/query/grep`). | The serving half of a data-dependent capability: the request also requires a materialized active grep root, and a namespace without one answers `not_supported` whatever this key advertises. |
 
 `admin/v0`'s only feature key is `admin.grep.index`; the rest of that plane
 is required ops. `acl.*` keys are unregistered until that plane
@@ -723,7 +723,7 @@ The table below lists the retry class for every v0 operation.
 | List checkpoints | `list_checkpoints` | `safe` | `GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` |
 | Release a checkpoint | `release_checkpoint` | `safe` | `POST /v0/admin/namespaces/{ns}/checkpoints/{checkpoint_id}/release` (idempotent and one-way; fork-owned records are rejected) |
 | Run maintenance | `maintenance_step` | `new_attempt` | `POST /v0/admin/namespaces/{ns}/maintenance/step` |
-| Search file contents | `grep` | `safe` | `POST /v0/namespaces/{ns}/query/grep`; requires the `query.grep` feature and an active index |
+| Search file contents | `grep` | `safe` | `GET /v0/namespaces/{ns}/query/grep?pattern=needle&case_insensitive=false&path_prefix=%2Fsrc&allow_scan=false&allow_stale=false&limit=100&cursor=...`; requires the `query.grep` feature and an active index |
 | Read grep index status | `get_grep_index_status` | `safe` | `GET /v0/admin/namespaces/{ns}/grep/index` |
 | Enable the grep index | `enable_grep_index` | `safe` | `POST /v0/admin/namespaces/{ns}/grep/index/enable`; idempotent |
 | Disable the grep index | `disable_grep_index` | `safe` | `POST /v0/admin/namespaces/{ns}/grep/index/disable`; idempotent |
@@ -2361,17 +2361,12 @@ same `namespace_exists` or `namespace_deleted` error as namespace creation.
 If the source checkpoint disappears before the operation completes, the
 server deletes the new target and returns `checkpoint_unavailable`.
 
-### 6.13 `POST /query/grep`
+### 6.13 `GET /query/grep`
 
 Representative request:
 
-```json
-{
-  "pattern": "fn (grep|search)",
-  "case_insensitive": false,
-  "path_prefix": "/src",
-  "limit": 100
-}
+```http
+GET /query/grep?pattern=fn%20%28grep%7Csearch%29&case_insensitive=false&path_prefix=%2Fsrc&limit=100
 ```
 
 Representative response:

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -142,12 +142,7 @@
             }
           }
         },
-        "x-loonfs-retry": "safe",
-        "x-fern-pagination": {
-          "cursor": "$request.after_seq",
-          "next_cursor": "$response.next_after_seq",
-          "results": "$response.changes"
-        }
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/mounts/{mount}/commits": {

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -898,7 +898,7 @@
       }
     },
     "/v0/mounts/{mount}/query/grep": {
-      "post": {
+      "get": {
         "tags": [
           "query"
         ],
@@ -914,18 +914,78 @@
             "schema": {
               "type": "string"
             }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GrepRequest"
-              }
+          },
+          {
+            "name": "pattern",
+            "in": "query",
+            "description": "Pattern in the Rust `regex` crate's dialect. Its UTF-8 encoding must be at most 1024 bytes.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           },
-          "required": true
-        },
+          {
+            "name": "case_insensitive",
+            "in": "query",
+            "description": "Match case-insensitively (`true` or `false`). Defaults to `false`.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "path_prefix",
+            "in": "query",
+            "description": "Complete absolute path used to restrict matches.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "allow_scan",
+            "in": "query",
+            "description": "Permit a capped exhaustive scan when the pattern has no required grams (`true` or `false`). Defaults to `false`.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "allow_stale",
+            "in": "query",
+            "description": "Return indexed-only results when the unindexed tail exceeds the scan budget (`true` or `false`). Defaults to `false`.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum matches per page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque grep page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "One page of matches",
@@ -1021,7 +1081,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.matches"
+        }
       }
     },
     "/v0/mounts/{mount}/uploads": {
@@ -2709,52 +2774,6 @@
             "description": "The matched revision (the newest visible one at the snapshot)."
           }
         }
-      },
-      "GrepRequest": {
-        "type": "object",
-        "description": "One content-search request.\n\nEvery field but `pattern` is optional, and each one selects results. A\nmisspelled `case_insensitive` or `path_prefix` would decode to the default\nand answer a different search than the caller asked for, with no sign that\nanything was dropped, so unknown fields are rejected.",
-        "required": [
-          "pattern"
-        ],
-        "properties": {
-          "allow_scan": {
-            "type": "boolean",
-            "description": "Permit a capped exhaustive scan when the pattern yields no required\ngrams. Refused beyond the server's scan budget."
-          },
-          "allow_stale": {
-            "type": "boolean",
-            "description": "When the unindexed tail exceeds the scan budget, return\nindexed-only results (reported via `tail_scanned: false`) instead\nof failing with `index_lagging`."
-          },
-          "case_insensitive": {
-            "type": "boolean",
-            "description": "Match case-insensitively. Verification is exact; the index remains\nconsulted through its case-folded grams."
-          },
-          "cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Resume cursor from a previous page. The cursor resumes strictly\nafter the last candidate the issuing page finished scanning and is\nbound to that page's request; each page is evaluated against the\nnamespace head at page time."
-          },
-          "limit": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32",
-            "description": "Maximum matches per page.",
-            "minimum": 0
-          },
-          "path_prefix": {
-            "$ref": "#/components/schemas/AbsolutePath",
-            "description": "Restrict matches to files under this complete absolute path, resolved\nto a directory inode before candidates are filtered."
-          },
-          "pattern": {
-            "type": "string",
-            "description": "The pattern, in the Rust `regex` crate's dialect (no backreferences\nor lookaround). Patterns that require no literal bytes are rejected\nwith `query_unindexable` unless `allow_scan` is set."
-          }
-        },
-        "additionalProperties": false
       },
       "GrepResponse": {
         "type": "object",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1339,12 +1339,7 @@
             }
           }
         },
-        "x-loonfs-retry": "safe",
-        "x-fern-pagination": {
-          "cursor": "$request.after_seq",
-          "next_cursor": "$response.next_after_seq",
-          "results": "$response.changes"
-        }
+        "x-loonfs-retry": "safe"
       }
     },
     "/v0/namespaces/{namespace_id}/commits": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2671,7 +2671,7 @@
       }
     },
     "/v0/namespaces/{namespace_id}/query/grep": {
-      "post": {
+      "get": {
         "tags": [
           "query"
         ],
@@ -2687,18 +2687,78 @@
             "schema": {
               "type": "string"
             }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GrepRequest"
-              }
+          },
+          {
+            "name": "pattern",
+            "in": "query",
+            "description": "Pattern in the Rust `regex` crate's dialect. Its UTF-8 encoding must be at most 1024 bytes.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           },
-          "required": true
-        },
+          {
+            "name": "case_insensitive",
+            "in": "query",
+            "description": "Match case-insensitively (`true` or `false`). Defaults to `false`.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "path_prefix",
+            "in": "query",
+            "description": "Complete absolute path used to restrict matches.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "allow_scan",
+            "in": "query",
+            "description": "Permit a capped exhaustive scan when the pattern has no required grams (`true` or `false`). Defaults to `false`.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "allow_stale",
+            "in": "query",
+            "description": "Return indexed-only results when the unindexed tail exceeds the scan budget (`true` or `false`). Defaults to `false`.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum matches per page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque grep page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "One page of matches",
@@ -2794,7 +2854,12 @@
             }
           }
         },
-        "x-loonfs-retry": "safe"
+        "x-loonfs-retry": "safe",
+        "x-fern-pagination": {
+          "cursor": "$request.cursor",
+          "next_cursor": "$response.next_cursor",
+          "results": "$response.matches"
+        }
       }
     },
     "/v0/namespaces/{namespace_id}/uploads": {
@@ -5009,7 +5074,7 @@
           },
           "pattern": {
             "type": "string",
-            "description": "The pattern, in the Rust `regex` crate's dialect (no backreferences\nor lookaround). Patterns that require no literal bytes are rejected\nwith `query_unindexable` unless `allow_scan` is set."
+            "description": "The pattern, in the Rust `regex` crate's dialect (no backreferences\nor lookaround). Its UTF-8 encoding must be at most 1024 bytes.\nPatterns that require no literal bytes are rejected with\n`query_unindexable` unless `allow_scan` is set."
           }
         },
         "additionalProperties": false

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -330,29 +330,32 @@ func runPagination(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	observed := make([]string, 0, len(request.EntryNames))
-	var cursor *string
 	pageCount := 0
 	var savedCursor *string
 	resumeOffset := -1
+	ctx := context.Background()
+	page, err := h.client.Filesystem.ListPathEntries(
+		ctx,
+		&loonfs.ListPathEntriesRequest{
+			NamespaceID: request.NamespaceID,
+			Path:        request.Directory,
+			Limit:       &request.PageSize,
+		},
+	)
+	if err != nil {
+		t.Fatalf("list first pagination page: %v", err)
+	}
+	var cursor *string
 	for {
-		page, err := h.client.Filesystem.ListPathEntries(
-			context.Background(),
-			&loonfs.ListPathEntriesRequest{
-				NamespaceID: request.NamespaceID,
-				Path:        request.Directory,
-				Limit:       &request.PageSize,
-				Cursor:      cursor,
-			},
-		)
-		if err != nil {
-			t.Fatalf("list pagination page: %v", err)
+		if page.Response == nil {
+			t.Fatal("pagination page has no response")
 		}
 		pageCount++
-		if int64(page.HeadSeq) != expected.HeadSeq {
-			t.Errorf("page %d head_seq = %d, want %d", pageCount, page.HeadSeq, expected.HeadSeq)
+		if int64(page.Response.HeadSeq) != expected.HeadSeq {
+			t.Errorf("page %d head_seq = %d, want %d", pageCount, page.Response.HeadSeq, expected.HeadSeq)
 		}
-		observed = append(observed, listedNames(t, page.Entries)...)
-		cursor = page.NextCursor
+		observed = append(observed, listedNames(t, page.Results)...)
+		cursor = page.Response.NextCursor
 		if pageCount == request.ResumeAfterPage {
 			if cursor != nil {
 				value := *cursor
@@ -362,6 +365,10 @@ func runPagination(t *testing.T, h *harness, testCase conformanceCase) {
 		}
 		if cursor == nil {
 			break
+		}
+		page, err = page.GetNextPage(ctx)
+		if err != nil {
+			t.Fatalf("list next pagination page: %v", err)
 		}
 	}
 	if len(observed) != expected.EntryCount {
@@ -381,24 +388,30 @@ func runPagination(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	resumed := make([]string, 0, len(request.EntryNames)-resumeOffset)
-	cursor = savedCursor
+	page, err = h.client.Filesystem.ListPathEntries(
+		ctx,
+		&loonfs.ListPathEntriesRequest{
+			NamespaceID: request.NamespaceID,
+			Path:        request.Directory,
+			Limit:       &request.PageSize,
+			Cursor:      savedCursor,
+		},
+	)
+	if err != nil {
+		t.Fatalf("resume pagination: %v", err)
+	}
 	for {
-		page, err := h.client.Filesystem.ListPathEntries(
-			context.Background(),
-			&loonfs.ListPathEntriesRequest{
-				NamespaceID: request.NamespaceID,
-				Path:        request.Directory,
-				Limit:       &request.PageSize,
-				Cursor:      cursor,
-			},
-		)
-		if err != nil {
-			t.Fatalf("resume pagination page: %v", err)
+		if page.Response == nil {
+			t.Fatal("resumed pagination page has no response")
 		}
-		resumed = append(resumed, listedNames(t, page.Entries)...)
-		cursor = page.NextCursor
+		resumed = append(resumed, listedNames(t, page.Results)...)
+		cursor = page.Response.NextCursor
 		if cursor == nil {
 			break
+		}
+		page, err = page.GetNextPage(ctx)
+		if err != nil {
+			t.Fatalf("resume next pagination page: %v", err)
 		}
 	}
 	if err := validatePageWalk(request.EntryNames, observed, resumeOffset, resumed); err != nil {


### PR DESCRIPTION
Moves grep to GET query parameters so SDK generators can expose the endpoint through their normal cursor pager. The public client API and retry behavior stay the same. Patterns longer than 1,024 bytes now return the existing invalid-pattern error, which sets a clear bound for URL-carried requests.

Adds grep’s `cursor` and `next_cursor` contract to the generated OpenAPI documents. `list_changes` remains outside generated pagination because the pinned Fern Go generator cannot combine its required `after_seq` request value with its optional `next_after_seq` response value. `gc_grep_index` remains outside because its cursor resumes maintenance work rather than paging through results. All supported paginated operations now use the same metadata shape.

Regenerates both OpenAPI documents and updates Go conformance coverage to consume `page.Results`, inspect metadata through `page.Response`, and advance with `GetNextPage`. The OpenAPI tests and Go SDK conformance suite pass locally.