### PR TITLE
test(conformance): collapse the fixture schema plumbing

### DIFF
--- a/crates/loonfs-conformance/README.md
+++ b/crates/loonfs-conformance/README.md
@@ -24,15 +24,13 @@ The Rust harness only checks that the fixture is valid.
 
 Each file in `cases/` contains:
 
-- `version`: the fixture format version, currently `1`
 - `name`: the case name, which must match the file name
 - `intent`: the behavior being tested
-- `family`: the Rust function that runs the case
 - `request`: input values for the case
 - `expected`: expected response fields and behavior
 
-Each case family has a Rust function that performs the calls. The JSON files
-contain only inputs and expected results.
+Each case has a Rust function that performs the calls. The JSON files contain
+only inputs and expected results.
 
 Large multipart cases use a repeatable byte pattern. For length `N` and
 modulus `M`, the byte at each zero-based offset is `offset % M`. Other payloads
@@ -48,5 +46,5 @@ The typed client cannot create malformed JSON or invalid query values, so the
 error case sends those two requests with a raw HTTP client. All other requests
 use `loonfs-client`.
 
-Unit tests cover fixture loading, byte-pattern generation, and pagination.
-The integration test requires local TCP listeners.
+Library unit tests cover fixture loading, byte-pattern generation, and
+pagination. The sole integration test requires local TCP listeners.

--- a/crates/loonfs-conformance/README.md
+++ b/crates/loonfs-conformance/README.md
@@ -46,5 +46,5 @@ The typed client cannot create malformed JSON or invalid query values, so the
 error case sends those two requests with a raw HTTP client. All other requests
 use `loonfs-client`.
 
-Library unit tests cover fixture loading, byte-pattern generation, and
-pagination. The sole integration test requires local TCP listeners.
+Unit tests cover fixture loading, byte patterns, and pagination. The
+integration test requires local TCP listeners.

--- a/crates/loonfs-conformance/cases/changes.json
+++ b/crates/loonfs-conformance/cases/changes.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "changes",
   "intent": "Checks the change feed fields returned after a supplied sequence.",
-  "family": "changes",
   "request": {
     "namespace_id": "conf-changes",
     "path": "/changed",
@@ -15,7 +13,6 @@
   },
   "expected": {
     "committed_seq": 1,
-    "change_count": 1,
-    "event_kind": "directory_created"
+    "change_count": 1
   }
 }

--- a/crates/loonfs-conformance/cases/commit_replay.json
+++ b/crates/loonfs-conformance/cases/commit_replay.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "commit_replay",
   "intent": "Checks that repeating apply_commit with the same commit_id returns the stored result.",
-  "family": "commit_replay",
   "request": {
     "namespace_id": "conf-commit-replay",
     "commit_id": "conf-commit-replay-001",

--- a/crates/loonfs-conformance/cases/download.json
+++ b/crates/loonfs-conformance/cases/download.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "download",
   "intent": "Checks direct download length, checksum, and content.",
-  "family": "download",
   "request": {
     "namespace_id": "conf-download",
     "path": "/download.txt",

--- a/crates/loonfs-conformance/cases/end_to_end.json
+++ b/crates/loonfs-conformance/cases/end_to_end.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "end_to_end",
   "intent": "Checks an end-to-end filesystem workflow, including history, changes, and trash.",
-  "family": "end_to_end",
   "request": {
     "namespace_id": "conf-end-to-end",
     "directory": "/documents",

--- a/crates/loonfs-conformance/cases/error_contract.json
+++ b/crates/loonfs-conformance/cases/error_contract.json
@@ -1,39 +1,13 @@
 {
-  "version": 1,
   "name": "error_contract",
   "intent": "Checks standard errors for missing authentication, malformed JSON, and invalid query values.",
-  "family": "error_contract",
   "request": {
-    "namespace_id": "conf-error-contract",
-    "malformed_body": {
-      "commit_id": "conf-error-malformed-body",
-      "actor": {
-        "kind": "service",
-        "id": "conformance-error"
-      },
-      "operations": [
-        {
-          "kind": "create_directory",
-          "path": "relative"
-        }
-      ]
-    },
-    "invalid_after_seq": "not-a-sequence"
+    "namespace_id": "conf-error-contract"
   },
   "expected": {
     "unauthenticated": {
       "status": 401,
       "code": "unauthorized"
-    },
-    "malformed_body": {
-      "status": 400,
-      "code": "invalid_request",
-      "param": "/operations/0/path"
-    },
-    "invalid_query": {
-      "status": 400,
-      "code": "invalid_request",
-      "param": "after_seq"
     }
   }
 }

--- a/crates/loonfs-conformance/cases/pagination.json
+++ b/crates/loonfs-conformance/cases/pagination.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "pagination",
   "intent": "Checks that pagination returns every entry once and can resume from a saved cursor.",
-  "family": "pagination",
   "request": {
     "namespace_id": "conf-pagination",
     "directory": "/entries",

--- a/crates/loonfs-conformance/cases/proxy.json
+++ b/crates/loonfs-conformance/cases/proxy.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "proxy",
   "intent": "A proxy maps each namespace alias to a namespace, adds server credentials, streams request and response bodies, and rejects routes outside the proxy API.",
-  "family": "proxy",
   "request": {
     "namespace_alias": "team-files",
     "namespace_id": "conf-proxy-namespace",

--- a/crates/loonfs-conformance/cases/upload_abort.json
+++ b/crates/loonfs-conformance/cases/upload_abort.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "upload_abort",
   "intent": "Checks that repeating abort_upload returns the stored result.",
-  "family": "upload_abort",
   "request": {
     "namespace_id": "conf-upload-abort"
   },

--- a/crates/loonfs-conformance/cases/upload_direct_put.json
+++ b/crates/loonfs-conformance/cases/upload_direct_put.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "upload_direct_put",
   "intent": "Checks a direct PUT upload from creation through a verified file read.",
-  "family": "upload_direct_put",
   "request": {
     "namespace_id": "conf-upload-direct-put",
     "path": "/direct-put.txt",

--- a/crates/loonfs-conformance/cases/upload_multipart.json
+++ b/crates/loonfs-conformance/cases/upload_multipart.json
@@ -1,8 +1,6 @@
 {
-  "version": 1,
   "name": "upload_multipart",
   "intent": "Checks that repeating complete_upload after a multipart upload returns the stored result.",
-  "family": "upload_multipart",
   "request": {
     "namespace_id": "conf-upload-multipart",
     "path": "/multipart.bin",

--- a/crates/loonfs-conformance/src/lib.rs
+++ b/crates/loonfs-conformance/src/lib.rs
@@ -11,64 +11,31 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-/// Supported fixture format version.
-pub const FIXTURE_VERSION: u32 = 1;
-
-/// Function that runs a test case.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CaseFamily {
-    /// Standard API errors.
-    ErrorContract,
-    /// Repeated commit requests.
-    CommitReplay,
-    /// Direct PUT upload.
-    UploadDirectPut,
-    /// Multipart upload and repeated completion.
-    UploadMultipart,
-    /// Repeated upload abort.
-    UploadAbort,
-    /// Direct download.
-    Download,
-    /// Cursor pagination and resume.
-    Pagination,
-    /// Namespace-alias-scoped requests through a proxy.
-    Proxy,
-    /// Change feed order and identity.
-    Changes,
-    /// End-to-end filesystem workflow.
-    EndToEnd,
-}
-
 /// One shared test case.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Case {
-    /// Fixture format version.
-    pub version: u32,
     /// Case name and file stem.
     pub name: String,
     /// Behavior being tested.
     pub intent: String,
-    /// Function that runs the case.
-    pub family: CaseFamily,
     /// Input values for this case.
     pub request: Value,
     /// Expected responses and behavior.
     pub expected: Value,
 }
 
-const EXPECTED_CASES: &[(&str, CaseFamily)] = &[
-    ("changes", CaseFamily::Changes),
-    ("commit_replay", CaseFamily::CommitReplay),
-    ("download", CaseFamily::Download),
-    ("end_to_end", CaseFamily::EndToEnd),
-    ("error_contract", CaseFamily::ErrorContract),
-    ("pagination", CaseFamily::Pagination),
-    ("proxy", CaseFamily::Proxy),
-    ("upload_abort", CaseFamily::UploadAbort),
-    ("upload_direct_put", CaseFamily::UploadDirectPut),
-    ("upload_multipart", CaseFamily::UploadMultipart),
+const EXPECTED_CASES: &[&str] = &[
+    "changes",
+    "commit_replay",
+    "download",
+    "end_to_end",
+    "error_contract",
+    "pagination",
+    "proxy",
+    "upload_abort",
+    "upload_direct_put",
+    "upload_multipart",
 ];
 
 /// Failure to read or validate the test cases.
@@ -151,12 +118,6 @@ fn validate_case(path: &Path, case: &Case) -> Result<(), FixtureError> {
         path: path.to_path_buf(),
         reason,
     };
-    if case.version != FIXTURE_VERSION {
-        return Err(invalid(format!(
-            "version must be {FIXTURE_VERSION}, found {}",
-            case.version
-        )));
-    }
     let stem = path.file_stem().and_then(|stem| stem.to_str());
     if stem != Some(case.name.as_str()) {
         return Err(invalid(format!(
@@ -181,20 +142,17 @@ fn validate_inventory(directory: &Path, cases: &[Case]) -> Result<(), FixtureErr
         return Err(FixtureError::Invalid {
             path: directory.to_path_buf(),
             reason: format!(
-                "version one requires {} cases, found {}",
+                "fixture corpus requires {} cases, found {}",
                 EXPECTED_CASES.len(),
                 cases.len()
             ),
         });
     }
-    for (case, (expected_name, expected_family)) in cases.iter().zip(EXPECTED_CASES) {
-        if case.name != *expected_name || case.family != *expected_family {
+    for (case, expected_name) in cases.iter().zip(EXPECTED_CASES) {
+        if case.name != *expected_name {
             return Err(FixtureError::Invalid {
                 path: directory.to_path_buf(),
-                reason: format!(
-                    "expected `{expected_name}` with family {expected_family:?}, found `{}` with family {:?}",
-                    case.name, case.family
-                ),
+                reason: format!("expected `{expected_name}`, found `{}`", case.name),
             });
         }
     }
@@ -207,17 +165,13 @@ pub enum PatternError {
     /// The modulus is zero.
     #[error("byte pattern modulus must be greater than zero")]
     ZeroModulus,
-    /// The length does not fit in `usize`.
-    #[error("byte pattern length does not fit usize")]
-    LengthOverflow,
 }
 
 /// Generates the byte pattern `offset % modulus`.
-pub fn byte_pattern(length: u64, modulus: u8) -> Result<Vec<u8>, PatternError> {
+pub fn byte_pattern(length: usize, modulus: u8) -> Result<Vec<u8>, PatternError> {
     if modulus == 0 {
         return Err(PatternError::ZeroModulus);
     }
-    let length = usize::try_from(length).map_err(|_| PatternError::LengthOverflow)?;
     Ok((0..length)
         .map(|offset| (offset % usize::from(modulus)) as u8)
         .collect())
@@ -276,10 +230,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_one_inventory_parses_and_is_complete() {
-        let cases = load_cases().expect("load version-one cases");
+    fn inventory_parses_and_is_complete() {
+        let cases = load_cases().expect("load cases");
         assert_eq!(cases.len(), EXPECTED_CASES.len());
-        assert!(cases.iter().all(|case| case.version == FIXTURE_VERSION));
     }
 
     #[test]

--- a/crates/loonfs-conformance/tests/reference.rs
+++ b/crates/loonfs-conformance/tests/reference.rs
@@ -5,8 +5,8 @@
 use bytes::Bytes;
 use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, CompleteMultipartUploadRequest, CompleteUploadRequest,
-    DirectMultipartUploadOptions, FilesystemChange, UploadContentClaim, UploadPartChecksumClaim,
-    UploadSessionStatus,
+    DirectMultipartUploadOptions, FilesystemChange, UploadContentClaim, UploadMode,
+    UploadPartChecksumClaim, UploadSessionStatus,
 };
 use loonfs_api::{
     ActorRef, ApiError, ChangeSeq, Checksum, CommitId, CommitRequest, FilesystemOperation,
@@ -17,50 +17,9 @@ use loonfs_client::{
     ListPathEntriesOptions, MoveOptions, NamespacePath, PutFileOptions, StatPathOptions,
 };
 use loonfs_conformance::server::{start_server, ConformanceServer, AUTH_TOKEN};
-use loonfs_conformance::{byte_pattern, load_cases, validate_page_walk, Case, CaseFamily};
+use loonfs_conformance::{byte_pattern, load_cases, validate_page_walk, Case};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use serde_json::Value;
-
-#[test]
-fn every_family_specific_fixture_shape_parses_without_a_server() {
-    for case in load_cases().expect("load cases") {
-        match case.family {
-            CaseFamily::ErrorContract => {
-                parse_values::<ErrorRequest, ErrorExpected>(&case);
-            }
-            CaseFamily::CommitReplay => {
-                parse_values::<CommitReplayRequest, CommitReplayExpected>(&case);
-            }
-            CaseFamily::UploadDirectPut => {
-                parse_values::<DirectPutRequest, DirectPutExpected>(&case);
-            }
-            CaseFamily::UploadMultipart => {
-                parse_values::<MultipartRequest, MultipartExpected>(&case);
-            }
-            CaseFamily::UploadAbort => {
-                parse_values::<AbortRequest, AbortExpected>(&case);
-            }
-            CaseFamily::Download => {
-                parse_values::<DownloadRequest, DownloadExpected>(&case);
-            }
-            CaseFamily::Pagination => {
-                parse_values::<PaginationRequest, PaginationExpected>(&case);
-            }
-            CaseFamily::Changes => {
-                parse_values::<ChangesRequest, ChangesExpected>(&case);
-            }
-            CaseFamily::EndToEnd => {
-                parse_values::<EndToEndRequest, EndToEndExpected>(&case);
-            }
-            // Each SDK harness tests its own proxy. Rust only validates the
-            // shared fixture.
-            CaseFamily::Proxy => {
-                assert!(case.request.is_object() && case.expected.is_object());
-            }
-        }
-    }
-}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn rust_client_matches_the_reference_corpus() {
@@ -68,18 +27,19 @@ async fn rust_client_matches_the_reference_corpus() {
     let harness = Harness::start().await;
 
     for case in &cases {
-        match case.family {
-            CaseFamily::ErrorContract => run_error_contract(&harness, case).await,
-            CaseFamily::CommitReplay => run_commit_replay(&harness, case).await,
-            CaseFamily::UploadDirectPut => run_direct_put(&harness, case).await,
-            CaseFamily::UploadMultipart => run_multipart(&harness, case).await,
-            CaseFamily::UploadAbort => run_abort(&harness, case).await,
-            CaseFamily::Download => run_download(&harness, case).await,
-            CaseFamily::Pagination => run_pagination(&harness, case).await,
-            CaseFamily::Changes => run_changes(&harness, case).await,
-            CaseFamily::EndToEnd => run_end_to_end(&harness, case).await,
+        match case.name.as_str() {
+            "error_contract" => run_error_contract(&harness, case).await,
+            "commit_replay" => run_commit_replay(&harness, case).await,
+            "upload_direct_put" => run_direct_put(&harness, case).await,
+            "upload_multipart" => run_multipart(&harness, case).await,
+            "upload_abort" => run_abort(&harness, case).await,
+            "download" => run_download(&harness, case).await,
+            "pagination" => run_pagination(&harness, case).await,
+            "changes" => run_changes(&harness, case).await,
+            "end_to_end" => run_end_to_end(&harness, case).await,
             // Each SDK harness runs this case against its own proxy.
-            CaseFamily::Proxy => {}
+            "proxy" => {}
+            name => panic!("unknown case {name}"),
         }
     }
 }
@@ -160,16 +120,12 @@ fn put_options(actor: &ActorRef, id: &str) -> PutFileOptions {
 #[serde(deny_unknown_fields)]
 struct ErrorRequest {
     namespace_id: String,
-    malformed_body: Value,
-    invalid_after_seq: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ErrorExpected {
     unauthenticated: UnauthorizedExpected,
-    malformed_body: ErrorOutcome,
-    invalid_query: ErrorOutcome,
 }
 
 #[derive(Debug, Deserialize)]
@@ -215,23 +171,49 @@ async fn run_error_contract(harness: &Harness, case: &Case) {
             harness.server_url, request.namespace_id
         ))
         .bearer_auth(AUTH_TOKEN)
-        .json(&request.malformed_body)
+        .json(&serde_json::json!({
+            "commit_id": "conf-error-malformed-body",
+            "actor": {
+                "kind": "service",
+                "id": "conformance-error",
+            },
+            "operations": [{
+                "kind": "create_directory",
+                "path": "relative",
+            }],
+        }))
         .send()
         .await
         .expect("send malformed body");
-    assert_raw_error(malformed, &expected.malformed_body).await;
+    assert_raw_error(
+        malformed,
+        &ErrorOutcome {
+            status: 400,
+            code: "invalid_request".to_owned(),
+            param: "/operations/0/path".to_owned(),
+        },
+    )
+    .await;
 
     let invalid_query = harness
         .raw_client
         .get(format!(
             "{}/v0/namespaces/{}/changes?after_seq={}",
-            harness.server_url, request.namespace_id, request.invalid_after_seq
+            harness.server_url, request.namespace_id, "not-a-sequence"
         ))
         .bearer_auth(AUTH_TOKEN)
         .send()
         .await
         .expect("send invalid query");
-    assert_raw_error(invalid_query, &expected.invalid_query).await;
+    assert_raw_error(
+        invalid_query,
+        &ErrorOutcome {
+            status: 400,
+            code: "invalid_request".to_owned(),
+            param: "after_seq".to_owned(),
+        },
+    )
+    .await;
 }
 
 async fn assert_raw_error(response: reqwest::Response, expected: &ErrorOutcome) {
@@ -325,6 +307,7 @@ async fn run_direct_put(harness: &Harness, case: &Case) {
         .begin_direct_put(&namespace, Some(payload.len() as u64))
         .await
         .expect("begin direct PUT");
+    assert_eq!(upload_mode_name(begin.mode()), expected.mode);
     let (upload_id, direct_put) = match begin {
         BeginUploadResponse::DirectPut {
             upload_id,
@@ -333,7 +316,6 @@ async fn run_direct_put(harness: &Harness, case: &Case) {
         } => (upload_id, direct_put),
         other => panic!("expected direct_put, found {other:?}"),
     };
-    assert_eq!(expected.mode, "direct_put");
     assert_eq!(
         direct_put.checksum_algorithm.as_str(),
         expected.checksum_algorithm
@@ -410,7 +392,7 @@ struct MultipartRequest {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct BytePattern {
-    length: u64,
+    length: usize,
     modulus: u8,
 }
 
@@ -447,6 +429,7 @@ async fn run_multipart(harness: &Harness, case: &Case) {
         )
         .await
         .expect("begin multipart upload");
+    assert_eq!(upload_mode_name(begin.mode()), expected.mode);
     let (upload_id, multipart) = match begin {
         BeginUploadResponse::DirectMultipart {
             upload_id,
@@ -455,7 +438,6 @@ async fn run_multipart(harness: &Harness, case: &Case) {
         } => (upload_id, direct_multipart),
         other => panic!("expected direct_multipart, found {other:?}"),
     };
-    assert_eq!(expected.mode, "direct_multipart");
     assert_eq!(multipart.part_size_bytes, request.part_size_bytes);
     assert_eq!(
         multipart.checksum_algorithm.as_str(),
@@ -581,6 +563,7 @@ async fn run_abort(harness: &Harness, case: &Case) {
         .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin abortable upload");
+    assert_eq!(upload_mode_name(begin.mode()), expected.mode);
     let first = harness
         .client
         .abort_upload(&namespace, begin.upload_id())
@@ -591,8 +574,7 @@ async fn run_abort(harness: &Harness, case: &Case) {
         .abort_upload(&namespace, begin.upload_id())
         .await
         .expect("replay abort");
-    assert_eq!(expected.mode, "service_proxied");
-    assert_eq!(expected.status, "aborted");
+    assert_eq!(upload_status_name(&first.status), expected.status);
     assert_eq!(replayed, first);
     let first_aborted_at_ms = aborted_at_ms(&first.status);
     assert_eq!(aborted_at_ms(&replayed.status), first_aborted_at_ms);
@@ -602,6 +584,22 @@ fn aborted_at_ms(status: &UploadSessionStatus) -> u64 {
     match status {
         UploadSessionStatus::Aborted { aborted_at_ms } => *aborted_at_ms,
         other => panic!("expected aborted upload, found {other:?}"),
+    }
+}
+
+fn upload_mode_name(mode: UploadMode) -> &'static str {
+    match mode {
+        UploadMode::ServiceProxied => "service_proxied",
+        UploadMode::DirectPut => "direct_put",
+        UploadMode::DirectMultipart => "direct_multipart",
+    }
+}
+
+fn upload_status_name(status: &UploadSessionStatus) -> &'static str {
+    match status {
+        UploadSessionStatus::Open { .. } => "open",
+        UploadSessionStatus::Completed { .. } => "completed",
+        UploadSessionStatus::Aborted { .. } => "aborted",
     }
 }
 
@@ -809,7 +807,6 @@ struct ChangesRequest {
 struct ChangesExpected {
     committed_seq: u64,
     change_count: usize,
-    event_kind: String,
 }
 
 async fn run_changes(harness: &Harness, case: &Case) {
@@ -844,7 +841,6 @@ async fn run_changes(harness: &Harness, case: &Case) {
     let change = feed.changes.first().expect("one change");
     assert_eq!(change.commit_id.as_str(), request.commit_id);
     assert_eq!(change.committed_by, request.actor);
-    assert_eq!(expected.event_kind, "directory_created");
     assert!(matches!(
         change.events.as_slice(),
         [FilesystemChange::DirectoryCreated { .. }]

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"hash/crc64"
 	"io"
 	"net/http"
@@ -28,31 +27,24 @@ import (
 	"github.com/loonfs/loonfs-sdk-go/transfers"
 )
 
-const fixtureVersion = 1
-
 type conformanceCase struct {
-	Version  int             `json:"version"`
 	Name     string          `json:"name"`
 	Intent   string          `json:"intent"`
-	Family   string          `json:"family"`
 	Request  json.RawMessage `json:"request"`
 	Expected json.RawMessage `json:"expected"`
 }
 
-var expectedCases = []struct {
-	name   string
-	family string
-}{
-	{name: "changes", family: "changes"},
-	{name: "commit_replay", family: "commit_replay"},
-	{name: "download", family: "download"},
-	{name: "end_to_end", family: "end_to_end"},
-	{name: "error_contract", family: "error_contract"},
-	{name: "pagination", family: "pagination"},
-	{name: "proxy", family: "proxy"},
-	{name: "upload_abort", family: "upload_abort"},
-	{name: "upload_direct_put", family: "upload_direct_put"},
-	{name: "upload_multipart", family: "upload_multipart"},
+var expectedCases = []string{
+	"changes",
+	"commit_replay",
+	"download",
+	"end_to_end",
+	"error_contract",
+	"pagination",
+	"proxy",
+	"upload_abort",
+	"upload_direct_put",
+	"upload_multipart",
 }
 
 type harness struct {
@@ -92,7 +84,7 @@ func TestSDKConformance(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			switch testCase.Family {
+			switch testCase.Name {
 			case "error_contract":
 				runErrorContract(t, h, testCase)
 			case "commit_replay":
@@ -114,7 +106,7 @@ func TestSDKConformance(t *testing.T) {
 			case "end_to_end":
 				runEndToEnd(t, h, testCase)
 			default:
-				t.Fatalf("unknown case family %q", testCase.Family)
+				t.Fatalf("unknown case %q", testCase.Name)
 			}
 		})
 	}
@@ -148,26 +140,17 @@ func loadCases(directory string) ([]conformanceCase, error) {
 		return cases[i].Name < cases[j].Name
 	})
 	if len(cases) != len(expectedCases) {
-		return nil, fmt.Errorf("fixture version 1 requires %d cases, found %d", len(expectedCases), len(cases))
+		return nil, fmt.Errorf("fixture corpus requires %d cases, found %d", len(expectedCases), len(cases))
 	}
 	for index, expected := range expectedCases {
-		if cases[index].Name != expected.name || cases[index].Family != expected.family {
-			return nil, fmt.Errorf(
-				"expected %q with family %q, found %q with family %q",
-				expected.name,
-				expected.family,
-				cases[index].Name,
-				cases[index].Family,
-			)
+		if cases[index].Name != expected {
+			return nil, fmt.Errorf("expected %q, found %q", expected, cases[index].Name)
 		}
 	}
 	return cases, nil
 }
 
 func validateCase(path string, testCase *conformanceCase) error {
-	if testCase.Version != fixtureVersion {
-		return fmt.Errorf("invalid fixture %s: version must be %d, found %d", path, fixtureVersion, testCase.Version)
-	}
 	stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	if testCase.Name != stem {
 		return fmt.Errorf("invalid fixture %s: name is %q, expected %q", path, testCase.Name, stem)
@@ -219,26 +202,16 @@ func decodeCaseValues[R, E any](t *testing.T, testCase conformanceCase) (R, E) {
 }
 
 type errorContractRequest struct {
-	NamespaceID     string          `json:"namespace_id"`
-	MalformedBody   json.RawMessage `json:"malformed_body"`
-	InvalidAfterSeq string          `json:"invalid_after_seq"`
+	NamespaceID string `json:"namespace_id"`
 }
 
 type errorContractExpected struct {
 	Unauthenticated errorStatusExpected `json:"unauthenticated"`
-	MalformedBody   errorOutcome        `json:"malformed_body"`
-	InvalidQuery    errorOutcome        `json:"invalid_query"`
 }
 
 type errorStatusExpected struct {
 	Status int    `json:"status"`
 	Code   string `json:"code"`
-}
-
-type errorOutcome struct {
-	Status int    `json:"status"`
-	Code   string `json:"code"`
-	Param  string `json:"param"`
 }
 
 func runErrorContract(t *testing.T, h *harness, testCase conformanceCase) {
@@ -345,11 +318,11 @@ func runDirectPut(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Fatalf("begin direct PUT: %v", err)
 	}
 	if begin.DirectPut == nil || begin.DirectPut.DirectPut == nil {
-		t.Fatalf("begin upload mode = %q, want direct_put", begin.Mode)
+		t.Fatalf("begin upload mode = %q, want %q", begin.Mode, expected.Mode)
 	}
 	directPut := begin.DirectPut.DirectPut
-	if expected.Mode != "direct_put" {
-		t.Errorf("expected mode = %q, want direct_put", expected.Mode)
+	if begin.Mode != expected.Mode {
+		t.Errorf("begin upload mode = %q, want %q", begin.Mode, expected.Mode)
 	}
 	if string(directPut.ChecksumAlgorithm) != expected.ChecksumAlgorithm {
 		t.Errorf("direct PUT checksum_algorithm = %q, want %q", directPut.ChecksumAlgorithm, expected.ChecksumAlgorithm)
@@ -443,11 +416,11 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Fatalf("begin multipart upload: %v", err)
 	}
 	if begin.DirectMultipart == nil || begin.DirectMultipart.DirectMultipart == nil {
-		t.Fatalf("begin upload mode = %q, want direct_multipart", begin.Mode)
+		t.Fatalf("begin upload mode = %q, want %q", begin.Mode, expected.Mode)
 	}
 	multipart := begin.DirectMultipart.DirectMultipart
-	if expected.Mode != "direct_multipart" {
-		t.Errorf("expected mode = %q, want direct_multipart", expected.Mode)
+	if begin.Mode != expected.Mode {
+		t.Errorf("begin upload mode = %q, want %q", begin.Mode, expected.Mode)
 	}
 	if multipart.PartSizeBytes != request.PartSizeBytes {
 		t.Errorf("part_size_bytes = %d, want %d", multipart.PartSizeBytes, request.PartSizeBytes)
@@ -598,7 +571,10 @@ func runAbort(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Fatalf("begin abortable upload: %v", err)
 	}
 	if begin.ServiceProxied == nil {
-		t.Fatalf("begin upload mode = %q, want service_proxied", begin.Mode)
+		t.Fatalf("begin upload mode = %q, want %q", begin.Mode, expected.Mode)
+	}
+	if begin.Mode != expected.Mode {
+		t.Errorf("begin upload mode = %q, want %q", begin.Mode, expected.Mode)
 	}
 	abort := &loonfs.AbortUploadRequest{
 		NamespaceID: request.NamespaceID,
@@ -612,13 +588,14 @@ func runAbort(t *testing.T, h *harness, testCase conformanceCase) {
 	if err != nil {
 		t.Fatalf("replay abort: %v", err)
 	}
-	if expected.Mode != "service_proxied" {
-		t.Errorf("expected mode = %q, want service_proxied", expected.Mode)
+	firstStatusEnvelope := uploadSessionStatus(t, first)
+	if firstStatusEnvelope.Status != expected.Status {
+		t.Errorf("upload status = %q, want %q", firstStatusEnvelope.Status, expected.Status)
 	}
-	if expected.Status != "aborted" {
-		t.Errorf("expected status = %q, want aborted", expected.Status)
+	if firstStatusEnvelope.Aborted == nil {
+		t.Fatalf("upload status = %q, want aborted", firstStatusEnvelope.Status)
 	}
-	firstStatus := requireAbortedStatus(t, first)
+	firstStatus := firstStatusEnvelope.Aborted
 	replayedStatus := requireAbortedStatus(t, replayed)
 	if replayed.NamespaceID != first.NamespaceID || replayed.UploadID != first.UploadID || replayed.Mode != first.Mode {
 		t.Errorf("replayed abort identity = %#v, want %#v", replayed, first)
@@ -1400,9 +1377,8 @@ type changesRequest struct {
 }
 
 type changesExpected struct {
-	CommittedSeq int64  `json:"committed_seq"`
-	ChangeCount  int    `json:"change_count"`
-	EventKind    string `json:"event_kind"`
+	CommittedSeq int64 `json:"committed_seq"`
+	ChangeCount  int   `json:"change_count"`
 }
 
 func runChanges(t *testing.T, h *harness, testCase conformanceCase) {
@@ -1448,18 +1424,12 @@ func runChanges(t *testing.T, h *harness, testCase conformanceCase) {
 		change.CommittedBy.Kind != request.Actor.Kind {
 		t.Errorf("change committed_by = %#v, want %#v", change.CommittedBy, request.Actor)
 	}
-	if expected.EventKind != "directory_created" {
-		t.Errorf("expected event kind = %q, want %q", expected.EventKind, "directory_created")
-	}
 	if len(change.Events) != 1 || change.Events[0] == nil || change.Events[0].DirectoryCreated == nil {
 		t.Errorf("change events = %#v, want one directory_created event", change.Events)
 	}
 }
 
-var (
-	conformanceCRC32CTable    = crc32.MakeTable(crc32.Castagnoli)
-	conformanceCRC64NVMeTable = crc64.MakeTable(0x9a6c9329ac4bc9b5)
-)
+var conformanceCRC64NVMeTable = crc64.MakeTable(0x9a6c9329ac4bc9b5)
 
 func makeBytePattern(t *testing.T, pattern bytePattern) []byte {
 	t.Helper()
@@ -1512,8 +1482,6 @@ func checksumFor(algorithm loonfs.ChecksumAlgorithm, payload []byte) (*loonfs.Ch
 		value = hex.EncodeToString(digest[:])
 	case loonfs.ChecksumAlgorithmCrc64Nvme:
 		value = fmt.Sprintf("%016x", crc64.Checksum(payload, conformanceCRC64NVMeTable))
-	case loonfs.ChecksumAlgorithmCrc32C:
-		value = fmt.Sprintf("%08x", crc32.Checksum(payload, conformanceCRC32CTable))
 	default:
 		return nil, fmt.Errorf("unsupported checksum algorithm %q", algorithm)
 	}

--- a/sdk/conformance/python/requirements.txt
+++ b/sdk/conformance/python/requirements.txt
@@ -1,6 +1,5 @@
 httpx>=0.21.2
-pydantic>=1.9.2
-pydantic-core>=2.18.2
+pydantic>=2
 typing_extensions>=4.0.0
 anyio>=3.5.0
 pytest>=8

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -278,7 +278,7 @@ class Harness:
 
 
 def _decode(case: ConformanceCase, request_type: Any, expected_type: Any) -> tuple[Any, Any]:
-    # Strict dataclasses accept fixture mappings through Pydantic's JSON validation path.
+    # Strict Pydantic dataclasses reject Python dictionaries, so validate JSON instead.
     return (
         pydantic.TypeAdapter(request_type).validate_json(json.dumps(case.request)),
         pydantic.TypeAdapter(expected_type).validate_json(json.dumps(case.expected)),

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import os
+import re
 import socket
 import threading
 import time
@@ -16,6 +16,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 import httpx
+import pydantic
 import pytest
 import uvicorn
 from loonfs_sdk import (
@@ -48,20 +49,18 @@ from loonfs_sdk.proxy import LoonFSProxy
 from loonfs_sdk.transfers import get_file, put_file
 
 
-FIXTURE_VERSION = 1
 RUNNER_SKIP = "run scripts/run-sdk-conformance.sh python"
-CASE_FIELDS = {"version", "name", "intent", "family", "request", "expected"}
 EXPECTED_CASES = [
-    ("changes", "changes"),
-    ("commit_replay", "commit_replay"),
-    ("download", "download"),
-    ("end_to_end", "end_to_end"),
-    ("error_contract", "error_contract"),
-    ("pagination", "pagination"),
-    ("proxy", "proxy"),
-    ("upload_abort", "upload_abort"),
-    ("upload_direct_put", "upload_direct_put"),
-    ("upload_multipart", "upload_multipart"),
+    "changes",
+    "commit_replay",
+    "download",
+    "end_to_end",
+    "error_contract",
+    "pagination",
+    "proxy",
+    "upload_abort",
+    "upload_direct_put",
+    "upload_multipart",
 ]
 pytestmark = pytest.mark.skipif(
     not os.environ.get("LOONFS_CONFORMANCE_URL"),
@@ -72,42 +71,31 @@ pytestmark = pytest.mark.skipif(
 JsonObject = dict[str, object]
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ConformanceCase:
     name: str
-    family: str
+    intent: str
     request: JsonObject
     expected: JsonObject
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ErrorStatusExpected:
     status: int
     code: str
 
 
-@dataclass(frozen=True)
-class ErrorOutcome:
-    status: int
-    code: str
-    param: str
-
-
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ErrorContractRequest:
     namespace_id: str
-    malformed_body: JsonObject
-    invalid_after_seq: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ErrorContractExpected:
     unauthenticated: ErrorStatusExpected
-    malformed_body: ErrorOutcome
-    invalid_query: ErrorOutcome
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class CommitReplayRequest:
     namespace_id: str
     commit_id: str
@@ -116,12 +104,12 @@ class CommitReplayRequest:
     path: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class CommitReplayExpected:
     committed_seq: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class DirectPutRequest:
     namespace_id: str
     path: str
@@ -130,7 +118,7 @@ class DirectPutRequest:
     content_utf8: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class DirectPutExpected:
     mode: str
     size_bytes: int
@@ -138,13 +126,13 @@ class DirectPutExpected:
     committed_seq: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class BytePattern:
     length: int
     modulus: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class MultipartRequest:
     namespace_id: str
     path: str
@@ -154,7 +142,7 @@ class MultipartRequest:
     content_pattern: BytePattern
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class MultipartExpected:
     mode: str
     part_count: int
@@ -163,18 +151,18 @@ class MultipartExpected:
     committed_seq: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class AbortRequest:
     namespace_id: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class AbortExpected:
     mode: str
     status: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class DownloadRequest:
     namespace_id: str
     path: str
@@ -183,14 +171,14 @@ class DownloadRequest:
     content_utf8: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class DownloadExpected:
     size_bytes: int
     checksum_algorithm: str
     committed_seq: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class EndToEndCommitIds:
     mkdir: str
     upload: str
@@ -198,7 +186,7 @@ class EndToEndCommitIds:
     remove: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class EndToEndRequest:
     namespace_id: str
     directory: str
@@ -209,7 +197,7 @@ class EndToEndRequest:
     commit_ids: EndToEndCommitIds
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class EndToEndExpected:
     mkdir_committed_seq: int
     upload_committed_seq: int
@@ -220,7 +208,7 @@ class EndToEndExpected:
     change_count: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class PaginationRequest:
     namespace_id: str
     directory: str
@@ -230,21 +218,21 @@ class PaginationRequest:
     resume_after_page: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class PaginationExpected:
     entry_count: int
     minimum_page_count: int
     head_seq: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ProxyCommitIds:
     directory: str
     proxied: str
     direct: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ProxyRequest:
     namespace_alias: str
     namespace_id: str
@@ -258,7 +246,7 @@ class ProxyRequest:
     disallowed_path_suffix: str
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ProxyExpected:
     mkdir_committed_seq: int
     proxied_committed_seq: int
@@ -268,7 +256,7 @@ class ProxyExpected:
     disallowed_route_status: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ChangesRequest:
     namespace_id: str
     path: str
@@ -277,11 +265,10 @@ class ChangesRequest:
     after_seq: int
 
 
-@dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class ChangesExpected:
     committed_seq: int
     change_count: int
-    event_kind: str
 
 
 @dataclass(frozen=True)
@@ -290,588 +277,11 @@ class Harness:
     unauthenticated: LoonFS
 
 
-@dataclass(frozen=True)
-class ProxyHarness:
-    base_url: str
-
-
-def _strict_object(value: object, fields: set[str], label: str) -> JsonObject:
-    if not isinstance(value, dict):
-        raise AssertionError(f"{label} must be a JSON object")
-    if not all(isinstance(key, str) for key in value):
-        raise AssertionError(f"{label} must use string keys")
-    actual = set(value)
-    if actual != fields:
-        unknown = sorted(actual - fields)
-        missing = sorted(fields - actual)
-        raise AssertionError(
-            f"{label} fields differ: unknown={unknown}, missing={missing}"
-        )
-    return value
-
-
-def _json_object(value: object, label: str) -> JsonObject:
-    if not isinstance(value, dict):
-        raise AssertionError(f"{label} must be a JSON object")
-    if not all(isinstance(key, str) for key in value):
-        raise AssertionError(f"{label} must use string keys")
-    return value
-
-
-def _string(value: object, label: str) -> str:
-    if not isinstance(value, str):
-        raise AssertionError(f"{label} must be a string")
-    return value
-
-
-def _integer(value: object, label: str) -> int:
-    if type(value) is not int:
-        raise AssertionError(f"{label} must be an integer")
-    return value
-
-
-def _string_list(value: object, label: str) -> list[str]:
-    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        raise AssertionError(f"{label} must be an array of strings")
-    return value
-
-
-def _actor(value: object, label: str) -> ActorRef:
-    actor = _strict_object(value, {"id", "kind"}, label)
-    actor_id = _string(actor["id"], f"{label}.id")
-    kind = _string(actor["kind"], f"{label}.kind")
-    if kind not in {"user", "service", "system"}:
-        raise AssertionError(f"{label}.kind is not a known actor kind")
-    return ActorRef(id=actor_id, kind=kind)
-
-
-def _error_status(value: object, label: str) -> ErrorStatusExpected:
-    data = _strict_object(value, {"status", "code"}, label)
-    return ErrorStatusExpected(
-        status=_integer(data["status"], f"{label}.status"),
-        code=_string(data["code"], f"{label}.code"),
-    )
-
-
-def _error_outcome(value: object, label: str) -> ErrorOutcome:
-    data = _strict_object(value, {"status", "code", "param"}, label)
-    return ErrorOutcome(
-        status=_integer(data["status"], f"{label}.status"),
-        code=_string(data["code"], f"{label}.code"),
-        param=_string(data["param"], f"{label}.param"),
-    )
-
-
-def _decode_error_contract(
-    test_case: ConformanceCase,
-) -> tuple[ErrorContractRequest, ErrorContractExpected]:
-    request = _strict_object(
-        test_case.request,
-        {"namespace_id", "malformed_body", "invalid_after_seq"},
-        f"{test_case.name} request",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {"unauthenticated", "malformed_body", "invalid_query"},
-        f"{test_case.name} expected",
-    )
+def _decode(case: ConformanceCase, request_type: Any, expected_type: Any) -> tuple[Any, Any]:
+    # Strict dataclasses accept fixture mappings through Pydantic's JSON validation path.
     return (
-        ErrorContractRequest(
-            namespace_id=_string(
-                request["namespace_id"], "error_contract request.namespace_id"
-            ),
-            malformed_body=_json_object(
-                request["malformed_body"], "error_contract request.malformed_body"
-            ),
-            invalid_after_seq=_string(
-                request["invalid_after_seq"], "error_contract request.invalid_after_seq"
-            ),
-        ),
-        ErrorContractExpected(
-            unauthenticated=_error_status(
-                expected["unauthenticated"], "error_contract expected.unauthenticated"
-            ),
-            malformed_body=_error_outcome(
-                expected["malformed_body"], "error_contract expected.malformed_body"
-            ),
-            invalid_query=_error_outcome(
-                expected["invalid_query"], "error_contract expected.invalid_query"
-            ),
-        ),
-    )
-
-
-def _decode_commit_replay(
-    test_case: ConformanceCase,
-) -> tuple[CommitReplayRequest, CommitReplayExpected]:
-    request = _strict_object(
-        test_case.request,
-        {"namespace_id", "commit_id", "actor", "message", "path"},
-        f"{test_case.name} request",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {"committed_seq"},
-        f"{test_case.name} expected",
-    )
-    return (
-        CommitReplayRequest(
-            namespace_id=_string(
-                request["namespace_id"], "commit_replay request.namespace_id"
-            ),
-            commit_id=_string(request["commit_id"], "commit_replay request.commit_id"),
-            actor=_actor(request["actor"], "commit_replay request.actor"),
-            message=_string(request["message"], "commit_replay request.message"),
-            path=_string(request["path"], "commit_replay request.path"),
-        ),
-        CommitReplayExpected(
-            committed_seq=_integer(
-                expected["committed_seq"], "commit_replay expected.committed_seq"
-            )
-        ),
-    )
-
-
-def _decode_direct_put(
-    test_case: ConformanceCase,
-) -> tuple[DirectPutRequest, DirectPutExpected]:
-    request = _strict_object(
-        test_case.request,
-        {"namespace_id", "path", "commit_id", "actor", "content_utf8"},
-        f"{test_case.name} request",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {"mode", "size_bytes", "checksum_algorithm", "committed_seq"},
-        f"{test_case.name} expected",
-    )
-    return (
-        DirectPutRequest(
-            namespace_id=_string(
-                request["namespace_id"], "upload_direct_put request.namespace_id"
-            ),
-            path=_string(request["path"], "upload_direct_put request.path"),
-            commit_id=_string(
-                request["commit_id"], "upload_direct_put request.commit_id"
-            ),
-            actor=_actor(request["actor"], "upload_direct_put request.actor"),
-            content_utf8=_string(
-                request["content_utf8"], "upload_direct_put request.content_utf8"
-            ),
-        ),
-        DirectPutExpected(
-            mode=_string(expected["mode"], "upload_direct_put expected.mode"),
-            size_bytes=_integer(
-                expected["size_bytes"], "upload_direct_put expected.size_bytes"
-            ),
-            checksum_algorithm=_string(
-                expected["checksum_algorithm"],
-                "upload_direct_put expected.checksum_algorithm",
-            ),
-            committed_seq=_integer(
-                expected["committed_seq"], "upload_direct_put expected.committed_seq"
-            ),
-        ),
-    )
-
-
-def _decode_multipart(
-    test_case: ConformanceCase,
-) -> tuple[MultipartRequest, MultipartExpected]:
-    request = _strict_object(
-        test_case.request,
-        {
-            "namespace_id",
-            "path",
-            "commit_id",
-            "actor",
-            "part_size_bytes",
-            "content_pattern",
-        },
-        f"{test_case.name} request",
-    )
-    pattern = _strict_object(
-        request["content_pattern"],
-        {"length", "modulus"},
-        "upload_multipart request.content_pattern",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {"mode", "part_count", "size_bytes", "checksum_algorithm", "committed_seq"},
-        f"{test_case.name} expected",
-    )
-    return (
-        MultipartRequest(
-            namespace_id=_string(
-                request["namespace_id"], "upload_multipart request.namespace_id"
-            ),
-            path=_string(request["path"], "upload_multipart request.path"),
-            commit_id=_string(
-                request["commit_id"], "upload_multipart request.commit_id"
-            ),
-            actor=_actor(request["actor"], "upload_multipart request.actor"),
-            part_size_bytes=_integer(
-                request["part_size_bytes"], "upload_multipart request.part_size_bytes"
-            ),
-            content_pattern=BytePattern(
-                length=_integer(
-                    pattern["length"], "upload_multipart request.content_pattern.length"
-                ),
-                modulus=_integer(
-                    pattern["modulus"],
-                    "upload_multipart request.content_pattern.modulus",
-                ),
-            ),
-        ),
-        MultipartExpected(
-            mode=_string(expected["mode"], "upload_multipart expected.mode"),
-            part_count=_integer(
-                expected["part_count"], "upload_multipart expected.part_count"
-            ),
-            size_bytes=_integer(
-                expected["size_bytes"], "upload_multipart expected.size_bytes"
-            ),
-            checksum_algorithm=_string(
-                expected["checksum_algorithm"],
-                "upload_multipart expected.checksum_algorithm",
-            ),
-            committed_seq=_integer(
-                expected["committed_seq"], "upload_multipart expected.committed_seq"
-            ),
-        ),
-    )
-
-
-def _decode_abort(test_case: ConformanceCase) -> tuple[AbortRequest, AbortExpected]:
-    request = _strict_object(
-        test_case.request,
-        {"namespace_id"},
-        f"{test_case.name} request",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {"mode", "status"},
-        f"{test_case.name} expected",
-    )
-    return (
-        AbortRequest(
-            namespace_id=_string(
-                request["namespace_id"], "upload_abort request.namespace_id"
-            )
-        ),
-        AbortExpected(
-            mode=_string(expected["mode"], "upload_abort expected.mode"),
-            status=_string(expected["status"], "upload_abort expected.status"),
-        ),
-    )
-
-
-def _decode_download(
-    test_case: ConformanceCase,
-) -> tuple[DownloadRequest, DownloadExpected]:
-    request = _strict_object(
-        test_case.request,
-        {"namespace_id", "path", "commit_id", "actor", "content_utf8"},
-        f"{test_case.name} request",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {"size_bytes", "checksum_algorithm", "committed_seq"},
-        f"{test_case.name} expected",
-    )
-    return (
-        DownloadRequest(
-            namespace_id=_string(
-                request["namespace_id"], "download request.namespace_id"
-            ),
-            path=_string(request["path"], "download request.path"),
-            commit_id=_string(request["commit_id"], "download request.commit_id"),
-            actor=_actor(request["actor"], "download request.actor"),
-            content_utf8=_string(
-                request["content_utf8"], "download request.content_utf8"
-            ),
-        ),
-        DownloadExpected(
-            size_bytes=_integer(expected["size_bytes"], "download expected.size_bytes"),
-            checksum_algorithm=_string(
-                expected["checksum_algorithm"], "download expected.checksum_algorithm"
-            ),
-            committed_seq=_integer(
-                expected["committed_seq"], "download expected.committed_seq"
-            ),
-        ),
-    )
-
-
-def _decode_end_to_end(
-    test_case: ConformanceCase,
-) -> tuple[EndToEndRequest, EndToEndExpected]:
-    request = _strict_object(
-        test_case.request,
-        {
-            "namespace_id",
-            "directory",
-            "upload_path",
-            "moved_path",
-            "actor",
-            "content_utf8",
-            "commit_ids",
-        },
-        f"{test_case.name} request",
-    )
-    commit_ids = _strict_object(
-        request["commit_ids"],
-        {"mkdir", "upload", "move", "remove"},
-        "end_to_end request.commit_ids",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {
-            "mkdir_committed_seq",
-            "upload_committed_seq",
-            "move_committed_seq",
-            "remove_committed_seq",
-            "size_bytes",
-            "revision_count",
-            "change_count",
-        },
-        f"{test_case.name} expected",
-    )
-    return (
-        EndToEndRequest(
-            namespace_id=_string(
-                request["namespace_id"], "end_to_end request.namespace_id"
-            ),
-            directory=_string(request["directory"], "end_to_end request.directory"),
-            upload_path=_string(
-                request["upload_path"], "end_to_end request.upload_path"
-            ),
-            moved_path=_string(request["moved_path"], "end_to_end request.moved_path"),
-            actor=_actor(request["actor"], "end_to_end request.actor"),
-            content_utf8=_string(
-                request["content_utf8"], "end_to_end request.content_utf8"
-            ),
-            commit_ids=EndToEndCommitIds(
-                mkdir=_string(
-                    commit_ids["mkdir"], "end_to_end request.commit_ids.mkdir"
-                ),
-                upload=_string(
-                    commit_ids["upload"], "end_to_end request.commit_ids.upload"
-                ),
-                move=_string(commit_ids["move"], "end_to_end request.commit_ids.move"),
-                remove=_string(
-                    commit_ids["remove"], "end_to_end request.commit_ids.remove"
-                ),
-            ),
-        ),
-        EndToEndExpected(
-            mkdir_committed_seq=_integer(
-                expected["mkdir_committed_seq"],
-                "end_to_end expected.mkdir_committed_seq",
-            ),
-            upload_committed_seq=_integer(
-                expected["upload_committed_seq"],
-                "end_to_end expected.upload_committed_seq",
-            ),
-            move_committed_seq=_integer(
-                expected["move_committed_seq"], "end_to_end expected.move_committed_seq"
-            ),
-            remove_committed_seq=_integer(
-                expected["remove_committed_seq"],
-                "end_to_end expected.remove_committed_seq",
-            ),
-            size_bytes=_integer(
-                expected["size_bytes"], "end_to_end expected.size_bytes"
-            ),
-            revision_count=_integer(
-                expected["revision_count"], "end_to_end expected.revision_count"
-            ),
-            change_count=_integer(
-                expected["change_count"], "end_to_end expected.change_count"
-            ),
-        ),
-    )
-
-
-def _decode_pagination(
-    test_case: ConformanceCase,
-) -> tuple[PaginationRequest, PaginationExpected]:
-    request = _strict_object(
-        test_case.request,
-        {
-            "namespace_id",
-            "directory",
-            "actor",
-            "entry_names",
-            "page_size",
-            "resume_after_page",
-        },
-        f"{test_case.name} request",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {"entry_count", "minimum_page_count", "head_seq"},
-        f"{test_case.name} expected",
-    )
-    return (
-        PaginationRequest(
-            namespace_id=_string(
-                request["namespace_id"], "pagination request.namespace_id"
-            ),
-            directory=_string(request["directory"], "pagination request.directory"),
-            actor=_actor(request["actor"], "pagination request.actor"),
-            entry_names=_string_list(
-                request["entry_names"], "pagination request.entry_names"
-            ),
-            page_size=_integer(request["page_size"], "pagination request.page_size"),
-            resume_after_page=_integer(
-                request["resume_after_page"], "pagination request.resume_after_page"
-            ),
-        ),
-        PaginationExpected(
-            entry_count=_integer(
-                expected["entry_count"], "pagination expected.entry_count"
-            ),
-            minimum_page_count=_integer(
-                expected["minimum_page_count"], "pagination expected.minimum_page_count"
-            ),
-            head_seq=_integer(expected["head_seq"], "pagination expected.head_seq"),
-        ),
-    )
-
-
-def _decode_proxy(
-    test_case: ConformanceCase,
-) -> tuple[ProxyRequest, ProxyExpected]:
-    request = _strict_object(
-        test_case.request,
-        {
-            "namespace_alias",
-            "namespace_id",
-            "unknown_namespace_alias",
-            "actor",
-            "directory",
-            "proxied_path",
-            "direct_path",
-            "commit_ids",
-            "content_utf8",
-            "disallowed_path_suffix",
-        },
-        f"{test_case.name} request",
-    )
-    commit_ids = _strict_object(
-        request["commit_ids"],
-        {"directory", "proxied", "direct"},
-        "proxy request.commit_ids",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {
-            "mkdir_committed_seq",
-            "proxied_committed_seq",
-            "direct_committed_seq",
-            "entry_count",
-            "unknown_namespace_alias_status",
-            "disallowed_route_status",
-        },
-        f"{test_case.name} expected",
-    )
-    return (
-        ProxyRequest(
-            namespace_alias=_string(request["namespace_alias"], "proxy request.namespace_alias"),
-            namespace_id=_string(
-                request["namespace_id"], "proxy request.namespace_id"
-            ),
-            unknown_namespace_alias=_string(
-                request["unknown_namespace_alias"], "proxy request.unknown_namespace_alias"
-            ),
-            actor=_actor(request["actor"], "proxy request.actor"),
-            directory=_string(request["directory"], "proxy request.directory"),
-            proxied_path=_string(
-                request["proxied_path"], "proxy request.proxied_path"
-            ),
-            direct_path=_string(
-                request["direct_path"], "proxy request.direct_path"
-            ),
-            commit_ids=ProxyCommitIds(
-                directory=_string(
-                    commit_ids["directory"], "proxy request.commit_ids.directory"
-                ),
-                proxied=_string(
-                    commit_ids["proxied"], "proxy request.commit_ids.proxied"
-                ),
-                direct=_string(
-                    commit_ids["direct"], "proxy request.commit_ids.direct"
-                ),
-            ),
-            content_utf8=_string(
-                request["content_utf8"], "proxy request.content_utf8"
-            ),
-            disallowed_path_suffix=_string(
-                request["disallowed_path_suffix"],
-                "proxy request.disallowed_path_suffix",
-            ),
-        ),
-        ProxyExpected(
-            mkdir_committed_seq=_integer(
-                expected["mkdir_committed_seq"],
-                "proxy expected.mkdir_committed_seq",
-            ),
-            proxied_committed_seq=_integer(
-                expected["proxied_committed_seq"],
-                "proxy expected.proxied_committed_seq",
-            ),
-            direct_committed_seq=_integer(
-                expected["direct_committed_seq"],
-                "proxy expected.direct_committed_seq",
-            ),
-            entry_count=_integer(
-                expected["entry_count"], "proxy expected.entry_count"
-            ),
-            unknown_namespace_alias_status=_integer(
-                expected["unknown_namespace_alias_status"],
-                "proxy expected.unknown_namespace_alias_status",
-            ),
-            disallowed_route_status=_integer(
-                expected["disallowed_route_status"],
-                "proxy expected.disallowed_route_status",
-            ),
-        ),
-    )
-
-
-def _decode_changes(
-    test_case: ConformanceCase,
-) -> tuple[ChangesRequest, ChangesExpected]:
-    request = _strict_object(
-        test_case.request,
-        {"namespace_id", "path", "commit_id", "actor", "after_seq"},
-        f"{test_case.name} request",
-    )
-    expected = _strict_object(
-        test_case.expected,
-        {"committed_seq", "change_count", "event_kind"},
-        f"{test_case.name} expected",
-    )
-    return (
-        ChangesRequest(
-            namespace_id=_string(
-                request["namespace_id"], "changes request.namespace_id"
-            ),
-            path=_string(request["path"], "changes request.path"),
-            commit_id=_string(request["commit_id"], "changes request.commit_id"),
-            actor=_actor(request["actor"], "changes request.actor"),
-            after_seq=_integer(request["after_seq"], "changes request.after_seq"),
-        ),
-        ChangesExpected(
-            committed_seq=_integer(
-                expected["committed_seq"], "changes expected.committed_seq"
-            ),
-            change_count=_integer(
-                expected["change_count"], "changes expected.change_count"
-            ),
-            event_kind=_string(expected["event_kind"], "changes expected.event_kind"),
-        ),
+        pydantic.TypeAdapter(request_type).validate_json(json.dumps(case.request)),
+        pydantic.TypeAdapter(expected_type).validate_json(json.dumps(case.expected)),
     )
 
 
@@ -880,33 +290,19 @@ def load_cases(directory: str) -> dict[str, ConformanceCase]:
     for path in sorted(Path(directory).iterdir()):
         if not path.is_file() or path.suffix != ".json":
             continue
-        root = _strict_object(json.loads(path.read_text()), CASE_FIELDS, str(path))
-        version = _integer(root["version"], f"{path} version")
-        if version != FIXTURE_VERSION:
+        test_case = pydantic.TypeAdapter(ConformanceCase).validate_json(path.read_text())
+        if test_case.name != path.stem:
             raise AssertionError(
-                f"invalid fixture {path}: version must be {FIXTURE_VERSION}, found {version}"
+                f"invalid fixture {path}: name is {test_case.name!r}, expected {path.stem!r}"
             )
-        name = _string(root["name"], f"{path} name")
-        if name != path.stem:
-            raise AssertionError(
-                f"invalid fixture {path}: name is {name!r}, expected {path.stem!r}"
-            )
-        intent = _string(root["intent"], f"{path} intent")
-        if not intent.strip():
+        if not test_case.intent.strip():
             raise AssertionError(f"invalid fixture {path}: intent must not be empty")
-        cases.append(
-            ConformanceCase(
-                name=name,
-                family=_string(root["family"], f"{path} family"),
-                request=_json_object(root["request"], f"{path} request"),
-                expected=_json_object(root["expected"], f"{path} expected"),
-            )
-        )
+        cases.append(test_case)
 
-    inventory = [(test_case.name, test_case.family) for test_case in cases]
+    inventory = [test_case.name for test_case in cases]
     if inventory != EXPECTED_CASES:
         raise AssertionError(
-            f"fixture version 1 inventory is {inventory!r}, expected {EXPECTED_CASES!r}"
+            f"fixture inventory is {inventory!r}, expected {EXPECTED_CASES!r}"
         )
     return {test_case.name: test_case for test_case in cases}
 
@@ -972,9 +368,7 @@ def _crc_table(polynomial: int, mask: int) -> tuple[int, ...]:
 
 
 _CRC64_NVME_MASK = (1 << 64) - 1
-_CRC32C_MASK = (1 << 32) - 1
 _CRC64_NVME_TABLE = _crc_table(0x9A6C9329AC4BC9B5, _CRC64_NVME_MASK)
-_CRC32C_TABLE = _crc_table(0x82F63B78, _CRC32C_MASK)
 
 
 @pytest.fixture(scope="session")
@@ -1005,105 +399,38 @@ def harness() -> Iterator[Harness]:
 @pytest.fixture(scope="session")
 def proxy_harness(
     cases: dict[str, ConformanceCase],
-) -> Iterator[ProxyHarness]:
-    request, _ = _decode_proxy(cases["proxy"])
+) -> Iterator[str]:
+    request, _ = _decode(cases["proxy"], ProxyRequest, ProxyExpected)
     app = LoonFSProxy(
         _required_environment("LOONFS_CONFORMANCE_URL"),
         _required_environment("LOONFS_CONFORMANCE_TOKEN"),
         {request.namespace_alias: request.namespace_id},
     )
-    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    listener.bind(("127.0.0.1", 0))
-    listener.listen()
-    _, port = listener.getsockname()
-    server = uvicorn.Server(
-        uvicorn.Config(
-            app,
-            log_level="critical",
-            access_log=False,
-            lifespan="on",
-        )
-    )
-    thread = threading.Thread(
-        target=server.run,
-        kwargs={"sockets": [listener]},
-        name="loonfs-python-proxy",
-        daemon=True,
-    )
-    thread.start()
-    try:
-        deadline = time.monotonic() + 5
-        while not server.started:
-            if not thread.is_alive():
-                raise AssertionError("Python proxy stopped during startup")
-            if time.monotonic() >= deadline:
-                raise AssertionError("Python proxy did not start within five seconds")
-            time.sleep(0.01)
-        yield ProxyHarness(base_url=f"http://127.0.0.1:{port}")
-    finally:
-        server.should_exit = True
-        thread.join(timeout=5)
-        listener.close()
-        if thread.is_alive():
-            raise AssertionError("Python proxy did not stop within five seconds")
+    with _serve_asgi(app, "loonfs-python-proxy") as base_url:
+        yield base_url
 
 
-def _apply_create_directory(
-    client: LoonFS,
-    namespace_id: str,
-    commit_id: str,
-    actor: ActorRef,
-    path: str,
-    message: str | None = None,
-) -> Any:
-    operation = FilesystemOperation_CreateDirectory(path=path, parents=False)
-    if message is None:
-        return client.filesystem.apply_commit(
-            namespace_id,
-            actor=actor,
-            commit_id=commit_id,
-            operations=[operation],
-        )
-    return client.filesystem.apply_commit(
-        namespace_id,
-        actor=actor,
-        commit_id=commit_id,
-        operations=[operation],
-        message=message,
-    )
-
-
-def _apply_put_file(
-    client: LoonFS,
-    namespace_id: str,
-    commit_id: str,
-    actor: ActorRef,
-    path: str,
-    content_ref: ContentRef,
-    content_token: str | None,
-) -> Any:
-    return client.filesystem.apply_commit(
-        namespace_id,
-        actor=actor,
-        commit_id=commit_id,
-        operations=[FilesystemOperation_PutFile(path=path, content_ref=content_ref)],
-        content_tokens=[content_token] if content_token is not None else [],
-    )
-
-
-def _apply_operation(
+def _apply(
     client: LoonFS,
     namespace_id: str,
     commit_id: str,
     actor: ActorRef,
     operation: Any,
+    *,
+    message: str | None = None,
+    content_tokens: list[str] | None = None,
 ) -> Any:
+    extra = {}
+    if message is not None:
+        extra["message"] = message
+    if content_tokens is not None:
+        extra["content_tokens"] = content_tokens
     return client.filesystem.apply_commit(
         namespace_id,
         actor=actor,
         commit_id=commit_id,
         operations=[operation],
+        **extra,
     )
 
 
@@ -1118,8 +445,6 @@ def _checksum(algorithm: str, content: bytes) -> Checksum:
         value = hashlib.sha256(content).hexdigest()
     elif algorithm == "crc64nvme":
         value = f"{_crc(content, _CRC64_NVME_TABLE, _CRC64_NVME_MASK):016x}"
-    elif algorithm == "crc32c":
-        value = f"{_crc(content, _CRC32C_TABLE, _CRC32C_MASK):08x}"
     else:
         raise AssertionError(f"unsupported checksum algorithm {algorithm!r}")
     return Checksum(algorithm=algorithm, value=value)
@@ -1166,7 +491,10 @@ def _read_proxied(client: LoonFS, namespace_id: str, path: str) -> bytes:
 
 def _proxy_response_json(response: httpx.Response, label: str) -> JsonObject:
     response.raise_for_status()
-    return _json_object(response.json(), label)
+    value = response.json()
+    if not isinstance(value, dict):
+        raise AssertionError(f"{label} must be a JSON object")
+    return value
 
 
 def _proxy_apply_commit(
@@ -1220,7 +548,9 @@ def _list_path_entries(
 
 
 def test_error_contract(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_error_contract(cases["error_contract"])
+    request, expected = _decode(
+        cases["error_contract"], ErrorContractRequest, ErrorContractExpected
+    )
     with pytest.raises(UnauthorizedError) as captured:
         harness.unauthenticated.namespaces.get_namespace(request.namespace_id)
 
@@ -1231,23 +561,25 @@ def test_error_contract(cases: dict[str, ConformanceCase], harness: Harness) -> 
 
 
 def test_commit_replay(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_commit_replay(cases["commit_replay"])
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
-    first = _apply_create_directory(
-        harness.client,
-        request.namespace_id,
-        request.commit_id,
-        request.actor,
-        request.path,
-        request.message,
+    request, expected = _decode(
+        cases["commit_replay"], CommitReplayRequest, CommitReplayExpected
     )
-    replayed = _apply_create_directory(
+    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    first = _apply(
         harness.client,
         request.namespace_id,
         request.commit_id,
         request.actor,
-        request.path,
-        request.message,
+        FilesystemOperation_CreateDirectory(path=request.path, parents=False),
+        message=request.message,
+    )
+    replayed = _apply(
+        harness.client,
+        request.namespace_id,
+        request.commit_id,
+        request.actor,
+        FilesystemOperation_CreateDirectory(path=request.path, parents=False),
+        message=request.message,
     )
 
     assert first.committed_seq == expected.committed_seq
@@ -1258,22 +590,26 @@ def test_commit_replay(cases: dict[str, ConformanceCase], harness: Harness) -> N
 
 
 def test_pagination(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_pagination(cases["pagination"])
+    request, expected = _decode(
+        cases["pagination"], PaginationRequest, PaginationExpected
+    )
     harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
-    _apply_create_directory(
+    _apply(
         harness.client,
         request.namespace_id,
         "conf-pagination-directory",
         request.actor,
-        request.directory,
+        FilesystemOperation_CreateDirectory(path=request.directory, parents=False),
     )
     for index, name in enumerate(request.entry_names):
-        _apply_create_directory(
+        _apply(
             harness.client,
             request.namespace_id,
             f"conf-pagination-entry-{index:02d}",
             request.actor,
-            f"{request.directory}/{name}",
+            FilesystemOperation_CreateDirectory(
+                path=f"{request.directory}/{name}", parents=False
+            ),
         )
 
     observed: list[str] = []
@@ -1319,15 +655,15 @@ def test_pagination(cases: dict[str, ConformanceCase], harness: Harness) -> None
 def test_proxy(
     cases: dict[str, ConformanceCase],
     harness: Harness,
-    proxy_harness: ProxyHarness,
+    proxy_harness: str,
 ) -> None:
-    request, expected = _decode_proxy(cases["proxy"])
+    request, expected = _decode(cases["proxy"], ProxyRequest, ProxyExpected)
     harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
     payload = request.content_utf8.encode()
     namespace_alias_base = f"/v0/namespace-aliases/{request.namespace_alias}"
 
     with httpx.Client(
-        base_url=proxy_harness.base_url,
+        base_url=proxy_harness,
         headers={"Authorization": "Bearer browser-token"},
     ) as client:
         mkdir = _proxy_apply_commit(
@@ -1374,15 +710,11 @@ def test_proxy(
         )
         proxied_complete = UploadSessionResponse(**proxied_complete_data)
         assert proxied_complete.status == "completed"
-        proxied_content_ref = _json_object(
-            proxied_complete_data["content_ref"],
-            "proxy service-proxied content_ref",
-        )
+        proxied_content_ref = proxied_complete_data["content_ref"]
+        assert isinstance(proxied_content_ref, dict)
         assert ContentRef(**proxied_content_ref) == uploaded.content_ref
-        proxied_content_token = _json_object(
-            proxied_complete_data["content_token"],
-            "proxy service-proxied content_token",
-        )
+        proxied_content_token = proxied_complete_data["content_token"]
+        assert isinstance(proxied_content_token, dict)
         proxied_commit = _proxy_apply_commit(
             client,
             request,
@@ -1438,14 +770,10 @@ def test_proxy(
         )
         direct_complete = UploadSessionResponse(**direct_complete_data)
         assert direct_complete.status == "completed"
-        direct_content_ref = _json_object(
-            direct_complete_data["content_ref"],
-            "proxy direct-PUT content_ref",
-        )
-        direct_content_token = _json_object(
-            direct_complete_data["content_token"],
-            "proxy direct-PUT content_token",
-        )
+        direct_content_ref = direct_complete_data["content_ref"]
+        assert isinstance(direct_content_ref, dict)
+        direct_content_token = direct_complete_data["content_token"]
+        assert isinstance(direct_content_token, dict)
         direct_commit = _proxy_apply_commit(
             client,
             request,
@@ -1491,14 +819,14 @@ def test_proxy(
 
 
 def test_changes(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_changes(cases["changes"])
+    request, expected = _decode(cases["changes"], ChangesRequest, ChangesExpected)
     harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
-    committed = _apply_create_directory(
+    committed = _apply(
         harness.client,
         request.namespace_id,
         request.commit_id,
         request.actor,
-        request.path,
+        FilesystemOperation_CreateDirectory(path=request.path, parents=False),
     )
     assert committed.committed_seq == expected.committed_seq
 
@@ -1512,13 +840,14 @@ def test_changes(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert change.commit_id == request.commit_id
     assert change.committed_by.id == request.actor.id
     assert change.committed_by.kind == request.actor.kind
-    assert expected.event_kind == "directory_created"
     assert len(change.events) == 1
     assert change.events[0].kind == "directory_created"
 
 
 def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_direct_put(cases["upload_direct_put"])
+    request, expected = _decode(
+        cases["upload_direct_put"], DirectPutRequest, DirectPutExpected
+    )
     harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
     payload = request.content_utf8.encode()
     begin = harness.client.uploads.begin_upload(
@@ -1526,7 +855,6 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
         request=BeginUploadRequest_DirectPut(size_bytes=len(payload)),
     )
 
-    assert expected.mode == "direct_put"
     assert begin.mode == expected.mode
     assert begin.direct_put.checksum_algorithm == expected.checksum_algorithm
 
@@ -1546,14 +874,13 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
     assert content_ref.checksum == claim.checksum
     assert content_ref.checksum == _checksum(content_ref.checksum.algorithm, payload)
 
-    committed = _apply_put_file(
+    committed = _apply(
         harness.client,
         request.namespace_id,
         request.commit_id,
         request.actor,
-        request.path,
-        content_ref,
-        content_token,
+        FilesystemOperation_PutFile(path=request.path, content_ref=content_ref),
+        content_tokens=[content_token] if content_token is not None else None,
     )
     assert committed.committed_seq == expected.committed_seq
     stat = harness.client.filesystem.stat_path(request.namespace_id, path=request.path)
@@ -1562,7 +889,9 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
 
 
 def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_multipart(cases["upload_multipart"])
+    request, expected = _decode(
+        cases["upload_multipart"], MultipartRequest, MultipartExpected
+    )
     harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
     payload = _byte_pattern(request.content_pattern)
     begin = harness.client.uploads.begin_upload(
@@ -1574,7 +903,6 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
         ),
     )
 
-    assert expected.mode == "direct_multipart"
     assert begin.mode == expected.mode
     assert begin.direct_multipart.part_size_bytes == request.part_size_bytes
     assert begin.direct_multipart.checksum_algorithm == expected.checksum_algorithm
@@ -1650,14 +978,15 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
         payload,
     )
 
-    committed = _apply_put_file(
+    committed = _apply(
         harness.client,
         request.namespace_id,
         request.commit_id,
         request.actor,
-        request.path,
-        first_content_ref,
-        replayed_token,
+        FilesystemOperation_PutFile(
+            path=request.path, content_ref=first_content_ref
+        ),
+        content_tokens=[replayed_token] if replayed_token is not None else None,
     )
     assert committed.committed_seq == expected.committed_seq
     assert _read_proxied(harness.client, request.namespace_id, request.path) == payload
@@ -1686,7 +1015,7 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
 
 
 def test_upload_abort(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_abort(cases["upload_abort"])
+    request, expected = _decode(cases["upload_abort"], AbortRequest, AbortExpected)
     harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
     begin = harness.client.uploads.begin_upload(
         request.namespace_id,
@@ -1697,8 +1026,6 @@ def test_upload_abort(cases: dict[str, ConformanceCase], harness: Harness) -> No
         request.namespace_id, begin.upload_id
     )
 
-    assert expected.mode == "service_proxied"
-    assert expected.status == "aborted"
     assert first.mode == expected.mode
     assert first.status == expected.status
     assert replayed == first
@@ -1706,7 +1033,9 @@ def test_upload_abort(cases: dict[str, ConformanceCase], harness: Harness) -> No
 
 
 def test_download(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_download(cases["download"])
+    request, expected = _decode(
+        cases["download"], DownloadRequest, DownloadExpected
+    )
     harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
     payload = request.content_utf8.encode()
     committed = put_file(
@@ -1737,14 +1066,16 @@ def test_download(cases: dict[str, ConformanceCase], harness: Harness) -> None:
 
 
 def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None:
-    request, expected = _decode_end_to_end(cases["end_to_end"])
+    request, expected = _decode(
+        cases["end_to_end"], EndToEndRequest, EndToEndExpected
+    )
     harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
-    mkdir = _apply_create_directory(
+    mkdir = _apply(
         harness.client,
         request.namespace_id,
         request.commit_ids.mkdir,
         request.actor,
-        request.directory,
+        FilesystemOperation_CreateDirectory(path=request.directory, parents=False),
     )
     assert mkdir.committed_seq == expected.mkdir_committed_seq
 
@@ -1777,7 +1108,7 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
     )
     assert downloaded.content == payload
 
-    moved = _apply_operation(
+    moved = _apply(
         harness.client,
         request.namespace_id,
         request.commit_ids.move,
@@ -1807,7 +1138,7 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
     )
     assert len(changes_before_remove.changes) == expected.change_count - 1
 
-    removed = _apply_operation(
+    removed = _apply(
         harness.client,
         request.namespace_id,
         request.commit_ids.remove,
@@ -1844,7 +1175,7 @@ def test_proxy_forwards_every_documented_route(
     cases: dict[str, ConformanceCase],
 ) -> None:
     """Proxy routes must reach the server. Excluded server routes must not."""
-    fixture, _ = _decode_proxy(cases["proxy"])
+    fixture, _ = _decode(cases["proxy"], ProxyRequest, ProxyExpected)
     with open(_required_environment("LOONFS_PROXY_DOCUMENT"), encoding="utf-8") as handle:
         proxy_document = json.load(handle)
     with open(_required_environment("LOONFS_SERVER_DOCUMENT"), encoding="utf-8") as handle:

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -20,27 +20,24 @@ import {
 import { createProxyHandler } from "../../../proxy/typescript/src/proxy.js";
 
 
-const FIXTURE_VERSION = 1;
 const RUNNER_SKIP = "run scripts/run-sdk-conformance.sh typescript";
-const CRC32C_POLYNOMIAL = 0x82f63b78;
 const CRC64_NVME_POLYNOMIAL = 0x9a6c9329ac4bc9b5n;
 const CRC64_MASK = 0xffffffffffffffffn;
 const BROWSER_MULTIPART_MIN_BYTES = 8 * 1024 * 1024;
 const PROXY_UPLOAD_MAX_BYTES = "upload.max_content_bytes";
-const CASE_FIELDS = ["expected", "family", "intent", "name", "request", "version"];
+const CASE_FIELDS = ["expected", "intent", "name", "request"];
 const EXPECTED_CASES = [
-    ["changes", "changes"],
-    ["commit_replay", "commit_replay"],
-    ["download", "download"],
-    ["end_to_end", "end_to_end"],
-    ["error_contract", "error_contract"],
-    ["pagination", "pagination"],
-    ["proxy", "proxy"],
-    ["upload_abort", "upload_abort"],
-    ["upload_direct_put", "upload_direct_put"],
-    ["upload_multipart", "upload_multipart"],
+    "changes",
+    "commit_replay",
+    "download",
+    "end_to_end",
+    "error_contract",
+    "pagination",
+    "proxy",
+    "upload_abort",
+    "upload_direct_put",
+    "upload_multipart",
 ] as const;
-const CRC32C_TABLE = makeCrc32cTable();
 const CRC64_NVME_TABLE = makeCrc64NvmeTable();
 type JsonObject = Record<string, unknown>;
 type ActorKind = "user" | "service" | "system";
@@ -52,7 +49,6 @@ interface ActorValue {
 
 interface ConformanceCase {
     name: string;
-    family: string;
     request: JsonObject;
     expected: JsonObject;
 }
@@ -62,78 +58,67 @@ interface ErrorStatusExpected {
     code: string;
 }
 
-interface ErrorOutcome {
-    status: number;
-    code: string;
-    param: string;
-}
-
 interface ErrorContractRequest {
-    namespaceId: string;
-    malformedBody: JsonObject;
-    invalidAfterSeq: string;
+    namespace_id: string;
 }
 
 interface ErrorContractExpected {
     unauthenticated: ErrorStatusExpected;
-    malformedBody: ErrorOutcome;
-    invalidQuery: ErrorOutcome;
 }
 
 interface CommitReplayRequest {
-    namespaceId: string;
-    commitId: string;
+    namespace_id: string;
+    commit_id: string;
     actor: ActorValue;
     message: string;
     path: string;
 }
 
 interface CommitReplayExpected {
-    committedSeq: number;
+    committed_seq: number;
 }
 
 interface PaginationRequest {
-    namespaceId: string;
+    namespace_id: string;
     directory: string;
     actor: ActorValue;
-    entryNames: string[];
-    pageSize: number;
-    resumeAfterPage: number;
+    entry_names: string[];
+    page_size: number;
+    resume_after_page: number;
 }
 
 interface PaginationExpected {
-    entryCount: number;
-    minimumPageCount: number;
-    headSeq: number;
+    entry_count: number;
+    minimum_page_count: number;
+    head_seq: number;
 }
 
 interface ChangesRequest {
-    namespaceId: string;
+    namespace_id: string;
     path: string;
-    commitId: string;
+    commit_id: string;
     actor: ActorValue;
-    afterSeq: number;
+    after_seq: number;
 }
 
 interface ChangesExpected {
-    committedSeq: number;
-    changeCount: number;
-    eventKind: string;
+    committed_seq: number;
+    change_count: number;
 }
 
 interface DirectPutRequest {
-    namespaceId: string;
+    namespace_id: string;
     path: string;
-    commitId: string;
+    commit_id: string;
     actor: ActorValue;
-    contentUtf8: string;
+    content_utf8: string;
 }
 
 interface DirectPutExpected {
     mode: string;
-    sizeBytes: number;
-    checksumAlgorithm: string;
-    committedSeq: number;
+    size_bytes: number;
+    checksum_algorithm: string;
+    committed_seq: number;
 }
 
 interface BytePattern {
@@ -142,24 +127,24 @@ interface BytePattern {
 }
 
 interface MultipartRequest {
-    namespaceId: string;
+    namespace_id: string;
     path: string;
-    commitId: string;
+    commit_id: string;
     actor: ActorValue;
-    partSizeBytes: number;
-    contentPattern: BytePattern;
+    part_size_bytes: number;
+    content_pattern: BytePattern;
 }
 
 interface MultipartExpected {
     mode: string;
-    partCount: number;
-    sizeBytes: number;
-    checksumAlgorithm: string;
-    committedSeq: number;
+    part_count: number;
+    size_bytes: number;
+    checksum_algorithm: string;
+    committed_seq: number;
 }
 
 interface AbortRequest {
-    namespaceId: string;
+    namespace_id: string;
 }
 
 interface AbortExpected {
@@ -168,17 +153,17 @@ interface AbortExpected {
 }
 
 interface DownloadRequest {
-    namespaceId: string;
+    namespace_id: string;
     path: string;
-    commitId: string;
+    commit_id: string;
     actor: ActorValue;
-    contentUtf8: string;
+    content_utf8: string;
 }
 
 interface DownloadExpected {
-    sizeBytes: number;
-    checksumAlgorithm: string;
-    committedSeq: number;
+    size_bytes: number;
+    checksum_algorithm: string;
+    committed_seq: number;
 }
 
 interface EndToEndCommitIds {
@@ -189,23 +174,23 @@ interface EndToEndCommitIds {
 }
 
 interface EndToEndRequest {
-    namespaceId: string;
+    namespace_id: string;
     directory: string;
-    uploadPath: string;
-    movedPath: string;
+    upload_path: string;
+    moved_path: string;
     actor: ActorValue;
-    contentUtf8: string;
-    commitIds: EndToEndCommitIds;
+    content_utf8: string;
+    commit_ids: EndToEndCommitIds;
 }
 
 interface EndToEndExpected {
-    mkdirCommittedSeq: number;
-    uploadCommittedSeq: number;
-    moveCommittedSeq: number;
-    removeCommittedSeq: number;
-    sizeBytes: number;
-    revisionCount: number;
-    changeCount: number;
+    mkdir_committed_seq: number;
+    upload_committed_seq: number;
+    move_committed_seq: number;
+    remove_committed_seq: number;
+    size_bytes: number;
+    revision_count: number;
+    change_count: number;
 }
 
 interface ProxyCommitIds {
@@ -215,25 +200,25 @@ interface ProxyCommitIds {
 }
 
 interface ProxyRequest {
-    namespaceAlias: string;
-    namespaceId: string;
-    unknownNamespaceAlias: string;
+    namespace_alias: string;
+    namespace_id: string;
+    unknown_namespace_alias: string;
     actor: ActorValue;
     directory: string;
-    proxiedPath: string;
-    directPath: string;
-    commitIds: ProxyCommitIds;
-    contentUtf8: string;
-    disallowedPathSuffix: string;
+    proxied_path: string;
+    direct_path: string;
+    commit_ids: ProxyCommitIds;
+    content_utf8: string;
+    disallowed_path_suffix: string;
 }
 
 interface ProxyExpected {
-    mkdirCommittedSeq: number;
-    proxiedCommittedSeq: number;
-    directCommittedSeq: number;
-    entryCount: number;
-    unknownNamespaceAliasStatus: number;
-    disallowedRouteStatus: number;
+    mkdir_committed_seq: number;
+    proxied_committed_seq: number;
+    direct_committed_seq: number;
+    entry_count: number;
+    unknown_namespace_alias_status: number;
+    disallowed_route_status: number;
 }
 
 interface Harness {
@@ -279,466 +264,203 @@ function strictObject(value: unknown, fields: readonly string[], label: string):
     return data;
 }
 
-function stringValue(value: unknown, label: string): string {
-    if (typeof value !== "string") {
-        throw new Error(`${label} must be a string`);
-    }
-    return value;
-}
-
-function integerValue(value: unknown, label: string): number {
-    if (typeof value !== "number" || !Number.isSafeInteger(value)) {
-        throw new Error(`${label} must be an integer`);
-    }
-    return value;
-}
-
-function byteValue(value: unknown, label: string): number {
-    const byte = integerValue(value, label);
-    if (byte < 0 || byte > 255) {
-        throw new Error(`${label} must fit in one byte`);
-    }
-    return byte;
-}
-
-function stringArray(value: unknown, label: string): string[] {
-    if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
-        throw new Error(`${label} must be an array of strings`);
-    }
-    return value;
-}
-
-function actorValue(value: unknown, label: string): ActorValue {
-    const actor = strictObject(value, ["id", "kind"], label);
-    const kind = stringValue(actor.kind, `${label}.kind`);
-    if (kind !== "user" && kind !== "service" && kind !== "system") {
-        throw new Error(`${label}.kind is not a known actor kind`);
-    }
-    return {
-        id: stringValue(actor.id, `${label}.id`),
-        kind,
-    };
-}
-
-function errorStatus(value: unknown, label: string): ErrorStatusExpected {
-    const data = strictObject(value, ["status", "code"], label);
-    return {
-        status: integerValue(data.status, `${label}.status`),
-        code: stringValue(data.code, `${label}.code`),
-    };
-}
-
-function errorOutcome(value: unknown, label: string): ErrorOutcome {
-    const data = strictObject(value, ["status", "code", "param"], label);
-    return {
-        status: integerValue(data.status, `${label}.status`),
-        code: stringValue(data.code, `${label}.code`),
-        param: stringValue(data.param, `${label}.param`),
-    };
-}
+const ERROR_CONTRACT_REQUEST_FIELDS = ["namespace_id"] as const;
+const ERROR_CONTRACT_EXPECTED_FIELDS = ["unauthenticated"] as const;
+const COMMIT_REPLAY_REQUEST_FIELDS = [
+    "namespace_id",
+    "commit_id",
+    "actor",
+    "message",
+    "path",
+] as const;
+const COMMIT_REPLAY_EXPECTED_FIELDS = ["committed_seq"] as const;
+const PAGINATION_REQUEST_FIELDS = [
+    "namespace_id",
+    "directory",
+    "actor",
+    "entry_names",
+    "page_size",
+    "resume_after_page",
+] as const;
+const PAGINATION_EXPECTED_FIELDS = ["entry_count", "minimum_page_count", "head_seq"] as const;
+const CHANGES_REQUEST_FIELDS = [
+    "namespace_id",
+    "path",
+    "commit_id",
+    "actor",
+    "after_seq",
+] as const;
+const CHANGES_EXPECTED_FIELDS = ["committed_seq", "change_count"] as const;
+const DIRECT_PUT_REQUEST_FIELDS = [
+    "namespace_id",
+    "path",
+    "commit_id",
+    "actor",
+    "content_utf8",
+] as const;
+const DIRECT_PUT_EXPECTED_FIELDS = [
+    "mode",
+    "size_bytes",
+    "checksum_algorithm",
+    "committed_seq",
+] as const;
+const MULTIPART_REQUEST_FIELDS = [
+    "namespace_id",
+    "path",
+    "commit_id",
+    "actor",
+    "part_size_bytes",
+    "content_pattern",
+] as const;
+const MULTIPART_EXPECTED_FIELDS = [
+    "mode",
+    "part_count",
+    "size_bytes",
+    "checksum_algorithm",
+    "committed_seq",
+] as const;
+const ABORT_REQUEST_FIELDS = ["namespace_id"] as const;
+const ABORT_EXPECTED_FIELDS = ["mode", "status"] as const;
+const DOWNLOAD_REQUEST_FIELDS = [
+    "namespace_id",
+    "path",
+    "commit_id",
+    "actor",
+    "content_utf8",
+] as const;
+const DOWNLOAD_EXPECTED_FIELDS = ["size_bytes", "checksum_algorithm", "committed_seq"] as const;
+const END_TO_END_REQUEST_FIELDS = [
+    "namespace_id",
+    "directory",
+    "upload_path",
+    "moved_path",
+    "actor",
+    "content_utf8",
+    "commit_ids",
+] as const;
+const END_TO_END_EXPECTED_FIELDS = [
+    "mkdir_committed_seq",
+    "upload_committed_seq",
+    "move_committed_seq",
+    "remove_committed_seq",
+    "size_bytes",
+    "revision_count",
+    "change_count",
+] as const;
+const PROXY_REQUEST_FIELDS = [
+    "namespace_alias",
+    "namespace_id",
+    "unknown_namespace_alias",
+    "actor",
+    "directory",
+    "proxied_path",
+    "direct_path",
+    "commit_ids",
+    "content_utf8",
+    "disallowed_path_suffix",
+] as const;
+const PROXY_EXPECTED_FIELDS = [
+    "mkdir_committed_seq",
+    "proxied_committed_seq",
+    "direct_committed_seq",
+    "entry_count",
+    "unknown_namespace_alias_status",
+    "disallowed_route_status",
+] as const;
 
 function decodeErrorContract(
     testCase: ConformanceCase,
 ): [ErrorContractRequest, ErrorContractExpected] {
-    const request = strictObject(
-        testCase.request,
-        ["namespace_id", "malformed_body", "invalid_after_seq"],
-        `${testCase.name} request`,
-    );
-    const expected = strictObject(
-        testCase.expected,
-        ["unauthenticated", "malformed_body", "invalid_query"],
-        `${testCase.name} expected`,
-    );
+    strictObject(testCase.request, ERROR_CONTRACT_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, ERROR_CONTRACT_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "error_contract request.namespace_id"),
-            malformedBody: jsonObject(request.malformed_body, "error_contract request.malformed_body"),
-            invalidAfterSeq: stringValue(
-                request.invalid_after_seq,
-                "error_contract request.invalid_after_seq",
-            ),
-        },
-        {
-            unauthenticated: errorStatus(
-                expected.unauthenticated,
-                "error_contract expected.unauthenticated",
-            ),
-            malformedBody: errorOutcome(
-                expected.malformed_body,
-                "error_contract expected.malformed_body",
-            ),
-            invalidQuery: errorOutcome(
-                expected.invalid_query,
-                "error_contract expected.invalid_query",
-            ),
-        },
+        testCase.request as unknown as ErrorContractRequest,
+        testCase.expected as unknown as ErrorContractExpected,
     ];
 }
 
 function decodeCommitReplay(
     testCase: ConformanceCase,
 ): [CommitReplayRequest, CommitReplayExpected] {
-    const request = strictObject(
-        testCase.request,
-        ["namespace_id", "commit_id", "actor", "message", "path"],
-        `${testCase.name} request`,
-    );
-    const expected = strictObject(testCase.expected, ["committed_seq"], `${testCase.name} expected`);
+    strictObject(testCase.request, COMMIT_REPLAY_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, COMMIT_REPLAY_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "commit_replay request.namespace_id"),
-            commitId: stringValue(request.commit_id, "commit_replay request.commit_id"),
-            actor: actorValue(request.actor, "commit_replay request.actor"),
-            message: stringValue(request.message, "commit_replay request.message"),
-            path: stringValue(request.path, "commit_replay request.path"),
-        },
-        {
-            committedSeq: integerValue(expected.committed_seq, "commit_replay expected.committed_seq"),
-        },
+        testCase.request as unknown as CommitReplayRequest,
+        testCase.expected as unknown as CommitReplayExpected,
     ];
 }
 
 function decodePagination(
     testCase: ConformanceCase,
 ): [PaginationRequest, PaginationExpected] {
-    const request = strictObject(
-        testCase.request,
-        ["namespace_id", "directory", "actor", "entry_names", "page_size", "resume_after_page"],
-        `${testCase.name} request`,
-    );
-    const expected = strictObject(
-        testCase.expected,
-        ["entry_count", "minimum_page_count", "head_seq"],
-        `${testCase.name} expected`,
-    );
+    strictObject(testCase.request, PAGINATION_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, PAGINATION_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "pagination request.namespace_id"),
-            directory: stringValue(request.directory, "pagination request.directory"),
-            actor: actorValue(request.actor, "pagination request.actor"),
-            entryNames: stringArray(request.entry_names, "pagination request.entry_names"),
-            pageSize: integerValue(request.page_size, "pagination request.page_size"),
-            resumeAfterPage: integerValue(
-                request.resume_after_page,
-                "pagination request.resume_after_page",
-            ),
-        },
-        {
-            entryCount: integerValue(expected.entry_count, "pagination expected.entry_count"),
-            minimumPageCount: integerValue(
-                expected.minimum_page_count,
-                "pagination expected.minimum_page_count",
-            ),
-            headSeq: integerValue(expected.head_seq, "pagination expected.head_seq"),
-        },
+        testCase.request as unknown as PaginationRequest,
+        testCase.expected as unknown as PaginationExpected,
     ];
 }
 
 function decodeChanges(testCase: ConformanceCase): [ChangesRequest, ChangesExpected] {
-    const request = strictObject(
-        testCase.request,
-        ["namespace_id", "path", "commit_id", "actor", "after_seq"],
-        `${testCase.name} request`,
-    );
-    const expected = strictObject(
-        testCase.expected,
-        ["committed_seq", "change_count", "event_kind"],
-        `${testCase.name} expected`,
-    );
+    strictObject(testCase.request, CHANGES_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, CHANGES_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "changes request.namespace_id"),
-            path: stringValue(request.path, "changes request.path"),
-            commitId: stringValue(request.commit_id, "changes request.commit_id"),
-            actor: actorValue(request.actor, "changes request.actor"),
-            afterSeq: integerValue(request.after_seq, "changes request.after_seq"),
-        },
-        {
-            committedSeq: integerValue(expected.committed_seq, "changes expected.committed_seq"),
-            changeCount: integerValue(expected.change_count, "changes expected.change_count"),
-            eventKind: stringValue(expected.event_kind, "changes expected.event_kind"),
-        },
+        testCase.request as unknown as ChangesRequest,
+        testCase.expected as unknown as ChangesExpected,
     ];
 }
 
 function decodeDirectPut(testCase: ConformanceCase): [DirectPutRequest, DirectPutExpected] {
-    const request = strictObject(
-        testCase.request,
-        ["namespace_id", "path", "commit_id", "actor", "content_utf8"],
-        `${testCase.name} request`,
-    );
-    const expected = strictObject(
-        testCase.expected,
-        ["mode", "size_bytes", "checksum_algorithm", "committed_seq"],
-        `${testCase.name} expected`,
-    );
+    strictObject(testCase.request, DIRECT_PUT_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, DIRECT_PUT_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "upload_direct_put request.namespace_id"),
-            path: stringValue(request.path, "upload_direct_put request.path"),
-            commitId: stringValue(request.commit_id, "upload_direct_put request.commit_id"),
-            actor: actorValue(request.actor, "upload_direct_put request.actor"),
-            contentUtf8: stringValue(request.content_utf8, "upload_direct_put request.content_utf8"),
-        },
-        {
-            mode: stringValue(expected.mode, "upload_direct_put expected.mode"),
-            sizeBytes: integerValue(expected.size_bytes, "upload_direct_put expected.size_bytes"),
-            checksumAlgorithm: stringValue(
-                expected.checksum_algorithm,
-                "upload_direct_put expected.checksum_algorithm",
-            ),
-            committedSeq: integerValue(
-                expected.committed_seq,
-                "upload_direct_put expected.committed_seq",
-            ),
-        },
+        testCase.request as unknown as DirectPutRequest,
+        testCase.expected as unknown as DirectPutExpected,
     ];
 }
 
-function bytePatternValue(value: unknown, label: string): BytePattern {
-    const pattern = strictObject(value, ["length", "modulus"], label);
-    return {
-        length: integerValue(pattern.length, `${label}.length`),
-        modulus: byteValue(pattern.modulus, `${label}.modulus`),
-    };
-}
-
 function decodeMultipart(testCase: ConformanceCase): [MultipartRequest, MultipartExpected] {
-    const request = strictObject(
-        testCase.request,
-        ["namespace_id", "path", "commit_id", "actor", "part_size_bytes", "content_pattern"],
-        `${testCase.name} request`,
-    );
-    const expected = strictObject(
-        testCase.expected,
-        ["mode", "part_count", "size_bytes", "checksum_algorithm", "committed_seq"],
-        `${testCase.name} expected`,
-    );
+    strictObject(testCase.request, MULTIPART_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, MULTIPART_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "upload_multipart request.namespace_id"),
-            path: stringValue(request.path, "upload_multipart request.path"),
-            commitId: stringValue(request.commit_id, "upload_multipart request.commit_id"),
-            actor: actorValue(request.actor, "upload_multipart request.actor"),
-            partSizeBytes: integerValue(
-                request.part_size_bytes,
-                "upload_multipart request.part_size_bytes",
-            ),
-            contentPattern: bytePatternValue(
-                request.content_pattern,
-                "upload_multipart request.content_pattern",
-            ),
-        },
-        {
-            mode: stringValue(expected.mode, "upload_multipart expected.mode"),
-            partCount: integerValue(expected.part_count, "upload_multipart expected.part_count"),
-            sizeBytes: integerValue(expected.size_bytes, "upload_multipart expected.size_bytes"),
-            checksumAlgorithm: stringValue(
-                expected.checksum_algorithm,
-                "upload_multipart expected.checksum_algorithm",
-            ),
-            committedSeq: integerValue(
-                expected.committed_seq,
-                "upload_multipart expected.committed_seq",
-            ),
-        },
+        testCase.request as unknown as MultipartRequest,
+        testCase.expected as unknown as MultipartExpected,
     ];
 }
 
 function decodeAbort(testCase: ConformanceCase): [AbortRequest, AbortExpected] {
-    const request = strictObject(testCase.request, ["namespace_id"], `${testCase.name} request`);
-    const expected = strictObject(testCase.expected, ["mode", "status"], `${testCase.name} expected`);
+    strictObject(testCase.request, ABORT_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, ABORT_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "upload_abort request.namespace_id"),
-        },
-        {
-            mode: stringValue(expected.mode, "upload_abort expected.mode"),
-            status: stringValue(expected.status, "upload_abort expected.status"),
-        },
+        testCase.request as unknown as AbortRequest,
+        testCase.expected as unknown as AbortExpected,
     ];
 }
 
 function decodeDownload(testCase: ConformanceCase): [DownloadRequest, DownloadExpected] {
-    const request = strictObject(
-        testCase.request,
-        ["namespace_id", "path", "commit_id", "actor", "content_utf8"],
-        `${testCase.name} request`,
-    );
-    const expected = strictObject(
-        testCase.expected,
-        ["size_bytes", "checksum_algorithm", "committed_seq"],
-        `${testCase.name} expected`,
-    );
+    strictObject(testCase.request, DOWNLOAD_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, DOWNLOAD_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "download request.namespace_id"),
-            path: stringValue(request.path, "download request.path"),
-            commitId: stringValue(request.commit_id, "download request.commit_id"),
-            actor: actorValue(request.actor, "download request.actor"),
-            contentUtf8: stringValue(request.content_utf8, "download request.content_utf8"),
-        },
-        {
-            sizeBytes: integerValue(expected.size_bytes, "download expected.size_bytes"),
-            checksumAlgorithm: stringValue(
-                expected.checksum_algorithm,
-                "download expected.checksum_algorithm",
-            ),
-            committedSeq: integerValue(expected.committed_seq, "download expected.committed_seq"),
-        },
+        testCase.request as unknown as DownloadRequest,
+        testCase.expected as unknown as DownloadExpected,
     ];
 }
 
 function decodeEndToEnd(testCase: ConformanceCase): [EndToEndRequest, EndToEndExpected] {
-    const request = strictObject(
-        testCase.request,
-        ["namespace_id", "directory", "upload_path", "moved_path", "actor", "content_utf8", "commit_ids"],
-        `${testCase.name} request`,
-    );
-    const commitIds = strictObject(
-        request.commit_ids,
-        ["mkdir", "upload", "move", "remove"],
-        "end_to_end request.commit_ids",
-    );
-    const expected = strictObject(
-        testCase.expected,
-        [
-            "mkdir_committed_seq",
-            "upload_committed_seq",
-            "move_committed_seq",
-            "remove_committed_seq",
-            "size_bytes",
-            "revision_count",
-            "change_count",
-        ],
-        `${testCase.name} expected`,
-    );
+    strictObject(testCase.request, END_TO_END_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, END_TO_END_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceId: stringValue(request.namespace_id, "end_to_end request.namespace_id"),
-            directory: stringValue(request.directory, "end_to_end request.directory"),
-            uploadPath: stringValue(request.upload_path, "end_to_end request.upload_path"),
-            movedPath: stringValue(request.moved_path, "end_to_end request.moved_path"),
-            actor: actorValue(request.actor, "end_to_end request.actor"),
-            contentUtf8: stringValue(request.content_utf8, "end_to_end request.content_utf8"),
-            commitIds: {
-                mkdir: stringValue(commitIds.mkdir, "end_to_end request.commit_ids.mkdir"),
-                upload: stringValue(commitIds.upload, "end_to_end request.commit_ids.upload"),
-                move: stringValue(commitIds.move, "end_to_end request.commit_ids.move"),
-                remove: stringValue(commitIds.remove, "end_to_end request.commit_ids.remove"),
-            },
-        },
-        {
-            mkdirCommittedSeq: integerValue(
-                expected.mkdir_committed_seq,
-                "end_to_end expected.mkdir_committed_seq",
-            ),
-            uploadCommittedSeq: integerValue(
-                expected.upload_committed_seq,
-                "end_to_end expected.upload_committed_seq",
-            ),
-            moveCommittedSeq: integerValue(
-                expected.move_committed_seq,
-                "end_to_end expected.move_committed_seq",
-            ),
-            removeCommittedSeq: integerValue(
-                expected.remove_committed_seq,
-                "end_to_end expected.remove_committed_seq",
-            ),
-            sizeBytes: integerValue(expected.size_bytes, "end_to_end expected.size_bytes"),
-            revisionCount: integerValue(
-                expected.revision_count,
-                "end_to_end expected.revision_count",
-            ),
-            changeCount: integerValue(expected.change_count, "end_to_end expected.change_count"),
-        },
+        testCase.request as unknown as EndToEndRequest,
+        testCase.expected as unknown as EndToEndExpected,
     ];
 }
 
 function decodeProxy(testCase: ConformanceCase): [ProxyRequest, ProxyExpected] {
-    const request = strictObject(
-        testCase.request,
-        [
-            "namespace_alias",
-            "namespace_id",
-            "unknown_namespace_alias",
-            "actor",
-            "directory",
-            "proxied_path",
-            "direct_path",
-            "commit_ids",
-            "content_utf8",
-            "disallowed_path_suffix",
-        ],
-        `${testCase.name} request`,
-    );
-    const commitIds = strictObject(
-        request.commit_ids,
-        ["directory", "proxied", "direct"],
-        "proxy request.commit_ids",
-    );
-    const expected = strictObject(
-        testCase.expected,
-        [
-            "mkdir_committed_seq",
-            "proxied_committed_seq",
-            "direct_committed_seq",
-            "entry_count",
-            "unknown_namespace_alias_status",
-            "disallowed_route_status",
-        ],
-        `${testCase.name} expected`,
-    );
+    strictObject(testCase.request, PROXY_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, PROXY_EXPECTED_FIELDS, `${testCase.name} expected`);
     return [
-        {
-            namespaceAlias: stringValue(
-                request.namespace_alias,
-                "proxy request.namespace_alias",
-            ),
-            namespaceId: stringValue(request.namespace_id, "proxy request.namespace_id"),
-            unknownNamespaceAlias: stringValue(
-                request.unknown_namespace_alias,
-                "proxy request.unknown_namespace_alias",
-            ),
-            actor: actorValue(request.actor, "proxy request.actor"),
-            directory: stringValue(request.directory, "proxy request.directory"),
-            proxiedPath: stringValue(request.proxied_path, "proxy request.proxied_path"),
-            directPath: stringValue(request.direct_path, "proxy request.direct_path"),
-            commitIds: {
-                directory: stringValue(commitIds.directory, "proxy request.commit_ids.directory"),
-                proxied: stringValue(commitIds.proxied, "proxy request.commit_ids.proxied"),
-                direct: stringValue(commitIds.direct, "proxy request.commit_ids.direct"),
-            },
-            contentUtf8: stringValue(request.content_utf8, "proxy request.content_utf8"),
-            disallowedPathSuffix: stringValue(
-                request.disallowed_path_suffix,
-                "proxy request.disallowed_path_suffix",
-            ),
-        },
-        {
-            mkdirCommittedSeq: integerValue(
-                expected.mkdir_committed_seq,
-                "proxy expected.mkdir_committed_seq",
-            ),
-            proxiedCommittedSeq: integerValue(
-                expected.proxied_committed_seq,
-                "proxy expected.proxied_committed_seq",
-            ),
-            directCommittedSeq: integerValue(
-                expected.direct_committed_seq,
-                "proxy expected.direct_committed_seq",
-            ),
-            entryCount: integerValue(expected.entry_count, "proxy expected.entry_count"),
-            unknownNamespaceAliasStatus: integerValue(
-                expected.unknown_namespace_alias_status,
-                "proxy expected.unknown_namespace_alias_status",
-            ),
-            disallowedRouteStatus: integerValue(
-                expected.disallowed_route_status,
-                "proxy expected.disallowed_route_status",
-            ),
-        },
+        testCase.request as unknown as ProxyRequest,
+        testCase.expected as unknown as ProxyExpected,
     ];
 }
 
@@ -748,32 +470,33 @@ function loadCases(directory: string): Map<string, ConformanceCase> {
         .sort((left, right) => left.name.localeCompare(right.name))
         .map((entry): ConformanceCase => {
             const path = join(directory, entry.name);
-            const root = strictObject(JSON.parse(readFileSync(path, "utf8")), CASE_FIELDS, path);
-            const version = integerValue(root.version, `${path} version`);
-            if (version !== FIXTURE_VERSION) {
-                throw new Error(
-                    `invalid fixture ${path}: version must be ${FIXTURE_VERSION}, found ${version}`,
-                );
-            }
-            const name = stringValue(root.name, `${path} name`);
+            const root = strictObject(
+                JSON.parse(readFileSync(path, "utf8")),
+                CASE_FIELDS,
+                path,
+            ) as unknown as {
+                name: string;
+                intent: string;
+                request: unknown;
+                expected: unknown;
+            };
+            const { name, intent } = root;
             const stem = basename(path, extname(path));
             if (name !== stem) {
                 throw new Error(`invalid fixture ${path}: name is ${name}, expected ${stem}`);
             }
-            const intent = stringValue(root.intent, `${path} intent`);
             if (intent.trim() === "") {
                 throw new Error(`invalid fixture ${path}: intent must not be empty`);
             }
             return {
                 name,
-                family: stringValue(root.family, `${path} family`),
                 request: jsonObject(root.request, `${path} request`),
                 expected: jsonObject(root.expected, `${path} expected`),
             };
         });
 
-    const inventory = cases.map((testCase) => [testCase.name, testCase.family]);
-    assert.deepEqual(inventory, EXPECTED_CASES, "fixture version 1 inventory differs");
+    const inventory = cases.map((testCase) => testCase.name);
+    assert.deepEqual(inventory, EXPECTED_CASES, "fixture inventory differs");
     return new Map(cases.map((testCase) => [testCase.name, testCase]));
 }
 
@@ -999,10 +722,10 @@ function checksum(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): LoonF
     switch (algorithm) {
         case "sha256":
             return { algorithm, value: createHash("sha256").update(bytes).digest("hex") };
-        case "crc32c":
-            return { algorithm, value: crc32c(bytes).toString(16).padStart(8, "0") };
         case "crc64nvme":
             return { algorithm, value: crc64Nvme(bytes).toString(16).padStart(16, "0") };
+        default:
+            throw new Error(`unsupported checksum algorithm ${algorithm}`);
     }
 }
 
@@ -1029,26 +752,6 @@ function streamedBytes(bytes: Uint8Array): ReadableStream<Uint8Array> {
             index += 1;
         },
     });
-}
-
-function makeCrc32cTable(): Uint32Array {
-    const table = new Uint32Array(256);
-    for (let index = 0; index < table.length; index += 1) {
-        let value = index;
-        for (let bit = 0; bit < 8; bit += 1) {
-            value = (value >>> 1) ^ ((value & 1) === 0 ? 0 : CRC32C_POLYNOMIAL);
-        }
-        table[index] = value >>> 0;
-    }
-    return table;
-}
-
-function crc32c(bytes: Uint8Array): number {
-    let value = 0xffffffff;
-    for (const byte of bytes) {
-        value = CRC32C_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
-    }
-    return (value ^ 0xffffffff) >>> 0;
 }
 
 function makeCrc64NvmeTable(): bigint[] {
@@ -1083,7 +786,7 @@ function listedNames(entries: LoonFS.AuthoritativePathEntry[]): string[] {
 async function startProxyServer(
     handler: (request: Request) => Promise<Response>,
 ): Promise<RunningProxy> {
-    const server = createServer((incoming, outgoing) => {
+    return startServer((incoming, outgoing) => {
         void serveProxyRequest(handler, incoming, outgoing).catch(() => {
             if (!outgoing.headersSent) {
                 outgoing.writeHead(500);
@@ -1091,6 +794,12 @@ async function startProxyServer(
             outgoing.end();
         });
     });
+}
+
+async function startServer(
+    listener: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<RunningProxy> {
+    const server = createServer(listener);
     await new Promise<void>((resolve, reject) => {
         const onError = (error: Error): void => reject(error);
         server.once("error", onError);
@@ -1119,7 +828,7 @@ async function startProxyServer(
 
 async function startRecordingServer(): Promise<RunningRecordingServer> {
     const requests: string[] = [];
-    const server = createServer((incoming, outgoing) => {
+    const handler = (incoming: IncomingMessage, outgoing: ServerResponse): void => {
         const method = incoming.method ?? "GET";
         const path = new URL(incoming.url ?? "/", "http://127.0.0.1").pathname;
         requests.push(`${method} ${path}`);
@@ -1129,32 +838,8 @@ async function startRecordingServer(): Promise<RunningRecordingServer> {
             "content-length": "2",
         });
         outgoing.end("{}");
-    });
-    await new Promise<void>((resolve, reject) => {
-        const onError = (error: Error): void => reject(error);
-        server.once("error", onError);
-        server.listen(0, "127.0.0.1", () => {
-            server.off("error", onError);
-            resolve();
-        });
-    });
-    const address = server.address();
-    assert.ok(address !== null && typeof address !== "string");
-    return {
-        baseUrl: `http://127.0.0.1:${address.port}`,
-        requests,
-        close: () =>
-            new Promise<void>((resolve, reject) => {
-                server.close((error) => {
-                    if (error === undefined) {
-                        resolve();
-                    } else {
-                        reject(error);
-                    }
-                });
-                server.closeIdleConnections();
-            }),
     };
+    return { ...(await startServer(handler)), requests };
 }
 
 async function serveProxyRequest(
@@ -1250,7 +935,7 @@ conformanceTest("error_contract", async (activeHarness, testCase) => {
     const [request, expected] = decodeErrorContract(testCase);
     let caught: unknown;
     try {
-        await activeHarness.unauthenticated.namespaces.getNamespace({ namespace_id: request.namespaceId });
+        await activeHarness.unauthenticated.namespaces.getNamespace({ namespace_id: request.namespace_id });
     } catch (error) {
         caught = error;
     }
@@ -1263,10 +948,10 @@ conformanceTest("error_contract", async (activeHarness, testCase) => {
 
 conformanceTest("commit_replay", async (activeHarness, testCase) => {
     const [request, expected] = decodeCommitReplay(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
     const commit = directoryCommit(
-        request.namespaceId,
-        request.commitId,
+        request.namespace_id,
+        request.commit_id,
         request.actor,
         request.path,
         request.message,
@@ -1274,27 +959,27 @@ conformanceTest("commit_replay", async (activeHarness, testCase) => {
     const first = await activeHarness.client.filesystem.applyCommit(commit);
     const replayed = await activeHarness.client.filesystem.applyCommit(commit);
 
-    assert.equal(first.committed_seq, expected.committedSeq);
-    assert.equal(first.commit_id, request.commitId);
+    assert.equal(first.committed_seq, expected.committed_seq);
+    assert.equal(first.commit_id, request.commit_id);
     assert.equal(replayed.committed_seq, first.committed_seq);
     assert.deepEqual(replayed, first);
 });
 
 conformanceTest("pagination", async (activeHarness, testCase) => {
     const [request, expected] = decodePagination(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
     await activeHarness.client.filesystem.applyCommit(
         directoryCommit(
-            request.namespaceId,
+            request.namespace_id,
             "conf-pagination-directory",
             request.actor,
             request.directory,
         ),
     );
-    for (const [index, name] of request.entryNames.entries()) {
+    for (const [index, name] of request.entry_names.entries()) {
         await activeHarness.client.filesystem.applyCommit(
             directoryCommit(
-                request.namespaceId,
+                request.namespace_id,
                 `conf-pagination-entry-${index.toString().padStart(2, "0")}`,
                 request.actor,
                 `${request.directory}/${name}`,
@@ -1307,17 +992,17 @@ conformanceTest("pagination", async (activeHarness, testCase) => {
     let savedCursor: string | undefined;
     let resumeOffset: number | undefined;
     let page = await activeHarness.client.filesystem.listPathEntries({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: request.directory,
-        limit: request.pageSize,
+        limit: request.page_size,
     });
     let cursor: string | undefined;
     while (true) {
         pageCount += 1;
-        assert.equal(page.response.head_seq, expected.headSeq);
+        assert.equal(page.response.head_seq, expected.head_seq);
         observed.push(...listedNames(page.data));
         cursor = page.response.next_cursor ?? undefined;
-        if (pageCount === request.resumeAfterPage) {
+        if (pageCount === request.resume_after_page) {
             savedCursor = cursor;
             resumeOffset = observed.length;
         }
@@ -1327,17 +1012,17 @@ conformanceTest("pagination", async (activeHarness, testCase) => {
         await page.getNextPage();
     }
 
-    assert.equal(observed.length, expected.entryCount);
-    assert.ok(pageCount >= expected.minimumPageCount);
+    assert.equal(observed.length, expected.entry_count);
+    assert.ok(pageCount >= expected.minimum_page_count);
     assert.equal(cursor, undefined);
     assert.ok(savedCursor !== undefined, "resume cursor was not recorded");
     assert.ok(resumeOffset !== undefined, "resume position was not recorded");
 
     const resumed: string[] = [];
     page = await activeHarness.client.filesystem.listPathEntries({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: request.directory,
-        limit: request.pageSize,
+        limit: request.page_size,
         cursor: savedCursor,
     });
     while (true) {
@@ -1350,9 +1035,9 @@ conformanceTest("pagination", async (activeHarness, testCase) => {
     }
 
     assert.equal(new Set(observed).size, observed.length, "pagination returned an entry more than once");
-    assert.deepEqual(observed, request.entryNames);
-    assert.ok(resumeOffset <= request.entryNames.length);
-    assert.deepEqual(resumed, request.entryNames.slice(resumeOffset));
+    assert.deepEqual(observed, request.entry_names);
+    assert.ok(resumeOffset <= request.entry_names.length);
+    assert.deepEqual(resumed, request.entry_names.slice(resumeOffset));
 });
 
 test("proxy", { skip: environmentSkip }, async (context) => {
@@ -1363,9 +1048,9 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     const proxyHandler = createProxyHandler({
         serverBaseUrl: activeHarness.serverBaseUrl,
         token: activeHarness.token,
-        namespaceAliases: { [request.namespaceAlias]: request.namespaceId },
+        namespaceAliases: { [request.namespace_alias]: request.namespace_id },
     });
-    const beginPath = `/v0/namespace-aliases/${encodeURIComponent(request.namespaceAlias)}/uploads`;
+    const beginPath = `/v0/namespace-aliases/${encodeURIComponent(request.namespace_alias)}/uploads`;
     const beginModes: string[] = [];
     const handler = async (incoming: Request): Promise<Response> => {
         if (incoming.method === "POST" && new URL(incoming.url).pathname === beginPath) {
@@ -1379,11 +1064,11 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     const proxy = await startProxyServer(handler);
     context.after(() => proxy.close());
 
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
     const namespaceAliasBase =
         `${proxy.baseUrl}/v0/namespace-aliases/` +
-        encodeURIComponent(request.namespaceAlias);
-    const payload = new TextEncoder().encode(request.contentUtf8);
+        encodeURIComponent(request.namespace_alias);
+    const payload = new TextEncoder().encode(request.content_utf8);
 
     const mkdir = await proxyJson<LoonFS.CommitResponse>(
         `${namespaceAliasBase}/commits`,
@@ -1392,7 +1077,7 @@ test("proxy", { skip: environmentSkip }, async (context) => {
             headers: { "content-type": "application/json" },
             body: JSON.stringify(
                 namespaceAliasDirectoryCommit(
-                    request.commitIds.directory,
+                    request.commit_ids.directory,
                     request.actor,
                     request.directory,
                 ),
@@ -1400,7 +1085,7 @@ test("proxy", { skip: environmentSkip }, async (context) => {
         },
         "proxy directory commit",
     );
-    assert.equal(mkdir.committed_seq, expected.mkdirCommittedSeq);
+    assert.equal(mkdir.committed_seq, expected.mkdir_committed_seq);
 
     const proxiedBegin = await proxyJson<LoonFS.BeginUploadResponse>(
         `${namespaceAliasBase}/uploads`,
@@ -1443,16 +1128,16 @@ test("proxy", { skip: environmentSkip }, async (context) => {
             headers: { "content-type": "application/json" },
             body: JSON.stringify(
                 namespaceAliasFileCommit(
-                    request.commitIds.proxied,
+                    request.commit_ids.proxied,
                     request.actor,
-                    request.proxiedPath,
+                    request.proxied_path,
                     proxiedCompleted,
                 ),
             ),
         },
         "proxy service upload commit",
     );
-    assert.equal(proxiedCommit.committed_seq, expected.proxiedCommittedSeq);
+    assert.equal(proxiedCommit.committed_seq, expected.proxied_committed_seq);
 
     const directBegin = await proxyJson<LoonFS.BeginUploadResponse>(
         `${namespaceAliasBase}/uploads`,
@@ -1488,16 +1173,16 @@ test("proxy", { skip: environmentSkip }, async (context) => {
             headers: { "content-type": "application/json" },
             body: JSON.stringify(
                 namespaceAliasFileCommit(
-                    request.commitIds.direct,
+                    request.commit_ids.direct,
                     request.actor,
-                    request.directPath,
+                    request.direct_path,
                     directCompleted,
                 ),
             ),
         },
         "proxy direct upload commit",
     );
-    assert.equal(directCommit.committed_seq, expected.directCommittedSeq);
+    assert.equal(directCommit.committed_seq, expected.direct_committed_seq);
 
     const listUrl = new URL(`${namespaceAliasBase}/filesystem/list`);
     listUrl.searchParams.set("path", request.directory);
@@ -1506,39 +1191,39 @@ test("proxy", { skip: environmentSkip }, async (context) => {
         { method: "GET" },
         "proxy directory listing",
     );
-    assert.equal(listing.entries.length, expected.entryCount);
+    assert.equal(listing.entries.length, expected.entry_count);
 
     const readUrl = new URL(`${namespaceAliasBase}/filesystem/content`);
-    readUrl.searchParams.set("path", request.proxiedPath);
+    readUrl.searchParams.set("path", request.proxied_path);
     const read = await fetchThroughProxy(readUrl);
     await requireSuccessfulResponse(read, "proxy file read");
     assert.deepEqual(new Uint8Array(await read.arrayBuffer()), payload);
 
     const unknownNamespaceAliasUrl = new URL(
-        `/v0/namespace-aliases/${encodeURIComponent(request.unknownNamespaceAlias)}/filesystem/list`,
+        `/v0/namespace-aliases/${encodeURIComponent(request.unknown_namespace_alias)}/filesystem/list`,
         proxy.baseUrl,
     );
     unknownNamespaceAliasUrl.searchParams.set("path", request.directory);
     const unknownNamespaceAlias = await fetchThroughProxy(unknownNamespaceAliasUrl);
-    assert.equal(unknownNamespaceAlias.status, expected.unknownNamespaceAliasStatus);
+    assert.equal(unknownNamespaceAlias.status, expected.unknown_namespace_alias_status);
     assert.equal((await unknownNamespaceAlias.arrayBuffer()).byteLength, 0);
 
     const disallowedRoute = await fetchThroughProxy(
-        `${namespaceAliasBase}${request.disallowedPathSuffix}`,
+        `${namespaceAliasBase}${request.disallowed_path_suffix}`,
     );
-    assert.equal(disallowedRoute.status, expected.disallowedRouteStatus);
+    assert.equal(disallowedRoute.status, expected.disallowed_route_status);
     assert.equal((await disallowedRoute.arrayBuffer()).byteLength, 0);
 
     beginModes.length = 0;
     const browserClient = new BrowserLoonFSClient({ environment: proxy.baseUrl });
-    const browserPath = `${request.proxiedPath}-browser`;
+    const browserPath = `${request.proxied_path}-browser`;
     await assertBrowserTransfer(
         browserClient,
-        request.namespaceAlias,
+        request.namespace_alias,
         browserPath,
         payload,
         request.actor,
-        `${request.commitIds.proxied}-browser`,
+        `${request.commit_ids.proxied}-browser`,
         "browser service-proxied transfer",
     );
     assert.deepEqual(beginModes, ["service_proxied"]);
@@ -1552,11 +1237,11 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     const directPutBytes = bytePattern({ length: directPutLength, modulus: 251 });
     await assertBrowserTransfer(
         browserClient,
-        request.namespaceAlias,
-        `${request.directPath}-browser`,
+        request.namespace_alias,
+        `${request.direct_path}-browser`,
         directPutBytes,
         request.actor,
-        `${request.commitIds.direct}-browser`,
+        `${request.commit_ids.direct}-browser`,
         "browser direct-PUT transfer",
     );
     assert.deepEqual(beginModes, ["service_proxied", "direct_put"]);
@@ -1567,11 +1252,11 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     });
     await assertBrowserTransfer(
         browserClient,
-        request.namespaceAlias,
-        `${request.directPath}-browser-multipart`,
+        request.namespace_alias,
+        `${request.direct_path}-browser-multipart`,
         multipartBytes,
         request.actor,
-        `${request.commitIds.direct}-browser-multipart`,
+        `${request.commit_ids.direct}-browser-multipart`,
         "browser multipart transfer",
     );
     assert.deepEqual(beginModes, ["service_proxied", "direct_put", "direct_multipart"]);
@@ -1579,15 +1264,15 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     // The rig fails only at begin. No session exists then, so mid-flow cleanup is not covered.
     await assert.rejects(
         putBrowserFile(browserClient, {
-            namespace_alias: request.unknownNamespaceAlias,
-            path: `${request.proxiedPath}-browser-failure`,
+            namespace_alias: request.unknown_namespace_alias,
+            path: `${request.proxied_path}-browser-failure`,
             bytes: payload,
             actor: request.actor,
-            commit_id: `${request.commitIds.proxied}-browser-failure`,
+            commit_id: `${request.commit_ids.proxied}-browser-failure`,
         }),
         (error: unknown) => {
             assert.ok(error instanceof BrowserLoonFS.NotFoundError);
-            assert.equal(error.statusCode, expected.unknownNamespaceAliasStatus);
+            assert.equal(error.statusCode, expected.unknown_namespace_alias_status);
             return true;
         },
     );
@@ -1595,52 +1280,51 @@ test("proxy", { skip: environmentSkip }, async (context) => {
 
 conformanceTest("changes", async (activeHarness, testCase) => {
     const [request, expected] = decodeChanges(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
     const committed = await activeHarness.client.filesystem.applyCommit(
-        directoryCommit(request.namespaceId, request.commitId, request.actor, request.path),
+        directoryCommit(request.namespace_id, request.commit_id, request.actor, request.path),
     );
-    assert.equal(committed.committed_seq, expected.committedSeq);
+    assert.equal(committed.committed_seq, expected.committed_seq);
 
     const feed = await activeHarness.client.filesystem.listChanges({
-        namespace_id: request.namespaceId,
-        after_seq: request.afterSeq,
+        namespace_id: request.namespace_id,
+        after_seq: request.after_seq,
     });
-    assert.equal(feed.changes.length, expected.changeCount);
+    assert.equal(feed.changes.length, expected.change_count);
     assert.ok(feed.changes.length > 0, "change feed is empty");
     const change = feed.changes[0];
-    assert.equal(change.commit_id, request.commitId);
+    assert.equal(change.commit_id, request.commit_id);
     assert.deepEqual(change.committed_by, request.actor);
-    assert.equal(expected.eventKind, "directory_created");
     assert.equal(change.events.length, 1);
     assert.equal(change.events[0]?.kind, "directory_created");
 });
 
 conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
     const [request, expected] = decodeDirectPut(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
-    const payload = new TextEncoder().encode(request.contentUtf8);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
+    const payload = new TextEncoder().encode(request.content_utf8);
     const begin = await activeHarness.client.uploads.beginUpload({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         body: { mode: "direct_put", size_bytes: payload.byteLength },
     });
-    assert.equal(begin.mode, "direct_put");
-    assert.equal(expected.mode, "direct_put");
-    assert.equal(begin.direct_put.checksum_algorithm, expected.checksumAlgorithm);
+    assert.equal(begin.mode, expected.mode);
+    const directPut = begin as LoonFS.BeginUploadResponse.DirectPut;
+    assert.equal(directPut.direct_put.checksum_algorithm, expected.checksum_algorithm);
 
-    await uploadPresigned(begin.direct_put.access, payload, "direct PUT");
+    await uploadPresigned(directPut.direct_put.access, payload, "direct PUT");
     const claim: LoonFS.UploadContentClaim = {
         size_bytes: payload.byteLength,
-        checksum: checksum(begin.direct_put.checksum_algorithm, payload),
+        checksum: checksum(directPut.direct_put.checksum_algorithm, payload),
     };
     const completed = completedUpload(
         await activeHarness.client.uploads.completeUpload({
-            namespace_id: request.namespaceId,
+            namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
             body: { mode: "direct_put", content: claim },
         }),
     );
-    assert.equal(completed.content_ref.size_bytes, expected.sizeBytes);
-    assert.equal(completed.content_ref.checksum.algorithm, expected.checksumAlgorithm);
+    assert.equal(completed.content_ref.size_bytes, expected.size_bytes);
+    assert.equal(completed.content_ref.checksum.algorithm, expected.checksum_algorithm);
     assert.deepEqual(completed.content_ref.checksum, claim.checksum);
     assert.deepEqual(
         completed.content_ref.checksum,
@@ -1649,54 +1333,54 @@ conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
 
     const committed = await activeHarness.client.filesystem.applyCommit(
         fileCommit(
-            request.namespaceId,
-            request.commitId,
+            request.namespace_id,
+            request.commit_id,
             request.actor,
             request.path,
             completed.content_ref,
             completed.content_token,
         ),
     );
-    assert.equal(committed.committed_seq, expected.committedSeq);
+    assert.equal(committed.committed_seq, expected.committed_seq);
     const stat = (await activeHarness.client.filesystem.statPath({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: request.path,
     })) as FileEntry;
     assert.deepEqual(stat.content_ref, completed.content_ref);
     assert.deepEqual(
-        await readProxied(activeHarness.client, request.namespaceId, request.path),
+        await readProxied(activeHarness.client, request.namespace_id, request.path),
         payload,
     );
 });
 
 conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     const [request, expected] = decodeMultipart(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
-    const payload = bytePattern(request.contentPattern);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
+    const payload = bytePattern(request.content_pattern);
     const begin = await activeHarness.client.uploads.beginUpload({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         body: {
             mode: "direct_multipart",
-            multipart: { part_size_bytes: request.partSizeBytes },
+            multipart: { part_size_bytes: request.part_size_bytes },
         },
     });
-    assert.equal(begin.mode, "direct_multipart");
-    assert.equal(expected.mode, "direct_multipart");
-    assert.equal(begin.direct_multipart.part_size_bytes, request.partSizeBytes);
-    assert.equal(begin.direct_multipart.checksum_algorithm, expected.checksumAlgorithm);
+    assert.equal(begin.mode, expected.mode);
+    const multipart = begin as LoonFS.BeginUploadResponse.DirectMultipart;
+    assert.equal(multipart.direct_multipart.part_size_bytes, request.part_size_bytes);
+    assert.equal(multipart.direct_multipart.checksum_algorithm, expected.checksum_algorithm);
 
-    const chunks = splitBytes(payload, begin.direct_multipart.part_size_bytes);
-    assert.equal(chunks.length, expected.partCount);
+    const chunks = splitBytes(payload, multipart.direct_multipart.part_size_bytes);
+    assert.equal(chunks.length, expected.part_count);
     const claims: LoonFS.UploadPartChecksumClaim[] = chunks.map((chunk, index) => ({
         part_number: index + 1,
-        checksum: checksum(begin.direct_multipart.checksum_algorithm, chunk),
+        checksum: checksum(multipart.direct_multipart.checksum_algorithm, chunk),
     }));
     const signed = await activeHarness.client.uploads.signUploadParts({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         upload_id: begin.upload_id,
         parts: claims,
     });
-    assert.equal(signed.parts.length, expected.partCount);
+    assert.equal(signed.parts.length, expected.part_count);
 
     const completedParts: LoonFS.CompletedUploadPart[] = [];
     for (const signedPart of signed.parts) {
@@ -1719,7 +1403,7 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
         });
     }
     completedParts.sort((left, right) => left.part_number - right.part_number);
-    const wholeChecksum = checksum(begin.direct_multipart.checksum_algorithm, payload);
+    const wholeChecksum = checksum(multipart.direct_multipart.checksum_algorithm, payload);
     const completion: LoonFS.CompleteUploadRequest = {
         mode: "direct_multipart",
         content: {
@@ -1730,14 +1414,14 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     };
     const first = completedUpload(
         await activeHarness.client.uploads.completeUpload({
-            namespace_id: request.namespaceId,
+            namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
             body: completion,
         }),
     );
     const replayed = completedUpload(
         await activeHarness.client.uploads.completeUpload({
-            namespace_id: request.namespaceId,
+            namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
             body: completion,
         }),
@@ -1747,23 +1431,23 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     assert.equal(replayed.mode, first.mode);
     assert.deepEqual(replayed.content_ref, first.content_ref);
     assert.equal(replayed.completed_at_ms, first.completed_at_ms);
-    assert.equal(first.content_ref.size_bytes, expected.sizeBytes);
+    assert.equal(first.content_ref.size_bytes, expected.size_bytes);
     assert.deepEqual(first.content_ref.checksum, wholeChecksum);
     assert.deepEqual(checksum(first.content_ref.checksum.algorithm, payload), wholeChecksum);
 
     const committed = await activeHarness.client.filesystem.applyCommit(
         fileCommit(
-            request.namespaceId,
-            request.commitId,
+            request.namespace_id,
+            request.commit_id,
             request.actor,
             request.path,
             first.content_ref,
             replayed.content_token,
         ),
     );
-    assert.equal(committed.committed_seq, expected.committedSeq);
+    assert.equal(committed.committed_seq, expected.committed_seq);
     assert.deepEqual(
-        await readProxied(activeHarness.client, request.namespaceId, request.path),
+        await readProxied(activeHarness.client, request.namespace_id, request.path),
         payload,
     );
 
@@ -1771,15 +1455,15 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     // part size, so this exercises putFile's multipart branch.
     const helperPath = `${request.path}-helper`;
     const helperCommit = await putFile(activeHarness.client, {
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: helperPath,
         bytes: payload,
         actor: request.actor,
-        commit_id: `${request.commitId}-helper`,
+        commit_id: `${request.commit_id}-helper`,
     });
     assert.ok(helperCommit.committed_seq > 0, "helper multipart put reported no committed_seq");
     const helperRead = await getFile(activeHarness.client, {
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: helperPath,
     });
     assert.deepEqual(helperRead.bytes, payload);
@@ -1790,25 +1474,23 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
 
 conformanceTest("upload_abort", async (activeHarness, testCase) => {
     const [request, expected] = decodeAbort(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
     const begin = await activeHarness.client.uploads.beginUpload({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         body: { mode: "service_proxied" },
     });
     const first = abortedUpload(
         await activeHarness.client.uploads.abortUpload({
-            namespace_id: request.namespaceId,
+            namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
         }),
     );
     const replayed = abortedUpload(
         await activeHarness.client.uploads.abortUpload({
-            namespace_id: request.namespaceId,
+            namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
         }),
     );
-    assert.equal(expected.mode, "service_proxied");
-    assert.equal(expected.status, "aborted");
     assert.equal(first.mode, expected.mode);
     assert.equal(first.status, expected.status);
     assert.deepEqual(replayed, first);
@@ -1817,27 +1499,27 @@ conformanceTest("upload_abort", async (activeHarness, testCase) => {
 
 conformanceTest("download", async (activeHarness, testCase) => {
     const [request, expected] = decodeDownload(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
-    const payload = new TextEncoder().encode(request.contentUtf8);
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
+    const payload = new TextEncoder().encode(request.content_utf8);
     const committed = await putFile(activeHarness.client, {
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: request.path,
         bytes: payload,
         actor: request.actor,
-        commit_id: request.commitId,
+        commit_id: request.commit_id,
     });
-    assert.equal(committed.committed_seq, expected.committedSeq);
+    assert.equal(committed.committed_seq, expected.committed_seq);
     const stat = (await activeHarness.client.filesystem.statPath({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: request.path,
     })) as FileEntry;
     const download = await getFile(activeHarness.client, {
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: request.path,
     });
     assert.deepEqual(stat.content_ref, download.content_ref);
-    assert.equal(download.content_ref.size_bytes, expected.sizeBytes);
-    assert.equal(download.content_ref.checksum.algorithm, expected.checksumAlgorithm);
+    assert.equal(download.content_ref.size_bytes, expected.size_bytes);
+    assert.equal(download.content_ref.checksum.algorithm, expected.checksum_algorithm);
     assert.equal(download.bytes.byteLength, download.content_ref.size_bytes);
     assert.deepEqual(
         checksum(download.content_ref.checksum.algorithm, download.bytes),
@@ -1848,95 +1530,95 @@ conformanceTest("download", async (activeHarness, testCase) => {
 
 conformanceTest("end_to_end", async (activeHarness, testCase) => {
     const [request, expected] = decodeEndToEnd(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespaceId });
+    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
     const mkdir = await activeHarness.client.filesystem.applyCommit(
         directoryCommit(
-            request.namespaceId,
-            request.commitIds.mkdir,
+            request.namespace_id,
+            request.commit_ids.mkdir,
             request.actor,
             request.directory,
         ),
     );
-    assert.equal(mkdir.committed_seq, expected.mkdirCommittedSeq);
+    assert.equal(mkdir.committed_seq, expected.mkdir_committed_seq);
 
-    const payload = new TextEncoder().encode(request.contentUtf8);
+    const payload = new TextEncoder().encode(request.content_utf8);
     const upload = await putFile(activeHarness.client, {
-        namespace_id: request.namespaceId,
-        path: request.uploadPath,
+        namespace_id: request.namespace_id,
+        path: request.upload_path,
         bytes: payload,
         actor: request.actor,
-        commit_id: request.commitIds.upload,
+        commit_id: request.commit_ids.upload,
     });
-    assert.equal(upload.committed_seq, expected.uploadCommittedSeq);
+    assert.equal(upload.committed_seq, expected.upload_committed_seq);
     const stat = (await activeHarness.client.filesystem.statPath({
-        namespace_id: request.namespaceId,
-        path: request.uploadPath,
+        namespace_id: request.namespace_id,
+        path: request.upload_path,
     })) as FileEntry;
-    assert.equal(stat.size_bytes, expected.sizeBytes);
+    assert.equal(stat.size_bytes, expected.size_bytes);
     const uploadedInode = stat.inode_id;
 
     const initialListing = await activeHarness.client.filesystem.listPathEntries({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: request.directory,
     });
-    assert.ok(initialListing.data.some((entry) => entry.path === request.uploadPath));
+    assert.ok(initialListing.data.some((entry) => entry.path === request.upload_path));
 
     const downloaded = await getFile(activeHarness.client, {
-        namespace_id: request.namespaceId,
-        path: request.uploadPath,
+        namespace_id: request.namespace_id,
+        path: request.upload_path,
     });
     assert.deepEqual(downloaded.bytes, payload);
 
     const moved = await activeHarness.client.filesystem.applyCommit(
         moveCommit(
-            request.namespaceId,
-            request.commitIds.move,
+            request.namespace_id,
+            request.commit_ids.move,
             request.actor,
-            request.uploadPath,
-            request.movedPath,
+            request.upload_path,
+            request.moved_path,
         ),
     );
-    assert.equal(moved.committed_seq, expected.moveCommittedSeq);
+    assert.equal(moved.committed_seq, expected.move_committed_seq);
     const movedListing = await activeHarness.client.filesystem.listPathEntries({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         path: request.directory,
     });
-    assert.ok(movedListing.data.some((entry) => entry.path === request.movedPath));
+    assert.ok(movedListing.data.some((entry) => entry.path === request.moved_path));
 
     const revisions = await activeHarness.client.filesystem.listFileRevisions({
-        namespace_id: request.namespaceId,
-        path: request.movedPath,
+        namespace_id: request.namespace_id,
+        path: request.moved_path,
     });
-    assert.equal(revisions.data.length, expected.revisionCount);
-    assert.equal(revisions.data[0]?.commit_id, request.commitIds.upload);
+    assert.equal(revisions.data.length, expected.revision_count);
+    assert.equal(revisions.data[0]?.commit_id, request.commit_ids.upload);
 
     let changes = await activeHarness.client.filesystem.listChanges({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         after_seq: 0,
     });
-    assert.equal(changes.changes.length, expected.changeCount - 1);
+    assert.equal(changes.changes.length, expected.change_count - 1);
     const removed = await activeHarness.client.filesystem.applyCommit(
         deleteCommit(
-            request.namespaceId,
-            request.commitIds.remove,
+            request.namespace_id,
+            request.commit_ids.remove,
             request.actor,
-            request.movedPath,
+            request.moved_path,
         ),
     );
-    assert.equal(removed.committed_seq, expected.removeCommittedSeq);
+    assert.equal(removed.committed_seq, expected.remove_committed_seq);
 
     changes = await activeHarness.client.filesystem.listChanges({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
         after_seq: 0,
     });
-    assert.equal(changes.changes.length, expected.changeCount);
+    assert.equal(changes.changes.length, expected.change_count);
     assert.deepEqual(
         changes.changes.map((change) => change.commit_id),
         [
-            request.commitIds.mkdir,
-            request.commitIds.upload,
-            request.commitIds.move,
-            request.commitIds.remove,
+            request.commit_ids.mkdir,
+            request.commit_ids.upload,
+            request.commit_ids.move,
+            request.commit_ids.remove,
         ],
     );
     for (const change of changes.changes) {
@@ -1944,7 +1626,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
     }
 
     const trash = await activeHarness.client.filesystem.listTrash({
-        namespace_id: request.namespaceId,
+        namespace_id: request.namespace_id,
     });
     const removedEntry = trash.data.find((entry) => entry.inode_id === uploadedInode);
     assert.ok(removedEntry !== undefined, "removed inode is missing from trash");
@@ -1978,14 +1660,14 @@ test("proxy forwards every documented route", { skip: environmentSkip }, async (
     const handler = createProxyHandler({
         serverBaseUrl: stub.baseUrl,
         token: "recording-stub-token",
-        namespaceAliases: { [fixture.namespaceAlias]: fixture.namespaceId },
+        namespaceAliases: { [fixture.namespace_alias]: fixture.namespace_id },
     });
     const proxy = await startProxyServer(handler);
     context.after(() => proxy.close());
 
     const instantiate = (template: string): string =>
         template.replace(/\{([^/{}]+)\}/g, (_placeholder, name: string) =>
-            name === "namespace_alias" ? fixture.namespaceAlias : "x",
+            name === "namespace_alias" ? fixture.namespace_alias : "x",
         );
     const proxyTemplateForServer = (template: string): string => {
         const serverNamespacePrefix = "/v0/namespaces/{namespace_id}";
@@ -2008,7 +1690,7 @@ test("proxy forwards every documented route", { skip: environmentSkip }, async (
             const path = instantiate(template);
             const forwardedTemplate = template.replace(
                 "/v0/namespace-aliases/{namespace_alias}",
-                `/v0/namespaces/${fixture.namespaceId}`,
+                `/v0/namespaces/${fixture.namespace_id}`,
             );
             expected.push(`${method} ${instantiate(forwardedTemplate)}`);
             const response = await fetchThroughProxy(`${proxy.baseUrl}${path}`, { method });


### PR DESCRIPTION
This removes duplicate fixture validation code from the conformance harnesses. Fixtures now use their file names as dispatch keys, Python uses strict Pydantic dataclasses, and TypeScript keeps fixture field names directly.

The shared cases still exercise the same server behavior in Rust, Go, Python, and TypeScript. Values that only the raw Rust client can send now live in that test instead of appearing as unused SDK fixture fields.