### PR TITLE
feat(sdk): TypeScript transfer orchestration and the full conformance run

### DIFF
--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -1,14 +1,18 @@
 import * as assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 import { basename, extname, join } from "node:path";
 import { test } from "node:test";
 
 import { LoonFS, LoonFSClient } from "../../../generated/typescript/index.js";
+import { getFile, putFile } from "../../../generated/typescript/transfers.js";
 
 
 const FIXTURE_VERSION = 1;
 const RUNNER_SKIP = "run scripts/run-sdk-conformance.sh typescript";
-const TRANSFER_SKIP = "file transfer cases are not implemented in the TypeScript harness yet";
+const CRC32C_POLYNOMIAL = 0x82f63b78;
+const CRC64_NVME_POLYNOMIAL = 0x9a6c9329ac4bc9b5n;
+const CRC64_MASK = 0xffffffffffffffffn;
 const CASE_FIELDS = ["expected", "family", "intent", "name", "request", "version"];
 const EXPECTED_CASES = [
     ["changes", "changes"],
@@ -21,15 +25,8 @@ const EXPECTED_CASES = [
     ["upload_direct_put", "upload_direct_put"],
     ["upload_multipart", "upload_multipart"],
 ] as const;
-const TRANSFER_CASES = [
-    "download",
-    "end_to_end",
-    "upload_abort",
-    "upload_direct_put",
-    "upload_multipart",
-] as const;
-
-
+const CRC32C_TABLE = makeCrc32cTable();
+const CRC64_NVME_TABLE = makeCrc64NvmeTable();
 type JsonObject = Record<string, unknown>;
 type ActorKind = "user" | "service" | "system";
 
@@ -109,10 +106,102 @@ interface ChangesExpected {
     eventKind: string;
 }
 
+interface DirectPutRequest {
+    namespaceId: string;
+    path: string;
+    commitId: string;
+    actor: ActorValue;
+    contentUtf8: string;
+}
+
+interface DirectPutExpected {
+    mode: string;
+    sizeBytes: number;
+    checksumAlgorithm: string;
+    committedSeq: number;
+}
+
+interface BytePattern {
+    length: number;
+    modulus: number;
+}
+
+interface MultipartRequest {
+    namespaceId: string;
+    path: string;
+    commitId: string;
+    actor: ActorValue;
+    partSizeBytes: number;
+    contentPattern: BytePattern;
+}
+
+interface MultipartExpected {
+    mode: string;
+    partCount: number;
+    sizeBytes: number;
+    checksumAlgorithm: string;
+    committedSeq: number;
+}
+
+interface AbortRequest {
+    namespaceId: string;
+}
+
+interface AbortExpected {
+    mode: string;
+    status: string;
+}
+
+interface DownloadRequest {
+    namespaceId: string;
+    path: string;
+    commitId: string;
+    actor: ActorValue;
+    contentUtf8: string;
+}
+
+interface DownloadExpected {
+    sizeBytes: number;
+    checksumAlgorithm: string;
+    committedSeq: number;
+}
+
+interface EndToEndCommitIds {
+    mkdir: string;
+    upload: string;
+    move: string;
+    remove: string;
+}
+
+interface EndToEndRequest {
+    namespaceId: string;
+    directory: string;
+    uploadPath: string;
+    movedPath: string;
+    actor: ActorValue;
+    contentUtf8: string;
+    commitIds: EndToEndCommitIds;
+}
+
+interface EndToEndExpected {
+    mkdirCommittedSeq: number;
+    uploadCommittedSeq: number;
+    moveCommittedSeq: number;
+    removeCommittedSeq: number;
+    sizeBytes: number;
+    revisionCount: number;
+    changeCount: number;
+}
+
 interface Harness {
     client: LoonFSClient;
     unauthenticated: LoonFSClient;
 }
+
+type CompletedUpload = LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
+type AbortedUpload = LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Aborted;
+type FileEntry = LoonFS.AuthoritativePathEntry &
+    LoonFS.AuthoritativePathEntryFile & { kind: "file" };
 
 
 function jsonObject(value: unknown, label: string): JsonObject {
@@ -146,6 +235,14 @@ function integerValue(value: unknown, label: string): number {
         throw new Error(`${label} must be an integer`);
     }
     return value;
+}
+
+function byteValue(value: unknown, label: string): number {
+    const byte = integerValue(value, label);
+    if (byte < 0 || byte > 255) {
+        throw new Error(`${label} must fit in one byte`);
+    }
+    return byte;
 }
 
 function stringArray(value: unknown, label: string): string[] {
@@ -309,6 +406,200 @@ function decodeChanges(testCase: ConformanceCase): [ChangesRequest, ChangesExpec
     ];
 }
 
+function decodeDirectPut(testCase: ConformanceCase): [DirectPutRequest, DirectPutExpected] {
+    const request = strictObject(
+        testCase.request,
+        ["namespace_id", "path", "commit_id", "actor", "content_utf8"],
+        `${testCase.name} request`,
+    );
+    const expected = strictObject(
+        testCase.expected,
+        ["mode", "size_bytes", "checksum_algorithm", "committed_seq"],
+        `${testCase.name} expected`,
+    );
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "upload_direct_put request.namespace_id"),
+            path: stringValue(request.path, "upload_direct_put request.path"),
+            commitId: stringValue(request.commit_id, "upload_direct_put request.commit_id"),
+            actor: actorValue(request.actor, "upload_direct_put request.actor"),
+            contentUtf8: stringValue(request.content_utf8, "upload_direct_put request.content_utf8"),
+        },
+        {
+            mode: stringValue(expected.mode, "upload_direct_put expected.mode"),
+            sizeBytes: integerValue(expected.size_bytes, "upload_direct_put expected.size_bytes"),
+            checksumAlgorithm: stringValue(
+                expected.checksum_algorithm,
+                "upload_direct_put expected.checksum_algorithm",
+            ),
+            committedSeq: integerValue(
+                expected.committed_seq,
+                "upload_direct_put expected.committed_seq",
+            ),
+        },
+    ];
+}
+
+function bytePatternValue(value: unknown, label: string): BytePattern {
+    const pattern = strictObject(value, ["length", "modulus"], label);
+    return {
+        length: integerValue(pattern.length, `${label}.length`),
+        modulus: byteValue(pattern.modulus, `${label}.modulus`),
+    };
+}
+
+function decodeMultipart(testCase: ConformanceCase): [MultipartRequest, MultipartExpected] {
+    const request = strictObject(
+        testCase.request,
+        ["namespace_id", "path", "commit_id", "actor", "part_size_bytes", "content_pattern"],
+        `${testCase.name} request`,
+    );
+    const expected = strictObject(
+        testCase.expected,
+        ["mode", "part_count", "size_bytes", "checksum_algorithm", "committed_seq"],
+        `${testCase.name} expected`,
+    );
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "upload_multipart request.namespace_id"),
+            path: stringValue(request.path, "upload_multipart request.path"),
+            commitId: stringValue(request.commit_id, "upload_multipart request.commit_id"),
+            actor: actorValue(request.actor, "upload_multipart request.actor"),
+            partSizeBytes: integerValue(
+                request.part_size_bytes,
+                "upload_multipart request.part_size_bytes",
+            ),
+            contentPattern: bytePatternValue(
+                request.content_pattern,
+                "upload_multipart request.content_pattern",
+            ),
+        },
+        {
+            mode: stringValue(expected.mode, "upload_multipart expected.mode"),
+            partCount: integerValue(expected.part_count, "upload_multipart expected.part_count"),
+            sizeBytes: integerValue(expected.size_bytes, "upload_multipart expected.size_bytes"),
+            checksumAlgorithm: stringValue(
+                expected.checksum_algorithm,
+                "upload_multipart expected.checksum_algorithm",
+            ),
+            committedSeq: integerValue(
+                expected.committed_seq,
+                "upload_multipart expected.committed_seq",
+            ),
+        },
+    ];
+}
+
+function decodeAbort(testCase: ConformanceCase): [AbortRequest, AbortExpected] {
+    const request = strictObject(testCase.request, ["namespace_id"], `${testCase.name} request`);
+    const expected = strictObject(testCase.expected, ["mode", "status"], `${testCase.name} expected`);
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "upload_abort request.namespace_id"),
+        },
+        {
+            mode: stringValue(expected.mode, "upload_abort expected.mode"),
+            status: stringValue(expected.status, "upload_abort expected.status"),
+        },
+    ];
+}
+
+function decodeDownload(testCase: ConformanceCase): [DownloadRequest, DownloadExpected] {
+    const request = strictObject(
+        testCase.request,
+        ["namespace_id", "path", "commit_id", "actor", "content_utf8"],
+        `${testCase.name} request`,
+    );
+    const expected = strictObject(
+        testCase.expected,
+        ["size_bytes", "checksum_algorithm", "committed_seq"],
+        `${testCase.name} expected`,
+    );
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "download request.namespace_id"),
+            path: stringValue(request.path, "download request.path"),
+            commitId: stringValue(request.commit_id, "download request.commit_id"),
+            actor: actorValue(request.actor, "download request.actor"),
+            contentUtf8: stringValue(request.content_utf8, "download request.content_utf8"),
+        },
+        {
+            sizeBytes: integerValue(expected.size_bytes, "download expected.size_bytes"),
+            checksumAlgorithm: stringValue(
+                expected.checksum_algorithm,
+                "download expected.checksum_algorithm",
+            ),
+            committedSeq: integerValue(expected.committed_seq, "download expected.committed_seq"),
+        },
+    ];
+}
+
+function decodeEndToEnd(testCase: ConformanceCase): [EndToEndRequest, EndToEndExpected] {
+    const request = strictObject(
+        testCase.request,
+        ["namespace_id", "directory", "upload_path", "moved_path", "actor", "content_utf8", "commit_ids"],
+        `${testCase.name} request`,
+    );
+    const commitIds = strictObject(
+        request.commit_ids,
+        ["mkdir", "upload", "move", "remove"],
+        "end_to_end request.commit_ids",
+    );
+    const expected = strictObject(
+        testCase.expected,
+        [
+            "mkdir_committed_seq",
+            "upload_committed_seq",
+            "move_committed_seq",
+            "remove_committed_seq",
+            "size_bytes",
+            "revision_count",
+            "change_count",
+        ],
+        `${testCase.name} expected`,
+    );
+    return [
+        {
+            namespaceId: stringValue(request.namespace_id, "end_to_end request.namespace_id"),
+            directory: stringValue(request.directory, "end_to_end request.directory"),
+            uploadPath: stringValue(request.upload_path, "end_to_end request.upload_path"),
+            movedPath: stringValue(request.moved_path, "end_to_end request.moved_path"),
+            actor: actorValue(request.actor, "end_to_end request.actor"),
+            contentUtf8: stringValue(request.content_utf8, "end_to_end request.content_utf8"),
+            commitIds: {
+                mkdir: stringValue(commitIds.mkdir, "end_to_end request.commit_ids.mkdir"),
+                upload: stringValue(commitIds.upload, "end_to_end request.commit_ids.upload"),
+                move: stringValue(commitIds.move, "end_to_end request.commit_ids.move"),
+                remove: stringValue(commitIds.remove, "end_to_end request.commit_ids.remove"),
+            },
+        },
+        {
+            mkdirCommittedSeq: integerValue(
+                expected.mkdir_committed_seq,
+                "end_to_end expected.mkdir_committed_seq",
+            ),
+            uploadCommittedSeq: integerValue(
+                expected.upload_committed_seq,
+                "end_to_end expected.upload_committed_seq",
+            ),
+            moveCommittedSeq: integerValue(
+                expected.move_committed_seq,
+                "end_to_end expected.move_committed_seq",
+            ),
+            removeCommittedSeq: integerValue(
+                expected.remove_committed_seq,
+                "end_to_end expected.remove_committed_seq",
+            ),
+            sizeBytes: integerValue(expected.size_bytes, "end_to_end expected.size_bytes"),
+            revisionCount: integerValue(
+                expected.revision_count,
+                "end_to_end expected.revision_count",
+            ),
+            changeCount: integerValue(expected.change_count, "end_to_end expected.change_count"),
+        },
+    ];
+}
+
 function loadCases(directory: string): Map<string, ConformanceCase> {
     const cases = readdirSync(directory, { withFileTypes: true })
         .filter((entry) => entry.isFile() && extname(entry.name) === ".json")
@@ -377,6 +668,181 @@ function directoryCommit(
         request.message = message;
     }
     return request;
+}
+
+function fileCommit(
+    namespaceId: string,
+    commitId: string,
+    actor: ActorValue,
+    path: string,
+    contentRef: LoonFS.ContentRef,
+    contentToken?: LoonFS.ContentToken,
+): LoonFS.CommitRequest {
+    const request: LoonFS.CommitRequest = {
+        namespace_id: namespaceId,
+        actor,
+        commit_id: commitId,
+        operations: [
+            {
+                kind: "put_file",
+                path,
+                content_ref: contentRef,
+                behavior: "no_replace",
+            },
+        ],
+    };
+    if (contentToken !== undefined) {
+        request.content_tokens = [contentToken];
+    }
+    return request;
+}
+
+function moveCommit(
+    namespaceId: string,
+    commitId: string,
+    actor: ActorValue,
+    fromPath: string,
+    toPath: string,
+): LoonFS.CommitRequest {
+    return {
+        namespace_id: namespaceId,
+        actor,
+        commit_id: commitId,
+        operations: [
+            {
+                kind: "move_path",
+                from_path: fromPath,
+                to_path: toPath,
+                behavior: "no_replace",
+            },
+        ],
+    };
+}
+
+function deleteCommit(
+    namespaceId: string,
+    commitId: string,
+    actor: ActorValue,
+    path: string,
+): LoonFS.CommitRequest {
+    return {
+        namespace_id: namespaceId,
+        actor,
+        commit_id: commitId,
+        operations: [{ kind: "delete_path", path, behavior: "non_recursive" }],
+    };
+}
+
+function bytePattern(pattern: BytePattern): Uint8Array {
+    if (pattern.length < 0 || pattern.modulus === 0) {
+        throw new Error("invalid byte pattern");
+    }
+    return Uint8Array.from({ length: pattern.length }, (_, offset) => offset % pattern.modulus);
+}
+
+function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
+    const parts: Uint8Array[] = [];
+    for (let offset = 0; offset < bytes.byteLength; offset += partSize) {
+        parts.push(bytes.subarray(offset, Math.min(offset + partSize, bytes.byteLength)));
+    }
+    return parts;
+}
+
+async function uploadPresigned(
+    access: LoonFS.ObjectTransferAccess,
+    bytes: Uint8Array,
+    label: string,
+): Promise<Response> {
+    assert.equal(access.method, "PUT", `${label} presigned method`);
+    const response = await fetch(access.url, {
+        method: access.method,
+        headers: access.headers,
+        body: arrayBuffer(bytes),
+    });
+    assert.ok(response.ok, `${label} failed with HTTP ${response.status}`);
+    return response;
+}
+
+async function readProxied(
+    client: LoonFSClient,
+    namespaceId: string,
+    path: string,
+): Promise<Uint8Array> {
+    const response = await client.filesystem.getFileBytes({
+        namespace_id: namespaceId,
+        path,
+    });
+    return new Uint8Array(await response.arrayBuffer());
+}
+
+function completedUpload(response: LoonFS.UploadSessionResponse): CompletedUpload {
+    const completed = response as CompletedUpload;
+    assert.equal(completed.status, "completed");
+    return completed;
+}
+
+function abortedUpload(response: LoonFS.UploadSessionResponse): AbortedUpload {
+    const aborted = response as AbortedUpload;
+    assert.equal(aborted.status, "aborted");
+    return aborted;
+}
+
+function checksum(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): LoonFS.Checksum {
+    switch (algorithm) {
+        case "sha256":
+            return { algorithm, value: createHash("sha256").update(bytes).digest("hex") };
+        case "crc32c":
+            return { algorithm, value: crc32c(bytes).toString(16).padStart(8, "0") };
+        case "crc64nvme":
+            return { algorithm, value: crc64Nvme(bytes).toString(16).padStart(16, "0") };
+    }
+}
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+    const copy = new Uint8Array(bytes.byteLength);
+    copy.set(bytes);
+    return copy.buffer;
+}
+
+function makeCrc32cTable(): Uint32Array {
+    const table = new Uint32Array(256);
+    for (let index = 0; index < table.length; index += 1) {
+        let value = index;
+        for (let bit = 0; bit < 8; bit += 1) {
+            value = (value >>> 1) ^ ((value & 1) === 0 ? 0 : CRC32C_POLYNOMIAL);
+        }
+        table[index] = value >>> 0;
+    }
+    return table;
+}
+
+function crc32c(bytes: Uint8Array): number {
+    let value = 0xffffffff;
+    for (const byte of bytes) {
+        value = CRC32C_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
+    }
+    return (value ^ 0xffffffff) >>> 0;
+}
+
+function makeCrc64NvmeTable(): bigint[] {
+    const table: bigint[] = [];
+    for (let index = 0; index < 256; index += 1) {
+        let value = BigInt(index);
+        for (let bit = 0; bit < 8; bit += 1) {
+            value = (value >> 1n) ^ ((value & 1n) === 0n ? 0n : CRC64_NVME_POLYNOMIAL);
+        }
+        table.push(value & CRC64_MASK);
+    }
+    return table;
+}
+
+function crc64Nvme(bytes: Uint8Array): bigint {
+    let value = CRC64_MASK;
+    for (const byte of bytes) {
+        const index = Number((value ^ BigInt(byte)) & 0xffn);
+        value = CRC64_NVME_TABLE[index]! ^ (value >> 8n);
+    }
+    return (value ^ CRC64_MASK) & CRC64_MASK;
 }
 
 function listedNames(entries: LoonFS.AuthoritativePathEntry[]): string[] {
@@ -546,6 +1012,334 @@ conformanceTest("changes", async (activeHarness, testCase) => {
     assert.equal(change.events[0]?.kind, "directory_created");
 });
 
-for (const caseName of TRANSFER_CASES) {
-    test(caseName, { skip: environmentSkip ?? TRANSFER_SKIP }, () => {});
-}
+conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
+    const [request, expected] = decodeDirectPut(testCase);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    const payload = new TextEncoder().encode(request.contentUtf8);
+    const claim: LoonFS.UploadContentClaim = {
+        size_bytes: payload.byteLength,
+        checksum: checksum("sha256", payload),
+    };
+    const begin = await activeHarness.client.uploads.beginUpload({
+        namespace_id: request.namespaceId,
+        body: { mode: "direct_put", content: claim },
+    });
+    assert.equal(begin.mode, "direct_put");
+    assert.equal(expected.mode, "direct_put");
+    assert.equal(begin.direct_put.content_ref.size_bytes, expected.sizeBytes);
+    assert.equal(begin.direct_put.content_ref.checksum.algorithm, expected.checksumAlgorithm);
+    assert.deepEqual(begin.direct_put.content_ref.checksum, claim.checksum);
+
+    await uploadPresigned(begin.direct_put.access, payload, "direct PUT");
+    const completed = completedUpload(
+        await activeHarness.client.uploads.completeUpload({
+            namespace_id: request.namespaceId,
+            upload_id: begin.upload_id,
+            body: { mode: "direct_put" },
+        }),
+    );
+    assert.deepEqual(completed.content_ref, begin.direct_put.content_ref);
+
+    const committed = await activeHarness.client.filesystem.applyCommit(
+        fileCommit(
+            request.namespaceId,
+            request.commitId,
+            request.actor,
+            request.path,
+            completed.content_ref,
+            completed.content_token,
+        ),
+    );
+    assert.equal(committed.committed_seq, expected.committedSeq);
+    const stat = (await activeHarness.client.filesystem.statPath({
+        namespace_id: request.namespaceId,
+        path: request.path,
+    })) as FileEntry;
+    assert.deepEqual(stat.content_ref, completed.content_ref);
+    assert.deepEqual(
+        await readProxied(activeHarness.client, request.namespaceId, request.path),
+        payload,
+    );
+});
+
+conformanceTest("upload_multipart", async (activeHarness, testCase) => {
+    const [request, expected] = decodeMultipart(testCase);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    const payload = bytePattern(request.contentPattern);
+    const begin = await activeHarness.client.uploads.beginUpload({
+        namespace_id: request.namespaceId,
+        body: {
+            mode: "direct_multipart",
+            multipart: { part_size_bytes: request.partSizeBytes },
+        },
+    });
+    assert.equal(begin.mode, "direct_multipart");
+    assert.equal(expected.mode, "direct_multipart");
+    assert.equal(begin.direct_multipart.part_size_bytes, request.partSizeBytes);
+    assert.equal(begin.direct_multipart.checksum_algorithm, expected.checksumAlgorithm);
+
+    const chunks = splitBytes(payload, begin.direct_multipart.part_size_bytes);
+    assert.equal(chunks.length, expected.partCount);
+    const claims: LoonFS.UploadPartChecksumClaim[] = chunks.map((chunk, index) => ({
+        part_number: index + 1,
+        checksum: checksum(begin.direct_multipart.checksum_algorithm, chunk),
+    }));
+    const signed = await activeHarness.client.uploads.signUploadParts({
+        namespace_id: request.namespaceId,
+        upload_id: begin.upload_id,
+        parts: claims,
+    });
+    assert.equal(signed.parts.length, expected.partCount);
+
+    const completedParts: LoonFS.CompletedUploadPart[] = [];
+    for (const signedPart of signed.parts) {
+        const index = signedPart.part_number - 1;
+        const chunk = chunks[index];
+        const claim = claims[index];
+        assert.ok(chunk !== undefined, `signed part ${signedPart.part_number} has no payload`);
+        assert.ok(claim !== undefined, `signed part ${signedPart.part_number} has no claim`);
+        const response = await uploadPresigned(
+            signedPart.access,
+            chunk,
+            `multipart part ${signedPart.part_number}`,
+        );
+        const etag = response.headers.get("etag");
+        assert.ok(etag !== null, `multipart part ${signedPart.part_number} returned no etag`);
+        completedParts.push({
+            part_number: signedPart.part_number,
+            checksum: claim.checksum,
+            etag,
+        });
+    }
+    completedParts.sort((left, right) => left.part_number - right.part_number);
+    const wholeChecksum = checksum(begin.direct_multipart.checksum_algorithm, payload);
+    const completion: LoonFS.CompleteUploadRequest = {
+        mode: "direct_multipart",
+        content: {
+            size_bytes: payload.byteLength,
+            checksum: wholeChecksum,
+        },
+        parts: completedParts,
+    };
+    const first = completedUpload(
+        await activeHarness.client.uploads.completeUpload({
+            namespace_id: request.namespaceId,
+            upload_id: begin.upload_id,
+            body: completion,
+        }),
+    );
+    const replayed = completedUpload(
+        await activeHarness.client.uploads.completeUpload({
+            namespace_id: request.namespaceId,
+            upload_id: begin.upload_id,
+            body: completion,
+        }),
+    );
+    assert.equal(replayed.namespace_id, first.namespace_id);
+    assert.equal(replayed.upload_id, first.upload_id);
+    assert.equal(replayed.mode, first.mode);
+    assert.deepEqual(replayed.content_ref, first.content_ref);
+    assert.equal(replayed.completed_at_ms, first.completed_at_ms);
+    assert.equal(first.content_ref.size_bytes, expected.sizeBytes);
+    assert.deepEqual(first.content_ref.checksum, wholeChecksum);
+    assert.deepEqual(checksum(first.content_ref.checksum.algorithm, payload), wholeChecksum);
+
+    const committed = await activeHarness.client.filesystem.applyCommit(
+        fileCommit(
+            request.namespaceId,
+            request.commitId,
+            request.actor,
+            request.path,
+            first.content_ref,
+            replayed.content_token,
+        ),
+    );
+    assert.equal(committed.committed_seq, expected.committedSeq);
+    assert.deepEqual(
+        await readProxied(activeHarness.client, request.namespaceId, request.path),
+        payload,
+    );
+
+    // The same content through the high-level helper: the payload exceeds the
+    // part size, so this exercises putFile's multipart branch.
+    const helperPath = `${request.path}-helper`;
+    const helperCommit = await putFile(activeHarness.client, {
+        namespace_id: request.namespaceId,
+        path: helperPath,
+        bytes: payload,
+        actor: request.actor,
+        commit_id: `${request.commitId}-helper`,
+    });
+    assert.ok(helperCommit.committed_seq > 0, "helper multipart put reported no committed_seq");
+    const helperRead = await getFile(activeHarness.client, {
+        namespace_id: request.namespaceId,
+        path: helperPath,
+    });
+    assert.deepEqual(helperRead.bytes, payload);
+    // Content ids are random per upload and the helper may choose a different
+    // checksum algorithm; the comparable content fact is the size.
+    assert.equal(helperRead.content_ref.size_bytes, first.content_ref.size_bytes);
+});
+
+conformanceTest("upload_abort", async (activeHarness, testCase) => {
+    const [request, expected] = decodeAbort(testCase);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    const begin = await activeHarness.client.uploads.beginUpload({
+        namespace_id: request.namespaceId,
+        body: { mode: "service_proxied" },
+    });
+    const first = abortedUpload(
+        await activeHarness.client.uploads.abortUpload({
+            namespace_id: request.namespaceId,
+            upload_id: begin.upload_id,
+        }),
+    );
+    const replayed = abortedUpload(
+        await activeHarness.client.uploads.abortUpload({
+            namespace_id: request.namespaceId,
+            upload_id: begin.upload_id,
+        }),
+    );
+    assert.equal(expected.mode, "service_proxied");
+    assert.equal(expected.status, "aborted");
+    assert.equal(first.mode, expected.mode);
+    assert.equal(first.status, expected.status);
+    assert.deepEqual(replayed, first);
+    assert.equal(replayed.aborted_at_ms, first.aborted_at_ms);
+});
+
+conformanceTest("download", async (activeHarness, testCase) => {
+    const [request, expected] = decodeDownload(testCase);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    const payload = new TextEncoder().encode(request.contentUtf8);
+    const committed = await putFile(activeHarness.client, {
+        namespace_id: request.namespaceId,
+        path: request.path,
+        bytes: payload,
+        actor: request.actor,
+        commit_id: request.commitId,
+    });
+    assert.equal(committed.committed_seq, expected.committedSeq);
+    const stat = (await activeHarness.client.filesystem.statPath({
+        namespace_id: request.namespaceId,
+        path: request.path,
+    })) as FileEntry;
+    const download = await getFile(activeHarness.client, {
+        namespace_id: request.namespaceId,
+        path: request.path,
+    });
+    assert.deepEqual(stat.content_ref, download.content_ref);
+    assert.equal(download.content_ref.size_bytes, expected.sizeBytes);
+    assert.equal(download.content_ref.checksum.algorithm, expected.checksumAlgorithm);
+    assert.equal(download.bytes.byteLength, download.content_ref.size_bytes);
+    assert.deepEqual(
+        checksum(download.content_ref.checksum.algorithm, download.bytes),
+        download.content_ref.checksum,
+    );
+    assert.deepEqual(download.bytes, payload);
+});
+
+conformanceTest("end_to_end", async (activeHarness, testCase) => {
+    const [request, expected] = decodeEndToEnd(testCase);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    const mkdir = await activeHarness.client.filesystem.applyCommit(
+        directoryCommit(
+            request.namespaceId,
+            request.commitIds.mkdir,
+            request.actor,
+            request.directory,
+        ),
+    );
+    assert.equal(mkdir.committed_seq, expected.mkdirCommittedSeq);
+
+    const payload = new TextEncoder().encode(request.contentUtf8);
+    const upload = await putFile(activeHarness.client, {
+        namespace_id: request.namespaceId,
+        path: request.uploadPath,
+        bytes: payload,
+        actor: request.actor,
+        commit_id: request.commitIds.upload,
+    });
+    assert.equal(upload.committed_seq, expected.uploadCommittedSeq);
+    const stat = (await activeHarness.client.filesystem.statPath({
+        namespace_id: request.namespaceId,
+        path: request.uploadPath,
+    })) as FileEntry;
+    assert.equal(stat.size_bytes, expected.sizeBytes);
+    const uploadedInode = stat.inode_id;
+
+    const initialListing = await activeHarness.client.filesystem.listPathEntries({
+        namespace_id: request.namespaceId,
+        path: request.directory,
+    });
+    assert.ok(initialListing.data.some((entry) => entry.path === request.uploadPath));
+
+    const downloaded = await getFile(activeHarness.client, {
+        namespace_id: request.namespaceId,
+        path: request.uploadPath,
+    });
+    assert.deepEqual(downloaded.bytes, payload);
+
+    const moved = await activeHarness.client.filesystem.applyCommit(
+        moveCommit(
+            request.namespaceId,
+            request.commitIds.move,
+            request.actor,
+            request.uploadPath,
+            request.movedPath,
+        ),
+    );
+    assert.equal(moved.committed_seq, expected.moveCommittedSeq);
+    const movedListing = await activeHarness.client.filesystem.listPathEntries({
+        namespace_id: request.namespaceId,
+        path: request.directory,
+    });
+    assert.ok(movedListing.data.some((entry) => entry.path === request.movedPath));
+
+    const revisions = await activeHarness.client.filesystem.listFileRevisions({
+        namespace_id: request.namespaceId,
+        path: request.movedPath,
+    });
+    assert.equal(revisions.data.length, expected.revisionCount);
+    assert.equal(revisions.data[0]?.commit_id, request.commitIds.upload);
+
+    let changes = await activeHarness.client.filesystem.listChanges({
+        namespace_id: request.namespaceId,
+        after_seq: 0,
+    });
+    assert.equal(changes.changes.length, expected.changeCount - 1);
+    const removed = await activeHarness.client.filesystem.applyCommit(
+        deleteCommit(
+            request.namespaceId,
+            request.commitIds.remove,
+            request.actor,
+            request.movedPath,
+        ),
+    );
+    assert.equal(removed.committed_seq, expected.removeCommittedSeq);
+
+    changes = await activeHarness.client.filesystem.listChanges({
+        namespace_id: request.namespaceId,
+        after_seq: 0,
+    });
+    assert.equal(changes.changes.length, expected.changeCount);
+    assert.deepEqual(
+        changes.changes.map((change) => change.commit_id),
+        [
+            request.commitIds.mkdir,
+            request.commitIds.upload,
+            request.commitIds.move,
+            request.commitIds.remove,
+        ],
+    );
+    for (const change of changes.changes) {
+        assert.deepEqual(change.committed_by, request.actor);
+    }
+
+    const trash = await activeHarness.client.filesystem.listTrash({
+        namespace_id: request.namespaceId,
+    });
+    const removedEntry = trash.data.find((entry) => entry.inode_id === uploadedInode);
+    assert.ok(removedEntry !== undefined, "removed inode is missing from trash");
+    assert.equal(removedEntry.deletion_seq, removed.committed_seq);
+});

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -1,0 +1,431 @@
+import { LoonFSClient } from "./Client.js";
+import type * as LoonFS from "./api/index.js";
+
+const DIRECT_MULTIPART_FEATURE = "core.uploads.direct_multipart";
+const DIRECT_PUT_FEATURE = "core.uploads.direct_put";
+const DIRECT_PUT_MAX_BYTES = "upload.direct_put_max_content_bytes";
+const PROXY_UPLOAD_MAX_BYTES = "upload.max_content_bytes";
+const MULTIPART_MIN_BYTES = 8 * 1024 * 1024;
+const CRC32C_POLYNOMIAL = 0x82f63b78;
+const CRC64_NVME_POLYNOMIAL = 0x9a6c9329ac4bc9b5n;
+const CRC64_MASK = 0xffffffffffffffffn;
+
+const DIRECT_PUT_CHECKSUM_FEATURES: readonly [string, LoonFS.ChecksumAlgorithm][] = [
+    ["core.uploads.direct_put.checksum.sha256", "sha256"],
+    ["core.uploads.direct_put.checksum.crc64nvme", "crc64nvme"],
+    ["core.uploads.direct_put.checksum.crc32c", "crc32c"],
+];
+
+const CRC32C_TABLE = makeCrc32cTable();
+const CRC64_NVME_TABLE = makeCrc64NvmeTable();
+
+export interface PutFileInput {
+    namespace_id: LoonFS.NamespaceId;
+    path: LoonFS.AbsolutePath;
+    bytes: Uint8Array;
+    actor: LoonFS.ActorRef;
+    commit_id: LoonFS.CommitId;
+    message?: string | null;
+    behavior?: LoonFS.DestinationBehavior;
+    expected_revision_no?: LoonFS.RevisionNo;
+}
+
+export interface PutFileResult {
+    namespace_id: LoonFS.NamespaceId;
+    commit_id: LoonFS.CommitId;
+    committed_seq: LoonFS.ChangeSeq;
+}
+
+export interface GetFileInput {
+    namespace_id: LoonFS.NamespaceId;
+    path: LoonFS.AbsolutePath;
+    revision_no?: LoonFS.RevisionNo;
+}
+
+export interface GetFileResult extends LoonFS.BeginDownloadResponse {
+    bytes: Uint8Array;
+}
+
+type CompletedUpload = LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
+
+interface StagedContent {
+    contentRef: LoonFS.ContentRef;
+    contentToken?: LoonFS.ContentToken;
+}
+
+/**
+ * Uploads in-memory bytes and commits them at one path.
+ * Streaming and resume are follow-ups.
+ */
+export async function putFile(client: LoonFSClient, input: PutFileInput): Promise<PutFileResult> {
+    const staged = await stageBytes(client, input.namespace_id, input.bytes);
+    const request: LoonFS.CommitRequest = {
+        namespace_id: input.namespace_id,
+        actor: input.actor,
+        commit_id: input.commit_id,
+        content_tokens: staged.contentToken === undefined ? [] : [staged.contentToken],
+        operations: [
+            {
+                kind: "put_file",
+                path: input.path,
+                content_ref: staged.contentRef,
+                behavior: input.behavior ?? "no_replace",
+                expected_revision_no: input.expected_revision_no,
+            },
+        ],
+    };
+    if (input.message !== undefined) {
+        request.message = input.message;
+    }
+    return client.filesystem.applyCommit(request);
+}
+
+/**
+ * Downloads one revision into memory and verifies its content claim.
+ * Streaming and resume are follow-ups.
+ */
+export async function getFile(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
+    const grant = await client.filesystem.beginDownload(input);
+    requirePresignedMethod(grant.access, "GET", "download");
+    const response = await fetch(grant.access.url, {
+        redirect: "error",
+        method: grant.access.method,
+        headers: grant.access.headers,
+    });
+    requireSuccessfulResponse(response, "download");
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength !== grant.content_ref.size_bytes) {
+        throw new Error(
+            `download returned ${bytes.byteLength} bytes, expected ${grant.content_ref.size_bytes}`,
+        );
+    }
+    const actual = await checksum(grant.content_ref.checksum.algorithm, bytes);
+    if (actual.value !== grant.content_ref.checksum.value) {
+        throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
+    }
+    return { ...grant, bytes };
+}
+
+async function stageBytes(
+    client: LoonFSClient,
+    namespaceId: LoonFS.NamespaceId,
+    bytes: Uint8Array,
+): Promise<StagedContent> {
+    const capabilities = await client.capabilities();
+    const beginRequest = await selectBeginRequest(capabilities, bytes);
+    const begin = await client.uploads.beginUpload({
+        namespace_id: namespaceId,
+        body: beginRequest,
+    });
+
+    switch (begin.mode) {
+        case "direct_put":
+            return stageDirectPut(client, namespaceId, bytes, begin);
+        case "direct_multipart":
+            return stageMultipart(client, namespaceId, bytes, begin);
+        case "service_proxied":
+            return stageServiceProxied(client, namespaceId, bytes, begin);
+    }
+}
+
+async function selectBeginRequest(
+    capabilities: LoonFS.CapabilityDocument,
+    bytes: Uint8Array,
+): Promise<LoonFS.BeginUploadRequest> {
+    const features = capabilities.features ?? {};
+    const limits = capabilities.limits ?? {};
+    const supportsMultipart = features[DIRECT_MULTIPART_FEATURE] === true;
+    const worthCutting = bytes.byteLength >= MULTIPART_MIN_BYTES;
+    if (worthCutting && supportsMultipart) {
+        return { mode: "direct_multipart" };
+    }
+
+    const directPutAlgorithm = features[DIRECT_PUT_FEATURE]
+        ? DIRECT_PUT_CHECKSUM_FEATURES.find(([feature]) => features[feature] === true)?.[1]
+        : undefined;
+    const proxyLimit = limits[PROXY_UPLOAD_MAX_BYTES];
+    const fitsProxy = proxyLimit === undefined || bytes.byteLength <= proxyLimit;
+    const directPutLimit = limits[DIRECT_PUT_MAX_BYTES];
+    const fitsDirectPut = directPutLimit === undefined || bytes.byteLength <= directPutLimit;
+    if (
+        directPutAlgorithm !== undefined &&
+        fitsDirectPut &&
+        (worthCutting || !fitsProxy)
+    ) {
+        return {
+            mode: "direct_put",
+            content: {
+                size_bytes: bytes.byteLength,
+                checksum: await checksum(directPutAlgorithm, bytes),
+            },
+        };
+    }
+    if (fitsProxy) {
+        return { mode: "service_proxied" };
+    }
+    throw new Error(`${bytes.byteLength} bytes fit no advertised upload transport`);
+}
+
+async function stageServiceProxied(
+    client: LoonFSClient,
+    namespaceId: LoonFS.NamespaceId,
+    bytes: Uint8Array,
+    begin: LoonFS.BeginUploadResponse.ServiceProxied,
+): Promise<StagedContent> {
+    try {
+        await client.uploads.uploadContent(arrayBuffer(bytes), namespaceId, begin.upload_id);
+        return stagedContent(
+            await client.uploads.completeUpload({
+                namespace_id: namespaceId,
+                upload_id: begin.upload_id,
+                body: { mode: "service_proxied" },
+            }),
+        );
+    } catch (error) {
+        await abortQuietly(client, namespaceId, begin.upload_id);
+        throw error;
+    }
+}
+
+async function stageDirectPut(
+    client: LoonFSClient,
+    namespaceId: LoonFS.NamespaceId,
+    bytes: Uint8Array,
+    begin: LoonFS.BeginUploadResponse.DirectPut,
+): Promise<StagedContent> {
+    const expected = begin.direct_put.content_ref;
+    if (expected.size_bytes !== bytes.byteLength) {
+        throw new Error("direct PUT response did not describe the requested size");
+    }
+    const actual = await checksum(expected.checksum.algorithm, bytes);
+    if (actual.value !== expected.checksum.value) {
+        throw new Error("direct PUT response did not describe the requested checksum");
+    }
+    try {
+        requirePresignedMethod(begin.direct_put.access, "PUT", "direct PUT");
+        const response = await fetch(begin.direct_put.access.url, {
+            redirect: "error",
+            method: begin.direct_put.access.method,
+            headers: begin.direct_put.access.headers,
+            body: arrayBuffer(bytes),
+        });
+        requireSuccessfulResponse(response, "direct PUT");
+    } catch (error) {
+        await abortQuietly(client, namespaceId, begin.upload_id);
+        throw error;
+    }
+    const completed = completedUpload(
+        await client.uploads.completeUpload({
+            namespace_id: namespaceId,
+            upload_id: begin.upload_id,
+            body: { mode: "direct_put" },
+        }),
+    );
+    if (!sameContentRef(completed.content_ref, expected)) {
+        throw new Error("direct PUT completion returned a different content reference");
+    }
+    return stagedContent(completed);
+}
+
+async function stageMultipart(
+    client: LoonFSClient,
+    namespaceId: LoonFS.NamespaceId,
+    bytes: Uint8Array,
+    begin: LoonFS.BeginUploadResponse.DirectMultipart,
+): Promise<StagedContent> {
+    const { checksum_algorithm: algorithm, part_size_bytes: partSize } = begin.direct_multipart;
+    if (!Number.isSafeInteger(partSize) || partSize <= 0) {
+        throw new Error(`invalid multipart part size ${partSize}`);
+    }
+    if (bytes.byteLength === 0) {
+        throw new Error("direct multipart upload cannot carry an empty payload");
+    }
+
+    const chunks = splitBytes(bytes, partSize);
+    const claims: LoonFS.UploadPartChecksumClaim[] = [];
+    for (const [index, chunk] of chunks.entries()) {
+        claims.push({
+            part_number: index + 1,
+            checksum: await checksum(algorithm, chunk),
+        });
+    }
+    const completedParts: LoonFS.CompletedUploadPart[] = [];
+    try {
+        const signed = await client.uploads.signUploadParts({
+            namespace_id: namespaceId,
+            upload_id: begin.upload_id,
+            parts: claims,
+        });
+        const accessByPart = new Map(signed.parts.map((part) => [part.part_number, part.access]));
+        for (const [index, claim] of claims.entries()) {
+            const access = accessByPart.get(claim.part_number);
+            if (access === undefined) {
+                throw new Error(`server did not sign part ${claim.part_number}`);
+            }
+            requirePresignedMethod(access, "PUT", `part ${claim.part_number}`);
+            const response = await fetch(access.url, {
+                redirect: "error",
+                method: access.method,
+                headers: access.headers,
+                body: arrayBuffer(chunks[index]!),
+            });
+            requireSuccessfulResponse(response, `part ${claim.part_number}`);
+            const etag = response.headers.get("etag");
+            if (etag === null) {
+                throw new Error(`part ${claim.part_number} upload returned no etag`);
+            }
+            completedParts.push({
+                part_number: claim.part_number,
+                checksum: claim.checksum,
+                etag,
+            });
+        }
+    } catch (error) {
+        await abortQuietly(client, namespaceId, begin.upload_id);
+        throw error;
+    }
+
+    return stagedContent(
+        await client.uploads.completeUpload({
+            namespace_id: namespaceId,
+            upload_id: begin.upload_id,
+            body: {
+                mode: "direct_multipart",
+                content: {
+                    size_bytes: bytes.byteLength,
+                    checksum: await checksum(algorithm, bytes),
+                },
+                parts: completedParts,
+            },
+        }),
+    );
+}
+
+function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
+    const parts: Uint8Array[] = [];
+    for (let offset = 0; offset < bytes.byteLength; offset += partSize) {
+        parts.push(bytes.subarray(offset, Math.min(offset + partSize, bytes.byteLength)));
+    }
+    return parts;
+}
+
+function completedUpload(response: LoonFS.UploadSessionResponse): CompletedUpload {
+    const completed = response as CompletedUpload;
+    if (completed.status !== "completed") {
+        throw new Error(`upload ${response.upload_id} completed with status ${completed.status}`);
+    }
+    return completed;
+}
+
+function stagedContent(response: LoonFS.UploadSessionResponse): StagedContent {
+    const completed = completedUpload(response);
+    return {
+        contentRef: completed.content_ref,
+        contentToken: completed.content_token,
+    };
+}
+
+async function abortQuietly(
+    client: LoonFSClient,
+    namespaceId: LoonFS.NamespaceId,
+    uploadId: LoonFS.UploadId,
+): Promise<void> {
+    try {
+        await client.uploads.abortUpload({ namespace_id: namespaceId, upload_id: uploadId });
+    } catch {
+        // Preserve the transfer error.
+    }
+}
+
+function sameContentRef(left: LoonFS.ContentRef, right: LoonFS.ContentRef): boolean {
+    return (
+        left.content_id === right.content_id &&
+        left.kind === right.kind &&
+        left.size_bytes === right.size_bytes &&
+        left.checksum.algorithm === right.checksum.algorithm &&
+        left.checksum.value === right.checksum.value
+    );
+}
+
+function requirePresignedMethod(
+    access: LoonFS.ObjectTransferAccess,
+    expected: "GET" | "PUT",
+    operation: string,
+): void {
+    if (access.method !== expected) {
+        throw new Error(`${operation} received unsupported presigned method ${access.method}`);
+    }
+}
+
+function requireSuccessfulResponse(response: Response, operation: string): void {
+    if (!response.ok) {
+        throw new Error(`${operation} failed with HTTP ${response.status}`);
+    }
+}
+
+async function checksum(
+    algorithm: LoonFS.ChecksumAlgorithm,
+    bytes: Uint8Array,
+): Promise<LoonFS.Checksum> {
+    switch (algorithm) {
+        case "sha256": {
+            const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer(bytes));
+            return { algorithm, value: hex(new Uint8Array(digest)) };
+        }
+        case "crc32c":
+            return { algorithm, value: crc32c(bytes).toString(16).padStart(8, "0") };
+        case "crc64nvme":
+            return { algorithm, value: crc64Nvme(bytes).toString(16).padStart(16, "0") };
+    }
+}
+
+function hex(bytes: Uint8Array): string {
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+    const copy = new Uint8Array(bytes.byteLength);
+    copy.set(bytes);
+    return copy.buffer;
+}
+
+function makeCrc32cTable(): Uint32Array {
+    const table = new Uint32Array(256);
+    for (let index = 0; index < table.length; index += 1) {
+        let value = index;
+        for (let bit = 0; bit < 8; bit += 1) {
+            value = (value >>> 1) ^ ((value & 1) === 0 ? 0 : CRC32C_POLYNOMIAL);
+        }
+        table[index] = value >>> 0;
+    }
+    return table;
+}
+
+function crc32c(bytes: Uint8Array): number {
+    let value = 0xffffffff;
+    for (const byte of bytes) {
+        value = CRC32C_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
+    }
+    return (value ^ 0xffffffff) >>> 0;
+}
+
+function makeCrc64NvmeTable(): bigint[] {
+    const table: bigint[] = [];
+    for (let index = 0; index < 256; index += 1) {
+        let value = BigInt(index);
+        for (let bit = 0; bit < 8; bit += 1) {
+            value = (value >> 1n) ^ ((value & 1n) === 0n ? 0n : CRC64_NVME_POLYNOMIAL);
+        }
+        table.push(value & CRC64_MASK);
+    }
+    return table;
+}
+
+function crc64Nvme(bytes: Uint8Array): bigint {
+    let value = CRC64_MASK;
+    for (const byte of bytes) {
+        const index = Number((value ^ BigInt(byte)) & 0xffn);
+        value = CRC64_NVME_TABLE[index]! ^ (value >> 8n);
+    }
+    return (value ^ CRC64_MASK) & CRC64_MASK;
+}


### PR DESCRIPTION
Adds TypeScript helpers for uploading and downloading files held in memory. putFile chooses an upload method supported by the server, calculates the required checksums, completes the upload, and commits the file. getFile downloads a revision and verifies its size and checksum.

The helpers support service-proxied uploads, direct PUT, and multipart uploads. The TypeScript conformance harness now runs all nine shared fixture families, including uploads, downloads, aborts, and the complete file lifecycle.

The full TypeScript conformance suite passes.