### PR TITLE
test(sdk): assemble handwritten transfer code into the generated SDKs

### DIFF
--- a/crates/loonfs-conformance/src/server.rs
+++ b/crates/loonfs-conformance/src/server.rs
@@ -25,7 +25,7 @@ use std::io;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::JoinHandle;
@@ -135,17 +135,29 @@ struct LoopbackIssuer {
     base_url: String,
 }
 
+/// A presigned URL expiry one hour past `now`, in Unix milliseconds.
+///
+/// Real issuers bound their expiries; a sentinel like `u64::MAX` overflows
+/// the signed 64-bit timestamp fields in the generated SDKs.
+fn presigned_expiry_ms(now: SystemTime) -> u64 {
+    let expiry = now + Duration::from_secs(3600);
+    expiry
+        .duration_since(UNIX_EPOCH)
+        .map(|since| u64::try_from(since.as_millis()).unwrap_or(u64::MAX >> 1))
+        .unwrap_or(0)
+}
+
 impl DirectGetIssuer for LoopbackIssuer {
     fn presign_get(
         &self,
         request: PresignedGetRequest<'_>,
-        _now: SystemTime,
+        now: SystemTime,
     ) -> Result<PresignedUrl, ObjectStoreError> {
         Ok(PresignedUrl {
             method: "GET".to_owned(),
             url: format!("{}/objects/{}", self.base_url, request.object_key),
             headers: BTreeMap::new(),
-            expires_at_ms: u64::MAX,
+            expires_at_ms: presigned_expiry_ms(now),
         })
     }
 }
@@ -162,13 +174,13 @@ impl DirectPutIssuer for LoopbackIssuer {
     fn presign_put(
         &self,
         request: PresignedPutRequest<'_>,
-        _now: SystemTime,
+        now: SystemTime,
     ) -> Result<PresignedUrl, ObjectStoreError> {
         Ok(PresignedUrl {
             method: "PUT".to_owned(),
             url: format!("{}/objects/{}", self.base_url, request.object_key),
             headers: BTreeMap::new(),
-            expires_at_ms: u64::MAX,
+            expires_at_ms: presigned_expiry_ms(now),
         })
     }
 }
@@ -177,7 +189,7 @@ impl DirectMultipartIssuer for LoopbackIssuer {
     fn presign_multipart_part(
         &self,
         request: PresignedPartRequest<'_>,
-        _now: SystemTime,
+        now: SystemTime,
     ) -> Result<PresignedUrl, ObjectStoreError> {
         Ok(PresignedUrl {
             method: "PUT".to_owned(),
@@ -186,7 +198,7 @@ impl DirectMultipartIssuer for LoopbackIssuer {
                 self.base_url, request.provider_upload_id, request.part_number
             ),
             headers: BTreeMap::new(),
-            expires_at_ms: u64::MAX,
+            expires_at_ms: presigned_expiry_ms(now),
         })
     }
 }

--- a/crates/loonfs-conformance/src/server.rs
+++ b/crates/loonfs-conformance/src/server.rs
@@ -135,10 +135,6 @@ struct LoopbackIssuer {
     base_url: String,
 }
 
-/// A presigned URL expiry one hour past `now`, in Unix milliseconds.
-///
-/// Real issuers bound their expiries; a sentinel like `u64::MAX` overflows
-/// the signed 64-bit timestamp fields in the generated SDKs.
 fn presigned_expiry_ms(now: SystemTime) -> u64 {
     let expiry = now + Duration::from_secs(3600);
     expiry

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -4,6 +4,8 @@
 #
 # Usage: scripts/generate-sdks.sh [go|python|typescript]
 # With no argument, validates the document and generates all three SDKs.
+# Handwritten transfer code under sdk/transfers/<language> is copied over the
+# generated tree, so sdk/generated holds the complete SDK.
 
 set -eu
 
@@ -12,13 +14,21 @@ cd "$(dirname "$0")/../sdk"
 
 npx --yes "fern-api@${FERN_CLI_VERSION}" check
 
+overlay_handwritten() {
+    if [ -d "transfers/$1" ]; then
+        cp -R "transfers/$1/." "generated/$1/"
+    fi
+}
+
 if [ "$#" -ge 1 ]; then
     rm -rf "generated/$1"
     npx --yes "fern-api@${FERN_CLI_VERSION}" generate --force --local --group "$1"
+    overlay_handwritten "$1"
     exit 0
 fi
 
 for group in go python typescript; do
     rm -rf "generated/${group}"
     npx --yes "fern-api@${FERN_CLI_VERSION}" generate --force --local --group "$group"
+    overlay_handwritten "$group"
 done

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -4,8 +4,8 @@
 #
 # Usage: scripts/generate-sdks.sh [go|python|typescript]
 # With no argument, validates the document and generates all three SDKs.
-# Handwritten transfer code under sdk/transfers/<language> is copied over the
-# generated tree, so sdk/generated holds the complete SDK.
+# Handwritten files under sdk/transfers/<language> are copied into each SDK
+# after generation.
 
 set -eu
 


### PR DESCRIPTION
The SDK generation script now copies handwritten transfer helpers into each freshly generated SDK. This keeps the generated output used by conformance tests and publication complete without editing generated code by hand.

The conformance server now gives loopback presigned URLs a one-hour expiry based on its clock. This keeps the timestamp within the signed 64-bit range used by generated SDKs.

The Rust and SDK conformance checks pass.