### PR TITLE
fix(api): serve deadline_exceeded as 503 and declare one shared 503 response per operation

### DIFF
--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -552,6 +552,12 @@ mod tests {
             &api("maintenance_required")
         ));
         assert!(!retryable_transport_failure(false, &api("index_lagging")));
+        // A server deadline uses 503 but is not safe to retry automatically.
+        // The caller must first determine whether a mutation completed.
+        assert!(!retryable_transport_failure(
+            false,
+            &api("deadline_exceeded")
+        ));
         assert!(!retryable_transport_failure(
             false,
             &ClientError::Http("http status 502 with a non-envelope body".to_owned())

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -142,9 +142,13 @@ fn status_for_error_kind(kind: ErrorKind) -> StatusCode {
         ErrorKind::MethodNotAllowed => StatusCode::METHOD_NOT_ALLOWED,
         ErrorKind::Gone => StatusCode::GONE,
         ErrorKind::AlreadyExists | ErrorKind::Conflict => StatusCode::CONFLICT,
-        ErrorKind::DeadlineExceeded => StatusCode::REQUEST_TIMEOUT,
         ErrorKind::NotSupported => StatusCode::NOT_IMPLEMENTED,
-        ErrorKind::Unavailable | ErrorKind::OutcomeUnknown => StatusCode::SERVICE_UNAVAILABLE,
+        // HTTP 408 means the client did not finish sending its request. A
+        // server-side deadline uses 503 instead. The error code remains
+        // non-retryable because a cancelled mutation may still complete.
+        ErrorKind::DeadlineExceeded | ErrorKind::Unavailable | ErrorKind::OutcomeUnknown => {
+            StatusCode::SERVICE_UNAVAILABLE
+        }
         ErrorKind::DataCorruption | ErrorKind::Internal => StatusCode::INTERNAL_SERVER_ERROR,
         // A kind without an explicit arm serves as 500 until someone decides
         // its real status. The spec-table test in `super::tests` fails on any

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -51,7 +51,7 @@ const DIRECT_GET_URL_TTL: Duration = Duration::from_secs(15 * 60);
             (status = 404, description = "Namespace, path, or revision not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 501, description = "Direct download is unsupported", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -119,7 +119,7 @@ pub(super) async fn begin_download(
             (status = 409, description = "Inode is not a file", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 501, description = "Direct download is unsupported", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -187,7 +187,7 @@ impl utoipa::ToSchema for OpenApiDefaultFalseBoolean {}
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or path not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -246,7 +246,7 @@ pub(super) async fn list_path_entries(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or path not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -296,7 +296,7 @@ pub(super) async fn stat_path(
             (status = 404, description = "Namespace, path, or revision not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 413, description = "Content exceeds the advertised `download.max_content_bytes` limit", body = ApiError),
-            (status = 503, description = "The server is at its concurrent content-read limit; retry shortly", body = ApiError)
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -360,7 +360,7 @@ pub(super) async fn get_file_bytes(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -408,7 +408,7 @@ pub(super) async fn list_trash(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or path not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -458,8 +458,7 @@ pub(super) async fn list_file_revisions(
             (status = 404, description = "Namespace or path not found", body = ApiError),
             (status = 409, description = "Operation conflict", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 503, description = "Commit unavailable", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -573,7 +572,7 @@ pub(super) async fn apply_commit(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -64,7 +64,7 @@ pub(super) struct StatInodeQuery {
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or visible inode not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -113,7 +113,7 @@ pub(super) async fn stat_inode(
             (status = 404, description = "Namespace or inode not found", body = ApiError),
             (status = 409, description = "Inode is not a file", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -165,7 +165,7 @@ pub(super) async fn list_file_revisions_by_inode(
             (status = 409, description = "Inode is not a file", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 413, description = "Content exceeds the advertised `download.max_content_bytes` limit", body = ApiError),
-            (status = 503, description = "The server is at its concurrent content-read limit; retry shortly", body = ApiError)
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -59,7 +59,7 @@ pub(super) struct CheckpointPageQuery {
         responses(
             (status = 200, description = "Capability document", body = loonfs_api::CapabilityDocument),
             (status = 401, description = "Unauthorized", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -178,7 +178,7 @@ pub(super) async fn capabilities(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 409, description = "Namespace already exists or is partial", body = ApiError),
             (status = 410, description = "Namespace id was deleted and retired", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -210,7 +210,7 @@ pub(super) async fn create_namespace(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -245,7 +245,7 @@ pub(super) async fn get_namespace(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -284,7 +284,7 @@ pub(super) async fn get_namespace_diagnostics(
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 409, description = "Delete conflict", body = ApiError),
             (status = 410, description = "Namespace already deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -334,7 +334,7 @@ fn parse_expected_head_seq(value: &str) -> Result<ChangeSeq, ApiResponseError> {
             (status = 404, description = "Source namespace not found", body = ApiError),
             (status = 409, description = "Fork conflict", body = ApiError),
             (status = 410, description = "Source namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -369,8 +369,7 @@ pub(super) async fn fork_namespace(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 503, description = "Checkpoint unavailable", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -413,7 +412,7 @@ pub(super) async fn create_checkpoint(
             (status = 400, description = "Invalid namespace id, limit, or cursor", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -471,7 +470,7 @@ pub(super) async fn list_checkpoints(
             (status = 400, description = "Invalid id, or the checkpoint is fork-owned", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -525,7 +524,8 @@ fn parse_checkpoint_id(value: &str) -> Result<CheckpointId, ApiResponseError> {
             (status = 400, description = "Invalid namespace id or options", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -61,9 +61,8 @@ pub(super) struct GrepQuery {
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 501, description = "This deployment does not serve grep queries, the grep index is not enabled, or its backfill has not completed on this namespace", body = ApiError),
-            (status = 503, description = "The index trails the head past the scan budget", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -188,7 +187,7 @@ pub(super) async fn grep_index_not_maintained(
             (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -236,7 +235,7 @@ pub(super) async fn enable_grep_index(
             (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -279,7 +278,7 @@ async fn read_grep_index_status(
             (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -328,7 +327,8 @@ pub(super) async fn disable_grep_index(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
-            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_store.rs
+++ b/crates/loonfs-server/src/http/handlers_store.rs
@@ -25,7 +25,8 @@ use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome};
         responses(
             (status = 200, description = "Probe completed; per-check outcomes are in the body", body = StoreProbeResponse),
             (status = 400, description = "Malformed request body", body = ApiError),
-            (status = 401, description = "Unauthorized", body = ApiError)
+            (status = 401, description = "Unauthorized", body = ApiError),
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -114,7 +114,7 @@ pub(super) struct UploadPathParams {
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 413, description = "Body exceeds the 1 MiB upload-control limit", body = ApiError),
             (status = 501, description = "Requested upload mode is unsupported", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -276,7 +276,7 @@ async fn begin_direct_multipart_upload(
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 413, description = "Body exceeds the 1 MiB upload-control limit", body = ApiError),
             (status = 501, description = "Direct multipart upload is unsupported", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -514,7 +514,7 @@ pub(super) fn current_unix_ms() -> Result<u64, ApiResponseError> {
             (status = 409, description = "Upload content conflict", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 413, description = "Body exceeds the advertised `upload.max_content_bytes` limit", body = ApiError),
-            (status = 503, description = "The server is at its concurrent proxied-upload limit; retry shortly", body = ApiError)
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -578,7 +578,7 @@ pub(super) async fn upload_content(
             (status = 409, description = "Upload completion conflict", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 413, description = "Completion body exceeds the advertised `upload.completion_max_body_bytes` limit", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -790,7 +790,7 @@ mod completion_body_tests {
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or upload not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -838,7 +838,7 @@ pub(super) async fn get_upload_status(
             (status = 404, description = "Namespace or upload not found", body = ApiError),
             (status = 409, description = "Upload already completed", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -30,7 +30,7 @@ pub use self::serve::{
 };
 pub use self::tls::TlsConfigError;
 
-use self::error::{ApiResponseError, ServedErrorCode};
+use self::error::{status_for_core_error_code, ApiResponseError, ServedErrorCode};
 use self::extractors::{
     authorize, server_busy_error, AppJson, AppPath, AppQuery, NamespaceIdPath, OptionalAppJson,
     UploadBodyBytes, UploadBodyStream, UploadControlJson, MAX_COMPLETION_BODY_BYTES,
@@ -147,7 +147,7 @@ async fn with_request_deadline(request_deadline_ms: u64, request: Request, next:
     {
         Ok(response) => response,
         Err(_) => ApiResponseError::new(
-            StatusCode::REQUEST_TIMEOUT,
+            status_for_core_error_code(ErrorCode::DeadlineExceeded),
             ErrorCode::DeadlineExceeded,
             &format!(
                 "the server cancelled the request at the configured deadline; \
@@ -450,7 +450,7 @@ async fn method_not_allowed() -> ApiResponseError {
         security(()),
         responses(
             (status = 200, description = "Server health check", body = String),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -473,8 +473,7 @@ async fn health() -> &'static str {
         security(()),
         responses(
             (status = 200, description = "The server admits new work", body = String),
-            (status = 503, description = "Shutdown has begun; admission is closed", body = loonfs_api::ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]
@@ -510,7 +509,7 @@ const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
         responses(
             (status = 200, description = "Prometheus text exposition", body = String),
             (status = 401, description = "Missing or invalid bearer token", body = loonfs_api::ApiError),
-            crate::http::openapi::DeadlineExceededResponses
+            crate::http::openapi::UnavailableResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -165,7 +165,7 @@ pub fn openapi_document() -> utoipa::openapi::OpenApi {
         loonfs_api::v0::StoreProbeCheckResult,
         loonfs_api::v0::StoreProbeResponse
         ),
-        responses(DeadlineExceededResponse)
+        responses(UnavailableResponse)
     ),
     // Applies to every operation that does not override it. `/health` and
     // `/readiness` do, with `security(())`: they are the probe surface and
@@ -185,28 +185,28 @@ pub fn openapi_document() -> utoipa::openapi::OpenApi {
 )]
 struct LoonfsOpenApi;
 
-/// OpenAPI definition for the 408 response returned after a request deadline.
+/// OpenAPI definition for the 503 response every operation can return.
 #[derive(utoipa::ToResponse)]
 #[response(
-    description = "The request exceeded `request_deadline_ms`. A timed-out mutation may still complete, so clients must determine its outcome before retrying."
+    description = "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, or required maintenance. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying."
 )]
 #[expect(
     dead_code,
     reason = "used only to generate the reusable OpenAPI response schema"
 )]
-pub(super) struct DeadlineExceededResponse(#[to_schema] ApiError);
+pub(super) struct UnavailableResponse(#[to_schema] ApiError);
 
-/// Adds the shared 408 response to an OpenAPI operation.
-pub(super) struct DeadlineExceededResponses;
+/// Adds the shared 503 response to an OpenAPI operation.
+pub(super) struct UnavailableResponses;
 
-impl utoipa::IntoResponses for DeadlineExceededResponses {
+impl utoipa::IntoResponses for UnavailableResponses {
     fn responses() -> std::collections::BTreeMap<
         String,
         utoipa::openapi::RefOr<utoipa::openapi::response::Response>,
     > {
-        let (name, _) = <DeadlineExceededResponse as utoipa::ToResponse>::response();
+        let (name, _) = <UnavailableResponse as utoipa::ToResponse>::response();
         utoipa::openapi::ResponsesBuilder::new()
-            .response("408", utoipa::openapi::Ref::from_response_name(name))
+            .response("503", utoipa::openapi::Ref::from_response_name(name))
             .build()
             .into()
     }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -716,7 +716,7 @@ async fn admin_namespace_diagnostics_route_answers_storage_fields() {
 #[tokio::test]
 #[allow(clippy::disallowed_methods)]
 // The sleeping handler is the controlled work the deadline cancels.
-async fn request_deadline_answers_408_and_leaves_fast_handlers_untouched() {
+async fn request_deadline_answers_503_and_leaves_fast_handlers_untouched() {
     use tower::ServiceExt;
 
     let request_deadline_ms = 10;
@@ -746,7 +746,13 @@ async fn request_deadline_answers_408_and_leaves_fast_handlers_untouched() {
         )
         .await
         .expect("slow response");
-    assert_eq!(slow.status(), axum::http::StatusCode::REQUEST_TIMEOUT);
+    assert_eq!(slow.status(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    // Do not advertise an automatic retry when the cancelled work may still
+    // complete.
+    assert!(slow
+        .headers()
+        .get(axum::http::header::RETRY_AFTER)
+        .is_none());
     let request_id = slow
         .headers()
         .get(super::REQUEST_ID_HEADER)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -284,7 +284,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `commit_queue_full` | 503 | The namespace write queue is full; back off and retry. |
 | `server_busy` | 503 | The server is at its configured concurrency limit for this kind of work (proxied upload bodies or proxied content reads); back off and retry. |
 | `shutting_down` | 503 | The serving process closed admission for shutdown; work admitted earlier still settles. Retry against a live instance. |
-| `deadline_exceeded` | 408 | The server cancelled a bounded request at its configured `request_deadline_ms`. A commit may still land after this response; reconcile it by commit id before retrying. |
+| `deadline_exceeded` | 503 | The server cancelled a bounded request at its configured `request_deadline_ms`. A commit may still land after this response; reconcile it by commit id before retrying. |
 | `checkpoint_unavailable` | 503 | Required checkpoint state is unavailable: not yet published, released during the operation, or referenced material is missing. Retry after maintenance. |
 | `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
 | `index_lagging` | 503 | The grep index trails the head past the exhaustive-scan budget; let the grep worker catch up (or set `allow_stale`) and retry. |

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -39,8 +39,8 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -128,9 +128,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -140,6 +137,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -215,9 +215,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Operation conflict",
             "content": {
@@ -239,14 +236,7 @@
             }
           },
           "503": {
-            "description": "Commit unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "replay"
@@ -356,14 +346,7 @@
             }
           },
           "503": {
-            "description": "The server is at its concurrent content-read limit; retry shortly",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -439,9 +422,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -461,6 +441,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -567,9 +550,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -579,6 +559,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -680,9 +663,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -692,6 +672,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -781,9 +764,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -793,6 +773,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -870,9 +853,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -882,6 +862,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -1032,9 +1015,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1066,14 +1046,7 @@
             }
           },
           "503": {
-            "description": "The index trails the head past the scan budget",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -1154,9 +1127,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1186,6 +1156,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -1260,9 +1233,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1272,6 +1242,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -1346,9 +1319,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Upload already completed",
             "content": {
@@ -1368,6 +1338,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -1453,9 +1426,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Upload completion conflict",
             "content": {
@@ -1485,6 +1455,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "replay"
@@ -1605,14 +1578,7 @@
             }
           },
           "503": {
-            "description": "The server is at its concurrent proxied-upload limit; retry shortly",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -1697,9 +1663,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Upload already completed",
             "content": {
@@ -1739,6 +1702,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -4080,8 +4046,8 @@
       }
     },
     "responses": {
-      "DeadlineExceededResponse": {
-        "description": "The request exceeded `request_deadline_ms`. A timed-out mutation may still complete, so clients must determine its outcome before retrying.",
+      "UnavailableResponse": {
+        "description": "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, or required maintenance. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying.",
         "content": {
           "application/json": {
             "schema": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -29,8 +29,8 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "security": [
@@ -68,8 +68,8 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -94,18 +94,8 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "503": {
-            "description": "Shutdown has begun; admission is closed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "security": [
@@ -196,8 +186,8 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -277,9 +267,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -291,14 +278,7 @@
             }
           },
           "503": {
-            "description": "Checkpoint unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -373,8 +353,8 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -440,9 +420,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -452,6 +429,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -507,9 +487,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "500": {
             "description": "The grep index is corrupt or its backing store is unavailable",
             "content": {
@@ -529,6 +506,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -594,9 +574,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Lost a grep root-pointer publication race; retry",
             "content": {
@@ -626,6 +603,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -691,9 +671,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Lost a grep root-pointer publication race; retry",
             "content": {
@@ -723,6 +700,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -816,6 +796,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -901,6 +884,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -955,6 +941,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -989,8 +978,8 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -1045,9 +1034,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Namespace already exists or is partial",
             "content": {
@@ -1067,6 +1053,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -1132,9 +1121,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1144,6 +1130,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -1216,9 +1205,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Delete conflict",
             "content": {
@@ -1238,6 +1224,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -1325,9 +1314,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1337,6 +1323,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -1412,9 +1401,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Operation conflict",
             "content": {
@@ -1436,14 +1422,7 @@
             }
           },
           "503": {
-            "description": "Commit unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "replay"
@@ -1553,14 +1532,7 @@
             }
           },
           "503": {
-            "description": "The server is at its concurrent content-read limit; retry shortly",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -1636,9 +1608,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1658,6 +1627,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -1764,9 +1736,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1776,6 +1745,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -1877,9 +1849,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1889,6 +1858,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -1978,9 +1950,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1990,6 +1959,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -2067,9 +2039,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -2079,6 +2048,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -2159,9 +2131,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Fork conflict",
             "content": {
@@ -2181,6 +2150,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -2267,9 +2239,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -2279,6 +2248,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -2377,9 +2349,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Inode is not a file",
             "content": {
@@ -2399,6 +2368,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -2525,14 +2497,7 @@
             }
           },
           "503": {
-            "description": "The server is at its concurrent content-read limit; retry shortly",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -2628,9 +2593,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Inode is not a file",
             "content": {
@@ -2660,6 +2622,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -2805,9 +2770,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -2839,14 +2801,7 @@
             }
           },
           "503": {
-            "description": "The index trails the head past the scan budget",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe",
@@ -2927,9 +2882,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -2959,6 +2911,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "new_attempt"
@@ -3033,9 +2988,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -3045,6 +2997,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -3119,9 +3074,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Upload already completed",
             "content": {
@@ -3141,6 +3093,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -3226,9 +3181,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Upload completion conflict",
             "content": {
@@ -3258,6 +3210,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "replay"
@@ -3378,14 +3333,7 @@
             }
           },
           "503": {
-            "description": "The server is at its concurrent proxied-upload limit; retry shortly",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -3470,9 +3418,6 @@
               }
             }
           },
-          "408": {
-            "$ref": "#/components/responses/DeadlineExceededResponse"
-          },
           "409": {
             "description": "Upload already completed",
             "content": {
@@ -3512,6 +3457,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "$ref": "#/components/responses/UnavailableResponse"
           }
         },
         "x-loonfs-retry": "safe"
@@ -7031,8 +6979,8 @@
       }
     },
     "responses": {
-      "DeadlineExceededResponse": {
-        "description": "The request exceeded `request_deadline_ms`. A timed-out mutation may still complete, so clients must determine its outcome before retrying.",
+      "UnavailableResponse": {
+        "description": "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, or required maintenance. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying.",
         "content": {
           "application/json": {
             "schema": {


### PR DESCRIPTION
Returns `deadline_exceeded` as HTTP 503 instead of 408. HTTP 408 describes a client that did not finish sending its request; this error is a deadline imposed by the server. It remains excluded from automatic retries because a cancelled mutation may still complete.

OpenAPI now uses one shared 503 response per operation instead of separate overlapping definitions. The error code still determines whether a response is retryable, and `deadline_exceeded` does not include `Retry-After`.