### PR TITLE
feat(sdk): browser transfers through the proxy

### DIFF
--- a/crates/loonfs-conformance/src/server.rs
+++ b/crates/loonfs-conformance/src/server.rs
@@ -34,6 +34,7 @@ use tokio::task::JoinHandle;
 pub const AUTH_TOKEN: &str = "conformance-test-token";
 
 const DIRECT_PUT_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const PROXY_UPLOAD_MAX_BYTES: u64 = 6 * 1024 * 1024;
 
 /// A running conformance API and transfer service.
 #[derive(Debug)]
@@ -120,6 +121,7 @@ fn write_server_config(path: &Path, store_root: &Path) -> io::Result<()> {
 auth_token = "{AUTH_TOKEN}"
 content_token_secret = "conformance-content-token-secret"
 writer_id = "loonfs-conformance"
+max_upload_bytes = {PROXY_UPLOAD_MAX_BYTES}
 
 [store]
 kind = "local-fs"

--- a/docs/specs/object-storage-providers.md
+++ b/docs/specs/object-storage-providers.md
@@ -71,8 +71,12 @@ The GCS adapter uses native V4 signed URLs. It does not use the GCS
 S3-interoperability API or implement multipart uploads, even though GCS
 documents an XML multipart API.[^46]
 
-Browser clients must configure CORS on the bucket because the browser sends
-the transfer request directly to the provider.
+Browser clients send direct transfers to the provider. Bucket CORS must allow
+the application origin. Allowed methods must include `PUT` and `GET`. Allowed
+request headers must include `if-none-match` and `x-amz-checksum-crc64nvme`
+for the S3 family, and `x-goog-if-generation-match` for GCS. The response must
+expose `ETag`. Browser multipart reads each part's `ETag` and fails when the
+header is not exposed.
 
 ## 4. Incremental writes and where they are real
 

--- a/scripts/run-sdk-conformance.sh
+++ b/scripts/run-sdk-conformance.sh
@@ -23,6 +23,10 @@ REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 if [ ! -d "$REPO_ROOT/sdk/generated/$LANGUAGE" ]; then
     "$REPO_ROOT/scripts/generate-sdks.sh" "$LANGUAGE"
 fi
+# The TypeScript harness also compiles the browser client and its transfers.
+if [ "$LANGUAGE" = "typescript" ] && [ ! -d "$REPO_ROOT/sdk/generated/typescript-client" ]; then
+    "$REPO_ROOT/scripts/generate-sdks.sh" typescript-client
+fi
 
 cd "$REPO_ROOT"
 cargo build -p loonfs-conformance --bin conformance-server

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -9,6 +9,11 @@ import { test } from "node:test";
 
 import { LoonFS, LoonFSClient } from "../../../generated/typescript/index.js";
 import { getFile, putFile } from "../../../generated/typescript/transfers.js";
+import { LoonFSClient as BrowserLoonFSClient } from "../../../generated/typescript-client/index.js";
+import {
+    getFile as getBrowserFile,
+    putFile as putBrowserFile,
+} from "../../../generated/typescript-client/transfers.js";
 import { createProxyHandler, PROXY_ROUTE_TABLE } from "../../../proxy/typescript/src/proxy.js";
 
 
@@ -1419,6 +1424,22 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     const disallowedRoute = await fetchThroughProxy(`${mountBase}${request.disallowedPathSuffix}`);
     assert.equal(disallowedRoute.status, expected.disallowedRouteStatus);
     assert.equal((await disallowedRoute.arrayBuffer()).byteLength, 0);
+
+    const browserClient = new BrowserLoonFSClient({ environment: proxy.baseUrl });
+    const browserPath = `${request.proxiedPath}-browser`;
+    const browserCommit = await putBrowserFile(browserClient, {
+        mount: request.mount,
+        path: browserPath,
+        bytes: payload,
+        actor: request.actor,
+        commit_id: `${request.commitIds.proxied}-browser`,
+    });
+    assert.ok(browserCommit.committed_seq > 0, "browser transfer commit sequence is not positive");
+    const browserFile = await getBrowserFile(browserClient, {
+        mount: request.mount,
+        path: browserPath,
+    });
+    assert.deepEqual(browserFile.bytes, payload);
 });
 
 conformanceTest("changes", async (activeHarness, testCase) => {

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -9,7 +9,10 @@ import { test } from "node:test";
 
 import { LoonFS, LoonFSClient } from "../../../generated/typescript/index.js";
 import { getFile, putFile } from "../../../generated/typescript/transfers.js";
-import { LoonFSClient as BrowserLoonFSClient } from "../../../generated/typescript-client/index.js";
+import {
+    LoonFS as BrowserLoonFS,
+    LoonFSClient as BrowserLoonFSClient,
+} from "../../../generated/typescript-client/index.js";
 import {
     getFile as getBrowserFile,
     putFile as putBrowserFile,
@@ -22,6 +25,8 @@ const RUNNER_SKIP = "run scripts/run-sdk-conformance.sh typescript";
 const CRC32C_POLYNOMIAL = 0x82f63b78;
 const CRC64_NVME_POLYNOMIAL = 0x9a6c9329ac4bc9b5n;
 const CRC64_MASK = 0xffffffffffffffffn;
+const BROWSER_MULTIPART_MIN_BYTES = 8 * 1024 * 1024;
+const PROXY_UPLOAD_MAX_BYTES = "upload.max_content_bytes";
 const CASE_FIELDS = ["expected", "family", "intent", "name", "request", "version"];
 const EXPECTED_CASES = [
     ["changes", "changes"],
@@ -938,6 +943,33 @@ async function readProxied(
     return new Uint8Array(await response.arrayBuffer());
 }
 
+async function assertBrowserTransfer(
+    client: BrowserLoonFSClient,
+    mount: string,
+    path: string,
+    bytes: Uint8Array,
+    actor: ActorValue,
+    commitId: string,
+    label: string,
+): Promise<void> {
+    const committed = await putBrowserFile(client, {
+        mount,
+        path,
+        bytes,
+        actor,
+        commit_id: commitId,
+    });
+    assert.ok(committed.committed_seq > 0, `${label} commit sequence is not positive`);
+
+    const readback = await getBrowserFile(client, { mount, path });
+    assert.deepEqual(readback.bytes, bytes);
+    assert.equal(readback.content_ref.size_bytes, bytes.byteLength);
+    const contentChecksum = readback.content_ref.checksum;
+    if (contentChecksum !== undefined) {
+        assert.deepEqual(checksum(contentChecksum.algorithm, bytes), contentChecksum);
+    }
+}
+
 function completedUpload(response: LoonFS.UploadSessionResponse): CompletedUpload {
     const completed = response as CompletedUpload;
     assert.equal(completed.status, "completed");
@@ -1275,11 +1307,22 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     assert.ok(cases != null);
     const activeHarness = harness;
     const [request, expected] = decodeProxy(caseNamed(cases, "proxy"));
-    const handler = createProxyHandler({
+    const proxyHandler = createProxyHandler({
         serverBaseUrl: activeHarness.serverBaseUrl,
         token: activeHarness.token,
         mounts: { [request.mount]: request.namespaceId },
     });
+    const beginPath = `/v0/mounts/${encodeURIComponent(request.mount)}/uploads`;
+    const beginModes: string[] = [];
+    const handler = async (incoming: Request): Promise<Response> => {
+        if (incoming.method === "POST" && new URL(incoming.url).pathname === beginPath) {
+            const body = (await incoming.clone().json()) as { mode?: unknown };
+            if (typeof body.mode === "string") {
+                beginModes.push(body.mode);
+            }
+        }
+        return proxyHandler(incoming);
+    };
     const proxy = await startProxyServer(handler);
     context.after(() => proxy.close());
 
@@ -1425,21 +1468,68 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     assert.equal(disallowedRoute.status, expected.disallowedRouteStatus);
     assert.equal((await disallowedRoute.arrayBuffer()).byteLength, 0);
 
+    beginModes.length = 0;
     const browserClient = new BrowserLoonFSClient({ environment: proxy.baseUrl });
     const browserPath = `${request.proxiedPath}-browser`;
-    const browserCommit = await putBrowserFile(browserClient, {
-        mount: request.mount,
-        path: browserPath,
-        bytes: payload,
-        actor: request.actor,
-        commit_id: `${request.commitIds.proxied}-browser`,
+    await assertBrowserTransfer(
+        browserClient,
+        request.mount,
+        browserPath,
+        payload,
+        request.actor,
+        `${request.commitIds.proxied}-browser`,
+        "browser service-proxied transfer",
+    );
+    assert.deepEqual(beginModes, ["service_proxied"]);
+
+    const capabilities = await browserClient.capabilities();
+    const proxyUploadMaxBytes = capabilities.limits?.[PROXY_UPLOAD_MAX_BYTES];
+    assert.ok(proxyUploadMaxBytes !== undefined, "browser proxy upload limit is not advertised");
+    assert.ok(Number.isSafeInteger(proxyUploadMaxBytes) && proxyUploadMaxBytes >= 0);
+    const directPutLength = proxyUploadMaxBytes + 1;
+    assert.ok(directPutLength < BROWSER_MULTIPART_MIN_BYTES);
+    const directPutBytes = bytePattern({ length: directPutLength, modulus: 251 });
+    await assertBrowserTransfer(
+        browserClient,
+        request.mount,
+        `${request.directPath}-browser`,
+        directPutBytes,
+        request.actor,
+        `${request.commitIds.direct}-browser`,
+        "browser direct-PUT transfer",
+    );
+    assert.deepEqual(beginModes, ["service_proxied", "direct_put"]);
+
+    const multipartBytes = bytePattern({
+        length: BROWSER_MULTIPART_MIN_BYTES + 1,
+        modulus: 251,
     });
-    assert.ok(browserCommit.committed_seq > 0, "browser transfer commit sequence is not positive");
-    const browserFile = await getBrowserFile(browserClient, {
-        mount: request.mount,
-        path: browserPath,
-    });
-    assert.deepEqual(browserFile.bytes, payload);
+    await assertBrowserTransfer(
+        browserClient,
+        request.mount,
+        `${request.directPath}-browser-multipart`,
+        multipartBytes,
+        request.actor,
+        `${request.commitIds.direct}-browser-multipart`,
+        "browser multipart transfer",
+    );
+    assert.deepEqual(beginModes, ["service_proxied", "direct_put", "direct_multipart"]);
+
+    // The rig fails only at begin. No session exists then, so mid-flow cleanup is not covered.
+    await assert.rejects(
+        putBrowserFile(browserClient, {
+            mount: request.unknownMount,
+            path: `${request.proxiedPath}-browser-failure`,
+            bytes: payload,
+            actor: request.actor,
+            commit_id: `${request.commitIds.proxied}-browser-failure`,
+        }),
+        (error: unknown) => {
+            assert.ok(error instanceof BrowserLoonFS.NotFoundError);
+            assert.equal(error.statusCode, expected.unknownMountStatus);
+            return true;
+        },
+    );
 });
 
 conformanceTest("changes", async (activeHarness, testCase) => {

--- a/sdk/conformance/typescript/tsconfig.json
+++ b/sdk/conformance/typescript/tsconfig.json
@@ -13,6 +13,7 @@
   "include": [
     "src/**/*.ts",
     "../../generated/typescript/**/*.ts",
+    "../../generated/typescript-client/**/*.ts",
     "../../proxy/typescript/src/**/*.ts"
   ]
 }

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -1,0 +1,423 @@
+import { LoonFSClient } from "./Client.js";
+import type * as LoonFS from "./api/index.js";
+
+const DIRECT_MULTIPART_FEATURE = "core.uploads.direct_multipart";
+const DIRECT_PUT_FEATURE = "core.uploads.direct_put";
+const DIRECT_PUT_MAX_BYTES = "upload.direct_put_max_content_bytes";
+const PROXY_UPLOAD_MAX_BYTES = "upload.max_content_bytes";
+const MULTIPART_MIN_BYTES = 8 * 1024 * 1024;
+
+// The CRC constants, tables, and functions are copied from
+// sdk/transfers/typescript/transfers.ts.
+const CRC32C_POLYNOMIAL = 0x82f63b78;
+const CRC64_NVME_POLYNOMIAL = 0x9a6c9329ac4bc9b5n;
+const CRC64_MASK = 0xffffffffffffffffn;
+
+const CRC32C_TABLE = makeCrc32cTable();
+const CRC64_NVME_TABLE = makeCrc64NvmeTable();
+
+export interface PutFileInput {
+    mount: string;
+    path: LoonFS.AbsolutePath;
+    bytes: Uint8Array;
+    actor: LoonFS.ActorRef;
+    commit_id: LoonFS.CommitId;
+    message?: string | null;
+    behavior?: LoonFS.DestinationBehavior;
+    expected_revision_no?: LoonFS.RevisionNo;
+}
+
+export interface PutFileResult {
+    namespace_id: LoonFS.NamespaceId;
+    commit_id: LoonFS.CommitId;
+    committed_seq: LoonFS.ChangeSeq;
+}
+
+export interface GetFileInput {
+    mount: string;
+    path: LoonFS.AbsolutePath;
+    revision_no?: LoonFS.RevisionNo;
+}
+
+export interface GetFileResult extends LoonFS.BeginDownloadResponse {
+    bytes: Uint8Array;
+}
+
+type CompletedUpload = LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
+
+interface StagedContent {
+    contentRef: LoonFS.ContentRef;
+    contentToken?: LoonFS.ContentToken;
+}
+
+interface DirectPutBody {
+    body: ArrayBuffer;
+    content: LoonFS.UploadContentClaim;
+}
+
+/**
+ * Uploads in-memory bytes and commits them at one mount path.
+ * Streaming and resume are follow-ups.
+ */
+export async function putFile(client: LoonFSClient, input: PutFileInput): Promise<PutFileResult> {
+    const staged = await stageBytes(client, input.mount, input.bytes);
+    const request: LoonFS.CommitRequest = {
+        mount: input.mount,
+        actor: input.actor,
+        commit_id: input.commit_id,
+        content_tokens: staged.contentToken === undefined ? [] : [staged.contentToken],
+        operations: [
+            {
+                kind: "put_file",
+                path: input.path,
+                content_ref: staged.contentRef,
+                behavior: input.behavior ?? "no_replace",
+                expected_revision_no: input.expected_revision_no,
+            },
+        ],
+    };
+    if (input.message !== undefined) {
+        request.message = input.message;
+    }
+    return client.filesystem.applyCommit(request);
+}
+
+/**
+ * Downloads one revision into memory and verifies its content claim.
+ * Streaming and resume are follow-ups.
+ */
+export async function getFile(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
+    const grant = await client.filesystem.beginDownload(input);
+    requirePresignedMethod(grant.access, "GET", "download");
+    const response = await fetch(grant.access.url, {
+        redirect: "error",
+        method: grant.access.method,
+        headers: grant.access.headers,
+    });
+    requireSuccessfulResponse(response, "download");
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength !== grant.content_ref.size_bytes) {
+        throw new Error(
+            `download returned ${bytes.byteLength} bytes, expected ${grant.content_ref.size_bytes}`,
+        );
+    }
+    const actual = await checksum(grant.content_ref.checksum.algorithm, bytes);
+    if (actual.value !== grant.content_ref.checksum.value) {
+        throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
+    }
+    return { ...grant, bytes };
+}
+
+async function stageBytes(
+    client: LoonFSClient,
+    mount: string,
+    bytes: Uint8Array,
+): Promise<StagedContent> {
+    const capabilities = await client.capabilities();
+    const beginRequest = selectBeginRequest(capabilities, bytes);
+    const begin = await client.uploads.beginUpload({
+        mount,
+        body: beginRequest,
+    });
+
+    switch (begin.mode) {
+        case "direct_put":
+            return stageDirectPut(client, mount, bytes, begin);
+        case "direct_multipart":
+            return stageMultipart(client, mount, bytes, begin);
+        case "service_proxied":
+            return stageServiceProxied(client, mount, bytes, begin);
+    }
+}
+
+function selectBeginRequest(
+    capabilities: LoonFS.CapabilityDocument,
+    bytes: Uint8Array,
+): LoonFS.BeginUploadRequest {
+    const features = capabilities.features ?? {};
+    const limits = capabilities.limits ?? {};
+    const supportsMultipart = features[DIRECT_MULTIPART_FEATURE] === true;
+    const worthCutting = bytes.byteLength >= MULTIPART_MIN_BYTES;
+    if (worthCutting && supportsMultipart) {
+        return { mode: "direct_multipart" };
+    }
+
+    const proxyLimit = limits[PROXY_UPLOAD_MAX_BYTES];
+    const fitsProxy = proxyLimit === undefined || bytes.byteLength <= proxyLimit;
+    const directPutLimit = limits[DIRECT_PUT_MAX_BYTES];
+    const fitsDirectPut = directPutLimit === undefined || bytes.byteLength <= directPutLimit;
+    if (
+        features[DIRECT_PUT_FEATURE] === true &&
+        fitsDirectPut &&
+        (worthCutting || !fitsProxy)
+    ) {
+        return {
+            mode: "direct_put",
+            size_bytes: bytes.byteLength,
+        };
+    }
+    if (fitsProxy) {
+        return { mode: "service_proxied" };
+    }
+    throw new Error(`${bytes.byteLength} bytes fit no advertised upload transport`);
+}
+
+async function stageServiceProxied(
+    client: LoonFSClient,
+    mount: string,
+    bytes: Uint8Array,
+    begin: LoonFS.BeginUploadResponse.ServiceProxied,
+): Promise<StagedContent> {
+    try {
+        await client.uploads.uploadContent(arrayBuffer(bytes), mount, begin.upload_id);
+        return stagedContent(
+            await client.uploads.completeUpload({
+                mount,
+                upload_id: begin.upload_id,
+                body: { mode: "service_proxied" },
+            }),
+        );
+    } catch (error) {
+        await abortQuietly(client, mount, begin.upload_id);
+        throw error;
+    }
+}
+
+async function stageDirectPut(
+    client: LoonFSClient,
+    mount: string,
+    bytes: Uint8Array,
+    begin: LoonFS.BeginUploadResponse.DirectPut,
+): Promise<StagedContent> {
+    let upload: DirectPutBody;
+    try {
+        requirePresignedMethod(begin.direct_put.access, "PUT", "direct PUT");
+        upload = await directPutBody(begin.direct_put.checksum_algorithm, bytes);
+        const response = await fetch(begin.direct_put.access.url, {
+            redirect: "error",
+            method: begin.direct_put.access.method,
+            headers: begin.direct_put.access.headers,
+            body: upload.body,
+        });
+        requireSuccessfulResponse(response, "direct PUT");
+    } catch (error) {
+        await abortQuietly(client, mount, begin.upload_id);
+        throw error;
+    }
+    const completed = completedUpload(
+        await client.uploads.completeUpload({
+            mount,
+            upload_id: begin.upload_id,
+            body: { mode: "direct_put", content: upload.content },
+        }),
+    );
+    return stagedContent(completed);
+}
+
+async function stageMultipart(
+    client: LoonFSClient,
+    mount: string,
+    bytes: Uint8Array,
+    begin: LoonFS.BeginUploadResponse.DirectMultipart,
+): Promise<StagedContent> {
+    const { checksum_algorithm: algorithm, part_size_bytes: partSize } = begin.direct_multipart;
+    if (!Number.isSafeInteger(partSize) || partSize <= 0) {
+        throw new Error(`invalid multipart part size ${partSize}`);
+    }
+    if (bytes.byteLength === 0) {
+        throw new Error("direct multipart upload cannot carry an empty payload");
+    }
+
+    const chunks = splitBytes(bytes, partSize);
+    const claims: LoonFS.UploadPartChecksumClaim[] = [];
+    for (const [index, chunk] of chunks.entries()) {
+        claims.push({
+            part_number: index + 1,
+            checksum: await checksum(algorithm, chunk),
+        });
+    }
+    const completedParts: LoonFS.CompletedUploadPart[] = [];
+    try {
+        const signed = await client.uploads.signUploadParts({
+            mount,
+            upload_id: begin.upload_id,
+            parts: claims,
+        });
+        const accessByPart = new Map(signed.parts.map((part) => [part.part_number, part.access]));
+        for (const [index, claim] of claims.entries()) {
+            const access = accessByPart.get(claim.part_number);
+            if (access === undefined) {
+                throw new Error(`server did not sign part ${claim.part_number}`);
+            }
+            requirePresignedMethod(access, "PUT", `part ${claim.part_number}`);
+            const response = await fetch(access.url, {
+                redirect: "error",
+                method: access.method,
+                headers: access.headers,
+                body: arrayBuffer(chunks[index]!),
+            });
+            requireSuccessfulResponse(response, `part ${claim.part_number}`);
+            const etag = response.headers.get("etag");
+            if (etag === null) {
+                throw new Error(`part ${claim.part_number} upload returned no etag`);
+            }
+            completedParts.push({
+                part_number: claim.part_number,
+                checksum: claim.checksum,
+                etag,
+            });
+        }
+    } catch (error) {
+        await abortQuietly(client, mount, begin.upload_id);
+        throw error;
+    }
+
+    return stagedContent(
+        await client.uploads.completeUpload({
+            mount,
+            upload_id: begin.upload_id,
+            body: {
+                mode: "direct_multipart",
+                content: {
+                    size_bytes: bytes.byteLength,
+                    checksum: await checksum(algorithm, bytes),
+                },
+                parts: completedParts,
+            },
+        }),
+    );
+}
+
+function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
+    const parts: Uint8Array[] = [];
+    for (let offset = 0; offset < bytes.byteLength; offset += partSize) {
+        parts.push(bytes.subarray(offset, Math.min(offset + partSize, bytes.byteLength)));
+    }
+    return parts;
+}
+
+function completedUpload(response: LoonFS.UploadSessionResponse): CompletedUpload {
+    const completed = response as CompletedUpload;
+    if (completed.status !== "completed") {
+        throw new Error(`upload ${response.upload_id} completed with status ${completed.status}`);
+    }
+    return completed;
+}
+
+function stagedContent(response: LoonFS.UploadSessionResponse): StagedContent {
+    const completed = completedUpload(response);
+    return {
+        contentRef: completed.content_ref,
+        contentToken: completed.content_token,
+    };
+}
+
+async function abortQuietly(
+    client: LoonFSClient,
+    mount: string,
+    uploadId: LoonFS.UploadId,
+): Promise<void> {
+    try {
+        await client.uploads.abortUpload({ mount, upload_id: uploadId });
+    } catch {
+        // Preserve the transfer error.
+    }
+}
+
+function requirePresignedMethod(
+    access: LoonFS.ObjectTransferAccess,
+    expected: "GET" | "PUT",
+    operation: string,
+): void {
+    if (access.method !== expected) {
+        throw new Error(`${operation} received unsupported presigned method ${access.method}`);
+    }
+}
+
+function requireSuccessfulResponse(response: Response, operation: string): void {
+    if (!response.ok) {
+        throw new Error(`${operation} failed with HTTP ${response.status}`);
+    }
+}
+
+async function directPutBody(
+    algorithm: LoonFS.ChecksumAlgorithm,
+    bytes: Uint8Array,
+): Promise<DirectPutBody> {
+    const body = arrayBuffer(bytes);
+    const sentBytes = new Uint8Array(body);
+    return {
+        body,
+        content: {
+            size_bytes: sentBytes.byteLength,
+            checksum: await checksum(algorithm, sentBytes),
+        },
+    };
+}
+
+async function checksum(
+    algorithm: LoonFS.ChecksumAlgorithm,
+    bytes: Uint8Array,
+): Promise<LoonFS.Checksum> {
+    switch (algorithm) {
+        case "sha256": {
+            const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer(bytes));
+            return { algorithm, value: hex(new Uint8Array(digest)) };
+        }
+        case "crc32c":
+            return { algorithm, value: crc32c(bytes).toString(16).padStart(8, "0") };
+        case "crc64nvme":
+            return { algorithm, value: crc64Nvme(bytes).toString(16).padStart(16, "0") };
+    }
+}
+
+function hex(bytes: Uint8Array): string {
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+    const copy = new Uint8Array(bytes.byteLength);
+    copy.set(bytes);
+    return copy.buffer;
+}
+
+function makeCrc32cTable(): Uint32Array {
+    const table = new Uint32Array(256);
+    for (let index = 0; index < table.length; index += 1) {
+        let value = index;
+        for (let bit = 0; bit < 8; bit += 1) {
+            value = (value >>> 1) ^ ((value & 1) === 0 ? 0 : CRC32C_POLYNOMIAL);
+        }
+        table[index] = value >>> 0;
+    }
+    return table;
+}
+
+function crc32c(bytes: Uint8Array): number {
+    let value = 0xffffffff;
+    for (const byte of bytes) {
+        value = CRC32C_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
+    }
+    return (value ^ 0xffffffff) >>> 0;
+}
+
+function makeCrc64NvmeTable(): bigint[] {
+    const table: bigint[] = [];
+    for (let index = 0; index < 256; index += 1) {
+        let value = BigInt(index);
+        for (let bit = 0; bit < 8; bit += 1) {
+            value = (value >> 1n) ^ ((value & 1n) === 0n ? 0n : CRC64_NVME_POLYNOMIAL);
+        }
+        table.push(value & CRC64_MASK);
+    }
+    return table;
+}
+
+function crc64Nvme(bytes: Uint8Array): bigint {
+    let value = CRC64_MASK;
+    for (const byte of bytes) {
+        const index = Number((value ^ BigInt(byte)) & 0xffn);
+        value = CRC64_NVME_TABLE[index]! ^ (value >> 8n);
+    }
+    return (value ^ CRC64_MASK) & CRC64_MASK;
+}


### PR DESCRIPTION
The browser client's transfer layer: putFile and getFile in sdk/transfers/typescript-client, overlaid into the generated browser client and shipped inside @loonfs/sdk-client at the next repository refresh.

It mirrors the server TypeScript transfers under the streaming-checksum protocol — begin without a claim, compute the dictated algorithm over exactly the bytes sent, complete with the content claim, commit — with the browser differences it has to have: sha256 through crypto.subtle (browsers have no incremental hash; the layer is bytes-in-memory, so a one-shot digest is honest), crc64nvme and crc32c as pure-TypeScript implementations copied byte-identically from the server transfers with the source named, and direct PUTs sending a fixed buffer snapshot because streamed request bodies are not portable across browsers. Mount-scoped calls go through the generated browser client; presigned requests go straight to the object store with redirect set to error.

Conformance: the proxy family in the TypeScript harness now also drives the full browser stack — the generated browser client plus these transfers, through the running proxy, to the server and store — with a putFile, a byte-for-byte getFile readback, and a committed-sequence assertion. The harness compiles all four TypeScript trees (server SDK, proxy package, browser client, browser transfers).

Verified locally: the full TypeScript conformance suite passes — ten families plus the route-table drift test, eleven green, with the browser leg inside the proxy family.

One observation for later: proxied responses carry namespace-scoped fields such as namespace_id, because the proxy passes server responses through untouched. That is the v1 contract working as ruled; a mount-scoped response profile would be a protocol decision, not an SDK one.