### PR TITLE
fix(sdk): keep the Python proxy importable on Python 3.8

### DIFF
--- a/sdk/proxy/python/proxy.py
+++ b/sdk/proxy/python/proxy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import Any
+from typing import Any, Dict
 from urllib.parse import quote
 
 import httpx
@@ -12,8 +12,10 @@ import httpx
 __all__ = ["LoonFSProxy", "ROUTES"]
 
 
-_Receive = Callable[[], Awaitable[dict[str, Any]]]
-_Send = Callable[[dict[str, Any]], Awaitable[None]]
+# typing.Dict keeps these runtime-evaluated aliases importable on Python 3.8;
+# builtin generics in aliases need 3.9.
+_Receive = Callable[[], Awaitable[Dict[str, Any]]]
+_Send = Callable[[Dict[str, Any]], Awaitable[None]]
 
 _HOP_BY_HOP_HEADERS = frozenset(
     {


### PR DESCRIPTION
The two module-level ASGI aliases evaluated builtin generics at runtime, which needs Python 3.9, while the package advertises 3.8; importing loonfs_sdk.proxy under 3.8 raised TypeError. The aliases now use typing.Dict with the reason in a comment. The annotated assignments and function annotations were already safe: the future-annotations import defers them. transfers.py has no runtime-evaluated generics. The Python SDK repository's CI gains a 3.8 leg in its refresh PR so the floor is tested, not asserted.