### PR TITLE
fix(openapi): drop null from optional response fields and mark always-written fields required

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -728,21 +728,17 @@ pub struct GcResponse {
     pub released_fork_checkpoints: u64,
     /// Checkpoint records released because their expiry passed, or because
     /// they sit on a terminally deleted namespace.
-    #[serde(default)]
     pub released_expired_checkpoints: u64,
     /// Upload-session control objects deleted after the reap window.
-    #[serde(default)]
     pub deleted_upload_sessions: u64,
     /// Content objects reclaimed because their upload session completed,
     /// aged past the derived reclamation grace, and nothing the namespace
     /// can reach references them. The upload half's cleanup of abandoned
     /// sessions is not counted here: it deletes unconditionally, whether or
     /// not the session ever wrote anything.
-    #[serde(default)]
     pub deleted_content_objects: u64,
     /// Active checkpoint records released because their basis manifest is
     /// verifiably gone.
-    #[serde(default)]
     pub released_missing_basis_checkpoints: u64,
     /// Candidates retained at delete time (grace window, missing
     /// timestamps, or reachable from the fresh root set).
@@ -750,7 +746,6 @@ pub struct GcResponse {
     /// The same total, split by the decision that spared each candidate.
     /// The total above stays because it is what every existing consumer
     /// reads; this says why.
-    #[serde(default)]
     pub retained: RetainedCandidates,
     /// True when ambiguous roots suppressed manifest/table deletion.
     pub degraded_retention: bool,
@@ -761,7 +756,6 @@ pub struct GcResponse {
     /// the whole scan reclaims what this one left behind. A pass that had
     /// room for the roots swept every other candidate normally around the
     /// skip, and one that did not also reports `budget_exhausted`.
-    #[serde(default)]
     pub content_reclamation_deferred: bool,
     /// True when the pass stopped because `max_objects` ran out before it
     /// finished. Whatever it did before that is reported here and stands;
@@ -769,7 +763,6 @@ pub struct GcResponse {
     /// continue. A budget too small for the namespace's own roots stops a
     /// pass before it decides anything at all, which is what this says and
     /// an empty report on its own does not.
-    #[serde(default)]
     pub budget_exhausted: bool,
     /// Opaque resume token when more candidates remain. Resuming rebuilds
     /// every safety proof; the token carries enumeration position only and

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -79,7 +79,6 @@ pub struct GrepMatch {
     /// The matching line, truncated to the server's line cap.
     pub line: String,
     /// True when `line` was truncated.
-    #[serde(default)]
     pub line_truncated: bool,
 }
 

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -194,6 +194,7 @@ pub(crate) fn openapi_json_pretty(
     let derived = serde_json::to_string(document)?;
     let mut document = serde_json::from_str(&derived)?;
     normalize_optional_schemas(&mut document);
+    drop_null_from_response_schemas(&mut document);
     add_union_discriminators(&mut document, &mut Vec::new());
     extract_union_variants(&mut document)?;
     add_operation_retry_classes(&mut document)?;
@@ -943,6 +944,162 @@ fn is_null_schema(value: &Value) -> bool {
     object.len() == 1 && object.get("type").and_then(Value::as_str) == Some("null")
 }
 
+/// Removes `null` from optional fields used in responses.
+///
+/// The server omits absent response fields. Request-only schemas keep `null`
+/// because serde accepts it. Shared request and response schemas use the
+/// response rule while keeping the field optional.
+fn drop_null_from_response_schemas(document: &mut Value) {
+    let mut pending = Vec::new();
+    collect_response_references(document, &mut pending);
+    let mut reachable = BTreeSet::new();
+
+    while let Some(reference) = pending.pop() {
+        let Some((component_type, component_name)) = component_reference_parts(&reference) else {
+            continue;
+        };
+        if !reachable.insert((component_type.clone(), component_name.clone())) {
+            continue;
+        }
+        let Some(component) = document
+            .get("components")
+            .and_then(|components| components.get(&component_type))
+            .and_then(Value::as_object)
+            .and_then(|entries| entries.get(&component_name))
+        else {
+            continue;
+        };
+        collect_component_references(component, &mut pending);
+    }
+
+    for responses in operation_responses_mut(document) {
+        drop_null_from_optional_properties(responses);
+    }
+
+    let Some(components) = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("components"))
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+    for (component_type, entries) in components {
+        let Some(entries) = entries.as_object_mut() else {
+            continue;
+        };
+        for (component_name, component) in entries {
+            if reachable.contains(&(component_type.clone(), component_name.clone())) {
+                drop_null_from_optional_properties(component);
+            }
+        }
+    }
+}
+
+/// Collects component references from every operation response.
+fn collect_response_references(document: &Value, references: &mut Vec<String>) {
+    let Some(paths) = document.get("paths").and_then(Value::as_object) else {
+        return;
+    };
+
+    for path_item in paths.values() {
+        let Some(path_item) = path_item.as_object() else {
+            continue;
+        };
+        for method in HTTP_METHODS {
+            let Some(responses) = path_item
+                .get(*method)
+                .and_then(|operation| operation.get("responses"))
+            else {
+                continue;
+            };
+            collect_component_references(responses, references);
+        }
+    }
+}
+
+/// Returns every operation's `responses` object for in-place updates.
+fn operation_responses_mut(document: &mut Value) -> Vec<&mut Value> {
+    let Some(paths) = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("paths"))
+        .and_then(Value::as_object_mut)
+    else {
+        return Vec::new();
+    };
+
+    paths
+        .values_mut()
+        .filter_map(Value::as_object_mut)
+        .flat_map(|path_item| {
+            path_item
+                .iter_mut()
+                .filter(|(method, _)| HTTP_METHODS.contains(&method.as_str()))
+                .filter_map(|(_, operation)| {
+                    operation
+                        .as_object_mut()
+                        .and_then(|operation| operation.get_mut("responses"))
+                })
+        })
+        .collect()
+}
+
+fn drop_null_from_optional_properties(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            let required = object
+                .get("required")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect::<BTreeSet<_>>();
+            if let Some(properties) = object.get_mut("properties").and_then(Value::as_object_mut) {
+                for (name, schema) in properties {
+                    if required.contains(name.as_str()) {
+                        continue;
+                    }
+                    let Some(replacement) = non_null_type(schema).cloned() else {
+                        continue;
+                    };
+                    let schema = schema
+                        .as_object_mut()
+                        .expect("schema with a type array is an object");
+                    schema.insert("type".to_owned(), replacement);
+                    schema.shift_remove("nullable");
+                }
+            }
+
+            for child in object.values_mut() {
+                drop_null_from_optional_properties(child);
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                drop_null_from_optional_properties(child);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+/// Returns `X` when the schema type is `["X", "null"]`.
+fn non_null_type(value: &Value) -> Option<&Value> {
+    let types = value.get("type")?.as_array()?;
+    if types.len() != 2 {
+        return None;
+    }
+
+    match (
+        types[0].as_str() == Some("null"),
+        types[1].as_str() == Some("null"),
+    ) {
+        (true, false) => Some(&types[1]),
+        (false, true) => Some(&types[0]),
+        (true, true) | (false, false) => None,
+    }
+}
+
 fn add_union_discriminators(value: &mut Value, path: &mut Vec<String>) {
     match value {
         Value::Object(object) => {
@@ -1325,6 +1482,132 @@ mod tests {
         }));
 
         normalize_optional_schemas(&mut document);
+    }
+
+    /// One request schema, one response schema, and one schema both reach.
+    fn request_and_response_document() -> Value {
+        ordered(serde_json::json!({
+            "paths": {
+                "/things": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ThingRequest"}
+                                }
+                            }
+                        },
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/ThingResponse"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "Shared": {
+                        "type": "object",
+                        "properties": {
+                            "label": {"type": ["string", "null"]}
+                        }
+                    },
+                    "ThingRequest": {
+                        "type": "object",
+                        "properties": {
+                            "cursor": {"type": ["string", "null"]},
+                            "shared": {"$ref": "#/components/schemas/Shared"}
+                        }
+                    },
+                    "ThingResponse": {
+                        "type": "object",
+                        "required": ["count"],
+                        "properties": {
+                            "count": {"type": "integer"},
+                            "next_cursor": {"type": ["string", "null"], "nullable": true},
+                            "shared": {"$ref": "#/components/schemas/Shared"}
+                        }
+                    }
+                }
+            }
+        }))
+    }
+
+    #[test]
+    fn drops_the_null_type_from_an_optional_response_property() {
+        let mut document = request_and_response_document();
+
+        drop_null_from_response_schemas(&mut document);
+        let actual = unordered(&document);
+        assert_eq!(
+            actual.pointer("/components/schemas/ThingResponse/properties/next_cursor"),
+            Some(&serde_json::json!({"type": "string"}))
+        );
+    }
+
+    #[test]
+    fn drops_the_null_type_from_a_schema_a_request_and_a_response_share() {
+        let mut document = request_and_response_document();
+
+        drop_null_from_response_schemas(&mut document);
+        let actual = unordered(&document);
+        assert_eq!(
+            actual.pointer("/components/schemas/Shared/properties/label"),
+            Some(&serde_json::json!({"type": "string"}))
+        );
+    }
+
+    #[test]
+    fn keeps_the_null_type_on_a_request_only_property() {
+        let mut document = request_and_response_document();
+
+        drop_null_from_response_schemas(&mut document);
+        let actual = unordered(&document);
+        assert_eq!(
+            actual.pointer("/components/schemas/ThingRequest/properties/cursor"),
+            Some(&serde_json::json!({"type": ["string", "null"]}))
+        );
+    }
+
+    #[test]
+    fn rewrites_only_optional_response_properties() {
+        let mut document = ordered(serde_json::json!({
+            "paths": {
+                "/things": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "required": ["marker"],
+                                            "properties": {
+                                                "marker": {"type": ["string", "null"]}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+
+        drop_null_from_response_schemas(&mut document);
+        let actual = unordered(&document);
+        assert_eq!(
+            actual.pointer(
+                "/paths/~1things/get/responses/200/content/application~1json/schema/properties/marker"
+            ),
+            Some(&serde_json::json!({"type": ["string", "null"]}))
+        );
     }
 
     #[test]

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -138,6 +138,68 @@ fn every_one_of_is_a_discriminated_non_null_union() {
     }
 }
 
+/// Checks success and error response schemas, including components used only
+/// by `ApiError` and `ErrorDetails`.
+#[test]
+fn no_schema_a_response_reaches_admits_null() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let mut visited = BTreeSet::new();
+    let mut properties = 0usize;
+
+    for (location, response) in documented_responses(&spec) {
+        assert_no_null_property(&spec, response, &location, &mut visited, &mut properties);
+    }
+
+    for schema_name in ["ApiError", "ErrorDetails", "GcResponse", "GrepMatch"] {
+        assert!(
+            visited.contains(&format!("#/components/schemas/{schema_name}")),
+            "the walk never reached `{schema_name}`"
+        );
+    }
+    assert!(
+        properties > 0,
+        "the walk reached no response schema properties"
+    );
+}
+
+/// Fields that the server always includes in these response types.
+const ALWAYS_SERIALIZED_RESPONSE_FIELDS: &[(&str, &str)] = &[
+    ("GcResponse", "budget_exhausted"),
+    ("GcResponse", "content_reclamation_deferred"),
+    ("GcResponse", "deleted_content_objects"),
+    ("GcResponse", "deleted_upload_sessions"),
+    ("GcResponse", "released_expired_checkpoints"),
+    ("GcResponse", "released_missing_basis_checkpoints"),
+    ("GcResponse", "retained"),
+    ("GrepMatch", "line_truncated"),
+];
+
+#[test]
+fn always_serialized_response_fields_are_required() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let schemas = spec
+        .get("components")
+        .and_then(|components| components.get("schemas"))
+        .and_then(Value::as_object)
+        .expect("openapi schemas object");
+
+    for (schema_name, field) in ALWAYS_SERIALIZED_RESPONSE_FIELDS {
+        let schema = schemas
+            .get(*schema_name)
+            .unwrap_or_else(|| panic!("openapi document has no `{schema_name}` schema"));
+        assert!(
+            required_fields(schema).contains(field),
+            "`{schema_name}.{field}` is written on every response but the document marks it optional"
+        );
+    }
+}
+
 #[test]
 fn openapi_documents_current_server_paths() {
     let spec: Value = serde_json::from_str(
@@ -1555,6 +1617,85 @@ fn collect_one_of_objects<'a>(
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
     }
+}
+
+/// Returns every response with its operation ID and status.
+fn documented_responses(spec: &Value) -> Vec<(String, &Value)> {
+    let mut responses = Vec::new();
+
+    for (operation_id, operation) in operations_by_id(spec) {
+        let Some(statuses) = operation.get("responses").and_then(Value::as_object) else {
+            continue;
+        };
+        for (status, response) in statuses {
+            responses.push((format!("{operation_id} {status}"), response));
+        }
+    }
+
+    responses
+}
+
+/// Checks a response and its referenced components for nullable properties.
+/// Optional response fields are omitted rather than encoded as `null`.
+fn assert_no_null_property<'a>(
+    spec: &'a Value,
+    value: &'a Value,
+    location: &str,
+    visited: &mut BTreeSet<String>,
+    properties: &mut usize,
+) {
+    match value {
+        Value::Object(object) => {
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                if visited.insert(reference.to_owned()) {
+                    let component = component_for_ref(spec, reference).unwrap_or_else(|| {
+                        panic!("{location} references a missing component: {reference}")
+                    });
+                    assert_no_null_property(spec, component, reference, visited, properties);
+                }
+            }
+
+            if let Some(schema_properties) = object.get("properties").and_then(Value::as_object) {
+                for (name, schema) in schema_properties {
+                    *properties += 1;
+                    assert!(
+                        !admits_null(schema),
+                        "response property `{name}` in {location} is typed null; \
+                         optional response fields are omitted when absent"
+                    );
+                    assert!(
+                        schema.get("nullable") != Some(&Value::Bool(true)),
+                        "response property `{name}` in {location} is marked nullable; \
+                         optional response fields are omitted when absent"
+                    );
+                }
+            }
+
+            for child in object.values() {
+                assert_no_null_property(spec, child, location, visited, properties);
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                assert_no_null_property(spec, child, location, visited, properties);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn admits_null(schema: &Value) -> bool {
+    schema
+        .get("type")
+        .and_then(Value::as_array)
+        .is_some_and(|types| types.iter().any(|entry| entry.as_str() == Some("null")))
+}
+
+fn component_for_ref<'a>(spec: &'a Value, reference: &str) -> Option<&'a Value> {
+    let (component_type, component_name) = component_reference_parts(reference)?;
+    spec.get("components")?
+        .get(component_type.as_str())?
+        .get(component_name.as_str())
 }
 
 fn required_fields(schema: &Value) -> BTreeSet<&str> {

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -1802,10 +1802,7 @@
             "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
           },
           "feature": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
           },
           "message": {
@@ -1813,17 +1810,11 @@
             "description": "Human-readable error message."
           },
           "param": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
           },
           "request_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
           }
         }
@@ -1868,10 +1859,7 @@
             "description": "The attribute revision this projection represents."
           },
           "attributes_updated_at_ms": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "format": "int64",
             "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
             "minimum": 0
@@ -2279,10 +2267,7 @@
             "description": "Semantic filesystem events for this commit, in the order the commit\napplied them. One request operation may produce more than one event\n(see [`FilesystemChange`])."
           },
           "message": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Caller annotation, omitted when absent and carrying no filesystem semantics."
           }
         }
@@ -2496,10 +2481,7 @@
         "description": "Optional machine-readable details for an [`ApiError`].\n\nClients make retry decisions from the error code and use these fields for\nrelevant identifiers such as commit ids, writer epochs, and revisions.\nFields may be absent and clients must ignore fields they do not use.",
         "properties": {
           "active_acquired_at_ms": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "format": "int64",
             "description": "Unix milliseconds at which the current epoch's acquirer took it, when\nthe head recorded one. Writer ids are process labels, so two runs on\none machine can share one; the stamp is what tells them apart.",
             "minimum": 0
@@ -2509,10 +2491,7 @@
             "description": "Deletion generation actually active for the inode."
           },
           "active_writer": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Writer id recorded by the current epoch's acquirer, when the head\nrecorded one."
           },
           "active_writer_epoch": {
@@ -2540,10 +2519,7 @@
             "description": "Idempotency key of the commit the error concerns."
           },
           "committed_fingerprint": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Semantic identity of the mutation that already landed under that\ncommit id, from the same receipt as `committed_seq` and present\nexactly when it is. A retry recomputes this value from the request it\njust made — see\n[`put_retry_fingerprint`](crate::put_retry_fingerprint) — and equality\nis what proves the two are the same request."
           },
           "committed_seq": {
@@ -2573,10 +2549,7 @@
             "pattern": "^ino_[1-9][0-9]*$"
           },
           "operation_index": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "format": "int32",
             "description": "Position, in the request's operation list, of the operation that\nfailed. A commit applies all of its operations or none of them, so\nthis names the one that stopped the whole request.",
             "minimum": 0
@@ -2727,7 +2700,8 @@
           "revision_no",
           "line_number",
           "byte_offset",
-          "line"
+          "line",
+          "line_truncated"
         ],
         "properties": {
           "byte_offset": {
@@ -2797,10 +2771,7 @@
             "description": "Namespace searched."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Present when another page follows."
           },
           "tail_scanned": {
@@ -2834,10 +2805,7 @@
             "description": "Namespace that was read."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Opaque cursor for the next page, if more revisions are available."
           },
           "revisions": {
@@ -2875,10 +2843,7 @@
             "description": "Namespace that was read."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Cursor for the next page, if more entries remain."
           },
           "path": {
@@ -2912,10 +2877,7 @@
             "description": "Namespace that was read."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Present when another page follows."
           }
         }
@@ -4101,10 +4063,7 @@
                   "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
                 },
                 "feature": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": "string",
                   "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
                 },
                 "message": {
@@ -4112,17 +4071,11 @@
                   "description": "Human-readable error message."
                 },
                 "param": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": "string",
                   "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
                 },
                 "request_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": "string",
                   "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
                 }
               }

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3588,10 +3588,7 @@
             "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
           },
           "feature": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
           },
           "message": {
@@ -3599,17 +3596,11 @@
             "description": "Human-readable error message."
           },
           "param": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
           },
           "request_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
           }
         }
@@ -3654,10 +3645,7 @@
             "description": "The attribute revision this projection represents."
           },
           "attributes_updated_at_ms": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "format": "int64",
             "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
             "minimum": 0
@@ -3996,10 +3984,7 @@
             "minimum": 0
           },
           "expires_at_ms": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "format": "int64",
             "description": "When garbage collection may release the record without being asked,\nin Unix milliseconds. Absent means the pin holds until it is\nreleased. An instant already in the past is a record whose expiry\nhas passed and which no collection pass has reached yet: it is still\na root, so it is still listed.",
             "minimum": 0
@@ -4173,10 +4158,7 @@
             "description": "Semantic filesystem events for this commit, in the order the commit\napplied them. One request operation may produce more than one event\n(see [`FilesystemChange`])."
           },
           "message": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Caller annotation, omitted when absent and carrying no filesystem semantics."
           }
         }
@@ -4466,10 +4448,7 @@
         "description": "Optional machine-readable details for an [`ApiError`].\n\nClients make retry decisions from the error code and use these fields for\nrelevant identifiers such as commit ids, writer epochs, and revisions.\nFields may be absent and clients must ignore fields they do not use.",
         "properties": {
           "active_acquired_at_ms": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "format": "int64",
             "description": "Unix milliseconds at which the current epoch's acquirer took it, when\nthe head recorded one. Writer ids are process labels, so two runs on\none machine can share one; the stamp is what tells them apart.",
             "minimum": 0
@@ -4479,10 +4458,7 @@
             "description": "Deletion generation actually active for the inode."
           },
           "active_writer": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Writer id recorded by the current epoch's acquirer, when the head\nrecorded one."
           },
           "active_writer_epoch": {
@@ -4510,10 +4486,7 @@
             "description": "Idempotency key of the commit the error concerns."
           },
           "committed_fingerprint": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Semantic identity of the mutation that already landed under that\ncommit id, from the same receipt as `committed_seq` and present\nexactly when it is. A retry recomputes this value from the request it\njust made — see\n[`put_retry_fingerprint`](crate::put_retry_fingerprint) — and equality\nis what proves the two are the same request."
           },
           "committed_seq": {
@@ -4543,10 +4516,7 @@
             "pattern": "^ino_[1-9][0-9]*$"
           },
           "operation_index": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "format": "int32",
             "description": "Position, in the request's operation list, of the operation that\nfailed. A commit applies all of its operations or none of them, so\nthis names the one that stopped the whole request.",
             "minimum": 0
@@ -4744,8 +4714,15 @@
           "deleted_manifests",
           "deleted_checkpoint_records",
           "released_fork_checkpoints",
+          "released_expired_checkpoints",
+          "deleted_upload_sessions",
+          "deleted_content_objects",
+          "released_missing_basis_checkpoints",
           "retained_candidates",
-          "degraded_retention"
+          "retained",
+          "degraded_retention",
+          "content_reclamation_deferred",
+          "budget_exhausted"
         ],
         "properties": {
           "budget_exhausted": {
@@ -4801,17 +4778,11 @@
             "description": "Namespace the pass ran against."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Opaque resume token when more candidates remain. Resuming rebuilds\nevery safety proof; the token carries enumeration position only and\nis valid only against the same namespace."
           },
           "next_reclamation_at_ms": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "format": "int64",
             "description": "The soonest instant still ahead of this pass at which something it\nretained becomes reclaimable: an open session's lease plus the grace\nwindow, an aborted session's grace, or a completed session's derived\ncontent-reclamation grace. A scheduler reads this to decide when to\ncome back, so a namespace needs no other side channel to have its\nreclamation happen.\n\nIt reports what this pass saw and nothing more. A pass that stopped\non `next_cursor` examined only part of the keyspace, and candidates\nthat age out under a plain grace window on their object timestamps\ncarry no deadline here at all, so absence is never a claim that\nnothing is owed.",
             "minimum": 0
@@ -4906,10 +4877,7 @@
             "description": "Whether an absent or tombstoned namespace had extension state reaped."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Present when the budget stopped the pass with keys left to examine."
           },
           "retained_candidates": {
@@ -4985,7 +4953,8 @@
           "revision_no",
           "line_number",
           "byte_offset",
-          "line"
+          "line",
+          "line_truncated"
         ],
         "properties": {
           "byte_offset": {
@@ -5055,10 +5024,7 @@
             "description": "Namespace searched."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Present when another page follows."
           },
           "tail_scanned": {
@@ -5095,10 +5061,7 @@
             "description": "Namespace the records belong to."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Opaque cursor for the next page."
           }
         }
@@ -5128,10 +5091,7 @@
             "description": "Namespace that was read."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Opaque cursor for the next page, if more revisions are available."
           },
           "revisions": {
@@ -5169,10 +5129,7 @@
             "description": "Namespace that was read."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Cursor for the next page, if more entries remain."
           },
           "path": {
@@ -5206,10 +5163,7 @@
             "description": "Namespace that was read."
           },
           "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "Present when another page follows."
           }
         }
@@ -5608,10 +5562,7 @@
         ],
         "properties": {
           "message": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "description": "What was expected and what happened instead. Present only on\n`failed`."
           },
           "name": {
@@ -7052,10 +7003,7 @@
                   "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
                 },
                 "feature": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": "string",
                   "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
                 },
                 "message": {
@@ -7063,17 +7011,11 @@
                   "description": "Human-readable error message."
                 },
                 "param": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": "string",
                   "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
                 },
                 "request_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": "string",
                   "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
                 }
               }


### PR DESCRIPTION
Corrects response schemas in the generated OpenAPI documents. Optional response fields are omitted when absent, so their schemas no longer allow `null`. Fields that the server always writes are now marked required.

Request-only schemas still allow explicit `null` where serde accepts it. This changes only the API description; server response bytes are unchanged.