### PR TITLE
chore(server): drop the direct-put and grep transition leftovers

### DIFF
--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -6,14 +6,7 @@ use serde::{Deserialize, Serialize};
 use xxhash_rust::xxh64::xxh64;
 
 /// One content-search request.
-///
-/// Every field but `pattern` is optional, and each one selects results. A
-/// misspelled `case_insensitive` or `path_prefix` would decode to the default
-/// and answer a different search than the caller asked for, with no sign that
-/// anything was dropped, so unknown fields are rejected.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrepRequest {
     /// The pattern, in the Rust `regex` crate's dialect (no backreferences
     /// or lookaround). Its UTF-8 encoding must be at most 1024 bytes.
@@ -22,30 +15,23 @@ pub struct GrepRequest {
     pub pattern: String,
     /// Match case-insensitively. Verification is exact; the index remains
     /// consulted through its case-folded grams.
-    #[serde(default)]
     pub case_insensitive: bool,
     /// Restrict matches to files under this complete absolute path, resolved
     /// to a directory inode before candidates are filtered.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(nullable = false))]
     pub path_prefix: Option<AbsolutePath>,
     /// Resume cursor from a previous page. The cursor resumes strictly
     /// after the last candidate the issuing page finished scanning and is
     /// bound to that page's request; each page is evaluated against the
     /// namespace head at page time.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
     /// Maximum matches per page.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
     /// When the unindexed tail exceeds the scan budget, return
     /// indexed-only results (reported via `tail_scanned: false`) instead
     /// of failing with `index_lagging`.
-    #[serde(default)]
     pub allow_stale: bool,
     /// Permit a capped exhaustive scan when the pattern yields no required
     /// grams. Refused beyond the server's scan budget.
-    #[serde(default)]
     pub allow_scan: bool,
 }
 
@@ -251,26 +237,6 @@ mod tests {
 
     #[test]
     fn grep_paths_keep_the_plain_string_wire_shape() {
-        let request = GrepRequest {
-            pattern: "needle".to_owned(),
-            case_insensitive: false,
-            path_prefix: Some(AbsolutePath::parse("/docs").expect("path prefix")),
-            cursor: None,
-            limit: None,
-            allow_stale: false,
-            allow_scan: false,
-        };
-        assert_eq!(
-            serde_json::to_value(request).expect("serialize grep request"),
-            serde_json::json!({
-                "pattern": "needle",
-                "case_insensitive": false,
-                "path_prefix": "/docs",
-                "allow_stale": false,
-                "allow_scan": false
-            })
-        );
-
         let found = GrepMatch {
             path: AbsolutePath::parse("/docs/a.txt").expect("match path"),
             inode_id: InodeId(2),
@@ -395,42 +361,7 @@ mod tests {
     }
 
     #[test]
-    fn grep_path_prefix_validates_during_deserialization() {
-        let encoded = serde_json::json!({
-            "pattern": "needle",
-            "path_prefix": "relative/path"
-        });
-
-        assert!(serde_json::from_value::<GrepRequest>(encoded).is_err());
-    }
-
-    /// Every optional field on a search body selects results, so a typo would
-    /// answer a different question than the caller asked and say nothing
-    /// about it.
-    #[test]
-    fn search_request_bodies_reject_unknown_fields() {
-        serde_json::from_value::<GrepRequest>(serde_json::json!({
-            "pattern": "needle",
-            "case_insensitive": true,
-            "path_prefix": "/docs",
-            "limit": 10,
-            "allow_stale": true,
-            "allow_scan": true
-        }))
-        .expect("the same body without a typo decodes");
-
-        for body in [
-            serde_json::json!({"pattern": "needle", "case_insensitve": true}),
-            serde_json::json!({"pattern": "needle", "caseInsensitive": true}),
-            serde_json::json!({"pattern": "needle", "pathPrefix": "/docs"}),
-            serde_json::json!({"pattern": "needle", "allow_scans": true}),
-        ] {
-            assert!(
-                serde_json::from_value::<GrepRequest>(body.clone()).is_err(),
-                "an unknown field decoded instead of failing the search: {body}"
-            );
-        }
-
+    fn grep_gc_request_bodies_reject_unknown_fields() {
         serde_json::from_value::<GrepGcRequest>(serde_json::json!({"max_objects": 8}))
             .expect("the same collection body without a typo decodes");
         assert!(

--- a/crates/loonfs-client/src/uploads/staging.rs
+++ b/crates/loonfs-client/src/uploads/staging.rs
@@ -81,14 +81,6 @@ enum UploadTransport {
     Proxied,
 }
 
-/// A payload length measured while reading the source.
-///
-/// File metadata is only a routing hint because the file may change before it
-/// is read. Only a measured length can produce
-/// [`ClientError::UploadTooLarge`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct MeasuredBytes(u64);
-
 /// No advertised transport accepts the measured payload size.
 struct NoTransportFits {
     /// Description of the relevant limits.
@@ -292,10 +284,7 @@ impl Client {
         bytes: &[u8],
     ) -> Result<StagedContent> {
         // The exact size is known, so transport limits can reject it now.
-        match self
-            .transport_for_measured(MeasuredBytes(bytes.len() as u64))
-            .await?
-        {
+        match self.transport_for_measured(bytes.len() as u64).await? {
             UploadTransport::Multipart => {
                 self.stage_via_multipart(
                     namespace_id,
@@ -305,7 +294,8 @@ impl Client {
                 .await
             }
             UploadTransport::DirectPut => {
-                self.stage_bytes_via_direct_put(namespace_id, bytes).await
+                self.direct_put_transfer(namespace_id, DirectPutBody::Held(bytes))
+                    .await
             }
             UploadTransport::Proxied => self.stage_bytes_via_server(namespace_id, bytes).await,
         }
@@ -333,21 +323,12 @@ impl Client {
                 .await
             }
             UploadTransport::DirectPut => {
-                self.stage_source_via_direct_put(namespace_id, source).await
+                self.direct_put_transfer(namespace_id, DirectPutBody::Streamed(source))
+                    .await
             }
             // Proxied uploads are one request and have no resumable parts.
             UploadTransport::Proxied => self.stage_source_via_server(namespace_id, source).await,
         }
-    }
-
-    /// Streams a payload through one presigned PUT while calculating its checksum.
-    async fn stage_source_via_direct_put(
-        &self,
-        namespace_id: &NamespaceId,
-        source: PayloadSource,
-    ) -> Result<StagedContent> {
-        self.direct_put_transfer(namespace_id, DirectPutBody::Streamed(source))
-            .await
     }
 
     /// Selects an initial transport from an optional size hint.
@@ -367,11 +348,11 @@ impl Client {
     ///
     /// Returns `UploadTooLarge` before transfer when no transport accepts the
     /// measured size.
-    async fn transport_for_measured(&self, size: MeasuredBytes) -> Result<UploadTransport> {
+    async fn transport_for_measured(&self, size_bytes: u64) -> Result<UploadTransport> {
         let capabilities = self.capabilities().await?;
-        Self::transport_for(&capabilities, Some(size.0)).map_err(|no_fit| {
+        Self::transport_for(&capabilities, Some(size_bytes)).map_err(|no_fit| {
             ClientError::UploadTooLarge {
-                size_bytes: size.0,
+                size_bytes,
                 reason: no_fit.reason,
             }
         })
@@ -438,16 +419,6 @@ impl Client {
             },
             direct_put_supported,
         })
-    }
-
-    /// Uploads in-memory bytes directly to object storage.
-    async fn stage_bytes_via_direct_put(
-        &self,
-        namespace_id: &NamespaceId,
-        bytes: &[u8],
-    ) -> Result<StagedContent> {
-        self.direct_put_transfer(namespace_id, DirectPutBody::Held(bytes))
-            .await
     }
 
     /// Opens a `direct_put` session, writes its object, and completes it.

--- a/crates/loonfs-client/src/uploads/staging/tests.rs
+++ b/crates/loonfs-client/src/uploads/staging/tests.rs
@@ -161,9 +161,8 @@ fn capabilities(direct_multipart: bool) -> Outcome {
 #[derive(Default, Clone, Copy)]
 struct Advertised {
     direct_multipart: bool,
-    /// The algorithm returned at begin, or `None` to advertise no
-    /// `direct_put` at all.
-    direct_put: Option<ChecksumAlgorithm>,
+    /// Whether the deployment advertises `direct_put`.
+    direct_put: bool,
     /// The service's own buffering cap, when the deployment advertises one.
     proxy_max_bytes: Option<u64>,
     /// The provider's single-request ceiling, when it advertises one.
@@ -175,7 +174,7 @@ fn capabilities_for(advertised: Advertised) -> Outcome {
         FEATURE_UPLOADS_DIRECT_MULTIPART.to_owned(),
         advertised.direct_multipart,
     )]);
-    if advertised.direct_put.is_some() {
+    if advertised.direct_put {
         features.insert(FEATURE_UPLOADS_DIRECT_PUT.to_owned(), true);
     }
     let mut limits = std::collections::BTreeMap::new();
@@ -646,7 +645,7 @@ async fn a_small_payload_past_the_proxy_cap_takes_direct_put() {
     let (source, _) = watched_source(&payload, 512);
     let transport = test_transport::script(vec![
         capabilities_for(Advertised {
-            direct_put: Some(ChecksumAlgorithm::Sha256),
+            direct_put: true,
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()
@@ -685,7 +684,7 @@ async fn an_unknown_length_payload_past_the_proxy_cap_takes_direct_put() {
     let transport = test_transport::script(vec![
         // GCS supports CRC-32C direct PUTs but not multipart uploads.
         capabilities_for(Advertised {
-            direct_put: Some(ChecksumAlgorithm::Crc32c),
+            direct_put: true,
             direct_multipart: false,
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024 * 1024),
@@ -730,7 +729,7 @@ async fn an_unknown_length_payload_takes_direct_put_without_a_preflight_read() {
 
     let transport = test_transport::script(vec![
         capabilities_for(Advertised {
-            direct_put: Some(ChecksumAlgorithm::Crc32c),
+            direct_put: true,
             direct_multipart: false,
             proxy_max_bytes: Some(4_096),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024 * 1024),
@@ -766,7 +765,7 @@ async fn a_direct_put_streams_its_payload_without_ever_holding_it() {
     let (source, retention) = watched_source(&payload, TEST_PART_BYTES as usize);
     let transport = test_transport::script(vec![
         capabilities_for(Advertised {
-            direct_put: Some(ChecksumAlgorithm::Sha256),
+            direct_put: true,
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()
@@ -840,7 +839,7 @@ async fn a_file_backed_direct_put_reads_the_file_once_without_spooling_it() {
 
     let transport = test_transport::script(vec![
         capabilities_for(Advertised {
-            direct_put: Some(ChecksumAlgorithm::Sha256),
+            direct_put: true,
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()
@@ -859,18 +858,6 @@ async fn a_file_backed_direct_put_reads_the_file_once_without_spooling_it() {
         )
         .await
         .expect("a file-backed direct put should land");
-
-    // Only the caller's own file was ever written; the upload added none.
-    let left_behind: Vec<_> = std::fs::read_dir(directory.path())
-        .expect("read the directory back")
-        .filter_map(std::result::Result::ok)
-        .map(|entry| entry.file_name())
-        .collect();
-    assert_eq!(
-        left_behind,
-        vec![std::ffi::OsString::from("payload.bin")],
-        "a file-backed payload should not be copied"
-    );
 
     let object_write = transport
         .sent()

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -182,7 +182,7 @@ pub use path::read::{
 };
 pub use protocol::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse,
-    DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget, MultipartPartTargets,
+    DirectMultipartUploadTarget, MultipartPartTarget, MultipartPartTargets,
     ResolvedUploadCompletion,
 };
 // The streaming read `loonfs`'s reader handle returns, and the chunk size it

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -41,6 +41,6 @@ pub(crate) use self::uploads::{
 };
 pub use self::uploads::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
-    DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget, MultipartPartTargets,
+    DirectMultipartUploadTarget, MultipartPartTarget, MultipartPartTargets,
     ResolvedUploadCompletion,
 };

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -50,19 +50,12 @@ use loonfs_objectstore::{
 };
 use std::num::NonZeroU64;
 
-/// Internal target used by server integrations before they mint a presigned URL.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DirectPutUploadTarget {
-    pub object_key: String,
-    pub checksum_algorithm: ChecksumAlgorithm,
-}
-
 /// Internal response for preparing a direct_put session before URL signing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BeginDirectPutUploadTargetResponse {
     pub namespace_id: NamespaceId,
     pub upload_id: UploadId,
-    pub target: DirectPutUploadTarget,
+    pub object_key: String,
 }
 
 /// Internal multipart target used by the server before signing part URLs.
@@ -93,10 +86,7 @@ pub enum ResolvedUploadCompletion {
     /// The session already contains all required content information.
     KnownContent,
     /// Content claim supplied when a direct PUT completes.
-    DirectPut {
-        content: UploadContentClaim,
-        max_content_bytes: u64,
-    },
+    DirectPut { content: UploadContentClaim },
     /// Multipart content information supplied at completion.
     Multipart(CompleteMultipartUploadRequest),
 }
@@ -173,10 +163,7 @@ pub(crate) async fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
     Ok(BeginDirectPutUploadTargetResponse {
         namespace_id: namespace_id.clone(),
         upload_id,
-        target: DirectPutUploadTarget {
-            object_key,
-            checksum_algorithm,
-        },
+        object_key,
     })
 }
 
@@ -1377,10 +1364,7 @@ enum CompletionPlan<'a> {
     /// Content previously staged through the server.
     Proxied { staged: Option<&'a ContentRef> },
     /// Directly uploaded content that must be checked at the provider.
-    DirectPut {
-        requested: ContentRef,
-        max_content_bytes: u64,
-    },
+    DirectPut { requested: ContentRef },
     /// Parts the provider must assemble and verify.
     DirectMultipart {
         requested: ContentRef,
@@ -1427,17 +1411,13 @@ fn completion_plan<'a>(
         }),
         (
             UploadSessionTransport::DirectPut { checksum_algorithm },
-            ResolvedUploadCompletion::DirectPut {
-                content,
-                max_content_bytes,
-            },
+            ResolvedUploadCompletion::DirectPut { content },
         ) => Ok(CompletionPlan::DirectPut {
             requested: claimed_content_ref(
                 session.content_id.clone(),
                 content,
                 *checksum_algorithm,
             )?,
-            max_content_bytes: *max_content_bytes,
         }),
         (
             UploadSessionTransport::DirectMultipart {
@@ -1468,12 +1448,6 @@ fn completion_plan<'a>(
             ))
         }
         (
-            UploadSessionTransport::DirectMultipart { .. },
-            ResolvedUploadCompletion::DirectPut { .. },
-        ) => Err(CoreError::InvalidUploadContent(
-            "direct_multipart completion requires a content claim and parts".to_owned(),
-        )),
-        (
             UploadSessionTransport::ServiceProxied { .. }
             | UploadSessionTransport::DirectPut { .. },
             ResolvedUploadCompletion::Multipart(_),
@@ -1483,7 +1457,7 @@ fn completion_plan<'a>(
         ))),
         (
             UploadSessionTransport::DirectMultipart { .. },
-            ResolvedUploadCompletion::KnownContent,
+            ResolvedUploadCompletion::KnownContent | ResolvedUploadCompletion::DirectPut { .. },
         ) => Err(CoreError::InvalidUploadContent(
             "direct_multipart completion requires a content claim and parts".to_owned(),
         )),
@@ -1509,17 +1483,8 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
             })?;
             Ok(CompletionOutcome::Verified(staged.clone()))
         }
-        CompletionPlan::DirectPut {
-            requested,
-            max_content_bytes,
-        } => {
+        CompletionPlan::DirectPut { requested } => {
             match verify_durable_content_checksum(store, content_store_id, &requested).await {
-                Ok(()) if requested.size_bytes > max_content_bytes => {
-                    Ok(CompletionOutcome::Unusable(format!(
-                        "direct_put content is {} bytes, over the provider's {max_content_bytes}-byte limit",
-                        requested.size_bytes
-                    )))
-                }
                 Ok(()) => Ok(CompletionOutcome::Verified(requested)),
                 Err(err) => Ok(CompletionOutcome::Unusable(content_failure_reason(err)?)),
             }
@@ -1769,7 +1734,6 @@ mod tests {
                     size_bytes: BYTES.len() as u64,
                     checksum: Checksum::crc32c(BYTES),
                 },
-                max_content_bytes: u64::MAX,
             },
             &context(2_000),
         )
@@ -1786,7 +1750,7 @@ mod tests {
 
         store
             .put(
-                &begin.target.object_key,
+                &begin.object_key,
                 Bytes::from_static(BYTES),
                 PutMode::CreateIfAbsent,
             )
@@ -1797,7 +1761,6 @@ mod tests {
                 size_bytes: BYTES.len() as u64,
                 checksum: Checksum::sha256(BYTES),
             },
-            max_content_bytes: u64::MAX,
         };
         let first = complete_upload(
             &store,
@@ -1820,66 +1783,6 @@ mod tests {
         .await
         .expect("replay direct-put completion");
         assert_eq!(replay, first);
-    }
-
-    #[tokio::test]
-    async fn a_direct_put_past_the_completion_limit_is_aborted_and_deleted() {
-        let temp_dir = tempdir().expect("tempdir");
-        let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-        let setup = context(1_000);
-        bootstrap_namespace(&store, &namespace_id, &setup, false)
-            .await
-            .expect("bootstrap");
-        let begin = begin_direct_put_upload_target(
-            &store,
-            &namespace_id,
-            ChecksumAlgorithm::Sha256,
-            &setup,
-        )
-        .await
-        .expect("begin direct put");
-        store
-            .put(
-                &begin.target.object_key,
-                Bytes::from_static(BYTES),
-                PutMode::CreateIfAbsent,
-            )
-            .await
-            .expect("write direct-put bytes");
-        let content_store_id = load_namespace_content_store_id(&store, &namespace_id)
-            .await
-            .expect("content store id");
-
-        let error = complete_upload(
-            &store,
-            &namespace_id,
-            &content_store_id,
-            &begin.upload_id,
-            ResolvedUploadCompletion::DirectPut {
-                content: UploadContentClaim {
-                    size_bytes: BYTES.len() as u64,
-                    checksum: Checksum::sha256(BYTES),
-                },
-                max_content_bytes: BYTES.len() as u64 - 1,
-            },
-            &context(2_000),
-        )
-        .await
-        .expect_err("stored content past the direct-put limit cannot complete");
-        assert!(matches!(error, CoreError::InvalidUploadContent(_)));
-        let state = load_upload_session_state(&store, &namespace_id, &begin.upload_id)
-            .await
-            .expect("session remains readable");
-        assert!(matches!(
-            state.state,
-            UploadSessionLifecycle::Aborted { .. }
-        ));
-        assert!(store
-            .head(&begin.target.object_key)
-            .await
-            .expect("head rejected direct put")
-            .is_none());
     }
 
     /// An aborted session is logically absent: it will never select content,
@@ -1947,7 +1850,7 @@ mod tests {
         .expect("begin direct put");
         store
             .put(
-                &begin.target.object_key,
+                &begin.object_key,
                 Bytes::from(vec![b'x'; BYTES.len()]),
                 PutMode::CreateIfAbsent,
             )
@@ -1967,7 +1870,6 @@ mod tests {
                     size_bytes: BYTES.len() as u64,
                     checksum: Checksum::sha256(BYTES),
                 },
-                max_content_bytes: u64::MAX,
             },
             &context(2_000),
         )
@@ -1984,7 +1886,7 @@ mod tests {
             }
         ));
         assert!(store
-            .head(&begin.target.object_key)
+            .head(&begin.object_key)
             .await
             .expect("head mismatched content")
             .is_none());
@@ -1999,7 +1901,6 @@ mod tests {
                     size_bytes: BYTES.len() as u64,
                     checksum: Checksum::sha256(BYTES),
                 },
-                max_content_bytes: u64::MAX,
             },
             &context(3_000),
         )

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -141,26 +141,15 @@ async fn begin_direct_put_mints_the_target_object_up_front() {
             .await
             .expect("second direct put target");
 
-    assert_eq!(first.target.checksum_algorithm, ChecksumAlgorithm::Sha256);
-    let first_content_id = first
-        .target
-        .object_key
-        .rsplit('/')
-        .next()
-        .expect("content id");
+    let first_content_id = first.object_key.rsplit('/').next().expect("content id");
     assert!(first_content_id.starts_with("con_"));
     // Same bytes, two sessions, two objects: nothing is shared, so neither
     // upload can observe the other.
     assert_ne!(
         first_content_id,
-        second
-            .target
-            .object_key
-            .rsplit('/')
-            .next()
-            .expect("content id")
+        second.object_key.rsplit('/').next().expect("content id")
     );
-    assert_ne!(first.target.object_key, second.target.object_key);
+    assert_ne!(first.object_key, second.object_key);
 }
 
 #[tokio::test]

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -508,11 +508,7 @@ async fn assert_put_stores_a_trustworthy_checksum<S: ObjectStore>(store: &S, pro
         payload.len() as u64,
         "{provider}: stored size does not match the uploaded bytes"
     );
-    let local = match stored.checksum.algorithm {
-        loonfs_api::ChecksumAlgorithm::Sha256 => Checksum::sha256(&payload),
-        loonfs_api::ChecksumAlgorithm::Crc64nvme => Checksum::crc64nvme(&payload),
-        loonfs_api::ChecksumAlgorithm::Crc32c => Checksum::crc32c(&payload),
-    };
+    let local = Checksum::compute(stored.checksum.algorithm, &payload);
     assert_eq!(
         stored.checksum, local,
         "{provider}: stored checksum does not match the uploaded bytes"

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -293,9 +293,6 @@ where
     }
 }
 
-/// Maximum UTF-8 byte length accepted for a grep pattern query parameter.
-pub(super) const MAX_GREP_PATTERN_BYTES: usize = 1024;
-
 /// Maximum body size for starting an upload or signing multipart parts.
 /// A request with 1,000 part claims is at most 131,011 bytes, so 1 MiB leaves
 /// ample room for every valid request.

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -20,7 +20,7 @@ use loonfs_api::{
 };
 use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError, NamespaceReads};
 
-/// Maximum UTF-8 byte length accepted for a grep pattern query parameter.
+/// Maximum grep pattern length in UTF-8 bytes.
 const MAX_GREP_PATTERN_BYTES: usize = 1024;
 
 #[derive(Debug, serde::Deserialize)]

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -6,7 +6,7 @@ use super::handlers_uploads::current_unix_ms;
 use super::{
     authorize,
     handlers_filesystem::{parse_boolean_query_param, required_query_param, resolve_page_limit},
-    AppQuery, AppState, NamespaceIdPath, OptionalAppJson, MAX_GREP_PATTERN_BYTES,
+    AppQuery, AppState, NamespaceIdPath, OptionalAppJson,
 };
 use crate::http::error::{status_for_core_error_code, ApiResponseError};
 use axum::extract::State;
@@ -19,6 +19,9 @@ use loonfs_api::{
     GrepRequest, GrepResponse, NamespaceId, FEATURE_ADMIN_GREP_INDEX, FEATURE_QUERY_GREP,
 };
 use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError, NamespaceReads};
+
+/// Maximum UTF-8 byte length accepted for a grep pattern query parameter.
+const MAX_GREP_PATTERN_BYTES: usize = 1024;
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct GrepQuery {

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -190,7 +190,7 @@ async fn begin_direct_put_upload(
     let signed = issuer
         .presign_put(
             PresignedPutRequest {
-                object_key: &prepared.target.object_key,
+                object_key: &prepared.object_key,
                 expires_in: DIRECT_PUT_URL_TTL,
             },
             presign_time(),
@@ -201,7 +201,7 @@ async fn begin_direct_put_upload(
         namespace_id: prepared.namespace_id,
         upload_id: prepared.upload_id,
         direct_put: DirectPutUpload {
-            checksum_algorithm: prepared.target.checksum_algorithm,
+            checksum_algorithm,
             access: ObjectTransferAccess::PresignedUrl {
                 method: signed.method,
                 url: signed.url,
@@ -588,15 +588,10 @@ pub(super) async fn complete_upload(
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let body = body.into_bytes();
-    let direct_put_max_content_bytes = state
-        .direct_transfers
-        .as_ref()
-        .and_then(|transfers| transfers.put.as_ref())
-        .map(|issuer| issuer.max_content_bytes());
     let completed = state
         .writer
         .complete_upload_prepared_for_mode(&namespace_id, &upload_id, |mode| {
-            decode_completion_body(mode, &body, direct_put_max_content_bytes)
+            decode_completion_body(mode, &body)
         })
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
@@ -610,7 +605,6 @@ pub(super) async fn complete_upload(
 fn decode_completion_body(
     mode: UploadMode,
     body: &[u8],
-    direct_put_max_content_bytes: Option<u64>,
 ) -> std::result::Result<ResolvedUploadCompletion, String> {
     let invalid = |error: serde_json::Error| {
         format!(
@@ -629,12 +623,9 @@ fn decode_completion_body(
 
     match request {
         CompleteUploadRequest::ServiceProxied {} => Ok(ResolvedUploadCompletion::KnownContent),
-        CompleteUploadRequest::DirectPut { content } => Ok(ResolvedUploadCompletion::DirectPut {
-            content,
-            max_content_bytes: direct_put_max_content_bytes.ok_or_else(|| {
-                "direct_put completion requires the configured provider limit".to_owned()
-            })?,
-        }),
+        CompleteUploadRequest::DirectPut { content } => {
+            Ok(ResolvedUploadCompletion::DirectPut { content })
+        }
         CompleteUploadRequest::DirectMultipart { content, parts } => Ok(
             ResolvedUploadCompletion::Multipart(CompleteMultipartUploadRequest { content, parts }),
         ),
@@ -666,7 +657,7 @@ mod completion_body_tests {
         let multipart_body =
             format!(r#"{{"mode":"direct_multipart","content":{CONTENT},"parts":[]}}"#);
         let direct_put_error =
-            decode_completion_body(UploadMode::DirectPut, multipart_body.as_bytes(), Some(10))
+            decode_completion_body(UploadMode::DirectPut, multipart_body.as_bytes())
                 .expect_err("multipart mode does not match direct put");
         assert_eq!(
             direct_put_error,
@@ -674,7 +665,7 @@ mod completion_body_tests {
              `direct_put`"
         );
 
-        let multipart_error = decode_completion_body(UploadMode::DirectMultipart, b"{}", None)
+        let multipart_error = decode_completion_body(UploadMode::DirectMultipart, b"{}")
             .expect_err("completion mode is required");
         assert_eq!(
             multipart_error,
@@ -684,7 +675,7 @@ mod completion_body_tests {
 
         let missing_parts = format!(r#"{{"mode":"direct_multipart","content":{CONTENT}}}"#);
         let missing_parts_error =
-            decode_completion_body(UploadMode::DirectMultipart, missing_parts.as_bytes(), None)
+            decode_completion_body(UploadMode::DirectMultipart, missing_parts.as_bytes())
                 .expect_err("multipart completion needs parts");
         assert_eq!(
             missing_parts_error,
@@ -705,7 +696,7 @@ mod completion_body_tests {
                 "content_ref",
             ),
         ] {
-            let error = decode_completion_body(UploadMode::ServiceProxied, body.as_bytes(), None)
+            let error = decode_completion_body(UploadMode::ServiceProxied, body.as_bytes())
                 .expect_err("retired completion field");
             assert!(
                 error.contains(&format!("unknown field `{field}`")),

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -34,7 +34,7 @@ use self::error::ApiResponseError;
 use self::extractors::{
     authorize, server_busy_error, AppJson, AppPath, AppQuery, NamespaceIdPath, OptionalAppJson,
     UploadBodyBytes, UploadBodyStream, UploadControlJson, MAX_COMPLETION_BODY_BYTES,
-    MAX_GREP_PATTERN_BYTES, MAX_UPLOAD_CONTROL_BODY_BYTES,
+    MAX_UPLOAD_CONTROL_BODY_BYTES,
 };
 use self::handlers_downloads::{begin_download, begin_download_by_inode};
 use self::handlers_filesystem::{

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -3786,10 +3786,6 @@ mod direct_download {
             !advertised.supports(FEATURE_UPLOADS_DIRECT_MULTIPART),
             "a provider with no multipart API must not advertise one"
         );
-        assert!(advertised
-            .features
-            .keys()
-            .all(|feature| !feature.starts_with("core.uploads.direct_put.checksum.")));
         assert_eq!(
             advertised
                 .limits
@@ -3889,10 +3885,6 @@ mod direct_download {
         let advertised = client.capabilities().await.expect("capabilities");
         assert!(advertised.supports(FEATURE_UPLOADS_DIRECT_PUT));
         assert!(advertised.supports(FEATURE_DOWNLOADS_DIRECT_GET));
-        assert!(advertised
-            .features
-            .keys()
-            .all(|feature| !feature.starts_with("core.uploads.direct_put.checksum.")));
         assert!(
             !advertised.supports(FEATURE_UPLOADS_DIRECT_MULTIPART),
             "this adapter signs no multipart for GCS, so the key must be absent"

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -146,10 +146,6 @@ async fn direct_put_round_trip(signed_write: SignedWriteHeaders, config: ServerC
         .await
         .expect("fetch capabilities");
     assert!(capabilities.supports("core.uploads.direct_put"));
-    assert!(capabilities
-        .features
-        .keys()
-        .all(|feature| !feature.starts_with("core.uploads.direct_put.checksum.")));
 
     harness
         .client
@@ -687,10 +683,6 @@ async fn gcp_gcs_signed_capabilities_are_scoped_bounded_and_single_use() {
         .expect("fetch capabilities");
     assert!(capabilities.supports("core.uploads.direct_put"));
     assert!(capabilities.supports("core.downloads.direct_get"));
-    assert!(capabilities
-        .features
-        .keys()
-        .all(|feature| !feature.starts_with("core.uploads.direct_put.checksum.")));
     assert!(
         !capabilities.supports("core.uploads.direct_multipart"),
         "this adapter signs no multipart for GCS, so the key must be absent"

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -597,30 +597,18 @@ fn every_registered_operation_publishes_its_retry_class() {
     let generated = openapi_postprocess::openapi_json_pretty(&loonfs_server::openapi_document())
         .expect("generate openapi json");
     let spec: Value = serde_json::from_str(&generated).expect("parse generated openapi json");
-    let paths = spec
-        .get("paths")
-        .and_then(Value::as_object)
-        .expect("openapi paths object");
-    let mut published = BTreeMap::new();
-    for path_item in paths.values().filter_map(Value::as_object) {
-        for method in ["get", "post", "put", "delete", "patch"] {
-            let Some(operation) = path_item.get(method) else {
-                continue;
-            };
-            let operation_id = operation
-                .get("operationId")
-                .and_then(Value::as_str)
-                .expect("OpenAPI operation has an operationId");
-            let retry_class = operation
-                .get("x-loonfs-retry")
-                .and_then(Value::as_str)
-                .expect("OpenAPI operation has an x-loonfs-retry extension");
-            assert!(
-                published.insert(operation_id, retry_class).is_none(),
-                "duplicate operationId `{operation_id}`"
-            );
-        }
-    }
+    let published = operations_by_id(&spec)
+        .into_iter()
+        .map(|(operation_id, operation)| {
+            (
+                operation_id,
+                operation
+                    .get("x-loonfs-retry")
+                    .and_then(Value::as_str)
+                    .expect("OpenAPI operation has an x-loonfs-retry extension"),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
 
     let expected = openapi_postprocess::OPERATION_RETRY_CLASSES
         .iter()
@@ -1037,10 +1025,6 @@ fn openapi_documents_string_id_contracts_without_dead_schemas() {
     );
     assert!(!schemas.contains_key("ContentStoreId"));
     assert!(!schemas.contains_key("FilesystemChangeCreated"));
-    assert!(
-        !schemas.contains_key("GrepRequest"),
-        "grep uses query parameters and must not publish an unused request schema"
-    );
     assert!(
         !raw.contains(r#""created""#),
         "retired creation-event kind remains in OpenAPI"

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -160,8 +160,8 @@ pub mod content_tokens {
 pub mod uploads {
     pub use loonfs_core::{
         BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse,
-        DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget,
-        MultipartPartTargets, ResolvedUploadCompletion,
+        DirectMultipartUploadTarget, MultipartPartTarget, MultipartPartTargets,
+        ResolvedUploadCompletion,
     };
 }
 

--- a/crates/loonfs/tests/it/capability_conformance.rs
+++ b/crates/loonfs/tests/it/capability_conformance.rs
@@ -49,14 +49,6 @@ fn is_grep_key(key: &str) -> bool {
     key.starts_with("query.") || key.starts_with("admin.grep.")
 }
 
-/// A registry row whose key carries a `<placeholder>` documents a *family*
-/// of keys, not one key. Only a deployment that offers the parent feature
-/// advertises a member, so no runtime advertises one unconditionally; the
-/// members are pinned against their constants below instead.
-fn is_key_family(key: &str) -> bool {
-    key.contains('<')
-}
-
 fn spec_section<'a>(spec: &'a str, start: &str, end: &str) -> &'a str {
     spec.split(start)
         .nth(1)
@@ -114,7 +106,7 @@ fn advertised_features_match_the_spec_feature_registry() {
 
     let runtime_registry: BTreeSet<String> = registry
         .into_iter()
-        .filter(|key| !is_grep_key(key) && !is_key_family(key))
+        .filter(|key| !is_grep_key(key))
         .collect();
     let advertised: BTreeSet<String> = embedded_capabilities().features.into_keys().collect();
     assert_eq!(

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -261,10 +261,7 @@ impl TestRuntime {
     ) -> loonfs::Result<UploadSessionResponse> {
         self.writer
             .complete_upload_prepared_for_mode(namespace_id, upload_id, |_| {
-                Ok(loonfs::uploads::ResolvedUploadCompletion::DirectPut {
-                    content,
-                    max_content_bytes: u64::MAX,
-                })
+                Ok(loonfs::uploads::ResolvedUploadCompletion::DirectPut { content })
             })
             .await
             .map(|completed| completed.response)

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -559,7 +559,7 @@ async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_cont
 
     harness
         .store
-        .put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes))
+        .put_if_absent(&begin.object_key, Bytes::copy_from_slice(bytes))
         .await
         .expect("drive direct provider upload");
     assert_content_counts(harness.recording.snapshot(), 0, 0, 1, 0);
@@ -573,7 +573,6 @@ async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_cont
                     size_bytes: bytes.len() as u64,
                     checksum: loonfs_api::Checksum::sha256(bytes),
                 },
-                max_content_bytes: u64::MAX,
             })
         })
         .await

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -108,14 +108,13 @@ fn direct_put_upload_flow_validates_durable_object_on_complete() {
     // The target is minted here, before a byte is written, and the key it
     // names is derived from that identity alone.
     assert!(begin
-        .target
         .object_key
         .rsplit('/')
         .next()
         .is_some_and(|content_id| content_id.starts_with("con_")));
 
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
-    block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
+    block_on(direct_store.put_if_absent(&begin.object_key, Bytes::copy_from_slice(bytes)))
         .expect("write direct object");
 
     let completed = block_on(fs.complete_direct_put(&namespace_id, &begin.upload_id, claim))
@@ -162,7 +161,7 @@ fn direct_put_completion_proves_upload_without_reading_content() {
 
     // Stands in for the provider-verified presigned upload.
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
-    block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
+    block_on(direct_store.put_if_absent(&begin.object_key, Bytes::copy_from_slice(bytes)))
         .expect("write direct object");
 
     raw_store.reset();
@@ -200,7 +199,7 @@ fn direct_put_completion_rejects_a_mis_declared_size() {
         block_on(fs.begin_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
             .expect("begin direct put");
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
-    block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
+    block_on(direct_store.put_if_absent(&begin.object_key, Bytes::copy_from_slice(bytes)))
         .expect("write direct object");
 
     let error = block_on(fs.complete_direct_put(&namespace_id, &begin.upload_id, claim))
@@ -230,10 +229,8 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
         block_on(fs.begin_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
             .expect("begin direct put");
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
-    block_on(
-        direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(delivered)),
-    )
-    .expect("write mismatched direct object");
+    block_on(direct_store.put_if_absent(&begin.object_key, Bytes::copy_from_slice(delivered)))
+        .expect("write mismatched direct object");
 
     let error = block_on(fs.complete_direct_put(&namespace_id, &begin.upload_id, claim))
         .expect_err("mismatched bytes must fail completion");
@@ -247,7 +244,7 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
         "completion names the checksum mismatch: {error}"
     );
     assert!(
-        block_on(direct_store.head(&begin.target.object_key))
+        block_on(direct_store.head(&begin.object_key))
             .expect("head rejected object")
             .is_none(),
         "a rejected completion leaves no orphan behind"
@@ -274,7 +271,7 @@ fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
             .expect("begin direct put");
 
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
-    block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
+    block_on(direct_store.put_if_absent(&begin.object_key, Bytes::copy_from_slice(bytes)))
         .expect("write direct object");
 
     raw_store.fail_next(1);
@@ -283,7 +280,7 @@ fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
     assert_eq!(error.code(), ErrorCode::ServerError);
     assert_eq!(raw_store.attempts(), 1, "the checksum head is what failed");
     assert!(
-        block_on(direct_store.head(&begin.target.object_key))
+        block_on(direct_store.head(&begin.object_key))
             .expect("head the uploaded object")
             .is_some(),
         "a store failure must not delete the client's object"

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1045,9 +1045,8 @@ content facts at completion.
 `size_bytes` is optional and advisory. When present, the server compares it
 with `upload.direct_put_max_content_bytes`, the provider's single-request
 ceiling, and answers `content_too_large` before issuing a capability when it
-is too large. The provider enforces the ceiling on the PUT. Completion verifies the
-stored content against the client's claim, not against the ceiling. Content past the limit
-moves as `direct_multipart` where that is advertised.
+is too large. The provider enforces the same limit when accepting the PUT.
+Larger content uses `direct_multipart` when available.
 
 The response includes only a short-lived transfer capability, never raw object-store credentials or a caller-managed object key. Required headers are provider-issued and must be echoed by the client; for example, an S3-compatible deployment may return:
 
@@ -1125,8 +1124,8 @@ difference answers `invalid_request`. The server builds the final content
 reference from the session's content identity and the completion claim. It
 then compares the claimed size and checksum with the object in storage. A
 mismatch makes the session unusable, and the server deletes the unpublished
-object. The provider enforces `upload.direct_put_max_content_bytes` on the PUT.
-Completion verifies the stored checksum and does not reapply that ceiling.
+object. Completion verifies the stored content against the client's claim; it
+does not reapply the provider's upload limit.
 If the provider metadata request fails, the server returns `server_error`
 without changing the object or session, so the client can retry. The server
 does not download the object during this check.

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1045,8 +1045,9 @@ content facts at completion.
 `size_bytes` is optional and advisory. When present, the server compares it
 with `upload.direct_put_max_content_bytes`, the provider's single-request
 ceiling, and answers `content_too_large` before issuing a capability when it
-is too large. The stored size is checked again at completion. Content past the
-limit moves as `direct_multipart` where that is advertised.
+is too large. The provider enforces the ceiling on the PUT. Completion verifies the
+stored content against the client's claim, not against the ceiling. Content past the limit
+moves as `direct_multipart` where that is advertised.
 
 The response includes only a short-lived transfer capability, never raw object-store credentials or a caller-managed object key. Required headers are provider-issued and must be echoed by the client; for example, an S3-compatible deployment may return:
 
@@ -1124,8 +1125,8 @@ difference answers `invalid_request`. The server builds the final content
 reference from the session's content identity and the completion claim. It
 then compares the claimed size and checksum with the object in storage. A
 mismatch makes the session unusable, and the server deletes the unpublished
-object. The provider-stored size must also be at most
-`upload.direct_put_max_content_bytes`.
+object. The provider enforces `upload.direct_put_max_content_bytes` on the PUT.
+Completion verifies the stored checksum and does not reapply that ceiling.
 If the provider metadata request fails, the server returns `server_error`
 without changing the object or session, so the client can retry. The server
 does not download the object during this check.


### PR DESCRIPTION
This simplifies the grep and direct PUT internals. GrepRequest is now an internal parameter struct, direct PUT completion no longer carries the provider size limit through the server and core, and one-field wrappers and duplicate tests are removed.

Direct PUT sizes are still checked before a transfer capability is issued when the client provides them, and the storage provider enforces the limit on the PUT. Completion continues to verify the stored size and checksum against the client claim.