### PR TITLE
fix(api): rename permission_denied to storage_permission_denied and serve it as 503

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -20,9 +20,9 @@ pub enum ErrorKind {
     /// operation. Send a smaller payload (for uploads, prefer `direct_put`);
     /// retrying unchanged will not succeed.
     ContentTooLarge,
-    /// The caller may not perform this operation. Request access; retrying
-    /// unchanged will not succeed.
-    PermissionDenied,
+    /// The backing object store rejected the deployment's credentials. The
+    /// operator must fix the credentials or bucket policy before retrying.
+    StoragePermissionDenied,
     /// The deployment does not implement this operation. Gate on the
     /// capability document instead of retrying.
     NotSupported,
@@ -130,7 +130,7 @@ macro_rules! error_codes {
 error_codes! {
     InvalidRequest => "invalid_request",
     Unauthorized => "unauthorized",
-    PermissionDenied => "permission_denied",
+    StoragePermissionDenied => "storage_permission_denied",
     ContentTooLarge => "content_too_large",
     NotSupported => "not_supported",
     RouteNotFound => "route_not_found",
@@ -181,10 +181,9 @@ impl ErrorCode {
             // into a capped scan.
             ErrorCode::InvalidRequest | ErrorCode::QueryUnindexable => ErrorKind::InvalidRequest,
             ErrorCode::Unauthorized => ErrorKind::Unauthorized,
-            // Produced when the backing object store rejects the
-            // deployment's credentials: operator-actionable and never
-            // transient, exactly the kind's contract.
-            ErrorCode::PermissionDenied => ErrorKind::PermissionDenied,
+            // This is a deployment storage failure, not a caller
+            // authorization failure.
+            ErrorCode::StoragePermissionDenied => ErrorKind::StoragePermissionDenied,
             ErrorCode::ContentTooLarge => ErrorKind::ContentTooLarge,
             ErrorCode::NotSupported => ErrorKind::NotSupported,
             ErrorCode::NamespaceNotFound
@@ -243,7 +242,7 @@ impl ErrorCode {
             ErrorCode::CommitQueueFull | ErrorCode::ServerBusy | ErrorCode::ShuttingDown => true,
             ErrorCode::InvalidRequest
             | ErrorCode::Unauthorized
-            | ErrorCode::PermissionDenied
+            | ErrorCode::StoragePermissionDenied
             | ErrorCode::ContentTooLarge
             | ErrorCode::NotSupported
             | ErrorCode::RouteNotFound

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -208,7 +208,9 @@ mod tests {
         }
 
         let remote_boundary = serde_json::to_string(&loonfs_api::ApiError {
-            code: loonfs_api::ErrorCode::PermissionDenied.as_str().to_owned(),
+            code: loonfs_api::ErrorCode::StoragePermissionDenied
+                .as_str()
+                .to_owned(),
             feature: None,
             message: public_message.clone(),
             param: None,
@@ -223,7 +225,7 @@ mod tests {
             profile: Some("remote".to_owned()),
             mode: Some("remote".to_owned()),
             error: Box::new(CliError::from(crate::backend_error::BackendError::from(
-                ClientError::from_api_error(403, body),
+                ClientError::from_api_error(503, body),
             ))),
         };
         let remote_human = human_error(&remote_failure.error);

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -318,7 +318,7 @@ impl From<ImmutableWriteError> for CoreError {
 
 fn classify_store_failure(class: StoreFailureClass) -> ErrorCode {
     match class {
-        StoreFailureClass::PermissionDenied => ErrorCode::PermissionDenied,
+        StoreFailureClass::PermissionDenied => ErrorCode::StoragePermissionDenied,
         StoreFailureClass::NotFound
         | StoreFailureClass::InvalidRequest
         | StoreFailureClass::PreconditionFailed
@@ -1089,9 +1089,9 @@ mod tests {
         assert!(CoreError::Internal("boom".to_owned()).details().is_none());
     }
 
-    /// Provider auth failures keep their class across the message-flattening
-    /// seams and reach the wire as `permission_denied`; every other store
-    /// failure stays `server_error`.
+    /// Provider authorization failures map to
+    /// `storage_permission_denied`. Other store failures map to
+    /// `server_error`.
     #[test]
     fn store_permission_denied_classifies_to_its_wire_code() {
         let denied = ObjectStoreError::PermissionDenied {
@@ -1099,8 +1099,8 @@ mod tests {
             message: "AccessDenied: bucket policy".to_owned(),
         };
         let error = CoreError::store("namespaces/demo/wal/head.json", &denied);
-        assert_eq!(error.code(), ErrorCode::PermissionDenied);
-        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert_eq!(error.code(), ErrorCode::StoragePermissionDenied);
+        assert_eq!(error.kind(), ErrorKind::StoragePermissionDenied);
 
         let transport = ObjectStoreError::transport("namespaces/demo/wal/head.json", "timed out");
         let error = CoreError::store("namespaces/demo/wal/head.json", &transport);
@@ -1122,11 +1122,11 @@ mod tests {
             CoreError::from(ControlUpdateError::LoadHead(denied.clone())),
         ];
         for error in core_wrappers {
-            assert_eq!(error.code(), ErrorCode::PermissionDenied);
+            assert_eq!(error.code(), ErrorCode::StoragePermissionDenied);
         }
         assert_eq!(
             BootstrapNamespaceError::Head(denied).code(),
-            ErrorCode::PermissionDenied
+            ErrorCode::StoragePermissionDenied
         );
     }
 }

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -54,7 +54,7 @@ impl BootstrapNamespaceError {
             BootstrapNamespaceError::Head(ControlObjectLoadError::Store {
                 class: StoreFailureClass::PermissionDenied,
                 ..
-            }) => ErrorCode::PermissionDenied,
+            }) => ErrorCode::StoragePermissionDenied,
             BootstrapNamespaceError::Head(_) => ErrorCode::ServerError,
             BootstrapNamespaceError::Core(error) => error.code(),
         }

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -280,7 +280,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_permission_denied_head_write_is_classified_as_permission_denied() {
+    async fn a_permission_denied_head_write_is_classified_as_storage_permission_denied() {
         let temp_dir = tempdir().expect("tempdir");
         let inner = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -308,7 +308,10 @@ mod tests {
                 ..
             }
         ));
-        assert_eq!(CoreError::from(error).code(), ErrorCode::PermissionDenied);
+        assert_eq!(
+            CoreError::from(error).code(),
+            ErrorCode::StoragePermissionDenied
+        );
     }
 
     #[tokio::test]

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -72,7 +72,7 @@ impl GrepError {
         match self {
             Self::NotEnabled | Self::Backfilling => ErrorCode::NotSupported,
             Self::StoreUnavailable { class, .. } => match class {
-                StoreFailureClass::PermissionDenied => ErrorCode::PermissionDenied,
+                StoreFailureClass::PermissionDenied => ErrorCode::StoragePermissionDenied,
                 _ => ErrorCode::ServerError,
             },
             Self::CorruptIndex { .. } => ErrorCode::IndexCorrupt,
@@ -129,7 +129,7 @@ mod tests {
         for (class, expected) in [
             (
                 StoreFailureClass::PermissionDenied,
-                ErrorCode::PermissionDenied,
+                ErrorCode::StoragePermissionDenied,
             ),
             (StoreFailureClass::Other, ErrorCode::ServerError),
         ] {

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -137,7 +137,12 @@ fn status_for_error_kind(kind: ErrorKind) -> StatusCode {
         ErrorKind::InvalidRequest => StatusCode::BAD_REQUEST,
         ErrorKind::Unauthorized => StatusCode::UNAUTHORIZED,
         ErrorKind::ContentTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
-        ErrorKind::PermissionDenied => StatusCode::FORBIDDEN,
+        // The backing object store rejected the deployment's storage
+        // credentials, which is not a statement about the caller. 403 would
+        // tell the caller to re-authenticate or to ask someone for access,
+        // and neither helps: the deployment cannot serve the request until
+        // an operator fixes the credentials or the bucket policy.
+        ErrorKind::StoragePermissionDenied => StatusCode::SERVICE_UNAVAILABLE,
         ErrorKind::NotFound => StatusCode::NOT_FOUND,
         ErrorKind::MethodNotAllowed => StatusCode::METHOD_NOT_ALLOWED,
         ErrorKind::Gone => StatusCode::GONE,

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -57,7 +57,6 @@ pub(super) struct GrepQuery {
             (status = 200, description = "One page of matches", body = GrepResponse),
             (status = 400, description = "Invalid pattern, cursor, or an unindexable pattern without allow_scan", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 501, description = "This deployment does not serve grep queries, the grep index is not enabled, or its backfill has not completed on this namespace", body = ApiError),
@@ -182,7 +181,6 @@ pub(super) async fn grep_index_not_maintained(
         responses(
             (status = 200, description = "Grep root enabled or already enabled", body = GrepIndexStatusResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
@@ -232,7 +230,6 @@ pub(super) async fn enable_grep_index(
         responses(
             (status = 200, description = "Grep index status and build progress", body = GrepIndexStatusResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
             crate::http::openapi::UnavailableResponses
@@ -273,7 +270,6 @@ async fn read_grep_index_status(
         responses(
             (status = 200, description = "Grep root disabled or already disabled", body = GrepIndexStatusResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
@@ -325,7 +321,6 @@ pub(super) async fn disable_grep_index(
             (status = 200, description = "Namespace grep garbage collection completed", body = GrepGcResponse),
             (status = 400, description = "Invalid budget or cursor", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
             crate::http::openapi::UnavailableResponses

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -1,7 +1,7 @@
 //! Upload session handlers plus the presign and content-token helpers
 //! backing them.
 
-use super::error::ApiResponseError;
+use super::error::{status_for_core_error_code, ApiResponseError};
 use super::{
     authorize, AppPath, AppState, NamespaceIdPath, UploadBodyBytes, UploadBodyStream,
     UploadControlJson, MAX_COMPLETION_BODY_BYTES, MAX_UPLOAD_CONTROL_BODY_BYTES,
@@ -357,9 +357,13 @@ pub(super) fn presign_issuer_error(error: ObjectStoreError) -> ApiResponseError 
             ApiResponseError::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, &message)
                 .with_param("/content")
         }
-        ObjectStoreError::PermissionDenied { .. } => {
-            ApiResponseError::new(StatusCode::FORBIDDEN, ErrorCode::PermissionDenied, &message)
-        }
+        // The status comes from the registry so this handler cannot drift
+        // from the status the rest of the server serves for the code.
+        ObjectStoreError::PermissionDenied { .. } => ApiResponseError::new(
+            status_for_core_error_code(ErrorCode::StoragePermissionDenied),
+            ErrorCode::StoragePermissionDenied,
+            &message,
+        ),
         _ => ApiResponseError::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             ErrorCode::ServerError,

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -204,7 +204,7 @@ fn request_log_severity(
     match code.kind() {
         ErrorKind::Internal | ErrorKind::DataCorruption => RequestLogSeverity::Error,
         ErrorKind::Unauthorized
-        | ErrorKind::PermissionDenied
+        | ErrorKind::StoragePermissionDenied
         | ErrorKind::Unavailable
         | ErrorKind::DeadlineExceeded
         | ErrorKind::OutcomeUnknown => RequestLogSeverity::Warn,

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -188,7 +188,7 @@ struct LoonfsOpenApi;
 /// OpenAPI definition for the 503 response every operation can return.
 #[derive(utoipa::ToResponse)]
 #[response(
-    description = "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, or required maintenance. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying."
+    description = "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, required maintenance, or invalid storage credentials. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying."
 )]
 #[expect(
     dead_code,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -508,7 +508,7 @@ async fn provider_failure_is_projected_in_the_remote_api_envelope() {
         .await
         .expect("create namespace response");
 
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let request_id = response
         .headers()
         .get(super::REQUEST_ID_HEADER)
@@ -540,7 +540,7 @@ async fn provider_failure_is_projected_in_the_presign_api_envelope() {
             .into_response()
         })
         .await;
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read presign failure body");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -254,7 +254,6 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | --- | --- | --- |
 | `invalid_request` | 400 | The request is malformed: a path, id, cursor, parameter, staged content reference, configuration value, or commit request limit fails validation. The message names the offending field or limit. |
 | `unauthorized` | 401 | Missing or wrong credentials. |
-| `permission_denied` | 403 | The backing object store rejected the deployment's storage credentials for this operation. Fix the storage credentials or bucket policy; retrying unchanged will not succeed. |
 | `content_too_large` | 413 | A request or proxied response exceeds its advertised size limit. Send smaller proxied uploads or use `direct_put` when available. Multipart completions must fit within `upload.completion_max_body_bytes`. For large reads, request a download grant when `core.downloads.direct_get` is available. |
 | `route_not_found` | 404 | No route matches the request path. |
 | `method_not_allowed` | 405 | The path exists but does not serve this HTTP method. |
@@ -288,18 +287,20 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `checkpoint_unavailable` | 503 | Required checkpoint state is unavailable: not yet published, released during the operation, or referenced material is missing. Retry after maintenance. |
 | `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
 | `index_lagging` | 503 | The grep index trails the head past the exhaustive-scan budget; let the grep worker catch up (or set `allow_stale`) and retry. |
+| `storage_permission_denied` | 503 | The backing object store rejected the deployment's storage credentials for this operation. Fix the storage credentials or bucket policy; an unchanged retry will not succeed. |
 | `index_corrupt` | 500 | The grep index's derived state failed validation. Disable and re-enable grep on the namespace to rebuild it; core filesystem state remains available. |
 | `namespace_corrupt` | 500 | Durable namespace state failed validation. |
 | `server_error` | 500 | Unclassified internal failure. |
 
-Automated retry is deliberately narrower than the shared HTTP status. Raw
-transport failures may be retried, and among registered error codes only
-`commit_queue_full`, `server_busy`, and `shutting_down` can clear without
-caller or operator action. `checkpoint_unavailable`, `maintenance_required`,
-and `index_lagging` remain 503 status groupings but require maintenance before
-an unchanged request can succeed; `commit_outcome_unknown` and
-`deadline_exceeded` require reconciliation before retrying a mutation.
-Responses carrying any of those three immediately retryable codes include
+Automated retry is narrower than the HTTP status. Raw transport failures may
+be retried. Of the registered error codes, only `commit_queue_full`,
+`server_busy`, and `shutting_down` can clear without caller or operator action.
+`checkpoint_unavailable`, `maintenance_required`, and `index_lagging` require
+maintenance. `storage_permission_denied` requires the operator to fix the
+storage credentials or bucket policy. `commit_outcome_unknown` and
+`deadline_exceeded` require the caller to determine whether a mutation
+completed before retrying it.
+Responses carrying one of the three immediately retryable codes include
 `Retry-After: 1`.
 
 Precondition failures surface as `409` resource-state conflicts

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -995,16 +995,6 @@
               }
             }
           },
-          "403": {
-            "description": "The backing store rejected its configured credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Namespace not found",
             "content": {
@@ -4009,7 +3999,7 @@
     },
     "responses": {
       "UnavailableResponse": {
-        "description": "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, or required maintenance. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying.",
+        "description": "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, required maintenance, or invalid storage credentials. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying.",
         "content": {
           "application/json": {
             "schema": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -477,16 +477,6 @@
               }
             }
           },
-          "403": {
-            "description": "The backing store rejected its configured credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "The grep index is corrupt or its backing store is unavailable",
             "content": {
@@ -546,16 +536,6 @@
           },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "The backing store rejected its configured credentials",
             "content": {
               "application/json": {
                 "schema": {
@@ -643,16 +623,6 @@
           },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "The backing store rejected its configured credentials",
             "content": {
               "application/json": {
                 "schema": {
@@ -759,16 +729,6 @@
           },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "The backing store rejected its configured credentials",
             "content": {
               "application/json": {
                 "schema": {
@@ -2742,16 +2702,6 @@
           },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "The backing store rejected its configured credentials",
             "content": {
               "application/json": {
                 "schema": {
@@ -6931,7 +6881,7 @@
     },
     "responses": {
       "UnavailableResponse": {
-        "description": "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, or required maintenance. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying.",
+        "description": "The server cannot complete the request now. Inspect `code` to determine whether the cause is a deadline, shutdown, load, required maintenance, or invalid storage credentials. A mutation may still complete after a deadline or lost acknowledgment, so determine its outcome before retrying.",
         "content": {
           "application/json": {
             "schema": {


### PR DESCRIPTION
Renames `permission_denied` to `storage_permission_denied` and returns it as HTTP 503. This error is produced when the backing object store rejects the deployment credentials, not when the API caller lacks permission.

The error remains non-retryable without operator action. The operator must fix the storage credentials or bucket policy before the same request can succeed.