### PR TITLE
test(sdk): run the conformance corpus through the Python and TypeScript SDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,54 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-sdk-conformance-
       - run: scripts/run-sdk-conformance.sh go
 
+  sdk-conformance-python:
+    name: SDK conformance (Python)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: scripts/generate-sdks.sh python
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-python-sdk-conformance-${{ hashFiles('sdk/conformance/python/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-python-sdk-conformance-
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-sdk-conformance-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-sdk-conformance-
+      - run: scripts/run-sdk-conformance.sh python
+
+  sdk-conformance-typescript:
+    name: SDK conformance (TypeScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: scripts/generate-sdks.sh typescript
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-typescript-sdk-conformance-${{ hashFiles('sdk/conformance/typescript/package.json') }}
+          restore-keys: ${{ runner.os }}-typescript-sdk-conformance-
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-sdk-conformance-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-sdk-conformance-
+      - run: scripts/run-sdk-conformance.sh typescript
+
   # Checks the declared minimum supported Rust version actually builds the
   # workspace. Keep the toolchain here in sync with `rust-version` in the
   # workspace Cargo.toml.

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -8,16 +8,13 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-/// Authoritative metadata for one visible path.
+/// Metadata for one path returned by stat and directory-listing operations.
 ///
-/// This is the result shape for stat/list style reads. The entry kind carries
-/// the file-only revision and content summary, so a directory cannot carry a
-/// partial file payload. Attributes are likewise projected as one value or
-/// omitted as one value, while serializing as prefixed sibling fields.
-/// The attribute revision is read independently — clients feed it to
-/// `expected_attributes_revision_no` on the next write without touching the
-/// values — so this is a prefixed-sibling projection rather than a value
-/// consumed as one nested unit.
+/// File entries include the current revision and content details. Directory
+/// entries do not. Attribute fields are included only when requested and are
+/// serialized at the top level of the entry. Callers can pass
+/// `attributes_revision_no` as `expected_attributes_revision_no` when updating
+/// attributes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AuthoritativePathEntry {
@@ -158,13 +155,11 @@ impl AuthoritativePathEntryKind {
     }
 }
 
-/// One inode's structurally complete attribute projection.
+/// Attributes returned for one inode.
 ///
-/// The projection appears only flattened into `AuthoritativePathEntry`, where
-/// the whole group is omitted unless the caller asks for attributes. The two
-/// always-present fields are therefore marked not-required in the document:
-/// `allOf` composition cannot express an optional flattened group any other
-/// way.
+/// A path entry omits this entire group unless the caller requests attributes.
+/// OpenAPI flattens these fields with `allOf`, so none of them can be marked as
+/// required on every path entry.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AttributesProjection {

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -159,10 +159,17 @@ impl AuthoritativePathEntryKind {
 }
 
 /// One inode's structurally complete attribute projection.
+///
+/// The projection appears only flattened into `AuthoritativePathEntry`, where
+/// the whole group is omitted unless the caller asks for attributes. The two
+/// always-present fields are therefore marked not-required in the document:
+/// `allOf` composition cannot express an optional flattened group any other
+/// way.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AttributesProjection {
     /// The attribute revision this projection represents.
+    #[cfg_attr(feature = "openapi", schema(required = false))]
     pub attributes_revision_no: AttributeRevisionNo,
     /// Actor responsible for the latest attribute update. This is `None` for
     /// the initial empty state at revision 0.
@@ -177,6 +184,7 @@ pub struct AttributesProjection {
     ///
     /// An inode that has never had attributes written is at revision 0 with
     /// an empty map.
+    #[cfg_attr(feature = "openapi", schema(required = false))]
     pub attributes: Attributes,
 }
 

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -1407,8 +1407,7 @@ fn openapi_flattens_the_path_entry_attribute_projection() {
     let required = required_fields(projection);
     assert!(
         !required.contains("attributes_revision_no") && !required.contains("attributes"),
-        "the projection is optionally flattened into the entry, and allOf merges \
-         required lists, so its fields must stay not required in the document"
+        "path entries may omit attribute fields when attributes are not requested"
     );
 
     let path_entry = schemas

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -1405,8 +1405,11 @@ fn openapi_flattens_the_path_entry_attribute_projection() {
     assert!(projection_properties.contains_key("attributes_revision_no"));
     assert!(projection_properties.contains_key("attributes"));
     let required = required_fields(projection);
-    assert!(required.contains("attributes_revision_no"));
-    assert!(required.contains("attributes"));
+    assert!(
+        !required.contains("attributes_revision_no") && !required.contains("attributes"),
+        "the projection is optionally flattened into the entry, and allOf merges \
+         required lists, so its fields must stay not required in the document"
+    );
 
     let path_entry = schemas
         .get("AuthoritativePathEntry")

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -1857,11 +1857,7 @@
       },
       "AttributesProjection": {
         "type": "object",
-        "description": "One inode's structurally complete attribute projection.",
-        "required": [
-          "attributes_revision_no",
-          "attributes"
-        ],
+        "description": "One inode's structurally complete attribute projection.\n\nThe projection appears only flattened into `AuthoritativePathEntry`, where\nthe whole group is omitted unless the caller asks for attributes. The two\nalways-present fields are therefore marked not-required in the document:\n`allOf` composition cannot express an optional flattened group any other\nway.",
         "properties": {
           "attributes": {
             "$ref": "#/components/schemas/Attributes",

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -1857,7 +1857,7 @@
       },
       "AttributesProjection": {
         "type": "object",
-        "description": "One inode's structurally complete attribute projection.\n\nThe projection appears only flattened into `AuthoritativePathEntry`, where\nthe whole group is omitted unless the caller asks for attributes. The two\nalways-present fields are therefore marked not-required in the document:\n`allOf` composition cannot express an optional flattened group any other\nway.",
+        "description": "Attributes returned for one inode.\n\nA path entry omits this entire group unless the caller requests attributes.\nOpenAPI flattens these fields with `allOf`, so none of them can be marked as\nrequired on every path entry.",
         "properties": {
           "attributes": {
             "$ref": "#/components/schemas/Attributes",
@@ -1944,7 +1944,7 @@
             }
           }
         ],
-        "description": "Authoritative metadata for one visible path.\n\nThis is the result shape for stat/list style reads. The entry kind carries\nthe file-only revision and content summary, so a directory cannot carry a\npartial file payload. Attributes are likewise projected as one value or\nomitted as one value, while serializing as prefixed sibling fields.\nThe attribute revision is read independently — clients feed it to\n`expected_attributes_revision_no` on the next write without touching the\nvalues — so this is a prefixed-sibling projection rather than a value\nconsumed as one nested unit."
+        "description": "Metadata for one path returned by stat and directory-listing operations.\n\nFile entries include the current revision and content details. Directory\nentries do not. Attribute fields are included only when requested and are\nserialized at the top level of the entry. Callers can pass\n`attributes_revision_no` as `expected_attributes_revision_no` when updating\nattributes."
       },
       "AuthoritativePathEntryKind": {
         "oneOf": [

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3643,7 +3643,7 @@
       },
       "AttributesProjection": {
         "type": "object",
-        "description": "One inode's structurally complete attribute projection.\n\nThe projection appears only flattened into `AuthoritativePathEntry`, where\nthe whole group is omitted unless the caller asks for attributes. The two\nalways-present fields are therefore marked not-required in the document:\n`allOf` composition cannot express an optional flattened group any other\nway.",
+        "description": "Attributes returned for one inode.\n\nA path entry omits this entire group unless the caller requests attributes.\nOpenAPI flattens these fields with `allOf`, so none of them can be marked as\nrequired on every path entry.",
         "properties": {
           "attributes": {
             "$ref": "#/components/schemas/Attributes",
@@ -3730,7 +3730,7 @@
             }
           }
         ],
-        "description": "Authoritative metadata for one visible path.\n\nThis is the result shape for stat/list style reads. The entry kind carries\nthe file-only revision and content summary, so a directory cannot carry a\npartial file payload. Attributes are likewise projected as one value or\nomitted as one value, while serializing as prefixed sibling fields.\nThe attribute revision is read independently — clients feed it to\n`expected_attributes_revision_no` on the next write without touching the\nvalues — so this is a prefixed-sibling projection rather than a value\nconsumed as one nested unit."
+        "description": "Metadata for one path returned by stat and directory-listing operations.\n\nFile entries include the current revision and content details. Directory\nentries do not. Attribute fields are included only when requested and are\nserialized at the top level of the entry. Callers can pass\n`attributes_revision_no` as `expected_attributes_revision_no` when updating\nattributes."
       },
       "AuthoritativePathEntryKind": {
         "oneOf": [

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3643,11 +3643,7 @@
       },
       "AttributesProjection": {
         "type": "object",
-        "description": "One inode's structurally complete attribute projection.",
-        "required": [
-          "attributes_revision_no",
-          "attributes"
-        ],
+        "description": "One inode's structurally complete attribute projection.\n\nThe projection appears only flattened into `AuthoritativePathEntry`, where\nthe whole group is omitted unless the caller asks for attributes. The two\nalways-present fields are therefore marked not-required in the document:\n`allOf` composition cannot express an optional flattened group any other\nway.",
         "properties": {
           "attributes": {
             "$ref": "#/components/schemas/Attributes",

--- a/scripts/run-sdk-conformance.sh
+++ b/scripts/run-sdk-conformance.sh
@@ -74,9 +74,29 @@ case "$LANGUAGE" in
             HARNESS_STATUS=$?
         fi
         ;;
-    python|typescript)
-        echo "harness not present yet" >&2
-        HARNESS_STATUS=1
+    python)
+        PYTHON_HARNESS="$REPO_ROOT/sdk/conformance/python"
+        if [ ! -d "$PYTHON_HARNESS/.venv" ]; then
+            python3 -m venv "$PYTHON_HARNESS/.venv"
+        fi
+        "$PYTHON_HARNESS/.venv/bin/pip" install -q -r "$PYTHON_HARNESS/requirements.txt"
+        if PYTHONPATH="$PYTHON_HARNESS" \
+            "$PYTHON_HARNESS/.venv/bin/python" -m pytest "$PYTHON_HARNESS/test_conformance.py"; then
+            HARNESS_STATUS=0
+        else
+            HARNESS_STATUS=$?
+        fi
+        ;;
+    typescript)
+        TYPESCRIPT_HARNESS="$REPO_ROOT/sdk/conformance/typescript"
+        if [ ! -d "$TYPESCRIPT_HARNESS/node_modules" ]; then
+            (cd "$TYPESCRIPT_HARNESS" && npm install --no-fund --no-audit)
+        fi
+        if (cd "$TYPESCRIPT_HARNESS" && npm run build && npm test); then
+            HARNESS_STATUS=0
+        else
+            HARNESS_STATUS=$?
+        fi
         ;;
 esac
 

--- a/sdk/conformance/python/.gitignore
+++ b/sdk/conformance/python/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+__pycache__/

--- a/sdk/conformance/python/loonfs_sdk
+++ b/sdk/conformance/python/loonfs_sdk
@@ -1,0 +1,1 @@
+../../generated/python

--- a/sdk/conformance/python/requirements.txt
+++ b/sdk/conformance/python/requirements.txt
@@ -1,0 +1,6 @@
+httpx>=0.21.2
+pydantic>=1.9.2
+pydantic-core>=2.18.2
+typing_extensions>=4.0.0
+anyio>=3.5.0
+pytest>=8

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from loonfs_sdk import ActorRef, FilesystemOperation_CreateDirectory, LoonFS, UnauthorizedError
+
+
+FIXTURE_VERSION = 1
+RUNNER_SKIP = "run scripts/run-sdk-conformance.sh python"
+TRANSFER_SKIP = "needs transfer orchestration; covered by the Rust reference harness"
+CASE_FIELDS = {"version", "name", "intent", "family", "request", "expected"}
+EXPECTED_CASES = [
+    ("changes", "changes"),
+    ("commit_replay", "commit_replay"),
+    ("download", "download"),
+    ("end_to_end", "end_to_end"),
+    ("error_contract", "error_contract"),
+    ("pagination", "pagination"),
+    ("upload_abort", "upload_abort"),
+    ("upload_direct_put", "upload_direct_put"),
+    ("upload_multipart", "upload_multipart"),
+]
+TRANSFER_CASES = [
+    "download",
+    "end_to_end",
+    "upload_abort",
+    "upload_direct_put",
+    "upload_multipart",
+]
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("LOONFS_CONFORMANCE_URL"),
+    reason=RUNNER_SKIP,
+)
+
+
+JsonObject = dict[str, object]
+
+
+@dataclass(frozen=True)
+class ConformanceCase:
+    name: str
+    family: str
+    request: JsonObject
+    expected: JsonObject
+
+
+@dataclass(frozen=True)
+class ErrorStatusExpected:
+    status: int
+    code: str
+
+
+@dataclass(frozen=True)
+class ErrorOutcome:
+    status: int
+    code: str
+    param: str
+
+
+@dataclass(frozen=True)
+class ErrorContractRequest:
+    namespace_id: str
+    malformed_body: JsonObject
+    invalid_after_seq: str
+
+
+@dataclass(frozen=True)
+class ErrorContractExpected:
+    unauthenticated: ErrorStatusExpected
+    malformed_body: ErrorOutcome
+    invalid_query: ErrorOutcome
+
+
+@dataclass(frozen=True)
+class CommitReplayRequest:
+    namespace_id: str
+    commit_id: str
+    actor: ActorRef
+    message: str
+    path: str
+
+
+@dataclass(frozen=True)
+class CommitReplayExpected:
+    committed_seq: int
+
+
+@dataclass(frozen=True)
+class PaginationRequest:
+    namespace_id: str
+    directory: str
+    actor: ActorRef
+    entry_names: list[str]
+    page_size: int
+    resume_after_page: int
+
+
+@dataclass(frozen=True)
+class PaginationExpected:
+    entry_count: int
+    minimum_page_count: int
+    head_seq: int
+
+
+@dataclass(frozen=True)
+class ChangesRequest:
+    namespace_id: str
+    path: str
+    commit_id: str
+    actor: ActorRef
+    after_seq: int
+
+
+@dataclass(frozen=True)
+class ChangesExpected:
+    committed_seq: int
+    change_count: int
+    event_kind: str
+
+
+@dataclass(frozen=True)
+class Harness:
+    client: LoonFS
+    unauthenticated: LoonFS
+
+
+def _strict_object(value: object, fields: set[str], label: str) -> JsonObject:
+    if not isinstance(value, dict):
+        raise AssertionError(f"{label} must be a JSON object")
+    if not all(isinstance(key, str) for key in value):
+        raise AssertionError(f"{label} must use string keys")
+    actual = set(value)
+    if actual != fields:
+        unknown = sorted(actual - fields)
+        missing = sorted(fields - actual)
+        raise AssertionError(f"{label} fields differ: unknown={unknown}, missing={missing}")
+    return value
+
+
+def _json_object(value: object, label: str) -> JsonObject:
+    if not isinstance(value, dict):
+        raise AssertionError(f"{label} must be a JSON object")
+    if not all(isinstance(key, str) for key in value):
+        raise AssertionError(f"{label} must use string keys")
+    return value
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise AssertionError(f"{label} must be a string")
+    return value
+
+
+def _integer(value: object, label: str) -> int:
+    if type(value) is not int:
+        raise AssertionError(f"{label} must be an integer")
+    return value
+
+
+def _string_list(value: object, label: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise AssertionError(f"{label} must be an array of strings")
+    return value
+
+
+def _actor(value: object, label: str) -> ActorRef:
+    actor = _strict_object(value, {"id", "kind"}, label)
+    actor_id = _string(actor["id"], f"{label}.id")
+    kind = _string(actor["kind"], f"{label}.kind")
+    if kind not in {"user", "service", "system"}:
+        raise AssertionError(f"{label}.kind is not a known actor kind")
+    return ActorRef(id=actor_id, kind=kind)
+
+
+def _error_status(value: object, label: str) -> ErrorStatusExpected:
+    data = _strict_object(value, {"status", "code"}, label)
+    return ErrorStatusExpected(
+        status=_integer(data["status"], f"{label}.status"),
+        code=_string(data["code"], f"{label}.code"),
+    )
+
+
+def _error_outcome(value: object, label: str) -> ErrorOutcome:
+    data = _strict_object(value, {"status", "code", "param"}, label)
+    return ErrorOutcome(
+        status=_integer(data["status"], f"{label}.status"),
+        code=_string(data["code"], f"{label}.code"),
+        param=_string(data["param"], f"{label}.param"),
+    )
+
+
+def _decode_error_contract(
+    test_case: ConformanceCase,
+) -> tuple[ErrorContractRequest, ErrorContractExpected]:
+    request = _strict_object(
+        test_case.request,
+        {"namespace_id", "malformed_body", "invalid_after_seq"},
+        f"{test_case.name} request",
+    )
+    expected = _strict_object(
+        test_case.expected,
+        {"unauthenticated", "malformed_body", "invalid_query"},
+        f"{test_case.name} expected",
+    )
+    return (
+        ErrorContractRequest(
+            namespace_id=_string(request["namespace_id"], "error_contract request.namespace_id"),
+            malformed_body=_json_object(request["malformed_body"], "error_contract request.malformed_body"),
+            invalid_after_seq=_string(
+                request["invalid_after_seq"], "error_contract request.invalid_after_seq"
+            ),
+        ),
+        ErrorContractExpected(
+            unauthenticated=_error_status(
+                expected["unauthenticated"], "error_contract expected.unauthenticated"
+            ),
+            malformed_body=_error_outcome(
+                expected["malformed_body"], "error_contract expected.malformed_body"
+            ),
+            invalid_query=_error_outcome(
+                expected["invalid_query"], "error_contract expected.invalid_query"
+            ),
+        ),
+    )
+
+
+def _decode_commit_replay(
+    test_case: ConformanceCase,
+) -> tuple[CommitReplayRequest, CommitReplayExpected]:
+    request = _strict_object(
+        test_case.request,
+        {"namespace_id", "commit_id", "actor", "message", "path"},
+        f"{test_case.name} request",
+    )
+    expected = _strict_object(
+        test_case.expected,
+        {"committed_seq"},
+        f"{test_case.name} expected",
+    )
+    return (
+        CommitReplayRequest(
+            namespace_id=_string(request["namespace_id"], "commit_replay request.namespace_id"),
+            commit_id=_string(request["commit_id"], "commit_replay request.commit_id"),
+            actor=_actor(request["actor"], "commit_replay request.actor"),
+            message=_string(request["message"], "commit_replay request.message"),
+            path=_string(request["path"], "commit_replay request.path"),
+        ),
+        CommitReplayExpected(
+            committed_seq=_integer(expected["committed_seq"], "commit_replay expected.committed_seq")
+        ),
+    )
+
+
+def _decode_pagination(
+    test_case: ConformanceCase,
+) -> tuple[PaginationRequest, PaginationExpected]:
+    request = _strict_object(
+        test_case.request,
+        {"namespace_id", "directory", "actor", "entry_names", "page_size", "resume_after_page"},
+        f"{test_case.name} request",
+    )
+    expected = _strict_object(
+        test_case.expected,
+        {"entry_count", "minimum_page_count", "head_seq"},
+        f"{test_case.name} expected",
+    )
+    return (
+        PaginationRequest(
+            namespace_id=_string(request["namespace_id"], "pagination request.namespace_id"),
+            directory=_string(request["directory"], "pagination request.directory"),
+            actor=_actor(request["actor"], "pagination request.actor"),
+            entry_names=_string_list(request["entry_names"], "pagination request.entry_names"),
+            page_size=_integer(request["page_size"], "pagination request.page_size"),
+            resume_after_page=_integer(
+                request["resume_after_page"], "pagination request.resume_after_page"
+            ),
+        ),
+        PaginationExpected(
+            entry_count=_integer(expected["entry_count"], "pagination expected.entry_count"),
+            minimum_page_count=_integer(
+                expected["minimum_page_count"], "pagination expected.minimum_page_count"
+            ),
+            head_seq=_integer(expected["head_seq"], "pagination expected.head_seq"),
+        ),
+    )
+
+
+def _decode_changes(test_case: ConformanceCase) -> tuple[ChangesRequest, ChangesExpected]:
+    request = _strict_object(
+        test_case.request,
+        {"namespace_id", "path", "commit_id", "actor", "after_seq"},
+        f"{test_case.name} request",
+    )
+    expected = _strict_object(
+        test_case.expected,
+        {"committed_seq", "change_count", "event_kind"},
+        f"{test_case.name} expected",
+    )
+    return (
+        ChangesRequest(
+            namespace_id=_string(request["namespace_id"], "changes request.namespace_id"),
+            path=_string(request["path"], "changes request.path"),
+            commit_id=_string(request["commit_id"], "changes request.commit_id"),
+            actor=_actor(request["actor"], "changes request.actor"),
+            after_seq=_integer(request["after_seq"], "changes request.after_seq"),
+        ),
+        ChangesExpected(
+            committed_seq=_integer(expected["committed_seq"], "changes expected.committed_seq"),
+            change_count=_integer(expected["change_count"], "changes expected.change_count"),
+            event_kind=_string(expected["event_kind"], "changes expected.event_kind"),
+        ),
+    )
+
+
+def load_cases(directory: str) -> dict[str, ConformanceCase]:
+    cases: list[ConformanceCase] = []
+    for path in sorted(Path(directory).iterdir()):
+        if not path.is_file() or path.suffix != ".json":
+            continue
+        root = _strict_object(json.loads(path.read_text()), CASE_FIELDS, str(path))
+        version = _integer(root["version"], f"{path} version")
+        if version != FIXTURE_VERSION:
+            raise AssertionError(
+                f"invalid fixture {path}: version must be {FIXTURE_VERSION}, found {version}"
+            )
+        name = _string(root["name"], f"{path} name")
+        if name != path.stem:
+            raise AssertionError(f"invalid fixture {path}: name is {name!r}, expected {path.stem!r}")
+        intent = _string(root["intent"], f"{path} intent")
+        if not intent.strip():
+            raise AssertionError(f"invalid fixture {path}: intent must not be empty")
+        cases.append(
+            ConformanceCase(
+                name=name,
+                family=_string(root["family"], f"{path} family"),
+                request=_json_object(root["request"], f"{path} request"),
+                expected=_json_object(root["expected"], f"{path} expected"),
+            )
+        )
+
+    inventory = [(test_case.name, test_case.family) for test_case in cases]
+    if inventory != EXPECTED_CASES:
+        raise AssertionError(f"fixture version 1 inventory is {inventory!r}, expected {EXPECTED_CASES!r}")
+    return {test_case.name: test_case for test_case in cases}
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise AssertionError(f"{name} is not set")
+    return value
+
+
+def _remove_authorization(request: httpx.Request) -> None:
+    request.headers.pop("Authorization", None)
+
+
+@pytest.fixture(scope="session")
+def cases() -> dict[str, ConformanceCase]:
+    return load_cases(_required_environment("LOONFS_CONFORMANCE_CASES"))
+
+
+@pytest.fixture(scope="session")
+def harness() -> Iterator[Harness]:
+    base_url = _required_environment("LOONFS_CONFORMANCE_URL")
+    token = _required_environment("LOONFS_CONFORMANCE_TOKEN")
+    unauthenticated_http = httpx.Client(event_hooks={"request": [_remove_authorization]})
+    try:
+        yield Harness(
+            client=LoonFS(base_url=base_url, token=token),
+            unauthenticated=LoonFS(
+                base_url=base_url,
+                token="",
+                httpx_client=unauthenticated_http,
+            ),
+        )
+    finally:
+        unauthenticated_http.close()
+
+
+def _apply_create_directory(
+    client: LoonFS,
+    namespace_id: str,
+    commit_id: str,
+    actor: ActorRef,
+    path: str,
+    message: str | None = None,
+) -> Any:
+    operation = FilesystemOperation_CreateDirectory(path=path, parents=False)
+    if message is None:
+        return client.filesystem.apply_commit(
+            namespace_id,
+            actor=actor,
+            commit_id=commit_id,
+            operations=[operation],
+        )
+    return client.filesystem.apply_commit(
+        namespace_id,
+        actor=actor,
+        commit_id=commit_id,
+        operations=[operation],
+        message=message,
+    )
+
+
+def _listed_names(entries: list[Any]) -> list[str]:
+    names: list[str] = []
+    for entry in entries:
+        assert entry.display_name is not None, "listed entry has no display_name"
+        names.append(entry.display_name)
+    return names
+
+
+def _list_path_entries(
+    client: LoonFS,
+    request: PaginationRequest,
+    cursor: str | None,
+) -> Any:
+    if cursor is None:
+        return client.filesystem.list_path_entries(
+            request.namespace_id,
+            path=request.directory,
+            limit=request.page_size,
+        )
+    return client.filesystem.list_path_entries(
+        request.namespace_id,
+        path=request.directory,
+        limit=request.page_size,
+        cursor=cursor,
+    )
+
+
+def test_error_contract(cases: dict[str, ConformanceCase], harness: Harness) -> None:
+    request, expected = _decode_error_contract(cases["error_contract"])
+    with pytest.raises(UnauthorizedError) as captured:
+        harness.unauthenticated.namespaces.get_namespace(request.namespace_id)
+
+    error = captured.value
+    assert error.status_code == expected.unauthenticated.status
+    assert error.body.code == expected.unauthenticated.code
+    assert error.body.request_id is not None
+
+
+def test_commit_replay(cases: dict[str, ConformanceCase], harness: Harness) -> None:
+    request, expected = _decode_commit_replay(cases["commit_replay"])
+    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    first = _apply_create_directory(
+        harness.client,
+        request.namespace_id,
+        request.commit_id,
+        request.actor,
+        request.path,
+        request.message,
+    )
+    replayed = _apply_create_directory(
+        harness.client,
+        request.namespace_id,
+        request.commit_id,
+        request.actor,
+        request.path,
+        request.message,
+    )
+
+    assert first.committed_seq == expected.committed_seq
+    assert first.commit_id == request.commit_id
+    assert replayed.committed_seq == first.committed_seq
+    assert replayed.commit_id == first.commit_id
+    assert replayed.namespace_id == first.namespace_id
+
+
+def test_pagination(cases: dict[str, ConformanceCase], harness: Harness) -> None:
+    request, expected = _decode_pagination(cases["pagination"])
+    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    _apply_create_directory(
+        harness.client,
+        request.namespace_id,
+        "conf-pagination-directory",
+        request.actor,
+        request.directory,
+    )
+    for index, name in enumerate(request.entry_names):
+        _apply_create_directory(
+            harness.client,
+            request.namespace_id,
+            f"conf-pagination-entry-{index:02d}",
+            request.actor,
+            f"{request.directory}/{name}",
+        )
+
+    observed: list[str] = []
+    cursor: str | None = None
+    saved_cursor: str | None = None
+    resume_offset: int | None = None
+    page_count = 0
+    while True:
+        page = _list_path_entries(harness.client, request, cursor)
+        page_count += 1
+        assert page.head_seq == expected.head_seq
+        observed.extend(_listed_names(page.entries))
+        cursor = page.next_cursor
+        if page_count == request.resume_after_page:
+            saved_cursor = cursor
+            resume_offset = len(observed)
+        if cursor is None:
+            break
+
+    assert len(observed) == expected.entry_count
+    assert page_count >= expected.minimum_page_count
+    assert cursor is None
+    assert saved_cursor is not None, "resume cursor was not recorded"
+    assert resume_offset is not None, "resume position was not recorded"
+
+    resumed: list[str] = []
+    cursor = saved_cursor
+    while True:
+        page = _list_path_entries(harness.client, request, cursor)
+        resumed.extend(_listed_names(page.entries))
+        cursor = page.next_cursor
+        if cursor is None:
+            break
+
+    assert len(set(observed)) == len(observed), "pagination returned an entry more than once"
+    assert observed == request.entry_names
+    assert resume_offset <= len(request.entry_names)
+    assert resumed == request.entry_names[resume_offset:]
+
+
+def test_changes(cases: dict[str, ConformanceCase], harness: Harness) -> None:
+    request, expected = _decode_changes(cases["changes"])
+    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    committed = _apply_create_directory(
+        harness.client,
+        request.namespace_id,
+        request.commit_id,
+        request.actor,
+        request.path,
+    )
+    assert committed.committed_seq == expected.committed_seq
+
+    feed = harness.client.filesystem.list_changes(
+        request.namespace_id,
+        after_seq=request.after_seq,
+    )
+    assert len(feed.changes) == expected.change_count
+    assert feed.changes, "change feed is empty"
+    change = feed.changes[0]
+    assert change.commit_id == request.commit_id
+    assert change.committed_by.id == request.actor.id
+    assert change.committed_by.kind == request.actor.kind
+    assert expected.event_kind == "directory_created"
+    assert len(change.events) == 1
+    assert change.events[0].kind == "directory_created"
+
+
+@pytest.mark.parametrize("case_name", TRANSFER_CASES)
+def test_transfer_family_is_skipped(
+    case_name: str,
+    cases: dict[str, ConformanceCase],
+) -> None:
+    assert cases[case_name].family == case_name
+    pytest.skip(TRANSFER_SKIP)

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -14,7 +14,7 @@ from loonfs_sdk import ActorRef, FilesystemOperation_CreateDirectory, LoonFS, Un
 
 FIXTURE_VERSION = 1
 RUNNER_SKIP = "run scripts/run-sdk-conformance.sh python"
-TRANSFER_SKIP = "needs transfer orchestration; covered by the Rust reference harness"
+TRANSFER_SKIP = "file transfer cases are not implemented in the Python harness yet"
 CASE_FIELDS = {"version", "name", "intent", "family", "request", "expected"}
 EXPECTED_CASES = [
     ("changes", "changes"),

--- a/sdk/conformance/typescript/.gitignore
+++ b/sdk/conformance/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/sdk/conformance/typescript/package-lock.json
+++ b/sdk/conformance/typescript/package-lock.json
@@ -1,0 +1,44 @@
+{
+  "name": "typescript",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/node": "^18.19.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdk/conformance/typescript/package.json
+++ b/sdk/conformance/typescript/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test dist/conformance/typescript/src/"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -8,7 +8,7 @@ import { LoonFS, LoonFSClient } from "../../../generated/typescript/index.js";
 
 const FIXTURE_VERSION = 1;
 const RUNNER_SKIP = "run scripts/run-sdk-conformance.sh typescript";
-const TRANSFER_SKIP = "needs transfer orchestration; covered by the Rust reference harness";
+const TRANSFER_SKIP = "file transfer cases are not implemented in the TypeScript harness yet";
 const CASE_FIELDS = ["expected", "family", "intent", "name", "request", "version"];
 const EXPECTED_CASES = [
     ["changes", "changes"],

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -1,0 +1,551 @@
+import * as assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+import { test } from "node:test";
+
+import { LoonFS, LoonFSClient } from "../../../generated/typescript/index.js";
+
+
+const FIXTURE_VERSION = 1;
+const RUNNER_SKIP = "run scripts/run-sdk-conformance.sh typescript";
+const TRANSFER_SKIP = "needs transfer orchestration; covered by the Rust reference harness";
+const CASE_FIELDS = ["expected", "family", "intent", "name", "request", "version"];
+const EXPECTED_CASES = [
+    ["changes", "changes"],
+    ["commit_replay", "commit_replay"],
+    ["download", "download"],
+    ["end_to_end", "end_to_end"],
+    ["error_contract", "error_contract"],
+    ["pagination", "pagination"],
+    ["upload_abort", "upload_abort"],
+    ["upload_direct_put", "upload_direct_put"],
+    ["upload_multipart", "upload_multipart"],
+] as const;
+const TRANSFER_CASES = [
+    "download",
+    "end_to_end",
+    "upload_abort",
+    "upload_direct_put",
+    "upload_multipart",
+] as const;
+
+
+type JsonObject = Record<string, unknown>;
+type ActorKind = "user" | "service" | "system";
+
+interface ActorValue {
+    id: string;
+    kind: ActorKind;
+}
+
+interface ConformanceCase {
+    name: string;
+    family: string;
+    request: JsonObject;
+    expected: JsonObject;
+}
+
+interface ErrorStatusExpected {
+    status: number;
+    code: string;
+}
+
+interface ErrorOutcome {
+    status: number;
+    code: string;
+    param: string;
+}
+
+interface ErrorContractRequest {
+    namespaceId: string;
+    malformedBody: JsonObject;
+    invalidAfterSeq: string;
+}
+
+interface ErrorContractExpected {
+    unauthenticated: ErrorStatusExpected;
+    malformedBody: ErrorOutcome;
+    invalidQuery: ErrorOutcome;
+}
+
+interface CommitReplayRequest {
+    namespaceId: string;
+    commitId: string;
+    actor: ActorValue;
+    message: string;
+    path: string;
+}
+
+interface CommitReplayExpected {
+    committedSeq: number;
+}
+
+interface PaginationRequest {
+    namespaceId: string;
+    directory: string;
+    actor: ActorValue;
+    entryNames: string[];
+    pageSize: number;
+    resumeAfterPage: number;
+}
+
+interface PaginationExpected {
+    entryCount: number;
+    minimumPageCount: number;
+    headSeq: number;
+}
+
+interface ChangesRequest {
+    namespaceId: string;
+    path: string;
+    commitId: string;
+    actor: ActorValue;
+    afterSeq: number;
+}
+
+interface ChangesExpected {
+    committedSeq: number;
+    changeCount: number;
+    eventKind: string;
+}
+
+interface Harness {
+    client: LoonFSClient;
+    unauthenticated: LoonFSClient;
+}
+
+
+function jsonObject(value: unknown, label: string): JsonObject {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error(`${label} must be a JSON object`);
+    }
+    return value as JsonObject;
+}
+
+function strictObject(value: unknown, fields: readonly string[], label: string): JsonObject {
+    const data = jsonObject(value, label);
+    const actual = Object.keys(data).sort();
+    const expected = [...fields].sort();
+    if (actual.length !== expected.length || actual.some((field, index) => field !== expected[index])) {
+        const unknown = actual.filter((field) => !expected.includes(field));
+        const missing = expected.filter((field) => !actual.includes(field));
+        throw new Error(`${label} fields differ: unknown=${unknown.join(",")}, missing=${missing.join(",")}`);
+    }
+    return data;
+}
+
+function stringValue(value: unknown, label: string): string {
+    if (typeof value !== "string") {
+        throw new Error(`${label} must be a string`);
+    }
+    return value;
+}
+
+function integerValue(value: unknown, label: string): number {
+    if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+        throw new Error(`${label} must be an integer`);
+    }
+    return value;
+}
+
+function stringArray(value: unknown, label: string): string[] {
+    if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+        throw new Error(`${label} must be an array of strings`);
+    }
+    return value;
+}
+
+function actorValue(value: unknown, label: string): ActorValue {
+    const actor = strictObject(value, ["id", "kind"], label);
+    const kind = stringValue(actor.kind, `${label}.kind`);
+    if (kind !== "user" && kind !== "service" && kind !== "system") {
+        throw new Error(`${label}.kind is not a known actor kind`);
+    }
+    return {
+        id: stringValue(actor.id, `${label}.id`),
+        kind,
+    };
+}
+
+function errorStatus(value: unknown, label: string): ErrorStatusExpected {
+    const data = strictObject(value, ["status", "code"], label);
+    return {
+        status: integerValue(data.status, `${label}.status`),
+        code: stringValue(data.code, `${label}.code`),
+    };
+}
+
+function errorOutcome(value: unknown, label: string): ErrorOutcome {
+    const data = strictObject(value, ["status", "code", "param"], label);
+    return {
+        status: integerValue(data.status, `${label}.status`),
+        code: stringValue(data.code, `${label}.code`),
+        param: stringValue(data.param, `${label}.param`),
+    };
+}
+
+function decodeErrorContract(
+    testCase: ConformanceCase,
+): [ErrorContractRequest, ErrorContractExpected] {
+    const request = strictObject(
+        testCase.request,
+        ["namespace_id", "malformed_body", "invalid_after_seq"],
+        `${testCase.name} request`,
+    );
+    const expected = strictObject(
+        testCase.expected,
+        ["unauthenticated", "malformed_body", "invalid_query"],
+        `${testCase.name} expected`,
+    );
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "error_contract request.namespace_id"),
+            malformedBody: jsonObject(request.malformed_body, "error_contract request.malformed_body"),
+            invalidAfterSeq: stringValue(
+                request.invalid_after_seq,
+                "error_contract request.invalid_after_seq",
+            ),
+        },
+        {
+            unauthenticated: errorStatus(
+                expected.unauthenticated,
+                "error_contract expected.unauthenticated",
+            ),
+            malformedBody: errorOutcome(
+                expected.malformed_body,
+                "error_contract expected.malformed_body",
+            ),
+            invalidQuery: errorOutcome(
+                expected.invalid_query,
+                "error_contract expected.invalid_query",
+            ),
+        },
+    ];
+}
+
+function decodeCommitReplay(
+    testCase: ConformanceCase,
+): [CommitReplayRequest, CommitReplayExpected] {
+    const request = strictObject(
+        testCase.request,
+        ["namespace_id", "commit_id", "actor", "message", "path"],
+        `${testCase.name} request`,
+    );
+    const expected = strictObject(testCase.expected, ["committed_seq"], `${testCase.name} expected`);
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "commit_replay request.namespace_id"),
+            commitId: stringValue(request.commit_id, "commit_replay request.commit_id"),
+            actor: actorValue(request.actor, "commit_replay request.actor"),
+            message: stringValue(request.message, "commit_replay request.message"),
+            path: stringValue(request.path, "commit_replay request.path"),
+        },
+        {
+            committedSeq: integerValue(expected.committed_seq, "commit_replay expected.committed_seq"),
+        },
+    ];
+}
+
+function decodePagination(
+    testCase: ConformanceCase,
+): [PaginationRequest, PaginationExpected] {
+    const request = strictObject(
+        testCase.request,
+        ["namespace_id", "directory", "actor", "entry_names", "page_size", "resume_after_page"],
+        `${testCase.name} request`,
+    );
+    const expected = strictObject(
+        testCase.expected,
+        ["entry_count", "minimum_page_count", "head_seq"],
+        `${testCase.name} expected`,
+    );
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "pagination request.namespace_id"),
+            directory: stringValue(request.directory, "pagination request.directory"),
+            actor: actorValue(request.actor, "pagination request.actor"),
+            entryNames: stringArray(request.entry_names, "pagination request.entry_names"),
+            pageSize: integerValue(request.page_size, "pagination request.page_size"),
+            resumeAfterPage: integerValue(
+                request.resume_after_page,
+                "pagination request.resume_after_page",
+            ),
+        },
+        {
+            entryCount: integerValue(expected.entry_count, "pagination expected.entry_count"),
+            minimumPageCount: integerValue(
+                expected.minimum_page_count,
+                "pagination expected.minimum_page_count",
+            ),
+            headSeq: integerValue(expected.head_seq, "pagination expected.head_seq"),
+        },
+    ];
+}
+
+function decodeChanges(testCase: ConformanceCase): [ChangesRequest, ChangesExpected] {
+    const request = strictObject(
+        testCase.request,
+        ["namespace_id", "path", "commit_id", "actor", "after_seq"],
+        `${testCase.name} request`,
+    );
+    const expected = strictObject(
+        testCase.expected,
+        ["committed_seq", "change_count", "event_kind"],
+        `${testCase.name} expected`,
+    );
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "changes request.namespace_id"),
+            path: stringValue(request.path, "changes request.path"),
+            commitId: stringValue(request.commit_id, "changes request.commit_id"),
+            actor: actorValue(request.actor, "changes request.actor"),
+            afterSeq: integerValue(request.after_seq, "changes request.after_seq"),
+        },
+        {
+            committedSeq: integerValue(expected.committed_seq, "changes expected.committed_seq"),
+            changeCount: integerValue(expected.change_count, "changes expected.change_count"),
+            eventKind: stringValue(expected.event_kind, "changes expected.event_kind"),
+        },
+    ];
+}
+
+function loadCases(directory: string): Map<string, ConformanceCase> {
+    const cases = readdirSync(directory, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && extname(entry.name) === ".json")
+        .sort((left, right) => left.name.localeCompare(right.name))
+        .map((entry): ConformanceCase => {
+            const path = join(directory, entry.name);
+            const root = strictObject(JSON.parse(readFileSync(path, "utf8")), CASE_FIELDS, path);
+            const version = integerValue(root.version, `${path} version`);
+            if (version !== FIXTURE_VERSION) {
+                throw new Error(
+                    `invalid fixture ${path}: version must be ${FIXTURE_VERSION}, found ${version}`,
+                );
+            }
+            const name = stringValue(root.name, `${path} name`);
+            const stem = basename(path, extname(path));
+            if (name !== stem) {
+                throw new Error(`invalid fixture ${path}: name is ${name}, expected ${stem}`);
+            }
+            const intent = stringValue(root.intent, `${path} intent`);
+            if (intent.trim() === "") {
+                throw new Error(`invalid fixture ${path}: intent must not be empty`);
+            }
+            return {
+                name,
+                family: stringValue(root.family, `${path} family`),
+                request: jsonObject(root.request, `${path} request`),
+                expected: jsonObject(root.expected, `${path} expected`),
+            };
+        });
+
+    const inventory = cases.map((testCase) => [testCase.name, testCase.family]);
+    assert.deepEqual(inventory, EXPECTED_CASES, "fixture version 1 inventory differs");
+    return new Map(cases.map((testCase) => [testCase.name, testCase]));
+}
+
+function requiredEnvironment(name: string): string {
+    const value = process.env[name];
+    if (value == null || value === "") {
+        throw new Error(`${name} is not set`);
+    }
+    return value;
+}
+
+function caseNamed(cases: Map<string, ConformanceCase>, name: string): ConformanceCase {
+    const testCase = cases.get(name);
+    if (testCase == null) {
+        throw new Error(`conformance case ${name} is missing`);
+    }
+    return testCase;
+}
+
+function directoryCommit(
+    namespaceId: string,
+    commitId: string,
+    actor: ActorValue,
+    path: string,
+    message?: string,
+): LoonFS.CommitRequest {
+    const request: LoonFS.CommitRequest = {
+        namespace_id: namespaceId,
+        actor,
+        commit_id: commitId,
+        operations: [{ kind: "create_directory", parents: false, path }],
+    };
+    if (message !== undefined) {
+        request.message = message;
+    }
+    return request;
+}
+
+function listedNames(entries: LoonFS.AuthoritativePathEntry[]): string[] {
+    return entries.map((entry) => {
+        const name = entry.display_name;
+        assert.ok(name != null, "listed entry has no display_name");
+        return name;
+    });
+}
+
+
+const baseUrl = process.env.LOONFS_CONFORMANCE_URL;
+const environmentSkip = baseUrl == null || baseUrl === "" ? RUNNER_SKIP : undefined;
+let harness: Harness | undefined;
+let cases: Map<string, ConformanceCase> | undefined;
+
+if (environmentSkip === undefined) {
+    const configuredBaseUrl = requiredEnvironment("LOONFS_CONFORMANCE_URL");
+    const token = requiredEnvironment("LOONFS_CONFORMANCE_TOKEN");
+    cases = loadCases(requiredEnvironment("LOONFS_CONFORMANCE_CASES"));
+    harness = {
+        client: new LoonFSClient({ environment: configuredBaseUrl, token }),
+        unauthenticated: new LoonFSClient({ environment: configuredBaseUrl, token, auth: false }),
+    };
+}
+
+function conformanceTest(
+    name: string,
+    run: (harness: Harness, testCase: ConformanceCase) => Promise<void>,
+): void {
+    test(name, { skip: environmentSkip }, async () => {
+        assert.ok(harness != null);
+        assert.ok(cases != null);
+        await run(harness, caseNamed(cases, name));
+    });
+}
+
+
+conformanceTest("error_contract", async (activeHarness, testCase) => {
+    const [request, expected] = decodeErrorContract(testCase);
+    let caught: unknown;
+    try {
+        await activeHarness.unauthenticated.namespaces.getNamespace({ namespace_id: request.namespaceId });
+    } catch (error) {
+        caught = error;
+    }
+
+    assert.ok(caught instanceof LoonFS.UnauthorizedError);
+    assert.equal(caught.statusCode, expected.unauthenticated.status);
+    assert.equal(caught.body.code, expected.unauthenticated.code);
+    assert.ok(caught.body.request_id != null);
+});
+
+conformanceTest("commit_replay", async (activeHarness, testCase) => {
+    const [request, expected] = decodeCommitReplay(testCase);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    const commit = directoryCommit(
+        request.namespaceId,
+        request.commitId,
+        request.actor,
+        request.path,
+        request.message,
+    );
+    const first = await activeHarness.client.filesystem.applyCommit(commit);
+    const replayed = await activeHarness.client.filesystem.applyCommit(commit);
+
+    assert.equal(first.committed_seq, expected.committedSeq);
+    assert.equal(first.commit_id, request.commitId);
+    assert.equal(replayed.committed_seq, first.committed_seq);
+    assert.deepEqual(replayed, first);
+});
+
+conformanceTest("pagination", async (activeHarness, testCase) => {
+    const [request, expected] = decodePagination(testCase);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    await activeHarness.client.filesystem.applyCommit(
+        directoryCommit(
+            request.namespaceId,
+            "conf-pagination-directory",
+            request.actor,
+            request.directory,
+        ),
+    );
+    for (const [index, name] of request.entryNames.entries()) {
+        await activeHarness.client.filesystem.applyCommit(
+            directoryCommit(
+                request.namespaceId,
+                `conf-pagination-entry-${index.toString().padStart(2, "0")}`,
+                request.actor,
+                `${request.directory}/${name}`,
+            ),
+        );
+    }
+
+    const observed: string[] = [];
+    let pageCount = 0;
+    let savedCursor: string | undefined;
+    let resumeOffset: number | undefined;
+    let page = await activeHarness.client.filesystem.listPathEntries({
+        namespace_id: request.namespaceId,
+        path: request.directory,
+        limit: request.pageSize,
+    });
+    let cursor: string | undefined;
+    while (true) {
+        pageCount += 1;
+        assert.equal(page.response.head_seq, expected.headSeq);
+        observed.push(...listedNames(page.data));
+        cursor = page.response.next_cursor ?? undefined;
+        if (pageCount === request.resumeAfterPage) {
+            savedCursor = cursor;
+            resumeOffset = observed.length;
+        }
+        if (cursor === undefined) {
+            break;
+        }
+        await page.getNextPage();
+    }
+
+    assert.equal(observed.length, expected.entryCount);
+    assert.ok(pageCount >= expected.minimumPageCount);
+    assert.equal(cursor, undefined);
+    assert.ok(savedCursor !== undefined, "resume cursor was not recorded");
+    assert.ok(resumeOffset !== undefined, "resume position was not recorded");
+
+    const resumed: string[] = [];
+    page = await activeHarness.client.filesystem.listPathEntries({
+        namespace_id: request.namespaceId,
+        path: request.directory,
+        limit: request.pageSize,
+        cursor: savedCursor,
+    });
+    while (true) {
+        resumed.push(...listedNames(page.data));
+        cursor = page.response.next_cursor ?? undefined;
+        if (cursor === undefined) {
+            break;
+        }
+        await page.getNextPage();
+    }
+
+    assert.equal(new Set(observed).size, observed.length, "pagination returned an entry more than once");
+    assert.deepEqual(observed, request.entryNames);
+    assert.ok(resumeOffset <= request.entryNames.length);
+    assert.deepEqual(resumed, request.entryNames.slice(resumeOffset));
+});
+
+conformanceTest("changes", async (activeHarness, testCase) => {
+    const [request, expected] = decodeChanges(testCase);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    const committed = await activeHarness.client.filesystem.applyCommit(
+        directoryCommit(request.namespaceId, request.commitId, request.actor, request.path),
+    );
+    assert.equal(committed.committed_seq, expected.committedSeq);
+
+    const feed = await activeHarness.client.filesystem.listChanges({
+        namespace_id: request.namespaceId,
+        after_seq: request.afterSeq,
+    });
+    assert.equal(feed.changes.length, expected.changeCount);
+    assert.ok(feed.changes.length > 0, "change feed is empty");
+    const change = feed.changes[0];
+    assert.equal(change.commit_id, request.commitId);
+    assert.deepEqual(change.committed_by, request.actor);
+    assert.equal(expected.eventKind, "directory_created");
+    assert.equal(change.events.length, 1);
+    assert.equal(change.events[0]?.kind, "directory_created");
+});
+
+for (const caseName of TRANSFER_CASES) {
+    test(caseName, { skip: environmentSkip ?? TRANSFER_SKIP }, () => {});
+}

--- a/sdk/conformance/typescript/tsconfig.json
+++ b/sdk/conformance/typescript/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "rootDir": "../..",
+    "outDir": "dist",
+    "types": ["node"],
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "../../generated/typescript/**/*.ts"]
+}


### PR DESCRIPTION
Adds conformance harnesses for the generated Python and TypeScript SDKs, so the shared behavioral cases now run through all three generated clients. Both new harnesses verify typed authentication errors, commit replay, pagination and resume behavior, and the change feed. Python follows cursor values directly, while TypeScript exercises the generated page helper. File transfer cases remain explicitly skipped until those harnesses support uploads and downloads.

Corrects the OpenAPI schema for optional attributes on path entries. Responses omit the attribute fields when callers do not request them, but the flattened schema previously made generated clients treat `attributes` and `attributes_revision_no` as required. The updated schema matches the actual response and allows the Python SDK to decode ordinary directory listings.

Adds runner support and separate CI jobs for Python and TypeScript. Each job generates the SDK, starts the local conformance server, and runs the shared cases through the generated client.