### PR TITLE
chore(sdk): collapse the transfer and proxy internals

### DIFF
--- a/sdk/proxy/go/proxy/proxy.go
+++ b/sdk/proxy/go/proxy/proxy.go
@@ -142,15 +142,12 @@ func (h *handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	outgoing.URL.Path = joinPath(h.target.Path, rewrittenPath)
 	outgoing.URL.RawPath = ""
 	outgoing.URL.RawQuery = request.URL.RawQuery
-	outgoing.URL.ForceQuery = request.URL.ForceQuery
 	outgoing.URL.Fragment = ""
 	outgoing.RequestURI = ""
 	outgoing.Host = h.target.Host
 	outgoing.Close = false
-	outgoing.Header = request.Header.Clone()
 	removeHopByHopHeaders(outgoing.Header)
-	// Remove the browser-facing host and application cookies before forwarding.
-	outgoing.Header.Del("Host")
+	// Remove application cookies before forwarding.
 	outgoing.Header.Del("Cookie")
 	outgoing.Header.Set("Authorization", "Bearer "+h.token)
 	if outgoing.Header.Get("User-Agent") == "" {

--- a/sdk/proxy/python/proxy.py
+++ b/sdk/proxy/python/proxy.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import re
-from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import Any, Dict
+from collections.abc import AsyncIterator
+from typing import Any, Awaitable, Callable, Dict
 from urllib.parse import quote
 
 import httpx
@@ -12,8 +12,8 @@ import httpx
 __all__ = ["LoonFSProxy"]
 
 
-# typing.Dict keeps these runtime-evaluated aliases importable on Python 3.8;
-# builtin generics in aliases need 3.9.
+# typing generics keep these runtime-evaluated aliases importable on Python 3.8;
+# builtin and collections.abc generics in aliases need 3.9.
 _Receive = Callable[[], Awaitable[Dict[str, Any]]]
 _Send = Callable[[Dict[str, Any]], Awaitable[None]]
 

--- a/sdk/proxy/python/proxy.py
+++ b/sdk/proxy/python/proxy.py
@@ -79,7 +79,7 @@ def _connection_headers(headers: list[tuple[bytes, bytes]]) -> set[bytes]:
 
 
 # Remove the browser-facing host and application cookies before forwarding.
-_REQUEST_EXCLUDED_HEADERS = frozenset({b"host", b"cookie"})
+_REQUEST_EXCLUDED_HEADERS = frozenset({b"host", b"cookie", b"authorization"})
 # Do not forward LoonFS cookies to the application.
 _RESPONSE_EXCLUDED_HEADERS = frozenset({b"set-cookie"})
 
@@ -87,18 +87,13 @@ _RESPONSE_EXCLUDED_HEADERS = frozenset({b"set-cookie"})
 def _forwarded_headers(
     headers: list[tuple[bytes, bytes]],
     extra_excluded: frozenset[bytes],
-    authorization: bytes | None = None,
 ) -> list[tuple[bytes, bytes]]:
     excluded = _HOP_BY_HOP_HEADERS | _connection_headers(headers) | extra_excluded
-    forwarded = [
+    return [
         (name, value)
         for name, value in headers
         if name.lower() not in excluded
-        and (authorization is None or name.lower() != b"authorization")
     ]
-    if authorization is not None:
-        forwarded.append((b"authorization", authorization))
-    return forwarded
 
 
 async def _request_body(receive: _Receive) -> AsyncIterator[bytes]:
@@ -106,8 +101,6 @@ async def _request_body(receive: _Receive) -> AsyncIterator[bytes]:
         message = await receive()
         if message["type"] == "http.disconnect":
             return
-        if message["type"] != "http.request":
-            continue
         body = message.get("body", b"")
         if body:
             yield body
@@ -144,9 +137,8 @@ class LoonFSProxy:
         target = httpx.URL(f"{self._server_base_url}{rewritten_path}").copy_with(
             query=scope.get("query_string", b"")
         )
-        headers = _forwarded_headers(
-            scope.get("headers", []), _REQUEST_EXCLUDED_HEADERS, self._authorization
-        )
+        headers = _forwarded_headers(scope.get("headers", []), _REQUEST_EXCLUDED_HEADERS)
+        headers.append((b"authorization", self._authorization))
         request = self._client.build_request(
             scope["method"],
             target,

--- a/sdk/proxy/python/proxy.py
+++ b/sdk/proxy/python/proxy.py
@@ -12,8 +12,7 @@ import httpx
 __all__ = ["LoonFSProxy"]
 
 
-# typing generics keep these runtime-evaluated aliases importable on Python 3.8;
-# builtin and collections.abc generics in aliases need 3.9.
+# Python 3.8 requires typing aliases for runtime-evaluated generics.
 _Receive = Callable[[], Awaitable[Dict[str, Any]]]
 _Send = Callable[[Dict[str, Any]], Awaitable[None]]
 

--- a/sdk/proxy/typescript/package.json
+++ b/sdk/proxy/typescript/package.json
@@ -21,5 +21,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0"
   }
 }

--- a/sdk/proxy/typescript/package.json
+++ b/sdk/proxy/typescript/package.json
@@ -21,9 +21,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "devDependencies": {
-    "typescript": "^5.5.0",
-    "@types/node": "^18.19.0"
   }
 }

--- a/sdk/proxy/typescript/src/proxy.ts
+++ b/sdk/proxy/typescript/src/proxy.ts
@@ -7,12 +7,6 @@ export interface ProxyConfig {
 interface ProxyRoute {
     method: "GET" | "POST" | "PUT";
     pattern: RegExp;
-    namespaceAliasScoped: boolean;
-}
-
-interface MatchedRoute {
-    route: ProxyRoute;
-    match: RegExpMatchArray;
 }
 
 const HOP_BY_HOP_HEADERS = [
@@ -71,14 +65,11 @@ function patternFor(template: string): RegExp {
 const PROXY_ROUTES: readonly ProxyRoute[] = PROXY_ROUTE_TABLE.map((entry) => ({
     method: entry.method,
     pattern: patternFor(entry.template),
-    namespaceAliasScoped: entry.template.includes("{namespace_alias}"),
 }));
 
 /** Creates a fetch-compatible handler for LoonFS browser requests. */
 export function createProxyHandler(config: ProxyConfig): (request: Request) => Promise<Response> {
     const serverBaseUrl = new URL(config.serverBaseUrl);
-    serverBaseUrl.search = "";
-    serverBaseUrl.hash = "";
     const serverBasePath = serverBaseUrl.pathname.replace(/\/+$/, "");
     const token = config.token;
     const namespaceAliases = new Map(Object.entries(config.namespaceAliases));
@@ -120,14 +111,14 @@ export function createProxyHandler(config: ProxyConfig): (request: Request) => P
     };
 }
 
-function matchRoute(method: string, pathname: string): MatchedRoute | undefined {
+function matchRoute(method: string, pathname: string): RegExpMatchArray | undefined {
     for (const route of PROXY_ROUTES) {
         if (route.method !== method) {
             continue;
         }
         const match = pathname.match(route.pattern);
         if (match !== null) {
-            return { route, match };
+            return match;
         }
     }
     return undefined;
@@ -135,16 +126,12 @@ function matchRoute(method: string, pathname: string): MatchedRoute | undefined 
 
 function rewritePath(
     pathname: string,
-    matched: MatchedRoute,
+    match: RegExpMatchArray,
     namespaceAliases: ReadonlyMap<string, string>,
 ): string | undefined {
-    if (!matched.route.namespaceAliasScoped) {
-        return pathname;
-    }
-
-    const encodedNamespaceAlias = matched.match.groups?.namespaceAlias;
+    const encodedNamespaceAlias = match.groups?.namespaceAlias;
     if (encodedNamespaceAlias === undefined) {
-        return undefined;
+        return pathname;
     }
     let namespaceAlias: string;
     try {

--- a/sdk/transfers/go/transfers/transfers.go
+++ b/sdk/transfers/go/transfers/transfers.go
@@ -295,10 +295,11 @@ func transferDirectMultipart(
 	if begin.DirectMultipart == nil {
 		return nil, fmt.Errorf("transfers: multipart response is incomplete")
 	}
-	if begin.DirectMultipart.PartSizeBytes <= 0 {
+	partSizeBytes := begin.DirectMultipart.PartSizeBytes
+	partSize := int(partSizeBytes)
+	if partSizeBytes <= 0 || int64(partSize) != partSizeBytes {
 		return nil, fmt.Errorf("transfers: invalid multipart part size %d", begin.DirectMultipart.PartSizeBytes)
 	}
-	partSize := int(begin.DirectMultipart.PartSizeBytes)
 	parts := splitParts(payload, partSize)
 	if len(parts) == 0 {
 		abortUpload(ctx, c, namespaceID, begin.UploadID)
@@ -346,6 +347,10 @@ func transferDirectMultipart(
 		if putErr != nil {
 			abortUpload(ctx, c, namespaceID, begin.UploadID)
 			return nil, fmt.Errorf("transfers: upload part %d: %w", partNumber, putErr)
+		}
+		if etag == "" {
+			abortUpload(ctx, c, namespaceID, begin.UploadID)
+			return nil, fmt.Errorf("transfers: upload part %d: presigned PUT response has no ETag", partNumber)
 		}
 		completedParts = append(completedParts, &loonfs.CompletedUploadPart{
 			Checksum:   claims[index].Checksum,
@@ -458,11 +463,7 @@ func putPresigned(
 		return "", responseStatusError(response)
 	}
 	_, _ = io.Copy(io.Discard, response.Body)
-	etag := response.Header.Get("ETag")
-	if etag == "" {
-		return "", fmt.Errorf("presigned PUT response has no ETag")
-	}
-	return etag, nil
+	return response.Header.Get("ETag"), nil
 }
 
 func getPresigned(ctx context.Context, access *loonfs.ObjectTransferAccess) ([]byte, error) {

--- a/sdk/transfers/go/transfers/transfers.go
+++ b/sdk/transfers/go/transfers/transfers.go
@@ -8,12 +8,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"hash"
 	"hash/crc32"
 	"hash/crc64"
 	"io"
 	"net/http"
-	"sort"
 	"strings"
 
 	loonfs "github.com/loonfs/loonfs-sdk-go"
@@ -23,7 +21,6 @@ import (
 
 const (
 	multipartMinimumBytes = 8 * 1024 * 1024
-	multipartMaximumParts = 10_000
 
 	featureDirectPut           = "core.uploads.direct_put"
 	featureDirectMultipart     = "core.uploads.direct_multipart"
@@ -36,7 +33,12 @@ const (
 var (
 	crc32CTable         = crc32.MakeTable(crc32.Castagnoli)
 	crc64NVMeTable      = crc64.MakeTable(crc64NVMePolynomial)
-	presignedHTTPClient = newPresignedHTTPClient()
+	presignedHTTPClient = &http.Client{
+		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 )
 
 // PutFileInput describes one in-memory file write.
@@ -88,12 +90,7 @@ func PutFile(ctx context.Context, c *client.Client, in PutFileInput) (*PutFileRe
 	if err != nil {
 		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
 	}
-	transport, err := chooseUploadTransport(capabilities, int64(len(in.Bytes)))
-	if err != nil {
-		return nil, err
-	}
-
-	beginRequest, err := beginUploadRequest(in.NamespaceID, int64(len(in.Bytes)), transport)
+	beginRequest, err := beginUploadRequest(capabilities, in.NamespaceID, int64(len(in.Bytes)))
 	if err != nil {
 		return nil, err
 	}
@@ -191,61 +188,38 @@ func GetFile(ctx context.Context, c *client.Client, in GetFileInput) (*GetFileRe
 	}, nil
 }
 
-type uploadTransport int
-
-const (
-	uploadServiceProxied uploadTransport = iota
-	uploadDirectPut
-	uploadDirectMultipart
-)
-
-func chooseUploadTransport(
-	capabilities *loonfs.CapabilityDocument,
-	sizeBytes int64,
-) (uploadTransport, error) {
-	if capabilities == nil {
-		return 0, fmt.Errorf("transfers: capability response is nil")
-	}
-	worthCutting := sizeBytes >= multipartMinimumBytes
-	if worthCutting && capabilities.Features[featureDirectMultipart] {
-		return uploadDirectMultipart, nil
-	}
-
-	proxyLimit, hasProxyLimit := capabilities.Limits[limitUploadMaximumBytes]
-	fitsProxy := !hasProxyLimit || sizeBytes <= proxyLimit
-	directPutLimit, hasDirectPutLimit := capabilities.Limits[limitDirectPutMaximumBytes]
-	fitsDirectPut := !hasDirectPutLimit || sizeBytes <= directPutLimit
-	if (worthCutting || !fitsProxy) && capabilities.Features[featureDirectPut] && fitsDirectPut {
-		return uploadDirectPut, nil
-	}
-	if fitsProxy {
-		return uploadServiceProxied, nil
-	}
-	return 0, fmt.Errorf(
-		"transfers: %d-byte upload fits no advertised transport",
-		sizeBytes,
-	)
-}
-
 func beginUploadRequest(
+	capabilities *loonfs.CapabilityDocument,
 	namespaceID loonfs.NamespaceID,
 	sizeBytes int64,
-	transport uploadTransport,
 ) (*loonfs.BeginUploadBody, error) {
+	if capabilities == nil {
+		return nil, fmt.Errorf("transfers: capability response is nil")
+	}
 	request := &loonfs.BeginUploadRequest{}
-	switch transport {
-	case uploadServiceProxied:
-		request.ServiceProxied = &loonfs.BeginUploadServiceProxied{}
-	case uploadDirectPut:
-		request.DirectPut = &loonfs.BeginUploadDirectPut{
-			SizeBytes: &sizeBytes,
-		}
-	case uploadDirectMultipart:
+	worthCutting := sizeBytes >= multipartMinimumBytes
+	if worthCutting && capabilities.Features[featureDirectMultipart] {
 		request.DirectMultipart = &loonfs.BeginUploadDirectMultipart{
 			Multipart: &loonfs.DirectMultipartUploadOptions{},
 		}
-	default:
-		return nil, fmt.Errorf("transfers: unsupported upload transport")
+	} else {
+		proxyLimit, hasProxyLimit := capabilities.Limits[limitUploadMaximumBytes]
+		fitsProxy := !hasProxyLimit || sizeBytes <= proxyLimit
+		directPutLimit, hasDirectPutLimit := capabilities.Limits[limitDirectPutMaximumBytes]
+		fitsDirectPut := !hasDirectPutLimit || sizeBytes <= directPutLimit
+		switch {
+		case (worthCutting || !fitsProxy) && capabilities.Features[featureDirectPut] && fitsDirectPut:
+			request.DirectPut = &loonfs.BeginUploadDirectPut{
+				SizeBytes: &sizeBytes,
+			}
+		case fitsProxy:
+			request.ServiceProxied = &loonfs.BeginUploadServiceProxied{}
+		default:
+			return nil, fmt.Errorf(
+				"transfers: %d-byte upload fits no advertised transport",
+				sizeBytes,
+			)
+		}
 	}
 	return &loonfs.BeginUploadBody{
 		NamespaceID: string(namespaceID),
@@ -285,15 +259,18 @@ func transferDirectPut(
 	if begin.DirectPut == nil {
 		return nil, fmt.Errorf("transfers: direct PUT response is incomplete")
 	}
-	content, err := putPresignedWithChecksum(
-		ctx,
-		begin.DirectPut.Access,
-		payload,
-		begin.DirectPut.ChecksumAlgorithm,
-	)
+	checksum, err := computeChecksum(begin.DirectPut.ChecksumAlgorithm, payload)
 	if err != nil {
 		abortUpload(ctx, c, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: direct PUT: %w", err)
+	}
+	if _, err := putPresigned(ctx, begin.DirectPut.Access, payload); err != nil {
+		abortUpload(ctx, c, namespaceID, begin.UploadID)
+		return nil, fmt.Errorf("transfers: direct PUT: %w", err)
+	}
+	content := &loonfs.UploadContentClaim{
+		Checksum:  checksum,
+		SizeBytes: int64(len(payload)),
 	}
 	completed, err := c.Uploads.CompleteUpload(ctx, &loonfs.CompleteUploadBody{
 		NamespaceID: string(namespaceID),
@@ -318,20 +295,15 @@ func transferDirectMultipart(
 	if begin.DirectMultipart == nil {
 		return nil, fmt.Errorf("transfers: multipart response is incomplete")
 	}
-	partSize, err := checkedPartSize(begin.DirectMultipart.PartSizeBytes)
-	if err != nil {
-		return nil, err
+	if begin.DirectMultipart.PartSizeBytes <= 0 {
+		return nil, fmt.Errorf("transfers: invalid multipart part size %d", begin.DirectMultipart.PartSizeBytes)
 	}
+	partSize := int(begin.DirectMultipart.PartSizeBytes)
 	parts := splitParts(payload, partSize)
 	if len(parts) == 0 {
 		abortUpload(ctx, c, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: multipart response selected for an empty payload")
 	}
-	if len(parts) > multipartMaximumParts {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: multipart upload requires %d parts, maximum is %d", len(parts), multipartMaximumParts)
-	}
-
 	claims := make([]*loonfs.UploadPartChecksumClaim, len(parts))
 	for index, part := range parts {
 		checksum, checksumErr := computeChecksum(begin.DirectMultipart.ChecksumAlgorithm, part)
@@ -357,32 +329,30 @@ func transferDirectMultipart(
 		abortUpload(ctx, c, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: sign multipart parts returned no response")
 	}
-	if len(signed.Parts) != len(parts) {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: server signed %d parts, expected %d", len(signed.Parts), len(parts))
+	accessByPart := make(map[int]*loonfs.SignedUploadPart, len(signed.Parts))
+	for _, signedPart := range signed.Parts {
+		accessByPart[signedPart.PartNumber] = signedPart
 	}
 
 	completedParts := make([]*loonfs.CompletedUploadPart, 0, len(parts))
-	for _, signedPart := range signed.Parts {
-		partNumber := signedPart.PartNumber
-		if partNumber < 1 || partNumber > len(parts) {
+	for index, part := range parts {
+		partNumber := index + 1
+		signedPart := accessByPart[partNumber]
+		if signedPart == nil {
 			abortUpload(ctx, c, namespaceID, begin.UploadID)
-			return nil, fmt.Errorf("transfers: server signed invalid part number %d", partNumber)
+			return nil, fmt.Errorf("transfers: server did not sign multipart part %d", partNumber)
 		}
-		etag, putErr := putPresigned(ctx, signedPart.Access, parts[partNumber-1], true)
+		etag, putErr := putPresigned(ctx, signedPart.Access, part)
 		if putErr != nil {
 			abortUpload(ctx, c, namespaceID, begin.UploadID)
 			return nil, fmt.Errorf("transfers: upload part %d: %w", partNumber, putErr)
 		}
 		completedParts = append(completedParts, &loonfs.CompletedUploadPart{
-			Checksum:   claims[partNumber-1].Checksum,
+			Checksum:   claims[index].Checksum,
 			Etag:       etag,
 			PartNumber: partNumber,
 		})
 	}
-	sort.Slice(completedParts, func(left, right int) bool {
-		return completedParts[left].PartNumber < completedParts[right].PartNumber
-	})
 	wholeChecksum, err := computeChecksum(begin.DirectMultipart.ChecksumAlgorithm, payload)
 	if err != nil {
 		abortUpload(ctx, c, namespaceID, begin.UploadID)
@@ -445,17 +415,6 @@ func abortUpload(ctx context.Context, c *client.Client, namespaceID loonfs.Names
 }
 
 func completedUploadStatus(response *loonfs.UploadSessionResponse) (*loonfs.UploadSessionStatusCompleted, error) {
-	status, err := uploadSessionStatus(response)
-	if err != nil {
-		return nil, err
-	}
-	if status.Completed == nil || status.Completed.ContentRef == nil {
-		return nil, fmt.Errorf("transfers: upload did not complete")
-	}
-	return status.Completed, nil
-}
-
-func uploadSessionStatus(response *loonfs.UploadSessionResponse) (*loonfs.UploadSessionStatus, error) {
 	if response == nil {
 		return nil, fmt.Errorf("transfers: upload session response is nil")
 	}
@@ -467,15 +426,10 @@ func uploadSessionStatus(response *loonfs.UploadSessionResponse) (*loonfs.Upload
 	if err := json.Unmarshal(data, &status); err != nil {
 		return nil, fmt.Errorf("transfers: decode upload status: %w", err)
 	}
-	return &status, nil
-}
-
-func checkedPartSize(sizeBytes int64) (int, error) {
-	maximumInt := int(^uint(0) >> 1)
-	if sizeBytes <= 0 || uint64(sizeBytes) > uint64(maximumInt) {
-		return 0, fmt.Errorf("transfers: invalid multipart part size %d", sizeBytes)
+	if status.Completed == nil || status.Completed.ContentRef == nil {
+		return nil, fmt.Errorf("transfers: upload did not complete")
 	}
-	return int(sizeBytes), nil
+	return status.Completed, nil
 }
 
 func splitParts(payload []byte, partSize int) [][]byte {
@@ -494,7 +448,6 @@ func putPresigned(
 	ctx context.Context,
 	access *loonfs.ObjectTransferAccess,
 	payload []byte,
-	requireETag bool,
 ) (string, error) {
 	response, err := sendPresigned(ctx, access, http.MethodPut, bytes.NewReader(payload), int64(len(payload)))
 	if err != nil {
@@ -506,54 +459,10 @@ func putPresigned(
 	}
 	_, _ = io.Copy(io.Discard, response.Body)
 	etag := response.Header.Get("ETag")
-	if requireETag && etag == "" {
+	if etag == "" {
 		return "", fmt.Errorf("presigned PUT response has no ETag")
 	}
 	return etag, nil
-}
-
-type checksumReader struct {
-	reader    io.Reader
-	hasher    hash.Hash
-	sizeBytes int64
-}
-
-func (r *checksumReader) Read(buffer []byte) (int, error) {
-	read, err := r.reader.Read(buffer)
-	if read > 0 {
-		_, _ = r.hasher.Write(buffer[:read])
-		r.sizeBytes += int64(read)
-	}
-	return read, err
-}
-
-func putPresignedWithChecksum(
-	ctx context.Context,
-	access *loonfs.ObjectTransferAccess,
-	payload []byte,
-	algorithm loonfs.ChecksumAlgorithm,
-) (*loonfs.UploadContentClaim, error) {
-	hasher, err := checksumHasher(algorithm)
-	if err != nil {
-		return nil, err
-	}
-	body := &checksumReader{reader: bytes.NewReader(payload), hasher: hasher}
-	response, err := sendPresigned(ctx, access, http.MethodPut, body, int64(len(payload)))
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		return nil, responseStatusError(response)
-	}
-	_, _ = io.Copy(io.Discard, response.Body)
-	return &loonfs.UploadContentClaim{
-		Checksum: &loonfs.Checksum{
-			Algorithm: algorithm,
-			Value:     hex.EncodeToString(hasher.Sum(nil)),
-		},
-		SizeBytes: body.sizeBytes,
-	}, nil
 }
 
 func getPresigned(ctx context.Context, access *loonfs.ObjectTransferAccess) ([]byte, error) {
@@ -607,15 +516,6 @@ func sendPresigned(
 	return response, nil
 }
 
-func newPresignedHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: http.DefaultTransport.(*http.Transport).Clone(),
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-}
-
 func responseStatusError(response *http.Response) error {
 	body, _ := io.ReadAll(io.LimitReader(response.Body, 4*1024))
 	detail := strings.TrimSpace(string(body))
@@ -640,26 +540,20 @@ func verifyChecksum(expected *loonfs.Checksum, payload []byte) error {
 }
 
 func computeChecksum(algorithm loonfs.ChecksumAlgorithm, payload []byte) (*loonfs.Checksum, error) {
-	hasher, err := checksumHasher(algorithm)
-	if err != nil {
-		return nil, err
-	}
-	_, _ = hasher.Write(payload)
-	return &loonfs.Checksum{
-		Algorithm: algorithm,
-		Value:     hex.EncodeToString(hasher.Sum(nil)),
-	}, nil
-}
-
-func checksumHasher(algorithm loonfs.ChecksumAlgorithm) (hash.Hash, error) {
+	var value string
 	switch algorithm {
 	case loonfs.ChecksumAlgorithmSha256:
-		return sha256.New(), nil
+		digest := sha256.Sum256(payload)
+		value = hex.EncodeToString(digest[:])
 	case loonfs.ChecksumAlgorithmCrc64Nvme:
-		return crc64.New(crc64NVMeTable), nil
+		value = fmt.Sprintf("%016x", crc64.Checksum(payload, crc64NVMeTable))
 	case loonfs.ChecksumAlgorithmCrc32C:
-		return crc32.New(crc32CTable), nil
+		value = fmt.Sprintf("%08x", crc32.Checksum(payload, crc32CTable))
 	default:
 		return nil, fmt.Errorf("unsupported checksum algorithm %q", algorithm)
 	}
+	return &loonfs.Checksum{
+		Algorithm: algorithm,
+		Value:     value,
+	}, nil
 }

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -6,7 +6,6 @@ Streaming and resume are follow-ups. AsyncLoonFS support is a follow-up.
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 
 import httpx
@@ -56,68 +55,6 @@ _CRC64_NVME_MASK = (1 << 64) - 1
 _CRC32C_MASK = (1 << 32) - 1
 _CRC64_NVME_TABLE = _crc_table(0x9A6C9329AC4BC9B5, _CRC64_NVME_MASK)
 _CRC32C_TABLE = _crc_table(0x82F63B78, _CRC32C_MASK)
-
-
-class _ChecksumAccumulator:
-    def __init__(self, algorithm: str) -> None:
-        self._algorithm = algorithm
-        self._sha256 = hashlib.sha256() if algorithm == "sha256" else None
-        if algorithm == "crc64nvme":
-            self._crc_table = _CRC64_NVME_TABLE
-            self._crc_mask = _CRC64_NVME_MASK
-        elif algorithm == "crc32c":
-            self._crc_table = _CRC32C_TABLE
-            self._crc_mask = _CRC32C_MASK
-        elif algorithm == "sha256":
-            self._crc_table = None
-            self._crc_mask = None
-        else:
-            raise RuntimeError(f"unsupported checksum algorithm {algorithm!r}")
-        self._crc_value = self._crc_mask
-
-    def update(self, content: bytes) -> None:
-        if self._sha256 is not None:
-            self._sha256.update(content)
-            return
-        assert self._crc_table is not None
-        assert self._crc_value is not None
-        for byte in content:
-            self._crc_value = (
-                self._crc_table[(self._crc_value ^ byte) & 0xFF]
-                ^ (self._crc_value >> 8)
-            )
-
-    def finish(self) -> Checksum:
-        if self._sha256 is not None:
-            value = self._sha256.hexdigest()
-        else:
-            assert self._crc_mask is not None
-            assert self._crc_value is not None
-            width = 16 if self._crc_mask == _CRC64_NVME_MASK else 8
-            value = f"{self._crc_value ^ self._crc_mask:0{width}x}"
-        return Checksum(algorithm=self._algorithm, value=value)
-
-
-class _UploadBody:
-    def __init__(self, algorithm: str, content: bytes) -> None:
-        self._content = content
-        self._checksum = _ChecksumAccumulator(algorithm)
-        self._size_bytes = 0
-        self._started = False
-
-    def __iter__(self) -> Iterator[bytes]:
-        if self._started:
-            raise RuntimeError("direct PUT body cannot be replayed")
-        self._started = True
-        self._checksum.update(self._content)
-        self._size_bytes += len(self._content)
-        yield self._content
-
-    def claim(self) -> UploadContentClaim:
-        return UploadContentClaim(
-            size_bytes=self._size_bytes,
-            checksum=self._checksum.finish(),
-        )
 
 
 @dataclass(frozen=True)
@@ -288,14 +225,12 @@ def _stage_upload(
             raise
         return _completed_content(completion)
     if begin.mode == "direct_put":
-        upload_body = _UploadBody(begin.direct_put.checksum_algorithm, content)
         try:
             _send_presigned(
                 transfer_client,
                 begin.direct_put.access,
                 "PUT",
-                content=upload_body,
-                content_length=len(content),
+                content=content,
             )
         except Exception:
             _abort_quietly(client, namespace_id, begin.upload_id)
@@ -303,7 +238,12 @@ def _stage_upload(
         completion = client.uploads.complete_upload(
             namespace_id,
             begin.upload_id,
-            request=CompleteUploadRequest_DirectPut(content=upload_body.claim()),
+            request=CompleteUploadRequest_DirectPut(
+                content=UploadContentClaim(
+                    size_bytes=len(content),
+                    checksum=_checksum(begin.direct_put.checksum_algorithm, content),
+                )
+            ),
         )
         return _completed_content(completion)
     if begin.mode == "direct_multipart":
@@ -395,16 +335,13 @@ def _send_presigned(
     access: ObjectTransferAccess,
     expected_method: str,
     *,
-    content: bytes | Iterable[bytes] | None = None,
-    content_length: int | None = None,
+    content: bytes | None = None,
 ) -> httpx.Response:
     if access.method.upper() != expected_method:
         raise RuntimeError(
             f"presigned access uses {access.method!r}, expected {expected_method!r}"
         )
     headers = httpx.Headers(access.headers or {})
-    if content_length is not None and "content-length" not in headers:
-        headers["content-length"] = str(content_length)
     response = client.request(
         expected_method,
         access.url,
@@ -416,23 +353,15 @@ def _send_presigned(
 
 
 def _completed_content(response) -> _StagedContent:
-    if getattr(response, "status", None) != "completed":
+    if response.status != "completed":
         raise RuntimeError(
             f"upload {response.upload_id!r} completed with status "
-            f"{getattr(response, 'status', None)!r}"
+            f"{response.status!r}"
         )
     return _StagedContent(
-        content_ref=_content_ref(getattr(response, "content_ref", None)),
-        content_token=getattr(response, "content_token", None),
+        content_ref=ContentRef(**response.content_ref),
+        content_token=response.content_token,
     )
-
-
-def _content_ref(value) -> ContentRef:
-    if isinstance(value, ContentRef):
-        return value
-    if isinstance(value, Mapping):
-        return ContentRef(**value)
-    raise RuntimeError("completed upload returned no content reference")
 
 
 def _abort_quietly(client: LoonFS, namespace_id: str, upload_id: str) -> None:
@@ -443,6 +372,15 @@ def _abort_quietly(client: LoonFS, namespace_id: str, upload_id: str) -> None:
 
 
 def _checksum(algorithm: str, content: bytes) -> Checksum:
-    accumulator = _ChecksumAccumulator(algorithm)
-    accumulator.update(content)
-    return accumulator.finish()
+    if algorithm == "sha256":
+        return Checksum(algorithm=algorithm, value=hashlib.sha256(content).hexdigest())
+    if algorithm == "crc64nvme":
+        table, mask, width = _CRC64_NVME_TABLE, _CRC64_NVME_MASK, 16
+    elif algorithm == "crc32c":
+        table, mask, width = _CRC32C_TABLE, _CRC32C_MASK, 8
+    else:
+        raise RuntimeError(f"unsupported checksum algorithm {algorithm!r}")
+    value = mask
+    for byte in content:
+        value = table[(value ^ byte) & 0xFF] ^ (value >> 8)
+    return Checksum(algorithm=algorithm, value=f"{value ^ mask:0{width}x}")

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -43,8 +43,6 @@ export interface GetFileResult extends LoonFS.BeginDownloadResponse {
     bytes: Uint8Array;
 }
 
-type CompletedUpload = LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
-
 interface StagedContent {
     contentRef: LoonFS.ContentRef;
     contentToken?: LoonFS.ContentToken;
@@ -204,14 +202,13 @@ async function stageDirectPut(
         await abortQuietly(client, namespaceAlias, begin.upload_id);
         throw error;
     }
-    const completed = completedUpload(
+    return stagedContent(
         await client.uploads.completeUpload({
             namespace_alias: namespaceAlias,
             upload_id: begin.upload_id,
             body: { mode: "direct_put", content: upload.content },
         }),
     );
-    return stagedContent(completed);
 }
 
 async function stageMultipart(
@@ -296,16 +293,11 @@ function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
     return parts;
 }
 
-function completedUpload(response: LoonFS.UploadSessionResponse): CompletedUpload {
-    const completed = response as CompletedUpload;
+function stagedContent(response: LoonFS.UploadSessionResponse): StagedContent {
+    const completed = response as LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
     if (completed.status !== "completed") {
         throw new Error(`upload ${response.upload_id} completed with status ${completed.status}`);
     }
-    return completed;
-}
-
-function stagedContent(response: LoonFS.UploadSessionResponse): StagedContent {
-    const completed = completedUpload(response);
     return {
         contentRef: completed.content_ref,
         contentToken: completed.content_token,

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -40,16 +40,14 @@ export interface GetFileResult extends LoonFS.BeginDownloadResponse {
     bytes: Uint8Array;
 }
 
-type CompletedUpload = LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
-
 interface StagedContent {
     contentRef: LoonFS.ContentRef;
     contentToken?: LoonFS.ContentToken;
 }
 
 interface DirectPutBody {
-    body: ReadableStream<Uint8Array>;
-    content: Promise<LoonFS.UploadContentClaim>;
+    body: ArrayBuffer;
+    content: LoonFS.UploadContentClaim;
 }
 
 /**
@@ -186,36 +184,28 @@ async function stageDirectPut(
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectPut,
 ): Promise<StagedContent> {
-    const upload = directPutBody(begin.direct_put.checksum_algorithm, bytes);
-    let content: LoonFS.UploadContentClaim;
+    let upload: DirectPutBody;
     try {
         requirePresignedMethod(begin.direct_put.access, "PUT", "direct PUT");
-        const headers = new Headers(begin.direct_put.access.headers);
-        if (!headers.has("content-length")) {
-            headers.set("content-length", bytes.byteLength.toString());
-        }
-        const request: RequestInit & { duplex: "half" } = {
+        upload = await directPutBody(begin.direct_put.checksum_algorithm, bytes);
+        const response = await fetch(begin.direct_put.access.url, {
             redirect: "error",
             method: begin.direct_put.access.method,
-            headers,
+            headers: begin.direct_put.access.headers,
             body: upload.body,
-            duplex: "half",
-        };
-        const response = await fetch(begin.direct_put.access.url, request);
+        });
         requireSuccessfulResponse(response, "direct PUT");
-        content = await upload.content;
     } catch (error) {
         await abortQuietly(client, namespaceId, begin.upload_id);
         throw error;
     }
-    const completed = completedUpload(
+    return stagedContent(
         await client.uploads.completeUpload({
             namespace_id: namespaceId,
             upload_id: begin.upload_id,
-            body: { mode: "direct_put", content },
+            body: { mode: "direct_put", content: upload.content },
         }),
     );
-    return stagedContent(completed);
 }
 
 async function stageMultipart(
@@ -300,16 +290,11 @@ function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
     return parts;
 }
 
-function completedUpload(response: LoonFS.UploadSessionResponse): CompletedUpload {
-    const completed = response as CompletedUpload;
+function stagedContent(response: LoonFS.UploadSessionResponse): StagedContent {
+    const completed = response as LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
     if (completed.status !== "completed") {
         throw new Error(`upload ${response.upload_id} completed with status ${completed.status}`);
     }
-    return completed;
-}
-
-function stagedContent(response: LoonFS.UploadSessionResponse): StagedContent {
-    const completed = completedUpload(response);
     return {
         contentRef: completed.content_ref,
         contentToken: completed.content_token,
@@ -344,38 +329,19 @@ function requireSuccessfulResponse(response: Response, operation: string): void 
     }
 }
 
-function directPutBody(
+async function directPutBody(
     algorithm: LoonFS.ChecksumAlgorithm,
     bytes: Uint8Array,
-): DirectPutBody {
-    let resolveContent!: (content: LoonFS.UploadContentClaim) => void;
-    let rejectContent!: (reason?: unknown) => void;
-    const content = new Promise<LoonFS.UploadContentClaim>((resolve, reject) => {
-        resolveContent = resolve;
-        rejectContent = reject;
-    });
-    void content.catch(() => undefined);
-
-    let sent = false;
-    const body = new ReadableStream<Uint8Array>({
-        pull(controller) {
-            if (sent) {
-                return;
-            }
-            sent = true;
-            const chunk = new Uint8Array(bytes.byteLength);
-            chunk.set(bytes);
-            controller.enqueue(chunk);
-            controller.close();
-            void checksum(algorithm, chunk).then((value) => {
-                resolveContent({ size_bytes: chunk.byteLength, checksum: value });
-            }, rejectContent);
+): Promise<DirectPutBody> {
+    const body = arrayBuffer(bytes);
+    const sentBytes = new Uint8Array(body);
+    return {
+        body,
+        content: {
+            size_bytes: sentBytes.byteLength,
+            checksum: await checksum(algorithm, sentBytes),
         },
-        cancel(reason) {
-            rejectContent(reason);
-        },
-    });
-    return { body, content };
+    };
 }
 
 async function checksum(


### PR DESCRIPTION
This removes unnecessary machinery from the handwritten SDK transfer and proxy code. In-memory uploads now compute checksums directly, transfer selection and completion use fewer special-case helpers, and the proxy implementations keep less state and perform less redundant header handling.

The existing SDK conformance suites cover service-proxied uploads, direct PUT, multipart uploads, downloads, and proxy behavior across Go, Python, and TypeScript. The Python proxy also keeps its runtime type aliases compatible with Python 3.8.