### PR TITLE
fix(cli): grammar, error parity, recursive transfers, and docs

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -168,11 +168,12 @@ Namespace management
 
 Pagination
   ls, grep, revisions, trash, changes, and admin checkpoint list return one
-  page by default. --limit sets the maximum number of results, --page-size
-  controls each request, and --cursor resumes a previous result. --all keeps
-  fetching until no pages remain or the limit is reached. --jsonl does the
-  same while writing one result per line. changes uses --after instead of
-  --cursor.
+  page by default. --limit sets the total maximum across pages, --page-size
+  controls each request, and --cursor resumes a previous result. --all is the
+  unbounded human form. Ordinary JSON is always bounded: one page by default
+  or the total set by --limit. --all cannot be combined with --json. --jsonl
+  is the unbounded machine form and writes one result per line. changes uses
+  --after instead of --cursor.
 
 Reading
   loonfs ls [path] [--limit <n>] [--page-size <n>] [--cursor <cursor>]

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -229,11 +229,18 @@ Writing
                          [--actor-kind <kind> --actor-id <id>]
     Write and remove attributes on a file or directory. --set takes
     key=value and splits on the first `=`, --remove takes a key, and both
-    repeat. A list value needs --attributes-json, which takes the whole
-    update as {"set": {...}, "remove": [...]} in the wire encoding and
-    cannot be combined with --set or --remove. The two --expected flags
-    refuse the update when the path has been rebound or the attributes have
-    moved on
+    repeat. Attribute values are strings. --attributes-json takes the whole
+    update document as {"set": {...}, "remove": [...]}, but values inside
+    set are still strings. Arrays, objects, numbers, booleans, and null are
+    rejected. To store serialized JSON, pass it as a string value.
+
+      loonfs annotate /docs/report.csv --set owner=ada
+      loonfs annotate /docs/report.csv --attributes-json \
+        '{"set":{"tags":"[\"red\",\"blue\"]"}}'
+
+    --attributes-json cannot be combined with --set or --remove. The two
+    --expected flags refuse the update when the path has been rebound or the
+    attributes have moved on
 
   loonfs rm <path> [-r] [--actor-kind <kind> --actor-id <id>]
     Delete a file, or with -r a directory and everything under it as one

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -192,8 +192,9 @@ Reading
 
   loonfs get <remote-path> [local-destination] [-r] [--revision <n>] [--force]
     Download one file, or with -r the directory tree rooted at the remote
-    path; --force overwrites the local destination and --revision downloads
-    an older revision of one file
+    path. A recursive destination is the exact root for the downloaded
+    contents. Reruns are no-clobber by default, --force rewrites existing
+    files, and --revision downloads an older revision of one file
 
   loonfs grep <pattern> [--path-prefix <path>] [-i] [--limit <n>]
                         [--page-size <n>] [--cursor <cursor>] [--all] [--jsonl]
@@ -584,10 +585,23 @@ Behavior notes
   larger than this process could hold costs no more memory than a tree of
   small ones
 
-  If `loonfs get` omits the local destination, the CLI writes to `./<remote-filename>`
+  If a one-file `loonfs get` omits the local destination, the CLI writes to
+  `./<remote-filename>`
 
-  A local destination that ends in `/` or is an existing directory means the
-  download lands inside it under its remote name
+  For one file, a local destination that ends in `/` or is an existing
+  directory means the download lands inside it under its remote name
+
+  A recursive get writes into the exact destination root.
+
+    loonfs get -r /reports ./download
+
+  This writes the contents directly under `./download`. It never writes
+  under `./download/reports`.
+
+    loonfs get -r /reports
+
+  This derives `./reports`. Reruns are no-clobber by default, and --force
+  rewrites existing files
 
   `loonfs get` refuses to overwrite an existing local file without --force,
   and writes through a partial file beside the target, so an interrupted

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -169,10 +169,9 @@ Namespace management
 Pagination
   ls, grep, revisions, trash, changes, and admin checkpoint list return one
   page by default. --limit sets the total maximum across pages, --page-size
-  controls each request, and --cursor resumes a previous result. --all is the
-  unbounded human form. Ordinary JSON is always bounded: one page by default
-  or the total set by --limit. --all cannot be combined with --json. --jsonl
-  is the unbounded machine form and writes one result per line. changes uses
+  controls each request, and --cursor resumes a previous result. --all fetches
+  every page for human output. --json returns a bounded document and cannot be
+  combined with --all. Use --jsonl to stream every result. changes uses
   --after instead of --cursor.
 
 Reading
@@ -181,20 +180,19 @@ Reading
     List the entries of a directory, or `/` when the path is omitted
 
   loonfs stat <path>
-    Describe one path: kind, size, revision, content digest, and the
-    inode's attributes as `attr.<key>` lines. Control characters in a
-    value print escaped, so a value stays on its own line; --json carries
-    the value itself
+  loonfs stat --inode <inode-id>
+    Describe a path or visible inode. The output includes its kind, size,
+    revision, content digest, and attributes
 
   loonfs cat <path> [--revision <n>]
     Print a file's bytes to stdout; --revision prints that revision instead
     of the current content
 
   loonfs get <remote-path> [local-destination] [-r] [--revision <n>] [--force]
-    Download one file, or with -r the directory tree rooted at the remote
-    path. A recursive destination is the exact root for the downloaded
-    contents. Reruns are no-clobber by default, --force rewrites existing
-    files, and --revision downloads an older revision of one file
+    Download one file, or use -r to download a directory. For recursive
+    downloads, the local destination is the root of the downloaded contents.
+    Existing files are not overwritten unless --force is set. --revision
+    downloads an older revision of one file
 
   loonfs grep <pattern> [--path-prefix <path>] [-i] [--limit <n>]
                         [--page-size <n>] [--cursor <cursor>] [--all] [--jsonl]
@@ -229,19 +227,18 @@ Writing
                          [--expected-attributes-revision <n>]
                          [--actor-kind <kind> --actor-id <id>]
     Write and remove attributes on a file or directory. --set takes
-    key=value and splits on the first `=`, --remove takes a key, and both
-    repeat. Attribute values are strings. --attributes-json takes the whole
-    update document as {"set": {...}, "remove": [...]}, but values inside
-    set are still strings. Arrays, objects, numbers, booleans, and null are
-    rejected. To store serialized JSON, pass it as a string value.
+    key=value and splits on the first `=`, --remove takes a key, and both can
+    be repeated. Attribute values must be strings. --attributes-json accepts
+    an update document in the form {"set": {...}, "remove": [...]}. Values
+    inside set must also be strings. To store JSON data, serialize it as a
+    string.
 
       loonfs annotate /docs/report.csv --set owner=ada
       loonfs annotate /docs/report.csv --attributes-json \
         '{"set":{"tags":"[\"red\",\"blue\"]"}}'
 
-    --attributes-json cannot be combined with --set or --remove. The two
-    --expected flags refuse the update when the path has been rebound or the
-    attributes have moved on
+    --attributes-json cannot be combined with --set or --remove. The expected
+    value flags reject the update if the inode or attributes changed
 
   loonfs rm <path> [-r] [--actor-kind <kind> --actor-id <id>]
     Delete a file, or with -r a directory and everything under it as one
@@ -585,40 +582,26 @@ Behavior notes
   larger than this process could hold costs no more memory than a tree of
   small ones
 
-  If a one-file `loonfs get` omits the local destination, the CLI writes to
-  `./<remote-filename>`
+  If a single-file `loonfs get` omits the local destination, the CLI writes to
+  `./<remote-filename>`. If the destination ends in `/` or is an existing
+  directory, the file is written there under its remote name
 
-  For one file, a local destination that ends in `/` or is an existing
-  directory means the download lands inside it under its remote name
-
-  A recursive get writes into the exact destination root.
+  A recursive get writes the directory contents directly into the destination:
 
     loonfs get -r /reports ./download
 
-  This writes the contents directly under `./download`. It never writes
-  under `./download/reports`.
+  This writes the contents of `/reports` under `./download`, not
+  `./download/reports`. If the destination is omitted, the CLI uses the remote
+  directory name:
 
     loonfs get -r /reports
 
-  This derives `./reports`. Reruns are no-clobber by default, and --force
-  rewrites existing files
+  Existing files are not overwritten unless --force is set. Downloads stream
+  without buffering the entire file. The CLI writes to a temporary file and
+  moves it into place after verification, so a failed download does not leave
+  a partial destination. When streaming to stdout with `-`, written bytes
+  cannot be taken back; check the exit status to confirm verification
 
-  `loonfs get` refuses to overwrite an existing local file without --force,
-  and writes through a partial file beside the target, so an interrupted
-  download leaves nothing truncated at the target itself
-
-  `loonfs get` writes a large file as it arrives and never holds it whole, so
-  what it costs in memory follows the transfer and not the file's size; an
-  embedded profile reads its own store in chunks, while a remote profile
-  streams files past the server's proxy cap directly from object storage and
-  receives smaller files in one proxied response
-
-  A file destination is renamed into place only once the download is complete
-  and its content verified, so content that fails verification leaves nothing
-  at the destination. `loonfs get ... -` hands bytes to stdout as they
-  arrive, so the same failure exits nonzero after part of the file has
-  already been written — with `-`, the exit status is what says the content
-  was verified
   A recursive put, get, or cp works file by file with bounded concurrency,
   so a partial failure reruns per file; --commit-id names one commit, so
   `put -r` and `cp -r` reject it, and `get -r` rejects --revision for the

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -65,6 +65,14 @@ pub(crate) struct Cli {
         value_hint = ValueHint::FilePath
     )]
     pub(crate) config: Option<PathBuf>,
+    /// Profile to run against. Precedence is `--profile`, `LOONFS_PROFILE`,
+    /// then the configured default profile.
+    #[arg(long, global = true, value_hint = ValueHint::Other)]
+    pub(crate) profile: Option<String>,
+    /// Namespace to run against. Precedence is `--namespace`,
+    /// `LOONFS_NAMESPACE`, then the profile default.
+    #[arg(long, global = true, value_hint = ValueHint::Other)]
+    pub(crate) namespace: Option<String>,
     /// Emit machine-readable JSON instead of human output.
     #[arg(long, global = true)]
     pub(crate) json: bool,
@@ -83,6 +91,12 @@ pub(crate) struct Cli {
 }
 
 pub(crate) fn validate_cli(cli: &Cli) -> Result<(), clap::Error> {
+    if cli.profile.is_some() && !cli.command.accepts_profile_selector() {
+        return Err(selector_not_accepted("--profile"));
+    }
+    if cli.namespace.is_some() && !cli.command.accepts_namespace_selector() {
+        return Err(selector_not_accepted("--namespace"));
+    }
     let Some(pagination) = cli.command.pagination() else {
         return Ok(());
     };
@@ -109,6 +123,18 @@ pub(crate) fn validate_cli(cli: &Cli) -> Result<(), clap::Error> {
         return Err(error);
     }
     Ok(())
+}
+
+fn selector_not_accepted(selector: &str) -> clap::Error {
+    let mut error = Cli::command().error(
+        clap::error::ErrorKind::ArgumentConflict,
+        format!("the argument '{selector}' cannot be used with this command"),
+    );
+    error.insert(
+        clap::error::ContextKind::InvalidArg,
+        clap::error::ContextValue::String(selector.to_owned()),
+    );
+    error
 }
 
 #[derive(Debug, Subcommand)]
@@ -185,6 +211,52 @@ pub(crate) enum Command {
 }
 
 impl Command {
+    fn accepts_profile_selector(&self) -> bool {
+        !matches!(
+            self,
+            Self::Init
+                | Self::Profile { .. }
+                | Self::Config { .. }
+                | Self::Completion(_)
+                | Self::Version
+        )
+    }
+
+    fn accepts_namespace_selector(&self) -> bool {
+        matches!(
+            self,
+            Self::Namespace {
+                command: NamespaceCommand::Show(_),
+            } | Self::Ls(_)
+                | Self::Stat(_)
+                | Self::Annotate(_)
+                | Self::Cat(_)
+                | Self::Grep(_)
+                | Self::Get(_)
+                | Self::Put(_)
+                | Self::Revisions(_)
+                | Self::Restore(_)
+                | Self::Undelete(_)
+                | Self::Mkdir(_)
+                | Self::Rm(_)
+                | Self::Mv(_)
+                | Self::Cp(_)
+                | Self::Trash(_)
+                | Self::Changes(_)
+                | Self::Doctor(_)
+                | Self::Admin {
+                    command: AdminCommand::Checkpoint { .. }
+                        | AdminCommand::Index { .. }
+                        | AdminCommand::Maintenance {
+                            command: AdminMaintenanceCommand::Step(_)
+                                | AdminMaintenanceCommand::Flush(_),
+                        }
+                        | AdminCommand::Retention { .. }
+                        | AdminCommand::Gc(_),
+                }
+        )
+    }
+
     fn pagination(&self) -> Option<&PaginationArgs> {
         match self {
             Self::Ls(args) => Some(&args.pagination),
@@ -466,9 +538,7 @@ pub(crate) struct ProfileUpdateArgs {
 
 #[derive(Debug, Args, Clone)]
 pub(crate) struct ProfileSelectorArgs {
-    /// Profile to run against. Precedence is `--profile`, `LOONFS_PROFILE`,
-    /// then the configured default profile.
-    #[arg(long, value_hint = ValueHint::Other)]
+    #[arg(from_global)]
     pub profile: Option<String>,
 }
 
@@ -482,9 +552,7 @@ pub(crate) struct RequestBehaviorArgs {
 pub(crate) struct TargetSelectorArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
-    /// Namespace to run against. Precedence is `--namespace`,
-    /// `LOONFS_NAMESPACE`, then the profile default.
-    #[arg(long, value_hint = ValueHint::Other)]
+    #[arg(from_global)]
     pub namespace: Option<String>,
     #[command(flatten)]
     pub request: RequestBehaviorArgs,
@@ -526,7 +594,7 @@ pub(crate) struct NamespaceUseArgs {
     #[command(flatten)]
     pub request: RequestBehaviorArgs,
     #[arg(value_hint = ValueHint::Other)]
-    pub namespace: String,
+    pub namespace_id: String,
 }
 
 #[derive(Debug, Args)]
@@ -1432,6 +1500,86 @@ mod tests {
     use super::*;
 
     #[test]
+    fn global_selectors_reach_leaf_arguments_from_every_position() {
+        let before_command = Cli::try_parse_from([
+            "loonfs",
+            "--profile",
+            "prod",
+            "--namespace",
+            "demo",
+            "ls",
+            "/",
+        ])
+        .expect("selectors before command");
+        assert_selected_target(&before_command, "prod", "demo");
+
+        let between_subcommands = Cli::try_parse_from([
+            "loonfs",
+            "admin",
+            "--profile",
+            "prod",
+            "checkpoint",
+            "--namespace",
+            "demo",
+            "list",
+        ])
+        .expect("selectors between subcommands");
+        assert_selected_target(&between_subcommands, "prod", "demo");
+
+        let after_leaf_arguments = Cli::try_parse_from([
+            "loonfs",
+            "ls",
+            "/",
+            "--profile",
+            "prod",
+            "--namespace",
+            "demo",
+        ])
+        .expect("selectors after leaf arguments");
+        assert_selected_target(&after_leaf_arguments, "prod", "demo");
+    }
+
+    #[test]
+    fn unused_global_selectors_are_rejected() {
+        let cases: &[(&[&str], &str)] = &[
+            (&["loonfs", "--namespace", "demo", "version"], "--namespace"),
+            (
+                &["loonfs", "--profile", "prod", "config", "path"],
+                "--profile",
+            ),
+            (
+                &["loonfs", "--namespace", "demo", "namespace", "create", "x"],
+                "--namespace",
+            ),
+            (&["loonfs", "use", "x", "--namespace", "y"], "--namespace"),
+        ];
+
+        for (arguments, selector) in cases {
+            let cli = Cli::try_parse_from(*arguments).expect("global selector parses once");
+            let error = validate_cli(&cli).expect_err("unused selector must fail");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+            assert!(error.to_string().contains(selector), "{error}");
+        }
+    }
+
+    fn assert_selected_target(cli: &Cli, profile: &str, namespace: &str) {
+        assert_eq!(cli.profile.as_deref(), Some(profile));
+        assert_eq!(cli.namespace.as_deref(), Some(namespace));
+        let target = match &cli.command {
+            Command::Ls(args) => &args.target,
+            Command::Admin {
+                command:
+                    AdminCommand::Checkpoint {
+                        command: AdminCheckpointCommand::List(args),
+                    },
+            } => &args.target,
+            command => panic!("expected command with selected target, got {command:?}"),
+        };
+        assert_eq!(target.profile.profile.as_deref(), Some(profile));
+        assert_eq!(target.namespace.as_deref(), Some(namespace));
+    }
+
+    #[test]
     fn every_paginated_listing_accepts_the_shared_flags() {
         let cases: &[&[&str]] = &[
             &[
@@ -1718,6 +1866,8 @@ mod tests {
         let command = Cli::command();
 
         assert_hint(&command, "config", ValueHint::FilePath);
+        assert_hint(&command, "profile", ValueHint::Other);
+        assert_hint(&command, "namespace", ValueHint::Other);
 
         let put = subcommand(&command, "put");
         assert_hint(put, "local_path", ValueHint::AnyPath);
@@ -1742,13 +1892,6 @@ mod tests {
         assert_hint(gcs, "service_account_key_path", ValueHint::FilePath);
         let namespace_show = subcommand(subcommand(&command, "namespace"), "show");
         assert_hint(namespace_show, "namespace_id", ValueHint::Other);
-
-        let capabilities = subcommand(&command, "capabilities");
-        assert_hint(capabilities, "profile", ValueHint::Other);
-
-        let doctor = subcommand(&command, "doctor");
-        assert_hint(doctor, "profile", ValueHint::Other);
-        assert_hint(doctor, "namespace", ValueHint::Other);
     }
 
     fn subcommand<'a>(command: &'a clap::Command, name: &str) -> &'a clap::Command {

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -111,10 +111,10 @@ pub(crate) fn validate_cli(cli: &Cli) -> Result<(), clap::Error> {
         );
         return Err(error);
     }
-    if cli.json && pagination.all && pagination.limit.is_none() {
+    if cli.json && pagination.all {
         let mut error = Cli::command().error(
             clap::error::ErrorKind::ArgumentConflict,
-            "'--all --json' requires '--limit'; use '--jsonl' to stream without a limit",
+            "--all cannot be used with --json; use --json --limit <n> for a bounded document or --jsonl to stream all results",
         );
         error.insert(
             clap::error::ContextKind::InvalidArg,
@@ -1670,21 +1670,38 @@ mod tests {
     }
 
     #[test]
-    fn unbounded_all_json_is_rejected_for_every_paginated_listing() {
+    fn all_json_is_rejected_for_every_paginated_listing() {
         let cases: &[&[&str]] = &[
-            &["loonfs", "--json", "ls", "--all"],
-            &["loonfs", "--json", "revisions", "/f", "--all"],
-            &["loonfs", "--json", "trash", "--all"],
-            &["loonfs", "--json", "changes", "--all"],
-            &["loonfs", "--json", "grep", "x", "--all"],
-            &["loonfs", "--json", "admin", "checkpoint", "list", "--all"],
+            &["loonfs", "--json", "ls", "--all", "--limit", "5"],
+            &[
+                "loonfs",
+                "--json",
+                "revisions",
+                "/f",
+                "--all",
+                "--limit",
+                "5",
+            ],
+            &["loonfs", "--json", "trash", "--all", "--limit", "5"],
+            &["loonfs", "--json", "changes", "--all", "--limit", "5"],
+            &["loonfs", "--json", "grep", "x", "--all", "--limit", "5"],
+            &[
+                "loonfs",
+                "--json",
+                "admin",
+                "checkpoint",
+                "list",
+                "--all",
+                "--limit",
+                "5",
+            ],
         ];
         for arguments in cases {
             let cli = Cli::try_parse_from(*arguments).expect("arguments parse");
-            let error = validate_cli(&cli).expect_err("unbounded JSON must fail");
-            assert!(error
-                .to_string()
-                .contains("use '--jsonl' to stream without a limit"));
+            let error = validate_cli(&cli).expect_err("--json --all must fail");
+            assert!(error.to_string().contains(
+                "--all cannot be used with --json; use --json --limit <n> for a bounded document or --jsonl to stream all results"
+            ));
         }
     }
 

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -871,29 +871,22 @@ pub(crate) struct FilesystemGetArgs {
     pub target: TargetSelectorArgs,
     #[arg(value_hint = ValueHint::Other)]
     pub remote_path: String,
-    /// Local destination (defaults to the remote basename). For one file,
-    /// `-` streams to stdout. A large file is written as it arrives and never
-    /// held whole, so what a get costs in memory does not follow what it
-    /// downloads. A file destination is written beside itself and renamed
-    /// into place only once the download is complete and its content verified,
-    /// so a failed download leaves nothing there. Streaming to stdout hands
-    /// bytes on as they arrive, so content that fails verification at the end
-    /// exits nonzero after part of it has already been written — the exit
-    /// status, not the output, is what says the content was verified.
+    /// Where to write the download. Defaults to the remote file or directory
+    /// name. Use `-` to stream one file to stdout. File downloads are streamed
+    /// to a temporary path and moved into place after verification. Stdout
+    /// cannot be rolled back if verification fails after bytes are written.
     #[arg(value_hint = ValueHint::AnyPath)]
     pub local_destination: Option<String>,
-    /// Download the directory tree into the exact local destination root.
-    /// `loonfs get -r /reports ./download` writes the contents directly under
-    /// `./download`, never `./download/reports`. With the destination omitted,
-    /// `loonfs get -r /reports` derives `./reports`. Reruns are no-clobber by
-    /// default; `--force` rewrites existing files.
+    /// Download a directory and its contents. The destination is the root of
+    /// the downloaded tree. For example, `loonfs get -r /reports ./download`
+    /// writes the contents of `/reports` directly under `./download`. If the
+    /// destination is omitted, the command uses `./reports`.
     #[arg(short, long)]
     pub recursive: bool,
     /// Download this revision instead of the current content.
     #[arg(long)]
     pub revision: Option<u64>,
-    /// Overwrite existing local files. Recursive reruns are no-clobber by
-    /// default.
+    /// Overwrite existing local files.
     #[arg(long)]
     pub force: bool,
 }
@@ -1508,7 +1501,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn global_selectors_reach_leaf_arguments_from_every_position() {
+    fn global_selectors_work_before_between_and_after_subcommands() {
         let before_command = Cli::try_parse_from([
             "loonfs",
             "--profile",
@@ -1595,41 +1588,20 @@ mod tests {
         Cli::try_parse_from(["loonfs", "stat", "--inode", "ino_2"]).expect("inode target");
     }
 
-    #[test]
-    fn recursive_get_help_names_the_exact_destination_root() {
-        let mut command = Cli::command();
-        let help = command
-            .find_subcommand_mut("get")
-            .expect("get command")
-            .render_long_help()
-            .to_string()
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        assert!(help.contains("loonfs get -r /reports ./download"), "{help}");
-        assert!(help.contains("never `./download/reports`"), "{help}");
-        assert!(
-            help.contains("loonfs get -r /reports` derives `./reports"),
-            "{help}"
-        );
-        assert!(help.contains("Reruns are no-clobber by default"), "{help}");
-        assert!(help.contains("--force` rewrites existing files"), "{help}");
-    }
-
     fn assert_selected_target(cli: &Cli, profile: &str, namespace: &str) {
         assert_eq!(cli.profile.as_deref(), Some(profile));
         assert_eq!(cli.namespace.as_deref(), Some(namespace));
         let target = match &cli.command {
-            Command::Ls(args) => &args.target,
+            Command::Ls(args) => Some(&args.target),
             Command::Admin {
                 command:
                     AdminCommand::Checkpoint {
                         command: AdminCheckpointCommand::List(args),
                     },
-            } => &args.target,
-            command => panic!("expected command with selected target, got {command:?}"),
-        };
+            } => Some(&args.target),
+            _ => None,
+        }
+        .expect("test command should accept profile and namespace selectors");
         assert_eq!(target.profile.profile.as_deref(), Some(profile));
         assert_eq!(target.namespace.as_deref(), Some(namespace));
     }

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -1,7 +1,7 @@
 //! The clap argument grammar for every `loonfs` command.
 
 use crate::progress::ProgressMode;
-use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum, ValueHint};
+use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand, ValueEnum, ValueHint};
 use loonfs_api::InodeId;
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -709,15 +709,20 @@ pub(crate) struct FilesystemLsArgs {
 }
 
 #[derive(Debug, Args)]
+#[command(
+    override_usage = "loonfs stat <PATH>\n       loonfs stat --inode <INODE_ID>",
+    group(
+        ArgGroup::new("stat_target")
+            .required(true)
+            .multiple(false)
+            .args(["path", "inode"])
+    )
+)]
 pub(crate) struct FilesystemStatArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     /// Absolute path to describe.
-    #[arg(
-        required_unless_present = "inode",
-        conflicts_with = "inode",
-        value_hint = ValueHint::Other
-    )]
+    #[arg(value_hint = ValueHint::Other)]
     pub path: Option<String>,
     /// Visible inode to describe instead of a path.
     #[arg(long, value_name = "INODE_ID", value_parser = parse_public_inode_id)]
@@ -1560,6 +1565,31 @@ mod tests {
             assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
             assert!(error.to_string().contains(selector), "{error}");
         }
+    }
+
+    #[test]
+    fn stat_help_and_parser_show_both_exclusive_target_forms() {
+        let mut command = Cli::command();
+        let help = command
+            .find_subcommand_mut("stat")
+            .expect("stat command")
+            .render_long_help()
+            .to_string();
+        assert!(help.contains("loonfs stat <PATH>"), "{help}");
+        assert!(help.contains("loonfs stat --inode <INODE_ID>"), "{help}");
+
+        let missing = Cli::try_parse_from(["loonfs", "stat"]).expect_err("target is required");
+        assert_eq!(
+            missing.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let both = Cli::try_parse_from(["loonfs", "stat", "/doc", "--inode", "ino_2"])
+            .expect_err("targets conflict");
+        assert_eq!(both.kind(), clap::error::ErrorKind::ArgumentConflict);
+
+        Cli::try_parse_from(["loonfs", "stat", "/doc"]).expect("path target");
+        Cli::try_parse_from(["loonfs", "stat", "--inode", "ino_2"]).expect("inode target");
     }
 
     fn assert_selected_target(cli: &Cli, profile: &str, namespace: &str) {

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -871,26 +871,29 @@ pub(crate) struct FilesystemGetArgs {
     pub target: TargetSelectorArgs,
     #[arg(value_hint = ValueHint::Other)]
     pub remote_path: String,
-    /// Local destination (defaults to the remote basename; `-` streams to
-    /// stdout). A large file is written as it arrives and never held whole,
-    /// so what a get costs in memory does not follow what it downloads. A
-    /// file destination is written beside itself and renamed into place only
-    /// once the download is complete and its content verified, so a failed
-    /// download leaves nothing there. Streaming to stdout hands bytes on as
-    /// they arrive, so content that fails verification at the end exits
-    /// nonzero after part of it has already been written — the exit status,
-    /// not the output, is what says the content was verified.
+    /// Local destination (defaults to the remote basename). For one file,
+    /// `-` streams to stdout. A large file is written as it arrives and never
+    /// held whole, so what a get costs in memory does not follow what it
+    /// downloads. A file destination is written beside itself and renamed
+    /// into place only once the download is complete and its content verified,
+    /// so a failed download leaves nothing there. Streaming to stdout hands
+    /// bytes on as they arrive, so content that fails verification at the end
+    /// exits nonzero after part of it has already been written — the exit
+    /// status, not the output, is what says the content was verified.
     #[arg(value_hint = ValueHint::AnyPath)]
     pub local_destination: Option<String>,
-    /// Download the directory tree rooted at `remote_path`, with bounded
-    /// concurrency and per-file outcomes. The local destination is created
-    /// if it does not exist.
+    /// Download the directory tree into the exact local destination root.
+    /// `loonfs get -r /reports ./download` writes the contents directly under
+    /// `./download`, never `./download/reports`. With the destination omitted,
+    /// `loonfs get -r /reports` derives `./reports`. Reruns are no-clobber by
+    /// default; `--force` rewrites existing files.
     #[arg(short, long)]
     pub recursive: bool,
     /// Download this revision instead of the current content.
     #[arg(long)]
     pub revision: Option<u64>,
-    /// Overwrite the local destination if it already exists.
+    /// Overwrite existing local files. Recursive reruns are no-clobber by
+    /// default.
     #[arg(long)]
     pub force: bool,
 }
@@ -1590,6 +1593,28 @@ mod tests {
 
         Cli::try_parse_from(["loonfs", "stat", "/doc"]).expect("path target");
         Cli::try_parse_from(["loonfs", "stat", "--inode", "ino_2"]).expect("inode target");
+    }
+
+    #[test]
+    fn recursive_get_help_names_the_exact_destination_root() {
+        let mut command = Cli::command();
+        let help = command
+            .find_subcommand_mut("get")
+            .expect("get command")
+            .render_long_help()
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(help.contains("loonfs get -r /reports ./download"), "{help}");
+        assert!(help.contains("never `./download/reports`"), "{help}");
+        assert!(
+            help.contains("loonfs get -r /reports` derives `./reports"),
+            "{help}"
+        );
+        assert!(help.contains("Reruns are no-clobber by default"), "{help}");
+        assert!(help.contains("--force` rewrites existing files"), "{help}");
     }
 
     fn assert_selected_target(cli: &Cli, profile: &str, namespace: &str) {

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -1278,8 +1278,6 @@ mod tests {
 
     #[test]
     fn page_limit_errors_report_the_registry_code_the_server_serves() {
-        // `--limit 0` fails the same PaginationPolicy check in both modes;
-        // embedded mode must answer with the same registry code as the server.
         let error = resolve_cli_page_limit(Some(0)).expect_err("zero limit is invalid");
         assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
         assert_eq!(error.param.as_deref(), Some("limit"));
@@ -1292,8 +1290,6 @@ mod tests {
 
     #[test]
     fn map_core_error_does_not_rewrite_invalid_id_codes() {
-        // Embedded mode must report the same code the server serves for the
-        // identical failure.
         let invalid_id = NamespaceId::parse("bad/name").expect_err("invalid namespace id");
         let error = map_runtime_error(RuntimeError::Core(CoreError::InvalidNamespaceId(
             invalid_id,

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -1279,8 +1279,7 @@ mod tests {
     #[test]
     fn page_limit_errors_report_the_registry_code_the_server_serves() {
         // `--limit 0` fails the same PaginationPolicy check in both modes;
-        // embedded mode must answer `invalid_request` like the server, not a
-        // CLI-local `invalid_input` rewrite.
+        // embedded mode must answer with the same registry code as the server.
         let error = resolve_cli_page_limit(Some(0)).expect_err("zero limit is invalid");
         assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
         assert_eq!(error.param.as_deref(), Some("limit"));
@@ -1294,7 +1293,7 @@ mod tests {
     #[test]
     fn map_core_error_does_not_rewrite_invalid_id_codes() {
         // Embedded mode must report the same code the server serves for the
-        // identical failure, not a CLI-local `invalid_input` rewrite.
+        // identical failure.
         let invalid_id = NamespaceId::parse("bad/name").expect_err("invalid namespace id");
         let error = map_runtime_error(RuntimeError::Core(CoreError::InvalidNamespaceId(
             invalid_id,

--- a/crates/loonfs-cli/src/backend_error.rs
+++ b/crates/loonfs-cli/src/backend_error.rs
@@ -9,8 +9,8 @@ use thiserror::Error;
 /// Error returned by either CLI backend.
 ///
 /// `code` is either a shared [`loonfs_api::ErrorCode`] string or one of the
-/// local codes created below: `invalid_config`, `invalid_input`,
-/// `client_error`, `io_error`, or `runtime_error`. Shared codes must come
+/// local codes created below: `invalid_config`, `client_error`, `io_error`,
+/// or `runtime_error`. Shared codes must come
 /// from the registry rather than duplicated string literals so embedded and
 /// remote profiles report the same condition consistently.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -52,8 +52,8 @@ impl BackendError {
     }
 
     /// Caller input rejected before it reached a backend.
-    pub(crate) fn invalid_input(message: impl Into<String>) -> Self {
-        Self::new("invalid_input", message)
+    pub(crate) fn invalid_request(message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidRequest.as_str(), message)
     }
 
     /// Transport failure between a client and a remote server.
@@ -97,7 +97,7 @@ impl From<ClientError> for BackendError {
             ClientError::ConfigValidation { field, reason } => {
                 Self::invalid_config(format!("invalid `{field}`: {reason}"))
             }
-            ClientError::InvalidNamespacePath(message) => Self::invalid_input(message),
+            ClientError::InvalidNamespacePath(message) => Self::invalid_request(message),
             ClientError::InvalidCommitId(message) | ClientError::InvalidCheckpointId(message) => {
                 // The registry code core and server report for a malformed
                 // id, so pre-flight client validation matches backend
@@ -239,5 +239,14 @@ mod tests {
         let error = BackendError::from(ClientError::Io("read failed".to_owned()));
         assert_eq!(error.code, "io_error");
         assert_eq!(error.message, "i/o error: read failed");
+    }
+
+    #[test]
+    fn invalid_namespace_paths_map_to_the_registry_request_code() {
+        let error = BackendError::from(ClientError::InvalidNamespacePath(
+            "path must be absolute".to_owned(),
+        ));
+
+        assert_eq!(error.code, loonfs_api::ErrorCode::InvalidRequest.as_str());
     }
 }

--- a/crates/loonfs-cli/src/backend_error.rs
+++ b/crates/loonfs-cli/src/backend_error.rs
@@ -8,11 +8,9 @@ use thiserror::Error;
 
 /// Error returned by either CLI backend.
 ///
-/// `code` is either a shared [`loonfs_api::ErrorCode`] string or one of the
-/// local codes created below: `invalid_config`, `client_error`, `io_error`,
-/// or `runtime_error`. Shared codes must come
-/// from the registry rather than duplicated string literals so embedded and
-/// remote profiles report the same condition consistently.
+/// `code` is either a shared [`loonfs_api::ErrorCode`] or a backend-local code.
+/// Shared codes come from the registry so embedded and remote profiles report
+/// the same code for the same failure.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("{code}: {message}")]
 pub(crate) struct BackendError {

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -166,11 +166,8 @@ pub(crate) fn directory_intent(path: &str) -> bool {
     path.len() > 1 && path.ends_with('/') && !path.ends_with("//")
 }
 
-/// Parses a human-entered CLI path with the wire's strictness, plus exactly
-/// one concession: a single trailing slash (directory intent) is accepted
-/// and dropped. Repeated separators, `.`/`..`, and relative spellings fail
-/// here exactly as the wire rejects them — the CLI never silently rewrites
-/// a path into something the caller did not type.
+/// Removes one trailing slash used to mark a directory. Repeated separators,
+/// `.` and `..` components, and relative paths remain invalid.
 pub(crate) fn parse_user_path_arg(
     param: &str,
     path: &str,
@@ -192,9 +189,8 @@ pub(crate) fn parse_user_path_arg(
     Ok(parsed)
 }
 
-/// Resolves a mutation destination: with directory intent the source's leaf
-/// name lands inside the named directory; otherwise the path is the full
-/// destination.
+/// Appends the source name when the destination ends in `/`. Otherwise, the
+/// destination is treated as the full path.
 pub(crate) fn destination_user_path(
     path_param: &str,
     source_leaf_param: &str,

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -149,12 +149,13 @@ async fn resolve_command_context_with_actor(
 
 pub(crate) fn namespace_path(
     namespace_id: &NamespaceId,
+    param: &str,
     path: &str,
     allow_root: bool,
 ) -> Result<NamespacePath, CliError> {
     Ok(NamespacePath::new(
         namespace_id.clone(),
-        parse_user_path(path, allow_root)?,
+        parse_user_path_arg(param, path, allow_root)?,
     ))
 }
 
@@ -170,18 +171,23 @@ pub(crate) fn directory_intent(path: &str) -> bool {
 /// and dropped. Repeated separators, `.`/`..`, and relative spellings fail
 /// here exactly as the wire rejects them — the CLI never silently rewrites
 /// a path into something the caller did not type.
-pub(crate) fn parse_user_path(path: &str, allow_root: bool) -> Result<AbsolutePath, CliError> {
+pub(crate) fn parse_user_path_arg(
+    param: &str,
+    path: &str,
+    allow_root: bool,
+) -> Result<AbsolutePath, CliError> {
     let trimmed = if directory_intent(path) {
         &path[..path.len() - 1]
     } else {
         path
     };
-    let parsed =
-        AbsolutePath::parse(trimmed).map_err(|error| CliError::invalid_input(error.to_string()))?;
+    let parsed = AbsolutePath::parse(trimmed)
+        .map_err(|error| CliError::invalid_request(error.to_string()).with_param(param))?;
     if !allow_root && parsed.is_root() {
-        return Err(CliError::invalid_input(
-            "root path is not allowed for this command",
-        ));
+        return Err(
+            CliError::invalid_request("root path is not allowed for this command")
+                .with_param(param),
+        );
     }
     Ok(parsed)
 }
@@ -190,33 +196,38 @@ pub(crate) fn parse_user_path(path: &str, allow_root: bool) -> Result<AbsolutePa
 /// name lands inside the named directory; otherwise the path is the full
 /// destination.
 pub(crate) fn destination_user_path(
+    path_param: &str,
+    source_leaf_param: &str,
     raw: &str,
     source_leaf: &str,
     allow_root_directory: bool,
 ) -> Result<AbsolutePath, CliError> {
     if directory_intent(raw) || raw == "/" {
-        let directory = parse_user_path(raw, true)?;
+        let directory = parse_user_path_arg(path_param, raw, true)?;
         if !allow_root_directory && directory.is_root() && raw == "/" {
-            return Err(CliError::invalid_input(
-                "root path is not allowed for this command",
-            ));
+            return Err(
+                CliError::invalid_request("root path is not allowed for this command")
+                    .with_param(path_param),
+            );
         }
-        let leaf = loonfs_api::DisplayName::parse(source_leaf)
-            .map_err(|error| CliError::invalid_input(error.to_string()))?;
+        let leaf = loonfs_api::DisplayName::parse(source_leaf).map_err(|error| {
+            CliError::invalid_request(error.to_string()).with_param(source_leaf_param)
+        })?;
         return Ok(directory.join(&leaf));
     }
-    parse_user_path(raw, false)
+    parse_user_path_arg(path_param, raw, false)
 }
 
 pub(crate) fn default_remote_put_path(local_path: &Path) -> Result<AbsolutePath, CliError> {
     let file_name = local_path.file_name().ok_or_else(|| {
-        CliError::invalid_input(format!(
+        CliError::invalid_request(format!(
             "unable to derive remote target from `{}`",
             local_path.display()
         ))
+        .with_param("local_path")
     })?;
     AbsolutePath::parse(format!("/{}", file_name.to_string_lossy()))
-        .map_err(|error| CliError::invalid_input(error.to_string()))
+        .map_err(|error| CliError::invalid_request(error.to_string()).with_param("local_path"))
 }
 
 pub(crate) fn destination_path_for_get(
@@ -228,9 +239,10 @@ pub(crate) fn destination_path_for_get(
             .file_name()
             .map(PathBuf::from)
             .ok_or_else(|| {
-                CliError::invalid_input(format!(
+                CliError::invalid_request(format!(
                     "unable to derive local destination from `{remote_path}`"
                 ))
+                .with_param("remote_path")
             })
     };
     match explicit_destination {
@@ -367,7 +379,7 @@ pub(crate) fn fail(
 
 #[cfg(test)]
 mod tests {
-    use super::{destination_user_path, parse_user_path, shell_quote};
+    use super::{destination_user_path, parse_user_path_arg, shell_quote};
 
     #[test]
     fn quoting_leaves_ordinary_paths_alone_and_survives_a_quote() {
@@ -393,31 +405,48 @@ mod tests {
         // One trailing slash is directory intent; everything else the wire
         // rejects, the CLI rejects too, instead of silently rewriting.
         assert_eq!(
-            parse_user_path("/docs/", false)
+            parse_user_path_arg("path", "/docs/", false)
                 .expect("dir intent")
                 .as_str(),
             "/docs"
         );
-        assert!(parse_user_path("//docs///A.txt/", false).is_err());
-        assert!(parse_user_path("//x.txt", false).is_err());
-        assert!(parse_user_path("docs/A.txt", false).is_err());
-        assert!(parse_user_path("", false).is_err());
-        assert_eq!(parse_user_path("/", true).expect("root").as_str(), "/");
+        assert!(parse_user_path_arg("path", "//docs///A.txt/", false).is_err());
+        assert!(parse_user_path_arg("path", "//x.txt", false).is_err());
+        assert!(parse_user_path_arg("path", "docs/A.txt", false).is_err());
+        assert!(parse_user_path_arg("path", "", false).is_err());
+        assert_eq!(
+            parse_user_path_arg("path", "/", true)
+                .expect("root")
+                .as_str(),
+            "/"
+        );
 
         assert_eq!(
-            destination_user_path("/docs/", "report.pdf", false)
-                .expect("into directory")
-                .as_str(),
+            destination_user_path(
+                "destination_path",
+                "source_path",
+                "/docs/",
+                "report.pdf",
+                false,
+            )
+            .expect("into directory")
+            .as_str(),
             "/docs/report.pdf"
         );
         assert_eq!(
-            destination_user_path("/docs/renamed.pdf", "report.pdf", false)
-                .expect("full destination")
-                .as_str(),
+            destination_user_path(
+                "destination_path",
+                "source_path",
+                "/docs/renamed.pdf",
+                "report.pdf",
+                false,
+            )
+            .expect("full destination")
+            .as_str(),
             "/docs/renamed.pdf"
         );
         assert_eq!(
-            destination_user_path("/", "report.pdf", true)
+            destination_user_path("destination_path", "source_path", "/", "report.pdf", true,)
                 .expect("into root")
                 .as_str(),
             "/report.pdf"

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -3,7 +3,7 @@
 
 use super::context::{
     default_remote_put_path, destination_path_for_get, destination_user_path, directory_intent,
-    fail, namespace_path, parse_public_ordinal_arg, parse_user_path, render_target,
+    fail, namespace_path, parse_public_ordinal_arg, parse_user_path_arg, render_target,
     resolve_command_context, resolve_mutation_context, CommandContext, UndeleteHint,
 };
 use super::output::{
@@ -47,7 +47,7 @@ fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliE
     commit_id
         .map(|value| {
             CommitId::parse(value).map_err(|error| {
-                CliError::invalid_input(format!("invalid --commit-id: {error}"))
+                CliError::invalid_request(format!("invalid --commit-id: {error}"))
                     .with_param("--commit-id")
             })
         })
@@ -127,6 +127,7 @@ pub(crate) async fn run_filesystem_ls(
     let allow_root = true;
     let spec = namespace_path(
         &context.namespace,
+        "path",
         args.path.as_deref().unwrap_or("/"),
         allow_root,
     )
@@ -212,7 +213,7 @@ pub(crate) async fn run_filesystem_stat(
                 .as_deref()
                 .expect("clap requires either path or --inode");
             let allow_root = true;
-            let spec = namespace_path(&context.namespace, path, allow_root)
+            let spec = namespace_path(&context.namespace, "path", path, allow_root)
                 .map_err(|error| context.fail(kind, error))?;
             context.target.stat_path(&spec).await
         }
@@ -232,7 +233,7 @@ pub(crate) async fn run_filesystem_stat(
 /// guessing what the caller meant.
 fn parse_attribute_assignment(argument: &str) -> Result<(AttributeKey, AttributeValue), CliError> {
     let Some((key, value)) = argument.split_once('=') else {
-        return Err(CliError::invalid_input(format!(
+        return Err(CliError::invalid_request(format!(
             "invalid --set `{argument}`: expected key=value"
         ))
         .with_param("--set"));
@@ -240,14 +241,14 @@ fn parse_attribute_assignment(argument: &str) -> Result<(AttributeKey, Attribute
     Ok((
         parse_attribute_key_arg("--set", key)?,
         AttributeValue::parse(value).map_err(|error| {
-            CliError::invalid_input(format!("invalid --set value: {error}")).with_param("--set")
+            CliError::invalid_request(format!("invalid --set value: {error}")).with_param("--set")
         })?,
     ))
 }
 
 fn parse_attribute_key_arg(flag: &str, key: &str) -> Result<AttributeKey, CliError> {
     AttributeKey::parse(key).map_err(|error| {
-        CliError::invalid_input(format!("invalid {flag} key: {error}")).with_param(flag)
+        CliError::invalid_request(format!("invalid {flag} key: {error}")).with_param(flag)
     })
 }
 
@@ -270,7 +271,7 @@ fn update_attributes_options(
     let (set, remove) = match args.attributes_json.as_deref() {
         Some(document) => {
             let update: AttributeUpdateJson = serde_json::from_str(document).map_err(|error| {
-                CliError::invalid_input(format!(
+                CliError::invalid_request(format!(
                     "invalid --attributes-json attribute update: {error}"
                 ))
                 .with_param("--attributes-json")
@@ -313,7 +314,7 @@ pub(crate) async fn run_filesystem_annotate(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_mutation_context(kind, config_path, &args.target, &args.actor).await?;
     let allow_root = true;
-    let spec = namespace_path(&context.namespace, &args.path, allow_root)
+    let spec = namespace_path(&context.namespace, "path", &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
     let options = update_attributes_options(&args, &context.actor)
         .map_err(|error| context.fail(kind, error))?;
@@ -346,7 +347,7 @@ pub(crate) async fn run_filesystem_grep(
     let path_prefix = args
         .path_prefix
         .as_deref()
-        .map(|path| parse_user_path(path, true))
+        .map(|path| parse_user_path_arg("--path-prefix", path, true))
         .transpose()
         .map_err(|error| context.fail(kind, error))?;
     let mut request = loonfs_api::GrepRequest {
@@ -422,7 +423,7 @@ pub(crate) async fn run_filesystem_cat(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
-    let spec = namespace_path(&context.namespace, &args.path, allow_root)
+    let spec = namespace_path(&context.namespace, "path", &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
     let revision_no = args
         .revision
@@ -465,8 +466,13 @@ pub(crate) async fn run_filesystem_get(
     }
 
     let allow_root = args.recursive;
-    let spec = namespace_path(&context.namespace, &args.remote_path, allow_root)
-        .map_err(|error| context.fail(kind, error))?;
+    let spec = namespace_path(
+        &context.namespace,
+        "remote_path",
+        &args.remote_path,
+        allow_root,
+    )
+    .map_err(|error| context.fail(kind, error))?;
     let revision_no = args
         .revision
         .map(|value| parse_public_ordinal_arg("--revision", value, RevisionNo::parse))
@@ -481,7 +487,7 @@ pub(crate) async fn run_filesystem_get(
         if entry.inode_kind() != InodeKind::Directory {
             return Err(context.fail(
                 kind,
-                CliError::invalid_input(format!(
+                CliError::invalid_request(format!(
                     "`{}` is not a directory; drop -r to download one file",
                     spec.absolute_path()
                 ))
@@ -491,7 +497,7 @@ pub(crate) async fn run_filesystem_get(
         if args.revision.is_some() {
             return Err(context.fail(
                 kind,
-                CliError::invalid_input("--revision applies to one file, not a tree")
+                CliError::invalid_request("--revision applies to one file, not a tree")
                     .with_param("--revision"),
             ));
         }
@@ -499,7 +505,8 @@ pub(crate) async fn run_filesystem_get(
             Some("-") => {
                 return Err(context.fail(
                     kind,
-                    CliError::invalid_input("`-` streams one file; a tree needs a directory"),
+                    CliError::invalid_request("`-` streams one file; a tree needs a directory")
+                        .with_param("local_destination"),
                 ))
             }
             Some(destination) => PathBuf::from(destination),
@@ -519,10 +526,11 @@ pub(crate) async fn run_filesystem_get(
     if entry.inode_kind() == InodeKind::Directory {
         return Err(context.fail(
             kind,
-            CliError::invalid_input(format!(
+            CliError::invalid_request(format!(
                 "`{}` is a directory; use `loonfs get -r` to download the tree",
                 spec.absolute_path()
-            )),
+            ))
+            .with_param("remote_path"),
         ));
     }
 
@@ -813,7 +821,7 @@ pub(crate) async fn run_filesystem_revisions(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
-    let spec = namespace_path(&context.namespace, &args.path, allow_root)
+    let spec = namespace_path(&context.namespace, "path", &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
     let mut plan = PagePlan::new(&args.pagination);
     let mut cursor = args.cursor.clone();
@@ -878,7 +886,7 @@ pub(crate) async fn run_filesystem_put(
         if !metadata.is_dir() {
             return Err(context.fail(
                 kind,
-                CliError::invalid_input(format!(
+                CliError::invalid_request(format!(
                     "`{}` is not a directory; drop -r to upload one file",
                     local_path.display()
                 ))
@@ -888,14 +896,14 @@ pub(crate) async fn run_filesystem_put(
         if args.commit_id.is_some() {
             return Err(context.fail(
                 kind,
-                CliError::invalid_input(
+                CliError::invalid_request(
                     "--commit-id names one commit; a recursive upload makes one commit per file",
                 )
                 .with_param("--commit-id"),
             ));
         }
         let remote_root = match args.remote_path {
-            Some(path) => parse_user_path(&path, true),
+            Some(path) => parse_user_path_arg("remote_path", &path, true),
             None => default_remote_put_path(&local_path),
         }
         .map_err(|error| context.fail(kind, error))?;
@@ -913,10 +921,11 @@ pub(crate) async fn run_filesystem_put(
     if metadata.is_dir() {
         return Err(context.fail(
             kind,
-            CliError::invalid_input(format!(
+            CliError::invalid_request(format!(
                 "`{}` is a directory; use `loonfs put -r` to upload the tree",
                 local_path.display()
-            )),
+            ))
+            .with_param("local_path"),
         ));
     }
 
@@ -926,16 +935,17 @@ pub(crate) async fn run_filesystem_put(
         .ok_or_else(|| {
             context.fail(
                 kind,
-                CliError::invalid_input(format!(
+                CliError::invalid_request(format!(
                     "unable to derive remote target from `{}`",
                     local_path.display()
-                )),
+                ))
+                .with_param("local_path"),
             )
         })?;
     let remote_path = match args.remote_path.as_deref() {
         // A trailing slash names the directory the file lands in — the
         // cp/rsync habit — while a plain path is the full destination.
-        Some(path) => destination_user_path(path, &local_leaf, true),
+        Some(path) => destination_user_path("remote_path", "local_path", path, &local_leaf, true),
         None => default_remote_put_path(&local_path),
     }
     .map_err(|error| context.fail(kind, error))?;
@@ -969,20 +979,22 @@ async fn run_filesystem_put_stdin(
     if args.recursive {
         return Err(context.fail(
             kind,
-            CliError::invalid_input("`-` streams one file; a tree needs a directory"),
+            CliError::invalid_request("`-` streams one file; a tree needs a directory")
+                .with_param("-r"),
         ));
     }
     let Some(remote_path) = args.remote_path.as_deref() else {
         return Err(context.fail(
             kind,
-            CliError::invalid_input(
+            CliError::invalid_request(
                 "reading from `-` needs an explicit remote path; there is no local name to \
                  derive one from",
-            ),
+            )
+            .with_param("remote_path"),
         ));
     };
-    let remote_path =
-        parse_user_path(remote_path, false).map_err(|error| context.fail(kind, error))?;
+    let remote_path = parse_user_path_arg("remote_path", remote_path, false)
+        .map_err(|error| context.fail(kind, error))?;
     let spec = NamespacePath::new(context.namespace.clone(), remote_path);
     let options =
         put_file_options(&args, &context.actor).map_err(|error| context.fail(kind, error))?;
@@ -1185,7 +1197,7 @@ pub(crate) async fn run_filesystem_rm(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_mutation_context(kind, &location.path, &args.target, &args.actor).await?;
     let allow_root = false;
-    let spec = namespace_path(&context.namespace, &args.path, allow_root)
+    let spec = namespace_path(&context.namespace, "path", &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
@@ -1247,7 +1259,7 @@ pub(crate) async fn run_filesystem_restore(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_mutation_context(kind, config_path, &args.target, &args.actor).await?;
     let allow_root = false;
-    let spec = namespace_path(&context.namespace, &args.path, allow_root)
+    let spec = namespace_path(&context.namespace, "path", &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
@@ -1291,7 +1303,7 @@ pub(crate) async fn run_filesystem_undelete(
     let spec = args
         .path
         .as_deref()
-        .map(|path| namespace_path(&context.namespace, path, allow_root))
+        .map(|path| namespace_path(&context.namespace, "path", path, allow_root))
         .transpose()
         .map_err(|error| context.fail(kind, error))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
@@ -1338,7 +1350,7 @@ pub(crate) async fn run_filesystem_mkdir(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_mutation_context(kind, config_path, &args.target, &args.actor).await?;
     let allow_root = false;
-    let spec = namespace_path(&context.namespace, &args.path, allow_root)
+    let spec = namespace_path(&context.namespace, "path", &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
@@ -1442,7 +1454,7 @@ async fn resolve_transfer_destination(
         return Ok(named);
     }
     let leaf = loonfs_api::DisplayName::parse(source_leaf)
-        .map_err(|error| CliError::invalid_input(error.to_string()))?;
+        .map_err(|error| CliError::invalid_request(error.to_string()).with_param("source_path"))?;
     Ok(NamespacePath::new(
         context.namespace.clone(),
         named.absolute_path().join(&leaf),
@@ -1460,13 +1472,18 @@ async fn run_filesystem_transfer(
     if args.recursive && transfer_kind == TransferKind::Move {
         return Err(context.fail(
             kind,
-            CliError::invalid_input("mv moves a directory in one commit; -r is not needed")
+            CliError::invalid_request("mv moves a directory in one commit; -r is not needed")
                 .with_param("-r"),
         ));
     }
     let allow_root = false;
-    let from = namespace_path(&context.namespace, &args.source_path, allow_root)
-        .map_err(|error| context.fail(kind, error))?;
+    let from = namespace_path(
+        &context.namespace,
+        "source_path",
+        &args.source_path,
+        allow_root,
+    )
+    .map_err(|error| context.fail(kind, error))?;
     let source_leaf = from
         .absolute_path()
         .final_component()
@@ -1474,12 +1491,19 @@ async fn run_filesystem_transfer(
         .ok_or_else(|| {
             context.fail(
                 kind,
-                CliError::invalid_input("root path is not allowed for this command"),
+                CliError::invalid_request("root path is not allowed for this command")
+                    .with_param("source_path"),
             )
         })?;
-    let named_destination = destination_user_path(&args.destination_path, &source_leaf, true)
-        .map(|path| NamespacePath::new(context.namespace.clone(), path))
-        .map_err(|error| context.fail(kind, error))?;
+    let named_destination = destination_user_path(
+        "destination_path",
+        "source_path",
+        &args.destination_path,
+        &source_leaf,
+        true,
+    )
+    .map(|path| NamespacePath::new(context.namespace.clone(), path))
+    .map_err(|error| context.fail(kind, error))?;
     // A destination spelled with a trailing slash already named the
     // directory to land in, and the leaf is already appended; looking again
     // would append it twice.
@@ -1508,7 +1532,7 @@ async fn run_filesystem_transfer(
             if entry.inode_kind() != InodeKind::Directory {
                 return Err(context.fail(
                     kind,
-                    CliError::invalid_input(format!(
+                    CliError::invalid_request(format!(
                         "`{}` is not a directory; drop -r to copy one file",
                         from.absolute_path()
                     ))
@@ -1518,7 +1542,7 @@ async fn run_filesystem_transfer(
             if args.commit_id.is_some() {
                 return Err(context.fail(
                     kind,
-                    CliError::invalid_input(
+                    CliError::invalid_request(
                         "--commit-id names one commit; a recursive copy makes one commit per item",
                     )
                     .with_param("--commit-id"),
@@ -1538,10 +1562,11 @@ async fn run_filesystem_transfer(
         if entry.inode_kind() == InodeKind::Directory {
             return Err(context.fail(
                 kind,
-                CliError::invalid_input(format!(
+                CliError::invalid_request(format!(
                     "`{}` is a directory; use `loonfs cp -r` to copy the tree",
                     from.absolute_path()
-                )),
+                ))
+                .with_param("source_path"),
             ));
         }
         context

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -117,7 +117,7 @@ fn run_completion(
                 kind,
                 None,
                 None,
-                CliError::invalid_input(COMPLETION_SHELL_REQUIRED).with_param("--shell"),
+                CliError::invalid_request(COMPLETION_SHELL_REQUIRED).with_param("--shell"),
             )
         })?;
     let mut script = Vec::new();

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -147,7 +147,7 @@ async fn run_namespace_delete(
                 kind,
                 Some(resolved.profile_name),
                 Some(mode),
-                CliError::invalid_input(format!(
+                CliError::invalid_request(format!(
                     "confirmation `{typed}` does not match namespace id `{}`",
                     args.namespace_id
                 )),

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -212,7 +212,7 @@ pub(crate) async fn run_namespace_use(
             .await
             .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    let namespace_id = parse_namespace_id(&args.namespace)
+    let namespace_id = parse_namespace_id(&args.namespace_id)
         .map_err(|error| error.with_param("namespace"))
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
@@ -223,7 +223,7 @@ pub(crate) async fn run_namespace_use(
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     mutate_config(&loaded.path, |config| {
-        set_default_namespace(config, &resolved.profile_name, &args.namespace)
+        set_default_namespace(config, &resolved.profile_name, &args.namespace_id)
     })
     .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
@@ -233,7 +233,7 @@ pub(crate) async fn run_namespace_use(
         mode: Some(mode),
         data: CommandData::DefaultNamespace {
             profile: resolved.profile_name,
-            namespace: args.namespace,
+            namespace: args.namespace_id,
         },
     })
 }

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -436,13 +436,13 @@ fn selected_credential_source(
     has_static_flags: bool,
 ) -> Result<CredentialSource, CliError> {
     match source {
-        Some("ambient") if has_static_flags => Err(CliError::invalid_input(
+        Some("ambient") if has_static_flags => Err(CliError::invalid_request(
             "`--credential-source ambient` cannot be combined with static credential flags",
         )
         .with_param("--credential-source")),
         Some("ambient") => Ok(CredentialSource::Ambient),
         Some("static") => Ok(CredentialSource::Static),
-        Some(other) => Err(CliError::invalid_input(format!(
+        Some(other) => Err(CliError::invalid_request(format!(
             "unknown credential source: `{other}` (expected ambient or static)"
         ))
         .with_param("--credential-source")),
@@ -503,18 +503,17 @@ fn profile_actor_config(
         (Some(kind), Some(id)) => Ok(ProfileActorConfig {
             actor_kind: Some(ActorKind::from(kind)),
             actor_id: Some(ActorId::parse(id).map_err(|error| {
-                CliError::invalid_input(format!("invalid --actor-id: {error}"))
+                CliError::invalid_request(format!("invalid --actor-id: {error}"))
                     .with_param("--actor-id")
             })?),
         }),
-        (None, Some(_)) => {
-            Err(CliError::invalid_input("--actor-id requires --actor-kind")
-                .with_param("--actor-id"))
-        }
-        (Some(_), None) => {
-            Err(CliError::invalid_input("--actor-kind requires --actor-id")
-                .with_param("--actor-kind"))
-        }
+        (None, Some(_)) => Err(
+            CliError::invalid_request("--actor-id requires --actor-kind").with_param("--actor-id"),
+        ),
+        (Some(_), None) => Err(
+            CliError::invalid_request("--actor-kind requires --actor-id")
+                .with_param("--actor-kind"),
+        ),
     }
 }
 
@@ -573,7 +572,7 @@ fn reject_inapplicable_update_flag(
     profile_label: &str,
 ) -> Result<(), CliError> {
     if is_set {
-        return Err(CliError::invalid_input(format!(
+        return Err(CliError::invalid_request(format!(
             "`--{flag}` does not apply to {profile_label} profiles"
         ))
         .with_param(format!("--{flag}")));
@@ -889,7 +888,7 @@ fn require_update_static_secret(
         .cloned()
         .map(SecretString::from)
         .ok_or_else(|| {
-            CliError::invalid_input(format!(
+            CliError::invalid_request(format!(
                 "switching to static credentials requires `--access-key-id` and \
                  `--secret-access-key`; missing `--{field}`"
             ))

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -148,7 +148,10 @@ pub(crate) async fn run_put_tree(
         let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
             Ok(spec) => spec,
             Err(error) => {
-                tally.fail(remote, CliError::invalid_input(error.to_string()));
+                tally.fail(
+                    remote,
+                    CliError::invalid_request(error.to_string()).with_param("local_path"),
+                );
                 continue;
             }
         };
@@ -190,7 +193,12 @@ pub(crate) async fn run_put_tree(
         async move {
             let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
                 Ok(spec) => spec,
-                Err(error) => return (remote, Err(CliError::invalid_input(error.to_string()))),
+                Err(error) => {
+                    return (
+                        remote,
+                        Err(CliError::invalid_request(error.to_string()).with_param("local_path")),
+                    )
+                }
             };
             // The walk states a file's length when the filesystem gave it
             // one, and that length is what decides how the payload travels.
@@ -284,7 +292,7 @@ pub(crate) async fn run_get_tree(
     std::fs::create_dir_all(local_root)
         .map_err(|error| context.fail(kind, CliError::io_for_path(local_root, error)))?;
     tally.directories += 1;
-    let listing = walk_remote_tree(context, kind, remote_root).await?;
+    let listing = walk_remote_tree(context, kind, "remote_path", remote_root).await?;
     if !runtime.json {
         if let Some(drift) = listing.head_drift.as_ref() {
             crate::render::write_listing_drift_warning(drift);
@@ -317,7 +325,12 @@ pub(crate) async fn run_get_tree(
         async move {
             let spec = match NamespacePath::parse(namespace.as_str(), &job.remote) {
                 Ok(spec) => spec,
-                Err(error) => return (job.remote, Err(CliError::invalid_input(error.to_string()))),
+                Err(error) => {
+                    return (
+                        job.remote,
+                        Err(CliError::invalid_request(error.to_string()).with_param("remote_path")),
+                    )
+                }
             };
             // One file of a tree travels exactly as a single `get` of it
             // would: past the deployment's proxy cap it streams straight
@@ -392,7 +405,7 @@ pub(crate) async fn run_copy_tree(
     message: Option<String>,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let listing = walk_remote_tree(context, kind, source_root).await?;
+    let listing = walk_remote_tree(context, kind, "source_path", source_root).await?;
     if !runtime.json {
         if let Some(drift) = listing.head_drift.as_ref() {
             crate::render::write_listing_drift_warning(drift);
@@ -411,7 +424,10 @@ pub(crate) async fn run_copy_tree(
         let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
             Ok(spec) => spec,
             Err(error) => {
-                tally.fail(remote, CliError::invalid_input(error.to_string()));
+                tally.fail(
+                    remote,
+                    CliError::invalid_request(error.to_string()).with_param("destination_path"),
+                );
                 continue;
             }
         };
@@ -461,8 +477,18 @@ pub(crate) async fn run_copy_tree(
             let to = NamespacePath::parse(namespace.as_str(), &destination);
             let (from, to) = match (from, to) {
                 (Ok(from), Ok(to)) => (from, to),
-                (Err(error), _) | (_, Err(error)) => {
-                    return (job.remote, Err(CliError::invalid_input(error.to_string())))
+                (Err(error), _) => {
+                    return (
+                        job.remote,
+                        Err(CliError::invalid_request(error.to_string()).with_param("source_path")),
+                    )
+                }
+                (_, Err(error)) => {
+                    return (
+                        job.remote,
+                        Err(CliError::invalid_request(error.to_string())
+                            .with_param("destination_path")),
+                    )
                 }
             };
             let result = backend
@@ -527,7 +553,8 @@ fn collect_local_tree(
     let mut all_dirs = Vec::new();
     for entry in walkdir::WalkDir::new(root).sort_by_file_name() {
         let entry = entry.map_err(|error| {
-            CliError::invalid_input(format!("failed to walk `{}`: {error}", root.display()))
+            CliError::invalid_request(format!("failed to walk `{}`: {error}", root.display()))
+                .with_param("local_path")
         })?;
         let relative = entry
             .path()
@@ -559,10 +586,11 @@ fn collect_local_tree(
         } else {
             tally.fail(
                 entry.path().display().to_string(),
-                CliError::invalid_input(
+                CliError::invalid_request(
                     "only regular files and directories transfer; symlinks and special \
                      files do not",
-                ),
+                )
+                .with_param("local_path"),
             );
         }
     }
@@ -608,6 +636,7 @@ struct RemoteTree {
 async fn walk_remote_tree(
     context: &CommandContext,
     kind: CommandKind,
+    remote_param: &str,
     root: &str,
 ) -> Result<RemoteTree, CommandFailure> {
     let mut tree = RemoteTree {
@@ -624,8 +653,12 @@ async fn walk_remote_tree(
         } else {
             &remote_dir
         };
-        let spec = NamespacePath::parse(context.namespace.as_str(), listed)
-            .map_err(|error| context.fail(kind, CliError::invalid_input(error.to_string())))?;
+        let spec = NamespacePath::parse(context.namespace.as_str(), listed).map_err(|error| {
+            context.fail(
+                kind,
+                CliError::invalid_request(error.to_string()).with_param(remote_param),
+            )
+        })?;
         let mut pager = context
             .target
             .list_path_entries_pager(&spec, None, None)

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -116,10 +116,8 @@ fn output(
     }
 }
 
-/// Uploads a local directory tree. Ancestor directories materialize through
-/// each file's own commit (`parents` semantics), so only subtrees holding no
-/// files need explicit `mkdir`s — which also keeps the two paths from racing
-/// each other over the same directory.
+/// Uploads a local directory tree. File uploads create their parent
+/// directories, so this function creates directories only for empty subtrees.
 pub(crate) async fn run_put_tree(
     kind: CommandKind,
     context: &CommandContext,
@@ -141,8 +139,7 @@ pub(crate) async fn run_put_tree(
         DestinationBehavior::NoReplace
     };
 
-    // Empty subtrees first: nothing else creates them, and their ancestors
-    // auto-create exactly like a file's would.
+    // Create empty subtrees before uploading files.
     for components in empty_dirs {
         let remote = joined_remote(remote_root, &components);
         let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
@@ -155,7 +152,7 @@ pub(crate) async fn run_put_tree(
                 continue;
             }
         };
-        match context
+        let progress_label = match context
             .target
             .create_directory(
                 &spec,
@@ -170,22 +167,28 @@ pub(crate) async fn run_put_tree(
             )
             .await
         {
-            Ok(_) => {}
+            Ok(_) => "created",
             Err(error) if error.code == ErrorCode::PathConflict.as_str() => {
-                let existing = context.target.stat_path_without_attributes(&spec).await;
-                if !matches!(existing, Ok(entry) if entry.inode_kind() == InodeKind::Directory) {
-                    tally.fail(remote, error.into());
-                    continue;
+                match context.target.stat_path_without_attributes(&spec).await {
+                    Ok(entry) if entry.inode_kind() == InodeKind::Directory => "already exists",
+                    Ok(_) => {
+                        tally.fail(remote, error.into());
+                        continue;
+                    }
+                    Err(error) => {
+                        tally.fail(remote, error.into());
+                        continue;
+                    }
                 }
             }
             Err(error) => {
                 tally.fail(remote, error.into());
                 continue;
             }
-        }
+        };
         tally.directories += 1;
         if runtime.progress.human_lines_enabled() {
-            write_stderr_progress(format_args!("ensured {}", spec_target(&spec)));
+            write_stderr_progress(format_args!("{progress_label} {}", spec_target(&spec)));
         }
     }
 
@@ -209,10 +212,8 @@ pub(crate) async fn run_put_tree(
                     )
                 }
             };
-            // The walk states a file's length when the filesystem gave it
-            // one, and that length is what decides how the payload travels.
-            // A file that still cannot state one fails on its own rather
-            // than taking the tree with it.
+            // Use the size found during the directory walk when available.
+            // If it was unavailable, try again before uploading this file.
             let size_bytes = match job.size_bytes {
                 Some(size_bytes) => size_bytes,
                 None => match std::fs::metadata(&job.local) {
@@ -221,13 +222,8 @@ pub(crate) async fn run_put_tree(
                 },
             };
             progress.file_started(&remote, Some(size_bytes));
-            // One file of a tree travels exactly as a single `put` of it
-            // would: held whole while it is small enough to hold, read once
-            // in pieces past that, and resumed from its own record where a
-            // single put would resume. So a tree holding a file this process
-            // could not hold costs no more memory than a tree of small ones,
-            // and its bytes are counted as they are read rather than a whole
-            // file at a time.
+            // Recursive uploads use the same streaming and resume behavior as
+            // single-file uploads.
             let payload = LocalPayload::file(&job.local, size_bytes);
             let result = super::fs::put_payload(
                 context,
@@ -278,9 +274,8 @@ pub(crate) async fn run_put_tree(
     ))
 }
 
-/// Downloads a directory tree. Local directories are created for every
-/// remote directory — including empty ones, and including the destination
-/// root itself — before any file lands.
+/// Downloads a directory tree. It creates the destination and all remote
+/// directories before downloading files.
 pub(crate) async fn run_get_tree(
     kind: CommandKind,
     context: &CommandContext,
@@ -290,14 +285,7 @@ pub(crate) async fn run_get_tree(
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let mut tally = TreeTally::new();
-    // The destination root, with any missing parents, belongs to this
-    // command the way `cp -r`'s target directory belongs to `cp`. It is made
-    // before the walk so a destination that can never hold the tree costs
-    // one error instead of a full traversal, and its failure ends the
-    // command: every file below would fail the same way, and one named
-    // error beats one per file. It counts like `cp -r` counts its own
-    // destination root, so the same tree reports the same directory total
-    // whichever way it is transferred.
+    // Fail early if the destination cannot be created.
     std::fs::create_dir_all(local_root)
         .map_err(|error| context.fail(kind, CliError::io_for_path(local_root, error)))?;
     tally.directories += 1;
@@ -341,11 +329,8 @@ pub(crate) async fn run_get_tree(
                     )
                 }
             };
-            // One file of a tree travels exactly as a single `get` of it
-            // would: past the deployment's proxy cap it streams straight
-            // from object storage, and the walk already read the size that
-            // decides which. It resumes the same way too, from bytes an
-            // interrupted run of this transfer left beside that file.
+            // Recursive downloads use the same streaming and resume behavior
+            // as single-file downloads.
             let meta = job
                 .content_ref
                 .as_ref()
@@ -403,8 +388,7 @@ pub(crate) async fn run_get_tree(
     ))
 }
 
-/// Copies a directory tree server-side: directories in parent-first order,
-/// then files as content-reference copies that move no bytes.
+/// Copies a directory tree without downloading file contents to the CLI.
 pub(crate) async fn run_copy_tree(
     kind: CommandKind,
     context: &CommandContext,
@@ -423,9 +407,7 @@ pub(crate) async fn run_copy_tree(
     let head_drift = listing.head_drift;
     let mut tally = TreeTally::new();
 
-    // The destination root materializes its own ancestors; every deeper
-    // directory arrives in parent-first walk order, so plain `mkdir`
-    // suffices and never races a sibling job.
+    // Create the destination root and then its child directories in order.
     let mut directories = vec![Vec::new()];
     directories.extend(listing.directories);
     for components in &directories {
@@ -548,10 +530,8 @@ fn spec_target(spec: &NamespacePath) -> String {
     super::context::render_target(spec.namespace(), spec.absolute_path())
 }
 
-/// Collects a local tree into file jobs (with relative remote components in
-/// `remote`) plus the component paths of subtrees holding no files at all.
-/// Entries that are neither files nor directories (symlinks, sockets)
-/// become per-path failures rather than silent skips.
+/// Collects upload jobs and empty directories from a local tree. Symlinks and
+/// special files are reported as failures.
 fn collect_local_tree(
     root: &Path,
     files: &mut Vec<FileJob>,
@@ -562,8 +542,13 @@ fn collect_local_tree(
     let mut all_dirs = Vec::new();
     for entry in walkdir::WalkDir::new(root).sort_by_file_name() {
         let entry = entry.map_err(|error| {
-            CliError::invalid_request(format!("failed to walk `{}`: {error}", root.display()))
-                .with_param("local_path")
+            CliError::new(
+                "io_error",
+                format!(
+                    "failed to read directory tree `{}`: {error}",
+                    root.display()
+                ),
+            )
         })?;
         let relative = entry
             .path()
@@ -585,10 +570,8 @@ fn collect_local_tree(
             files.push(FileJob {
                 local: entry.path().to_path_buf(),
                 remote: components.join("/"),
-                // A local length nobody can read leaves the tree's total
-                // unknown rather than wrong, and the upload proceeds either
-                // way — the failure that matters surfaces when the file is
-                // read.
+                // The upload retries metadata lookup if this first lookup
+                // fails.
                 size_bytes: entry.metadata().ok().map(|metadata| metadata.len()),
                 content_ref: None,
             });
@@ -603,8 +586,7 @@ fn collect_local_tree(
             );
         }
     }
-    // A directory is worth an explicit mkdir only when no descendant file
-    // will create it — and its ancestors come along through `parents`.
+    // Files create ancestor directories, so only empty subtrees need mkdir.
     let mut candidates: Vec<Vec<String>> = all_dirs
         .into_iter()
         .filter(|dir| {
@@ -613,9 +595,7 @@ fn collect_local_tree(
                 .any(|with_files| with_files.starts_with(dir.as_slice()))
         })
         .collect();
-    // Keep only the deepest directory of each empty chain: its `parents`
-    // mkdir materializes the ancestors, and sequential creation means no
-    // sibling job races a shared parent.
+    // Creating the deepest directory also creates its empty parents.
     candidates.sort();
     let deepest: Vec<Vec<String>> = candidates
         .iter()
@@ -639,9 +619,8 @@ struct RemoteTree {
     head_drift: Option<ListingHeadDrift>,
 }
 
-/// Breadth-first remote walk from `root`. Each directory lists at its own
-/// head (drift-tolerant listings), so the walk is not a snapshot — the
-/// same contract as section 9.3's client-side traversal.
+/// Walks a remote tree breadth-first. Each directory is listed separately, so
+/// concurrent changes may appear in the results.
 async fn walk_remote_tree(
     context: &CommandContext,
     kind: CommandKind,

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -20,7 +20,7 @@ use crate::payload::LocalPayload;
 use crate::progress::{ProgressOp, ProgressReporter};
 use crate::render::write_stderr_progress;
 use futures::StreamExt;
-use loonfs_api::{AuthoritativePathEntryKind, DestinationBehavior};
+use loonfs_api::{AuthoritativePathEntryKind, DestinationBehavior, ErrorCode, InodeKind};
 use loonfs_client::{CommitOptions, CreateDirectoryOptions, NamespacePath, PutFileOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -170,13 +170,22 @@ pub(crate) async fn run_put_tree(
             )
             .await
         {
-            Ok(_) => {
-                tally.directories += 1;
-                if runtime.progress.human_lines_enabled() {
-                    write_stderr_progress(format_args!("created {}", spec_target(&spec)));
+            Ok(_) => {}
+            Err(error) if error.code == ErrorCode::PathConflict.as_str() => {
+                let existing = context.target.stat_path_without_attributes(&spec).await;
+                if !matches!(existing, Ok(entry) if entry.inode_kind() == InodeKind::Directory) {
+                    tally.fail(remote, error.into());
+                    continue;
                 }
             }
-            Err(error) => tally.fail(remote, error.into()),
+            Err(error) => {
+                tally.fail(remote, error.into());
+                continue;
+            }
+        }
+        tally.directories += 1;
+        if runtime.progress.human_lines_enabled() {
+            write_stderr_progress(format_args!("ensured {}", spec_target(&spec)));
         }
     }
 

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -6,26 +6,13 @@ use serde::Serialize;
 
 /// Structured failure surfaced by every CLI command (`--json` renders it verbatim).
 ///
-/// `code` draws from exactly three namespaces:
+/// `code` is either a shared API error code or a code local to the backend or
+/// CLI.
 ///
-/// - **Registry codes** ([`loonfs_api::ErrorCode`]) pass through verbatim from
-///   whichever backend produced them, so embedded and remote profiles surface
-///   the same code for the same failure. Never restate a registry code as a
-///   string literal; use `ErrorCode::X.as_str()` or an error's `code()`.
-/// - **Backend-local codes** ([`crate::backend_error::BackendError`]) pass
-///   through verbatim from the backend: `invalid_config`,
-///   `client_error`, `io_error`, and `runtime_error`.
-/// - **CLI request validation** uses the registry's `invalid_request` code
-///   before dispatch when a parsed value cannot form a LoonFS request.
-/// - **CLI-local codes** cover failures that never reach a backend. The
-///   complete list, each owned by a constructor below, is: `invalid_config`,
-///   `profile_not_found`, `no_default_profile`, `no_default_namespace`,
-///   `profile_already_exists`, `config_already_exists`, `destination_exists`,
-///   `non_interactive_input_required`, `json_not_supported_for_streaming`,
-///   `invalid_usage`, `io_error`, and `cancelled`. Overlaps with backend-local
-///   codes are deliberate: the same string means the same thing in both
-///   layers. A local configuration failure is `invalid_config` whether the
-///   CLI or backend detects it.
+/// API codes pass through unchanged so embedded and remote profiles report the
+/// same code. Validation after argument parsing uses `invalid_request`.
+/// Parser errors use the CLI-local `invalid_usage` code. Other local codes are
+/// created by the constructors below.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct CliError {
     pub code: String,
@@ -161,9 +148,8 @@ impl CliError {
         )
     }
 
-    /// A command line the parser rejected: an unknown command, a bad value,
-    /// a missing option. Distinct from `invalid_request`, which reports a
-    /// parsed value that cannot form a LoonFS request.
+    /// A command line rejected by the argument parser. Validation that runs
+    /// after parsing uses `invalid_request` instead.
     pub(crate) fn invalid_usage(message: impl Into<String>) -> Self {
         Self::new("invalid_usage", message)
     }
@@ -181,27 +167,5 @@ impl CliError {
 
     pub(crate) fn cancelled() -> Self {
         Self::new("cancelled", "operation cancelled")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn retired_error_code_is_absent_from_the_cli_tree() {
-        let retired = ["invalid", "input"].join("_");
-        for entry in walkdir::WalkDir::new(env!("CARGO_MANIFEST_DIR")) {
-            let entry = entry.expect("walk CLI tree");
-            if !entry.file_type().is_file() {
-                continue;
-            }
-            let bytes = std::fs::read(entry.path()).expect("read CLI source or fixture");
-            assert!(
-                !bytes
-                    .windows(retired.len())
-                    .any(|window| window == retired.as_bytes()),
-                "retired error code remains in {}",
-                entry.path().display()
-            );
-        }
     }
 }

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -1,6 +1,7 @@
 //! [`CliError`]: the structured failure every command surfaces.
 
 use crate::config::NAMESPACE_ENV;
+use loonfs_api::ErrorCode;
 use serde::Serialize;
 
 /// Structured failure surfaced by every CLI command (`--json` renders it verbatim).
@@ -13,18 +14,18 @@ use serde::Serialize;
 ///   string literal; use `ErrorCode::X.as_str()` or an error's `code()`.
 /// - **Backend-local codes** ([`crate::backend_error::BackendError`]) pass
 ///   through verbatim from the backend: `invalid_config`,
-///   `invalid_input`, `client_error`, `io_error`, and `runtime_error`.
+///   `client_error`, `io_error`, and `runtime_error`.
+/// - **CLI request validation** uses the registry's `invalid_request` code
+///   before dispatch when a parsed value cannot form a LoonFS request.
 /// - **CLI-local codes** cover failures that never reach a backend. The
 ///   complete list, each owned by a constructor below, is: `invalid_config`,
-///   `invalid_input`, `profile_not_found`, `no_default_profile`,
-///   `no_default_namespace`, `profile_already_exists`,
-///   `config_already_exists`, `destination_exists`,
+///   `profile_not_found`, `no_default_profile`, `no_default_namespace`,
+///   `profile_already_exists`, `config_already_exists`, `destination_exists`,
 ///   `non_interactive_input_required`, `json_not_supported_for_streaming`,
-///   `invalid_usage`, `io_error`, and `cancelled`. Overlaps with
-///   backend-local codes are deliberate: the same string means the same thing
-///   in both layers. A local configuration failure is `invalid_config`
-///   whether the CLI or backend detects it, and registry codes are reserved
-///   for failures a server could also produce.
+///   `invalid_usage`, `io_error`, and `cancelled`. Overlaps with backend-local
+///   codes are deliberate: the same string means the same thing in both
+///   layers. A local configuration failure is `invalid_config` whether the
+///   CLI or backend detects it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct CliError {
     pub code: String,
@@ -87,8 +88,8 @@ impl CliError {
         Self::new("invalid_config", message)
     }
 
-    pub(crate) fn invalid_input(message: impl Into<String>) -> Self {
-        Self::new("invalid_input", message)
+    pub(crate) fn invalid_request(message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidRequest.as_str(), message)
     }
 
     pub(crate) fn with_param(mut self, param: impl Into<String>) -> Self {
@@ -161,8 +162,8 @@ impl CliError {
     }
 
     /// A command line the parser rejected: an unknown command, a bad value,
-    /// a missing option. Distinct from `invalid_input`, which a command that
-    /// ran reports about what it was asked to do.
+    /// a missing option. Distinct from `invalid_request`, which reports a
+    /// parsed value that cannot form a LoonFS request.
     pub(crate) fn invalid_usage(message: impl Into<String>) -> Self {
         Self::new("invalid_usage", message)
     }
@@ -180,5 +181,27 @@ impl CliError {
 
     pub(crate) fn cancelled() -> Self {
         Self::new("cancelled", "operation cancelled")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn retired_error_code_is_absent_from_the_cli_tree() {
+        let retired = ["invalid", "input"].join("_");
+        for entry in walkdir::WalkDir::new(env!("CARGO_MANIFEST_DIR")) {
+            let entry = entry.expect("walk CLI tree");
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let bytes = std::fs::read(entry.path()).expect("read CLI source or fixture");
+            assert!(
+                !bytes
+                    .windows(retired.len())
+                    .any(|window| window == retired.as_bytes()),
+                "retired error code remains in {}",
+                entry.path().display()
+            );
+        }
     }
 }

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -453,7 +453,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                 "directories"
             };
             let mut summary = format!(
-                "{verb} {files} files and explicitly ensured {directories} {directory_noun} ({source} -> {destination})"
+                "{verb} {files} files and {directories} {directory_noun} ({source} -> {destination})"
             );
             if !failures.is_empty() {
                 summary.push_str(&format!("; {} failed", failures.len()));

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -447,8 +447,13 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                     failure.path, failure.error.code, failure.error.message
                 ));
             }
+            let directory_noun = if *directories == 1 {
+                "directory"
+            } else {
+                "directories"
+            };
             let mut summary = format!(
-                "{verb} {files} files and {directories} directories ({source} -> {destination})"
+                "{verb} {files} files and explicitly ensured {directories} {directory_noun} ({source} -> {destination})"
             );
             if !failures.is_empty() {
                 summary.push_str(&format!("; {} failed", failures.len()));

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -11,7 +11,7 @@ use crate::error::CliError;
 use crate::profiles::{default_namespace, resolve_profile};
 use loonfs::{FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreKind};
 use loonfs_api::env::AUTH_TOKEN_ENV;
-use loonfs_api::{ActorId, ActorKind, ActorRef, ErrorCode, NamespaceId, SecretString};
+use loonfs_api::{ActorId, ActorKind, ActorRef, NamespaceId, SecretString};
 use loonfs_client::{Client, ClientConfig};
 use loonfs_grep::{GrepBlockCache, GrepService, DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES};
 use std::sync::Arc;
@@ -67,7 +67,8 @@ pub(crate) fn resolve_namespace(
 ) -> Result<ResolvedNamespace, CliError> {
     if let Some(namespace) = explicit_namespace {
         return Ok(ResolvedNamespace {
-            namespace: parse_namespace_id(namespace)?,
+            namespace: parse_namespace_id(namespace)
+                .map_err(|error| error.with_param("--namespace"))?,
         });
     }
     if let Some(namespace) = non_empty_env(NAMESPACE_ENV) {
@@ -146,7 +147,7 @@ fn parse_actor_kind(name: &str, value: &str) -> Result<ActorKind, CliError> {
 }
 
 fn named_cli_input_error(name: &str, message: String) -> CliError {
-    let error = CliError::invalid_input(message);
+    let error = CliError::invalid_request(message);
     if name.starts_with('-') {
         error.with_param(name)
     } else {
@@ -158,8 +159,7 @@ fn named_cli_input_error(name: &str, message: String) -> CliError {
 /// surfaces its registry code so both profile modes report the same code
 /// the server would serve for it.
 pub(crate) fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
-    NamespaceId::parse(namespace)
-        .map_err(|error| CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
+    NamespaceId::parse(namespace).map_err(|error| CliError::invalid_request(error.to_string()))
 }
 
 fn default_writer_id() -> String {

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -155,9 +155,8 @@ fn named_cli_input_error(name: &str, message: String) -> CliError {
     }
 }
 
-/// Parses a namespace argument once at the CLI boundary. A malformed id
-/// surfaces its registry code so both profile modes report the same code
-/// the server would serve for it.
+/// Parses a namespace ID after argument parsing. Invalid IDs use the shared
+/// `invalid_request` code in both embedded and remote modes.
 pub(crate) fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
     NamespaceId::parse(namespace).map_err(|error| CliError::invalid_request(error.to_string()))
 }

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -1857,6 +1857,33 @@ fn annotate_rejects_a_set_without_an_equals_and_a_document_beside_the_flags() {
     assert_failure(&both);
     assert_eq!(both.status.code(), Some(2));
     assert_eq!(parse_json(&both.stderr)["error"]["code"], "invalid_usage");
+
+    let string_value = harness.run(&[
+        "--json",
+        "annotate",
+        "/docs",
+        "--attributes-json",
+        r#"{"set":{"tags":"[\"red\",\"blue\"]"}}"#,
+    ]);
+    assert_success(&string_value);
+    let stat = harness.run(&["--json", "stat", "/docs"]);
+    assert_success(&stat);
+    assert_eq!(
+        json_data(&stat)["attributes"]["tags"],
+        serde_json::json!(r#"["red","blue"]"#)
+    );
+
+    let native_array = harness.run(&[
+        "--json",
+        "annotate",
+        "/docs",
+        "--attributes-json",
+        r#"{"set":{"tags":["red","blue"]}}"#,
+    ]);
+    assert_failure(&native_array);
+    let error = json_error(&native_array);
+    assert_eq!(error["code"], "invalid_request");
+    assert_eq!(error["param"], "--attributes-json");
 }
 
 /// `mkdir -p` on a directory that is already there succeeds, the way Unix

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -526,7 +526,7 @@ fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
 
     let no_destination = harness.run_with_stdin(&["--json", "put", "-"], b"anything");
     assert_failure(&no_destination);
-    assert_eq!(json_error(&no_destination)["code"], "invalid_input");
+    assert_eq!(json_error(&no_destination)["code"], "invalid_request");
 }
 
 /// A file many chunks long round-trips through an embedded profile to a
@@ -1136,6 +1136,54 @@ fn remote_namespace_commands_reject_invalid_namespace_ids_before_http() {
     let use_namespace = harness.run(&["--json", "use", "bad/name"]);
     assert_failure(&use_namespace);
     assert_eq!(json_error(&use_namespace)["code"], "invalid_request");
+}
+
+#[test]
+fn malformed_paths_are_invalid_request_in_both_modes_and_output_formats() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("embedded");
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "remote",
+        "remote",
+        "--server-url",
+        "http://127.0.0.1:9",
+    ]);
+    assert_success(&add_remote);
+
+    for profile in ["embedded", "remote"] {
+        let human = harness.run(&[
+            "stat",
+            "--profile",
+            profile,
+            "--namespace",
+            "demo",
+            "relative/path",
+        ]);
+        assert_failure(&human);
+        assert!(stderr_string(&human).contains("absolute"), "{human:?}");
+        assert!(stderr_string(&human).contains("param: path"), "{human:?}");
+
+        let json = harness.run(&[
+            "--json",
+            "stat",
+            "--profile",
+            profile,
+            "--namespace",
+            "demo",
+            "relative/path",
+        ]);
+        assert_failure(&json);
+        let error = json_error(&json);
+        assert_eq!(error["code"], "invalid_request");
+        assert_eq!(error["param"], "path");
+        assert!(error["message"]
+            .as_str()
+            .expect("error message")
+            .contains("absolute"));
+    }
 }
 
 #[test]
@@ -1790,7 +1838,7 @@ fn annotate_rejects_a_set_without_an_equals_and_a_document_beside_the_flags() {
 
     let no_equals = harness.run(&["--json", "annotate", "/docs", "--set", "owner"]);
     assert_failure(&no_equals);
-    assert_eq!(json_error(&no_equals)["code"], "invalid_input");
+    assert_eq!(json_error(&no_equals)["code"], "invalid_request");
     assert!(json_error(&no_equals)["message"]
         .as_str()
         .expect("json string")

--- a/crates/loonfs-cli/tests/it/output.rs
+++ b/crates/loonfs-cli/tests/it/output.rs
@@ -411,6 +411,35 @@ fn unused_global_selectors_are_invalid_usage() {
     }
 }
 
+#[test]
+fn json_all_is_invalid_usage_even_with_a_limit() {
+    let harness = Harness::new();
+
+    for arguments in [
+        vec!["--json", "ls", "--all", "--limit", "1"],
+        vec!["--json", "changes", "--all", "--limit", "1"],
+        vec![
+            "--json",
+            "admin",
+            "checkpoint",
+            "list",
+            "--all",
+            "--limit",
+            "1",
+        ],
+    ] {
+        let output = harness.run(&arguments);
+        assert_eq!(output.status.code(), Some(2), "{output:?}");
+        let error = &parse_json(&output.stderr)["error"];
+        assert_eq!(error["code"], "invalid_usage");
+        assert_eq!(error["param"], "--all");
+        assert!(error["message"]
+            .as_str()
+            .expect("error message")
+            .contains("--all cannot be used with --json"));
+    }
+}
+
 /// Embedded and remote profiles must report the same `code` for the same
 /// failure: registry codes pass through verbatim in both modes instead of
 /// being rewritten to CLI-local codes on one side.
@@ -576,21 +605,21 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     );
     assert!(!stdout_string(&all).contains("more entries exist"));
 
-    let all_json = harness.run(&["--json", "ls", "/listing", "--all", "--limit", "1001"]);
-    assert_success(&all_json);
-    let all_json_data = json_data(&all_json);
-    assert_eq!(all_json_data["namespace_id"], "demo");
-    assert_eq!(all_json_data["path"], "/listing");
-    assert!(all_json_data["head_seq"].is_u64());
-    assert!(all_json_data.get("head_drift").is_none());
+    let bounded_json = harness.run(&["--json", "ls", "/listing", "--limit", "1001"]);
+    assert_success(&bounded_json);
+    let bounded_json_data = json_data(&bounded_json);
+    assert_eq!(bounded_json_data["namespace_id"], "demo");
+    assert_eq!(bounded_json_data["path"], "/listing");
+    assert!(bounded_json_data["head_seq"].is_u64());
+    assert!(bounded_json_data.get("head_drift").is_none());
     assert_eq!(
-        all_json_data["entries"]
+        bounded_json_data["entries"]
             .as_array()
             .expect("all entries")
             .len(),
         loonfs_api::DEFAULT_PAGE_LIMIT as usize + 1
     );
-    assert!(all_json_data.get("next_cursor").is_none());
+    assert!(bounded_json_data.get("next_cursor").is_none());
 
     let jsonl = harness.run(&["ls", "/listing", "--all", "--jsonl"]);
     assert_success(&jsonl);
@@ -649,7 +678,7 @@ fn ls_surfaces_head_drift_from_paged_responses() {
         }),
     ]);
     harness.write_remote_listing_config(&server_url);
-    let json = harness.run(&["--json", "ls", "/docs", "--all", "--limit", "2"]);
+    let json = harness.run(&["--json", "ls", "/docs", "--limit", "2"]);
     assert_success(&json);
     assert!(json.stderr.is_empty());
     let data = json_data(&json);
@@ -697,7 +726,7 @@ fn ls_surfaces_head_drift_from_paged_responses() {
     server.join().expect("listing server");
 }
 
-/// `--limit` still applies with `--all`, and buffered JSON requires a limit.
+/// `--limit` still applies with human `--all`, and buffered JSON rejects it.
 #[test]
 fn ls_limit_bounds_the_whole_listing_and_rejects_unbounded_json() {
     let harness = Harness::new();
@@ -715,11 +744,11 @@ fn ls_limit_bounds_the_whole_listing_and_rejects_unbounded_json() {
         ]));
     }
 
-    // Explicitly unbounded JSON must use JSONL or add a bound.
+    // Explicitly unbounded JSON must use JSONL.
     let all = harness.run(&["--json", "ls", "--all"]);
     assert_failure(&all);
     assert_eq!(all.status.code(), Some(2));
-    assert!(stderr_string(&all).contains("use '--jsonl' to stream without a limit"));
+    assert!(stderr_string(&all).contains("--all cannot be used with --json"));
 
     // A bound stops at exactly that many entries and returns a cursor.
     let first = harness.run(&["--json", "ls", "--limit", "2"]);

--- a/crates/loonfs-cli/tests/it/output.rs
+++ b/crates/loonfs-cli/tests/it/output.rs
@@ -726,9 +726,8 @@ fn ls_surfaces_head_drift_from_paged_responses() {
     server.join().expect("listing server");
 }
 
-/// `--limit` still applies with human `--all`, and buffered JSON rejects it.
 #[test]
-fn ls_limit_bounds_the_whole_listing_and_rejects_unbounded_json() {
+fn ls_limit_bounds_the_whole_listing_and_json_rejects_all() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
     assert_success(&harness.run(&["namespace", "create", "demo"]));
@@ -744,7 +743,6 @@ fn ls_limit_bounds_the_whole_listing_and_rejects_unbounded_json() {
         ]));
     }
 
-    // Explicitly unbounded JSON must use JSONL.
     let all = harness.run(&["--json", "ls", "--all"]);
     assert_failure(&all);
     assert_eq!(all.status.code(), Some(2));

--- a/crates/loonfs-cli/tests/it/output.rs
+++ b/crates/loonfs-cli/tests/it/output.rs
@@ -395,6 +395,22 @@ fn json_covers_command_lines_the_parser_rejects() {
     assert_success(&version);
 }
 
+#[test]
+fn unused_global_selectors_are_invalid_usage() {
+    let harness = Harness::new();
+
+    for arguments in [
+        vec!["--json", "--namespace", "demo", "version"],
+        vec!["--json", "--profile", "prod", "config", "path"],
+        vec!["--json", "--namespace", "demo", "namespace", "create", "x"],
+        vec!["--json", "use", "x", "--namespace", "y"],
+    ] {
+        let output = harness.run(&arguments);
+        assert_eq!(output.status.code(), Some(2), "{output:?}");
+        assert_eq!(parse_json(&output.stderr)["error"]["code"], "invalid_usage");
+    }
+}
+
 /// Embedded and remote profiles must report the same `code` for the same
 /// failure: registry codes pass through verbatim in both modes instead of
 /// being rewritten to CLI-local codes on one side.

--- a/crates/loonfs-cli/tests/it/recursive.rs
+++ b/crates/loonfs-cli/tests/it/recursive.rs
@@ -382,7 +382,7 @@ fn recursive_transfers_roundtrip_a_tree() {
     assert_success(&harness.run(&["--json", "stat", "/moved/docs/a.txt"]));
     let mv_recursive = harness.run(&["--json", "mv", "-r", "/moved", "/again"]);
     assert_failure(&mv_recursive);
-    assert_eq!(json_error(&mv_recursive)["code"], "invalid_input");
+    assert_eq!(json_error(&mv_recursive)["code"], "invalid_request");
 }
 
 /// A recursive get creates the destination it was handed, parents included,

--- a/crates/loonfs-cli/tests/it/recursive.rs
+++ b/crates/loonfs-cli/tests/it/recursive.rs
@@ -317,9 +317,10 @@ fn recursive_transfers_roundtrip_a_tree() {
     assert_failure(&rerun);
     let rerun_data = json_data(&rerun);
     assert_eq!(rerun_data["files"], 0);
+    assert_eq!(rerun_data["directories"], 1);
     assert_eq!(
         rerun_data["failures"].as_array().expect("failures").len(),
-        4
+        3
     );
     assert_eq!(
         rerun_data["failures"][0]["error"]["code"], "path_conflict",
@@ -333,13 +334,14 @@ fn recursive_transfers_roundtrip_a_tree() {
         "/up",
         "--force",
     ]);
-    assert_failure(&forced);
+    assert_success(&forced);
     let forced_data = json_data(&forced);
     assert_eq!(forced_data["files"], 3);
+    assert_eq!(forced_data["directories"], 1);
     assert_eq!(
         forced_data["failures"].as_array().expect("failures").len(),
-        1,
-        "the empty directory still conflicts: {forced_data}"
+        0,
+        "the existing empty directory is already ensured: {forced_data}"
     );
 
     // Download the tree and compare bytes; empty directories materialize.
@@ -383,6 +385,40 @@ fn recursive_transfers_roundtrip_a_tree() {
     let mv_recursive = harness.run(&["--json", "mv", "-r", "/moved", "/again"]);
     assert_failure(&mv_recursive);
     assert_eq!(json_error(&mv_recursive)["code"], "invalid_request");
+}
+
+#[test]
+fn recursive_empty_directory_ensures_are_idempotent_but_files_still_conflict() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let tree = harness.temp_dir.path().join("empty-tree");
+    fs::create_dir_all(tree.join("empty")).expect("create empty directory");
+    let local_tree = tree.to_str().expect("utf-8 path");
+    assert_success(&harness.run(&["put", "-r", local_tree, "/tree"]));
+
+    let rerun = harness.run(&["--no-progress", "put", "-r", "--force", local_tree, "/tree"]);
+    assert_success(&rerun);
+    assert!(
+        stdout_string(&rerun).contains("explicitly ensured 1 directory"),
+        "{}",
+        stdout_string(&rerun)
+    );
+
+    let payload = harness.temp_dir.path().join("payload.txt");
+    fs::write(&payload, b"file").expect("write payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/blocked/empty",
+    ]));
+    let blocked = harness.run(&["--json", "put", "-r", "--force", local_tree, "/blocked"]);
+    assert_failure(&blocked);
+    let data = json_data(&blocked);
+    assert_eq!(data["directories"], 0);
+    assert_eq!(data["failures"][0]["error"]["code"], "path_conflict");
 }
 
 /// A recursive get creates the destination it was handed, parents included,

--- a/crates/loonfs-cli/tests/it/recursive.rs
+++ b/crates/loonfs-cli/tests/it/recursive.rs
@@ -388,7 +388,7 @@ fn recursive_transfers_roundtrip_a_tree() {
 }
 
 #[test]
-fn recursive_empty_directory_ensures_are_idempotent_but_files_still_conflict() {
+fn recursive_put_reuses_existing_directories_but_rejects_files() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
     assert_success(&harness.run(&["namespace", "create", "demo"]));
@@ -402,7 +402,7 @@ fn recursive_empty_directory_ensures_are_idempotent_but_files_still_conflict() {
     let rerun = harness.run(&["--no-progress", "put", "-r", "--force", local_tree, "/tree"]);
     assert_success(&rerun);
     assert!(
-        stdout_string(&rerun).contains("explicitly ensured 1 directory"),
+        stdout_string(&rerun).contains("stored 0 files and 1 directory"),
         "{}",
         stdout_string(&rerun)
     );


### PR DESCRIPTION
This makes --profile and --namespace global selectors, while rejecting them for commands that cannot use them. It also rejects --json with --all, shows both stat target forms in help, and reports values rejected after argument parsing as invalid_request. Parser errors remain invalid_usage.

Recursive uploads now accept an existing destination directory and still reject a file at that path. Directory walk failures remain io_error, and the transfer summary uses plain language. The CLI documentation now explains pagination, string-valued attributes, stat by inode, and recursive download destinations more clearly.

The CLI unit and integration tests cover selector placement and precedence, JSON modes, error codes, recursive directory behavior, and the documented command forms.