### PR TITLE
docs(cli): fix docs cli output guidance

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -92,7 +92,7 @@ Setup and configuration
     Print the config file with secrets redacted
 
   loonfs version
-    Print the version, commit, and build date
+    Print the version
 
 Config file location
   One config file per invocation, chosen by the first rule that applies:


### PR DESCRIPTION
The command reference promised that loonfs version prints the version, commit, and build date.