### PR TITLE
fix(openapi): name the FilesystemOperation variant schemas after their parent

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -245,7 +245,10 @@ pub enum DeleteDirectoryBehavior {
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum FilesystemOperation {
     /// Create one directory.
-    #[cfg_attr(feature = "openapi", schema(title = "FsOpCreateDirectory"))]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(title = "FilesystemOperationCreateDirectory")
+    )]
     CreateDirectory {
         /// Absolute destination path, rejected when invalid or already bound.
         path: AbsolutePath,
@@ -255,7 +258,7 @@ pub enum FilesystemOperation {
         parents: bool,
     },
     /// Create or replace one file with an already-durable content ref.
-    #[cfg_attr(feature = "openapi", schema(title = "FsOpPutFile"))]
+    #[cfg_attr(feature = "openapi", schema(title = "FilesystemOperationPutFile"))]
     PutFile {
         /// Absolute destination path; missing ancestors are created automatically.
         path: AbsolutePath,
@@ -273,7 +276,7 @@ pub enum FilesystemOperation {
         expected_revision_no: Option<RevisionNo>,
     },
     /// Delete one path.
-    #[cfg_attr(feature = "openapi", schema(title = "FsOpDeletePath"))]
+    #[cfg_attr(feature = "openapi", schema(title = "FilesystemOperationDeletePath"))]
     DeletePath {
         /// Absolute path that must resolve to a visible inode.
         path: AbsolutePath,
@@ -295,7 +298,7 @@ pub enum FilesystemOperation {
         expected_inode_id: Option<InodeId>,
     },
     /// Move one path to another path.
-    #[cfg_attr(feature = "openapi", schema(title = "FsOpMovePath"))]
+    #[cfg_attr(feature = "openapi", schema(title = "FilesystemOperationMovePath"))]
     MovePath {
         /// Absolute source path that must resolve to a visible inode.
         from_path: AbsolutePath,
@@ -306,7 +309,7 @@ pub enum FilesystemOperation {
         behavior: DestinationBehavior,
     },
     /// Copy one file path to another path.
-    #[cfg_attr(feature = "openapi", schema(title = "FsOpCopyPath"))]
+    #[cfg_attr(feature = "openapi", schema(title = "FilesystemOperationCopyPath"))]
     CopyPath {
         /// Absolute source path that must resolve to a visible file.
         from_path: AbsolutePath,
@@ -320,7 +323,7 @@ pub enum FilesystemOperation {
     ///
     /// `inode_id` and `deletion_seq` identify one exact deletion. A stale
     /// sequence returns `not_deleted` and cannot undo a later deletion.
-    #[cfg_attr(feature = "openapi", schema(title = "FsOpUndelete"))]
+    #[cfg_attr(feature = "openapi", schema(title = "FilesystemOperationUndelete"))]
     Undelete {
         /// Deleted inode to make reachable again.
         #[serde(with = "crate::public_inode_id")]
@@ -342,7 +345,10 @@ pub enum FilesystemOperation {
         path: Option<AbsolutePath>,
     },
     /// Restore an older revision as the current revision for a path.
-    #[cfg_attr(feature = "openapi", schema(title = "FsOpRestoreRevision"))]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(title = "FilesystemOperationRestoreRevision")
+    )]
     RestoreRevision {
         /// Absolute path that must resolve to a visible file.
         path: AbsolutePath,
@@ -350,7 +356,10 @@ pub enum FilesystemOperation {
         source_revision_no: RevisionNo,
     },
     /// Write and remove attributes on the inode one path resolves to.
-    #[cfg_attr(feature = "openapi", schema(title = "FsOpUpdateAttributes"))]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(title = "FilesystemOperationUpdateAttributes")
+    )]
     UpdateAttributes {
         /// Absolute path that must resolve to a visible file or directory.
         path: AbsolutePath,

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -932,14 +932,14 @@ fn openapi_names_tagged_one_of_alternatives() {
         (
             "FilesystemOperation",
             &[
-                "FsOpCreateDirectory",
-                "FsOpPutFile",
-                "FsOpDeletePath",
-                "FsOpMovePath",
-                "FsOpCopyPath",
-                "FsOpUndelete",
-                "FsOpRestoreRevision",
-                "FsOpUpdateAttributes",
+                "FilesystemOperationCreateDirectory",
+                "FilesystemOperationPutFile",
+                "FilesystemOperationDeletePath",
+                "FilesystemOperationMovePath",
+                "FilesystemOperationCopyPath",
+                "FilesystemOperationUndelete",
+                "FilesystemOperationRestoreRevision",
+                "FilesystemOperationUpdateAttributes",
             ][..],
         ),
         (
@@ -1436,8 +1436,8 @@ fn openapi_documents_delete_path_behavior() {
         .and_then(Value::as_object)
         .expect("openapi schemas object");
     let delete_schema = schemas
-        .get("FsOpDeletePath")
-        .expect("FsOpDeletePath component schema");
+        .get("FilesystemOperationDeletePath")
+        .expect("FilesystemOperationDeletePath component schema");
 
     assert!(!delete_schema
         .get("required")

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -2679,42 +2679,42 @@
       "FilesystemOperation": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/FsOpCreateDirectory"
+            "$ref": "#/components/schemas/FilesystemOperationCreateDirectory"
           },
           {
-            "$ref": "#/components/schemas/FsOpPutFile"
+            "$ref": "#/components/schemas/FilesystemOperationPutFile"
           },
           {
-            "$ref": "#/components/schemas/FsOpDeletePath"
+            "$ref": "#/components/schemas/FilesystemOperationDeletePath"
           },
           {
-            "$ref": "#/components/schemas/FsOpMovePath"
+            "$ref": "#/components/schemas/FilesystemOperationMovePath"
           },
           {
-            "$ref": "#/components/schemas/FsOpCopyPath"
+            "$ref": "#/components/schemas/FilesystemOperationCopyPath"
           },
           {
-            "$ref": "#/components/schemas/FsOpUndelete"
+            "$ref": "#/components/schemas/FilesystemOperationUndelete"
           },
           {
-            "$ref": "#/components/schemas/FsOpRestoreRevision"
+            "$ref": "#/components/schemas/FilesystemOperationRestoreRevision"
           },
           {
-            "$ref": "#/components/schemas/FsOpUpdateAttributes"
+            "$ref": "#/components/schemas/FilesystemOperationUpdateAttributes"
           }
         ],
         "description": "One path-oriented filesystem operation.\n\nUnknown fields are rejected because concurrency guards are optional. A\nmisspelled guard must fail decoding instead of silently becoming `None`\nand allowing an unguarded write. Any future fieldless variant must use\nempty braces so serde also rejects unexpected fields for that variant.",
         "discriminator": {
           "propertyName": "kind",
           "mapping": {
-            "create_directory": "#/components/schemas/FsOpCreateDirectory",
-            "put_file": "#/components/schemas/FsOpPutFile",
-            "delete_path": "#/components/schemas/FsOpDeletePath",
-            "move_path": "#/components/schemas/FsOpMovePath",
-            "copy_path": "#/components/schemas/FsOpCopyPath",
-            "undelete": "#/components/schemas/FsOpUndelete",
-            "restore_revision": "#/components/schemas/FsOpRestoreRevision",
-            "update_attributes": "#/components/schemas/FsOpUpdateAttributes"
+            "create_directory": "#/components/schemas/FilesystemOperationCreateDirectory",
+            "put_file": "#/components/schemas/FilesystemOperationPutFile",
+            "delete_path": "#/components/schemas/FilesystemOperationDeletePath",
+            "move_path": "#/components/schemas/FilesystemOperationMovePath",
+            "copy_path": "#/components/schemas/FilesystemOperationCopyPath",
+            "undelete": "#/components/schemas/FilesystemOperationUndelete",
+            "restore_revision": "#/components/schemas/FilesystemOperationRestoreRevision",
+            "update_attributes": "#/components/schemas/FilesystemOperationUpdateAttributes"
           }
         }
       },
@@ -3711,7 +3711,7 @@
           }
         }
       },
-      "FsOpCreateDirectory": {
+      "FilesystemOperationCreateDirectory": {
         "type": "object",
         "description": "Create one directory.",
         "required": [
@@ -3735,7 +3735,7 @@
           }
         }
       },
-      "FsOpPutFile": {
+      "FilesystemOperationPutFile": {
         "type": "object",
         "description": "Create or replace one file with an already-durable content ref.",
         "required": [
@@ -3768,7 +3768,7 @@
           }
         }
       },
-      "FsOpDeletePath": {
+      "FilesystemOperationDeletePath": {
         "type": "object",
         "description": "Delete one path.",
         "required": [
@@ -3798,7 +3798,7 @@
           }
         }
       },
-      "FsOpMovePath": {
+      "FilesystemOperationMovePath": {
         "type": "object",
         "description": "Move one path to another path.",
         "required": [
@@ -3827,7 +3827,7 @@
           }
         }
       },
-      "FsOpCopyPath": {
+      "FilesystemOperationCopyPath": {
         "type": "object",
         "description": "Copy one file path to another path.",
         "required": [
@@ -3856,7 +3856,7 @@
           }
         }
       },
-      "FsOpUndelete": {
+      "FilesystemOperationUndelete": {
         "type": "object",
         "description": "Restore a deleted file or subtree.\n\n`inode_id` and `deletion_seq` identify one exact deletion. A stale\nsequence returns `not_deleted` and cannot undo a later deletion.",
         "required": [
@@ -3887,7 +3887,7 @@
           }
         }
       },
-      "FsOpRestoreRevision": {
+      "FilesystemOperationRestoreRevision": {
         "type": "object",
         "description": "Restore an older revision as the current revision for a path.",
         "required": [
@@ -3912,7 +3912,7 @@
           }
         }
       },
-      "FsOpUpdateAttributes": {
+      "FilesystemOperationUpdateAttributes": {
         "type": "object",
         "description": "Write and remove attributes on the inode one path resolves to.",
         "required": [

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4649,42 +4649,42 @@
       "FilesystemOperation": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/FsOpCreateDirectory"
+            "$ref": "#/components/schemas/FilesystemOperationCreateDirectory"
           },
           {
-            "$ref": "#/components/schemas/FsOpPutFile"
+            "$ref": "#/components/schemas/FilesystemOperationPutFile"
           },
           {
-            "$ref": "#/components/schemas/FsOpDeletePath"
+            "$ref": "#/components/schemas/FilesystemOperationDeletePath"
           },
           {
-            "$ref": "#/components/schemas/FsOpMovePath"
+            "$ref": "#/components/schemas/FilesystemOperationMovePath"
           },
           {
-            "$ref": "#/components/schemas/FsOpCopyPath"
+            "$ref": "#/components/schemas/FilesystemOperationCopyPath"
           },
           {
-            "$ref": "#/components/schemas/FsOpUndelete"
+            "$ref": "#/components/schemas/FilesystemOperationUndelete"
           },
           {
-            "$ref": "#/components/schemas/FsOpRestoreRevision"
+            "$ref": "#/components/schemas/FilesystemOperationRestoreRevision"
           },
           {
-            "$ref": "#/components/schemas/FsOpUpdateAttributes"
+            "$ref": "#/components/schemas/FilesystemOperationUpdateAttributes"
           }
         ],
         "description": "One path-oriented filesystem operation.\n\nUnknown fields are rejected because concurrency guards are optional. A\nmisspelled guard must fail decoding instead of silently becoming `None`\nand allowing an unguarded write. Any future fieldless variant must use\nempty braces so serde also rejects unexpected fields for that variant.",
         "discriminator": {
           "propertyName": "kind",
           "mapping": {
-            "create_directory": "#/components/schemas/FsOpCreateDirectory",
-            "put_file": "#/components/schemas/FsOpPutFile",
-            "delete_path": "#/components/schemas/FsOpDeletePath",
-            "move_path": "#/components/schemas/FsOpMovePath",
-            "copy_path": "#/components/schemas/FsOpCopyPath",
-            "undelete": "#/components/schemas/FsOpUndelete",
-            "restore_revision": "#/components/schemas/FsOpRestoreRevision",
-            "update_attributes": "#/components/schemas/FsOpUpdateAttributes"
+            "create_directory": "#/components/schemas/FilesystemOperationCreateDirectory",
+            "put_file": "#/components/schemas/FilesystemOperationPutFile",
+            "delete_path": "#/components/schemas/FilesystemOperationDeletePath",
+            "move_path": "#/components/schemas/FilesystemOperationMovePath",
+            "copy_path": "#/components/schemas/FilesystemOperationCopyPath",
+            "undelete": "#/components/schemas/FilesystemOperationUndelete",
+            "restore_revision": "#/components/schemas/FilesystemOperationRestoreRevision",
+            "update_attributes": "#/components/schemas/FilesystemOperationUpdateAttributes"
           }
         }
       },
@@ -6412,7 +6412,7 @@
           }
         }
       },
-      "FsOpCreateDirectory": {
+      "FilesystemOperationCreateDirectory": {
         "type": "object",
         "description": "Create one directory.",
         "required": [
@@ -6436,7 +6436,7 @@
           }
         }
       },
-      "FsOpPutFile": {
+      "FilesystemOperationPutFile": {
         "type": "object",
         "description": "Create or replace one file with an already-durable content ref.",
         "required": [
@@ -6469,7 +6469,7 @@
           }
         }
       },
-      "FsOpDeletePath": {
+      "FilesystemOperationDeletePath": {
         "type": "object",
         "description": "Delete one path.",
         "required": [
@@ -6499,7 +6499,7 @@
           }
         }
       },
-      "FsOpMovePath": {
+      "FilesystemOperationMovePath": {
         "type": "object",
         "description": "Move one path to another path.",
         "required": [
@@ -6528,7 +6528,7 @@
           }
         }
       },
-      "FsOpCopyPath": {
+      "FilesystemOperationCopyPath": {
         "type": "object",
         "description": "Copy one file path to another path.",
         "required": [
@@ -6557,7 +6557,7 @@
           }
         }
       },
-      "FsOpUndelete": {
+      "FilesystemOperationUndelete": {
         "type": "object",
         "description": "Restore a deleted file or subtree.\n\n`inode_id` and `deletion_seq` identify one exact deletion. A stale\nsequence returns `not_deleted` and cannot undo a later deletion.",
         "required": [
@@ -6588,7 +6588,7 @@
           }
         }
       },
-      "FsOpRestoreRevision": {
+      "FilesystemOperationRestoreRevision": {
         "type": "object",
         "description": "Restore an older revision as the current revision for a path.",
         "required": [
@@ -6613,7 +6613,7 @@
           }
         }
       },
-      "FsOpUpdateAttributes": {
+      "FilesystemOperationUpdateAttributes": {
         "type": "object",
         "description": "Write and remove attributes on the inode one path resolves to.",
         "required": [

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -746,7 +746,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 		CommitID:    loonfs.CommitID(request.CommitIDs.Move),
 		Operations: []*loonfs.FilesystemOperation{
 			{
-				MovePath: &loonfs.FsOpMovePath{
+				MovePath: &loonfs.FilesystemOperationMovePath{
 					Behavior: &noReplace,
 					FromPath: loonfs.AbsolutePath(request.UploadPath),
 					ToPath:   loonfs.AbsolutePath(request.MovedPath),
@@ -787,7 +787,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 		CommitID:    loonfs.CommitID(request.CommitIDs.Remove),
 		Operations: []*loonfs.FilesystemOperation{
 			{
-				DeletePath: &loonfs.FsOpDeletePath{
+				DeletePath: &loonfs.FilesystemOperationDeletePath{
 					Behavior: &nonRecursive,
 					Path:     loonfs.AbsolutePath(request.MovedPath),
 				},
@@ -1258,7 +1258,7 @@ func proxyCommitCompletedFile(
 		ContentTokens: contentTokens,
 		Operations: []*loonfs.FilesystemOperation{
 			{
-				PutFile: &loonfs.FsOpPutFile{
+				PutFile: &loonfs.FilesystemOperationPutFile{
 					Behavior:   &noReplace,
 					ContentRef: contentRef,
 					Path:       loonfs.AbsolutePath(path),
@@ -1684,7 +1684,7 @@ func commitCompletedFile(
 		ContentTokens: contentTokens,
 		Operations: []*loonfs.FilesystemOperation{
 			{
-				PutFile: &loonfs.FsOpPutFile{
+				PutFile: &loonfs.FilesystemOperationPutFile{
 					Behavior:   &noReplace,
 					ContentRef: contentRef,
 					Path:       loonfs.AbsolutePath(path),
@@ -1816,7 +1816,7 @@ func createDirectoryCommit(
 		Message:     message,
 		Operations: []*loonfs.FilesystemOperation{
 			{
-				CreateDirectory: &loonfs.FsOpCreateDirectory{
+				CreateDirectory: &loonfs.FilesystemOperationCreateDirectory{
 					Parents: &parents,
 					Path:    loonfs.AbsolutePath(path),
 				},

--- a/sdk/transfers/go/transfers/transfers.go
+++ b/sdk/transfers/go/transfers/transfers.go
@@ -128,7 +128,7 @@ func PutFile(ctx context.Context, c *client.Client, in PutFileInput) (*PutFileRe
 		Message:       in.Message,
 		Operations: []*loonfs.FilesystemOperation{
 			{
-				PutFile: &loonfs.FsOpPutFile{
+				PutFile: &loonfs.FilesystemOperationPutFile{
 					Behavior:           &behavior,
 					ContentRef:         status.ContentRef,
 					ExpectedRevisionNo: in.ExpectedRevisionNo,


### PR DESCRIPTION
Renames the OpenAPI schemas for filesystem operation variants from names such as `FsOpPutFile` to `FilesystemOperationPutFile`. This makes generated SDK type names consistent across languages and with the existing `FilesystemChange` variants.

The JSON wire format is unchanged. Generated SDK source names change, which is acceptable before the first release.