### PR TITLE
fix(objectstore): keep provider internals out of public errors

### DIFF
--- a/crates/loonfs-cli/src/backend_error.rs
+++ b/crates/loonfs-cli/src/backend_error.rs
@@ -131,16 +131,17 @@ impl From<ClientError> for BackendError {
 }
 
 pub(crate) fn map_runtime_error(error: RuntimeError) -> BackendError {
+    let public_message = error.public_message().into_owned();
     match error {
-        RuntimeError::Config(message) => BackendError::invalid_config(message),
-        RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
+        RuntimeError::Config(_) => BackendError::invalid_config(public_message),
+        RuntimeError::RuntimeTask(_) => BackendError::runtime_error(public_message),
         // The embedded surface reports the same structured details a server
         // puts in its error envelope for the same condition, so `--json`
         // consumers read one contract from both backends.
         error => BackendError {
             code: error.code().as_str().to_owned(),
             feature: None,
-            message: error.to_string(),
+            message: public_message,
             param: None,
             request_id: None,
             details: error.details().map(Box::new),
@@ -182,7 +183,10 @@ pub(crate) fn map_namespace_scoped_grep_error(
                 response
             }
         }
-        error => BackendError::new(error.code().as_str(), error.to_string()),
+        error => {
+            let message = error.public_message().into_owned();
+            BackendError::new(error.code().as_str(), message)
+        }
     }
 }
 

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -590,6 +590,16 @@ fn human_doctor(checks: &[DoctorCheck]) -> String {
     let mut lines = Vec::new();
     for check in checks {
         if check.status == DoctorStatus::Failed {
+            if let Some(response) = &check.store_probe {
+                let groups = store_probe_failure_group_lines(response);
+                if !groups.is_empty() {
+                    lines.push(format!("FAILED  {}", check.name));
+                    lines.extend(groups.into_iter().map(|line| format!("        {line}")));
+                    continue;
+                }
+            }
+        }
+        if check.status == DoctorStatus::Failed {
             lines.push(format!("{}: failed", check.name));
             let mut detail = format!("  detail: {}", single_line(&check.message));
             if let Some(request_id) = &check.request_id {

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -115,11 +115,42 @@ mod tests {
     use crate::error::CliError;
     use crate::profiles::ProfileSummary;
     use insta::{assert_json_snapshot, assert_snapshot};
+    use loonfs_api::v0::{StoreProbeCheckOutcome, StoreProbeCheckResult, StoreProbeResponse};
     use loonfs_api::{
         AbsolutePath, AttributesProjection, AuthoritativePathEntry, AuthoritativePathEntryKind,
         ChangeSeq, DisplayName, InodeId, NamespaceId,
     };
     use loonfs_client::ClientError;
+
+    const POISON_PROVIDER_DETAIL: &str = "<Error>AccessDenied</Error> \
+        arn:aws:iam::123456789012:role/private-role private-bucket \
+        namespaces/customer-a/head.json x-amz-request-id=provider-request \
+        x-amz-id-2=provider-host-id AKIAEXAMPLE";
+
+    fn assert_provider_markers_absent(rendered: &str) {
+        for marker in [
+            "<Error>AccessDenied</Error>",
+            "arn:aws:iam::123456789012:role/private-role",
+            "private-bucket",
+            "namespaces/customer-a/head.json",
+            "x-amz-request-id=provider-request",
+            "x-amz-id-2=provider-host-id",
+            "AKIAEXAMPLE",
+        ] {
+            assert!(
+                !rendered.contains(marker),
+                "rendered output leaked {marker}: {rendered}"
+            );
+        }
+    }
+
+    fn poison_permission_runtime_error() -> loonfs::RuntimeError {
+        loonfs::RuntimeError::Core(loonfs::CoreError::Store {
+            object_key: "namespaces/customer-a/head.json".to_owned(),
+            message: POISON_PROVIDER_DETAIL.to_owned(),
+            class: loonfs::StoreFailureClass::PermissionDenied,
+        })
+    }
 
     fn rendered_remote_error(server_boundary: &str) -> serde_json::Value {
         let body: loonfs_api::ApiError =
@@ -150,6 +181,137 @@ mod tests {
                 "server field `{field}` was lost before CLI JSON"
             );
         }
+    }
+
+    #[test]
+    fn provider_failure_is_safe_on_embedded_remote_and_doctor_surfaces() {
+        let public_message = loonfs::ObjectStoreError::PermissionDenied {
+            object_key: "namespaces/customer-a/head.json".to_owned(),
+            message: POISON_PROVIDER_DETAIL.to_owned(),
+        }
+        .public_message()
+        .into_owned();
+
+        let embedded_failure = CommandFailure {
+            kind: CommandKind::ConfigShow,
+            profile: Some("embedded".to_owned()),
+            mode: Some("embedded".to_owned()),
+            error: Box::new(CliError::from(crate::backend_error::map_runtime_error(
+                poison_permission_runtime_error(),
+            ))),
+        };
+        let embedded_human = human_error(&embedded_failure.error);
+        let embedded_json = json_error(&embedded_failure).expect("embedded JSON error renders");
+        for rendered in [&embedded_human, &embedded_json] {
+            assert_provider_markers_absent(rendered);
+            assert!(rendered.contains(&public_message), "{rendered}");
+        }
+
+        let remote_boundary = serde_json::to_string(&loonfs_api::ApiError {
+            code: loonfs_api::ErrorCode::PermissionDenied.as_str().to_owned(),
+            feature: None,
+            message: public_message.clone(),
+            param: None,
+            request_id: Some("req_provider_hygiene".to_owned()),
+            details: None,
+        })
+        .expect("remote boundary serializes");
+        let body: loonfs_api::ApiError =
+            serde_json::from_str(&remote_boundary).expect("remote boundary is valid JSON");
+        let remote_failure = CommandFailure {
+            kind: CommandKind::ConfigShow,
+            profile: Some("remote".to_owned()),
+            mode: Some("remote".to_owned()),
+            error: Box::new(CliError::from(crate::backend_error::BackendError::from(
+                ClientError::from_api_error(403, body),
+            ))),
+        };
+        let remote_human = human_error(&remote_failure.error);
+        let remote_json = json_error(&remote_failure).expect("remote JSON error renders");
+        for rendered in [&remote_human, &remote_json] {
+            assert_provider_markers_absent(rendered);
+            assert!(rendered.contains(&public_message), "{rendered}");
+            assert!(rendered.contains("req_provider_hygiene"), "{rendered}");
+        }
+
+        let checks = vec![
+            StoreProbeCheckResult {
+                name: "create_if_absent_enforced".to_owned(),
+                outcome: StoreProbeCheckOutcome::Failed,
+                message: Some(format!("create failed: {public_message}")),
+            },
+            StoreProbeCheckResult {
+                name: "compare_and_swap_rejects_stale".to_owned(),
+                outcome: StoreProbeCheckOutcome::Failed,
+                message: Some(format!(" create   failed:  {public_message}\n")),
+            },
+            StoreProbeCheckResult {
+                name: "stored_checksum_readback".to_owned(),
+                outcome: StoreProbeCheckOutcome::Failed,
+                message: Some(format!("checksum head failed: {public_message}")),
+            },
+            StoreProbeCheckResult {
+                name: "range_reads".to_owned(),
+                outcome: StoreProbeCheckOutcome::Failed,
+                message: Some(
+                    "range read failed: object-store is temporarily unavailable; retry the operation"
+                        .to_owned(),
+                ),
+            },
+        ];
+        let doctor = CommandOutput {
+            kind: CommandKind::Doctor,
+            profile: Some("embedded".to_owned()),
+            mode: Some("embedded".to_owned()),
+            data: CommandData::Doctor {
+                checks: vec![DoctorCheck {
+                    name: "store_probe".to_owned(),
+                    status: DoctorStatus::Failed,
+                    message: "store probe probe_poison: 4 of 4 checks failed".to_owned(),
+                    request_id: None,
+                    store_probe: Some(StoreProbeResponse {
+                        run_id: "probe_poison".to_owned(),
+                        checks: checks.clone(),
+                    }),
+                }],
+            },
+        };
+        let doctor_human = human_success(&doctor);
+        let doctor_json = json_success(&doctor).expect("doctor JSON renders");
+        for rendered in [&doctor_human, &doctor_json] {
+            assert_provider_markers_absent(rendered);
+            assert!(rendered.contains(&public_message), "{rendered}");
+        }
+        assert!(
+            doctor_human.contains("FAILED  store_probe"),
+            "{doctor_human}"
+        );
+        assert!(
+            doctor_human.contains("3 checks failed: object-store permission denied;"),
+            "{doctor_human}"
+        );
+        assert!(
+            doctor_human.contains(
+                "affected: create_if_absent_enforced, compare_and_swap_rejects_stale, stored_checksum_readback"
+            ),
+            "{doctor_human}"
+        );
+        assert!(
+            doctor_human.contains(
+                "1 check failed: object-store is temporarily unavailable; retry the operation"
+            ),
+            "{doctor_human}"
+        );
+        assert!(
+            doctor_human.contains("affected: range_reads"),
+            "{doctor_human}"
+        );
+        let doctor_value: serde_json::Value =
+            serde_json::from_str(&doctor_json).expect("doctor JSON is valid");
+        assert_eq!(
+            doctor_value["data"]["checks"][0]["store_probe"]["checks"],
+            serde_json::to_value(checks).expect("probe checks serialize")
+        );
     }
 
     fn path_entry(path: &str, display_name: Option<&str>) -> AuthoritativePathEntry {

--- a/crates/loonfs-cli/src/render/summaries.rs
+++ b/crates/loonfs-cli/src/render/summaries.rs
@@ -45,6 +45,48 @@ pub(super) fn store_probe_report_lines(
     lines
 }
 
+/// Groups failed probe checks by the one-line message shown by `doctor`.
+pub(super) fn store_probe_failure_group_lines(
+    response: &loonfs_api::v0::StoreProbeResponse,
+) -> Vec<String> {
+    let mut groups: Vec<(String, Vec<&str>)> = Vec::new();
+    for check in &response.checks {
+        if check.outcome != StoreProbeCheckOutcome::Failed {
+            continue;
+        }
+        let message = check
+            .message
+            .as_deref()
+            .map(normalize_probe_message)
+            .filter(|message| !message.is_empty())
+            .unwrap_or_else(|| "object-store check failed".to_owned());
+        match groups.iter_mut().find(|(existing, _)| *existing == message) {
+            Some((_, affected)) => affected.push(check.name.as_str()),
+            None => groups.push((message, vec![check.name.as_str()])),
+        }
+    }
+
+    groups
+        .into_iter()
+        .flat_map(|(message, affected)| {
+            let count = affected.len();
+            let noun = if count == 1 { "check" } else { "checks" };
+            [
+                format!("{count} {noun} failed: {message}"),
+                format!("affected: {}", affected.join(", ")),
+            ]
+        })
+        .collect()
+}
+
+fn normalize_probe_message(message: &str) -> String {
+    let normalized = message.split_whitespace().collect::<Vec<_>>().join(" ");
+    match normalized.find("object-store ") {
+        Some(public_start) => normalized[public_start..].to_owned(),
+        None => normalized,
+    }
+}
+
 /// Formats the result of one WAL flush step.
 pub(super) fn wal_flush_summary(outcome: &WalFlushStepOutcome, tail_segments: u64) -> String {
     match outcome {

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -237,7 +237,7 @@ impl EmbeddedTarget {
         // deliberately share one provider client.
         let store: SharedObjectStore = store_config
             .configured_object_store()
-            .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}")))?
+            .map_err(|err| CliError::invalid_config(err.public_message().into_owned()))?
             .into_shared();
         Self::over_store(store, writer_id, TraceStoreKind::from(store_config.kind())).await
     }

--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -151,7 +151,7 @@ pub(super) async fn load_section_bytes<S: ObjectStore + ?Sized>(
         .await
         .map_err(|err| ManifestLoadError::ReadSegment {
             object_key: object_key.to_owned(),
-            message: err.to_string(),
+            message: err.public_message().into_owned(),
         })?
     else {
         return Err(ManifestLoadError::MissingSegment {

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -209,7 +209,7 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
             .await
             .map_err(|err| ManifestLoadError::ReadManifest {
                 object_key: manifest_key.clone(),
-                message: err.to_string(),
+                message: err.public_message().into_owned(),
             })?
         else {
             return Err(ManifestLoadError::MissingManifest {
@@ -315,7 +315,7 @@ pub(crate) async fn load_namespace_manifest_envelope_if_present<S: ObjectStore +
         .await
         .map_err(|err| ManifestLoadError::ReadManifest {
             object_key: manifest_key.to_owned(),
-            message: err.to_string(),
+            message: err.public_message().into_owned(),
         })?
     else {
         return Ok(None);

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -59,13 +59,15 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
         Err(ImmutableWriteError::Transport { source, .. }) => Err(
             MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ReadManifest {
                 object_key: manifest_key,
-                message: source.message(),
+                message: source.public_message().into_owned(),
             }),
         ),
-        Err(error) => Err(MetadataProjectionLoadError::ManifestLoad(
+        Err(_) => Err(MetadataProjectionLoadError::ManifestLoad(
             ManifestLoadError::ReadManifest {
                 object_key: manifest_key,
-                message: error.to_string(),
+                message: loonfs_objectstore::ObjectStoreErrorClass::Other
+                    .public_message()
+                    .into_owned(),
             },
         )),
     }

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -807,7 +807,10 @@ async fn checkpoint_basis_verification_store_failure_surfaces_and_releases_recor
             },
         )) => {
             assert_eq!(object_key, manifest_key);
-            assert!(message.contains("injected basis verification failure"));
+            assert_eq!(
+                message,
+                loonfs_objectstore::ObjectStoreErrorClass::Other.public_message()
+            );
         }
         other => panic!("expected a classified manifest store error, got {other:?}"),
     }

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -148,12 +148,12 @@ fn map_object_store_error(object_key: &str, err: ObjectStoreError) -> CommitHead
         ObjectStoreError::PreconditionFailed { .. } => CommitHeadPublishError::StaleHead,
         // A transport failure after the CAS was sent leaves the outcome
         // unobserved: the head may already reference the new segment.
-        ObjectStoreError::Transport { message, .. } => {
-            CommitHeadPublishError::OutcomeUnknown(message)
+        error @ ObjectStoreError::Transport { .. } => {
+            CommitHeadPublishError::OutcomeUnknown(error.public_message().into_owned())
         }
         other => CommitHeadPublishError::Store {
             object_key: object_key.to_owned(),
-            message: other.to_string(),
+            message: other.public_message().into_owned(),
         },
     }
 }
@@ -171,7 +171,11 @@ mod tests {
                 "namespaces/demo/control/head.json",
                 ObjectStoreError::transport("namespaces/demo/control/head.json", "timeout"),
             ),
-            CommitHeadPublishError::OutcomeUnknown("timeout".to_owned())
+            CommitHeadPublishError::OutcomeUnknown(
+                loonfs_objectstore::ObjectStoreErrorClass::Other
+                    .public_message()
+                    .into_owned()
+            )
         );
         assert_eq!(
             map_object_store_error(

--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -150,7 +150,7 @@ fn classify(object_key: &str, failure: ControlLoadFailure) -> ControlObjectLoadE
         },
         ControlLoadFailure::Store(error) => ControlObjectLoadError::Store {
             object_key: object_key.to_owned(),
-            message: error.message(),
+            message: error.public_message().into_owned(),
             class: StoreFailureClass::of(&error),
         },
     }

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -88,7 +88,7 @@ where
             Err(error) => {
                 return Err(E::from(ControlUpdateError::Store {
                     object_key: loaded.object_key,
-                    message: error.message(),
+                    message: error.public_message().into_owned(),
                     class: StoreFailureClass::of(&error),
                 }))
             }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -33,6 +33,7 @@ pub use self::CoreError as Error;
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 pub use loonfs_api::{ErrorCode, ErrorKind};
+pub use loonfs_objectstore::ObjectStoreErrorClass as StoreFailureClass;
 
 /// Detailed core error.
 ///
@@ -303,7 +304,7 @@ impl From<ImmutableWriteError> for CoreError {
             )),
             ImmutableWriteError::Transport { object_key, source } => Self::Store {
                 object_key,
-                message: source.message(),
+                message: source.public_message().into_owned(),
                 class: StoreFailureClass::of(&source),
             },
             error => Self::Store {
@@ -315,32 +316,17 @@ impl From<ImmutableWriteError> for CoreError {
     }
 }
 
-/// Classifies a provider failure by the action required to fix it. This
-/// classification is preserved after the original error is converted to a
-/// message so the wire error code remains accurate.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum StoreFailureClass {
-    /// The provider rejected the deployment's credentials: operator work,
-    /// never transient. Served as `permission_denied`.
-    PermissionDenied,
-    /// Everything else is internal from the caller's point of view.
-    Other,
-}
-
-impl StoreFailureClass {
-    /// Classifies a provider error before converting it to a stored message.
-    pub fn of(error: &ObjectStoreError) -> Self {
-        match error {
-            ObjectStoreError::PermissionDenied { .. } => Self::PermissionDenied,
-            _ => Self::Other,
-        }
-    }
-}
-
 fn classify_store_failure(class: StoreFailureClass) -> ErrorCode {
     match class {
         StoreFailureClass::PermissionDenied => ErrorCode::PermissionDenied,
-        StoreFailureClass::Other => ErrorCode::ServerError,
+        StoreFailureClass::NotFound
+        | StoreFailureClass::InvalidRequest
+        | StoreFailureClass::PreconditionFailed
+        | StoreFailureClass::StoredChecksumMissing
+        | StoreFailureClass::Unsupported
+        | StoreFailureClass::Configuration
+        | StoreFailureClass::RetryableTransport
+        | StoreFailureClass::Other => ErrorCode::ServerError,
     }
 }
 
@@ -354,7 +340,7 @@ impl CoreError {
     pub(crate) fn store(object_key: impl Into<String>, error: &ObjectStoreError) -> Self {
         Self::Store {
             object_key: object_key.into(),
-            message: error.message(),
+            message: error.public_message().into_owned(),
             class: StoreFailureClass::of(error),
         }
     }
@@ -444,6 +430,33 @@ impl CoreError {
         self.to_string()
     }
 
+    /// Returns the shared public projection when this core error wraps a
+    /// provider or store-protocol failure.
+    pub fn object_store_public_message(&self) -> Option<std::borrow::Cow<'static, str>> {
+        match self {
+            CoreError::MetadataProjection(error) => metadata_projection_store_message(error),
+            CoreError::DurableContent(error) => match error {
+                DurableContentValidationError::Store { message, .. } => {
+                    Some(std::borrow::Cow::Owned(message.clone()))
+                }
+                _ => None,
+            },
+            CoreError::WriterEpoch(error) => writer_epoch_store_message(error),
+            CoreError::HeadPublish(error) => match error {
+                CommitHeadPublishError::OutcomeUnknown(message)
+                | CommitHeadPublishError::Store { message, .. } => {
+                    Some(std::borrow::Cow::Owned(message.clone()))
+                }
+                _ => None,
+            },
+            CoreError::WalWrite { class, .. } | CoreError::Store { class, .. } => {
+                Some(class.public_message())
+            }
+            CoreError::FailedOperation { source, .. } => source.object_store_public_message(),
+            _ => None,
+        }
+    }
+
     /// Structured wire details for this error, when the variant carries
     /// machine-usable identity (API spec, "Standard error contract"). The
     /// server serializes this beside [`CoreError::code`]; embedded callers
@@ -490,6 +503,41 @@ impl CoreError {
             }),
             _ => None,
         }
+    }
+}
+
+fn metadata_projection_store_message(
+    error: &MetadataProjectionLoadError,
+) -> Option<std::borrow::Cow<'static, str>> {
+    match error {
+        MetadataProjectionLoadError::LoadHead(error) => control_object_store_message(error),
+        MetadataProjectionLoadError::WalChainLoad(WalChainLoadError::ReadWal {
+            message, ..
+        })
+        | MetadataProjectionLoadError::ManifestLoad(
+            ManifestLoadError::ReadManifest { message, .. }
+            | ManifestLoadError::ReadSegment { message, .. },
+        ) => Some(std::borrow::Cow::Owned(message.clone())),
+        _ => None,
+    }
+}
+
+fn control_object_store_message(
+    error: &ControlObjectLoadError,
+) -> Option<std::borrow::Cow<'static, str>> {
+    match error {
+        ControlObjectLoadError::Store { class, .. } => Some(class.public_message()),
+        _ => None,
+    }
+}
+
+fn writer_epoch_store_message(
+    error: &WriterEpochAcquireError,
+) -> Option<std::borrow::Cow<'static, str>> {
+    match error {
+        WriterEpochAcquireError::LoadHead(error) => control_object_store_message(error),
+        WriterEpochAcquireError::HeadWrite { class, .. } => Some(class.public_message()),
+        _ => None,
     }
 }
 

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -430,25 +430,18 @@ impl CoreError {
         self.to_string()
     }
 
-    /// Returns the shared public projection when this core error wraps a
-    /// provider or store-protocol failure.
+    /// Returns a safe message when this error came from the object store.
     pub fn object_store_public_message(&self) -> Option<std::borrow::Cow<'static, str>> {
         match self {
             CoreError::MetadataProjection(error) => metadata_projection_store_message(error),
-            CoreError::DurableContent(error) => match error {
-                DurableContentValidationError::Store { message, .. } => {
-                    Some(std::borrow::Cow::Owned(message.clone()))
-                }
-                _ => None,
-            },
+            CoreError::DurableContent(DurableContentValidationError::Store { message, .. }) => {
+                Some(std::borrow::Cow::Owned(message.clone()))
+            }
             CoreError::WriterEpoch(error) => writer_epoch_store_message(error),
-            CoreError::HeadPublish(error) => match error {
+            CoreError::HeadPublish(
                 CommitHeadPublishError::OutcomeUnknown(message)
-                | CommitHeadPublishError::Store { message, .. } => {
-                    Some(std::borrow::Cow::Owned(message.clone()))
-                }
-                _ => None,
-            },
+                | CommitHeadPublishError::Store { message, .. },
+            ) => Some(std::borrow::Cow::Owned(message.clone())),
             CoreError::WalWrite { class, .. } | CoreError::Store { class, .. } => {
                 Some(class.public_message())
             }

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -73,8 +73,7 @@ impl BootstrapNamespaceError {
         }
     }
 
-    /// Returns the shared public projection for an object-store failure
-    /// carried through bootstrap.
+    /// Returns a safe message when bootstrap failed in the object store.
     pub fn object_store_public_message(&self) -> Option<std::borrow::Cow<'static, str>> {
         match self {
             BootstrapNamespaceError::Head(ControlObjectLoadError::Store { class, .. }) => {

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -72,6 +72,18 @@ impl BootstrapNamespaceError {
             | BootstrapNamespaceError::Head(_) => None,
         }
     }
+
+    /// Returns the shared public projection for an object-store failure
+    /// carried through bootstrap.
+    pub fn object_store_public_message(&self) -> Option<std::borrow::Cow<'static, str>> {
+        match self {
+            BootstrapNamespaceError::Head(ControlObjectLoadError::Store { class, .. }) => {
+                Some(class.public_message())
+            }
+            BootstrapNamespaceError::Core(error) => error.object_store_public_message(),
+            _ => None,
+        }
+    }
 }
 
 pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -317,7 +317,7 @@ fn wal_immutable_write_error(error: ImmutableWriteError) -> CoreError {
             format!("immutable WAL segment `{object_key}` already exists with different bytes"),
         ),
         ImmutableWriteError::Transport { object_key, source } => {
-            let message = source.message();
+            let message = source.public_message().into_owned();
             let class = StoreFailureClass::of(&source);
             CoreError::WalWrite {
                 object_key,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -295,7 +295,7 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
             CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(
                 ControlObjectLoadError::Store {
                     object_key: object_key.clone(),
-                    message: error.message(),
+                    message: error.public_message().into_owned(),
                     class: StoreFailureClass::of(&error),
                 },
             ))

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -155,7 +155,7 @@ pub(crate) async fn verify_durable_content_checksum<S: ObjectStore + ?Sized>(
         Err(err) => {
             return Err(DurableContentValidationError::Store {
                 object_key,
-                message: err.message(),
+                message: err.public_message().into_owned(),
             })
         }
     };
@@ -196,7 +196,7 @@ pub(crate) async fn delete_unpublished_content_object<S: ObjectStore + ?Sized>(
     if let Err(error) = store.delete(&object_key).await {
         tracing::warn!(
             content_id = %content_id,
-            error = %error,
+            error_class = ?error.class(),
             "failed to remove the content object of a terminated upload session"
         );
     }
@@ -223,7 +223,7 @@ pub(crate) async fn abort_unpublished_multipart_upload<S: ObjectStore + ?Sized>(
     {
         tracing::warn!(
             content_id = %content_id,
-            error = %error,
+            error_class = ?error.class(),
             "failed to abandon the multipart upload of a terminated upload session"
         );
     }
@@ -423,7 +423,7 @@ impl<S: ObjectStore> FileContentStream<S> {
             Err(err) => {
                 return Err(DurableContentValidationError::Store {
                     object_key: self.object_key.clone(),
-                    message: err.message(),
+                    message: err.public_message().into_owned(),
                 })
             }
         };
@@ -563,7 +563,7 @@ async fn validate_content_size<S: ObjectStore + ?Sized>(
         Err(err) => {
             return Err(DurableContentValidationError::Store {
                 object_key: object_key.to_owned(),
-                message: err.message(),
+                message: err.public_message().into_owned(),
             })
         }
     };
@@ -764,7 +764,7 @@ async fn load_required_object<S: ObjectStore + ?Sized>(
         }),
         Err(err) => Err(DurableContentValidationError::Store {
             object_key: object_key.to_owned(),
-            message: err.message(),
+            message: err.public_message().into_owned(),
         }),
     }
 }

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -93,7 +93,7 @@ async fn prefetch_recent_segments<S: ObjectStore + ?Sized>(
                 Ok(None) => {}
                 Err(error) => {
                     failed_requests += 1;
-                    first_error.get_or_insert_with(|| error.to_string());
+                    first_error.get_or_insert_with(|| error.public_message().into_owned());
                 }
             }
         }
@@ -241,7 +241,7 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
                     .await
                     .map_err(|err| WalChainLoadError::ReadWal {
                         object_key: object_key.clone(),
-                        message: err.to_string(),
+                        message: err.public_message().into_owned(),
                     })?
                     .ok_or_else(|| WalChainLoadError::MissingWalObject {
                         object_key: object_key.clone(),

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -73,11 +73,24 @@ impl GrepError {
             Self::NotEnabled | Self::Backfilling => ErrorCode::NotSupported,
             Self::StoreUnavailable { class, .. } => match class {
                 StoreFailureClass::PermissionDenied => ErrorCode::PermissionDenied,
-                StoreFailureClass::Other => ErrorCode::ServerError,
+                _ => ErrorCode::ServerError,
             },
             Self::CorruptIndex { .. } => ErrorCode::IndexCorrupt,
             Self::PublicationConflict { .. } => ErrorCode::StaleHead,
             Self::Runtime(error) => error.code(),
+        }
+    }
+
+    /// Renders object-store failures through the shared provider-independent
+    /// projection used by the runtime and server.
+    pub fn public_message(&self) -> std::borrow::Cow<'static, str> {
+        match self {
+            Self::StoreUnavailable { class, .. } => class.public_message(),
+            Self::Runtime(error) => error.public_message(),
+            Self::PublicationConflict { .. } => {
+                std::borrow::Cow::Borrowed("grep index publication conflict; retry")
+            }
+            _ => std::borrow::Cow::Owned(self.to_string()),
         }
     }
 }

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -81,8 +81,7 @@ impl GrepError {
         }
     }
 
-    /// Renders object-store failures through the shared provider-independent
-    /// projection used by the runtime and server.
+    /// Returns an error message safe to show to users.
     pub fn public_message(&self) -> std::borrow::Cow<'static, str> {
         match self {
             Self::StoreUnavailable { class, .. } => class.public_message(),

--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -57,7 +57,7 @@ async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
         .await
         .map_err(|error| GrepError::StoreUnavailable {
             object_key: object_key.to_owned(),
-            message: error.message(),
+            message: error.public_message().into_owned(),
             class: StoreFailureClass::of(&error),
         })?
         .ok_or_else(|| GrepError::CorruptIndex {

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -185,7 +185,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepGcJo
                 // its own safety proof from durable state.
                 tracing::info!(
                     namespace_id = %namespace_id,
-                    error = %error,
+                    error = %error.public_message(),
                     "grep collection rejected its resume position; restarting the pass"
                 );
                 return Ok(MaintenanceStepReport::concluded(

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -303,7 +303,7 @@ fn corrupt(object_key: &str, error: impl ToString) -> GrepRootError {
 fn store_error(object_key: &str, error: &ObjectStoreError) -> GrepRootError {
     GrepRootError::Store {
         object_key: object_key.to_owned(),
-        message: error.message(),
+        message: error.public_message().into_owned(),
         class: StoreFailureClass::of(error),
     }
 }

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -1832,7 +1832,7 @@ fn next_grep_run_ordinal(current: u64) -> Result<u64> {
 fn core_store_error(object_key: &str, error: &ObjectStoreError) -> GrepError {
     GrepError::StoreUnavailable {
         object_key: object_key.to_owned(),
-        message: error.message(),
+        message: error.public_message().into_owned(),
         class: StoreFailureClass::of(error),
     }
 }

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -134,7 +134,7 @@ impl GcpGcsStore {
             .http
             .execute(request)
             .await
-            .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
+            .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
 
         let mut parts = http::Response::new(());
         *parts.status_mut() = response.status();
@@ -199,12 +199,17 @@ impl ObjectStore for GcpGcsStore {
             });
         }
         if !status.is_success() {
-            // A HEAD carries no body to quote, so the status is the whole
-            // diagnostic the provider gives us.
-            return Err(ObjectStoreError::transport(
-                key,
-                format!("checksum head failed with {status}"),
-            ));
+            let message = format!("checksum head failed with {status}");
+            return Err(
+                if status == http::StatusCode::REQUEST_TIMEOUT
+                    || status == http::StatusCode::TOO_MANY_REQUESTS
+                    || status.is_server_error()
+                {
+                    ObjectStoreError::retryable_transport(key, message)
+                } else {
+                    ObjectStoreError::transport(key, message)
+                },
+            );
         }
 
         let headers = response.headers();

--- a/crates/loonfs-objectstore/src/immutable_write.rs
+++ b/crates/loonfs-objectstore/src/immutable_write.rs
@@ -74,7 +74,6 @@ pub(crate) async fn put<S: ObjectStore + ?Sized>(
                     bytes.len() as u64,
                     &mut retries,
                     Some(&deadline),
-                    &error,
                 ) else {
                     return resolve_readback(store, key, &bytes, error).await;
                 };

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -40,7 +40,8 @@ pub use immutable_write::ImmutableWriteError;
 pub use object_store::ObjectStoreError as Error;
 pub use object_store::{
     ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
-    ObjectStore, ObjectStoreError, PutMode, Result, SharedObjectStore, StoredObjectChecksum,
+    ObjectStore, ObjectStoreError, ObjectStoreErrorClass, PutMode, Result, SharedObjectStore,
+    StoredObjectChecksum,
 };
 pub use probe::{run_store_contract_probe, StoreProbeCheck, StoreProbeOutcome, StoreProbeReport};
 pub use provider_object_store::{

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -191,8 +191,7 @@ pub enum ObjectStoreError {
     },
 }
 
-/// Provider-independent classification retained after an object-store error
-/// crosses a boundary that cannot keep the original error value.
+/// A provider-independent category for an object-store error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ObjectStoreErrorClass {
     /// A required object was absent.
@@ -216,12 +215,12 @@ pub enum ObjectStoreErrorClass {
 }
 
 impl ObjectStoreErrorClass {
-    /// Classifies an object-store failure without retaining provider or object identity.
+    /// Returns the category for an object-store error.
     pub fn of(error: &ObjectStoreError) -> Self {
         error.class()
     }
 
-    /// Renders the provider-independent message safe for user-facing output.
+    /// Returns a safe message for users.
     pub fn public_message(self) -> Cow<'static, str> {
         Cow::Borrowed(match self {
             Self::NotFound => "object-store object not found",
@@ -270,7 +269,7 @@ impl ObjectStoreError {
         }
     }
 
-    /// Classifies the failure without carrying provider or object identity.
+    /// Returns this error's provider-independent category.
     pub fn class(&self) -> ObjectStoreErrorClass {
         match self {
             Self::NotFound { .. } => ObjectStoreErrorClass::NotFound,
@@ -291,7 +290,7 @@ impl ObjectStoreError {
         }
     }
 
-    /// Renders the provider-independent message safe for user-facing output.
+    /// Returns a safe message for users.
     pub fn public_message(&self) -> Cow<'static, str> {
         self.class().public_message()
     }

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{BoxStream, TryStreamExt};
 use loonfs_api::Checksum;
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc;
 use thiserror::Error;
@@ -185,7 +186,69 @@ pub enum ObjectStoreError {
         object_key: String,
         /// Sanitized provider or local-IO diagnostic.
         message: String,
+        /// Whether repeating the operation may succeed without operator action.
+        retryable: bool,
     },
+}
+
+/// Provider-independent classification retained after an object-store error
+/// crosses a boundary that cannot keep the original error value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ObjectStoreErrorClass {
+    /// A required object was absent.
+    NotFound,
+    /// A key, content reference, or range was invalid.
+    InvalidRequest,
+    /// A conditional operation observed a conflicting state.
+    PreconditionFailed,
+    /// The selected identity or credentials were rejected.
+    PermissionDenied,
+    /// The object exists without the checksum metadata LoonFS requires.
+    StoredChecksumMissing,
+    /// The provider does not implement the requested capability.
+    Unsupported,
+    /// Store construction or configuration failed.
+    Configuration,
+    /// A transient transport failure may succeed when repeated.
+    RetryableTransport,
+    /// A non-retryable transport or provider-protocol failure occurred.
+    Other,
+}
+
+impl ObjectStoreErrorClass {
+    /// Classifies an object-store failure without retaining provider or object identity.
+    pub fn of(error: &ObjectStoreError) -> Self {
+        error.class()
+    }
+
+    /// Renders the provider-independent message safe for user-facing output.
+    pub fn public_message(self) -> Cow<'static, str> {
+        Cow::Borrowed(match self {
+            Self::NotFound => "object-store object not found",
+            Self::InvalidRequest => "object-store request is invalid",
+            Self::PreconditionFailed => {
+                "object-store precondition failed; retry against the latest state"
+            }
+            Self::PermissionDenied => {
+                "object-store permission denied; verify that the selected credentials can access the configured bucket and key prefix"
+            }
+            Self::StoredChecksumMissing => {
+                "object-store checksum metadata is missing; rewrite the object with checksum support"
+            }
+            Self::Unsupported => {
+                "object-store capability is not supported by the selected provider"
+            }
+            Self::Configuration => {
+                "object-store configuration is invalid; verify the provider, bucket, credentials, endpoint, and key prefix fields"
+            }
+            Self::RetryableTransport => {
+                "object-store is temporarily unavailable; retry the operation"
+            }
+            Self::Other => {
+                "object-store request failed; verify the selected provider and endpoint configuration"
+            }
+        })
+    }
 }
 
 impl ObjectStoreError {
@@ -194,7 +257,43 @@ impl ObjectStoreError {
         Self::Transport {
             object_key: object_key.into(),
             message: message.into(),
+            retryable: false,
         }
+    }
+
+    /// Builds a retryable transport failure for an operation on `object_key`.
+    pub fn retryable_transport(object_key: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Transport {
+            object_key: object_key.into(),
+            message: message.into(),
+            retryable: true,
+        }
+    }
+
+    /// Classifies the failure without carrying provider or object identity.
+    pub fn class(&self) -> ObjectStoreErrorClass {
+        match self {
+            Self::NotFound { .. } => ObjectStoreErrorClass::NotFound,
+            Self::InvalidKey { .. } | Self::InvalidContentRef(_) | Self::InvalidRange { .. } => {
+                ObjectStoreErrorClass::InvalidRequest
+            }
+            Self::PreconditionFailed { .. } => ObjectStoreErrorClass::PreconditionFailed,
+            Self::PermissionDenied { .. } => ObjectStoreErrorClass::PermissionDenied,
+            Self::StoredChecksumMissing { .. } => ObjectStoreErrorClass::StoredChecksumMissing,
+            Self::Unsupported(_) => ObjectStoreErrorClass::Unsupported,
+            Self::Configuration(_) => ObjectStoreErrorClass::Configuration,
+            Self::Transport {
+                retryable: true, ..
+            } => ObjectStoreErrorClass::RetryableTransport,
+            Self::Transport {
+                retryable: false, ..
+            } => ObjectStoreErrorClass::Other,
+        }
+    }
+
+    /// Renders the provider-independent message safe for user-facing output.
+    pub fn public_message(&self) -> Cow<'static, str> {
+        self.class().public_message()
     }
 
     /// Key of the object (or listed prefix) the failing operation targeted,
@@ -679,6 +778,46 @@ mod tests {
     use super::*;
     use futures::stream;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    const POISON_PROVIDER_DETAIL: &str = "<Error>AccessDenied</Error> \
+        arn:aws:iam::123456789012:role/private-role private-bucket \
+        namespaces/customer-a/head.json x-amz-request-id=provider-request \
+        x-amz-id-2=provider-host-id AKIAEXAMPLE";
+
+    #[test]
+    fn public_permission_message_drops_every_provider_marker() {
+        let error = ObjectStoreError::PermissionDenied {
+            object_key: "namespaces/customer-a/head.json".to_owned(),
+            message: POISON_PROVIDER_DETAIL.to_owned(),
+        };
+
+        let public = error.public_message();
+        assert_eq!(
+            public,
+            "object-store permission denied; verify that the selected credentials can access the configured bucket and key prefix"
+        );
+        for marker in [
+            "<Error>AccessDenied</Error>",
+            "arn:aws:iam::123456789012:role/private-role",
+            "private-bucket",
+            "namespaces/customer-a/head.json",
+            "x-amz-request-id=provider-request",
+            "x-amz-id-2=provider-host-id",
+            "AKIAEXAMPLE",
+        ] {
+            assert!(!public.contains(marker), "public message leaked {marker}");
+        }
+    }
+
+    #[test]
+    fn retryable_transport_has_a_distinct_public_projection() {
+        let retryable = ObjectStoreError::retryable_transport("private-key", "provider timeout");
+        let protocol = ObjectStoreError::transport("private-key", "malformed response");
+
+        assert_eq!(retryable.class(), ObjectStoreErrorClass::RetryableTransport);
+        assert_eq!(protocol.class(), ObjectStoreErrorClass::Other);
+        assert_ne!(retryable.public_message(), protocol.public_message());
+    }
 
     #[derive(Debug)]
     struct ListOverrideStore {

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -1,33 +1,12 @@
-//! On-demand proof that a configured store honours the object-store
-//! contract LoonFS depends on.
+//! Checks whether a configured store supports the guarantees LoonFS needs.
 //!
-//! Fencing, publication, and upload completion are all decided by provider
-//! preconditions: a gateway that accepts a create-if-absent write over an
-//! existing object, or a compare-and-swap against a stale token, corrupts
-//! data rather than failing. Nothing about a store's configuration proves
-//! it honours those preconditions, so an operator asks — and this module is
-//! the question. It is never asked implicitly: a probe writes and deletes
-//! objects, so only an explicit operator decision runs one.
+//! The probe runs only when requested because it writes and deletes objects.
+//! It runs every check even after a failure so operators receive a complete
+//! report. Objects use the `probe-runs/{run_id}/` prefix, and the final check
+//! removes them.
 //!
-//! Every check reports its own outcome and no check can end the run, so one
-//! probe answers the whole question rather than the first thing that went
-//! wrong. A check that fails names what it expected; a store that lacks an
-//! optional capability answers [`StoreProbeOutcome::Unsupported`], which is
-//! an answer and not a failure.
-//!
-//! Every object a probe writes lives under `probe-runs/{run_id}/`, which is
-//! not a durable object family: garbage collection enumerates the durable
-//! families by name and never sees this prefix, and nothing else reads it.
-//! The final check deletes the run's objects and proves the prefix empty, so
-//! a probe that completes leaves nothing behind. A probe that dies partway
-//! leaves orphans under a prefix nothing consults — harmless, and removable
-//! by prefix.
-//!
-//! This module does not decide whether a store may serve presigned direct
-//! transfers. That trust is settled by whether
-//! [`crate::ConfiguredObjectStore::direct_transfers`] built a bundle at all,
-//! because a probe exercises the store's own request path and never a
-//! presigned capability handed to a client.
+//! This probe does not test presigned direct transfers. Those are enabled only
+//! when [`crate::ConfiguredObjectStore::direct_transfers`] returns a bundle.
 
 use crate::object_store::Result as StoreResult;
 use crate::{
@@ -38,24 +17,20 @@ use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::{Checksum, ChecksumAlgorithm};
 
-/// Prefix owning every object a probe run writes.
+/// Prefix for objects created by store probes.
 const PROBE_RUN_PREFIX: &str = "probe-runs";
 
-/// What one probe run observed, check by check.
+/// Results from one store probe.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoreProbeReport {
-    /// Caller-minted label scoping this run's objects and naming it in logs.
+    /// Label used to isolate this run's objects.
     pub run_id: String,
-    /// Every check the run performed, in the order it performed them.
+    /// Checks in execution order.
     pub checks: Vec<StoreProbeCheck>,
 }
 
 impl StoreProbeReport {
-    /// Whether the store answered every check acceptably.
-    ///
-    /// An [`StoreProbeOutcome::Unsupported`] answer counts as acceptable:
-    /// the optional capabilities are declared missing rather than found
-    /// broken, and a deployment that does not need them is unaffected.
+    /// Returns true when every check passed or reported an unsupported option.
     pub fn all_passed(&self) -> bool {
         self.checks.iter().all(|check| {
             matches!(
@@ -66,18 +41,17 @@ impl StoreProbeReport {
     }
 }
 
-/// One named contract check and what the store did with it.
+/// The result of one store contract check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoreProbeCheck {
-    /// Stable check name. Names are part of the report's contract: callers
-    /// and operators match on them, so they are renamed deliberately.
+    /// Stable name used by callers and operators.
     pub name: &'static str,
-    /// What the store did.
+    /// Result of the check.
     pub outcome: StoreProbeOutcome,
 }
 
 impl StoreProbeCheck {
-    /// Renders this check as one operator-facing report line.
+    /// Formats the check as one report line.
     pub fn check_line(&self) -> String {
         match &self.outcome {
             StoreProbeOutcome::Passed => format!("{}: passed", self.name),
@@ -89,35 +63,24 @@ impl StoreProbeCheck {
     }
 }
 
-/// What one check concluded about the store.
+/// Result of a store contract check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StoreProbeOutcome {
-    /// The store behaved as the contract requires.
+    /// The store meets the requirement.
     Passed,
-    /// The store declares it cannot do this at all. Only the optional
-    /// capabilities — client-driven multipart and stored-checksum readback
-    /// — can answer this way, and a deployment that offers neither
-    /// `direct_put` nor multipart uploads is unaffected by it.
+    /// The store does not support this optional capability.
     Unsupported,
-    /// The store did something the contract forbids, or the operation
-    /// failed outright. Either way the store is not trustworthy for the
-    /// behaviour this check names.
+    /// The store failed the check.
     Failed {
-        /// What was expected and what happened instead. Provider text
-        /// arrives already sanitized, so no credential material reaches
-        /// this message.
+        /// Safe explanation of the failure.
         message: String,
     },
 }
 
-/// Runs every contract check against `store`, scoping the run's objects
-/// under `run_id`.
+/// Runs every contract check and stores temporary objects under `run_id`.
 ///
-/// This never fails as a whole: a check that cannot complete records its
-/// own failure and the remaining checks still run, because an operator
-/// asking "is this store trustworthy?" is owed the full answer rather than
-/// the first symptom. `run_id` scopes the run's keys, so concurrent probes
-/// against one store do not collide; callers mint it.
+/// A failed check does not stop the remaining checks. Callers must provide a
+/// unique `run_id` when probes may run at the same time.
 pub async fn run_store_contract_probe(store: &dyn ObjectStore, run_id: &str) -> StoreProbeReport {
     let run = ProbeRun {
         prefix: format!("{PROBE_RUN_PREFIX}/{run_id}"),
@@ -169,9 +132,7 @@ pub async fn run_store_contract_probe(store: &dyn ObjectStore, run_id: &str) -> 
             "stored_checksum_readback",
             stored_checksum_readback(store, &run).await,
         ),
-        // Last, and last for a reason: it deletes what every check above
-        // wrote and then proves the prefix empty, so cleanup is itself
-        // under test rather than a hope.
+        // Run cleanup last so it can remove objects created by every check.
         check(
             "cleanup_leaves_prefix_empty",
             cleanup_leaves_prefix_empty(store, &run).await,
@@ -184,28 +145,28 @@ pub async fn run_store_contract_probe(store: &dyn ObjectStore, run_id: &str) -> 
     }
 }
 
-/// One run's key scope.
+/// Key prefix for one run.
 struct ProbeRun {
     prefix: String,
 }
 
 impl ProbeRun {
-    /// A key inside this run's scope.
+    /// Returns a key inside this run's prefix.
     fn key(&self, name: &str) -> String {
         format!("{}/{name}", self.prefix)
     }
 
-    /// A listing prefix inside this run's scope.
+    /// Returns a listing prefix inside this run's prefix.
     fn listing(&self, name: &str) -> String {
         format!("{}/{name}/", self.prefix)
     }
 }
 
-/// What a check concluded, before it becomes a reportable outcome.
+/// Internal check result.
 enum CheckFailure {
-    /// The store declares the capability absent.
+    /// The store does not support this optional capability.
     Unsupported,
-    /// The store is wrong, or the operation could not complete.
+    /// The store returned the wrong result or the operation failed.
     Failed(String),
 }
 

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -220,16 +220,10 @@ fn check(name: &'static str, result: CheckResult) -> StoreProbeCheck {
     StoreProbeCheck { name, outcome }
 }
 
-/// Turns a store failure into a reportable one, naming the operation that
-/// failed and the object it was about.
+/// Turns a store failure into a reportable one without exposing provider or
+/// object identity.
 fn failed(operation: &str, error: &ObjectStoreError) -> CheckFailure {
-    match error.object_key() {
-        Some(object_key) => CheckFailure::Failed(format!(
-            "{operation} failed for `{object_key}`: {}",
-            error.message()
-        )),
-        None => CheckFailure::Failed(format!("{operation} failed: {}", error.message())),
-    }
+    CheckFailure::Failed(format!("{operation} failed: {}", error.public_message()))
 }
 
 /// Reports what the store did instead of what the contract requires.
@@ -267,7 +261,7 @@ fn refused<T>(what: &str, result: StoreResult<T>) -> CheckResult {
         Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(()),
         Err(error) => Err(wrong(format!(
             "{what} should have been refused as a failed precondition, but failed differently: {}",
-            error.message()
+            error.public_message()
         ))),
         Ok(_) => Err(wrong(format!(
             "{what} was accepted; the store does not enforce this precondition"
@@ -506,9 +500,9 @@ async fn visibility_after_write(store: &dyn ObjectStore, run: &ProbeRun) -> Chec
     )?;
     let listed = ok("list", store.list_prefix(&prefix).await)?;
     if listed != vec![key.clone()] {
-        return Err(wrong(format!(
-            "listing a prefix straight after a write into it answered {listed:?}"
-        )));
+        return Err(wrong(
+            "listing immediately after a write did not return exactly the newly written object",
+        ));
     }
     Ok(())
 }
@@ -529,9 +523,9 @@ async fn visibility_after_delete(store: &dyn ObjectStore, run: &ProbeRun) -> Che
     ok("delete", store.delete(&key).await)?;
     let listed = ok("list", store.list_prefix(&prefix).await)?;
     if !listed.is_empty() {
-        return Err(wrong(format!(
-            "listing a prefix straight after deleting its only object answered {listed:?}"
-        )));
+        return Err(wrong(
+            "listing immediately after deleting its only object still returned objects",
+        ));
     }
     Ok(())
 }
@@ -581,13 +575,13 @@ async fn sorted_listing(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult 
     let listed = ok("list", store.list_prefix(&prefix).await)?;
     if streamed != keys {
         return Err(wrong(format!(
-            "streaming a prefix answered {streamed:?}, not the {} objects written under it",
+            "streaming a prefix did not return the {} objects written under it",
             keys.len()
         )));
     }
     if listed != keys {
         return Err(wrong(format!(
-            "listing a prefix answered {listed:?}, not the {} objects written under it in key order",
+            "listing a prefix did not return the {} objects written under it in key order",
             keys.len()
         )));
     }
@@ -615,40 +609,38 @@ async fn range_reads(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
 
     let read = ok("bounded read", store.get(&key, bounded(1, 4)).await)?;
     if read != Some(Bytes::from_static(b"bcd")) {
-        return Err(wrong(format!(
-            "a bounded read of bytes 1..4 answered {read:?}"
-        )));
+        return Err(wrong("a bounded read of bytes 1..4 returned wrong bytes"));
     }
     // The bounded-read contract, uniform across providers: an end past the
     // object clamps, reading at the exact end is empty, and a start past
     // the end is an invalid range.
     let clamped = ok("clamped read", store.get(&key, bounded(4, 99)).await)?;
     if clamped != Some(Bytes::from_static(b"ef")) {
-        return Err(wrong(format!(
-            "a read whose end runs past the object should clamp, but answered {clamped:?}"
-        )));
+        return Err(wrong(
+            "a read whose end runs past the object did not clamp to the expected bytes",
+        ));
     }
     let at_end = ok(
         "read at the exact end",
         store.get(&key, bounded(6, 8)).await,
     )?;
     if at_end != Some(Bytes::new()) {
-        return Err(wrong(format!(
-            "a read starting at the object's exact end should be empty, but answered {at_end:?}"
-        )));
+        return Err(wrong(
+            "a read starting at the object's exact end did not return an empty range",
+        ));
     }
     match store.get(&key, bounded(7, 8)).await {
         Err(ObjectStoreError::InvalidRange { .. }) => {}
         Err(error) => {
             return Err(wrong(format!(
                 "a read starting past the object's end should be an invalid range, but failed differently: {}",
-                error.message()
+                error.public_message()
             )))
         }
-        Ok(answer) => {
-            return Err(wrong(format!(
-                "a read starting past the object's end should be an invalid range, but answered {answer:?}"
-            )))
+        Ok(_) => {
+            return Err(wrong(
+                "a read starting past the object's end should be an invalid range, but returned a response",
+            ))
         }
     }
 
@@ -746,7 +738,7 @@ async fn stored_checksum_readback(store: &dyn ObjectStore, run: &ProbeRun) -> Ch
     let checksum = stored.checksum;
     checksum
         .validate()
-        .map_err(|error| wrong(format!("a stored checksum is invalid: {error}")))?;
+        .map_err(|_| wrong("the provider returned an invalid stored checksum"))?;
     if checksum.algorithm == ChecksumAlgorithm::Sha256 && checksum != Checksum::sha256(&payload) {
         return Err(wrong(
             "a reported sha256 does not describe the bytes actually stored",
@@ -765,7 +757,8 @@ async fn cleanup_leaves_prefix_empty(store: &dyn ObjectStore, run: &ProbeRun) ->
     let remaining = ok("list after cleanup", store.list_prefix(&prefix).await)?;
     if !remaining.is_empty() {
         return Err(wrong(format!(
-            "the probe's own prefix still holds {remaining:?} after cleanup"
+            "the probe's own prefix still holds {} objects after cleanup",
+            remaining.len()
         )));
     }
     Ok(())
@@ -782,6 +775,11 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
+    const POISON_PROVIDER_DETAIL: &str = "<Error>AccessDenied</Error> \
+        arn:aws:iam::123456789012:role/private-role private-bucket \
+        namespaces/customer-a/head.json x-amz-request-id=provider-request \
+        x-amz-id-2=provider-host-id AKIAEXAMPLE";
+
     fn outcome<'a>(report: &'a StoreProbeReport, name: &str) -> &'a StoreProbeOutcome {
         &report
             .checks
@@ -789,6 +787,92 @@ mod tests {
             .find(|check| check.name == name)
             .expect("report should carry the named check")
             .outcome
+    }
+
+    #[derive(Debug)]
+    struct PoisonPermissionStore;
+
+    impl PoisonPermissionStore {
+        fn denied(key: &str) -> ObjectStoreError {
+            ObjectStoreError::PermissionDenied {
+                object_key: key.to_owned(),
+                message: POISON_PROVIDER_DETAIL.to_owned(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for PoisonPermissionStore {
+        async fn head(&self, key: &str) -> StoreResult<Option<ObjectMetadata>> {
+            Err(Self::denied(key))
+        }
+
+        async fn get_with_metadata(&self, key: &str) -> StoreResult<Option<ObjectBody>> {
+            Err(Self::denied(key))
+        }
+
+        async fn get(&self, key: &str, _range: Option<ByteRange>) -> StoreResult<Option<Bytes>> {
+            Err(Self::denied(key))
+        }
+
+        async fn put(
+            &self,
+            key: &str,
+            _bytes: Bytes,
+            _mode: PutMode,
+        ) -> StoreResult<ObjectMetadata> {
+            Err(Self::denied(key))
+        }
+
+        async fn delete(&self, key: &str) -> StoreResult<()> {
+            Err(Self::denied(key))
+        }
+
+        fn list_prefix_from_stream(
+            &self,
+            prefix: &str,
+            _start_after: Option<&str>,
+        ) -> BoxStream<'static, StoreResult<String>> {
+            Box::pin(futures::stream::once(std::future::ready(Err(
+                Self::denied(prefix),
+            ))))
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_failures_make_every_probe_message_safe_to_paste() {
+        let report = run_store_contract_probe(&PoisonPermissionStore, "probe_poison").await;
+        let messages: Vec<_> = report
+            .checks
+            .iter()
+            .filter_map(|check| match &check.outcome {
+                StoreProbeOutcome::Failed { message } => Some(message.as_str()),
+                StoreProbeOutcome::Passed | StoreProbeOutcome::Unsupported => None,
+            })
+            .collect();
+
+        assert!(!messages.is_empty());
+        for message in messages {
+            assert!(
+                message.contains("object-store permission denied"),
+                "{message}"
+            );
+            for marker in [
+                "<Error>AccessDenied</Error>",
+                "arn:aws:iam::123456789012:role/private-role",
+                "private-bucket",
+                "namespaces/customer-a/head.json",
+                "x-amz-request-id=provider-request",
+                "x-amz-id-2=provider-host-id",
+                "AKIAEXAMPLE",
+                "probe-runs/probe_poison",
+            ] {
+                assert!(
+                    !message.contains(marker),
+                    "probe message leaked {marker}: {message}"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -421,11 +421,10 @@ impl Drop for AbortUploadOnDrop {
         let path = self.path.clone();
         let upload_id = std::mem::take(&mut self.upload_id);
         handle.spawn(async move {
-            if let Err(err) = multipart.abort_multipart(&path, &upload_id).await {
+            if let Err(_err) = multipart.abort_multipart(&path, &upload_id).await {
                 tracing::warn!(
                     object_key = %path,
                     operation = "abort_multipart",
-                    error = %err,
                     "failed to abort the multipart upload of an abandoned write",
                 );
             }
@@ -466,7 +465,6 @@ impl MultipartWrite<'_> {
                 payload_bytes,
                 &mut retries,
                 None,
-                &err,
             ) else {
                 return Err(map_provider_error(self.key, err));
             };
@@ -617,7 +615,6 @@ impl MultipartWrite<'_> {
                 payload_bytes,
                 &mut retries,
                 None,
-                &err,
             ) else {
                 return Err(map_provider_error(self.key, err));
             };
@@ -706,11 +703,10 @@ impl MultipartWrite<'_> {
         match self.multipart.abort_multipart(self.path, upload_id).await {
             Ok(()) => {}
             Err(err) if provider_not_found(&err) => {}
-            Err(err) => {
+            Err(_err) => {
                 tracing::warn!(
                     object_key = self.key,
                     operation = "abort_multipart",
-                    error = %err,
                     "failed to abort multipart upload; parts remain until the bucket lifecycle rule collects them",
                 );
             }
@@ -940,7 +936,6 @@ impl ObjectStore for ProviderObjectStore {
                 0,
                 &mut retries,
                 Some(&deadline),
-                &err,
             ) else {
                 return Err(map_provider_error(key, err));
             };
@@ -1074,9 +1069,10 @@ fn map_provider_error(object_key: &str, err: provider_store::Error) -> ObjectSto
                 format!("unknown {store} configuration key `{key}`"),
             )
         }
-        provider_store::Error::Generic { source, .. } => {
-            ObjectStoreError::transport(object_key, sanitize_provider_message(&source.to_string()))
-        }
+        provider_store::Error::Generic { source, .. } => ObjectStoreError::retryable_transport(
+            object_key,
+            sanitize_provider_message(&source.to_string()),
+        ),
         provider_store::Error::JoinError { source } => {
             ObjectStoreError::transport(object_key, sanitize_provider_message(&source.to_string()))
         }
@@ -1212,6 +1208,19 @@ mod tests {
         assert_eq!(last_modified_ms(i64::MIN), None);
         assert_eq!(last_modified_ms(1), Some(1));
         assert_eq!(last_modified_ms(1_754_000_000_000), Some(1_754_000_000_000));
+    }
+
+    #[test]
+    fn provider_client_failures_are_classified_at_the_adapter_boundary() {
+        let path = Path::from("private-key");
+        assert_eq!(
+            map_provider_error("private-key", transport_glitch()).class(),
+            crate::ObjectStoreErrorClass::RetryableTransport
+        );
+        assert_eq!(
+            map_provider_error("private-key", auth_rejection(&path)).class(),
+            crate::ObjectStoreErrorClass::PermissionDenied
+        );
     }
 
     #[test]

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -1089,8 +1089,7 @@ fn map_provider_error(object_key: &str, err: provider_store::Error) -> ObjectSto
     }
 }
 
-/// Query parameters whose values are credential material when they appear in
-/// a URL a provider error echoes back (signed and presigned requests).
+/// Credential query parameters that providers may include in error messages.
 const CREDENTIAL_QUERY_PARAMS: &[&str] = &[
     "X-Amz-Signature",
     "X-Amz-Credential",
@@ -1100,8 +1099,7 @@ const CREDENTIAL_QUERY_PARAMS: &[&str] = &[
     "sig",
 ];
 
-/// Response-body XML elements that echo signing inputs back to the caller in
-/// provider auth failures (`SignatureDoesNotMatch` and friends).
+/// XML elements that may contain signing data in authentication errors.
 const CREDENTIAL_XML_ELEMENTS: &[&str] = &[
     "StringToSign",
     "StringToSignBytes",
@@ -1110,10 +1108,7 @@ const CREDENTIAL_XML_ELEMENTS: &[&str] = &[
     "AWSAccessKeyId",
 ];
 
-/// Strips credential material from free-text provider errors before they
-/// enter the error chain: signature/credential query parameters in echoed
-/// URLs, and the signing-input elements auth-failure bodies quote back.
-/// The diagnosable parts (status, provider error code, cause) stay.
+/// Redacts credential and signing data from provider error messages.
 fn sanitize_provider_message(message: &str) -> String {
     let mut sanitized = message.to_owned();
     for param in CREDENTIAL_QUERY_PARAMS {
@@ -1125,9 +1120,7 @@ fn sanitize_provider_message(message: &str) -> String {
     sanitized
 }
 
-/// Replaces every `?param=value` / `&param=value` occurrence's value with
-/// `<redacted>`. Matches only at a query-parameter boundary so `Signature=`
-/// does not fire inside `X-Amz-Signature=`.
+/// Redacts a query parameter without matching it inside a longer name.
 fn mask_query_param_values(message: &str, param: &str) -> String {
     let needle = format!("{param}=");
     let mut out = String::with_capacity(message.len());
@@ -1152,9 +1145,7 @@ fn mask_query_param_values(message: &str, param: &str) -> String {
     out
 }
 
-/// Replaces the text inside `<element>...</element>` with `<redacted>`; if
-/// the closing tag never arrives (truncated body), everything after the
-/// opening tag goes.
+/// Redacts an XML element, including a truncated element without a closing tag.
 fn mask_xml_element_text(message: &str, element: &str) -> String {
     let open = format!("<{element}>");
     let close = format!("</{element}>");

--- a/crates/loonfs-objectstore/src/retry.rs
+++ b/crates/loonfs-objectstore/src/retry.rs
@@ -3,7 +3,6 @@
 use crate::attempts::count_retry_attempt;
 use crate::timing::MonotonicTimer;
 use crate::PROVIDER_OPERATION_DEADLINE;
-use std::fmt::Display;
 use std::time::Duration;
 
 /// Bounded retry configuration matching the provider client's read budget.
@@ -43,7 +42,6 @@ pub(crate) fn next_retry_backoff(
     payload_bytes: u64,
     retries: &mut u32,
     deadline: Option<&OperationDeadline<'_>>,
-    error: &dyn Display,
 ) -> Option<Duration> {
     if *retries >= policy.max_retries {
         tracing::warn!(
@@ -51,7 +49,6 @@ pub(crate) fn next_retry_backoff(
             operation,
             retry = *retries,
             payload_bytes,
-            error = %error,
             "object store write retry budget exhausted; not retrying",
         );
         return None;
@@ -64,7 +61,6 @@ pub(crate) fn next_retry_backoff(
                 operation,
                 retry = *retries,
                 payload_bytes,
-                error = %error,
                 "object store operation deadline exhausted; not retrying",
             );
             return None;
@@ -80,7 +76,6 @@ pub(crate) fn next_retry_backoff(
         retry = *retries,
         max_retries = policy.max_retries,
         backoff_ms = u64::try_from(backoff.as_millis()).unwrap_or(u64::MAX),
-        error = %error,
         "transient object store write failure, backing off before retry",
     );
     Some(backoff)
@@ -135,7 +130,6 @@ mod tests {
             max_backoff: Duration::from_millis(1),
             operation_deadline: Duration::from_secs(1),
         };
-        let error = "injected transport failure".to_owned();
         let (_, attempts) = counting_attempts(async {
             let mut retries = 0;
             assert_eq!(
@@ -146,7 +140,6 @@ mod tests {
                     7,
                     &mut retries,
                     None,
-                    &error,
                 ),
                 Some(Duration::from_millis(1))
             );

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -289,7 +289,7 @@ impl S3CompatibleStore {
             .http
             .execute(request)
             .await
-            .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
+            .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
 
         let status = response.status();
         let headers = response.headers().clone();
@@ -297,7 +297,7 @@ impl S3CompatibleStore {
             .into_body()
             .bytes()
             .await
-            .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
+            .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
         Ok(SignedResponse {
             status,
             headers,
@@ -334,7 +334,17 @@ impl SignedResponse {
         if self.status.is_success() && !text.contains("<Error") {
             return None;
         }
-        Some(xml_element(&text, "Code").unwrap_or_else(|| self.status.to_string()))
+        let code = xml_element(&text, "Code").unwrap_or_else(|| self.status.to_string());
+        tracing::debug!(
+            provider_status = self.status.as_u16(),
+            provider_error_code = code,
+            provider_request_id = self
+                .headers
+                .get("x-amz-request-id")
+                .and_then(|value| value.to_str().ok()),
+            "S3-compatible provider request failed"
+        );
+        Some(code)
     }
 }
 
@@ -365,10 +375,9 @@ impl ObjectStore for S3CompatibleStore {
             });
         }
         if !status.is_success() {
-            // A HEAD carries no body to quote, so the status is the whole
-            // diagnostic the provider gives us.
-            return Err(ObjectStoreError::transport(
+            return Err(transport_for_status(
                 key,
+                status,
                 format!("checksum head failed with {status}"),
             ));
         }
@@ -577,7 +586,36 @@ fn multipart_error(key: &str, operation: &str, code: &str) -> ObjectStoreError {
                 message: format!("provider refused multipart {operation}: {code}"),
             }
         }
+        "NoSuchBucket" | "NoSuchKey" => ObjectStoreError::NotFound {
+            object_key: key.to_owned(),
+        },
+        "ConditionalRequestConflict" | "PreconditionFailed" => {
+            ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            }
+        }
+        "InternalError" | "RequestTimeout" | "ServiceUnavailable" | "SlowDown" => {
+            ObjectStoreError::retryable_transport(
+                key,
+                format!("multipart {operation} failed: {code}"),
+            )
+        }
         code => ObjectStoreError::transport(key, format!("multipart {operation} failed: {code}")),
+    }
+}
+
+fn transport_for_status(
+    key: &str,
+    status: http::StatusCode,
+    message: impl Into<String>,
+) -> ObjectStoreError {
+    if status == http::StatusCode::REQUEST_TIMEOUT
+        || status == http::StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+    {
+        ObjectStoreError::retryable_transport(key, message)
+    } else {
+        ObjectStoreError::transport(key, message)
     }
 }
 
@@ -631,9 +669,10 @@ fn object_store_endpoint_url(
 #[cfg(test)]
 mod tests {
     use super::{
-        object_store_endpoint_url, S3CompatibleConfig, S3CompatibleStore,
+        multipart_error, object_store_endpoint_url, S3CompatibleConfig, S3CompatibleStore,
         AWS_S3_MAX_DIRECT_PUT_BYTES,
     };
+    use crate::ObjectStoreErrorClass;
 
     fn test_config() -> S3CompatibleConfig {
         S3CompatibleConfig {
@@ -663,6 +702,26 @@ mod tests {
         let mut config = test_config();
         config.access_key_id = "".into();
         assert!(S3CompatibleStore::new(config).is_err());
+    }
+
+    #[test]
+    fn multipart_provider_codes_are_classified_at_the_adapter_boundary() {
+        for (code, expected) in [
+            ("AccessDenied", ObjectStoreErrorClass::PermissionDenied),
+            ("NoSuchKey", ObjectStoreErrorClass::NotFound),
+            (
+                "PreconditionFailed",
+                ObjectStoreErrorClass::PreconditionFailed,
+            ),
+            ("SlowDown", ObjectStoreErrorClass::RetryableTransport),
+            ("MalformedXML", ObjectStoreErrorClass::Other),
+        ] {
+            assert_eq!(
+                multipart_error("private-key", "complete", code).class(),
+                expected,
+                "wrong class for {code}"
+            );
+        }
     }
 
     #[test]

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -389,7 +389,7 @@ impl ServerConfig {
             .configured_object_store()
             .map_err(|err| ServerConfigError::InvalidField {
                 field: "store",
-                reason: err.to_string(),
+                reason: err.public_message().into_owned(),
             })
     }
 

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -105,12 +105,8 @@ impl ApiResponseError {
     pub(super) fn runtime(error: RuntimeError) -> Self {
         let code = error.code();
         let details = error.details();
-        let rendered = error.to_string();
-        let message = match &error {
-            RuntimeError::Config(message) => message.as_str(),
-            _ => rendered.as_str(),
-        };
-        let mut response = Self::new(status_for_core_error_code(code), code, message);
+        let message = error.public_message();
+        let mut response = Self::new(status_for_core_error_code(code), code, &message);
         response.body.details = details.map(Box::new);
         response
     }

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -369,7 +369,7 @@ fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> A
     match error {
         // Both cases mean the advertised query.grep capability is unavailable.
         error @ (GrepError::NotEnabled | GrepError::Backfilling) => {
-            ApiResponseError::not_supported(FEATURE_QUERY_GREP, &error.to_string())
+            ApiResponseError::not_supported(FEATURE_QUERY_GREP, &error.public_message())
         }
         GrepError::Runtime(error) => {
             let cursor_is_invalid = matches!(
@@ -383,7 +383,11 @@ fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> A
                 response
             }
         }
-        error => ApiResponseError::new(status_for_core_error_code(code), code, &error.to_string()),
+        error => ApiResponseError::new(
+            status_for_core_error_code(code),
+            code,
+            &error.public_message(),
+        ),
     }
 }
 

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -351,15 +351,19 @@ fn sign_parts(
 }
 
 pub(super) fn presign_issuer_error(error: ObjectStoreError) -> ApiResponseError {
+    let message = error.public_message();
     match error {
-        ObjectStoreError::InvalidContentRef(message) => {
+        ObjectStoreError::InvalidContentRef(_) => {
             ApiResponseError::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, &message)
                 .with_param("/content")
         }
-        error => ApiResponseError::new(
+        ObjectStoreError::PermissionDenied { .. } => {
+            ApiResponseError::new(StatusCode::FORBIDDEN, ErrorCode::PermissionDenied, &message)
+        }
+        _ => ApiResponseError::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             ErrorCode::ServerError,
-            &error.to_string(),
+            &message,
         ),
     }
 }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1446,8 +1446,6 @@ async fn grep_error_store_outage_is_provider_failure_and_core_reads_survive() {
         result.await,
         500,
         ErrorCode::ServerError,
-        // The injected provider detail must not surface; the public
-        // projection speaks for the store instead.
         "object-store request failed",
     )
     .await;

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -408,6 +408,151 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
 
+const POISON_PROVIDER_DETAIL: &str = "<Error>AccessDenied</Error> \
+    arn:aws:iam::123456789012:role/private-role private-bucket \
+    namespaces/customer-a/head.json x-amz-request-id=provider-request \
+    x-amz-id-2=provider-host-id AKIAEXAMPLE";
+
+fn assert_provider_markers_absent(rendered: &str) {
+    for marker in [
+        "<Error>AccessDenied</Error>",
+        "arn:aws:iam::123456789012:role/private-role",
+        "private-bucket",
+        "namespaces/customer-a/head.json",
+        "x-amz-request-id=provider-request",
+        "x-amz-id-2=provider-host-id",
+        "AKIAEXAMPLE",
+    ] {
+        assert!(
+            !rendered.contains(marker),
+            "API body leaked {marker}: {rendered}"
+        );
+    }
+}
+
+#[derive(Debug)]
+struct PoisonProviderStore;
+
+impl PoisonProviderStore {
+    fn denied(key: &str) -> ObjectStoreError {
+        ObjectStoreError::PermissionDenied {
+            object_key: key.to_owned(),
+            message: POISON_PROVIDER_DETAIL.to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for PoisonProviderStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        Err(Self::denied(key))
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        Err(Self::denied(key))
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        _range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        Err(Self::denied(key))
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        _bytes: Bytes,
+        _mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        Err(Self::denied(key))
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        Err(Self::denied(key))
+    }
+
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        _start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        Box::pin(futures::stream::once(std::future::ready(Err(
+            Self::denied(prefix),
+        ))))
+    }
+}
+
+#[tokio::test]
+async fn provider_failure_is_projected_in_the_remote_api_envelope() {
+    use tower::ServiceExt;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let router = app_with_store(
+        test_config(temp_dir.path(), "provider-hygiene-writer"),
+        Arc::new(PoisonProviderStore),
+    )
+    .await
+    .expect("build app");
+    let response = router
+        .oneshot(
+            axum::http::Request::builder()
+                .method(axum::http::Method::POST)
+                .uri("/v0/namespaces")
+                .header(axum::http::header::AUTHORIZATION, "Bearer test-token")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(r#"{"namespace_id":"customer-a"}"#))
+                .expect("create namespace request"),
+        )
+        .await
+        .expect("create namespace response");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let request_id = response
+        .headers()
+        .get(super::REQUEST_ID_HEADER)
+        .expect("request id header")
+        .to_str()
+        .expect("request id header is text")
+        .to_owned();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read provider failure body");
+    let rendered = String::from_utf8(body.to_vec()).expect("API body is UTF-8");
+
+    assert_provider_markers_absent(&rendered);
+    assert!(rendered.contains(
+        "object-store permission denied; verify that the selected credentials can access the configured bucket and key prefix"
+    ));
+    assert!(rendered.contains(&request_id), "{rendered}");
+}
+
+#[tokio::test]
+async fn provider_failure_is_projected_in_the_presign_api_envelope() {
+    use axum::response::IntoResponse;
+
+    let response = super::REQUEST_ID
+        .scope("req_presign_hygiene".to_owned(), async {
+            super::handlers_uploads::presign_issuer_error(PoisonProviderStore::denied(
+                "namespaces/customer-a/head.json",
+            ))
+            .into_response()
+        })
+        .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read presign failure body");
+    let rendered = String::from_utf8(body.to_vec()).expect("API body is UTF-8");
+
+    assert_provider_markers_absent(&rendered);
+    assert!(rendered.contains(
+        "object-store permission denied; verify that the selected credentials can access the configured bucket and key prefix"
+    ));
+    assert!(rendered.contains("req_presign_hygiene"), "{rendered}");
+}
+
 #[derive(Debug)]
 struct StaleHeadOnceStore {
     inner: LocalFsStore,
@@ -1301,7 +1446,9 @@ async fn grep_error_store_outage_is_provider_failure_and_core_reads_survive() {
         result.await,
         500,
         ErrorCode::ServerError,
-        "injected grep-root outage",
+        // The injected provider detail must not surface; the public
+        // projection speaks for the store instead.
+        "object-store request failed",
     )
     .await;
     harness.server.abort();

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -307,7 +307,7 @@ impl ReadCore {
             .await
             .map_err(|error| ControlObjectLoadError::Store {
                 object_key: object_key.to_owned(),
-                message: error.message(),
+                message: error.public_message().into_owned(),
                 class: StoreFailureClass::of(&error),
             })?
             .ok_or_else(|| ControlObjectLoadError::MissingObject {

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -609,7 +609,7 @@ impl FsAdmin {
             Err(error) => tracing::warn!(
                 namespace_id = %namespace_id,
                 families = ?spec.families(),
-                error = %error,
+                error = %error.public_message(),
                 "streaming metadata compaction failed; a later step plans it again"
             ),
         }

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -75,9 +75,9 @@ impl HandleBuilderCore {
         let (store, derived_kind) = match self.source {
             StoreSource::Config(config) => {
                 let kind = TraceStoreKind::from(config.kind());
-                let store = config.configured_object_store().map_err(|error| {
-                    RuntimeError::Config(format!("invalid store config: {error}"))
-                })?;
+                let store = config
+                    .configured_object_store()
+                    .map_err(|error| RuntimeError::Config(error.public_message().into_owned()))?;
                 (store.into_shared(), kind)
             }
             StoreSource::Shared(store) => (store, TraceStoreKind::Unknown),

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -256,8 +256,7 @@ impl RuntimeError {
         }
     }
 
-    /// Renders a public message while projecting object-store failures through
-    /// the provider-independent object-store boundary.
+    /// Returns an error message safe to show to users.
     pub fn public_message(&self) -> std::borrow::Cow<'static, str> {
         let store_message = match self {
             Self::Core(error) => error.object_store_public_message(),

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -255,4 +255,25 @@ impl RuntimeError {
             Self::Config(_) | Self::RuntimeTask(_) => None,
         }
     }
+
+    /// Renders a public message while projecting object-store failures through
+    /// the provider-independent object-store boundary.
+    pub fn public_message(&self) -> std::borrow::Cow<'static, str> {
+        let store_message = match self {
+            Self::Core(error) => error.object_store_public_message(),
+            Self::Bootstrap(error) => error.object_store_public_message(),
+            Self::Config(_) | Self::RuntimeTask(_) => None,
+        };
+        if let Some(message) = store_message {
+            return message;
+        }
+
+        match self {
+            Self::Config(message) | Self::RuntimeTask(message) => {
+                std::borrow::Cow::Owned(message.clone())
+            }
+            Self::Core(error) => std::borrow::Cow::Owned(error.to_string()),
+            Self::Bootstrap(error) => std::borrow::Cow::Owned(error.to_string()),
+        }
+    }
 }

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -216,7 +216,7 @@ impl MaintenanceJob for GcJob {
                 // rebuilds its safety checks from durable state.
                 tracing::info!(
                     namespace_id = %namespace_id,
-                    error = %error,
+                    error = %error.public_message(),
                     "collection rejected its resume position; restarting the pass"
                 );
                 return Ok(MaintenanceStepReport::concluded(


### PR DESCRIPTION
This prevents object-store provider errors from exposing upstream response bodies, IAM principals, bucket names, object keys, access-key IDs, or provider request IDs through the CLI or API. Public errors now use a provider-independent message based on the failure category.

Embedded commands, remote commands, presigned-transfer endpoints, grep, and store probes use the same safe messages. Human doctor output groups checks that failed for the same reason, while JSON output keeps each check result.

Tests cover embedded and remote output, presigned-transfer errors, request IDs, store probes, and common provider failure categories.