### PR TITLE
feat(api): return the committed change from the commit response

### DIFF
--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -421,11 +421,10 @@ where
     {
         return Err(conflict);
     }
-    Ok(crate::v0::CommitResponse {
-        namespace_id: attempt.namespace_id.clone(),
-        commit_id: committed.commit_id,
-        committed_seq: committed.committed_seq,
-    })
+    Ok(crate::v0::CommitResponse::from_committed_change(
+        attempt.namespace_id.clone(),
+        committed,
+    ))
 }
 
 /// Returns the content reference when a committed change wrote exactly one

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -15,6 +15,9 @@ use serde::{Deserialize, Serialize};
 /// explicit commits, embedded or remote. The commit id is the caller's
 /// reconciliation handle: resubmitting the same request with the same id
 /// replays this result instead of committing twice.
+///
+/// The response includes the same attribution and events as
+/// [`CommittedChange`], including IDs created by the commit.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CommitResponse {
@@ -25,6 +28,36 @@ pub struct CommitResponse {
     pub commit_id: CommitId,
     /// Sequence number where the commit became visible.
     pub committed_seq: ChangeSeq,
+    /// Actor responsible for the commit, as supplied by the application.
+    pub committed_by: crate::ActorRef,
+    /// Wall-clock stamp of the commit, in Unix milliseconds.
+    /// Observational: `committed_seq` is the order.
+    pub committed_at_ms: u64,
+    /// Caller annotation, omitted when absent and carrying no filesystem
+    /// semantics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub message: Option<String>,
+    /// Semantic filesystem events in commit order. This is omitted only when
+    /// replaying a commit whose WAL history is no longer retained.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub events: Option<Vec<FilesystemChange>>,
+}
+
+impl CommitResponse {
+    /// Builds the response for a commit the change feed reports in full.
+    pub fn from_committed_change(namespace_id: NamespaceId, change: CommittedChange) -> Self {
+        Self {
+            namespace_id,
+            commit_id: change.commit_id,
+            committed_seq: change.committed_seq,
+            committed_by: change.committed_by,
+            committed_at_ms: change.committed_at_ms,
+            message: change.message,
+            events: Some(change.events),
+        }
+    }
 }
 
 /// Directory entry removed by a delete operation.
@@ -251,7 +284,7 @@ pub struct ChangesResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{CommittedChange, FilesystemChange};
+    use super::{CommitResponse, CommittedChange, FilesystemChange};
     use crate::InodeId;
 
     #[test]
@@ -273,6 +306,68 @@ mod tests {
                 "committed_by": { "kind": "system", "id": "loonfs" },
                 "committed_at_ms": 1_752_624_000_000_u64,
                 "events": [],
+            })
+        );
+    }
+
+    #[test]
+    fn a_commit_response_carries_the_committed_change_at_the_top_level() {
+        let response = CommitResponse::from_committed_change(
+            crate::NamespaceId::parse("demo").expect("valid namespace id"),
+            CommittedChange {
+                committed_seq: crate::ChangeSeq(419),
+                commit_id: crate::CommitId::parse("example-commit").expect("valid commit id"),
+                committed_by: crate::ActorRef::loonfs_system(),
+                committed_at_ms: 1_752_624_000_000,
+                message: Some("import the reports".to_owned()),
+                events: vec![FilesystemChange::DirectoryCreated {
+                    inode_id: InodeId(43),
+                    parent_inode_id: InodeId(1),
+                    display_name: crate::DisplayName::parse("docs").expect("valid display name"),
+                }],
+            },
+        );
+
+        assert_eq!(
+            serde_json::to_value(response).expect("serialize commit response"),
+            serde_json::json!({
+                "namespace_id": "demo",
+                "commit_id": "example-commit",
+                "committed_seq": 419,
+                "committed_by": { "kind": "system", "id": "loonfs" },
+                "committed_at_ms": 1_752_624_000_000_u64,
+                "message": "import the reports",
+                "events": [{
+                    "kind": "directory_created",
+                    "inode_id": "ino_43",
+                    "parent_inode_id": "ino_1",
+                    "display_name": "docs",
+                }],
+            })
+        );
+    }
+
+    /// A receipt-only replay has no retained events.
+    #[test]
+    fn a_commit_response_omits_absent_events_and_message() {
+        let response = CommitResponse {
+            namespace_id: crate::NamespaceId::parse("demo").expect("valid namespace id"),
+            commit_id: crate::CommitId::parse("example-commit").expect("valid commit id"),
+            committed_seq: crate::ChangeSeq(419),
+            committed_by: crate::ActorRef::loonfs_system(),
+            committed_at_ms: 1_752_624_000_000,
+            message: None,
+            events: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("serialize commit response"),
+            serde_json::json!({
+                "namespace_id": "demo",
+                "commit_id": "example-commit",
+                "committed_seq": 419,
+                "committed_by": { "kind": "system", "id": "loonfs" },
+                "committed_at_ms": 1_752_624_000_000_u64,
             })
         );
     }

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -702,6 +702,10 @@ mod tests {
             namespace_id: namespace_id.clone(),
             commit_id: commit_id.clone(),
             committed_seq: ChangeSeq(1),
+            committed_by: loonfs_test_support::test_actor(),
+            committed_at_ms: 1_752_624_000_000,
+            message: None,
+            events: Some(Vec::new()),
         };
         let transport = crate::transport::test_transport::failure_then_success(
             serde_json::to_vec(&response).expect("serialize response"),

--- a/crates/loonfs-client/src/uploads/staging/tests.rs
+++ b/crates/loonfs-client/src/uploads/staging/tests.rs
@@ -287,6 +287,10 @@ fn commit_landed() -> Outcome {
         namespace_id: namespace_id(),
         commit_id: CommitId::parse("c_00000000000000000000000000000001").expect("valid commit id"),
         committed_seq: ChangeSeq(1),
+        committed_by: loonfs_test_support::test_actor(),
+        committed_at_ms: 1_752_624_000_000,
+        message: None,
+        events: Some(Vec::new()),
     })
 }
 

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -51,6 +51,11 @@ pub(crate) struct VerifiedMetadataTables<'a, S: ObjectStore + ?Sized> {
 }
 
 impl<'a, S: ObjectStore + ?Sized> VerifiedMetadataTables<'a, S> {
+    /// Returns the store the tables were loaded from.
+    pub(crate) fn store(&self) -> &'a S {
+        self.store
+    }
+
     /// Wraps a manifest that was synthesized rather than loaded: the
     /// genesis basis of a namespace that has published none. It names no
     /// metadata files, so no scan it backs ever reaches the store, and its

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -5,6 +5,7 @@
 use super::candidates::{
     prepare_candidate_request, validate_commit_content_references, BatchDedup, CandidateAdmission,
 };
+use super::changes::committed_change_from_wal_record;
 use super::publish_view::PublishMetadataView;
 use crate::commit::{
     materialize_commit, prepare_commit_head_publish, publish_commit_head,
@@ -230,16 +231,12 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     };
 
     let wal_records = wal.envelope.payload.records.clone();
-    for (accepted_index, (outcome_index, record)) in accepted_indexes
-        .into_iter()
-        .zip(accepted_commits)
-        .enumerate()
-    {
-        outcomes[outcome_index] = Some(Ok(ApiCommitResponse {
-            namespace_id: namespace_id.clone(),
-            commit_id: record.commit.commit_id,
-            committed_seq: wal_records[accepted_index].seq,
-        }));
+    // Build responses from the WAL records already in memory.
+    for (outcome_index, record) in accepted_indexes.into_iter().zip(&wal_records) {
+        outcomes[outcome_index] =
+            Some(committed_change_from_wal_record(record).map(|change| {
+                ApiCommitResponse::from_committed_change(namespace_id.clone(), change)
+            }));
     }
     PublishBatchAgainstViewResult {
         results: dedup.finish(outcomes),

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -205,22 +205,52 @@ async fn resolve_commit_id_reuse<S: ObjectStore + ?Sized>(
                     committed_fingerprint: Some(existing.semantic_commit_fingerprint.clone()),
                 })
             } else {
-                Ok(commit_response_from_commit_receipt(namespace_id, &existing))
+                commit_response_from_commit_receipt(namespace_id, view, &existing).await
             },
         )));
     }
     Ok(dedup.admit(index, commit_id, semantic_identity))
 }
 
-fn commit_response_from_commit_receipt(
+/// Builds a replay response from the commit receipt and retained WAL record.
+/// A recent replay usually reads one WAL segment. If the WAL record has been
+/// retired but the receipt remains, the response omits `events`.
+async fn commit_response_from_commit_receipt<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
+    view: &PublishMetadataView<'_, S>,
     record: &CommitReceiptRecord,
-) -> ApiCommitResponse {
-    ApiCommitResponse {
-        namespace_id: namespace_id.clone(),
-        commit_id: record.commit_id.clone(),
-        committed_seq: record.committed_seq,
+) -> Result<ApiCommitResponse> {
+    let change = match view.find_committed_change_at(record.committed_seq).await {
+        Ok(Some(change)) => change,
+        Ok(None) => {
+            return Err(CoreError::Internal(format!(
+            "commit receipt for `{}` names sequence `{}`, where the change feed reports no commit",
+            record.commit_id, record.committed_seq
+        )))
+        }
+        Err(CoreError::RebootstrapRequired { .. }) => {
+            return Ok(ApiCommitResponse {
+                namespace_id: namespace_id.clone(),
+                commit_id: record.commit_id.clone(),
+                committed_seq: record.committed_seq,
+                committed_by: record.actor.clone(),
+                committed_at_ms: record.committed_at_ms,
+                message: record.message.clone(),
+                events: None,
+            })
+        }
+        Err(error) => return Err(error),
+    };
+    if change.commit_id != record.commit_id {
+        return Err(CoreError::Internal(format!(
+            "commit receipt for `{}` names sequence `{}`, where the change feed reports commit `{}`",
+            record.commit_id, record.committed_seq, change.commit_id
+        )));
     }
+    Ok(ApiCommitResponse::from_committed_change(
+        namespace_id.clone(),
+        change,
+    ))
 }
 
 struct CommitContentAdmissions<'a> {

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -7,9 +7,10 @@ use crate::namespace::control::load_namespace_head_control;
 use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
 use loonfs_api::v0::{ChangesResponse, CommittedChange, FilesystemChange};
 use loonfs_api::wire::control::NamespaceState;
-use loonfs_api::wire::wal::{WalCommitDelta, WalDelta};
+use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalDelta};
 use loonfs_api::{ChangeSeq, EffectiveLimit, NamespaceId};
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroU32;
 
 pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     store: &S,
@@ -72,14 +73,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
         for record in segment.records() {
             if record.seq > after_seq {
                 let committed_seq = record.seq;
-                changes.push(CommittedChange {
-                    committed_seq,
-                    commit_id: record.commit_id.clone(),
-                    committed_by: record.actor.clone(),
-                    committed_at_ms: record.committed_at_ms,
-                    message: record.message.clone(),
-                    events: events_from_wal_deltas(&record.deltas)?,
-                });
+                changes.push(committed_change_from_wal_record(record)?);
                 if changes.len() == limit.as_usize() {
                     through_seq = committed_seq;
                     if committed_seq < head.seq {
@@ -97,6 +91,41 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
         through_seq,
         next_after_seq,
         changes,
+    })
+}
+
+/// Reads the committed change at `committed_seq` through the normal change
+/// feed path. Returns `None` when no commit exists at that sequence and
+/// `RebootstrapRequired` when its WAL history is no longer retained.
+pub(super) async fn find_committed_change_at<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    committed_seq: ChangeSeq,
+) -> Result<Option<CommittedChange>> {
+    let page = list_changes_after(
+        store,
+        namespace_id,
+        ChangeSeq(committed_seq.0.saturating_sub(1)),
+        EffectiveLimit::new(NonZeroU32::MIN),
+    )
+    .await?;
+    Ok(page
+        .changes
+        .into_iter()
+        .find(|change| change.committed_seq == committed_seq))
+}
+
+/// Converts one WAL commit record into the shared API change shape.
+pub(super) fn committed_change_from_wal_record(
+    record: &WalCommitPayload,
+) -> Result<CommittedChange> {
+    Ok(CommittedChange {
+        committed_seq: record.seq,
+        commit_id: record.commit_id.clone(),
+        committed_by: record.actor.clone(),
+        committed_at_ms: record.committed_at_ms,
+        message: record.message.clone(),
+        events: events_from_wal_deltas(&record.deltas)?,
     })
 }
 

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -14,6 +14,7 @@ use crate::namespace::basis::{load_head_and_metadata_basis, MetadataBasis, Metad
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::control::load_head_object;
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
+use loonfs_api::v0::CommittedChange;
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState};
 use loonfs_api::{ChangeSeq, CommitId, ContentStoreId, NamespaceId};
 use loonfs_objectstore::keys::wal_head;
@@ -42,6 +43,19 @@ impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
         commit_id: &CommitId,
     ) -> Result<Option<CommitReceiptRecord>> {
         self.metadata_view().find_commit_receipt(commit_id).await
+    }
+
+    /// Reads the retained change for a commit receipt.
+    pub(super) async fn find_committed_change_at(
+        &self,
+        committed_seq: ChangeSeq,
+    ) -> Result<Option<CommittedChange>> {
+        super::changes::find_committed_change_at(
+            self.manifest_tables.store(),
+            &self.head.namespace_id,
+            committed_seq,
+        )
+        .await
     }
 }
 

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -1311,6 +1311,12 @@ async fn checkpoint_receipt_keeps_actor_identity_after_the_commit_wal_is_compact
     create_checkpoint(&store, &namespace_id, &first_context)
         .await
         .expect("compact commit into receipt row");
+    // Retire the commit's history, which is what leaves the receipt as the
+    // only record of it.
+    namespace_engine(&store, &namespace_id, &first_context)
+        .advance_retention_floor()
+        .await
+        .expect("advance retention floor past the commit");
 
     // Corrupt the original WAL so the checks below can only use the commit
     // receipt stored in the checkpoint.
@@ -1339,7 +1345,18 @@ async fn checkpoint_receipt_keeps_actor_identity_after_the_commit_wal_is_compact
     )
     .await
     .expect("same actor and request replay from receipt");
-    assert_eq!(replay, first, "committed_at_ms is outside identity");
+    assert_eq!(replay.committed_seq, first.committed_seq);
+    assert_eq!(replay.commit_id, first.commit_id);
+    assert_eq!(replay.committed_by, first.committed_by);
+    assert_eq!(
+        replay.committed_at_ms, first.committed_at_ms,
+        "committed_at_ms is outside identity"
+    );
+    assert_eq!(replay.message, first.message);
+    // The retired commit's events are gone with its history, so the receipt
+    // answers without them.
+    assert_eq!(replay.events, None);
+    assert!(first.events.is_some());
 
     for conflicting_actor in [
         ActorRef::user(ActorId::parse("different-id").expect("actor id")),

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -8,9 +8,12 @@ use crate::common::http_split_support::*;
 use crate::common::start_server;
 use loonfs::publish::CommitRequest as CoreCommitRequest;
 use loonfs::{CreateNamespaceOptions, FsWriter, ListChangesOptions, StoreConfig};
+use loonfs_api::v0::{CreateCheckpointRequest, MaintenanceStepRequest};
 use loonfs_api::{
-    v0::CommittedChange, AbsolutePath, ApiError, ChangeSeq, CommitId, CommitRequest, ContentRef,
+    v0::{CommittedChange, FilesystemChange},
+    AbsolutePath, ApiError, ChangeSeq, CommitId, CommitRequest, ContentRef,
     DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, FilesystemOperation, RevisionNo,
+    ROOT_INODE_ID,
 };
 use loonfs_client::{ClientError, NamespacePath};
 use loonfs_test_support::ids::namespace_id;
@@ -18,6 +21,7 @@ use tempfile::tempdir;
 
 const REPORTS_DIR: &str = "/reports";
 const FIRST_FILE: &str = "/reports/january.txt";
+const ROOT_FILE: &str = "/january.txt";
 const SECOND_FILE: &str = "/reports/february.txt";
 const FIRST_BYTES: &[u8] = b"january numbers";
 const SECOND_BYTES: &[u8] = b"february numbers";
@@ -207,6 +211,208 @@ async fn a_batch_commits_once_and_matches_the_same_batch_embedded() {
         .shutdown()
         .await
         .expect("settle embedded background work");
+    harness.server.abort();
+}
+
+/// A commit answers with the change it committed, so a caller reads the
+/// inode id its put created out of the response instead of stating the path
+/// afterward. A replay of the same request answers with that same row.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_commit_returns_the_change_it_committed_and_replays_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-commit-row",
+        "http-commit-row",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let staged = stage_uploaded_content(&harness.client, &namespace, FIRST_BYTES).await;
+    let request = || CommitRequest {
+        commit_id: commit_id("returns-its-change"),
+        actor: loonfs_test_support::test_actor(),
+        message: Some("the first report".to_owned()),
+        content_tokens: vec![content_token(&staged)],
+        operations: vec![FilesystemOperation::PutFile {
+            path: absolute(ROOT_FILE),
+            content_ref: staged.content_ref.clone(),
+            behavior: DestinationBehavior::NoReplace,
+            expected_revision_no: None,
+        }],
+    };
+
+    let committed = harness
+        .client
+        .commit(&namespace, &request())
+        .await
+        .expect("the put commits");
+    assert_eq!(committed.committed_by, loonfs_test_support::test_actor());
+    assert_eq!(committed.message.as_deref(), Some("the first report"));
+    let events = committed
+        .events
+        .clone()
+        .expect("a fresh commit reports its events");
+    let created_inode_id = match events.as_slice() {
+        [FilesystemChange::FileCreated {
+            inode_id,
+            parent_inode_id,
+            display_name,
+            revision_no,
+            content_ref,
+        }] => {
+            assert_eq!(*parent_inode_id, ROOT_INODE_ID);
+            assert_eq!(display_name.as_str(), "january.txt");
+            assert_eq!(*revision_no, RevisionNo(1));
+            assert_eq!(*content_ref, staged.content_ref);
+            *inode_id
+        }
+        other => panic!("expected one file_created event, got {other:?}"),
+    };
+
+    // The id the response reported is the file's own.
+    let spec = NamespacePath::parse("demo", ROOT_FILE).expect("path");
+    let entry = harness
+        .client
+        .stat_path(&spec, &Default::default())
+        .await
+        .expect("stat the new file");
+    assert_eq!(entry.inode_id, created_inode_id);
+
+    // The response is the feed's row for that commit, field for field.
+    let feed = harness
+        .client
+        .list_changes(&namespace, ChangeSeq(0), None)
+        .await
+        .expect("changes");
+    assert_eq!(feed.changes.len(), 1, "{feed:?}");
+    let row = &feed.changes[0];
+    assert_eq!(row.committed_seq, committed.committed_seq);
+    assert_eq!(row.commit_id, committed.commit_id);
+    assert_eq!(row.committed_by, committed.committed_by);
+    assert_eq!(row.committed_at_ms, committed.committed_at_ms);
+    assert_eq!(row.message, committed.message);
+    assert_eq!(row.events, events);
+
+    // The replay answers with the same row, events included, and commits
+    // nothing new.
+    let replayed = harness
+        .client
+        .commit(&namespace, &request())
+        .await
+        .expect("an identical resubmission replays");
+    assert_eq!(replayed, committed);
+    assert_eq!(
+        harness
+            .client
+            .get_namespace(&namespace)
+            .await
+            .expect("status")
+            .head_seq,
+        committed.committed_seq,
+        "the replay committed nothing new"
+    );
+
+    harness.server.abort();
+}
+
+/// Retirement is the one case where a replay cannot report events. Once the
+/// retention floor passes a commit, the record holding its events is no
+/// longer readable while the commit receipt still is, so the replay answers
+/// from the receipt and omits `events`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_replay_below_the_retention_floor_omits_its_events() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-retired-row",
+        "http-retired-row",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let staged = stage_uploaded_content(&harness.client, &namespace, FIRST_BYTES).await;
+    // Resubmitting the same `content_ref` is what makes the retry
+    // semantically identical, so the server replays rather than conflicts.
+    let request = || CommitRequest {
+        commit_id: commit_id("outlives-its-history"),
+        actor: loonfs_test_support::test_actor(),
+        message: Some("retired later".to_owned()),
+        content_tokens: vec![content_token(&staged)],
+        operations: vec![FilesystemOperation::PutFile {
+            path: absolute(ROOT_FILE),
+            content_ref: staged.content_ref.clone(),
+            behavior: DestinationBehavior::NoReplace,
+            expected_revision_no: None,
+        }],
+    };
+
+    let committed = harness
+        .client
+        .commit(&namespace, &request())
+        .await
+        .expect("the put commits");
+    assert!(
+        committed.events.is_some(),
+        "the fresh commit reports its events"
+    );
+
+    // Pin the head, then give up incremental replay below it.
+    harness
+        .client
+        .create_checkpoint(
+            &namespace,
+            &CreateCheckpointRequest {
+                name: "retired".to_owned(),
+                ttl_ms: None,
+            },
+        )
+        .await
+        .expect("create checkpoint");
+    let advanced = harness
+        .client
+        .maintenance_step(
+            &namespace,
+            &MaintenanceStepRequest {
+                advance_retention: true,
+                ..MaintenanceStepRequest::default()
+            },
+        )
+        .await
+        .expect("advance retention floor")
+        .retention
+        .expect("a step selecting the retention advance reports it");
+    assert!(
+        advanced.retention_floor_seq >= committed.committed_seq,
+        "the floor must cover the commit for this to test anything: floor {:?}, commit {:?}",
+        advanced.retention_floor_seq,
+        committed.committed_seq
+    );
+
+    let replayed = harness
+        .client
+        .commit(&namespace, &request())
+        .await
+        .expect("an identical resubmission still replays");
+    assert_eq!(replayed.committed_seq, committed.committed_seq);
+    assert_eq!(replayed.commit_id, committed.commit_id);
+    // The receipt keeps the commit's own attribution and annotation; only
+    // the events are gone.
+    assert_eq!(replayed.committed_by, committed.committed_by);
+    assert_eq!(replayed.committed_at_ms, committed.committed_at_ms);
+    assert_eq!(replayed.message, committed.message);
+    assert_eq!(replayed.events, None);
+
     harness.server.abort();
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -502,6 +502,10 @@ became visible. When the caller did not supply a commit id, the surface that
 accepted the request generates one and returns it, so every caller holds the
 identity it needs to reconcile an uncertain outcome.
 
+The response also includes `committed_by`, `committed_at_ms`, the optional `message`, and `events`. These match the change feed, so the caller immediately receives values such as newly created inode IDs.
+
+A replay reads these fields from the retained WAL record. If that record has been retired but its commit receipt has not yet been removed, the response omits `events`. The receipt still supplies the commit ID, sequence, actor, timestamp, and message.
+
 The retry rule has three cases:
 
 - Resubmitting the semantically identical commit with the same `commit_id`
@@ -1765,7 +1769,20 @@ Representative response:
 {
   "namespace_id": "demo",
   "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
-  "committed_seq": 419
+  "committed_seq": 419,
+  "committed_by": { "kind": "user", "id": "usr_8f3c" },
+  "committed_at_ms": 1752624000000,
+  "message": "import the January report",
+  "events": [
+    {
+      "kind": "file_created",
+      "inode_id": "ino_43",
+      "parent_inode_id": "ino_12",
+      "display_name": "january.pdf",
+      "revision_no": 1,
+      "content_ref": { "kind": "blob_v1", "content_id": "con_9f2a...", "size_bytes": 1234, "checksum": { "algorithm": "sha256", "value": "..." } }
+    }
+  ]
 }
 ```
 

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -2221,20 +2221,43 @@
       },
       "CommitResponse": {
         "type": "object",
-        "description": "Result of one commit.\n\nEvery commit resolves to this envelope — path-oriented operations and\nexplicit commits, embedded or remote. The commit id is the caller's\nreconciliation handle: resubmitting the same request with the same id\nreplays this result instead of committing twice.",
+        "description": "Result of one commit.\n\nEvery commit resolves to this envelope — path-oriented operations and\nexplicit commits, embedded or remote. The commit id is the caller's\nreconciliation handle: resubmitting the same request with the same id\nreplays this result instead of committing twice.\n\nThe response includes the same attribution and events as\n[`CommittedChange`], including IDs created by the commit.",
         "required": [
           "namespace_id",
           "commit_id",
-          "committed_seq"
+          "committed_seq",
+          "committed_by",
+          "committed_at_ms"
         ],
         "properties": {
           "commit_id": {
             "$ref": "#/components/schemas/CommitId",
             "description": "Idempotency key the commit landed under: caller-supplied, or\ngenerated on the caller's behalf when the request carried none."
           },
+          "committed_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Wall-clock stamp of the commit, in Unix milliseconds.\nObservational: `committed_seq` is the order.",
+            "minimum": 0
+          },
+          "committed_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the commit, as supplied by the application."
+          },
           "committed_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Sequence number where the commit became visible."
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilesystemChange"
+            },
+            "description": "Semantic filesystem events in commit order. This is omitted only when\nreplaying a commit whose WAL history is no longer retained."
+          },
+          "message": {
+            "type": "string",
+            "description": "Caller annotation, omitted when absent and carrying no filesystem\nsemantics."
           },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4115,20 +4115,43 @@
       },
       "CommitResponse": {
         "type": "object",
-        "description": "Result of one commit.\n\nEvery commit resolves to this envelope — path-oriented operations and\nexplicit commits, embedded or remote. The commit id is the caller's\nreconciliation handle: resubmitting the same request with the same id\nreplays this result instead of committing twice.",
+        "description": "Result of one commit.\n\nEvery commit resolves to this envelope — path-oriented operations and\nexplicit commits, embedded or remote. The commit id is the caller's\nreconciliation handle: resubmitting the same request with the same id\nreplays this result instead of committing twice.\n\nThe response includes the same attribution and events as\n[`CommittedChange`], including IDs created by the commit.",
         "required": [
           "namespace_id",
           "commit_id",
-          "committed_seq"
+          "committed_seq",
+          "committed_by",
+          "committed_at_ms"
         ],
         "properties": {
           "commit_id": {
             "$ref": "#/components/schemas/CommitId",
             "description": "Idempotency key the commit landed under: caller-supplied, or\ngenerated on the caller's behalf when the request carried none."
           },
+          "committed_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Wall-clock stamp of the commit, in Unix milliseconds.\nObservational: `committed_seq` is the order.",
+            "minimum": 0
+          },
+          "committed_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the commit, as supplied by the application."
+          },
           "committed_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Sequence number where the commit became visible."
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilesystemChange"
+            },
+            "description": "Semantic filesystem events in commit order. This is omitted only when\nreplaying a commit whose WAL history is no longer retained."
+          },
+          "message": {
+            "type": "string",
+            "description": "Caller annotation, omitted when absent and carrying no filesystem\nsemantics."
           },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",


### PR DESCRIPTION
Adds commit attribution and filesystem events to commit responses. Callers receive `committed_by`, `committed_at_ms`, the optional message, and the same events exposed by the change feed, including newly allocated inode IDs.

Fresh commits build the response from the WAL record already in memory. Replayed commits read the retained WAL record; if that history has already been retired but the receipt remains, the response omits `events`.