### PR TITLE
feat(objectstore): resolve ambient aws credentials through the standard chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,401 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c18d005c70d2b9c0c1ea8876c039db0ec7fb71164d25c73ccea21bf41fd02171"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d2a4d2753a2304cc0a86cff15581179c420c7b3054c0cbc884a2e497e79ae5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719f007d6914388e2f14943c663447cfc44bb9d0478bb96df891258ba5145f82"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efcc3dbb630f3e0d16a4f79fcd4b3fb1c59cb89f1031c46e44976f640b5de27"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,8 +555,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -191,8 +586,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -207,6 +602,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bincode"
@@ -245,6 +650,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -358,6 +773,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmsketch"
@@ -553,6 +977,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -766,6 +1196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,7 +1359,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -975,6 +1411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1438,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1006,12 +1459,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1022,8 +1486,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1056,8 +1520,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1073,7 +1537,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1093,8 +1557,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -1426,7 +1890,7 @@ dependencies = [
  "fs4",
  "futures",
  "hostname",
- "http",
+ "http 1.4.0",
  "insta",
  "loonfs",
  "loonfs-api",
@@ -1450,7 +1914,7 @@ version = "0.2.1"
 dependencies = [
  "bytes",
  "futures",
- "http",
+ "http 1.4.0",
  "loonfs-api",
  "loonfs-test-support",
  "reqwest",
@@ -1541,13 +2005,15 @@ name = "loonfs-objectstore"
 version = "0.2.1"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-credential-types",
  "base64",
  "bytes",
  "fs4",
  "futures",
  "hmac",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "loonfs-api",
  "object_store",
  "ring",
@@ -1573,8 +2039,8 @@ dependencies = [
  "foyer",
  "fs4",
  "futures",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "indexmap",
  "loonfs",
  "loonfs-api",
@@ -1825,7 +2291,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "httparse",
  "humantime",
@@ -1876,6 +2342,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -1947,6 +2419,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2159,6 +2637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,8 +2659,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -2263,6 +2747,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2309,6 +2794,7 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2829,8 +3315,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -3057,6 +3543,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,6 +3563,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3556,6 +4058,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -217,14 +217,14 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.9"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
+checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -241,14 +241,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.75.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d2a4d2753a2304cc0a86cff15581179c420c7b3054c0cbc884a2e497e79ae5"
+checksum = "e0a69de9c1b9272da2872af60c7402683e7f45c06267735b4332deacb203239b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -263,14 +263,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.76.0"
+version = "1.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719f007d6914388e2f14943c663447cfc44bb9d0478bb96df891258ba5145f82"
+checksum = "f0b161d836fac72bdd5ac1a4cd1cdc38ab888c7af26cfd95f661be4409505e63"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -285,14 +285,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.77.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efcc3dbb630f3e0d16a4f79fcd4b3fb1c59cb89f1031c46e44976f640b5de27"
+checksum = "cb1cd79a3412751a341a28e2cd0d6fa4345241976da427b075a0c0cd5409f886"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -313,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.3.0"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -341,16 +341,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.6"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
- "futures-util",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -361,31 +360,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-http-client"
-version = "1.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
+checksum = "8aff1159006441d02e57204bf57a1b890ba68bedb6904ffd2873c1c4c11c546b"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -400,34 +378,33 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
  "tower",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.9"
+version = "0.61.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.3.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -435,16 +412,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.14.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
+checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.64.0",
+ "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -452,7 +428,6 @@ dependencies = [
  "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -461,12 +436,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+checksum = "bd8531b6d8882fd8f48f82a9754e682e29dd44cff27154af51fa3eb730f59efb"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -478,32 +452,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-runtime-api-macros"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "aws-smithy-schema"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "http 1.4.0",
-]
-
-[[package]]
 name = "aws-smithy-types"
-version = "1.6.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -524,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
 dependencies = [
  "xmlparser",
 ]
@@ -1009,7 +961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2007,6 +1959,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "aws-types",
  "base64",
  "bytes",
  "fs4",
@@ -2232,7 +2185,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2738,7 +2691,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3091,7 +3044,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3779,7 +3732,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/loonfs-conformance/src/server.rs
+++ b/crates/loonfs-conformance/src/server.rs
@@ -145,8 +145,9 @@ fn presigned_expiry_ms(now: SystemTime) -> u64 {
         .unwrap_or(0)
 }
 
+#[async_trait]
 impl DirectGetIssuer for LoopbackIssuer {
-    fn presign_get(
+    async fn presign_get(
         &self,
         request: PresignedGetRequest<'_>,
         now: SystemTime,
@@ -160,6 +161,7 @@ impl DirectGetIssuer for LoopbackIssuer {
     }
 }
 
+#[async_trait]
 impl DirectPutIssuer for LoopbackIssuer {
     fn stored_checksum_algorithm(&self) -> ChecksumAlgorithm {
         ChecksumAlgorithm::Sha256
@@ -169,7 +171,7 @@ impl DirectPutIssuer for LoopbackIssuer {
         DIRECT_PUT_MAX_BYTES
     }
 
-    fn presign_put(
+    async fn presign_put(
         &self,
         request: PresignedPutRequest<'_>,
         now: SystemTime,
@@ -183,8 +185,9 @@ impl DirectPutIssuer for LoopbackIssuer {
     }
 }
 
+#[async_trait]
 impl DirectMultipartIssuer for LoopbackIssuer {
-    fn presign_multipart_part(
+    async fn presign_multipart_part(
         &self,
         request: PresignedPartRequest<'_>,
         now: SystemTime,

--- a/crates/loonfs-objectstore/Cargo.toml
+++ b/crates/loonfs-objectstore/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+aws-config = { version = "=1.8.1", default-features = false, features = ["credentials-process", "rt-tokio", "rustls", "sso"] }
+aws-credential-types = "=1.2.3"
 base64.workspace = true
 bytes.workspace = true
 fs4.workspace = true

--- a/crates/loonfs-objectstore/Cargo.toml
+++ b/crates/loonfs-objectstore/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 async-trait.workspace = true
 aws-config = { version = "=1.8.1", default-features = false, features = ["credentials-process", "rt-tokio", "rustls", "sso"] }
 aws-credential-types = "=1.2.3"
+aws-types = "=1.3.7"
 base64.workspace = true
 bytes.workspace = true
 fs4.workspace = true

--- a/crates/loonfs-objectstore/src/aws_credentials.rs
+++ b/crates/loonfs-objectstore/src/aws_credentials.rs
@@ -43,9 +43,10 @@ pub(crate) type SharedAwsCredentialsSource = Arc<dyn AwsCredentialsSource>;
 /// Builds the runtime source selected by the AWS S3 configuration.
 pub(crate) fn aws_credentials_source(
     credentials: &AwsS3Credentials,
+    region: &str,
 ) -> Result<SharedAwsCredentialsSource, ObjectStoreError> {
     match credentials {
-        AwsS3Credentials::Ambient {} => Ok(Arc::new(AmbientAwsCredentialsSource::default())),
+        AwsS3Credentials::Ambient {} => Ok(Arc::new(AmbientAwsCredentialsSource::new(region))),
         AwsS3Credentials::Static {
             access_key_id,
             secret_access_key,
@@ -119,8 +120,8 @@ impl AwsCredentialsSource for StaticAwsCredentialsSource {
     }
 }
 
-#[derive(Default)]
 struct AmbientAwsCredentialsSource {
+    region: String,
     provider: OnceCell<SharedCredentialsProvider>,
 }
 
@@ -132,10 +133,20 @@ impl fmt::Debug for AmbientAwsCredentialsSource {
 }
 
 impl AmbientAwsCredentialsSource {
+    fn new(region: &str) -> Self {
+        Self {
+            region: region.to_owned(),
+            provider: OnceCell::new(),
+        }
+    }
+
     async fn provider(&self) -> &SharedCredentialsProvider {
         self.provider
             .get_or_init(|| async {
-                let chain = DefaultCredentialsChain::builder().build().await;
+                let chain = DefaultCredentialsChain::builder()
+                    .region(aws_types::region::Region::new(self.region.clone()))
+                    .build()
+                    .await;
                 SharedCredentialsProvider::new(chain)
             })
             .await
@@ -304,7 +315,7 @@ mod tests {
             )),
         );
 
-        let source = aws_credentials_source(&AwsS3Credentials::Ambient {})
+        let source = aws_credentials_source(&AwsS3Credentials::Ambient {}, "us-east-1")
             .expect("construct ambient source");
         let credentials = source
             .credentials()
@@ -330,7 +341,7 @@ mod tests {
         )
         .expect("write shared credentials file");
 
-        let source = aws_credentials_source(&AwsS3Credentials::Ambient {})
+        let source = aws_credentials_source(&AwsS3Credentials::Ambient {}, "us-east-1")
             .expect("construct ambient source");
         let credentials = source
             .credentials()
@@ -348,11 +359,14 @@ mod tests {
 
     #[tokio::test]
     async fn static_credentials_are_returned_exactly() {
-        let source = aws_credentials_source(&AwsS3Credentials::Static {
-            access_key_id: "static-access".into(),
-            secret_access_key: "static-secret".into(),
-            session_token: Some("static-session".into()),
-        })
+        let source = aws_credentials_source(
+            &AwsS3Credentials::Static {
+                access_key_id: "static-access".into(),
+                secret_access_key: "static-secret".into(),
+                session_token: Some("static-session".into()),
+            },
+            "us-east-1",
+        )
         .expect("construct static source");
 
         let credentials = source
@@ -373,7 +387,7 @@ mod tests {
         let _lock = ENVIRONMENT.lock().await;
         let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
         let _environment = isolated_aws_environment(&tempdir, None);
-        let source = aws_credentials_source(&AwsS3Credentials::Ambient {})
+        let source = aws_credentials_source(&AwsS3Credentials::Ambient {}, "us-east-1")
             .expect("construct ambient source");
 
         let error = source

--- a/crates/loonfs-objectstore/src/aws_credentials.rs
+++ b/crates/loonfs-objectstore/src/aws_credentials.rs
@@ -1,0 +1,395 @@
+//! AWS credential sources shared by provider requests and presigners.
+
+use crate::store_config::AwsS3Credentials;
+use crate::ObjectStoreError;
+use async_trait::async_trait;
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
+use loonfs_api::SecretString;
+use object_store::aws::AwsCredential;
+use object_store::client::CredentialProvider;
+use std::fmt;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+
+/// One credential snapshot used to sign one AWS operation.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct AwsSigningCredentials {
+    pub(crate) access_key_id: SecretString,
+    pub(crate) secret_access_key: SecretString,
+    pub(crate) session_token: Option<SecretString>,
+}
+
+impl fmt::Debug for AwsSigningCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AwsSigningCredentials")
+            .field("access_key_id", &"<redacted>")
+            .field("secret_access_key", &"<redacted>")
+            .field(
+                "session_token",
+                &self.session_token.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+#[async_trait]
+pub(crate) trait AwsCredentialsSource: Send + Sync + fmt::Debug {
+    async fn credentials(&self) -> Result<AwsSigningCredentials, ObjectStoreError>;
+}
+
+pub(crate) type SharedAwsCredentialsSource = Arc<dyn AwsCredentialsSource>;
+
+/// Builds the runtime source selected by the AWS S3 configuration.
+pub(crate) fn aws_credentials_source(
+    credentials: &AwsS3Credentials,
+) -> Result<SharedAwsCredentialsSource, ObjectStoreError> {
+    match credentials {
+        AwsS3Credentials::Ambient {} => Ok(Arc::new(AmbientAwsCredentialsSource::default())),
+        AwsS3Credentials::Static {
+            access_key_id,
+            secret_access_key,
+            session_token,
+        } => {
+            if access_key_id.expose().trim().is_empty() {
+                return Err(ObjectStoreError::Configuration(
+                    "access key id must not be empty".to_owned(),
+                ));
+            }
+            if secret_access_key.expose().trim().is_empty() {
+                return Err(ObjectStoreError::Configuration(
+                    "secret access key must not be empty".to_owned(),
+                ));
+            }
+            if session_token
+                .as_ref()
+                .is_some_and(|token| token.expose().trim().is_empty())
+            {
+                return Err(ObjectStoreError::Configuration(
+                    "session token must not be empty".to_owned(),
+                ));
+            }
+            Ok(Arc::new(StaticAwsCredentialsSource::new(
+                AwsSigningCredentials {
+                    access_key_id: access_key_id.clone(),
+                    secret_access_key: secret_access_key.clone(),
+                    session_token: session_token.clone(),
+                },
+            )))
+        }
+    }
+}
+
+/// Builds a source for an already resolved S3-compatible credential set.
+pub(crate) fn static_aws_credentials_source(
+    access_key_id: SecretString,
+    secret_access_key: SecretString,
+    session_token: Option<SecretString>,
+) -> SharedAwsCredentialsSource {
+    Arc::new(StaticAwsCredentialsSource::new(AwsSigningCredentials {
+        access_key_id,
+        secret_access_key,
+        session_token,
+    }))
+}
+
+#[derive(Clone)]
+struct StaticAwsCredentialsSource {
+    credentials: AwsSigningCredentials,
+}
+
+impl StaticAwsCredentialsSource {
+    fn new(credentials: AwsSigningCredentials) -> Self {
+        Self { credentials }
+    }
+}
+
+impl fmt::Debug for StaticAwsCredentialsSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StaticAwsCredentialsSource")
+            .field("credentials", &"<redacted>")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl AwsCredentialsSource for StaticAwsCredentialsSource {
+    async fn credentials(&self) -> Result<AwsSigningCredentials, ObjectStoreError> {
+        Ok(self.credentials.clone())
+    }
+}
+
+#[derive(Default)]
+struct AmbientAwsCredentialsSource {
+    provider: OnceCell<SharedCredentialsProvider>,
+}
+
+impl fmt::Debug for AmbientAwsCredentialsSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AmbientAwsCredentialsSource")
+            .finish_non_exhaustive()
+    }
+}
+
+impl AmbientAwsCredentialsSource {
+    async fn provider(&self) -> &SharedCredentialsProvider {
+        self.provider
+            .get_or_init(|| async {
+                let chain = DefaultCredentialsChain::builder().build().await;
+                SharedCredentialsProvider::new(chain)
+            })
+            .await
+    }
+}
+
+#[async_trait]
+impl AwsCredentialsSource for AmbientAwsCredentialsSource {
+    async fn credentials(&self) -> Result<AwsSigningCredentials, ObjectStoreError> {
+        let credentials = self
+            .provider()
+            .await
+            .provide_credentials()
+            .await
+            .map_err(|_| {
+                ObjectStoreError::Configuration(
+                    "could not resolve `store.credentials` through the standard AWS credential chain"
+                        .to_owned(),
+                )
+            })?;
+        Ok(AwsSigningCredentials {
+            access_key_id: SecretString::new(credentials.access_key_id()),
+            secret_access_key: SecretString::new(credentials.secret_access_key()),
+            session_token: credentials.session_token().map(SecretString::new),
+        })
+    }
+}
+
+/// Adapts the shared LoonFS source to the provider client's credential API.
+#[derive(Clone)]
+pub(crate) struct ObjectStoreAwsCredentialProvider {
+    source: SharedAwsCredentialsSource,
+}
+
+impl ObjectStoreAwsCredentialProvider {
+    pub(crate) fn new(source: SharedAwsCredentialsSource) -> Self {
+        Self { source }
+    }
+}
+
+impl fmt::Debug for ObjectStoreAwsCredentialProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObjectStoreAwsCredentialProvider")
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl CredentialProvider for ObjectStoreAwsCredentialProvider {
+    type Credential = AwsCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<Self::Credential>> {
+        let credentials =
+            self.source
+                .credentials()
+                .await
+                .map_err(|source| object_store::Error::Generic {
+                    store: "S3",
+                    source: Box::new(source),
+                })?;
+        Ok(Arc::new(AwsCredential {
+            key_id: credentials.access_key_id.expose().to_owned(),
+            secret_key: credentials.secret_access_key.expose().to_owned(),
+            token: credentials
+                .session_token
+                .as_ref()
+                .map(|token| token.expose().to_owned()),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::aws_credentials_source;
+    use crate::{AwsS3Credentials, ObjectStoreError};
+    use loonfs_api::SecretString;
+    use std::ffi::OsString;
+    use std::fs;
+
+    static ENVIRONMENT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    struct EnvGuard {
+        name: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+
+        fn unset(name: &'static str) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::remove_var(name);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+
+    fn isolated_aws_environment(
+        tempdir: &tempfile::TempDir,
+        environment_credentials: Option<(&str, &str, Option<&str>)>,
+    ) -> Vec<EnvGuard> {
+        let credentials_file = tempdir.path().join("credentials");
+        let config_file = tempdir.path().join("config");
+        fs::write(&credentials_file, "").expect("write empty credentials file");
+        fs::write(&config_file, "").expect("write empty config file");
+
+        let mut environment = match environment_credentials {
+            Some((access_key_id, secret_access_key, session_token)) => vec![
+                EnvGuard::set("AWS_ACCESS_KEY_ID", access_key_id),
+                EnvGuard::set("AWS_SECRET_ACCESS_KEY", secret_access_key),
+                match session_token {
+                    Some(session_token) => EnvGuard::set("AWS_SESSION_TOKEN", session_token),
+                    None => EnvGuard::unset("AWS_SESSION_TOKEN"),
+                },
+            ],
+            None => vec![
+                EnvGuard::unset("AWS_ACCESS_KEY_ID"),
+                EnvGuard::unset("AWS_SECRET_ACCESS_KEY"),
+                EnvGuard::unset("AWS_SESSION_TOKEN"),
+            ],
+        };
+        environment.extend([
+            EnvGuard::set("AWS_SHARED_CREDENTIALS_FILE", credentials_file),
+            EnvGuard::set("AWS_CONFIG_FILE", config_file),
+            EnvGuard::set("AWS_PROFILE", "loonfs-test"),
+            EnvGuard::set("AWS_REGION", "us-east-1"),
+            EnvGuard::set("AWS_EC2_METADATA_DISABLED", "true"),
+            EnvGuard::unset("AWS_WEB_IDENTITY_TOKEN_FILE"),
+            EnvGuard::unset("AWS_ROLE_ARN"),
+            EnvGuard::unset("AWS_ROLE_SESSION_NAME"),
+            EnvGuard::unset("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),
+            EnvGuard::unset("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
+            EnvGuard::unset("AWS_CONTAINER_AUTHORIZATION_TOKEN"),
+            EnvGuard::unset("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
+        ]);
+        if std::env::var_os("SSL_CERT_FILE").is_none()
+            && std::path::Path::new("/etc/ssl/cert.pem").is_file()
+        {
+            environment.push(EnvGuard::set("SSL_CERT_FILE", "/etc/ssl/cert.pem"));
+        }
+        environment
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn environment_pair_resolves_through_the_ambient_source() {
+        let _lock = ENVIRONMENT.lock().await;
+        let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
+        let _environment = isolated_aws_environment(
+            &tempdir,
+            Some((
+                "environment-access",
+                "environment-secret",
+                Some("environment-session"),
+            )),
+        );
+
+        let source = aws_credentials_source(&AwsS3Credentials::Ambient {})
+            .expect("construct ambient source");
+        let credentials = source
+            .credentials()
+            .await
+            .expect("resolve environment pair");
+
+        assert_eq!(credentials.access_key_id.expose(), "environment-access");
+        assert_eq!(credentials.secret_access_key.expose(), "environment-secret");
+        assert_eq!(
+            credentials.session_token.as_ref().map(SecretString::expose),
+            Some("environment-session")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shared_credentials_file_and_profile_resolve_through_the_ambient_source() {
+        let _lock = ENVIRONMENT.lock().await;
+        let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
+        let environment = isolated_aws_environment(&tempdir, None);
+        fs::write(
+            tempdir.path().join("credentials"),
+            "[loonfs-test]\naws_access_key_id = profile-access\naws_secret_access_key = profile-secret\naws_session_token = profile-session\n",
+        )
+        .expect("write shared credentials file");
+
+        let source = aws_credentials_source(&AwsS3Credentials::Ambient {})
+            .expect("construct ambient source");
+        let credentials = source
+            .credentials()
+            .await
+            .expect("resolve profile credentials");
+
+        assert_eq!(credentials.access_key_id.expose(), "profile-access");
+        assert_eq!(credentials.secret_access_key.expose(), "profile-secret");
+        assert_eq!(
+            credentials.session_token.as_ref().map(SecretString::expose),
+            Some("profile-session")
+        );
+        drop(environment);
+    }
+
+    #[tokio::test]
+    async fn static_credentials_are_returned_exactly() {
+        let source = aws_credentials_source(&AwsS3Credentials::Static {
+            access_key_id: "static-access".into(),
+            secret_access_key: "static-secret".into(),
+            session_token: Some("static-session".into()),
+        })
+        .expect("construct static source");
+
+        let credentials = source
+            .credentials()
+            .await
+            .expect("resolve static credentials");
+
+        assert_eq!(credentials.access_key_id.expose(), "static-access");
+        assert_eq!(credentials.secret_access_key.expose(), "static-secret");
+        assert_eq!(
+            credentials.session_token.as_ref().map(SecretString::expose),
+            Some("static-session")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn an_empty_chain_reports_only_the_configuration_field() {
+        let _lock = ENVIRONMENT.lock().await;
+        let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
+        let _environment = isolated_aws_environment(&tempdir, None);
+        let source = aws_credentials_source(&AwsS3Credentials::Ambient {})
+            .expect("construct ambient source");
+
+        let error = source
+            .credentials()
+            .await
+            .expect_err("isolated chain has no credentials");
+
+        assert!(matches!(error, ObjectStoreError::Configuration(_)));
+        assert_eq!(
+            error.to_string(),
+            "invalid object store configuration: could not resolve `store.credentials` through the standard AWS credential chain"
+        );
+        let public = error.public_message();
+        assert!(public.contains("credentials"), "{public}");
+        for provider_detail in ["Environment", "Profile", "WebIdentity", "Ecs", "Imds"] {
+            assert!(!public.contains(provider_detail), "{public}");
+        }
+    }
+}

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -2,6 +2,7 @@
 //! paired with the direct transfers that provider can authorize.
 
 use crate::abs::{AzureAbsStore, AzureAbsStoreConfig};
+use crate::aws_credentials::{aws_credentials_source, static_aws_credentials_source};
 use crate::gcs::{GcpGcsStore, GcpGcsStoreConfig};
 use crate::local_fs_store::LocalFsStore;
 use crate::object_store::{Result, SharedObjectStore};
@@ -81,24 +82,25 @@ impl ConfiguredObjectStore {
     ///
     /// Construction fails when signing, provider, runtime, or key-prefix configuration is invalid.
     pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self> {
+        let credentials = aws_credentials_source(&config.credentials)?;
         let direct_transfers =
             endpoint_is_proven(config.endpoint_url.as_deref(), AWS_S3_PROVEN_DOMAINS)
                 .then(|| {
-                    S3CompatiblePresigner::new(S3PresignerConfig {
-                        bucket: config.bucket.clone(),
-                        region: config.region.clone(),
-                        endpoint_url: config.endpoint_url.clone(),
-                        access_key_id: config.access_key_id.clone(),
-                        secret_access_key: config.secret_access_key.clone(),
-                        session_token: config.session_token.clone(),
-                        key_prefix: config.key_prefix.clone(),
-                        force_path_style: config.force_path_style,
-                        direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
-                    })
+                    S3CompatiblePresigner::with_credentials(
+                        S3PresignerConfig {
+                            bucket: config.bucket.clone(),
+                            region: config.region.clone(),
+                            endpoint_url: config.endpoint_url.clone(),
+                            key_prefix: config.key_prefix.clone(),
+                            force_path_style: config.force_path_style,
+                            direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
+                        },
+                        Arc::clone(&credentials),
+                    )
                     .map(s3_compatible_transfers)
                 })
                 .transpose()?;
-        let store = S3CompatibleStore::aws_s3(config)?;
+        let store = S3CompatibleStore::aws_s3_with_credentials(config, credentials)?;
         Ok(Self {
             inner: Arc::new(store),
             direct_transfers,
@@ -110,26 +112,31 @@ impl ConfiguredObjectStore {
     ///
     /// Construction fails when signing, provider, runtime, or key-prefix configuration is invalid.
     pub fn cloudflare_r2(config: CloudflareR2StoreConfig) -> Result<Self> {
+        let credentials = static_aws_credentials_source(
+            config.access_key_id.clone(),
+            config.secret_access_key.clone(),
+            None,
+        );
         let direct_transfers = endpoint_is_proven(
             Some(config.endpoint_url.as_str()),
             CLOUDFLARE_R2_PROVEN_DOMAINS,
         )
         .then(|| {
-            S3CompatiblePresigner::new(S3PresignerConfig {
-                bucket: config.bucket.clone(),
-                region: "auto".to_owned(),
-                endpoint_url: Some(config.endpoint_url.clone()),
-                access_key_id: config.access_key_id.clone(),
-                secret_access_key: config.secret_access_key.clone(),
-                session_token: None,
-                key_prefix: config.key_prefix.clone(),
-                force_path_style: true,
-                direct_put_max_content_bytes: CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
-            })
+            S3CompatiblePresigner::with_credentials(
+                S3PresignerConfig {
+                    bucket: config.bucket.clone(),
+                    region: "auto".to_owned(),
+                    endpoint_url: Some(config.endpoint_url.clone()),
+                    key_prefix: config.key_prefix.clone(),
+                    force_path_style: true,
+                    direct_put_max_content_bytes: CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
+                },
+                Arc::clone(&credentials),
+            )
             .map(s3_compatible_transfers)
         })
         .transpose()?;
-        let store = S3CompatibleStore::cloudflare_r2(config)?;
+        let store = S3CompatibleStore::cloudflare_r2_with_credentials(config, credentials)?;
         Ok(Self {
             inner: Arc::new(store),
             direct_transfers,
@@ -257,8 +264,8 @@ mod tests {
     };
     use crate::s3_compatible::{AwsS3StoreConfig, CloudflareR2StoreConfig};
     use crate::test_support::{gcs_fixture_service_account_key_file, AZURITE_ACCOUNT_KEY};
-    use crate::ObjectStore;
     use crate::ObjectStoreError;
+    use crate::{AwsS3Credentials, ObjectStore};
     use bytes::Bytes;
     use loonfs_api::ChecksumAlgorithm;
     use std::sync::Arc;
@@ -333,8 +340,8 @@ mod tests {
     }
 
     /// GCS signs the configured prefix and create-only precondition.
-    #[test]
-    fn the_gcs_bundle_signs_native_generation_preconditions() {
+    #[tokio::test]
+    async fn the_gcs_bundle_signs_native_generation_preconditions() {
         let issuer = proven_gcs_store()
             .direct_transfers()
             .and_then(|transfers| transfers.put)
@@ -349,6 +356,7 @@ mod tests {
                 },
                 UNIX_EPOCH + Duration::from_secs(1_700_000_000),
             )
+            .await
             .expect("presign");
 
         assert!(signed
@@ -466,17 +474,21 @@ mod tests {
     #[test]
     fn a_bundle_can_offer_put_and_get_without_multipart() {
         let presigner = Arc::new(
-            S3CompatiblePresigner::new(S3PresignerConfig {
-                bucket: "bucket".to_owned(),
-                region: "us-east-1".to_owned(),
-                endpoint_url: None,
-                access_key_id: "access".into(),
-                secret_access_key: "secret".into(),
-                session_token: None,
-                key_prefix: None,
-                force_path_style: false,
-                direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
-            })
+            S3CompatiblePresigner::new(
+                S3PresignerConfig {
+                    bucket: "bucket".to_owned(),
+                    region: "us-east-1".to_owned(),
+                    endpoint_url: None,
+                    key_prefix: None,
+                    force_path_style: false,
+                    direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
+                },
+                AwsS3Credentials::Static {
+                    access_key_id: "access".into(),
+                    secret_access_key: "secret".into(),
+                    session_token: None,
+                },
+            )
             .expect("presigner"),
         );
         let transfers = DirectTransferIssuers::read_only(presigner.clone()).with_put(presigner);
@@ -490,9 +502,11 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: endpoint_url.map(ToOwned::to_owned),
-            access_key_id: "access".into(),
-            secret_access_key: "secret".into(),
-            session_token: None,
+            credentials: AwsS3Credentials::Static {
+                access_key_id: "access".into(),
+                secret_access_key: "secret".into(),
+                session_token: None,
+            },
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: true,
         })
@@ -536,8 +550,8 @@ mod tests {
         .expect("construct r2 store")
     }
 
-    #[test]
-    fn cloudflare_r2_presigner_uses_path_style_account_endpoint() {
+    #[tokio::test]
+    async fn cloudflare_r2_presigner_uses_path_style_account_endpoint() {
         let store = ConfiguredObjectStore::cloudflare_r2(CloudflareR2StoreConfig {
             bucket: "bucket".to_owned(),
             account_id: "account".to_owned(),
@@ -561,6 +575,7 @@ mod tests {
                 },
                 UNIX_EPOCH + Duration::from_secs(1_700_000_000),
             )
+            .await
             .expect("presign");
 
         assert!(signed.url.starts_with(

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -82,7 +82,7 @@ impl ConfiguredObjectStore {
     ///
     /// Construction fails when signing, provider, runtime, or key-prefix configuration is invalid.
     pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self> {
-        let credentials = aws_credentials_source(&config.credentials)?;
+        let credentials = aws_credentials_source(&config.credentials, &config.region)?;
         let direct_transfers =
             endpoint_is_proven(config.endpoint_url.as_deref(), AWS_S3_PROVEN_DOMAINS)
                 .then(|| {

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod abs;
 mod attempts;
+mod aws_credentials;
 mod configured;
 pub mod crypto;
 pub mod gcs;

--- a/crates/loonfs-objectstore/src/presign/gcs.rs
+++ b/crates/loonfs-objectstore/src/presign/gcs.rs
@@ -17,6 +17,7 @@ use crate::presign::v4::{
     percent_encode_segment, signing_dates, unix_ms,
 };
 use crate::ObjectStoreError;
+use async_trait::async_trait;
 use base64::Engine as _;
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::{Checksum, ChecksumAlgorithm};
@@ -270,6 +271,7 @@ impl GcsV4Presigner {
     }
 }
 
+#[async_trait]
 impl DirectPutIssuer for GcsV4Presigner {
     fn stored_checksum_algorithm(&self) -> ChecksumAlgorithm {
         ChecksumAlgorithm::Crc32c
@@ -279,7 +281,7 @@ impl DirectPutIssuer for GcsV4Presigner {
         GCP_GCS_MAX_DIRECT_PUT_BYTES
     }
 
-    fn presign_put(
+    async fn presign_put(
         &self,
         request: PresignedPutRequest<'_>,
         now: SystemTime,
@@ -298,8 +300,9 @@ impl DirectPutIssuer for GcsV4Presigner {
     }
 }
 
+#[async_trait]
 impl DirectGetIssuer for GcsV4Presigner {
-    fn presign_get(
+    async fn presign_get(
         &self,
         request: PresignedGetRequest<'_>,
         now: SystemTime,
@@ -430,7 +433,7 @@ mod tests {
         .expect("signer")
     }
 
-    fn presign_put(signer: &GcsV4Presigner) -> crate::presign::PresignedUrl {
+    async fn presign_put(signer: &GcsV4Presigner) -> crate::presign::PresignedUrl {
         signer
             .presign_put(
                 PresignedPutRequest {
@@ -439,13 +442,14 @@ mod tests {
                 },
                 signing_time(),
             )
+            .await
             .expect("presign put")
     }
 
     /// The signature covers the object path and create-only precondition.
-    #[test]
-    fn presigned_put_binds_the_scoped_path_and_create_only_precondition() {
-        let signed = presign_put(&presigner(Some("tenant-a")));
+    #[tokio::test]
+    async fn presigned_put_binds_the_scoped_path_and_create_only_precondition() {
+        let signed = presign_put(&presigner(Some("tenant-a"))).await;
 
         assert_eq!(signed.method, "PUT");
         assert_eq!(
@@ -473,8 +477,8 @@ mod tests {
     /// The read capability signs `host` and nothing else, which is what
     /// leaves `Range` outside the signature: one issued URL serves ranged,
     /// resumed, and parallel reads without another round trip to the server.
-    #[test]
-    fn presigned_get_signs_only_the_host_so_range_stays_unsigned() {
+    #[tokio::test]
+    async fn presigned_get_signs_only_the_host_so_range_stays_unsigned() {
         let signed = presigner(Some("tenant-a"))
             .presign_get(
                 PresignedGetRequest {
@@ -483,6 +487,7 @@ mod tests {
                 },
                 signing_time(),
             )
+            .await
             .expect("presign get");
 
         assert_eq!(signed.method, "GET");
@@ -522,9 +527,9 @@ mod tests {
     /// The key prefix is part of what is signed, not decoration on the URL:
     /// dropping it produces a different signature, so a capability issued for
     /// one tenant's prefix cannot be replayed against another's.
-    #[test]
-    fn the_key_prefix_is_inside_the_signature() {
-        let unprefixed = presign_put(&presigner(None));
+    #[tokio::test]
+    async fn the_key_prefix_is_inside_the_signature() {
+        let unprefixed = presign_put(&presigner(None)).await;
 
         assert_eq!(
             unprefixed.url,
@@ -549,8 +554,8 @@ mod tests {
     /// written through such a capability is committed and then invisible to
     /// every read, listing, and collection the store performs — durable
     /// nowhere anything looks.
-    #[test]
-    fn the_signer_and_the_store_resolve_a_key_to_the_same_string() {
+    #[tokio::test]
+    async fn the_signer_and_the_store_resolve_a_key_to_the_same_string() {
         for raw_prefix in [None, Some("   "), Some(""), Some("tenant-a")] {
             let signed = presigner(raw_prefix)
                 .presign_get(
@@ -560,6 +565,7 @@ mod tests {
                     },
                     signing_time(),
                 )
+                .await
                 .expect("presign get");
 
             // Exactly what `ProviderObjectStore` does with the same value.
@@ -601,8 +607,8 @@ mod tests {
     /// Path segments are percent-encoded, and the separators between them are
     /// not. Getting either wrong signs a different object than the one the
     /// URL addresses.
-    #[test]
-    fn path_segments_are_percent_encoded_and_separators_are_not() {
+    #[tokio::test]
+    async fn path_segments_are_percent_encoded_and_separators_are_not() {
         let signed = presigner(Some("tenant-a"))
             .presign_get(
                 PresignedGetRequest {
@@ -611,6 +617,7 @@ mod tests {
                 },
                 signing_time(),
             )
+            .await
             .expect("presign get");
 
         assert_eq!(
@@ -625,10 +632,10 @@ mod tests {
 
     /// Reads and writes of the same object address the same URL, so a
     /// deployment cannot sign a write it is unable to sign a read of.
-    #[test]
-    fn presigned_get_addresses_the_same_object_the_write_did() {
+    #[tokio::test]
+    async fn presigned_get_addresses_the_same_object_the_write_did() {
         let signer = presigner(Some("tenant-a"));
-        let written = presign_put(&signer);
+        let written = presign_put(&signer).await;
         let read = signer
             .presign_get(
                 PresignedGetRequest {
@@ -637,6 +644,7 @@ mod tests {
                 },
                 signing_time(),
             )
+            .await
             .expect("presign get");
 
         let object_of = |url: &str| url.split('?').next().expect("url path").to_owned();
@@ -654,20 +662,20 @@ mod tests {
         assert_eq!(GCP_GCS_MAX_DIRECT_PUT_BYTES, 5 * 1024 * 1024 * 1024 * 1024);
     }
 
-    #[test]
-    fn expiry_outside_googles_documented_window_is_a_configuration_error() {
+    #[tokio::test]
+    async fn expiry_outside_googles_documented_window_is_a_configuration_error() {
         let signer = presigner(None);
         for expires_in in [Duration::ZERO, Duration::from_secs(7 * 24 * 60 * 60 + 1)] {
-            assert!(matches!(
-                signer.presign_get(
+            let result = signer
+                .presign_get(
                     PresignedGetRequest {
                         object_key: CONTENT_KEY,
                         expires_in,
                     },
                     signing_time(),
-                ),
-                Err(ObjectStoreError::Configuration(_))
-            ));
+                )
+                .await;
+            assert!(matches!(result, Err(ObjectStoreError::Configuration(_))));
         }
     }
 

--- a/crates/loonfs-objectstore/src/presign/issuer.rs
+++ b/crates/loonfs-objectstore/src/presign/issuer.rs
@@ -1,6 +1,7 @@
 //! Interfaces for issuing presigned reads and writes.
 
 use crate::object_store::Result;
+use async_trait::async_trait;
 use loonfs_api::{Checksum, ChecksumAlgorithm};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -62,6 +63,7 @@ pub struct PresignedUrl {
 ///
 /// A provider that cannot preserve create-only writes and report a durable
 /// full-object checksum must not implement this trait.
+#[async_trait]
 pub trait DirectPutIssuer: Send + Sync + std::fmt::Debug {
     /// The whole-object checksum this provider stores for a single PUT.
     ///
@@ -79,7 +81,7 @@ pub trait DirectPutIssuer: Send + Sync + std::fmt::Debug {
     ///
     /// Issuance fails for invalid keys, invalid expiry policy, unusable signing
     /// time, or malformed provider configuration.
-    fn presign_put(
+    async fn presign_put(
         &self,
         request: PresignedPutRequest<'_>,
         now: SystemTime,
@@ -88,6 +90,7 @@ pub trait DirectPutIssuer: Send + Sync + std::fmt::Debug {
 
 /// Issues read capabilities for content objects a client fetches straight
 /// from the provider.
+#[async_trait]
 pub trait DirectGetIssuer: Send + Sync + std::fmt::Debug {
     /// Issues a read capability for one content object.
     ///
@@ -97,7 +100,7 @@ pub trait DirectGetIssuer: Send + Sync + std::fmt::Debug {
     ///
     /// Issuance fails for invalid keys, invalid expiry policy, unusable
     /// signing time, or malformed provider configuration.
-    fn presign_get(
+    async fn presign_get(
         &self,
         request: PresignedGetRequest<'_>,
         now: SystemTime,
@@ -105,12 +108,13 @@ pub trait DirectGetIssuer: Send + Sync + std::fmt::Debug {
 }
 
 /// Issues write permissions for an open multipart upload.
+#[async_trait]
 pub trait DirectMultipartIssuer: Send + Sync + std::fmt::Debug {
     /// Issues a write capability for one part of an open multipart upload.
     ///
     /// Multipart parts are replaceable so clients can retry them. The signed
     /// request includes the checksum that the provider must enforce.
-    fn presign_multipart_part(
+    async fn presign_multipart_part(
         &self,
         request: PresignedPartRequest<'_>,
         now: SystemTime,

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -4,6 +4,9 @@ use super::{
     DirectGetIssuer, DirectMultipartIssuer, DirectPutIssuer, PresignedGetRequest,
     PresignedPartRequest, PresignedPutRequest, PresignedUrl, MAX_PRESIGN_EXPIRY,
 };
+use crate::aws_credentials::{
+    aws_credentials_source, AwsSigningCredentials, SharedAwsCredentialsSource,
+};
 use crate::crypto::hmac_sha256;
 use crate::keyspace::{normalize_key_prefix, parse_endpoint_url, scope_object_key};
 use crate::object_store::Result;
@@ -12,9 +15,10 @@ use crate::presign::v4::{
     percent_encode_segment, signing_dates, unix_ms,
 };
 use crate::ObjectStoreError;
+use async_trait::async_trait;
 use base64::Engine as _;
 use loonfs_api::wire::hex::hex_decode_bytes;
-use loonfs_api::{Checksum, ChecksumAlgorithm, SecretString};
+use loonfs_api::{Checksum, ChecksumAlgorithm};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
@@ -49,7 +53,7 @@ pub const AWS_S3_MAX_DIRECT_PUT_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 /// stated separately rather than assumed equal to AWS's.
 pub const CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES: u64 = 5 * 1024 * 1024 * 1024 - 5 * 1024 * 1024;
 
-/// Supplies explicit SigV4 credentials and endpoint addressing for direct-put URLs.
+/// Supplies SigV4 endpoint addressing and signing policy for S3-compatible URLs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct S3PresignerConfig {
     /// Bucket incorporated into the signed request target.
@@ -58,12 +62,6 @@ pub struct S3PresignerConfig {
     pub region: String,
     /// S3-compatible endpoint override, or `None` for the regional AWS endpoint.
     pub endpoint_url: Option<String>,
-    /// Access-key id exposed in the signed credential parameter.
-    pub access_key_id: SecretString,
-    /// Secret access key used to derive the request signature.
-    pub secret_access_key: SecretString,
-    /// Temporary credential token signed into the request, or `None` for long-lived credentials.
-    pub session_token: Option<SecretString>,
     /// Logical prefix prepended before the object key is encoded and signed.
     pub key_prefix: Option<String>,
     /// Selects path-style bucket addressing instead of virtual-hosted style.
@@ -79,6 +77,13 @@ pub struct S3PresignerConfig {
 #[derive(Debug, Clone)]
 pub struct S3CompatiblePresigner {
     config: S3PresignerConfig,
+    credentials: SharedAwsCredentialsSource,
+}
+
+#[derive(Default)]
+struct SigningRequestParts {
+    operation_query: BTreeMap<String, String>,
+    required_headers: BTreeMap<String, String>,
 }
 
 impl S3CompatiblePresigner {
@@ -90,7 +95,14 @@ impl S3CompatiblePresigner {
     /// Blank required values and an unusable key prefix fail immediately;
     /// endpoint, content, expiry, and signing-time failures surface when
     /// [`DirectPutIssuer::presign_put`] runs.
-    pub fn new(mut config: S3PresignerConfig) -> Result<Self> {
+    pub fn new(config: S3PresignerConfig, credentials: crate::AwsS3Credentials) -> Result<Self> {
+        Self::with_credentials(config, aws_credentials_source(&credentials)?)
+    }
+
+    pub(crate) fn with_credentials(
+        mut config: S3PresignerConfig,
+        credentials: SharedAwsCredentialsSource,
+    ) -> Result<Self> {
         if config.bucket.trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "bucket must not be empty".to_owned(),
@@ -101,18 +113,11 @@ impl S3CompatiblePresigner {
                 "region must not be empty".to_owned(),
             ));
         }
-        if config.access_key_id.expose().trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "access key id must not be empty".to_owned(),
-            ));
-        }
-        if config.secret_access_key.expose().trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "secret access key must not be empty".to_owned(),
-            ));
-        }
         config.key_prefix = normalize_key_prefix(config.key_prefix.as_deref())?;
-        Ok(Self { config })
+        Ok(Self {
+            config,
+            credentials,
+        })
     }
 
     /// Signs a `HeadObject` that asks the provider to report the object's
@@ -121,13 +126,15 @@ impl S3CompatiblePresigner {
     /// `GetObjectAttributes` would answer the same question on AWS S3 and
     /// return 501 on Cloudflare R2, so the head is the only portable surface
     /// and the only one this crate signs.
-    pub(crate) fn presign_head_stored_checksum(
+    pub(crate) async fn presign_head_stored_checksum(
         &self,
         object_key: &str,
         expires_in: Duration,
         now: SystemTime,
     ) -> Result<PresignedUrl> {
+        let credentials = self.credentials.credentials().await?;
         self.presign(
+            &credentials,
             "HEAD",
             object_key,
             BTreeMap::from([(S3_CHECKSUM_MODE_HEADER.to_owned(), "ENABLED".to_owned())]),
@@ -138,44 +145,55 @@ impl S3CompatiblePresigner {
 
     /// Signs `CreateMultipartUpload` for an object whose checksum will cover
     /// the whole assembly.
-    pub(crate) fn presign_create_multipart(
+    pub(crate) async fn presign_create_multipart(
         &self,
         object_key: &str,
         expires_in: Duration,
         now: SystemTime,
     ) -> Result<PresignedUrl> {
+        let credentials = self.credentials.credentials().await?;
         self.presign_with_query(
+            &credentials,
             "POST",
             object_key,
-            BTreeMap::from([("uploads".to_owned(), String::new())]),
-            BTreeMap::from([
-                (
-                    S3_CHECKSUM_ALGORITHM_HEADER.to_owned(),
-                    S3_CRC64NVME_ALGORITHM.to_owned(),
-                ),
-                (
-                    S3_CHECKSUM_TYPE_HEADER.to_owned(),
-                    S3_FULL_OBJECT_CHECKSUM_TYPE.to_owned(),
-                ),
-            ]),
+            SigningRequestParts {
+                operation_query: BTreeMap::from([("uploads".to_owned(), String::new())]),
+                required_headers: BTreeMap::from([
+                    (
+                        S3_CHECKSUM_ALGORITHM_HEADER.to_owned(),
+                        S3_CRC64NVME_ALGORITHM.to_owned(),
+                    ),
+                    (
+                        S3_CHECKSUM_TYPE_HEADER.to_owned(),
+                        S3_FULL_OBJECT_CHECKSUM_TYPE.to_owned(),
+                    ),
+                ]),
+            },
             expires_in,
             now,
         )
     }
 
     /// Signs `AbortMultipartUpload`, the cleanup a terminated session runs.
-    pub(crate) fn presign_abort_multipart(
+    pub(crate) async fn presign_abort_multipart(
         &self,
         object_key: &str,
         provider_upload_id: &str,
         expires_in: Duration,
         now: SystemTime,
     ) -> Result<PresignedUrl> {
+        let credentials = self.credentials.credentials().await?;
         self.presign_with_query(
+            &credentials,
             "DELETE",
             object_key,
-            BTreeMap::from([("uploadId".to_owned(), provider_upload_id.to_owned())]),
-            BTreeMap::new(),
+            SigningRequestParts {
+                operation_query: BTreeMap::from([(
+                    "uploadId".to_owned(),
+                    provider_upload_id.to_owned(),
+                )]),
+                ..SigningRequestParts::default()
+            },
             expires_in,
             now,
         )
@@ -187,7 +205,7 @@ impl S3CompatiblePresigner {
     /// an object that does not match it. Cloudflare R2 accepts the request
     /// and stores the true checksum instead, which is why completion still
     /// reads the object back rather than trusting this call's success.
-    pub(crate) fn presign_complete_multipart(
+    pub(crate) async fn presign_complete_multipart(
         &self,
         object_key: &str,
         provider_upload_id: &str,
@@ -195,14 +213,21 @@ impl S3CompatiblePresigner {
         expires_in: Duration,
         now: SystemTime,
     ) -> Result<PresignedUrl> {
+        let credentials = self.credentials.credentials().await?;
         self.presign_with_query(
+            &credentials,
             "POST",
             object_key,
-            BTreeMap::from([("uploadId".to_owned(), provider_upload_id.to_owned())]),
-            BTreeMap::from([(
-                S3_CRC64NVME_CHECKSUM_HEADER.to_owned(),
-                base64_crc64nvme(checksum)?,
-            )]),
+            SigningRequestParts {
+                operation_query: BTreeMap::from([(
+                    "uploadId".to_owned(),
+                    provider_upload_id.to_owned(),
+                )]),
+                required_headers: BTreeMap::from([(
+                    S3_CRC64NVME_CHECKSUM_HEADER.to_owned(),
+                    base64_crc64nvme(checksum)?,
+                )]),
+            },
             expires_in,
             now,
         )
@@ -210,6 +235,7 @@ impl S3CompatiblePresigner {
 
     fn presign(
         &self,
+        credentials: &AwsSigningCredentials,
         method: &str,
         object_key: &str,
         required_headers: BTreeMap<String, String>,
@@ -217,10 +243,13 @@ impl S3CompatiblePresigner {
         now: SystemTime,
     ) -> Result<PresignedUrl> {
         self.presign_with_query(
+            credentials,
             method,
             object_key,
-            BTreeMap::new(),
-            required_headers,
+            SigningRequestParts {
+                required_headers,
+                ..SigningRequestParts::default()
+            },
             expires_in,
             now,
         )
@@ -234,10 +263,10 @@ impl S3CompatiblePresigner {
     /// participate in the signature or the provider computes a different one.
     fn presign_with_query(
         &self,
+        credentials: &AwsSigningCredentials,
         method: &str,
         object_key: &str,
-        operation_query: BTreeMap<String, String>,
-        required_headers: BTreeMap<String, String>,
+        request_parts: SigningRequestParts,
         expires_in: Duration,
         now: SystemTime,
     ) -> Result<PresignedUrl> {
@@ -263,12 +292,12 @@ impl S3CompatiblePresigner {
         );
         let credential = format!(
             "{}/{}",
-            self.config.access_key_id.expose(),
+            credentials.access_key_id.expose(),
             credential_scope
         );
 
         let mut headers_to_sign = BTreeMap::from([("host".to_owned(), endpoint.host.clone())]);
-        for (name, value) in &required_headers {
+        for (name, value) in &request_parts.required_headers {
             headers_to_sign.insert(name.to_ascii_lowercase(), normalize_header_value(value));
         }
         let signed_headers = headers_to_sign
@@ -282,7 +311,7 @@ impl S3CompatiblePresigner {
                 .expect("writing to a String should not fail");
         }
 
-        let mut query = operation_query;
+        let mut query = request_parts.operation_query;
         query.extend([
             ("X-Amz-Algorithm".to_owned(), "AWS4-HMAC-SHA256".to_owned()),
             ("X-Amz-Credential".to_owned(), credential),
@@ -290,7 +319,7 @@ impl S3CompatiblePresigner {
             ("X-Amz-Expires".to_owned(), expires_in.as_secs().to_string()),
             ("X-Amz-SignedHeaders".to_owned(), signed_headers.clone()),
         ]);
-        if let Some(token) = &self.config.session_token {
+        if let Some(token) = &credentials.session_token {
             query.insert("X-Amz-Security-Token".to_owned(), token.expose().to_owned());
         }
         let canonical_query = canonical_query_string(&query);
@@ -304,7 +333,7 @@ impl S3CompatiblePresigner {
             dates.timestamp, credential_scope, hashed_request
         );
         let signing_key = signing_key(
-            self.config.secret_access_key.expose(),
+            credentials.secret_access_key.expose(),
             &dates.short_date,
             &self.config.region,
         );
@@ -318,7 +347,7 @@ impl S3CompatiblePresigner {
         Ok(PresignedUrl {
             method: method.to_owned(),
             url,
-            headers: required_headers,
+            headers: request_parts.required_headers,
             expires_at_ms,
         })
     }
@@ -387,6 +416,7 @@ impl S3CompatiblePresigner {
     }
 }
 
+#[async_trait]
 impl DirectPutIssuer for S3CompatiblePresigner {
     fn stored_checksum_algorithm(&self) -> ChecksumAlgorithm {
         ChecksumAlgorithm::Crc64nvme
@@ -396,12 +426,14 @@ impl DirectPutIssuer for S3CompatiblePresigner {
         self.config.direct_put_max_content_bytes
     }
 
-    fn presign_put(
+    async fn presign_put(
         &self,
         request: PresignedPutRequest<'_>,
         now: SystemTime,
     ) -> Result<PresignedUrl> {
+        let credentials = self.credentials.credentials().await?;
         self.presign(
+            &credentials,
             "PUT",
             request.object_key,
             BTreeMap::from([(S3_CREATE_ONLY_HEADER.to_owned(), "*".to_owned())]),
@@ -411,8 +443,9 @@ impl DirectPutIssuer for S3CompatiblePresigner {
     }
 }
 
+#[async_trait]
 impl DirectMultipartIssuer for S3CompatiblePresigner {
-    fn presign_multipart_part(
+    async fn presign_multipart_part(
         &self,
         request: PresignedPartRequest<'_>,
         now: SystemTime,
@@ -423,25 +456,30 @@ impl DirectMultipartIssuer for S3CompatiblePresigner {
         // No create-only header here, deliberately. A part is not the object:
         // re-uploading one is how a client retries a failed transfer, and both
         // providers take the last write and follow it with the checksum.
+        let credentials = self.credentials.credentials().await?;
         self.presign_with_query(
+            &credentials,
             "PUT",
             request.object_key,
-            BTreeMap::from([
-                ("partNumber".to_owned(), request.part_number.to_string()),
-                ("uploadId".to_owned(), request.provider_upload_id.to_owned()),
-            ]),
-            BTreeMap::from([(
-                S3_CRC64NVME_CHECKSUM_HEADER.to_owned(),
-                base64_crc64nvme(request.checksum)?,
-            )]),
+            SigningRequestParts {
+                operation_query: BTreeMap::from([
+                    ("partNumber".to_owned(), request.part_number.to_string()),
+                    ("uploadId".to_owned(), request.provider_upload_id.to_owned()),
+                ]),
+                required_headers: BTreeMap::from([(
+                    S3_CRC64NVME_CHECKSUM_HEADER.to_owned(),
+                    base64_crc64nvme(request.checksum)?,
+                )]),
+            },
             request.expires_in,
             now,
         )
     }
 }
 
+#[async_trait]
 impl DirectGetIssuer for S3CompatiblePresigner {
-    fn presign_get(
+    async fn presign_get(
         &self,
         request: PresignedGetRequest<'_>,
         now: SystemTime,
@@ -452,7 +490,9 @@ impl DirectGetIssuer for S3CompatiblePresigner {
         // entirely, and one issued URL serves ranged, resumed, and parallel
         // reads of the object without another round trip to the server.
         // Adding a required header here would silently cost that.
+        let credentials = self.credentials.credentials().await?;
         self.presign(
+            &credentials,
             "GET",
             request.object_key,
             BTreeMap::new(),
@@ -498,33 +538,73 @@ fn signing_key(secret: &str, date: &str, region: &str) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::{S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES};
+    use crate::aws_credentials::{
+        AwsCredentialsSource, AwsSigningCredentials, ObjectStoreAwsCredentialProvider,
+        SharedAwsCredentialsSource,
+    };
     use crate::keyspace::{normalize_key_prefix, scope_object_key};
     use crate::presign::{
         DirectGetIssuer, DirectPutIssuer, PresignedGetRequest, PresignedPutRequest,
     };
-    use crate::ObjectStoreError;
+    use crate::{AwsS3Credentials, ObjectStoreError};
+    use async_trait::async_trait;
+    use object_store::client::CredentialProvider;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
     use std::time::{Duration, UNIX_EPOCH};
 
     const CONTENT_KEY: &str =
         "content-stores/cs/objects/01/23/con_0123456789abcdef0123456789abcdef";
 
-    fn presigner(key_prefix: Option<&str>, endpoint_url: Option<&str>) -> S3CompatiblePresigner {
-        S3CompatiblePresigner::new(S3PresignerConfig {
+    #[derive(Debug, Default)]
+    struct RotatingCredentialsSource {
+        next: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl AwsCredentialsSource for RotatingCredentialsSource {
+        async fn credentials(&self) -> Result<AwsSigningCredentials, ObjectStoreError> {
+            let version = self.next.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(AwsSigningCredentials {
+                access_key_id: format!("rotating-access-{version}").into(),
+                secret_access_key: format!("rotating-secret-{version}").into(),
+                session_token: None,
+            })
+        }
+    }
+
+    fn presigner_config() -> S3PresignerConfig {
+        S3PresignerConfig {
             bucket: "bucket".to_owned(),
-            region: endpoint_url.map_or("us-east-1", |_| "us-east-2").to_owned(),
-            endpoint_url: endpoint_url.map(ToOwned::to_owned),
-            access_key_id: "access".into(),
-            secret_access_key: "secret".into(),
-            session_token: None,
-            key_prefix: key_prefix.map(ToOwned::to_owned),
+            region: "us-east-1".to_owned(),
+            endpoint_url: None,
+            key_prefix: None,
             force_path_style: false,
             direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
-        })
+        }
+    }
+
+    fn presigner(key_prefix: Option<&str>, endpoint_url: Option<&str>) -> S3CompatiblePresigner {
+        S3CompatiblePresigner::new(
+            S3PresignerConfig {
+                bucket: "bucket".to_owned(),
+                region: endpoint_url.map_or("us-east-1", |_| "us-east-2").to_owned(),
+                endpoint_url: endpoint_url.map(ToOwned::to_owned),
+                key_prefix: key_prefix.map(ToOwned::to_owned),
+                force_path_style: false,
+                direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
+            },
+            AwsS3Credentials::Static {
+                access_key_id: "access".into(),
+                secret_access_key: "secret".into(),
+                session_token: None,
+            },
+        )
         .expect("signer")
     }
 
-    #[test]
-    fn presigned_put_scopes_key_and_signs_s3_compatible_required_headers() {
+    #[tokio::test]
+    async fn presigned_put_scopes_key_and_signs_s3_compatible_required_headers() {
         let signed = presigner(Some("tenant-a"), None)
             .presign_put(
                 PresignedPutRequest {
@@ -533,6 +613,7 @@ mod tests {
                 },
                 UNIX_EPOCH + Duration::from_secs(1_700_000_000),
             )
+            .await
             .expect("presign");
 
         assert_eq!(signed.method, "PUT");
@@ -550,16 +631,83 @@ mod tests {
         assert!(!signed.url.contains("secret"));
     }
 
+    #[tokio::test]
+    async fn one_rotating_source_serves_the_presigner_and_provider_bridge() {
+        let source: SharedAwsCredentialsSource = Arc::new(RotatingCredentialsSource::default());
+        let bridge = ObjectStoreAwsCredentialProvider::new(Arc::clone(&source));
+        let signer = S3CompatiblePresigner::with_credentials(presigner_config(), source)
+            .expect("construct signer");
+
+        let first_provider = bridge
+            .get_credential()
+            .await
+            .expect("first provider credential");
+        assert_eq!(first_provider.key_id, "rotating-access-1");
+
+        let later_signed = signer
+            .presign_get(
+                PresignedGetRequest {
+                    object_key: CONTENT_KEY,
+                    expires_in: Duration::from_secs(900),
+                },
+                UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+            )
+            .await
+            .expect("presign with rotated credentials");
+        assert!(
+            later_signed
+                .url
+                .contains("X-Amz-Credential=rotating-access-2%2F"),
+            "{}",
+            later_signed.url
+        );
+
+        let later_provider = bridge
+            .get_credential()
+            .await
+            .expect("later provider credential");
+        assert_eq!(later_provider.key_id, "rotating-access-3");
+    }
+
+    #[tokio::test]
+    async fn presigned_url_includes_the_current_session_token() {
+        let signer = S3CompatiblePresigner::new(
+            presigner_config(),
+            AwsS3Credentials::Static {
+                access_key_id: "temporary-access".into(),
+                secret_access_key: "temporary-secret".into(),
+                session_token: Some("temporary-session-token".into()),
+            },
+        )
+        .expect("construct signer");
+
+        let signed = signer
+            .presign_put(
+                PresignedPutRequest {
+                    object_key: CONTENT_KEY,
+                    expires_in: Duration::from_secs(900),
+                },
+                UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+            )
+            .await
+            .expect("presign with temporary credentials");
+
+        assert!(signed
+            .url
+            .contains("X-Amz-Security-Token=temporary-session-token"));
+    }
+
     /// The checksum readback rides the signature the same way the write's
     /// checksum does, so an operator cannot strip it in flight.
-    #[test]
-    fn presigned_head_signs_the_checksum_mode_header() {
+    #[tokio::test]
+    async fn presigned_head_signs_the_checksum_mode_header() {
         let signed = presigner(Some("tenant-a"), None)
             .presign_head_stored_checksum(
                 CONTENT_KEY,
                 Duration::from_secs(60),
                 UNIX_EPOCH + Duration::from_secs(1_700_000_000),
             )
+            .await
             .expect("presign head");
 
         assert_eq!(signed.method, "HEAD");
@@ -582,8 +730,8 @@ mod tests {
     /// leaves `Range` outside the signature: one issued URL serves ranged,
     /// resumed, and parallel reads without another round trip to the
     /// server. The live suite proves the provider agrees.
-    #[test]
-    fn presigned_get_signs_only_the_host_so_range_stays_unsigned() {
+    #[tokio::test]
+    async fn presigned_get_signs_only_the_host_so_range_stays_unsigned() {
         let signed = presigner(Some("tenant-a"), None)
             .presign_get(
                 PresignedGetRequest {
@@ -592,6 +740,7 @@ mod tests {
                 },
                 UNIX_EPOCH + Duration::from_secs(1_700_000_000),
             )
+            .await
             .expect("presign get");
 
         assert_eq!(signed.method, "GET");
@@ -611,8 +760,8 @@ mod tests {
     /// the key prefix and endpoint style resolve to for one, they resolve
     /// to for the other, so a deployment cannot sign a write it is unable
     /// to sign a read of.
-    #[test]
-    fn presigned_get_addresses_the_same_object_the_write_did() {
+    #[tokio::test]
+    async fn presigned_get_addresses_the_same_object_the_write_did() {
         let signer = presigner(
             Some("tenant-a"),
             Some("https://bucket.s3.us-east-2.amazonaws.com"),
@@ -626,6 +775,7 @@ mod tests {
                 },
                 now,
             )
+            .await
             .expect("presign put");
         let read = signer
             .presign_get(
@@ -635,6 +785,7 @@ mod tests {
                 },
                 now,
             )
+            .await
             .expect("presign get");
 
         let object_of = |url: &str| url.split('?').next().expect("url path").to_owned();
@@ -649,8 +800,8 @@ mod tests {
     /// the signer kept it raw and addressed `%20%20%20/...`. An object
     /// written through such a capability is committed and then invisible to
     /// every read, listing, and collection the store performs.
-    #[test]
-    fn the_signer_and_the_store_resolve_a_key_to_the_same_string() {
+    #[tokio::test]
+    async fn the_signer_and_the_store_resolve_a_key_to_the_same_string() {
         for raw_prefix in [None, Some("   "), Some(""), Some("tenant-a")] {
             let signed = presigner(raw_prefix, None)
                 .presign_get(
@@ -660,6 +811,7 @@ mod tests {
                     },
                     UNIX_EPOCH + Duration::from_secs(1_700_000_000),
                 )
+                .await
                 .expect("presign get");
 
             // Exactly what `ProviderObjectStore` does with the same value.
@@ -686,24 +838,28 @@ mod tests {
     fn an_unusable_key_prefix_fails_construction() {
         for raw_prefix in ["tenant-a//bad", "../escape"] {
             assert!(matches!(
-                S3CompatiblePresigner::new(S3PresignerConfig {
-                    bucket: "bucket".to_owned(),
-                    region: "us-east-1".to_owned(),
-                    endpoint_url: None,
-                    access_key_id: "access".into(),
-                    secret_access_key: "secret".into(),
-                    session_token: None,
-                    key_prefix: Some(raw_prefix.to_owned()),
-                    force_path_style: false,
-                    direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
-                }),
+                S3CompatiblePresigner::new(
+                    S3PresignerConfig {
+                        bucket: "bucket".to_owned(),
+                        region: "us-east-1".to_owned(),
+                        endpoint_url: None,
+                        key_prefix: Some(raw_prefix.to_owned()),
+                        force_path_style: false,
+                        direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
+                    },
+                    AwsS3Credentials::Static {
+                        access_key_id: "access".into(),
+                        secret_access_key: "secret".into(),
+                        session_token: None,
+                    }
+                ),
                 Err(ObjectStoreError::InvalidKey { .. })
             ));
         }
     }
 
-    #[test]
-    fn presigned_put_accepts_bucket_specific_custom_endpoint() {
+    #[tokio::test]
+    async fn presigned_put_accepts_bucket_specific_custom_endpoint() {
         let signed = presigner(
             Some("tenant-a"),
             Some("https://bucket.s3.us-east-2.amazonaws.com"),
@@ -715,6 +871,7 @@ mod tests {
             },
             UNIX_EPOCH + Duration::from_secs(1_700_000_000),
         )
+        .await
         .expect("presign");
 
         assert!(signed
@@ -729,19 +886,25 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: None,
-            access_key_id: "access".into(),
-            secret_access_key: "debug-secret".into(),
-            session_token: Some("debug-session-token".into()),
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: false,
             direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
         };
+        let credentials = AwsS3Credentials::Static {
+            access_key_id: "debug-access-key".into(),
+            secret_access_key: "debug-secret".into(),
+            session_token: Some("debug-session-token".into()),
+        };
 
         let config_debug = format!("{config:?}");
-        let signer = S3CompatiblePresigner::new(config).expect("signer");
+        let credentials_debug = format!("{credentials:?}");
+        let signer = S3CompatiblePresigner::new(config, credentials).expect("signer");
         let signer_debug = format!("{signer:?}");
 
-        for rendered in [config_debug, signer_debug] {
+        assert!(!config_debug.contains("debug-secret"));
+        assert!(!config_debug.contains("debug-access-key"));
+        assert!(!config_debug.contains("debug-session-token"));
+        for rendered in [credentials_debug, signer_debug] {
             assert!(!rendered.contains("debug-secret"));
             assert!(!rendered.contains("debug-access-key"));
             assert!(!rendered.contains("debug-session-token"));

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -96,7 +96,8 @@ impl S3CompatiblePresigner {
     /// endpoint, content, expiry, and signing-time failures surface when
     /// [`DirectPutIssuer::presign_put`] runs.
     pub fn new(config: S3PresignerConfig, credentials: crate::AwsS3Credentials) -> Result<Self> {
-        Self::with_credentials(config, aws_credentials_source(&credentials)?)
+        let source = aws_credentials_source(&credentials, &config.region)?;
+        Self::with_credentials(config, source)
     }
 
     pub(crate) fn with_credentials(

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -4,6 +4,10 @@
 //! uploads carry a client-computed checksum -- not by behaviour worth a type
 //! each, so both are constructors here.
 
+use crate::aws_credentials::{
+    aws_credentials_source, static_aws_credentials_source, ObjectStoreAwsCredentialProvider,
+    SharedAwsCredentialsSource,
+};
 use crate::keyspace::parse_endpoint_url;
 use crate::object_store::Result;
 use crate::presign::PresignedUrl;
@@ -41,7 +45,7 @@ const S3_CHECKSUM_HEADERS: &[(&str, ChecksumAlgorithm)] = &[
     ("x-amz-checksum-crc32c", ChecksumAlgorithm::Crc32c),
 ];
 
-/// Supplies explicit credentials, addressing, and key scoping for AWS S3.
+/// Supplies credentials, addressing, and key scoping for AWS S3.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AwsS3StoreConfig {
     /// Bucket that acts as the LoonFS object-store root.
@@ -50,12 +54,8 @@ pub struct AwsS3StoreConfig {
     pub region: String,
     /// S3-compatible endpoint override, or `None` for the regional AWS endpoint.
     pub endpoint_url: Option<String>,
-    /// Access-key id used for SigV4 request signing.
-    pub access_key_id: SecretString,
-    /// Secret access key used for SigV4 request signing.
-    pub secret_access_key: SecretString,
-    /// Temporary credential token, or `None` for long-lived credentials.
-    pub session_token: Option<SecretString>,
+    /// Credential source shared by provider requests and presigned URLs.
+    pub credentials: crate::AwsS3Credentials,
     /// Logical prefix prepended to every key, or `None` to use the bucket root.
     pub key_prefix: Option<String>,
     /// Selects path-style bucket addressing for compatible endpoints that require it.
@@ -79,15 +79,13 @@ pub struct CloudflareR2StoreConfig {
     pub key_prefix: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 struct S3CompatibleConfig {
     provider_name: &'static str,
     bucket: String,
     region: String,
     endpoint_url: Option<String>,
-    access_key_id: SecretString,
-    secret_access_key: SecretString,
-    session_token: Option<SecretString>,
+    credentials: SharedAwsCredentialsSource,
     key_prefix: Option<String>,
     force_path_style: bool,
     /// Attach a client-computed SHA-256 to every upload so the provider
@@ -129,17 +127,24 @@ impl fmt::Debug for S3CompatibleStore {
 impl S3CompatibleStore {
     /// Builds an AWS S3 store with bounded retries and SHA-256 upload checksums.
     ///
-    /// Construction fails for invalid credentials, bucket, region, endpoint,
-    /// key prefix, runtime initialization, or provider-client configuration.
+    /// Construction fails for invalid static credentials, bucket, region,
+    /// endpoint, key prefix, runtime initialization, or provider-client
+    /// configuration. Ambient credential resolution remains lazy.
     pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self> {
+        let credentials = aws_credentials_source(&config.credentials)?;
+        Self::aws_s3_with_credentials(config, credentials)
+    }
+
+    pub(crate) fn aws_s3_with_credentials(
+        config: AwsS3StoreConfig,
+        credentials: SharedAwsCredentialsSource,
+    ) -> Result<Self> {
         Self::new(S3CompatibleConfig {
             provider_name: "aws-s3",
             bucket: config.bucket,
             region: config.region,
             endpoint_url: config.endpoint_url,
-            access_key_id: config.access_key_id,
-            secret_access_key: config.secret_access_key,
-            session_token: config.session_token,
+            credentials,
             key_prefix: config.key_prefix,
             force_path_style: config.force_path_style,
             sha256_upload_checksum: true,
@@ -152,9 +157,31 @@ impl S3CompatibleStore {
     /// Construction fails for a blank account id or any invalid shared
     /// configuration, including credentials, endpoint, and key prefix.
     pub fn cloudflare_r2(config: CloudflareR2StoreConfig) -> Result<Self> {
+        let credentials = static_aws_credentials_source(
+            config.access_key_id.clone(),
+            config.secret_access_key.clone(),
+            None,
+        );
+        Self::cloudflare_r2_with_credentials(config, credentials)
+    }
+
+    pub(crate) fn cloudflare_r2_with_credentials(
+        config: CloudflareR2StoreConfig,
+        credentials: SharedAwsCredentialsSource,
+    ) -> Result<Self> {
         if config.account_id.trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "account id must not be empty".to_owned(),
+            ));
+        }
+        if config.access_key_id.expose().trim().is_empty() {
+            return Err(ObjectStoreError::Configuration(
+                "access key id must not be empty".to_owned(),
+            ));
+        }
+        if config.secret_access_key.expose().trim().is_empty() {
+            return Err(ObjectStoreError::Configuration(
+                "secret access key must not be empty".to_owned(),
             ));
         }
         Self::new(S3CompatibleConfig {
@@ -162,9 +189,7 @@ impl S3CompatibleStore {
             bucket: config.bucket,
             region: "auto".to_owned(),
             endpoint_url: Some(config.endpoint_url),
-            access_key_id: config.access_key_id,
-            secret_access_key: config.secret_access_key,
-            session_token: None,
+            credentials,
             key_prefix: config.key_prefix,
             // The configured endpoint is the bucket-less account host; path
             // style makes the client append the bucket. Virtual hosting would
@@ -195,17 +220,17 @@ impl S3CompatibleStore {
                 object_store_endpoint_url(&config.bucket, endpoint, config.force_path_style)
             })
             .transpose()?;
-        let request_signer = S3CompatiblePresigner::new(S3PresignerConfig {
-            bucket: config.bucket.clone(),
-            region: config.region.clone(),
-            endpoint_url: config.endpoint_url.clone(),
-            access_key_id: config.access_key_id.clone(),
-            secret_access_key: config.secret_access_key.clone(),
-            session_token: config.session_token.clone(),
-            key_prefix: config.key_prefix.clone(),
-            force_path_style: config.force_path_style,
-            direct_put_max_content_bytes: config.direct_put_max_content_bytes,
-        })?;
+        let request_signer = S3CompatiblePresigner::with_credentials(
+            S3PresignerConfig {
+                bucket: config.bucket.clone(),
+                region: config.region.clone(),
+                endpoint_url: config.endpoint_url.clone(),
+                key_prefix: config.key_prefix.clone(),
+                force_path_style: config.force_path_style,
+                direct_put_max_content_bytes: config.direct_put_max_content_bytes,
+            },
+            Arc::clone(&config.credentials),
+        )?;
 
         let io_runtime = StoreIoRuntime::new()?;
         let http = io_runtime
@@ -218,8 +243,9 @@ impl S3CompatibleStore {
             .with_retry(crate::provider_object_store::provider_retry_config())
             .with_bucket_name(config.bucket)
             .with_region(config.region)
-            .with_access_key_id(config.access_key_id.expose())
-            .with_secret_access_key(config.secret_access_key.expose())
+            .with_credentials(Arc::new(ObjectStoreAwsCredentialProvider::new(
+                config.credentials,
+            )))
             .with_virtual_hosted_style_request(!config.force_path_style);
 
         if let Some(endpoint_url) = endpoint_url {
@@ -227,9 +253,6 @@ impl S3CompatibleStore {
             builder = builder
                 .with_endpoint(endpoint_url)
                 .with_allow_http(allow_http);
-        }
-        if let Some(session_token) = &config.session_token {
-            builder = builder.with_token(session_token.expose());
         }
         if config.sha256_upload_checksum {
             builder = builder.with_checksum_algorithm(ProviderChecksum::SHA256);
@@ -355,11 +378,10 @@ impl ObjectStore for S3CompatibleStore {
     }
 
     async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
-        let signed = self.request_signer.presign_head_stored_checksum(
-            key,
-            CHECKSUM_HEAD_TTL,
-            Self::signing_time(),
-        )?;
+        let signed = self
+            .request_signer
+            .presign_head_stored_checksum(key, CHECKSUM_HEAD_TTL, Self::signing_time())
+            .await?;
         let response = self
             .execute_signed(key, signed, HttpRequestBody::empty())
             .await?;
@@ -403,11 +425,10 @@ impl ObjectStore for S3CompatibleStore {
     }
 
     async fn create_multipart_upload(&self, key: &str) -> Result<String> {
-        let signed = self.request_signer.presign_create_multipart(
-            key,
-            MULTIPART_CONTROL_TTL,
-            Self::signing_time(),
-        )?;
+        let signed = self
+            .request_signer
+            .presign_create_multipart(key, MULTIPART_CONTROL_TTL, Self::signing_time())
+            .await?;
         let response = self
             .execute_signed(key, signed, HttpRequestBody::empty())
             .await?;
@@ -426,13 +447,16 @@ impl ObjectStore for S3CompatibleStore {
         parts: &[MultipartPart],
         checksum: &Checksum,
     ) -> Result<MultipartCompletion> {
-        let signed = self.request_signer.presign_complete_multipart(
-            key,
-            provider_upload_id,
-            checksum,
-            MULTIPART_CONTROL_TTL,
-            Self::signing_time(),
-        )?;
+        let signed = self
+            .request_signer
+            .presign_complete_multipart(
+                key,
+                provider_upload_id,
+                checksum,
+                MULTIPART_CONTROL_TTL,
+                Self::signing_time(),
+            )
+            .await?;
         let response = self
             .execute_signed(key, signed, complete_multipart_body(parts)?.into())
             .await?;
@@ -447,12 +471,15 @@ impl ObjectStore for S3CompatibleStore {
     }
 
     async fn abort_multipart_upload(&self, key: &str, provider_upload_id: &str) -> Result<()> {
-        let signed = self.request_signer.presign_abort_multipart(
-            key,
-            provider_upload_id,
-            MULTIPART_CONTROL_TTL,
-            Self::signing_time(),
-        )?;
+        let signed = self
+            .request_signer
+            .presign_abort_multipart(
+                key,
+                provider_upload_id,
+                MULTIPART_CONTROL_TTL,
+                Self::signing_time(),
+            )
+            .await?;
         let response = self
             .execute_signed(key, signed, HttpRequestBody::empty())
             .await?;
@@ -630,16 +657,6 @@ fn validate_config(config: &S3CompatibleConfig) -> Result<()> {
             "region must not be empty".to_owned(),
         ));
     }
-    if config.access_key_id.expose().trim().is_empty() {
-        return Err(ObjectStoreError::Configuration(
-            "access key id must not be empty".to_owned(),
-        ));
-    }
-    if config.secret_access_key.expose().trim().is_empty() {
-        return Err(ObjectStoreError::Configuration(
-            "secret access key must not be empty".to_owned(),
-        ));
-    }
     Ok(())
 }
 
@@ -669,10 +686,11 @@ fn object_store_endpoint_url(
 #[cfg(test)]
 mod tests {
     use super::{
-        multipart_error, object_store_endpoint_url, S3CompatibleConfig, S3CompatibleStore,
-        AWS_S3_MAX_DIRECT_PUT_BYTES,
+        multipart_error, object_store_endpoint_url, AwsS3StoreConfig, S3CompatibleConfig,
+        S3CompatibleStore, AWS_S3_MAX_DIRECT_PUT_BYTES,
     };
-    use crate::ObjectStoreErrorClass;
+    use crate::aws_credentials::static_aws_credentials_source;
+    use crate::{AwsS3Credentials, ObjectStoreErrorClass};
 
     fn test_config() -> S3CompatibleConfig {
         S3CompatibleConfig {
@@ -680,9 +698,7 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: Some("http://127.0.0.1:9000".to_owned()),
-            access_key_id: "access".into(),
-            secret_access_key: "secret".into(),
-            session_token: None,
+            credentials: static_aws_credentials_source("access".into(), "secret".into(), None),
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: true,
             sha256_upload_checksum: true,
@@ -698,10 +714,16 @@ mod tests {
     }
 
     #[test]
-    fn s3_compatible_store_rejects_blank_credentials() {
-        let mut config = test_config();
-        config.access_key_id = "".into();
-        assert!(S3CompatibleStore::new(config).is_err());
+    fn ambient_aws_store_construction_does_not_resolve_credentials() {
+        S3CompatibleStore::aws_s3(AwsS3StoreConfig {
+            bucket: "bucket".to_owned(),
+            region: "us-east-1".to_owned(),
+            endpoint_url: Some("http://127.0.0.1:9000".to_owned()),
+            credentials: AwsS3Credentials::Ambient {},
+            key_prefix: Some("tenant-a".to_owned()),
+            force_path_style: true,
+        })
+        .expect("construct ambient AWS store lazily");
     }
 
     #[test]

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -131,7 +131,7 @@ impl S3CompatibleStore {
     /// endpoint, key prefix, runtime initialization, or provider-client
     /// configuration. Ambient credential resolution remains lazy.
     pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self> {
-        let credentials = aws_credentials_source(&config.credentials)?;
+        let credentials = aws_credentials_source(&config.credentials, &config.region)?;
         Self::aws_s3_with_credentials(config, credentials)
     }
 

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -19,18 +19,18 @@ use loonfs_api::SecretString;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// Environment variable ambient S3-compatible credentials read their access-key id from.
+/// Standard AWS environment credential name for the access-key id.
 pub const ACCESS_KEY_ID_ENV: &str = "AWS_ACCESS_KEY_ID";
-/// Environment variable ambient S3-compatible credentials read their secret access key from.
+/// Standard AWS environment credential name for the secret access key.
 pub const SECRET_ACCESS_KEY_ENV: &str = "AWS_SECRET_ACCESS_KEY";
-/// Environment variable ambient AWS credentials read an optional session token from.
+/// Standard AWS environment credential name for the optional session token.
 pub const SESSION_TOKEN_ENV: &str = "AWS_SESSION_TOKEN";
 
 /// AWS S3 credential source, stored separately from provider settings.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
 pub enum AwsS3Credentials {
-    /// Resolves credentials from the process environment when the store is constructed.
+    /// Resolves refreshable credentials through the standard AWS SDK chain.
     Ambient {},
     /// Uses the complete credential set stored in the configuration file.
     Static {
@@ -108,7 +108,7 @@ pub enum StoreConfig {
         /// Service endpoint override, or `None` to derive the regional AWS endpoint.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         endpoint_url: Option<String>,
-        /// Credential source resolved when the store is constructed.
+        /// Credential source used by every provider request and presigned URL.
         credentials: AwsS3Credentials,
         /// Logical prefix applied inside the bucket, or `None` to expose its root.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -237,20 +237,14 @@ impl StoreConfig {
                 credentials,
                 key_prefix,
                 force_path_style,
-            } => {
-                let (access_key_id, secret_access_key, session_token) =
-                    resolve_aws_s3_credentials(credentials, |name| std::env::var(name).ok())?;
-                ConfiguredObjectStore::aws_s3(AwsS3StoreConfig {
-                    bucket: bucket.clone(),
-                    region: region.clone(),
-                    endpoint_url: endpoint_url.clone(),
-                    access_key_id,
-                    secret_access_key,
-                    session_token,
-                    key_prefix: key_prefix.clone(),
-                    force_path_style: *force_path_style,
-                })
-            }
+            } => ConfiguredObjectStore::aws_s3(AwsS3StoreConfig {
+                bucket: bucket.clone(),
+                region: region.clone(),
+                endpoint_url: endpoint_url.clone(),
+                credentials: credentials.clone(),
+                key_prefix: key_prefix.clone(),
+                force_path_style: *force_path_style,
+            }),
             StoreConfig::CloudflareR2 {
                 bucket,
                 account_id,
@@ -451,35 +445,6 @@ fn validate_r2_credentials(credentials: &CloudflareR2Credentials) -> Result<(), 
     Ok(())
 }
 
-fn resolve_aws_s3_credentials(
-    credentials: &AwsS3Credentials,
-    lookup: impl Fn(&str) -> Option<String>,
-) -> crate::object_store::Result<(SecretString, SecretString, Option<SecretString>)> {
-    match credentials {
-        AwsS3Credentials::Static {
-            access_key_id,
-            secret_access_key,
-            session_token,
-        } => Ok((
-            access_key_id.clone(),
-            secret_access_key.clone(),
-            session_token.clone(),
-        )),
-        AwsS3Credentials::Ambient {} => {
-            let access_key_id = non_blank(lookup(ACCESS_KEY_ID_ENV));
-            let secret_access_key = non_blank(lookup(SECRET_ACCESS_KEY_ENV));
-            match (access_key_id, secret_access_key) {
-                (Some(access_key_id), Some(secret_access_key)) => Ok((
-                    SecretString::new(access_key_id),
-                    SecretString::new(secret_access_key),
-                    non_blank(lookup(SESSION_TOKEN_ENV)).map(SecretString::new),
-                )),
-                _ => Err(missing_ambient_credentials("aws-s3", true)),
-            }
-        }
-    }
-}
-
 fn resolve_r2_credentials(
     credentials: &CloudflareR2Credentials,
     lookup: impl Fn(&str) -> Option<String>,
@@ -497,21 +462,16 @@ fn resolve_r2_credentials(
                     SecretString::new(access_key_id),
                     SecretString::new(secret_access_key),
                 )),
-                _ => Err(missing_ambient_credentials("cloudflare-r2", false)),
+                _ => Err(missing_r2_ambient_credentials()),
             }
         }
     }
 }
 
-fn missing_ambient_credentials(provider: &str, session_token: bool) -> ObjectStoreError {
-    let optional_session = if session_token {
-        format!("; `{SESSION_TOKEN_ENV}` is optional")
-    } else {
-        String::new()
-    };
+fn missing_r2_ambient_credentials() -> ObjectStoreError {
     ObjectStoreError::Configuration(format!(
-        "{provider} ambient credentials require non-blank `{ACCESS_KEY_ID_ENV}` and \
-         `{SECRET_ACCESS_KEY_ENV}`{optional_session}; set them in the environment or configure \
+        "cloudflare-r2 ambient credentials require non-blank `{ACCESS_KEY_ID_ENV}` and \
+         `{SECRET_ACCESS_KEY_ENV}`; set them in the environment or configure \
          `store.credentials.kind = \"static\"`"
     ))
 }
@@ -602,12 +562,8 @@ mod tests {
     #![allow(clippy::panic)]
     // Config tests use panic in unexpected match arms for precise diagnostics.
 
-    use super::{
-        resolve_aws_s3_credentials, resolve_r2_credentials, AwsS3Credentials,
-        CloudflareR2Credentials, StoreConfig, StoreConfigError,
-    };
+    use super::{resolve_r2_credentials, CloudflareR2Credentials, StoreConfig, StoreConfigError};
     use crate::ConfiguredObjectStoreKind;
-    use loonfs_api::SecretString;
 
     fn parse(contents: &str) -> StoreConfig {
         toml::from_str(contents).expect("parse store config")
@@ -744,7 +700,7 @@ secret_access_key = "secret"
     }
 
     #[test]
-    fn ambient_credentials_resolve_without_mutating_the_serialized_source() {
+    fn ambient_credential_sources_serialize_without_resolved_secrets() {
         let environment = |name: &str| match name {
             "AWS_ACCESS_KEY_ID" => Some("env-access".to_owned()),
             "AWS_SECRET_ACCESS_KEY" => Some("env-secret".to_owned()),
@@ -764,17 +720,9 @@ kind = "ambient"
         );
         aws.validate()
             .expect("ambient is a valid credential source");
-        let StoreConfig::AwsS3 { credentials, .. } = &aws else {
+        let StoreConfig::AwsS3 { .. } = &aws else {
             panic!("expected aws-s3")
         };
-        let (access_key_id, secret_access_key, session_token) =
-            resolve_aws_s3_credentials(credentials, environment).expect("resolve ambient aws");
-        assert_eq!(access_key_id.expose(), "env-access");
-        assert_eq!(secret_access_key.expose(), "env-secret");
-        assert_eq!(
-            session_token.as_ref().map(SecretString::expose),
-            Some("env-session")
-        );
         let rendered = toml::to_string_pretty(&aws).expect("serialize ambient aws");
         assert!(rendered.contains("kind = \"ambient\""));
         assert!(!rendered.contains("env-access"));
@@ -802,23 +750,8 @@ kind = "ambient"
     }
 
     #[test]
-    fn missing_runtime_ambient_credentials_are_provider_specific_and_actionable() {
+    fn missing_r2_ambient_credentials_are_actionable() {
         let missing = |_: &str| None;
-        let aws_error = resolve_aws_s3_credentials(&AwsS3Credentials::Ambient {}, missing)
-            .expect_err("missing aws ambient credentials");
-        let aws_message = aws_error.to_string();
-        assert!(
-            aws_message.contains("aws-s3 ambient credentials"),
-            "{aws_message}"
-        );
-        assert!(aws_message.contains("AWS_ACCESS_KEY_ID"), "{aws_message}");
-        assert!(
-            aws_message.contains("AWS_SECRET_ACCESS_KEY"),
-            "{aws_message}"
-        );
-        assert!(aws_message.contains("AWS_SESSION_TOKEN"), "{aws_message}");
-        assert!(aws_message.contains("kind = \"static\""), "{aws_message}");
-
         let r2_error = resolve_r2_credentials(&CloudflareR2Credentials::Ambient {}, missing)
             .expect_err("missing r2 ambient credentials");
         let r2_message = r2_error.to_string();

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -18,8 +18,8 @@ use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, Sto
 use loonfs_objectstore::s3_compatible::{
     AwsS3StoreConfig, CloudflareR2StoreConfig, S3CompatibleStore,
 };
-use loonfs_objectstore::ObjectStore;
 use loonfs_objectstore::ObjectStoreError;
+use loonfs_objectstore::{AwsS3Credentials, ObjectStore};
 use tempfile::TempDir;
 
 #[test]
@@ -128,9 +128,11 @@ async fn aws_s3_real_provider_conformance() {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id,
-        secret_access_key: config.secret_access_key,
-        session_token: config.session_token,
+        credentials: AwsS3Credentials::Static {
+            access_key_id: config.access_key_id,
+            secret_access_key: config.secret_access_key,
+            session_token: config.session_token,
+        },
         key_prefix: Some(config.prefix),
         force_path_style: false,
     })
@@ -151,9 +153,11 @@ async fn aws_s3_streamed_write_round_trips() {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id,
-        secret_access_key: config.secret_access_key,
-        session_token: config.session_token,
+        credentials: AwsS3Credentials::Static {
+            access_key_id: config.access_key_id,
+            secret_access_key: config.secret_access_key,
+            session_token: config.session_token,
+        },
         key_prefix: Some(config.prefix),
         force_path_style: false,
     })
@@ -189,9 +193,11 @@ async fn aws_s3_put_stores_a_trustworthy_checksum() {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id,
-        secret_access_key: config.secret_access_key,
-        session_token: config.session_token,
+        credentials: AwsS3Credentials::Static {
+            access_key_id: config.access_key_id,
+            secret_access_key: config.secret_access_key,
+            session_token: config.session_token,
+        },
         key_prefix: Some(config.prefix),
         force_path_style: false,
     })
@@ -243,9 +249,11 @@ fn aws_s3_store_survives_alternating_current_thread_runtimes() {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id,
-        secret_access_key: config.secret_access_key,
-        session_token: config.session_token,
+        credentials: AwsS3Credentials::Static {
+            access_key_id: config.access_key_id,
+            secret_access_key: config.secret_access_key,
+            session_token: config.session_token,
+        },
         key_prefix: Some(config.prefix),
         force_path_style: false,
     })

--- a/crates/loonfs-server/config/aws-s3.example.toml
+++ b/crates/loonfs-server/config/aws-s3.example.toml
@@ -24,17 +24,15 @@ region = "us-east-1"
 key_prefix = "loonfs-demo"
 force_path_style = false
 
-# Ambient credentials use the standard AWS SDK chain: environment variables,
-# shared config and credentials files selected by AWS_PROFILE, credential
-# processes, SSO, web identity, ECS task credentials, and EC2 instance
-# metadata. Temporary credentials refresh, and presigned URLs include the
-# current session token.
+# Uses the standard AWS SDK credential chain, including environment variables,
+# profiles, SSO, web identity, and AWS compute roles. Temporary credentials
+# refresh automatically.
 [store.credentials]
 kind = "ambient"
 
-# Static credentials remain available instead. session_token is optional.
-#[store.credentials]
-#kind = "static"
-#access_key_id = "YOUR_ACCESS_KEY_ID"
-#secret_access_key = "YOUR_SECRET_ACCESS_KEY"
-#session_token = "YOUR_SESSION_TOKEN"
+# To use static credentials instead:
+# [store.credentials]
+# kind = "static"
+# access_key_id = "YOUR_ACCESS_KEY_ID"
+# secret_access_key = "YOUR_SECRET_ACCESS_KEY"
+# session_token = "YOUR_SESSION_TOKEN" # optional

--- a/crates/loonfs-server/config/aws-s3.example.toml
+++ b/crates/loonfs-server/config/aws-s3.example.toml
@@ -24,8 +24,17 @@ region = "us-east-1"
 key_prefix = "loonfs-demo"
 force_path_style = false
 
-# Static credentials are stored in this file; session_token is optional.
+# Ambient credentials use the standard AWS SDK chain: environment variables,
+# shared config and credentials files selected by AWS_PROFILE, credential
+# processes, SSO, web identity, ECS task credentials, and EC2 instance
+# metadata. Temporary credentials refresh, and presigned URLs include the
+# current session token.
 [store.credentials]
-kind = "static"
-access_key_id = "YOUR_ACCESS_KEY_ID"
-secret_access_key = "YOUR_SECRET_ACCESS_KEY"
+kind = "ambient"
+
+# Static credentials remain available instead. session_token is optional.
+#[store.credentials]
+#kind = "static"
+#access_key_id = "YOUR_ACCESS_KEY_ID"
+#secret_access_key = "YOUR_SECRET_ACCESS_KEY"
+#session_token = "YOUR_SESSION_TOKEN"

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -628,8 +628,7 @@ mod tests {
         }
     }
 
-    /// Loading a config preserves its credential source. Environment
-    /// credentials are read only when the object store is constructed.
+    /// Loading a config preserves its credential source without resolving it.
     #[test]
     fn ambient_credential_sources_survive_loading_with_environment_credentials_set() {
         let path = write_config(

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -85,7 +85,7 @@ pub(super) async fn begin_download(
         .direct_download_target(&namespace_id, request.path.as_str(), request.revision_no)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    let access = presigned_access(issuer, &target.object_key)?;
+    let access = presigned_access(issuer, &target.object_key).await?;
 
     Ok(Json(BeginDownloadResponse {
         namespace_id,
@@ -140,7 +140,7 @@ pub(super) async fn begin_download_by_inode(
         .direct_download_target_by_inode(&namespace_id, inode_id, revision_no)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    let access = presigned_access(issuer, &target.object_key)?;
+    let access = presigned_access(issuer, &target.object_key).await?;
     Ok(Json(BeginDownloadByInodeResponse {
         namespace_id,
         inode_id: target.inode_id,
@@ -165,7 +165,7 @@ fn direct_get_issuer(state: &AppState) -> Result<&dyn DirectGetIssuer, ApiRespon
         })
 }
 
-fn presigned_access(
+async fn presigned_access(
     issuer: &dyn DirectGetIssuer,
     object_key: &str,
 ) -> Result<ObjectTransferAccess, ApiResponseError> {
@@ -177,6 +177,7 @@ fn presigned_access(
             },
             presign_time(),
         )
+        .await
         .map_err(presign_issuer_error)?;
     Ok(ObjectTransferAccess::PresignedUrl {
         method: signed.method,

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -195,6 +195,7 @@ async fn begin_direct_put_upload(
             },
             presign_time(),
         )
+        .await
         .map_err(presign_issuer_error)?;
 
     Ok(Json(BeginUploadResponse::DirectPut {
@@ -307,7 +308,7 @@ pub(super) async fn sign_upload_parts(
         .direct_multipart_part_targets(&namespace_id, &upload_id, &request.parts)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    let parts = sign_parts(issuer.as_ref(), &targets)?;
+    let parts = sign_parts(issuer.as_ref(), &targets).await?;
 
     Ok(Json(SignUploadPartsResponse {
         namespace_id,
@@ -316,38 +317,37 @@ pub(super) async fn sign_upload_parts(
     }))
 }
 
-fn sign_parts(
+async fn sign_parts(
     issuer: &dyn DirectMultipartIssuer,
     targets: &loonfs::uploads::MultipartPartTargets,
 ) -> Result<Vec<SignedUploadPart>, ApiResponseError> {
     let signing_time = presign_time();
-    targets
-        .parts
-        .iter()
-        .map(|part| {
-            let signed = issuer
-                .presign_multipart_part(
-                    PresignedPartRequest {
-                        object_key: &targets.object_key,
-                        provider_upload_id: &targets.provider_upload_id,
-                        part_number: part.part_number,
-                        checksum: &part.checksum,
-                        expires_in: MULTIPART_PART_URL_TTL,
-                    },
-                    signing_time,
-                )
-                .map_err(presign_issuer_error)?;
-            Ok(SignedUploadPart {
-                part_number: part.part_number,
-                access: ObjectTransferAccess::PresignedUrl {
-                    method: signed.method,
-                    url: signed.url,
-                    headers: signed.headers,
-                    expires_at_ms: signed.expires_at_ms,
+    let mut signed_parts = Vec::with_capacity(targets.parts.len());
+    for part in &targets.parts {
+        let signed = issuer
+            .presign_multipart_part(
+                PresignedPartRequest {
+                    object_key: &targets.object_key,
+                    provider_upload_id: &targets.provider_upload_id,
+                    part_number: part.part_number,
+                    checksum: &part.checksum,
+                    expires_in: MULTIPART_PART_URL_TTL,
                 },
-            })
-        })
-        .collect()
+                signing_time,
+            )
+            .await
+            .map_err(presign_issuer_error)?;
+        signed_parts.push(SignedUploadPart {
+            part_number: part.part_number,
+            access: ObjectTransferAccess::PresignedUrl {
+                method: signed.method,
+                url: signed.url,
+                headers: signed.headers,
+                expires_at_ms: signed.expires_at_ms,
+            },
+        });
+    }
+    Ok(signed_parts)
 }
 
 pub(super) fn presign_issuer_error(error: ObjectStoreError) -> ApiResponseError {

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -3522,8 +3522,9 @@ mod direct_download {
         }
     }
 
+    #[async_trait]
     impl DirectGetIssuer for LoopbackIssuer {
-        fn presign_get(
+        async fn presign_get(
             &self,
             request: PresignedGetRequest<'_>,
             _now: SystemTime,
@@ -3537,6 +3538,7 @@ mod direct_download {
         }
     }
 
+    #[async_trait]
     impl DirectPutIssuer for LoopbackIssuer {
         fn stored_checksum_algorithm(&self) -> ChecksumAlgorithm {
             self.checksum_algorithm
@@ -3546,7 +3548,7 @@ mod direct_download {
             LOOPBACK_DIRECT_PUT_MAX_BYTES
         }
 
-        fn presign_put(
+        async fn presign_put(
             &self,
             request: PresignedPutRequest<'_>,
             _now: SystemTime,

--- a/docs/specs/object-storage-providers.md
+++ b/docs/specs/object-storage-providers.md
@@ -21,18 +21,11 @@ This document is a non-normative reference: provider limits and performance data
 | **Request scale, partitions, throughput** | At least 3,500 write-class requests/s and 5,500 GET/HEAD requests/s per partitioned prefix; unlimited prefixes; scaling is gradual and may return 503 Slow Down. AWS also cites up to 100 Gb/s from a single EC2 instance and aggregate multi-Tb/s workloads.[^9] | Initial bucket scale is about 1,000 writes/s and 5,000 reads/s, then auto-scales. Ramp no faster than roughly doubling every 20 minutes. Sequential names can hotspot; random prefixes improve initial fanout. Internet egress default quota is commonly 200 Gbps per region, subject to account history and quotas.[^19][^20] | Public r2.dev buckets are test-only and may throttle at hundreds of req/s; production should use custom domains or direct APIs. Cloudflare REST management API is not for high-throughput object I/O; use S3-compatible or Workers APIs.[^32] | Standard GPv2/blob accounts: default max request rate 40,000 req/s in many listed regions, 20,000 elsewhere; ingress commonly 60/25 Gbps and egress 200/50 Gbps by region, increaseable by request. Partition hot spots can cause 503/500; use distribution and backoff.[^44][^45] | Vendor-specific. Run compatibility and load tests before relying on any numbers. |
 | **Published GET/HEAD latency** | AWS publishes rough general S3 small-object / first-byte latencies of about 100-200 ms.[^10] | No provider-published average GET/HEAD latency found. Need to benchmark. | No provider-published average GET/HEAD latency found. Need to benchmark. | No provider-published average GET/HEAD latency found. Need to benchmark. | Need to benchmark to verify. |
 
-AWS S3 credentials with `kind = "ambient"` use the standard AWS SDK
-credential chain. The chain checks environment variables, shared config and
-credentials files selected by `AWS_PROFILE`, credential processes, SSO, web
-identity, ECS task credentials, and EC2 instance metadata. Temporary
-credentials refresh through the SDK provider. Every AWS request resolves its
-credentials from the same source, including direct transfers, checksum
-requests, multipart control requests, and store probes. A presigned URL made
-with temporary credentials includes the current `X-Amz-Security-Token`.
+AWS S3 credentials with `kind = "ambient"` use the standard AWS SDK credential chain. It checks environment variables, shared config and credentials files, credential processes, SSO, web identity, ECS task credentials, and EC2 instance metadata. `AWS_PROFILE` selects a named profile.
 
-Cloudflare R2 does not use the AWS credential chain. R2 ambient credentials
-continue to read `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from the
-process environment when the store is constructed.
+The provider client and presigned URLs use the same credential source. Temporary credentials refresh automatically, and presigned URLs include the current session token.
+
+Cloudflare R2 does not use this chain. R2 ambient credentials read `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` when the store starts.
 
 ## 3. Proven providers and direct-put
 

--- a/docs/specs/object-storage-providers.md
+++ b/docs/specs/object-storage-providers.md
@@ -21,6 +21,19 @@ This document is a non-normative reference: provider limits and performance data
 | **Request scale, partitions, throughput** | At least 3,500 write-class requests/s and 5,500 GET/HEAD requests/s per partitioned prefix; unlimited prefixes; scaling is gradual and may return 503 Slow Down. AWS also cites up to 100 Gb/s from a single EC2 instance and aggregate multi-Tb/s workloads.[^9] | Initial bucket scale is about 1,000 writes/s and 5,000 reads/s, then auto-scales. Ramp no faster than roughly doubling every 20 minutes. Sequential names can hotspot; random prefixes improve initial fanout. Internet egress default quota is commonly 200 Gbps per region, subject to account history and quotas.[^19][^20] | Public r2.dev buckets are test-only and may throttle at hundreds of req/s; production should use custom domains or direct APIs. Cloudflare REST management API is not for high-throughput object I/O; use S3-compatible or Workers APIs.[^32] | Standard GPv2/blob accounts: default max request rate 40,000 req/s in many listed regions, 20,000 elsewhere; ingress commonly 60/25 Gbps and egress 200/50 Gbps by region, increaseable by request. Partition hot spots can cause 503/500; use distribution and backoff.[^44][^45] | Vendor-specific. Run compatibility and load tests before relying on any numbers. |
 | **Published GET/HEAD latency** | AWS publishes rough general S3 small-object / first-byte latencies of about 100-200 ms.[^10] | No provider-published average GET/HEAD latency found. Need to benchmark. | No provider-published average GET/HEAD latency found. Need to benchmark. | No provider-published average GET/HEAD latency found. Need to benchmark. | Need to benchmark to verify. |
 
+AWS S3 credentials with `kind = "ambient"` use the standard AWS SDK
+credential chain. The chain checks environment variables, shared config and
+credentials files selected by `AWS_PROFILE`, credential processes, SSO, web
+identity, ECS task credentials, and EC2 instance metadata. Temporary
+credentials refresh through the SDK provider. Every AWS request resolves its
+credentials from the same source, including direct transfers, checksum
+requests, multipart control requests, and store probes. A presigned URL made
+with temporary credentials includes the current `X-Amz-Security-Token`.
+
+Cloudflare R2 does not use the AWS credential chain. R2 ambient credentials
+continue to read `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from the
+process environment when the store is constructed.
+
 ## 3. Proven providers and direct-put
 
 Direct PUT is enabled only when the provider can do both of these things:


### PR DESCRIPTION
This changes ambient AWS S3 credentials to use the standard AWS SDK credential chain. Environment variables, shared credentials files, named profiles, credential processes, SSO, web identity, ECS task roles, and EC2 instance roles can now supply credentials. Temporary credentials refresh automatically.

Provider requests and presigned operations share the same credential source. Each signed operation uses the current credentials and includes the session token when present. Static AWS credentials keep their existing behavior, and Cloudflare R2 remains unchanged.

Configuration validation no longer requires the AWS environment variable pair because ambient credentials may come from another source. The AWS dependencies are locked to versions that support Rust 1.85. Tests cover environment, profile, static, rotating, and session-token credentials.