### PR TITLE
fix(sdk): fall back to proxied reads when direct_get is unavailable

### DIFF
--- a/sdk/transfers/go/transfers/transfers.go
+++ b/sdk/transfers/go/transfers/transfers.go
@@ -22,6 +22,7 @@ import (
 const (
 	multipartMinimumBytes = 8 * 1024 * 1024
 
+	featureDirectGet           = "core.downloads.direct_get"
 	featureDirectPut           = "core.uploads.direct_put"
 	featureDirectMultipart     = "core.uploads.direct_multipart"
 	limitUploadMaximumBytes    = "upload.max_content_bytes"
@@ -152,6 +153,13 @@ func GetFile(ctx context.Context, c *client.Client, in GetFileInput) (*GetFileRe
 	if c == nil {
 		return nil, fmt.Errorf("transfers: client is nil")
 	}
+	capabilities, err := c.Capabilities(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
+	}
+	if capabilities == nil || !capabilities.Features[featureDirectGet] {
+		return getFileProxied(ctx, c, in)
+	}
 	grant, err := c.Filesystem.BeginDownload(ctx, &loonfs.BeginDownloadRequest{
 		NamespaceID: string(in.NamespaceID),
 		Path:        in.Path,
@@ -186,6 +194,105 @@ func GetFile(ctx context.Context, c *client.Client, in GetFileInput) (*GetFileRe
 		RevisionNo:  grant.RevisionNo,
 		ContentRef:  grant.ContentRef,
 	}, nil
+}
+
+// getFileProxied reads through the service instead of a presigned URL, for
+// deployments whose object store cannot presign reads. The content route
+// returns bare bytes, so the content claim to verify against comes from the
+// metadata surface first, and the read pins an explicit revision so a
+// concurrent commit cannot slip between the claim and the bytes.
+func getFileProxied(ctx context.Context, c *client.Client, in GetFileInput) (*GetFileResult, error) {
+	revisionNo := in.RevisionNo
+	var claim *loonfs.ContentRef
+	if revisionNo == nil {
+		entry, err := c.Filesystem.StatPath(ctx, &loonfs.StatPathRequest{
+			NamespaceID: string(in.NamespaceID),
+			Path:        string(in.Path),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("transfers: stat path: %w", err)
+		}
+		file, err := fileProjection(entry)
+		if err != nil {
+			return nil, err
+		}
+		headRevision := file.RevisionNo
+		revisionNo = &headRevision
+		claim = file.ContentRef
+	} else {
+		page, err := c.Filesystem.ListFileRevisions(ctx, &loonfs.ListFileRevisionsRequest{
+			NamespaceID: string(in.NamespaceID),
+			Path:        string(in.Path),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("transfers: list file revisions: %w", err)
+		}
+		iterator := page.Iterator()
+		for iterator.Next(ctx) {
+			revision := iterator.Current()
+			if revision.RevisionNo == *revisionNo {
+				claim = revision.ContentRef
+				break
+			}
+		}
+		if claim == nil {
+			return nil, fmt.Errorf("transfers: revision %d not found for %s", *revisionNo, in.Path)
+		}
+	}
+	if claim == nil {
+		return nil, fmt.Errorf("transfers: revision has no content reference")
+	}
+
+	reader, err := c.Filesystem.GetFileBytes(ctx, &loonfs.GetFileBytesRequest{
+		NamespaceID: string(in.NamespaceID),
+		Path:        string(in.Path),
+		RevisionNo:  revisionNo,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transfers: read content: %w", err)
+	}
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("transfers: read content: %w", err)
+	}
+	if int64(len(payload)) != claim.SizeBytes {
+		return nil, fmt.Errorf(
+			"transfers: proxied read returned %d bytes, expected %d",
+			len(payload),
+			claim.SizeBytes,
+		)
+	}
+	if err := verifyChecksum(claim.Checksum, payload); err != nil {
+		return nil, fmt.Errorf("transfers: verify proxied read: %w", err)
+	}
+
+	return &GetFileResult{
+		Bytes:       payload,
+		NamespaceID: in.NamespaceID,
+		Path:        in.Path,
+		RevisionNo:  *revisionNo,
+		ContentRef:  claim,
+	}, nil
+}
+
+// fileProjection decodes the entry's kind projection, which fern-go surfaces
+// through extra properties (the same shape the upload status decode handles).
+func fileProjection(entry *loonfs.AuthoritativePathEntry) (*loonfs.AuthoritativePathEntryFile, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("transfers: path entry is nil")
+	}
+	data, err := json.Marshal(entry.GetExtraProperties())
+	if err != nil {
+		return nil, fmt.Errorf("transfers: encode path entry projection: %w", err)
+	}
+	var projection loonfs.AuthoritativePathEntryKind
+	if err := json.Unmarshal(data, &projection); err != nil {
+		return nil, fmt.Errorf("transfers: decode path entry projection: %w", err)
+	}
+	if projection.File == nil {
+		return nil, fmt.Errorf("transfers: path is a %s, not a file", projection.InodeKind)
+	}
+	return projection.File, nil
 }
 
 func beginUploadRequest(

--- a/sdk/transfers/go/transfers/transfers.go
+++ b/sdk/transfers/go/transfers/transfers.go
@@ -196,11 +196,9 @@ func GetFile(ctx context.Context, c *client.Client, in GetFileInput) (*GetFileRe
 	}, nil
 }
 
-// getFileProxied reads through the service instead of a presigned URL, for
-// deployments whose object store cannot presign reads. The content route
-// returns bare bytes, so the content claim to verify against comes from the
-// metadata surface first, and the read pins an explicit revision so a
-// concurrent commit cannot slip between the claim and the bytes.
+// getFileProxied reads through LoonFS when direct reads are unavailable.
+// It loads the content reference first, then requests the exact revision so
+// the reference and returned bytes describe the same file version.
 func getFileProxied(ctx context.Context, c *client.Client, in GetFileInput) (*GetFileResult, error) {
 	revisionNo := in.RevisionNo
 	var claim *loonfs.ContentRef
@@ -275,8 +273,7 @@ func getFileProxied(ctx context.Context, c *client.Client, in GetFileInput) (*Ge
 	}, nil
 }
 
-// fileProjection decodes the entry's kind projection, which fern-go surfaces
-// through extra properties (the same shape the upload status decode handles).
+// fileProjection decodes the file fields stored in Fern's extra properties.
 func fileProjection(entry *loonfs.AuthoritativePathEntry) (*loonfs.AuthoritativePathEntryFile, error) {
 	if entry == nil {
 		return nil, fmt.Errorf("transfers: path entry is nil")

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -35,6 +35,7 @@ __all__ = ["GetFileResult", "PutFileResult", "get_file", "put_file"]
 
 
 _MULTIPART_MIN_BYTES = 8 * 1024 * 1024
+_DIRECT_GET_FEATURE = "core.downloads.direct_get"
 _DIRECT_MULTIPART_FEATURE = "core.uploads.direct_multipart"
 _DIRECT_PUT_FEATURE = "core.uploads.direct_put"
 _PROXY_UPLOAD_LIMIT = "upload.max_content_bytes"
@@ -141,6 +142,11 @@ def get_file(
 ) -> GetFileResult:
     """Download one file revision into memory and verify its checksum."""
 
+    capabilities = client.capabilities()
+    if not capabilities.features.get(_DIRECT_GET_FEATURE, False):
+        return _get_file_proxied(
+            client, namespace_id=namespace_id, path=path, revision_no=revision_no
+        )
     if revision_no is None:
         grant = client.filesystem.begin_download(namespace_id, path=path)
     else:
@@ -170,6 +176,58 @@ def get_file(
         path=grant.path,
         revision_no=grant.revision_no,
         content_ref=grant.content_ref,
+    )
+
+
+def _get_file_proxied(
+    client: LoonFS,
+    *,
+    namespace_id: str,
+    path: str,
+    revision_no: RevisionNo | None,
+) -> GetFileResult:
+    """Read through the service for deployments whose object store cannot
+    presign reads. The content route returns bare bytes, so the content claim
+    to verify against comes from the metadata surface first, and the read pins
+    an explicit revision so a concurrent commit cannot slip between the claim
+    and the bytes."""
+    if revision_no is None:
+        entry = client.filesystem.stat_path(namespace_id, path=path)
+        if entry.inode_kind != "file":
+            raise RuntimeError(f"path {path!r} is a {entry.inode_kind}, not a file")
+        claim = ContentRef(**entry.content_ref)
+        revision_no = entry.revision_no
+    else:
+        claim = None
+        cursor = None
+        while True:
+            page = client.filesystem.list_file_revisions(
+                namespace_id, path=path, cursor=cursor
+            )
+            for revision in page.revisions:
+                if revision.revision_no == revision_no:
+                    claim = revision.content_ref
+                    break
+            if claim is not None or page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+        if claim is None:
+            raise RuntimeError(f"revision {revision_no} not found for {path!r}")
+    content = b"".join(
+        client.filesystem.get_file_bytes(namespace_id, path=path, revision_no=revision_no)
+    )
+    if len(content) != claim.size_bytes:
+        raise RuntimeError(
+            f"proxied read returned {len(content)} bytes, expected {claim.size_bytes}"
+        )
+    if _checksum(claim.checksum.algorithm, content) != claim.checksum:
+        raise RuntimeError("proxied read checksum did not match its content reference")
+    return GetFileResult(
+        content=content,
+        namespace_id=namespace_id,
+        path=path,
+        revision_no=revision_no,
+        content_ref=claim,
     )
 
 

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -186,11 +186,11 @@ def _get_file_proxied(
     path: str,
     revision_no: RevisionNo | None,
 ) -> GetFileResult:
-    """Read through the service for deployments whose object store cannot
-    presign reads. The content route returns bare bytes, so the content claim
-    to verify against comes from the metadata surface first, and the read pins
-    an explicit revision so a concurrent commit cannot slip between the claim
-    and the bytes."""
+    """Read through LoonFS when direct reads are unavailable.
+
+    Load the content reference first, then request the exact revision so the
+    reference and returned bytes describe the same file version.
+    """
     if revision_no is None:
         entry = client.filesystem.stat_path(namespace_id, path=path)
         if entry.inode_kind != "file":

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -1,6 +1,7 @@
 import { LoonFSClient } from "./Client.js";
 import type * as LoonFS from "./api/index.js";
 
+const DIRECT_GET_FEATURE = "core.downloads.direct_get";
 const DIRECT_MULTIPART_FEATURE = "core.uploads.direct_multipart";
 const DIRECT_PUT_FEATURE = "core.uploads.direct_put";
 const DIRECT_PUT_MAX_BYTES = "upload.direct_put_max_content_bytes";
@@ -39,7 +40,11 @@ export interface GetFileInput {
     revision_no?: LoonFS.RevisionNo;
 }
 
-export interface GetFileResult extends LoonFS.BeginDownloadResponse {
+export interface GetFileResult {
+    namespace_alias: string;
+    path: LoonFS.AbsolutePath;
+    revision_no: LoonFS.RevisionNo;
+    content_ref: LoonFS.ContentRef;
     bytes: Uint8Array;
 }
 
@@ -85,6 +90,10 @@ export async function putFile(client: LoonFSClient, input: PutFileInput): Promis
  * Streaming and resume are follow-ups.
  */
 export async function getFile(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
+    const capabilities = await client.capabilities();
+    if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
+        return getFileProxied(client, input);
+    }
     const grant = await client.filesystem.beginDownload(input);
     requirePresignedMethod(grant.access, "GET", "download");
     const response = await fetch(grant.access.url, {
@@ -103,7 +112,61 @@ export async function getFile(client: LoonFSClient, input: GetFileInput): Promis
     if (actual.value !== grant.content_ref.checksum.value) {
         throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
     }
-    return { ...grant, bytes };
+    return {
+        namespace_alias: input.namespace_alias,
+        path: grant.path,
+        revision_no: grant.revision_no,
+        content_ref: grant.content_ref,
+        bytes,
+    };
+}
+
+// Reads through the service for deployments whose object store cannot presign
+// reads. The content route returns bare bytes, so the content claim to verify
+// against comes from the metadata surface first, and the read pins an explicit
+// revision so a concurrent commit cannot slip between the claim and the bytes.
+async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
+    let revisionNo = input.revision_no;
+    let claim: LoonFS.ContentRef | undefined;
+    if (revisionNo === undefined) {
+        const entry = (await client.filesystem.statPath({
+            namespace_alias: input.namespace_alias,
+            path: input.path,
+        })) as LoonFS.AuthoritativePathEntry & LoonFS.AuthoritativePathEntryKind.File;
+        if (entry.inode_kind !== "file") {
+            throw new Error(`path ${input.path} is a ${entry.inode_kind}, not a file`);
+        }
+        claim = entry.content_ref;
+        revisionNo = entry.revision_no;
+    } else {
+        const page = await client.filesystem.listFileRevisions({
+            namespace_alias: input.namespace_alias,
+            path: input.path,
+        });
+        for await (const revision of page) {
+            if (revision.revision_no === revisionNo) {
+                claim = revision.content_ref;
+                break;
+            }
+        }
+        if (claim === undefined) {
+            throw new Error(`revision ${revisionNo} not found for ${input.path}`);
+        }
+    }
+    const body = await client.filesystem.getFileBytes({
+        namespace_alias: input.namespace_alias,
+        path: input.path,
+        revision_no: revisionNo,
+    });
+    const bytes = new Uint8Array(await body.arrayBuffer());
+    if (bytes.byteLength !== claim.size_bytes) {
+        throw new Error(`proxied read returned ${bytes.byteLength} bytes, expected ${claim.size_bytes}`);
+    }
+    const actual = await checksum(claim.checksum.algorithm, bytes);
+    if (actual.value !== claim.checksum.value) {
+        throw new Error(`proxied read checksum did not match ${claim.checksum.algorithm} claim`);
+    }
+    return { namespace_alias: input.namespace_alias, path: input.path, revision_no: revisionNo, content_ref: claim, bytes };
 }
 
 async function stageBytes(

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -121,10 +121,9 @@ export async function getFile(client: LoonFSClient, input: GetFileInput): Promis
     };
 }
 
-// Reads through the service for deployments whose object store cannot presign
-// reads. The content route returns bare bytes, so the content claim to verify
-// against comes from the metadata surface first, and the read pins an explicit
-// revision so a concurrent commit cannot slip between the claim and the bytes.
+// Reads through LoonFS when direct reads are unavailable. It loads the content
+// reference first, then requests the exact revision so the reference and
+// returned bytes describe the same file version.
 async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -1,6 +1,7 @@
 import { LoonFSClient } from "./Client.js";
 import type * as LoonFS from "./api/index.js";
 
+const DIRECT_GET_FEATURE = "core.downloads.direct_get";
 const DIRECT_MULTIPART_FEATURE = "core.uploads.direct_multipart";
 const DIRECT_PUT_FEATURE = "core.uploads.direct_put";
 const DIRECT_PUT_MAX_BYTES = "upload.direct_put_max_content_bytes";
@@ -36,7 +37,11 @@ export interface GetFileInput {
     revision_no?: LoonFS.RevisionNo;
 }
 
-export interface GetFileResult extends LoonFS.BeginDownloadResponse {
+export interface GetFileResult {
+    namespace_id: LoonFS.NamespaceId;
+    path: LoonFS.AbsolutePath;
+    revision_no: LoonFS.RevisionNo;
+    content_ref: LoonFS.ContentRef;
     bytes: Uint8Array;
 }
 
@@ -82,6 +87,10 @@ export async function putFile(client: LoonFSClient, input: PutFileInput): Promis
  * Streaming and resume are follow-ups.
  */
 export async function getFile(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
+    const capabilities = await client.capabilities();
+    if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
+        return getFileProxied(client, input);
+    }
     const grant = await client.filesystem.beginDownload(input);
     requirePresignedMethod(grant.access, "GET", "download");
     const response = await fetch(grant.access.url, {
@@ -100,7 +109,61 @@ export async function getFile(client: LoonFSClient, input: GetFileInput): Promis
     if (actual.value !== grant.content_ref.checksum.value) {
         throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
     }
-    return { ...grant, bytes };
+    return {
+        namespace_id: input.namespace_id,
+        path: grant.path,
+        revision_no: grant.revision_no,
+        content_ref: grant.content_ref,
+        bytes,
+    };
+}
+
+// Reads through the service for deployments whose object store cannot presign
+// reads. The content route returns bare bytes, so the content claim to verify
+// against comes from the metadata surface first, and the read pins an explicit
+// revision so a concurrent commit cannot slip between the claim and the bytes.
+async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
+    let revisionNo = input.revision_no;
+    let claim: LoonFS.ContentRef | undefined;
+    if (revisionNo === undefined) {
+        const entry = (await client.filesystem.statPath({
+            namespace_id: input.namespace_id,
+            path: input.path,
+        })) as LoonFS.AuthoritativePathEntry & LoonFS.AuthoritativePathEntryKind.File;
+        if (entry.inode_kind !== "file") {
+            throw new Error(`path ${input.path} is a ${entry.inode_kind}, not a file`);
+        }
+        claim = entry.content_ref;
+        revisionNo = entry.revision_no;
+    } else {
+        const page = await client.filesystem.listFileRevisions({
+            namespace_id: input.namespace_id,
+            path: input.path,
+        });
+        for await (const revision of page) {
+            if (revision.revision_no === revisionNo) {
+                claim = revision.content_ref;
+                break;
+            }
+        }
+        if (claim === undefined) {
+            throw new Error(`revision ${revisionNo} not found for ${input.path}`);
+        }
+    }
+    const body = await client.filesystem.getFileBytes({
+        namespace_id: input.namespace_id,
+        path: input.path,
+        revision_no: revisionNo,
+    });
+    const bytes = new Uint8Array(await body.arrayBuffer());
+    if (bytes.byteLength !== claim.size_bytes) {
+        throw new Error(`proxied read returned ${bytes.byteLength} bytes, expected ${claim.size_bytes}`);
+    }
+    const actual = await checksum(claim.checksum.algorithm, bytes);
+    if (actual.value !== claim.checksum.value) {
+        throw new Error(`proxied read checksum did not match ${claim.checksum.algorithm} claim`);
+    }
+    return { namespace_id: input.namespace_id, path: input.path, revision_no: revisionNo, content_ref: claim, bytes };
 }
 
 async function stageBytes(

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -118,10 +118,9 @@ export async function getFile(client: LoonFSClient, input: GetFileInput): Promis
     };
 }
 
-// Reads through the service for deployments whose object store cannot presign
-// reads. The content route returns bare bytes, so the content claim to verify
-// against comes from the metadata surface first, and the read pins an explicit
-// revision so a concurrent commit cannot slip between the claim and the bytes.
+// Reads through LoonFS when direct reads are unavailable. It loads the content
+// reference first, then requests the exact revision so the reference and
+// returned bytes describe the same file version.
 async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;


### PR DESCRIPTION
This makes get_file work on deployments that cannot issue presigned download URLs. Each SDK reads the capability document first. When direct_get is unavailable, it loads the content reference, pins the requested file revision, reads the bytes through LoonFS, and verifies their size and checksum.

The direct-download path is unchanged. The TypeScript result now contains the namespace, path, revision, content reference, and bytes directly instead of extending BeginDownloadResponse, because a proxied read has no access grant.

The Go, Python, and TypeScript conformance suites pass. The fallback was also tested against a local-filesystem server for both the current file revision and an older pinned revision.