### PR TITLE
fix(client): plaintext token rejection and typed log severity

### DIFF
--- a/crates/loonfs-cli/src/commands/config.rs
+++ b/crates/loonfs-cli/src/commands/config.rs
@@ -37,7 +37,7 @@ pub(crate) fn run_config_init(
             ));
         }
         let name = prompt::prompt_line_default("profile name", "default")?;
-        let profile = build_profile_interactive(runtime)?;
+        let profile = build_profile_interactive(&name, runtime)?;
 
         mutate_config(config_path, |config| {
             let (profile_name, redacted) = add_profile(config, &name, profile)?;

--- a/crates/loonfs-cli/src/commands/profile.rs
+++ b/crates/loonfs-cli/src/commands/profile.rs
@@ -72,7 +72,7 @@ fn run_profile_create(
 ) -> Result<CommandOutput, CommandFailure> {
     let (name, spec) = create_profile_spec_from_create(command);
     let result = (|| -> Result<(String, ProfileConfig), CliError> {
-        let profile = build_profile_from_create_spec(spec, runtime)?;
+        let profile = build_profile_from_create_spec(&name, spec, runtime)?;
         mutate_config(config_path, |config| add_profile(config, &name, profile))
     })()
     .map_err(|error| fail(kind, Some(name.clone()), None, error))?;
@@ -105,7 +105,7 @@ fn run_profile_update(
             .clone();
 
         let updated = if has_update_flags(&args) {
-            apply_update_flags(existing, &args)?
+            apply_update_flags(&name, existing, &args)?
         } else if runtime.interactive {
             apply_update_interactive(existing)?
         } else {

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -5,7 +5,9 @@ use crate::args::{
     ProfileCreateGcsArgs, ProfileCreateLocalArgs, ProfileCreateR2Args, ProfileCreateRemoteArgs,
     ProfileCreateS3Args, ProfileUpdateArgs, RuntimeBehavior,
 };
-use crate::config::{ProfileActorConfig, ProfileConfig, StoreConfig};
+use crate::config::{
+    validate_remote_client_config, ProfileActorConfig, ProfileConfig, StoreConfig,
+};
 use crate::error::CliError;
 use crate::prompt;
 use loonfs_api::{ActorId, ActorKind, SecretString};
@@ -267,6 +269,7 @@ fn create_remote_spec(args: ProfileCreateRemoteArgs) -> (String, CreateProfileSp
 }
 
 pub(super) fn build_profile_interactive(
+    name: &str,
     runtime: RuntimeBehavior,
 ) -> Result<ProfileConfig, CliError> {
     if !runtime.interactive {
@@ -286,6 +289,7 @@ pub(super) fn build_profile_interactive(
             _ => CreateProviderSpec::Remote(ProfileCreateRemoteSpec::default()),
         };
     build_profile_from_create_spec(
+        name,
         CreateProfileSpec {
             provider,
             actor: CreateActorSpec {
@@ -298,6 +302,7 @@ pub(super) fn build_profile_interactive(
 }
 
 pub(super) fn build_profile_from_create_spec(
+    name: &str,
     spec: CreateProfileSpec,
     runtime: RuntimeBehavior,
 ) -> Result<ProfileConfig, CliError> {
@@ -396,12 +401,21 @@ pub(super) fn build_profile_from_create_spec(
                 None if runtime.interactive => prompt::prompt_secret_optional("auth token", None)?,
                 None => None,
             };
+            let server_url = require_or_prompt(spec.server_url.as_ref(), "server-url", runtime)?;
+            let auth_token = auth_token.map(SecretString::from);
+            let ca_cert_path = blank_to_none(spec.ca_cert_path);
+            validate_remote_client_config(
+                &format!("{name}.server_url"),
+                &server_url,
+                auth_token.as_ref(),
+                ca_cert_path.as_deref(),
+            )?;
             Ok(ProfileConfig::Remote {
-                server_url: require_or_prompt(spec.server_url.as_ref(), "server-url", runtime)?,
+                server_url,
                 actor,
                 default_namespace: None,
-                auth_token: auth_token.map(SecretString::from),
-                ca_cert_path: blank_to_none(spec.ca_cert_path),
+                auth_token,
+                ca_cert_path,
             })
         }
     }
@@ -699,6 +713,7 @@ fn validate_remote_update_flags(args: &ProfileUpdateArgs) -> Result<(), CliError
 }
 
 pub(super) fn apply_update_flags(
+    name: &str,
     existing: ProfileConfig,
     args: &ProfileUpdateArgs,
 ) -> Result<ProfileConfig, CliError> {
@@ -818,16 +833,27 @@ pub(super) fn apply_update_flags(
             default_namespace,
             auth_token,
             ca_cert_path,
-        } => Ok(ProfileConfig::Remote {
-            server_url: args.server_url.clone().unwrap_or(server_url),
-            actor: updated_actor(actor, args)?,
-            default_namespace,
-            auth_token: match args.auth_token.clone() {
+        } => {
+            let server_url = args.server_url.clone().unwrap_or(server_url);
+            let auth_token = match args.auth_token.clone() {
                 Some(token) => blank_to_none(Some(token)).map(SecretString::from),
                 None => auth_token,
-            },
-            ca_cert_path: blank_to_none(args.ca_cert_path.clone()).or(ca_cert_path),
-        }),
+            };
+            let ca_cert_path = blank_to_none(args.ca_cert_path.clone()).or(ca_cert_path);
+            validate_remote_client_config(
+                &format!("{name}.server_url"),
+                &server_url,
+                auth_token.as_ref(),
+                ca_cert_path.as_deref(),
+            )?;
+            Ok(ProfileConfig::Remote {
+                server_url,
+                actor: updated_actor(actor, args)?,
+                default_namespace,
+                auth_token,
+                ca_cert_path,
+            })
+        }
     }
 }
 
@@ -1097,6 +1123,7 @@ mod tests {
     #[test]
     fn create_profile_supports_azure_abs() {
         let profile = build_profile_from_create_spec(
+            "default",
             CreateProfileSpec {
                 provider: CreateProviderSpec::Azure(ProfileCreateAzureSpec {
                     account_name: Some("devstoreaccount1".to_owned()),
@@ -1145,6 +1172,7 @@ mod tests {
     #[test]
     fn no_static_flags_select_ambient_without_storing_secrets() {
         let s3 = build_profile_from_create_spec(
+            "default",
             CreateProfileSpec {
                 provider: CreateProviderSpec::S3(ProfileCreateS3Spec {
                     bucket: Some("bucket".to_owned()),
@@ -1169,6 +1197,7 @@ mod tests {
     #[test]
     fn remote_creation_never_captures_an_environment_token() {
         let remote = build_profile_from_create_spec(
+            "default",
             CreateProfileSpec {
                 provider: CreateProviderSpec::Remote(ProfileCreateRemoteSpec {
                     server_url: Some("http://127.0.0.1:9400".to_owned()),
@@ -1188,6 +1217,7 @@ mod tests {
     #[test]
     fn static_flags_imply_static_and_require_the_complete_set() {
         let incomplete = build_profile_from_create_spec(
+            "default",
             CreateProfileSpec {
                 provider: CreateProviderSpec::S3(ProfileCreateS3Spec {
                     bucket: Some("bucket".to_owned()),
@@ -1203,6 +1233,7 @@ mod tests {
         assert!(incomplete.message.contains("secret-access-key"));
 
         let complete = build_profile_from_create_spec(
+            "default",
             CreateProfileSpec {
                 provider: CreateProviderSpec::S3(ProfileCreateS3Spec {
                     bucket: Some("bucket".to_owned()),
@@ -1242,6 +1273,7 @@ mod tests {
         };
 
         let error = apply_update_flags(
+            "default",
             local_fs.clone(),
             &ProfileUpdateArgs {
                 bucket: Some("bucket".to_owned()),
@@ -1255,6 +1287,7 @@ mod tests {
         );
 
         let error = apply_update_flags(
+            "default",
             local_fs,
             &ProfileUpdateArgs {
                 auth_token: Some("token".to_owned()),
@@ -1279,6 +1312,7 @@ mod tests {
         };
 
         let updated = apply_update_flags(
+            "default",
             remote,
             &ProfileUpdateArgs {
                 auth_token: Some("new-token".to_owned()),
@@ -1299,6 +1333,37 @@ mod tests {
     }
 
     #[test]
+    fn remote_update_rejects_a_token_over_non_loopback_plaintext_http() {
+        let remote = ProfileConfig::Remote {
+            server_url: "https://example.internal".to_owned(),
+            actor: crate::config::ProfileActorConfig::default(),
+            default_namespace: None,
+            auth_token: None,
+            ca_cert_path: None,
+        };
+
+        let error = apply_update_flags(
+            "default",
+            remote,
+            &ProfileUpdateArgs {
+                server_url: Some("http://example.internal".to_owned()),
+                auth_token: Some("new-token".to_owned()),
+                ..empty_update_args()
+            },
+        )
+        .expect_err("unsafe effective remote profile should be rejected");
+
+        assert_eq!(error.code, "invalid_config");
+        assert!(
+            error
+                .message
+                .contains("bearer tokens require https except for loopback http URLs"),
+            "{}",
+            error.message
+        );
+    }
+
+    #[test]
     fn update_switches_credential_source_only_with_a_complete_static_set() {
         let profile = ProfileConfig::Embedded {
             store: StoreConfig::AwsS3 {
@@ -1315,6 +1380,7 @@ mod tests {
         };
 
         let error = apply_update_flags(
+            "default",
             profile.clone(),
             &ProfileUpdateArgs {
                 credential_source: Some("static".to_owned()),
@@ -1336,6 +1402,7 @@ mod tests {
         ));
 
         let updated = apply_update_flags(
+            "default",
             profile,
             &ProfileUpdateArgs {
                 credential_source: Some("static".to_owned()),

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -405,7 +405,7 @@ pub(super) fn build_profile_from_create_spec(
             let auth_token = auth_token.map(SecretString::from);
             let ca_cert_path = blank_to_none(spec.ca_cert_path);
             validate_remote_client_config(
-                &format!("{name}.server_url"),
+                name,
                 &server_url,
                 auth_token.as_ref(),
                 ca_cert_path.as_deref(),
@@ -841,7 +841,7 @@ pub(super) fn apply_update_flags(
             };
             let ca_cert_path = blank_to_none(args.ca_cert_path.clone()).or(ca_cert_path);
             validate_remote_client_config(
-                &format!("{name}.server_url"),
+                name,
                 &server_url,
                 auth_token.as_ref(),
                 ca_cert_path.as_deref(),

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -202,10 +202,12 @@ impl ProfileConfig {
                 ca_cert_path,
             } => {
                 validate_actor_and_default_namespace(name, actor, default_namespace.as_deref())?;
-                validate_http_url(&profile_field(name, "server_url"), server_url)?;
-                if let Some(token) = auth_token {
-                    require_non_empty(&profile_field(name, "auth_token"), token.expose())?;
-                }
+                validate_remote_client_config(
+                    &profile_field(name, "server_url"),
+                    server_url,
+                    auth_token.as_ref(),
+                    ca_cert_path.as_deref(),
+                )?;
                 if let Some(path) = ca_cert_path {
                     require_non_empty(&profile_field(name, "ca_cert_path"), path)?;
                 }
@@ -649,14 +651,19 @@ fn validate_default_namespace(field: &str, value: &str) -> Result<(), CliError> 
         .map_err(|err| CliError::invalid_config(format!("invalid `{field}`: {err}")))
 }
 
-fn validate_http_url(field: &str, value: &str) -> Result<(), CliError> {
-    // One URL grammar authority: the client's own config validation.
+pub(crate) fn validate_remote_client_config(
+    field: &str,
+    server_url: &str,
+    auth_token: Option<&SecretString>,
+    ca_cert_path: Option<&str>,
+) -> Result<(), CliError> {
+    // One remote-client policy authority: the client's own config validation.
     ClientConfig {
-        server_url: value.to_owned(),
-        auth_token: None,
+        server_url: server_url.to_owned(),
+        auth_token: auth_token.cloned(),
         request_timeout_ms: None,
         disable_transient_retry: false,
-        ca_cert_path: None,
+        ca_cert_path: ca_cert_path.map(ToOwned::to_owned),
     }
     .validate()
     .map_err(|error| CliError::invalid_config(format!("invalid `{field}`: {error}")))

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -2,7 +2,7 @@
 
 use crate::error::CliError;
 use loonfs_api::{ActorId, ActorKind, ActorRef, NamespaceId, SecretString};
-use loonfs_client::ClientConfig;
+use loonfs_client::{ClientConfig, ClientError};
 use loonfs_objectstore::StoreConfigError;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -203,14 +203,11 @@ impl ProfileConfig {
             } => {
                 validate_actor_and_default_namespace(name, actor, default_namespace.as_deref())?;
                 validate_remote_client_config(
-                    &profile_field(name, "server_url"),
+                    name,
                     server_url,
                     auth_token.as_ref(),
                     ca_cert_path.as_deref(),
                 )?;
-                if let Some(path) = ca_cert_path {
-                    require_non_empty(&profile_field(name, "ca_cert_path"), path)?;
-                }
                 Ok(())
             }
         }
@@ -652,12 +649,11 @@ fn validate_default_namespace(field: &str, value: &str) -> Result<(), CliError> 
 }
 
 pub(crate) fn validate_remote_client_config(
-    field: &str,
+    profile_name: &str,
     server_url: &str,
     auth_token: Option<&SecretString>,
     ca_cert_path: Option<&str>,
 ) -> Result<(), CliError> {
-    // One remote-client policy authority: the client's own config validation.
     ClientConfig {
         server_url: server_url.to_owned(),
         auth_token: auth_token.cloned(),
@@ -666,7 +662,16 @@ pub(crate) fn validate_remote_client_config(
         ca_cert_path: ca_cert_path.map(ToOwned::to_owned),
     }
     .validate()
-    .map_err(|error| CliError::invalid_config(format!("invalid `{field}`: {error}")))
+    .map_err(|error| match error {
+        ClientError::MissingConfigField { field } => {
+            CliError::invalid_config(format!("missing `{}`", profile_field(profile_name, field)))
+        }
+        ClientError::ConfigValidation { field, reason } => CliError::invalid_config(format!(
+            "invalid `{}`: {reason}",
+            profile_field(profile_name, field)
+        )),
+        error => CliError::invalid_config(error.to_string()),
+    })
 }
 
 #[cfg(test)]

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -336,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    fn environment_token_is_rejected_when_client_construction_sees_non_loopback_http() {
+    fn environment_token_is_rejected_for_non_loopback_http() {
         let auth_token = resolve_remote_auth_token_from(&None, |name| {
             assert_eq!(name, AUTH_TOKEN_ENV);
             Some("environment-token".to_owned())

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -313,7 +313,8 @@ impl RemoteTarget {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_remote_auth_token_from;
+    use super::{resolve_remote_auth_token_from, RemoteTarget};
+    use loonfs_api::env::AUTH_TOKEN_ENV;
     use loonfs_api::SecretString;
 
     #[test]
@@ -332,5 +333,25 @@ mod tests {
         );
 
         assert!(resolve_remote_auth_token_from(&None, |_| Some("  ".to_owned())).is_none());
+    }
+
+    #[test]
+    fn environment_token_is_rejected_when_client_construction_sees_non_loopback_http() {
+        let auth_token = resolve_remote_auth_token_from(&None, |name| {
+            assert_eq!(name, AUTH_TOKEN_ENV);
+            Some("environment-token".to_owned())
+        });
+        let error = RemoteTarget::new("http://example.internal", auth_token, None, false)
+            .err()
+            .expect("environment token over non-loopback plaintext HTTP should be rejected");
+
+        assert_eq!(error.code, "invalid_config");
+        assert!(
+            error
+                .message
+                .contains("bearer tokens require https except for loopback http URLs"),
+            "{}",
+            error.message
+        );
     }
 }

--- a/crates/loonfs-cli/tests/it/profile.rs
+++ b/crates/loonfs-cli/tests/it/profile.rs
@@ -1076,7 +1076,7 @@ fn invalid_remote_urls_are_rejected() {
 }
 
 #[test]
-fn profile_create_rejects_a_token_over_non_loopback_plaintext_before_writing() {
+fn profile_create_rejects_token_over_non_loopback_http_before_writing() {
     let harness = Harness::new();
     let create = harness.run(&[
         "--json",

--- a/crates/loonfs-cli/tests/it/profile.rs
+++ b/crates/loonfs-cli/tests/it/profile.rs
@@ -1076,6 +1076,34 @@ fn invalid_remote_urls_are_rejected() {
 }
 
 #[test]
+fn profile_create_rejects_a_token_over_non_loopback_plaintext_before_writing() {
+    let harness = Harness::new();
+    let create = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "remote",
+        "default",
+        "--server-url",
+        "http://example.internal",
+        "--auth-token",
+        "test-token",
+    ]);
+
+    assert_failure(&create);
+    let error = json_error(&create);
+    assert_eq!(error["code"], "invalid_config");
+    assert!(error["message"]
+        .as_str()
+        .expect("json string")
+        .contains("bearer tokens require https except for loopback http URLs"));
+    assert!(
+        !harness.config_path.exists(),
+        "unsafe profile must be rejected before creating the config file"
+    );
+}
+
+#[test]
 fn external_remote_profile_executes_through_http() {
     let harness = Harness::new();
     let remote_server =

--- a/crates/loonfs-client/src/config.rs
+++ b/crates/loonfs-client/src/config.rs
@@ -211,9 +211,11 @@ mod tests {
             "http://127.8.9.10",
             "http://[::1]",
         ] {
-            config(server_url, Some("test-token"))
-                .validate()
-                .unwrap_or_else(|error| panic!("{server_url} should be accepted: {error}"));
+            let result = config(server_url, Some("test-token")).validate();
+            assert!(
+                result.is_ok(),
+                "{server_url} should be accepted: {result:?}"
+            );
         }
     }
 

--- a/crates/loonfs-client/src/config.rs
+++ b/crates/loonfs-client/src/config.rs
@@ -6,6 +6,7 @@ use http::Uri;
 use loonfs_api::SecretString;
 use serde::Deserialize;
 use std::fs;
+use std::net::IpAddr;
 use std::path::Path;
 
 /// Client configuration loaded from TOML or built by the caller.
@@ -65,12 +66,18 @@ impl ClientConfig {
     /// [`Client::new`](crate::Client::new) both run this, so a file-loaded
     /// config and a directly built one cannot diverge in what they accept.
     pub fn validate(&self) -> Result<()> {
-        validate_absolute_http_url("server_url", &self.server_url)?;
+        let server_uri = validate_absolute_http_url("server_url", &self.server_url)?;
         if let Some(token) = &self.auth_token {
             if token.is_blank() {
                 return Err(ClientError::ConfigValidation {
                     field: "auth_token",
                     reason: "must not be empty".to_owned(),
+                });
+            }
+            if server_uri.scheme_str() == Some("http") && !is_literal_loopback_host(&server_uri) {
+                return Err(ClientError::ConfigValidation {
+                    field: "server_url",
+                    reason: "bearer tokens require https except for loopback http URLs".to_owned(),
                 });
             }
         }
@@ -121,7 +128,7 @@ impl ClientConfig {
     }
 }
 
-fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<()> {
+fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<Uri> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Err(ClientError::MissingConfigField { field });
@@ -158,5 +165,81 @@ fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<()> {
         });
     }
 
-    Ok(())
+    Ok(uri)
+}
+
+fn is_literal_loopback_host(uri: &Uri) -> bool {
+    let Some(host) = uri.host() else {
+        return false;
+    };
+    if host
+        .strip_suffix('.')
+        .unwrap_or(host)
+        .eq_ignore_ascii_case("localhost")
+    {
+        return true;
+    }
+    let host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(server_url: &str, auth_token: Option<&str>) -> ClientConfig {
+        ClientConfig {
+            server_url: server_url.to_owned(),
+            auth_token: auth_token.map(SecretString::from),
+            request_timeout_ms: None,
+            disable_transient_retry: false,
+            ca_cert_path: None,
+        }
+    }
+
+    #[test]
+    fn bearer_tokens_are_allowed_over_https_and_literal_loopback_http() {
+        for server_url in [
+            "https://example.internal",
+            "http://localhost",
+            "http://LOCALHOST",
+            "http://localhost.",
+            "http://127.0.0.1",
+            "http://127.8.9.10",
+            "http://[::1]",
+        ] {
+            config(server_url, Some("test-token"))
+                .validate()
+                .unwrap_or_else(|error| panic!("{server_url} should be accepted: {error}"));
+        }
+    }
+
+    #[test]
+    fn bearer_tokens_are_rejected_over_non_loopback_http() {
+        for server_url in ["http://example.internal", "http://192.0.2.1"] {
+            let error = config(server_url, Some("test-token"))
+                .validate()
+                .expect_err("non-loopback plaintext URL should be rejected");
+            assert!(
+                matches!(
+                    error,
+                    ClientError::ConfigValidation {
+                        field: "server_url",
+                        ref reason,
+                    } if reason == "bearer tokens require https except for loopback http URLs"
+                ),
+                "unexpected validation error for {server_url}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn plaintext_http_without_a_bearer_token_is_allowed() {
+        config("http://example.internal", None)
+            .validate()
+            .expect("unauthenticated plaintext deployments remain supported");
+    }
 }

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -452,7 +452,7 @@ mod tests {
     fn client_and_config_debug_redact_the_auth_token() {
         let raw_token = "client-debug-secret";
         let config = ClientConfig {
-            server_url: "http://example.com".to_owned(),
+            server_url: "https://example.com".to_owned(),
             auth_token: Some(raw_token.into()),
             request_timeout_ms: None,
             disable_transient_retry: false,

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -9,8 +9,12 @@ use loonfs_api::{
     ApiError, CommitId, ErrorCode, ErrorDetails, ErrorKind, NamespaceId, NamespaceIdValidationError,
 };
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct ServedErrorCode(pub(super) ErrorCode);
+
 pub(super) struct ApiResponseError {
     status: StatusCode,
+    code: ErrorCode,
     body: Box<ApiError>,
     /// Emitted as a `Retry-After` header, for retryable capacity errors.
     retry_after_seconds: Option<u32>,
@@ -20,6 +24,7 @@ impl ApiResponseError {
     pub(super) fn new(status: StatusCode, code: ErrorCode, message: &str) -> Self {
         let response = Self {
             status,
+            code,
             body: Box::new(ApiError {
                 code: code.as_str().to_owned(),
                 feature: None,
@@ -38,18 +43,13 @@ impl ApiResponseError {
     }
 
     pub(super) fn not_supported(feature: &str, message: &str) -> Self {
-        Self {
-            status: StatusCode::NOT_IMPLEMENTED,
-            body: Box::new(ApiError {
-                code: ErrorCode::NotSupported.as_str().to_owned(),
-                feature: Some(feature.to_owned()),
-                message: message.to_owned(),
-                param: None,
-                request_id: None,
-                details: None,
-            }),
-            retry_after_seconds: None,
-        }
+        let mut response = Self::new(
+            StatusCode::NOT_IMPLEMENTED,
+            ErrorCode::NotSupported,
+            message,
+        );
+        response.body.feature = Some(feature.to_owned());
+        response
     }
 
     /// Stamps a `Retry-After` hint onto the response, HTTP's native shape
@@ -165,6 +165,7 @@ impl IntoResponse for ApiResponseError {
         // directly) simply omits it.
         self.body.request_id = super::REQUEST_ID.try_with(|id| id.clone()).ok();
         let mut response = (self.status, Json(self.body)).into_response();
+        response.extensions_mut().insert(ServedErrorCode(self.code));
         if let Some(seconds) = self.retry_after_seconds {
             if let Ok(value) = axum::http::HeaderValue::from_str(&seconds.to_string()) {
                 response
@@ -186,6 +187,11 @@ mod tests {
             let response =
                 ApiResponseError::new(status_for_core_error_code(code), code, "test response")
                     .into_response();
+            assert_eq!(
+                response.extensions().get::<ServedErrorCode>(),
+                Some(&ServedErrorCode(code)),
+                "response extension lost {code}"
+            );
             let retry_after = response
                 .headers()
                 .get(axum::http::header::RETRY_AFTER)
@@ -193,5 +199,15 @@ mod tests {
             let expected = code.retryable_without_operator_action().then_some("1");
             assert_eq!(retry_after, expected, "unexpected Retry-After for {code}");
         }
+    }
+
+    #[test]
+    fn not_supported_response_keeps_its_typed_code_extension() {
+        let response =
+            ApiResponseError::not_supported("test.feature", "not available").into_response();
+        assert_eq!(
+            response.extensions().get::<ServedErrorCode>(),
+            Some(&ServedErrorCode(ErrorCode::NotSupported))
+        );
     }
 }

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -30,7 +30,7 @@ pub use self::serve::{
 };
 pub use self::tls::TlsConfigError;
 
-use self::error::ApiResponseError;
+use self::error::{ApiResponseError, ServedErrorCode};
 use self::extractors::{
     authorize, server_busy_error, AppJson, AppPath, AppQuery, NamespaceIdPath, OptionalAppJson,
     UploadBodyBytes, UploadBodyStream, UploadControlJson, MAX_COMPLETION_BODY_BYTES,
@@ -73,6 +73,7 @@ use axum::Router;
 use loonfs::ErrorCode;
 #[cfg(test)]
 use loonfs::SharedObjectStore;
+use loonfs_api::ErrorKind;
 
 /// Response header carrying the request's correlation id.
 const REQUEST_ID_HEADER: &str = "x-request-id";
@@ -96,6 +97,13 @@ macro_rules! request_completion_event {
             "request completed"
         )
     };
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RequestLogSeverity {
+    Error,
+    Warn,
+    Debug,
 }
 
 // Membership is limited to streamed content and operator work that is long by design.
@@ -161,6 +169,10 @@ async fn with_request_observability(
     let started = request_clock();
     let response = next.run(request).await;
     let status = response.status();
+    let severity = request_log_severity(
+        status,
+        response.extensions().get::<ServedErrorCode>().copied(),
+    );
     let route = state.metrics.request_served(
         matched_route.as_ref().map(MatchedPath::as_str),
         &method,
@@ -168,16 +180,52 @@ async fn with_request_observability(
         started.elapsed().as_secs_f64(),
     );
 
-    REQUEST_ID.with(|request_id| match status {
-        status if status.is_server_error() => {
+    REQUEST_ID.with(|request_id| match severity {
+        RequestLogSeverity::Error => {
             request_completion_event!(error, method, route, status, started, request_id)
         }
-        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+        RequestLogSeverity::Warn => {
             request_completion_event!(warn, method, route, status, started, request_id)
         }
-        _ => request_completion_event!(debug, method, route, status, started, request_id),
+        RequestLogSeverity::Debug => {
+            request_completion_event!(debug, method, route, status, started, request_id)
+        }
     });
     response
+}
+
+fn request_log_severity(
+    status: StatusCode,
+    served_error_code: Option<ServedErrorCode>,
+) -> RequestLogSeverity {
+    let Some(ServedErrorCode(code)) = served_error_code else {
+        return fallback_request_log_severity(status);
+    };
+    match code.kind() {
+        ErrorKind::Internal | ErrorKind::DataCorruption => RequestLogSeverity::Error,
+        ErrorKind::Unauthorized
+        | ErrorKind::PermissionDenied
+        | ErrorKind::Unavailable
+        | ErrorKind::DeadlineExceeded
+        | ErrorKind::OutcomeUnknown => RequestLogSeverity::Warn,
+        ErrorKind::InvalidRequest
+        | ErrorKind::ContentTooLarge
+        | ErrorKind::NotSupported
+        | ErrorKind::NotFound
+        | ErrorKind::MethodNotAllowed
+        | ErrorKind::Gone
+        | ErrorKind::AlreadyExists
+        | ErrorKind::Conflict => RequestLogSeverity::Debug,
+        _ => fallback_request_log_severity(status),
+    }
+}
+
+fn fallback_request_log_severity(status: StatusCode) -> RequestLogSeverity {
+    match status {
+        status if status.is_server_error() => RequestLogSeverity::Error,
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => RequestLogSeverity::Warn,
+        _ => RequestLogSeverity::Debug,
+    }
 }
 
 #[allow(clippy::disallowed_methods)]

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1,15 +1,16 @@
 #![allow(clippy::panic)]
 // HTTP smoke helpers panic in unexpected match arms for precise diagnostics.
 
-use super::error::status_for_core_error_code;
+use super::error::{status_for_core_error_code, ServedErrorCode};
 use super::{
-    app_with_store, app_with_store_and_state, build_handles_with_metrics_jsonl_path, AppState,
-    SharedObjectStore,
+    app_with_store, app_with_store_and_state, build_handles_with_metrics_jsonl_path,
+    request_log_severity, AppState, RequestLogSeverity, SharedObjectStore,
 };
 use crate::config::RuntimeCacheConfigOverrides;
 use crate::{ServerConfig, StoreConfig};
 use async_trait::async_trait;
 use axum::body::Bytes;
+use axum::http::StatusCode;
 use futures::stream::{BoxStream, StreamExt};
 use loonfs::{
     CreateNamespaceOptions, DeleteOptions, FsAdmin, FsReader, FsWriter, MaintenanceJob,
@@ -227,6 +228,47 @@ fn error_status_mapping_matches_the_api_spec_table() {
         "api.md documents codes this build does not register: {documented:?}"
     );
     assert_api_spec_error_codes_are_registered(&spec);
+}
+
+#[test]
+fn request_log_severity_uses_typed_codes_and_status_only_as_a_fallback() {
+    assert_eq!(
+        request_log_severity(
+            StatusCode::NOT_IMPLEMENTED,
+            Some(ServedErrorCode(ErrorCode::NotSupported)),
+        ),
+        RequestLogSeverity::Debug
+    );
+    assert_eq!(
+        request_log_severity(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Some(ServedErrorCode(ErrorCode::ServerError)),
+        ),
+        RequestLogSeverity::Error
+    );
+    assert_eq!(
+        request_log_severity(
+            StatusCode::SERVICE_UNAVAILABLE,
+            Some(ServedErrorCode(ErrorCode::ServerBusy)),
+        ),
+        RequestLogSeverity::Warn
+    );
+    assert_eq!(
+        request_log_severity(StatusCode::NOT_IMPLEMENTED, None),
+        RequestLogSeverity::Error
+    );
+    assert_eq!(
+        request_log_severity(StatusCode::UNAUTHORIZED, None),
+        RequestLogSeverity::Warn
+    );
+    assert_eq!(
+        request_log_severity(StatusCode::FORBIDDEN, None),
+        RequestLogSeverity::Warn
+    );
+    assert_eq!(
+        request_log_severity(StatusCode::NOT_FOUND, None),
+        RequestLogSeverity::Debug
+    );
 }
 
 #[test]

--- a/crates/loonfs-server/tests/logging.rs
+++ b/crates/loonfs-server/tests/logging.rs
@@ -7,14 +7,17 @@
 mod common;
 
 use axum::body::{to_bytes, Body};
-use axum::http::Request;
+use axum::http::{Method, Request};
 use axum::Router;
+use bytes::Bytes;
 use common::http_split_support::test_config;
 use loonfs::{CreateNamespaceOptions, FsWriter, SharedObjectStore, TraceMode, TraceStoreKind};
+use loonfs_api::v0::BeginUploadRequest;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_server::{app, app_with_store, MaintenanceMode};
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{FailStore, InjectedError, KeyPredicate, OperationClass};
+use std::convert::Infallible;
 use std::fmt;
 use std::sync::{Arc, Mutex, OnceLock};
 use tower::ServiceExt as _;
@@ -31,6 +34,10 @@ struct CapturedEvent {
     target: String,
     message: Option<String>,
     request_id: Option<String>,
+    method: Option<String>,
+    route: Option<String>,
+    status: Option<u64>,
+    elapsed_ms: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -68,6 +75,10 @@ where
                 target: event.metadata().target().to_owned(),
                 message: fields.message,
                 request_id: fields.request_id,
+                method: fields.method,
+                route: fields.route,
+                status: fields.status,
+                elapsed_ms: fields.elapsed_ms,
             });
     }
 }
@@ -76,6 +87,10 @@ where
 struct CapturedFields {
     message: Option<String>,
     request_id: Option<String>,
+    method: Option<String>,
+    route: Option<String>,
+    status: Option<u64>,
+    elapsed_ms: Option<u64>,
 }
 
 impl CapturedFields {
@@ -83,6 +98,8 @@ impl CapturedFields {
         match field.name() {
             "message" => self.message = Some(value),
             "request_id" => self.request_id = Some(value),
+            "method" => self.method = Some(value),
+            "route" => self.route = Some(value),
             _ => {}
         }
     }
@@ -95,6 +112,14 @@ impl Visit for CapturedFields {
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         self.record(field, format!("{value:?}").trim_matches('"').to_owned());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "status" => self.status = Some(value),
+            "elapsed_ms" => self.elapsed_ms = Some(value),
+            _ => {}
+        }
     }
 }
 
@@ -114,15 +139,30 @@ fn capture() -> &'static Capture {
 }
 
 async fn request_error(router: &Router, uri: &str) -> (u16, loonfs_api::ApiError, String) {
+    request_error_with(
+        router,
+        Method::GET,
+        uri,
+        Some("Bearer test-token"),
+        Body::empty(),
+    )
+    .await
+}
+
+async fn request_error_with(
+    router: &Router,
+    method: Method,
+    uri: &str,
+    authorization: Option<&str>,
+    body: Body,
+) -> (u16, loonfs_api::ApiError, String) {
+    let mut request = Request::builder().method(method).uri(uri);
+    if let Some(authorization) = authorization {
+        request = request.header("authorization", authorization);
+    }
     let response = router
         .clone()
-        .oneshot(
-            Request::builder()
-                .uri(uri)
-                .header("authorization", "Bearer test-token")
-                .body(Body::empty())
-                .expect("request"),
-        )
+        .oneshot(request.body(body).expect("request"))
         .await
         .expect("route request");
     let status = response.status().as_u16();
@@ -139,6 +179,20 @@ async fn request_error(router: &Router, uri: &str) -> (u16, loonfs_api::ApiError
     let body = serde_json::from_slice::<loonfs_api::ApiError>(&bytes).expect("API error body");
     assert_eq!(body.request_id.as_deref(), Some(request_id.as_str()));
     (status, body, request_id)
+}
+
+fn assert_completion_fields(
+    event: &CapturedEvent,
+    request_id: &str,
+    method: &str,
+    route: &str,
+    status: u64,
+) {
+    assert_eq!(event.request_id.as_deref(), Some(request_id));
+    assert_eq!(event.method.as_deref(), Some(method));
+    assert_eq!(event.route.as_deref(), Some(route));
+    assert_eq!(event.status, Some(status));
+    assert!(event.elapsed_ms.is_some(), "missing elapsed_ms: {event:#?}");
 }
 
 fn completion_events<'a>(events: &'a [CapturedEvent], request_id: &str) -> Vec<&'a CapturedEvent> {
@@ -195,6 +249,119 @@ async fn missing_path_has_one_debug_completion_and_no_errors() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expected_typed_errors_use_debug_or_warn_and_keep_completion_fields() {
+    let capture = capture();
+    let _test_guard = capture.test_lock.lock().await;
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let mut config = test_config(
+        temp_dir.path().join("store"),
+        "logging-expected-errors",
+        "logging-expected-errors",
+    );
+    config.maintenance = MaintenanceMode::Manual;
+    config.max_concurrent_uploads = 1;
+    let (router, writer, _local_cache) = app(config).await.expect("build app");
+    let namespace = namespace_id("demo");
+    writer
+        .create_namespace(&namespace, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let upload = writer
+        .begin_upload(&namespace, BeginUploadRequest::ServiceProxied {})
+        .await
+        .expect("begin upload");
+
+    capture.clear();
+    let (status, body, request_id) =
+        request_error(&router, "/v0/namespaces/demo/query/grep?pattern=x").await;
+    assert_eq!(status, 501);
+    assert_eq!(body.code, "not_supported");
+    let events = capture.snapshot();
+    assert!(
+        events.iter().all(|event| event.level != Level::ERROR),
+        "not_supported emitted ERROR events: {events:#?}"
+    );
+    let completions = completion_events(&events, &request_id);
+    assert_eq!(completions.len(), 1, "completion events: {events:#?}");
+    assert_eq!(completions[0].level, Level::DEBUG);
+    assert_completion_fields(
+        completions[0],
+        &request_id,
+        "GET",
+        "/v0/namespaces/{namespace_id}/query/grep",
+        501,
+    );
+
+    capture.clear();
+    let (status, body, request_id) = request_error_with(
+        &router,
+        Method::GET,
+        "/v0/namespaces/demo",
+        None,
+        Body::empty(),
+    )
+    .await;
+    assert_eq!(status, 401);
+    assert_eq!(body.code, "unauthorized");
+    let events = capture.snapshot();
+    let completions = completion_events(&events, &request_id);
+    assert_eq!(completions.len(), 1, "completion events: {events:#?}");
+    assert_eq!(completions[0].level, Level::WARN);
+    assert_completion_fields(
+        completions[0],
+        &request_id,
+        "GET",
+        "/v0/namespaces/{namespace_id}",
+        401,
+    );
+
+    let (body_polled_tx, body_polled_rx) = tokio::sync::oneshot::channel();
+    let stalled_body = Body::from_stream(futures::stream::once(async move {
+        let _ = body_polled_tx.send(());
+        std::future::pending::<Result<Bytes, Infallible>>().await
+    }));
+    let upload_uri = format!("/v0/namespaces/demo/uploads/{}/content", upload.upload_id());
+    let stalled_request = Request::builder()
+        .method(Method::PUT)
+        .uri(&upload_uri)
+        .header("authorization", "Bearer test-token")
+        .body(stalled_body)
+        .expect("stalled upload request");
+    let stalled_upload = tokio::spawn(router.clone().oneshot(stalled_request));
+    tokio::time::timeout(std::time::Duration::from_secs(5), body_polled_rx)
+        .await
+        .expect("stalled body should be polled after taking the upload permit")
+        .expect("body poll notification");
+
+    capture.clear();
+    let (status, body, request_id) = request_error_with(
+        &router,
+        Method::PUT,
+        &upload_uri,
+        Some("Bearer test-token"),
+        Body::empty(),
+    )
+    .await;
+    assert_eq!(status, 503);
+    assert_eq!(body.code, "server_busy");
+    let events = capture.snapshot();
+    let completions = completion_events(&events, &request_id);
+    assert_eq!(completions.len(), 1, "completion events: {events:#?}");
+    assert_eq!(completions[0].level, Level::WARN);
+    assert_completion_fields(
+        completions[0],
+        &request_id,
+        "PUT",
+        "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content",
+        503,
+    );
+
+    stalled_upload.abort();
+    let _ = stalled_upload.await;
+    writer.shutdown().await.expect("shutdown writer");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn store_fault_has_one_error_from_the_boundary() {
     let capture = capture();
     let _test_guard = capture.test_lock.lock().await;
@@ -232,8 +399,9 @@ async fn store_fault_has_one_error_from_the_boundary() {
     failing.fail_all();
     let router = app_with_store(config, store).await.expect("build app");
     capture.clear();
-    let (status, _body, request_id) = request_error(&router, "/v0/namespaces/faulty").await;
+    let (status, body, request_id) = request_error(&router, "/v0/namespaces/faulty").await;
     assert_eq!(status, 500);
+    assert_eq!(body.code, "server_error");
 
     let events = capture.snapshot();
     let errors: Vec<_> = events
@@ -245,6 +413,13 @@ async fn store_fault_has_one_error_from_the_boundary() {
     assert_eq!(errors[0].message.as_deref(), Some(COMPLETION_MESSAGE));
     assert_eq!(errors[0].request_id.as_deref(), Some(request_id.as_str()));
     assert_eq!(completion_events(&events, &request_id).len(), 1);
+    assert_completion_fields(
+        errors[0],
+        &request_id,
+        "GET",
+        "/v0/namespaces/{namespace_id}",
+        500,
+    );
 
     drop(router);
 }


### PR DESCRIPTION
This prevents the client and CLI from sending bearer tokens over plaintext HTTP except to localhost and literal loopback IP addresses. HTTPS remains allowed, and plaintext HTTP remains available when no token is configured. Profile creation and updates validate the final configuration before writing it.

The server now chooses the request completion log level from the typed API error code instead of relying only on the HTTP status. Internal and corruption errors log as errors, temporary and authorization failures log as warnings, and expected request failures such as not_supported and not_found log at debug. Response bodies and metrics are unchanged.

Client, CLI, server, and integration tests cover accepted and rejected URLs, profile validation, environment tokens, and request log levels.