### PR TITLE
api: generate a clear grep request type in SDKs

### DIFF
--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -154,7 +154,6 @@ pub fn openapi_document() -> utoipa::openapi::OpenApi {
         DeletedDirentry,
         loonfs_api::v0::CommittedChange,
         ChangesResponse,
-        loonfs_api::v0::GrepRequest,
         loonfs_api::v0::GrepMatch,
         loonfs_api::v0::GrepResponse,
         loonfs_api::v0::GrepIndexLifecycle,

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -1028,6 +1028,10 @@ fn openapi_documents_string_id_contracts_without_dead_schemas() {
     assert!(!schemas.contains_key("ContentStoreId"));
     assert!(!schemas.contains_key("FilesystemChangeCreated"));
     assert!(
+        !schemas.contains_key("GrepRequest"),
+        "grep uses query parameters and must not publish an unused request schema"
+    );
+    assert!(
         !raw.contains(r#""created""#),
         "retired creation-event kind remains in OpenAPI"
     );

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -5024,52 +5024,6 @@
           }
         }
       },
-      "GrepRequest": {
-        "type": "object",
-        "description": "One content-search request.\n\nEvery field but `pattern` is optional, and each one selects results. A\nmisspelled `case_insensitive` or `path_prefix` would decode to the default\nand answer a different search than the caller asked for, with no sign that\nanything was dropped, so unknown fields are rejected.",
-        "required": [
-          "pattern"
-        ],
-        "properties": {
-          "allow_scan": {
-            "type": "boolean",
-            "description": "Permit a capped exhaustive scan when the pattern yields no required\ngrams. Refused beyond the server's scan budget."
-          },
-          "allow_stale": {
-            "type": "boolean",
-            "description": "When the unindexed tail exceeds the scan budget, return\nindexed-only results (reported via `tail_scanned: false`) instead\nof failing with `index_lagging`."
-          },
-          "case_insensitive": {
-            "type": "boolean",
-            "description": "Match case-insensitively. Verification is exact; the index remains\nconsulted through its case-folded grams."
-          },
-          "cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Resume cursor from a previous page. The cursor resumes strictly\nafter the last candidate the issuing page finished scanning and is\nbound to that page's request; each page is evaluated against the\nnamespace head at page time."
-          },
-          "limit": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32",
-            "description": "Maximum matches per page.",
-            "minimum": 0
-          },
-          "path_prefix": {
-            "$ref": "#/components/schemas/AbsolutePath",
-            "description": "Restrict matches to files under this complete absolute path, resolved\nto a directory inode before candidates are filtered."
-          },
-          "pattern": {
-            "type": "string",
-            "description": "The pattern, in the Rust `regex` crate's dialect (no backreferences\nor lookaround). Its UTF-8 encoding must be at most 1024 bytes.\nPatterns that require no literal bytes are rejected with\n`query_unindexable` unless `allow_scan` is set."
-          }
-        },
-        "additionalProperties": false
-      },
       "GrepResponse": {
         "type": "object",
         "description": "One content-search page.",


### PR DESCRIPTION
Removes the unused `GrepRequest` OpenAPI component. Its name collided with Fern’s generated operation request, so the Go and TypeScript clients exposed `GrepBody` for a GET request and Python exported a model that no method used.

Fern now generates one `GrepRequest` type for the Go and TypeScript methods and omits the unused Python model. The OpenAPI tests and fresh generation with all three pinned SDK generators pass.