### PR TITLE
fix(format): tolerate additive fields in durable objects

### DIFF
--- a/crates/loonfs-api/src/actor.rs
+++ b/crates/loonfs-api/src/actor.rs
@@ -13,6 +13,9 @@ const MAX_ACTOR_ID_BYTES: usize = 256;
 ///
 /// LoonFS stores this value as provided. It does not authenticate the actor or
 /// look up profile information.
+// This type also appears in request bodies, so it rejects unknown fields in
+// every context. Add new actor kinds instead of new fields. This is not
+// rustdoc because it describes storage behavior, not the public API.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]

--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -111,6 +111,9 @@ impl fmt::Display for ChecksumAlgorithm {
 /// An algorithm and its canonical lowercase-hex checksum value.
 ///
 /// The enclosing value defines which bytes the checksum covers.
+// This type also appears in request bodies, so it rejects unknown fields in
+// every context. Add new algorithms instead of new fields. This is not
+// rustdoc because it describes storage behavior, not the public API.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
@@ -388,6 +391,9 @@ pub enum ContentRefValidationError {
 ///
 /// A `ContentRef` is safe to publish only after the referenced bytes are
 /// durable in the namespace's content store.
+// This type also appears in request bodies, so it rejects unknown fields in
+// every context. Add new content kinds instead of new fields. This is not
+// rustdoc because it describes storage behavior, not the public API.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -293,9 +293,11 @@ pub struct CheckpointRecordState {
 
 /// Links one accepted WAL segment identity to its verified sequence range.
 ///
+/// Pointers in immutable WAL segments accept unknown fields. The mutable head
+/// uses a strict decoder for the same shape so a rewrite cannot discard data.
+///
 /// See [WAL segment rules](../../../docs/specs/format.md#15-wal-segment-rules).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct WalSegmentPointer {
     /// Segment identity used to derive the immutable object key and expected
     /// to agree with the decoded payload.
@@ -307,6 +309,48 @@ pub struct WalSegmentPointer {
     /// Checksum of the referenced segment's payload bytes, in `sha256:<hex>`
     /// form. Must equal the `payload_checksum` in the referenced envelope.
     pub payload_checksum: String,
+}
+
+/// Strict WAL pointer shape used only while decoding the mutable head.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictWalSegmentPointer {
+    segment_id: WalSegmentId,
+    start_seq: ChangeSeq,
+    end_seq: ChangeSeq,
+    payload_checksum: String,
+}
+
+impl From<StrictWalSegmentPointer> for WalSegmentPointer {
+    fn from(pointer: StrictWalSegmentPointer) -> Self {
+        Self {
+            segment_id: pointer.segment_id,
+            start_seq: pointer.start_seq,
+            end_seq: pointer.end_seq,
+            payload_checksum: pointer.payload_checksum,
+        }
+    }
+}
+
+/// Decodes the head's visible WAL tip without accepting unknown fields.
+fn strict_wal_segment_pointer<'de, D>(
+    deserializer: D,
+) -> Result<Option<WalSegmentPointer>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<StrictWalSegmentPointer>::deserialize(deserializer)?.map(Into::into))
+}
+
+/// Decodes the head's predecessor hints without accepting unknown fields.
+fn strict_wal_segment_pointers<'de, D>(deserializer: D) -> Result<Vec<WalSegmentPointer>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Vec::<StrictWalSegmentPointer>::deserialize(deserializer)?
+        .into_iter()
+        .map(Into::into)
+        .collect())
 }
 
 /// Who most recently acquired the writer epoch, and when.
@@ -423,13 +467,21 @@ pub struct HeadState {
     /// First namespace-scoped inode identity available for allocation.
     pub next_inode_id: InodeId,
     /// Accepted tip of the visible WAL chain, or `None` before the first commit.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "strict_wal_segment_pointer"
+    )]
     pub visible_wal_tip: Option<WalSegmentPointer>,
     /// Bounded newest-first predecessor accelerator below `visible_wal_tip`.
     /// Chain links remain the only history authority — any disagreement
     /// resolves in favor of the chain, and this array never protects anything
     /// from GC.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "strict_wal_segment_pointers"
+    )]
     pub recent_segments: Vec<WalSegmentPointer>,
     /// Lifecycle state. Absent means active, on read and on write, so the
     /// field appears only in deleted heads.
@@ -1132,15 +1184,21 @@ mod tests {
         );
     }
 
+    /// The mutable head rejects pointer fields that it cannot preserve during
+    /// a rewrite.
     #[test]
-    fn old_pointer_object_key_is_rejected() {
+    fn head_rejects_a_pointer_field_it_does_not_define() {
         let mut tip = wal_pointer_json("00000000000000000002-fedcba9876543210", 2, 2);
         tip["object_key"] = serde_json::json!(
             "namespaces/demo/wal/segments/00000000000000000002-fedcba9876543210.wal.zst"
         );
 
-        serde_json::from_value::<HeadState>(head_json(Some(tip), Vec::new()))
-            .expect_err("the v1 hard cutover rejects the former stored object key");
+        serde_json::from_value::<HeadState>(head_json(Some(tip.clone()), Vec::new()))
+            .expect_err("the head rejects a field its tip pointer does not define");
+
+        let older = wal_pointer_json("00000000000000000001-0123456789abcdef", 1, 1);
+        serde_json::from_value::<HeadState>(head_json(Some(older), vec![tip]))
+            .expect_err("the head rejects a field a predecessor hint does not define");
     }
 
     #[test]

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -272,10 +272,11 @@ pub enum MetadataRow {
 ///
 /// Shared by the tombstone row and the WAL delta that revokes one, so a
 /// revoke names its target in the same spelling everywhere.
+///
+/// This type appears only in immutable data, so it accepts unknown fields.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
-#[serde(deny_unknown_fields)]
 pub struct TombstoneGeneration {
     /// Commit sequence that published the event.
     pub seq: ChangeSeq,
@@ -287,8 +288,9 @@ pub struct TombstoneGeneration {
 ///
 /// Tombstones retain this binding after the corresponding unbind row may be
 /// collected. Undelete uses it to restore the original parent and name.
+///
+/// This type appears only in immutable data, so it accepts unknown fields.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct DeletedDirentry {
     /// Directory that held the binding.
     pub parent_inode_id: InodeId,
@@ -313,8 +315,10 @@ where
 }
 
 /// Tombstone-row event vocabulary (format spec, "Tombstones and deletion").
+///
+/// This type appears only in immutable rows, so it accepts unknown fields.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TombstoneRowAction {
     /// The subtree rooted at the row's inode is deleted.
     Set {

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -15,8 +15,11 @@
 //!   another implementation of the same format version wrote — a
 //!   compatibility break once that format is deployed.
 //! - Additive payload fields in immutable families must keep decoding
-//!   (`*_tolerates_additive_*`). Mutable control objects reject unknown
-//!   fields so an older reader cannot erase them during a guarded rewrite.
+//!   (`*_tolerates_additive_*`), at every level of nesting. Mutable control
+//!   objects reject unknown fields so an older reader cannot erase them
+//!   during a guarded rewrite. `ContentRef`, `Checksum`, and `ActorRef` are
+//!   closed shapes: they reject unknown fields everywhere, because the same
+//!   types decode HTTP request bodies.
 
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointOwner, CheckpointRecordLifecycle,
@@ -804,11 +807,23 @@ fn mutable_control_nested_structs_reject_unknown_fields_as_corruption() {
         ControlObjectKind::WalHead,
         |payload| payload["writer"]["field_from_the_future"] = serde_json::Value::from(true),
     );
+    // Both head pointer fields must reject data that a rewrite would drop.
     assert_control_payload_edit_is_corrupt::<HeadState>(
         "control_wal_head.v1.json",
         ControlObjectKind::WalHead,
         |payload| {
             payload["visible_wal_tip"]["field_from_the_future"] = serde_json::Value::from(true);
+        },
+    );
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        |payload| {
+            // The fixture has no predecessor hints, so add one based on the
+            // visible tip and include an unknown field.
+            let mut hint = payload["visible_wal_tip"].clone();
+            hint["field_from_the_future"] = serde_json::Value::from(true);
+            payload["recent_segments"] = serde_json::Value::Array(vec![hint]);
         },
     );
     assert_control_payload_edit_is_corrupt::<HeadState>(
@@ -1251,6 +1266,71 @@ fn content_store_id() -> ContentStoreId {
 // Version, kind, and corruption semantics
 // ---------------------------------------------------------------------------
 
+/// Edits a WAL payload and updates its checksum.
+fn wal_document_with_payload_edit(
+    envelope: &WalSegmentEnvelope,
+    edit: impl FnOnce(&mut ciborium::Value),
+) -> Vec<u8> {
+    let document = unzstd(&encode_wal_segment_envelope_zstd(envelope).expect("wal"));
+    let document_value: ciborium::Value =
+        ciborium::de::from_reader(document.as_slice()).expect("decode document map");
+    let payload_bytes = document_value
+        .as_map()
+        .expect("document is a map")
+        .iter()
+        .find(|(key, _)| key.as_text() == Some("payload"))
+        .and_then(|(_, value)| value.as_bytes())
+        .expect("payload is a byte string")
+        .clone();
+    let mut payload: ciborium::Value =
+        ciborium::de::from_reader(payload_bytes.as_slice()).expect("decode payload");
+    edit(&mut payload);
+    let mut edited = Vec::new();
+    ciborium::ser::into_writer(&payload, &mut edited).expect("encode edited payload");
+
+    let with_payload = with_cbor_document_entry(&document, "payload", |value| {
+        *value = ciborium::Value::Bytes(edited.clone());
+    });
+    let restated = with_cbor_document_entry(&with_payload, "payload_checksum", |value| {
+        *value = ciborium::Value::from(sha256_digest(&edited));
+    });
+    rezstd(&restated)
+}
+
+/// Adds an unknown field to a CBOR map.
+fn with_future_field(value: &mut ciborium::Value) {
+    cbor_map_of(value).push((
+        ciborium::Value::from("field_from_the_future"),
+        ciborium::Value::from(true),
+    ));
+}
+
+/// Returns the sample WAL payload's only commit.
+fn payload_commit(payload: &mut ciborium::Value) -> &mut ciborium::Value {
+    cbor_entry(payload, "records")
+        .as_array_mut()
+        .expect("records is an array")
+        .first_mut()
+        .expect("the sample carries one commit")
+}
+
+/// Returns the delta at `position` in the sample commit.
+fn commit_delta(payload: &mut ciborium::Value, position: usize) -> &mut ciborium::Value {
+    let delta = cbor_entry(payload_commit(payload), "deltas")
+        .as_array_mut()
+        .expect("deltas is an array")
+        .get_mut(position)
+        .expect("the commit carries this delta");
+    cbor_entry(delta, "delta")
+}
+
+/// Builds a sample segment with the supplied deltas.
+fn wal_envelope_with_deltas(deltas: Vec<WalCommitDelta>) -> WalSegmentEnvelope {
+    let mut payload = sample_wal_envelope().payload;
+    payload.records[0].deltas = deltas;
+    WalSegmentEnvelope::from_payload(payload).expect("wal envelope")
+}
+
 /// Rewrites one top-level entry of a CBOR document map.
 fn with_cbor_document_entry(
     document: &[u8],
@@ -1360,110 +1440,89 @@ fn wal_decode_tolerates_additive_payload_fields() {
     // payload bytes change (and so does their checksum), but readers that do
     // not know the field must still decode the segment.
     let envelope = sample_wal_envelope();
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&envelope).expect("wal"));
+    let document = wal_document_with_payload_edit(&envelope, with_future_field);
 
-    let document_value: ciborium::Value =
-        ciborium::de::from_reader(document.as_slice()).expect("decode document map");
-    let payload_bytes = document_value
-        .as_map()
-        .expect("document is a map")
-        .iter()
-        .find(|(key, _)| key.as_text() == Some("payload"))
-        .and_then(|(_, value)| value.as_bytes())
-        .expect("payload is a byte string")
-        .clone();
-    let mut payload_value: ciborium::Value =
-        ciborium::de::from_reader(payload_bytes.as_slice()).expect("decode payload");
-    payload_value.as_map_mut().expect("payload is a map").push((
-        ciborium::Value::from("field_from_the_future"),
-        ciborium::Value::from(true),
-    ));
-    let mut future_payload = Vec::new();
-    ciborium::ser::into_writer(&payload_value, &mut future_payload).expect("encode payload");
-
-    let with_payload = with_cbor_document_entry(&document, "payload", |value| {
-        *value = ciborium::Value::Bytes(future_payload.clone());
-    });
-    let future_document = with_cbor_document_entry(&with_payload, "payload_checksum", |value| {
-        *value = ciborium::Value::from(sha256_digest(&future_payload));
-    });
-
-    let decoded = decode_wal_segment_envelope_zstd(&rezstd(&future_document))
+    let decoded = decode_wal_segment_envelope_zstd(&document)
         .expect("additive payload fields must remain readable");
     assert_eq!(decoded.payload, envelope.payload);
 }
 
+/// Immutable WAL segments accept unknown predecessor-pointer fields.
 #[test]
-fn wal_decode_rejects_old_key_bearing_predecessor_pointer() {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
-    let document_value: ciborium::Value =
-        ciborium::de::from_reader(document.as_slice()).expect("decode document map");
-    let payload_bytes = document_value
-        .as_map()
-        .expect("document is a map")
-        .iter()
-        .find(|(key, _)| key.as_text() == Some("payload"))
-        .and_then(|(_, value)| value.as_bytes())
-        .expect("payload is a byte string");
-    let mut payload: ciborium::Value =
-        ciborium::de::from_reader(payload_bytes.as_slice()).expect("decode payload");
-    cbor_map_of(cbor_entry(&mut payload, "prev_visible_segment")).push((
-        ciborium::Value::from("object_key"),
-        ciborium::Value::from(
-            "namespaces/demo/wal/segments/00000000000000000002-fedcba9876543210.wal.zst",
-        ),
-    ));
-    let mut key_bearing_payload = Vec::new();
-    ciborium::ser::into_writer(&payload, &mut key_bearing_payload)
-        .expect("encode old key-bearing payload");
-
-    let with_payload = with_cbor_document_entry(&document, "payload", |value| {
-        *value = ciborium::Value::Bytes(key_bearing_payload.clone());
+fn wal_decode_tolerates_an_additive_field_inside_the_predecessor_pointer() {
+    let envelope = sample_wal_envelope();
+    let document = wal_document_with_payload_edit(&envelope, |payload| {
+        with_future_field(cbor_entry(payload, "prev_visible_segment"));
     });
-    let key_bearing_document =
-        with_cbor_document_entry(&with_payload, "payload_checksum", |value| {
-            *value = ciborium::Value::from(sha256_digest(&key_bearing_payload));
-        });
 
-    let error = decode_wal_segment_envelope_zstd(&rezstd(&key_bearing_document))
-        .expect_err("version-one predecessor pointers reject the former stored object key");
+    let decoded = decode_wal_segment_envelope_zstd(&document)
+        .expect("an additive field inside the predecessor pointer must remain readable");
+    assert_eq!(decoded.payload, envelope.payload);
+}
+
+/// Immutable WAL segments accept unknown fields nested in tombstone deltas.
+#[test]
+fn wal_decode_tolerates_additive_fields_inside_tombstone_deltas() {
+    let envelope = wal_envelope_with_deltas(vec![
+        WalCommitDelta {
+            semantic_op_index: 0,
+            delta: WalDelta::TombstoneSubtree {
+                delta_index: 0,
+                root_inode_id: InodeId(9),
+                deleted_direntry: Some(DeletedDirentry {
+                    parent_inode_id: InodeId(1),
+                    name_key: name_key("old.txt"),
+                    display_name: loonfs_api::DisplayName::parse("Old.txt")
+                        .expect("valid display name"),
+                }),
+            },
+        },
+        WalCommitDelta {
+            semantic_op_index: 1,
+            delta: WalDelta::RevokeSubtreeTombstone {
+                delta_index: 1,
+                root_inode_id: InodeId(9),
+                target: TombstoneGeneration {
+                    seq: ChangeSeq(1),
+                    delta_index: 0,
+                },
+            },
+        },
+    ]);
+    let document = wal_document_with_payload_edit(&envelope, |payload| {
+        with_future_field(cbor_entry(commit_delta(payload, 0), "deleted_direntry"));
+        with_future_field(cbor_entry(commit_delta(payload, 1), "target"));
+    });
+
+    let decoded = decode_wal_segment_envelope_zstd(&document)
+        .expect("additive fields inside a delta must remain readable");
+    assert_eq!(decoded.payload, envelope.payload);
+}
+
+/// Actor references reject unknown fields in every context because the same
+/// type is also used in request bodies.
+#[test]
+fn wal_decode_rejects_an_additive_field_inside_the_commit_actor() {
+    let document = wal_document_with_payload_edit(&sample_wal_envelope(), |payload| {
+        with_future_field(cbor_entry(payload_commit(payload), "actor"));
+    });
+
+    let error = decode_wal_segment_envelope_zstd(&document)
+        .expect_err("the actor rejects a field it does not define");
     assert!(
         matches!(&error, EnvelopeCodecError::PayloadDecode(message)
-            if message.contains("unknown field") && message.contains("object_key")),
+            if message.contains("unknown field") && message.contains("field_from_the_future")),
         "unexpected corruption error: {error}"
     );
 }
 
 #[test]
 fn wal_decode_rejects_a_version_one_commit_without_an_actor() {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
-    let document_value: ciborium::Value =
-        ciborium::de::from_reader(document.as_slice()).expect("decode document map");
-    let payload_bytes = document_value
-        .as_map()
-        .expect("document is a map")
-        .iter()
-        .find(|(key, _)| key.as_text() == Some("payload"))
-        .and_then(|(_, value)| value.as_bytes())
-        .expect("payload is a byte string");
-    let mut payload: ciborium::Value =
-        ciborium::de::from_reader(payload_bytes.as_slice()).expect("decode payload");
-    let records = cbor_entry(&mut payload, "records")
-        .as_array_mut()
-        .expect("records is an array");
-    cbor_map_of(records.first_mut().expect("one commit"))
-        .retain(|(key, _)| key.as_text() != Some("actor"));
-    let mut actorless_payload = Vec::new();
-    ciborium::ser::into_writer(&payload, &mut actorless_payload).expect("encode actorless payload");
-
-    let with_payload = with_cbor_document_entry(&document, "payload", |value| {
-        *value = ciborium::Value::Bytes(actorless_payload.clone());
-    });
-    let actorless_document = with_cbor_document_entry(&with_payload, "payload_checksum", |value| {
-        *value = ciborium::Value::from(sha256_digest(&actorless_payload));
+    let document = wal_document_with_payload_edit(&sample_wal_envelope(), |payload| {
+        cbor_map_of(payload_commit(payload)).retain(|(key, _)| key.as_text() != Some("actor"));
     });
 
-    let error = decode_wal_segment_envelope_zstd(&rezstd(&actorless_document))
+    let error = decode_wal_segment_envelope_zstd(&document)
         .expect_err("version-one WAL commits require an actor");
     assert!(
         matches!(&error, EnvelopeCodecError::PayloadDecode(message) if message.contains("actor")),
@@ -2119,6 +2178,14 @@ fn assert_row_is_corrupt(row: &ciborium::Value, why: &str) -> String {
     }
 }
 
+/// Decodes a row after applying an edit to its CBOR representation.
+fn decode_edited_row(row: &ciborium::Value, why: &str) -> MetadataRow {
+    let mut encoded = Vec::new();
+    ciborium::ser::into_writer(row, &mut encoded).expect("encode edited row");
+    ciborium::de::from_reader::<MetadataRow, _>(encoded.as_slice())
+        .unwrap_or_else(|error| panic!("{why}, but the row failed to decode: {error}"))
+}
+
 #[test]
 fn commit_receipt_rows_without_an_actor_are_corrupt() {
     let mut row = row_cbor(&MetadataRow::CommitReceipt {
@@ -2154,20 +2221,47 @@ fn tombstone_rows_reject_a_partial_deleted_direntry() {
     }
 }
 
-/// Only a `set` deletes something, so only a `set` has a binding to record.
-/// A `revoke` carrying one is bytes no writer produces, and reading it as a
-/// revoke that happens to have extra baggage would hide that.
+/// Immutable metadata rows accept unknown tombstone fields at every level.
 #[test]
-fn tombstone_revoke_rows_reject_a_deleted_direntry() {
-    let mut row = row_cbor(&sample_tombstone_revoke_row());
+fn tombstone_rows_tolerate_additive_fields_at_every_level() {
+    let expected = sample_tombstone_set_row();
+    let paths: [&[&str]; 3] = [
+        &["generation"],
+        &["action"],
+        &["action", "deleted_direntry"],
+    ];
+
+    for path in paths {
+        let mut row = row_cbor(&expected);
+        let mut target = &mut row;
+        for key in path {
+            target = cbor_entry(target, key);
+        }
+        with_future_field(target);
+        assert_eq!(
+            decode_edited_row(
+                &row,
+                "an immutable row tolerates a field it does not define"
+            ),
+            expected,
+            "the unknown field under {path:?} changed the decoded row"
+        );
+    }
+}
+
+/// A `revoke` ignores `deleted_direntry`, which is valid only for `set`.
+#[test]
+fn tombstone_revoke_rows_ignore_a_deleted_direntry() {
+    let expected = sample_tombstone_revoke_row();
+    let mut row = row_cbor(&expected);
     cbor_map_of(cbor_entry(&mut row, "action")).push((
         ciborium::Value::from("deleted_direntry"),
         sample_deleted_direntry_cbor(),
     ));
-    let refusal = assert_row_is_corrupt(&row, "a revoke has no binding to carry");
-    assert!(
-        refusal.contains("unknown field `deleted_direntry`"),
-        "unexpected refusal: {refusal}"
+
+    assert_eq!(
+        decode_edited_row(&row, "a revoke tolerates a field it does not define"),
+        expected
     );
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -671,9 +671,13 @@ preconditions, so a field the server does not recognize cannot be ignored: a
 misspelled guard would decode to its default and the server would carry out
 a different request than the caller asked for. Response bodies are the other
 way round, because a client must keep working against a server newer than
-itself and so must tolerate fields it does not know (section 7.2). The
-encoding conventions in `format.md` state the same two rules and extend them
-to durable shapes.
+itself and so must tolerate fields it does not know (section 7.2).
+`ContentRef`, `Checksum`, and `ActorRef` are closed shapes on both sides: a
+response never adds a field to one of them, and new content strategies or
+checksum algorithms arrive as new `kind` and `algorithm` values, which is why
+those three schemas are `additionalProperties: false` in responses too. The
+encoding conventions in `format.md` state the same rules and extend them to
+durable shapes.
 
 The token is a bearer credential and so is everything the upload routes hand
 back: a presigned direct-upload URL is a capability to write to the

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -30,13 +30,17 @@ meant to send:
   request, at every level of nesting.
 - **HTTP response bodies tolerate them**, so a client keeps working against a
   server newer than itself.
-- **Immutable, never-rewritten durable families tolerate them**, for the same
-  reason: nothing rewrites them, so nothing can erase a field it did not
-  understand.
+- **Immutable, never-rewritten durable families tolerate them**, at every
+  level of nesting, for the same reason: nothing rewrites them, so nothing
+  can erase a field it did not understand.
 - **Mutable control-object envelopes and payloads reject them**, because a
   reader that tolerated an unknown field would erase it on the next
   read-modify-write and still report a successful guarded update
   (section 1.7).
+- **`ContentRef`, `Checksum`, and `ActorRef` are closed shapes.** They reject
+  unknown fields wherever they appear, in request bodies and in durable rows
+  alike, because the same types decode request bodies. They evolve only by
+  new `kind` and `algorithm` values, never by new fields.
 
 Durable formats store inode IDs as integers. The public API uses strings such
 as `ino_27`; this does not change stored data.
@@ -332,6 +336,11 @@ newer field, erase it during read-modify-write, and still report a successful
 guarded update. All six registered kinds use that strict decoder; immutable
 WAL segments, metadata segments, namespace manifests, grep segments, and grep
 manifests remain tolerant of additive fields.
+
+WAL segment pointers in immutable segments may contain unknown fields. The
+same pointers in the mutable head may not. The head uses strict decoders for
+`visible_wal_tip` and `recent_segments` so a guarded rewrite cannot discard
+unknown data.
 
 Readers of small mutable control objects must use a full-object read that
 returns bytes and the object identity metadata for those same bytes. This does
@@ -679,8 +688,8 @@ The core rules are:
 - future content strategies must use a new `content_ref.kind` and name their
   durability and validation rules before revisions may reference them.
 
-The `ContentRef` document rejects unknown fields, so a field this format does
-not define is corruption, not a future extension:
+`ContentRef` rejects unknown fields in every context, including immutable
+durable records. Extend it with new `kind` values instead of adding fields:
 
 ```json
 {
@@ -740,9 +749,10 @@ A `set` also carries the binding the delete removed, as one
 deleted name survives after unbind rows age out, and it is the binding
 undelete restores in place. A delete addressed by inode has no name to
 record and writes `deleted_direntry` as `null`; the field is always
-written, so an encoding that omits it is not a deletion without a name but
-corruption. Only a `set` can carry one, and a `revoke` that does is
-corruption too — a partial binding is not expressible at all. This schema
+written, so omitting it is corruption rather than an unnamed deletion. Only a
+`set` includes this field. A reader ignores it on a `revoke`, just like any
+other unknown field (encoding conventions above). A partial binding is not
+valid. This schema
 evolves in place at metadata-row version 1 before the first stable
 release; the implementation carries no compatibility shim for intermediate
 pre-release encodings, and in particular the earlier encoding that spelled
@@ -2002,8 +2012,10 @@ and grep maintenance does not collect core-owned objects.
 ### 4.3 Evolution rules
 
 - **Additive within a released version.** Readers ignore unknown payload and
-  envelope fields. After the first stable release, adding such fields is the
-  only change permitted within an existing format version.
+  envelope fields, at every level of nesting, except inside the closed shapes
+  named in the encoding conventions above. After the first stable release,
+  adding such fields is the only change permitted within an existing format
+  version.
 - **Other post-release changes require a new version.** After the first stable
   release, renaming, removing, retyping, or re-tagging any field — or changing
   the payload encoding — requires a new `format_version` for the owning family.


### PR DESCRIPTION
Lets immutable durable records ignore unknown fields at every nesting level, as the format specification requires. This includes nested WAL pointers and tombstone data, so older readers can read records written with additive fields.

Mutable control objects remain strict because rewriting them could discard unknown data. `ContentRef`, `Checksum`, and `ActorRef` also remain strict because the same types are used in request bodies.