### PR TITLE
fix(openapi): render the three flattened union responses as top-level discriminated unions

### DIFF
--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -100,6 +100,20 @@ pub(crate) enum OpenapiPostprocessError {
     InvalidPaginationOperation { method: &'static str, path: String },
     #[error("OpenAPI union variant `{schema_name}` conflicts with an existing component schema")]
     UnionVariantSchemaCollision { schema_name: String },
+    #[error("OpenAPI composite `{schema_name}` combines two discriminated unions")]
+    UnionCompositeHasTwoUnions { schema_name: String },
+    #[error("OpenAPI composite `{schema_name}` defines property `{property}` twice")]
+    UnionCompositeDuplicateProperty {
+        schema_name: String,
+        property: String,
+    },
+    #[error(
+        "OpenAPI union `{union_name}` is flattened into `{schema_name}` and referenced elsewhere"
+    )]
+    SharedUnionComposite {
+        schema_name: String,
+        union_name: String,
+    },
     #[error("proxy operation `{operation_id}` does not appear in the full OpenAPI document")]
     MissingProxyOperation { operation_id: String },
     #[error(
@@ -165,6 +179,13 @@ impl Value {
         }
     }
 
+    fn as_array_mut(&mut self) -> Option<&mut Vec<Self>> {
+        match self {
+            Self::Array(values) => Some(values),
+            _ => None,
+        }
+    }
+
     fn as_object(&self) -> Option<&Map> {
         match self {
             Self::Object(object) => Some(object),
@@ -197,6 +218,7 @@ pub(crate) fn openapi_json_pretty(
     drop_null_from_response_schemas(&mut document);
     add_union_discriminators(&mut document, &mut Vec::new());
     extract_union_variants(&mut document)?;
+    merge_union_composites(&mut document)?;
     add_operation_retry_classes(&mut document)?;
     add_pagination_metadata(&mut document)?;
     Ok(serde_json::to_string_pretty(&document)?)
@@ -826,6 +848,279 @@ fn register_extracted_schema(
     Ok(())
 }
 
+/// Planned rewrite for an `allOf` that contains a discriminated union.
+struct UnionComposite {
+    composite_name: String,
+    union_name: String,
+    /// Variant references for the replacement `oneOf`.
+    one_of: Vec<Value>,
+    /// Component names for the variants that receive envelope fields.
+    variant_names: Vec<String>,
+    discriminator: Value,
+    envelope: UnionEnvelope,
+    /// Components that may be removed after the rewrite.
+    merged_names: Vec<String>,
+}
+
+/// Non-union fields from an `allOf` composite.
+#[derive(Default)]
+struct UnionEnvelope {
+    properties: Map,
+    required: Vec<String>,
+}
+
+impl UnionEnvelope {
+    /// Adds one composite member's fields in document order.
+    fn extend(
+        &mut self,
+        composite_name: &str,
+        member: &Value,
+    ) -> Result<(), OpenapiPostprocessError> {
+        if let Some(properties) = member.get("properties").and_then(Value::as_object) {
+            for (name, schema) in properties {
+                insert_new_property(composite_name, &mut self.properties, name, schema.clone())?;
+            }
+        }
+        for name in required_names(member) {
+            if !self.required.contains(&name) {
+                self.required.push(name);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Rewrites `allOf: [union, envelope]` as a top-level discriminated `oneOf`.
+/// Each variant receives the envelope fields. This preserves the wire schema
+/// while avoiding generator bugs that discard either half of `allOf`.
+fn merge_union_composites(document: &mut Value) -> Result<(), OpenapiPostprocessError> {
+    let schemas = document
+        .get("components")
+        .and_then(|components| components.get("schemas"))
+        .and_then(Value::as_object)
+        .expect("OpenAPI document has no component schemas object");
+    let mut composites = Vec::new();
+
+    for (composite_name, composite) in schemas {
+        if let Some(composite) = plan_union_composite(schemas, composite_name, composite)? {
+            composites.push(composite);
+        }
+    }
+    if composites.is_empty() {
+        return Ok(());
+    }
+    reject_shared_unions(document, &composites)?;
+
+    let mut merged_names = BTreeSet::new();
+    let schemas = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("components"))
+        .and_then(Value::as_object_mut)
+        .and_then(|components| components.get_mut("schemas"))
+        .and_then(Value::as_object_mut)
+        .expect("OpenAPI document has no component schemas object");
+
+    for composite in composites {
+        for variant_name in &composite.variant_names {
+            let variant = schemas
+                .get_mut(variant_name)
+                .expect("OpenAPI union variant component is missing");
+            merge_envelope(&composite.composite_name, variant, &composite.envelope)?;
+        }
+
+        let schema = schemas
+            .get_mut(&composite.composite_name)
+            .and_then(Value::as_object_mut)
+            .expect("OpenAPI composite component is not an object");
+        for field in ["allOf", "properties", "required", "type"] {
+            schema.shift_remove(field);
+        }
+        schema.insert("oneOf".to_owned(), Value::Array(composite.one_of));
+        schema.insert("discriminator".to_owned(), composite.discriminator);
+        merged_names.extend(composite.merged_names);
+    }
+
+    remove_unreferenced_components(document, &merged_names);
+    Ok(())
+}
+
+/// Plans a union-composite rewrite, or returns `None` for other schemas.
+fn plan_union_composite(
+    schemas: &Map,
+    composite_name: &str,
+    composite: &Value,
+) -> Result<Option<UnionComposite>, OpenapiPostprocessError> {
+    let Some(members) = composite.get("allOf").and_then(Value::as_array) else {
+        return Ok(None);
+    };
+    let mut union = None;
+    let mut envelope = UnionEnvelope::default();
+    let mut merged_names = Vec::new();
+
+    for member in members {
+        let referenced = member
+            .get("$ref")
+            .and_then(Value::as_str)
+            .and_then(component_schema_name)
+            .and_then(|name| Some((schemas.get(&name)?, name)));
+        match referenced {
+            Some((schema, name)) if is_discriminated_union(schema) => {
+                if union.is_some() {
+                    return Err(OpenapiPostprocessError::UnionCompositeHasTwoUnions {
+                        schema_name: composite_name.to_owned(),
+                    });
+                }
+                merged_names.push(name.clone());
+                union = Some((schema, name));
+            }
+            Some((schema, name)) => {
+                merged_names.push(name);
+                envelope.extend(composite_name, schema)?;
+            }
+            None => envelope.extend(composite_name, member)?,
+        }
+    }
+
+    let Some((union, union_name)) = union else {
+        return Ok(None);
+    };
+    let one_of = union
+        .get("oneOf")
+        .and_then(Value::as_array)
+        .expect("discriminated union has a oneOf array")
+        .clone();
+    let variant_names = one_of
+        .iter()
+        .map(|variant| {
+            variant
+                .get("$ref")
+                .and_then(Value::as_str)
+                .and_then(component_schema_name)
+                .expect("extracted union variant references a component schema")
+        })
+        .collect();
+
+    Ok(Some(UnionComposite {
+        composite_name: composite_name.to_owned(),
+        union_name,
+        one_of,
+        variant_names,
+        discriminator: union
+            .get("discriminator")
+            .expect("discriminated union has a discriminator")
+            .clone(),
+        envelope,
+        merged_names,
+    }))
+}
+
+/// Returns whether a schema is a discriminated `oneOf`.
+fn is_discriminated_union(schema: &Value) -> bool {
+    schema.get("oneOf").and_then(Value::as_array).is_some() && schema.get("discriminator").is_some()
+}
+
+/// Adds the envelope fields to one union variant.
+fn merge_envelope(
+    composite_name: &str,
+    variant: &mut Value,
+    envelope: &UnionEnvelope,
+) -> Result<(), OpenapiPostprocessError> {
+    let variant = variant
+        .as_object_mut()
+        .expect("OpenAPI union variant is not an object");
+    let properties = variant
+        .entry("properties".to_owned())
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .expect("OpenAPI union variant properties is not an object");
+    for (name, schema) in &envelope.properties {
+        insert_new_property(composite_name, properties, name, schema.clone())?;
+    }
+
+    let required = variant
+        .entry("required".to_owned())
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .expect("OpenAPI union variant required is not an array");
+    for name in &envelope.required {
+        if !required.iter().any(|value| value.as_str() == Some(name)) {
+            required.push(Value::String(name.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn insert_new_property(
+    composite_name: &str,
+    properties: &mut Map,
+    name: &str,
+    schema: Value,
+) -> Result<(), OpenapiPostprocessError> {
+    if properties.contains_key(name) {
+        return Err(OpenapiPostprocessError::UnionCompositeDuplicateProperty {
+            schema_name: composite_name.to_owned(),
+            property: name.to_owned(),
+        });
+    }
+    properties.insert(name.to_owned(), schema);
+    Ok(())
+}
+
+/// Rejects a union referenced outside the composite being rewritten. Reusing
+/// its modified variants elsewhere would add fields that are not present there.
+fn reject_shared_unions(
+    document: &Value,
+    composites: &[UnionComposite],
+) -> Result<(), OpenapiPostprocessError> {
+    let mut references = Vec::new();
+    collect_component_references(document, &mut references);
+
+    for composite in composites {
+        let reference = component_schema_reference(&composite.union_name);
+        let readers = references
+            .iter()
+            .filter(|candidate| **candidate == reference)
+            .count();
+        if readers > 1 {
+            return Err(OpenapiPostprocessError::SharedUnionComposite {
+                schema_name: composite.composite_name.clone(),
+                union_name: composite.union_name.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Removes merged components that are no longer referenced.
+fn remove_unreferenced_components(document: &mut Value, merged_names: &BTreeSet<String>) {
+    let mut references = Vec::new();
+    collect_component_references(document, &mut references);
+    let referenced = references.into_iter().collect::<BTreeSet<_>>();
+
+    let schemas = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("components"))
+        .and_then(Value::as_object_mut)
+        .and_then(|components| components.get_mut("schemas"))
+        .and_then(Value::as_object_mut)
+        .expect("OpenAPI document has no component schemas object");
+    schemas.retain(|name, _| {
+        !merged_names.contains(name) || referenced.contains(&component_schema_reference(name))
+    });
+}
+
+/// Returns a schema's required property names in document order.
+fn required_names(schema: &Value) -> Vec<String> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect()
+}
+
 fn fixed_discriminator_value(variant: &Value, property_name: &str) -> Option<String> {
     fixed_required_properties(variant)?
         .into_iter()
@@ -833,9 +1128,13 @@ fn fixed_discriminator_value(variant: &Value, property_name: &str) -> Option<Str
 }
 
 fn component_schema_for_reference<'a>(schemas: &'a Map, reference: &str) -> Option<&'a Value> {
-    let encoded_name = reference.strip_prefix("#/components/schemas/")?;
-    let schema_name = decode_json_pointer_segment(encoded_name);
-    schemas.get(&schema_name)
+    schemas.get(&component_schema_name(reference)?)
+}
+
+fn component_schema_name(reference: &str) -> Option<String> {
+    reference
+        .strip_prefix("#/components/schemas/")
+        .map(decode_json_pointer_segment)
 }
 
 fn component_schema_reference(schema_name: &str) -> String {
@@ -1356,6 +1655,243 @@ mod tests {
             unordered(&document).pointer("/components/schemas/Choice/oneOf/0/$ref"),
             Some(&serde_json::json!("#/components/schemas/ChoiceFirst"))
         );
+    }
+
+    /// Extracts union variants and then rewrites their composites.
+    fn extract_and_merge(document: &mut Value) -> Result<(), OpenapiPostprocessError> {
+        add_union_discriminators(document, &mut Vec::new());
+        extract_union_variants(document).expect("extract union variants");
+        merge_union_composites(document)
+    }
+
+    #[test]
+    fn merges_an_inline_envelope_into_every_union_variant() {
+        let mut document = ordered(serde_json::json!({
+            "components": {
+                "schemas": {
+                    "Session": {
+                        "allOf": [
+                            {"$ref": "#/components/schemas/SessionStatus"},
+                            {
+                                "type": "object",
+                                "required": ["upload_id"],
+                                "properties": {"upload_id": {"type": "string"}}
+                            }
+                        ],
+                        "description": "One upload session."
+                    },
+                    "SessionStatus": {
+                        "oneOf": [
+                            {
+                                "title": "SessionStatusOpen",
+                                "required": ["status"],
+                                "properties": {"status": {"const": "open"}}
+                            },
+                            {
+                                "title": "SessionStatusDone",
+                                "required": ["status"],
+                                "properties": {"status": {"const": "done"}}
+                            }
+                        ]
+                    }
+                }
+            }
+        }));
+
+        extract_and_merge(&mut document).expect("merge union composites");
+        let actual = unordered(&document);
+        assert_eq!(
+            actual.pointer("/components/schemas/Session"),
+            Some(&serde_json::json!({
+                "description": "One upload session.",
+                "oneOf": [
+                    {"$ref": "#/components/schemas/SessionStatusOpen"},
+                    {"$ref": "#/components/schemas/SessionStatusDone"}
+                ],
+                "discriminator": {
+                    "propertyName": "status",
+                    "mapping": {
+                        "open": "#/components/schemas/SessionStatusOpen",
+                        "done": "#/components/schemas/SessionStatusDone"
+                    }
+                }
+            }))
+        );
+        assert_eq!(
+            actual.pointer("/components/schemas/SessionStatusOpen"),
+            Some(&serde_json::json!({
+                "required": ["status", "upload_id"],
+                "properties": {
+                    "status": {"const": "open"},
+                    "upload_id": {"type": "string"}
+                }
+            }))
+        );
+        assert_eq!(
+            actual.pointer("/components/schemas/SessionStatusDone/properties/upload_id"),
+            Some(&serde_json::json!({"type": "string"}))
+        );
+        assert_eq!(
+            actual.pointer("/components/schemas/SessionStatus"),
+            None,
+            "the union component is unreferenced after the composite is rewritten"
+        );
+    }
+
+    #[test]
+    fn merges_a_referenced_envelope_and_drops_its_component() {
+        let mut document = ordered(serde_json::json!({
+            "components": {
+                "schemas": {
+                    // The union does not have to come first.
+                    "Entry": {
+                        "allOf": [
+                            {"$ref": "#/components/schemas/EntryAttributes"},
+                            {"$ref": "#/components/schemas/EntryKind"},
+                            {
+                                "type": "object",
+                                "required": ["path"],
+                                "properties": {"path": {"type": "string"}}
+                            }
+                        ]
+                    },
+                    "EntryKind": {
+                        "oneOf": [{
+                            "title": "EntryDirectory",
+                            "required": ["inode_kind"],
+                            "properties": {"inode_kind": {"const": "dir"}}
+                        }]
+                    },
+                    "EntryAttributes": {
+                        "type": "object",
+                        "properties": {"attributes": {"type": "string"}}
+                    }
+                }
+            }
+        }));
+
+        extract_and_merge(&mut document).expect("merge union composites");
+        let actual = unordered(&document);
+        assert_eq!(
+            actual.pointer("/components/schemas/EntryDirectory"),
+            Some(&serde_json::json!({
+                "required": ["inode_kind", "path"],
+                "properties": {
+                    "inode_kind": {"const": "dir"},
+                    "attributes": {"type": "string"},
+                    "path": {"type": "string"}
+                }
+            }))
+        );
+        assert_eq!(actual.pointer("/components/schemas/EntryKind"), None);
+        assert_eq!(actual.pointer("/components/schemas/EntryAttributes"), None);
+    }
+
+    #[test]
+    fn leaves_a_composite_without_a_union_unchanged() {
+        let mut document = ordered(serde_json::json!({
+            "components": {
+                "schemas": {
+                    "CreateCheckpointResponse": {
+                        "allOf": [
+                            {"$ref": "#/components/schemas/Checkpoint"},
+                            {
+                                "type": "object",
+                                "required": ["namespace_id"],
+                                "properties": {"namespace_id": {"type": "string"}}
+                            }
+                        ]
+                    },
+                    "Checkpoint": {
+                        "type": "object",
+                        "required": ["checkpoint_id"],
+                        "properties": {"checkpoint_id": {"type": "string"}}
+                    }
+                }
+            }
+        }));
+        let before = document.clone();
+
+        merge_union_composites(&mut document).expect("leave the composite alone");
+        assert_eq!(document, before);
+    }
+
+    #[test]
+    fn rejects_a_composite_that_redefines_a_variant_property() {
+        let mut document = ordered(serde_json::json!({
+            "components": {
+                "schemas": {
+                    "Session": {
+                        "allOf": [
+                            {"$ref": "#/components/schemas/SessionStatus"},
+                            {
+                                "type": "object",
+                                "required": ["status"],
+                                "properties": {"status": {"type": "string"}}
+                            }
+                        ]
+                    },
+                    "SessionStatus": {
+                        "oneOf": [{
+                            "title": "SessionStatusOpen",
+                            "required": ["status"],
+                            "properties": {"status": {"const": "open"}}
+                        }]
+                    }
+                }
+            }
+        }));
+
+        let error = extract_and_merge(&mut document)
+            .expect_err("a redefined property should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::UnionCompositeDuplicateProperty {
+                schema_name,
+                property,
+            } if schema_name == "Session" && property == "status"
+        ));
+    }
+
+    #[test]
+    fn rejects_a_union_a_second_schema_also_reads() {
+        let mut document = ordered(serde_json::json!({
+            "components": {
+                "schemas": {
+                    "Session": {
+                        "allOf": [
+                            {"$ref": "#/components/schemas/SessionStatus"},
+                            {
+                                "type": "object",
+                                "required": ["upload_id"],
+                                "properties": {"upload_id": {"type": "string"}}
+                            }
+                        ]
+                    },
+                    "SessionStatus": {
+                        "oneOf": [{
+                            "title": "SessionStatusOpen",
+                            "required": ["status"],
+                            "properties": {"status": {"const": "open"}}
+                        }]
+                    },
+                    "SessionAudit": {
+                        "type": "object",
+                        "properties": {"status": {"$ref": "#/components/schemas/SessionStatus"}}
+                    }
+                }
+            }
+        }));
+
+        let error =
+            extract_and_merge(&mut document).expect_err("a shared union should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::SharedUnionComposite {
+                schema_name,
+                union_name,
+            } if schema_name == "Session" && union_name == "SessionStatus"
+        ));
     }
 
     #[test]

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -957,7 +957,7 @@ fn openapi_names_tagged_one_of_alternatives() {
 
     for (schema_name, expected_names) in [
         (
-            "AuthoritativePathEntryKind",
+            "AuthoritativePathEntry",
             &[
                 "AuthoritativePathEntryDirectory",
                 "AuthoritativePathEntryFile",
@@ -1009,7 +1009,7 @@ fn openapi_names_tagged_one_of_alternatives() {
             &["ObjectTransferAccessPresignedUrl"][..],
         ),
         (
-            "UploadSessionStatus",
+            "UploadSessionResponse",
             &[
                 "UploadSessionStatusOpen",
                 "UploadSessionStatusCompleted",
@@ -1029,7 +1029,7 @@ fn openapi_names_tagged_one_of_alternatives() {
             ][..],
         ),
         (
-            "GrepIndexLifecycle",
+            "GrepIndexStatusResponse",
             &[
                 "GrepIndexLifecycleDisabled",
                 "GrepIndexLifecycleBackfilling",
@@ -1063,6 +1063,93 @@ fn openapi_names_tagged_one_of_alternatives() {
             names, expected_names,
             "unexpected oneOf schema names for `{schema_name}`"
         );
+    }
+}
+
+/// Responses that flatten a Rust enum, and the fields their envelope adds to
+/// every variant.
+const UNION_COMPOSITE_ENVELOPES: &[(&str, &[&str])] = &[
+    (
+        "AuthoritativePathEntry",
+        &[
+            "namespace_id",
+            "path",
+            "inode_id",
+            "created_by",
+            "created_at_ms",
+            "head_seq",
+        ],
+    ),
+    (
+        "UploadSessionResponse",
+        &["mode", "namespace_id", "upload_id"],
+    ),
+    (
+        "GrepIndexStatusResponse",
+        &["namespace_id", "next_run_ordinal", "reorganize_pending"],
+    ),
+];
+
+/// A response that flattens an enum is one discriminated union, never an
+/// `allOf` wrapped around one. SDK generators keep the envelope half of such
+/// an `allOf` and drop the union half, so the generated type would lose every
+/// field the variants carry.
+#[test]
+fn no_openapi_schema_wraps_an_all_of_around_a_one_of() {
+    for document_path in [OPENAPI_JSON_PATH, PROXY_OPENAPI_JSON_PATH] {
+        let spec: Value = serde_json::from_str(
+            &std::fs::read_to_string(document_path).expect("read static openapi json"),
+        )
+        .expect("parse openapi json");
+        let schemas = spec
+            .pointer("/components/schemas")
+            .and_then(Value::as_object)
+            .expect("openapi schemas object");
+        let mut composites = Vec::new();
+        collect_all_of_members(&spec, "openapi", &mut composites);
+
+        for (location, members) in composites {
+            for member in members {
+                let member = match member.get("$ref").and_then(Value::as_str) {
+                    Some(reference) => {
+                        component_schema_for_ref(schemas, reference).unwrap_or_else(|| {
+                            panic!("{location} references a missing component: {reference}")
+                        })
+                    }
+                    None => member,
+                };
+                assert!(
+                    member.get("oneOf").is_none(),
+                    "{location} in {document_path} wraps an allOf around a oneOf"
+                );
+            }
+        }
+
+        for (composite_name, envelope) in UNION_COMPOSITE_ENVELOPES {
+            // The proxy document publishes only the operations it serves.
+            let Some(composite) = schemas.get(*composite_name) else {
+                continue;
+            };
+            let discriminator = composite
+                .get("discriminator")
+                .and_then(Value::as_object)
+                .unwrap_or_else(|| panic!("{composite_name} has no discriminator"));
+            assert!(discriminator.contains_key("propertyName"));
+            assert!(discriminator.contains_key("mapping"));
+
+            for variant_name in one_of_schema_names(schemas, composite_name) {
+                let variant = schemas
+                    .get(variant_name)
+                    .unwrap_or_else(|| panic!("{variant_name} schema"));
+                let required = required_fields(variant);
+                for field in *envelope {
+                    assert!(
+                        required.contains(field),
+                        "{variant_name} in {document_path} must require `{field}`"
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -1136,18 +1223,18 @@ fn openapi_caps_public_ordinals_and_uses_string_inode_ids() {
         "public inode fields use inline string schemas"
     );
 
-    assert_eq!(
-        schemas
-            .get("GrepIndexStatusResponse")
-            .and_then(|schema| schema.get("allOf"))
-            .and_then(Value::as_array)
-            .and_then(|schemas| schemas.iter().find_map(|schema| schema.get("properties")))
-            .and_then(|properties| properties.get("next_run_ordinal"))
-            .and_then(|schema| schema.get("maximum"))
-            .and_then(Value::as_u64),
-        Some(loonfs_api::MAX_PUBLIC_INTEGER),
-        "next_run_ordinal must use the public maximum"
-    );
+    for variant in one_of_schema_names(schemas, "GrepIndexStatusResponse") {
+        let schema = schemas
+            .get(variant)
+            .unwrap_or_else(|| panic!("{variant} schema"));
+        assert_eq!(
+            schema
+                .pointer("/properties/next_run_ordinal/maximum")
+                .and_then(Value::as_u64),
+            Some(loonfs_api::MAX_PUBLIC_INTEGER),
+            "next_run_ordinal must use the public maximum in {variant}"
+        );
+    }
 }
 
 #[test]
@@ -1279,7 +1366,6 @@ fn openapi_reuses_the_one_checksum_and_upload_claim_shapes() {
     assert!(schemas.contains_key("ContentToken"));
     assert!(schemas.contains_key("UploadMode"));
     assert!(schemas.contains_key("UploadSessionResponse"));
-    assert!(schemas.contains_key("UploadSessionStatus"));
     for retired_response in [
         "CompleteUploadResponse",
         "AbortUploadResponse",
@@ -1305,28 +1391,22 @@ fn openapi_reuses_the_one_checksum_and_upload_claim_shapes() {
     let session_response = schemas
         .get("UploadSessionResponse")
         .expect("UploadSessionResponse schema");
-    let session_response_refs: BTreeSet<_> = session_response
-        .get("allOf")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|schema| schema.get("$ref").and_then(Value::as_str))
-        .collect();
-    assert!(session_response_refs.contains("#/components/schemas/UploadSessionStatus"));
-    assert!(serde_json::to_string(
-        schemas
-            .get("UploadSessionStatus")
-            .expect("UploadSessionStatus schema")
-    )
-    .expect("serialize UploadSessionStatus schema")
-    .contains(r#""status""#));
-    assert!(!serde_json::to_string(
-        schemas
-            .get("UploadSessionStatus")
-            .expect("UploadSessionStatus schema")
-    )
-    .expect("serialize UploadSessionStatus schema")
-    .contains(r#""state""#));
+    assert_eq!(
+        session_response
+            .pointer("/discriminator/propertyName")
+            .and_then(Value::as_str),
+        Some("status"),
+        "the upload session union tags on `status`"
+    );
+    for variant_name in one_of_schema_names(schemas, "UploadSessionResponse") {
+        let variant = schemas
+            .get(variant_name)
+            .unwrap_or_else(|| panic!("{variant_name} schema"));
+        let encoded =
+            serde_json::to_string(variant).expect("serialize upload session variant schema");
+        assert!(encoded.contains(r#""status""#));
+        assert!(!encoded.contains(r#""state""#));
+    }
 
     for (path, method) in [
         ("/v0/namespaces/{namespace_id}/uploads/{upload_id}", "get"),
@@ -1454,36 +1534,36 @@ fn openapi_flattens_the_path_entry_attribute_projection() {
         .and_then(Value::as_object)
         .expect("openapi schemas object");
     assert!(!schemas.contains_key("AuthoritativeAttributes"));
-
-    let projection = schemas
-        .get("AttributesProjection")
-        .expect("AttributesProjection schema");
-    let projection_properties = projection
-        .get("properties")
-        .and_then(Value::as_object)
-        .expect("attribute projection properties");
-    assert!(projection_properties.contains_key("attributes_revision_no"));
-    assert!(projection_properties.contains_key("attributes"));
-    let required = required_fields(projection);
     assert!(
-        !required.contains("attributes_revision_no") && !required.contains("attributes"),
-        "path entries may omit attribute fields when attributes are not requested"
+        !schemas.contains_key("AttributesProjection"),
+        "the attribute fields are flattened into each path entry variant"
     );
 
-    let path_entry = schemas
-        .get("AuthoritativePathEntry")
-        .expect("AuthoritativePathEntry schema");
-    let flattened_projection_ref = path_entry
-        .get("allOf")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|schema| schema.get("$ref").and_then(Value::as_str))
-        .any(|reference| reference == "#/components/schemas/AttributesProjection");
-    assert!(
-        flattened_projection_ref,
-        "path entries must flatten AttributesProjection at the top level"
-    );
+    for variant_name in one_of_schema_names(schemas, "AuthoritativePathEntry") {
+        let variant = schemas
+            .get(variant_name)
+            .unwrap_or_else(|| panic!("{variant_name} schema"));
+        let properties = variant
+            .get("properties")
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| panic!("{variant_name} properties"));
+        let required = required_fields(variant);
+        for attribute_field in [
+            "attributes",
+            "attributes_revision_no",
+            "attributes_updated_at_ms",
+            "attributes_updated_by",
+        ] {
+            assert!(
+                properties.contains_key(attribute_field),
+                "{variant_name} must carry `{attribute_field}` at the top level"
+            );
+            assert!(
+                !required.contains(attribute_field),
+                "path entries may omit attribute fields when attributes are not requested"
+            );
+        }
+    }
 }
 
 #[test]
@@ -1613,6 +1693,30 @@ fn collect_one_of_objects<'a>(
         Value::Array(values) => {
             for child in values {
                 collect_one_of_objects(child, unions);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+/// Collects each `allOf` member list with its document location.
+fn collect_all_of_members<'a>(
+    value: &'a Value,
+    location: &str,
+    composites: &mut Vec<(String, &'a Vec<Value>)>,
+) {
+    match value {
+        Value::Object(object) => {
+            if let Some(members) = object.get("allOf").and_then(Value::as_array) {
+                composites.push((location.to_owned(), members));
+            }
+            for (name, child) in object {
+                collect_all_of_members(child, &format!("{location}.{name}"), composites);
+            }
+        }
+        Value::Array(values) => {
+            for (index, child) in values.iter().enumerate() {
+                collect_all_of_members(child, &format!("{location}[{index}]"), composites);
             }
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -1802,95 +1802,8 @@
           "type": "string"
         }
       },
-      "AttributesProjection": {
-        "type": "object",
-        "description": "Attributes returned for one inode.\n\nA path entry omits this entire group unless the caller requests attributes.\nOpenAPI flattens these fields with `allOf`, so none of them can be marked as\nrequired on every path entry.",
-        "properties": {
-          "attributes": {
-            "$ref": "#/components/schemas/Attributes",
-            "description": "The complete attribute map at `attributes_revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
-          },
-          "attributes_revision_no": {
-            "$ref": "#/components/schemas/AttributeRevisionNo",
-            "description": "The attribute revision this projection represents."
-          },
-          "attributes_updated_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
-            "minimum": 0
-          },
-          "attributes_updated_by": {
-            "$ref": "#/components/schemas/ActorRef",
-            "description": "Actor responsible for the latest attribute update. This is `None` for\nthe initial empty state at revision 0."
-          }
-        }
-      },
       "AuthoritativePathEntry": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/AuthoritativePathEntryKind",
-            "description": "File-or-directory classification and its kind-specific payload."
-          },
-          {
-            "$ref": "#/components/schemas/AttributesProjection",
-            "description": "The inode's attribute projection, when requested."
-          },
-          {
-            "type": "object",
-            "required": [
-              "namespace_id",
-              "path",
-              "inode_id",
-              "created_by",
-              "created_at_ms",
-              "head_seq"
-            ],
-            "properties": {
-              "created_at_ms": {
-                "type": "integer",
-                "format": "int64",
-                "description": "Time the inode was created, in Unix milliseconds. Sequence numbers\ndetermine order.",
-                "minimum": 0
-              },
-              "created_by": {
-                "$ref": "#/components/schemas/ActorRef",
-                "description": "Actor that created this inode, as supplied by the application."
-              },
-              "display_name": {
-                "$ref": "#/components/schemas/DisplayName",
-                "description": "Stored display name for this path component, absent for the nameless root."
-              },
-              "head_seq": {
-                "$ref": "#/components/schemas/ChangeSeq",
-                "description": "Namespace head sequence this answer was read from."
-              },
-              "inode_id": {
-                "type": "string",
-                "description": "Stable inode ID within a namespace",
-                "example": "ino_123",
-                "pattern": "^ino_[1-9][0-9]*$"
-              },
-              "namespace_id": {
-                "$ref": "#/components/schemas/NamespaceId",
-                "description": "Namespace that was read."
-              },
-              "parent_inode_id": {
-                "type": "string",
-                "description": "Stable inode ID within a namespace",
-                "example": "ino_123",
-                "pattern": "^ino_[1-9][0-9]*$"
-              },
-              "path": {
-                "$ref": "#/components/schemas/AbsolutePath",
-                "description": "Absolute path as rendered from stored display names."
-              }
-            }
-          }
-        ],
-        "description": "Metadata for one path returned by stat and directory-listing operations.\n\nFile entries include the current revision and content details. Directory\nentries do not. Attribute fields are included only when requested and are\nserialized at the top level of the entry. Callers can pass\n`attributes_revision_no` as `expected_attributes_revision_no` when updating\nattributes."
-      },
-      "AuthoritativePathEntryKind": {
+        "description": "Metadata for one path returned by stat and directory-listing operations.\n\nFile entries include the current revision and content details. Directory\nentries do not. Attribute fields are included only when requested and are\nserialized at the top level of the entry. Callers can pass\n`attributes_revision_no` as `expected_attributes_revision_no` when updating\nattributes.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/AuthoritativePathEntryDirectory"
@@ -1899,7 +1812,6 @@
             "$ref": "#/components/schemas/AuthoritativePathEntryFile"
           }
         ],
-        "description": "Kind-specific metadata for an authoritative path entry.",
         "discriminator": {
           "propertyName": "inode_kind",
           "mapping": {
@@ -3083,37 +2995,7 @@
         "additionalProperties": false
       },
       "UploadSessionResponse": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UploadSessionStatus",
-            "description": "The session's lifecycle and state-specific fields. Completed HTTP\nresponses carry a fresh receipt while the minting window remains open."
-          },
-          {
-            "type": "object",
-            "required": [
-              "namespace_id",
-              "upload_id",
-              "mode"
-            ],
-            "properties": {
-              "mode": {
-                "$ref": "#/components/schemas/UploadMode",
-                "description": "Transport selected when the session began."
-              },
-              "namespace_id": {
-                "$ref": "#/components/schemas/NamespaceId",
-                "description": "Namespace that owns the session."
-              },
-              "upload_id": {
-                "$ref": "#/components/schemas/UploadId",
-                "description": "Session represented by this view."
-              }
-            }
-          }
-        ],
-        "description": "Current view of one upload session."
-      },
-      "UploadSessionStatus": {
+        "description": "Current view of one upload session.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/UploadSessionStatusOpen"
@@ -3125,7 +3007,6 @@
             "$ref": "#/components/schemas/UploadSessionStatusAborted"
           }
         ],
-        "description": "Observed state of an upload session.\n\nA session starts as `Open` and ends as either `Completed` or `Aborted`.\nBoth final states are permanent. Reading a completed session issues a new\nreceipt for the durable content, so a lost commit response does not require\nthe content to be uploaded again.",
         "discriminator": {
           "propertyName": "status",
           "mapping": {
@@ -3146,7 +3027,13 @@
         "type": "object",
         "description": "A directory, which has no revision payload in v0.\n\nThe entry tag reuses [`InodeKind`]'s wire vocabulary.",
         "required": [
-          "inode_kind"
+          "inode_kind",
+          "namespace_id",
+          "path",
+          "inode_id",
+          "created_by",
+          "created_at_ms",
+          "head_seq"
         ],
         "properties": {
           "inode_kind": {
@@ -3154,6 +3041,62 @@
             "enum": [
               "dir"
             ]
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/Attributes",
+            "description": "The complete attribute map at `attributes_revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
+          },
+          "attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "The attribute revision this projection represents."
+          },
+          "attributes_updated_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
+            "minimum": 0
+          },
+          "attributes_updated_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the latest attribute update. This is `None` for\nthe initial empty state at revision 0."
+          },
+          "created_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time the inode was created, in Unix milliseconds. Sequence numbers\ndetermine order.",
+            "minimum": 0
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor that created this inode, as supplied by the application."
+          },
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "Stored display name for this path component, absent for the nameless root."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence this answer was read from."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path as rendered from stored display names."
           }
         }
       },
@@ -3166,7 +3109,13 @@
           "content_ref",
           "revision_committed_by",
           "revision_committed_at_ms",
-          "inode_kind"
+          "inode_kind",
+          "namespace_id",
+          "path",
+          "inode_id",
+          "created_by",
+          "created_at_ms",
+          "head_seq"
         ],
         "properties": {
           "content_ref": {
@@ -3198,6 +3147,62 @@
             "format": "int64",
             "description": "Current file size in bytes.\n\nThis remains explicit even though `content_ref` also carries the\nlength because callers sort directory listings by this field.",
             "minimum": 0
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/Attributes",
+            "description": "The complete attribute map at `attributes_revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
+          },
+          "attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "The attribute revision this projection represents."
+          },
+          "attributes_updated_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
+            "minimum": 0
+          },
+          "attributes_updated_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the latest attribute update. This is `None` for\nthe initial empty state at revision 0."
+          },
+          "created_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time the inode was created, in Unix milliseconds. Sequence numbers\ndetermine order.",
+            "minimum": 0
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor that created this inode, as supplied by the application."
+          },
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "Stored display name for this path component, absent for the nameless root."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence this answer was read from."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path as rendered from stored display names."
           }
         }
       },
@@ -3949,7 +3954,10 @@
         "description": "Accepting content until its lease passes.",
         "required": [
           "expires_at_ms",
-          "status"
+          "status",
+          "namespace_id",
+          "upload_id",
+          "mode"
         ],
         "properties": {
           "expires_at_ms": {
@@ -3963,6 +3971,18 @@
             "enum": [
               "open"
             ]
+          },
+          "mode": {
+            "$ref": "#/components/schemas/UploadMode",
+            "description": "Transport selected when the session began."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that owns the session."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Session represented by this view."
           }
         }
       },
@@ -3972,7 +3992,10 @@
         "required": [
           "completed_at_ms",
           "content_ref",
-          "status"
+          "status",
+          "namespace_id",
+          "upload_id",
+          "mode"
         ],
         "properties": {
           "completed_at_ms": {
@@ -3994,6 +4017,18 @@
             "enum": [
               "completed"
             ]
+          },
+          "mode": {
+            "$ref": "#/components/schemas/UploadMode",
+            "description": "Transport selected when the session began."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that owns the session."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Session represented by this view."
           }
         }
       },
@@ -4002,7 +4037,10 @@
         "description": "Final: the session selected no content and its object is gone.",
         "required": [
           "aborted_at_ms",
-          "status"
+          "status",
+          "namespace_id",
+          "upload_id",
+          "mode"
         ],
         "properties": {
           "aborted_at_ms": {
@@ -4016,6 +4054,18 @@
             "enum": [
               "aborted"
             ]
+          },
+          "mode": {
+            "$ref": "#/components/schemas/UploadMode",
+            "description": "Transport selected when the session began."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that owns the session."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Session represented by this view."
           }
         }
       }

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3530,95 +3530,8 @@
           "type": "string"
         }
       },
-      "AttributesProjection": {
-        "type": "object",
-        "description": "Attributes returned for one inode.\n\nA path entry omits this entire group unless the caller requests attributes.\nOpenAPI flattens these fields with `allOf`, so none of them can be marked as\nrequired on every path entry.",
-        "properties": {
-          "attributes": {
-            "$ref": "#/components/schemas/Attributes",
-            "description": "The complete attribute map at `attributes_revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
-          },
-          "attributes_revision_no": {
-            "$ref": "#/components/schemas/AttributeRevisionNo",
-            "description": "The attribute revision this projection represents."
-          },
-          "attributes_updated_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
-            "minimum": 0
-          },
-          "attributes_updated_by": {
-            "$ref": "#/components/schemas/ActorRef",
-            "description": "Actor responsible for the latest attribute update. This is `None` for\nthe initial empty state at revision 0."
-          }
-        }
-      },
       "AuthoritativePathEntry": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/AuthoritativePathEntryKind",
-            "description": "File-or-directory classification and its kind-specific payload."
-          },
-          {
-            "$ref": "#/components/schemas/AttributesProjection",
-            "description": "The inode's attribute projection, when requested."
-          },
-          {
-            "type": "object",
-            "required": [
-              "namespace_id",
-              "path",
-              "inode_id",
-              "created_by",
-              "created_at_ms",
-              "head_seq"
-            ],
-            "properties": {
-              "created_at_ms": {
-                "type": "integer",
-                "format": "int64",
-                "description": "Time the inode was created, in Unix milliseconds. Sequence numbers\ndetermine order.",
-                "minimum": 0
-              },
-              "created_by": {
-                "$ref": "#/components/schemas/ActorRef",
-                "description": "Actor that created this inode, as supplied by the application."
-              },
-              "display_name": {
-                "$ref": "#/components/schemas/DisplayName",
-                "description": "Stored display name for this path component, absent for the nameless root."
-              },
-              "head_seq": {
-                "$ref": "#/components/schemas/ChangeSeq",
-                "description": "Namespace head sequence this answer was read from."
-              },
-              "inode_id": {
-                "type": "string",
-                "description": "Stable inode ID within a namespace",
-                "example": "ino_123",
-                "pattern": "^ino_[1-9][0-9]*$"
-              },
-              "namespace_id": {
-                "$ref": "#/components/schemas/NamespaceId",
-                "description": "Namespace that was read."
-              },
-              "parent_inode_id": {
-                "type": "string",
-                "description": "Stable inode ID within a namespace",
-                "example": "ino_123",
-                "pattern": "^ino_[1-9][0-9]*$"
-              },
-              "path": {
-                "$ref": "#/components/schemas/AbsolutePath",
-                "description": "Absolute path as rendered from stored display names."
-              }
-            }
-          }
-        ],
-        "description": "Metadata for one path returned by stat and directory-listing operations.\n\nFile entries include the current revision and content details. Directory\nentries do not. Attribute fields are included only when requested and are\nserialized at the top level of the entry. Callers can pass\n`attributes_revision_no` as `expected_attributes_revision_no` when updating\nattributes."
-      },
-      "AuthoritativePathEntryKind": {
+        "description": "Metadata for one path returned by stat and directory-listing operations.\n\nFile entries include the current revision and content details. Directory\nentries do not. Attribute fields are included only when requested and are\nserialized at the top level of the entry. Callers can pass\n`attributes_revision_no` as `expected_attributes_revision_no` when updating\nattributes.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/AuthoritativePathEntryDirectory"
@@ -3627,7 +3540,6 @@
             "$ref": "#/components/schemas/AuthoritativePathEntryFile"
           }
         ],
-        "description": "Kind-specific metadata for an authoritative path entry.",
         "discriminator": {
           "propertyName": "inode_kind",
           "mapping": {
@@ -4809,7 +4721,8 @@
           }
         }
       },
-      "GrepIndexLifecycle": {
+      "GrepIndexStatusResponse": {
+        "description": "The namespace's grep-index lifecycle and its cheap bookkeeping (admin\nplane).",
         "oneOf": [
           {
             "$ref": "#/components/schemas/GrepIndexLifecycleDisabled"
@@ -4821,7 +4734,6 @@
             "$ref": "#/components/schemas/GrepIndexLifecycleActive"
           }
         ],
-        "description": "Where a namespace's grep index is in its lifecycle.\n\nEach status contains only the fields valid for that lifecycle state.\n`Backfilling` reports its target and current position. `Active` reports\nhow far the index has been built. Clients should treat a namespace as\nsearchable only when the index is `Active`.",
         "discriminator": {
           "propertyName": "status",
           "mapping": {
@@ -4830,40 +4742,6 @@
             "active": "#/components/schemas/GrepIndexLifecycleActive"
           }
         }
-      },
-      "GrepIndexStatusResponse": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GrepIndexLifecycle",
-            "description": "Where the index is in its lifecycle."
-          },
-          {
-            "type": "object",
-            "required": [
-              "namespace_id",
-              "next_run_ordinal",
-              "reorganize_pending"
-            ],
-            "properties": {
-              "namespace_id": {
-                "$ref": "#/components/schemas/NamespaceId",
-                "description": "Namespace the status describes."
-              },
-              "next_run_ordinal": {
-                "type": "integer",
-                "format": "int64",
-                "description": "Next logical run ordinal the index will allocate.",
-                "maximum": 9007199254740991,
-                "minimum": 0
-              },
-              "reorganize_pending": {
-                "type": "boolean",
-                "description": "True while a partitioned segment reorganization is in progress."
-              }
-            }
-          }
-        ],
-        "description": "The namespace's grep-index lifecycle and its cheap bookkeeping (admin\nplane)."
       },
       "GrepMatch": {
         "type": "object",
@@ -5649,37 +5527,7 @@
         "additionalProperties": false
       },
       "UploadSessionResponse": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UploadSessionStatus",
-            "description": "The session's lifecycle and state-specific fields. Completed HTTP\nresponses carry a fresh receipt while the minting window remains open."
-          },
-          {
-            "type": "object",
-            "required": [
-              "namespace_id",
-              "upload_id",
-              "mode"
-            ],
-            "properties": {
-              "mode": {
-                "$ref": "#/components/schemas/UploadMode",
-                "description": "Transport selected when the session began."
-              },
-              "namespace_id": {
-                "$ref": "#/components/schemas/NamespaceId",
-                "description": "Namespace that owns the session."
-              },
-              "upload_id": {
-                "$ref": "#/components/schemas/UploadId",
-                "description": "Session represented by this view."
-              }
-            }
-          }
-        ],
-        "description": "Current view of one upload session."
-      },
-      "UploadSessionStatus": {
+        "description": "Current view of one upload session.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/UploadSessionStatusOpen"
@@ -5691,7 +5539,6 @@
             "$ref": "#/components/schemas/UploadSessionStatusAborted"
           }
         ],
-        "description": "Observed state of an upload session.\n\nA session starts as `Open` and ends as either `Completed` or `Aborted`.\nBoth final states are permanent. Reading a completed session issues a new\nreceipt for the durable content, so a lost commit response does not require\nthe content to be uploaded again.",
         "discriminator": {
           "propertyName": "status",
           "mapping": {
@@ -5738,7 +5585,13 @@
         "type": "object",
         "description": "A directory, which has no revision payload in v0.\n\nThe entry tag reuses [`InodeKind`]'s wire vocabulary.",
         "required": [
-          "inode_kind"
+          "inode_kind",
+          "namespace_id",
+          "path",
+          "inode_id",
+          "created_by",
+          "created_at_ms",
+          "head_seq"
         ],
         "properties": {
           "inode_kind": {
@@ -5746,6 +5599,62 @@
             "enum": [
               "dir"
             ]
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/Attributes",
+            "description": "The complete attribute map at `attributes_revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
+          },
+          "attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "The attribute revision this projection represents."
+          },
+          "attributes_updated_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
+            "minimum": 0
+          },
+          "attributes_updated_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the latest attribute update. This is `None` for\nthe initial empty state at revision 0."
+          },
+          "created_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time the inode was created, in Unix milliseconds. Sequence numbers\ndetermine order.",
+            "minimum": 0
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor that created this inode, as supplied by the application."
+          },
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "Stored display name for this path component, absent for the nameless root."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence this answer was read from."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path as rendered from stored display names."
           }
         }
       },
@@ -5758,7 +5667,13 @@
           "content_ref",
           "revision_committed_by",
           "revision_committed_at_ms",
-          "inode_kind"
+          "inode_kind",
+          "namespace_id",
+          "path",
+          "inode_id",
+          "created_by",
+          "created_at_ms",
+          "head_seq"
         ],
         "properties": {
           "content_ref": {
@@ -5790,6 +5705,62 @@
             "format": "int64",
             "description": "Current file size in bytes.\n\nThis remains explicit even though `content_ref` also carries the\nlength because callers sort directory listings by this field.",
             "minimum": 0
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/Attributes",
+            "description": "The complete attribute map at `attributes_revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
+          },
+          "attributes_revision_no": {
+            "$ref": "#/components/schemas/AttributeRevisionNo",
+            "description": "The attribute revision this projection represents."
+          },
+          "attributes_updated_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
+            "minimum": 0
+          },
+          "attributes_updated_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor responsible for the latest attribute update. This is `None` for\nthe initial empty state at revision 0."
+          },
+          "created_at_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time the inode was created, in Unix milliseconds. Sequence numbers\ndetermine order.",
+            "minimum": 0
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/ActorRef",
+            "description": "Actor that created this inode, as supplied by the application."
+          },
+          "display_name": {
+            "$ref": "#/components/schemas/DisplayName",
+            "description": "Stored display name for this path component, absent for the nameless root."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence this answer was read from."
+          },
+          "inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "parent_inode_id": {
+            "type": "string",
+            "description": "Stable inode ID within a namespace",
+            "example": "ino_123",
+            "pattern": "^ino_[1-9][0-9]*$"
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path as rendered from stored display names."
           }
         }
       },
@@ -6538,7 +6509,10 @@
         "type": "object",
         "description": "No index is maintained for this namespace.",
         "required": [
-          "status"
+          "status",
+          "namespace_id",
+          "next_run_ordinal",
+          "reorganize_pending"
         ],
         "properties": {
           "status": {
@@ -6546,6 +6520,21 @@
             "enum": [
               "disabled"
             ]
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the status describes."
+          },
+          "next_run_ordinal": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Next logical run ordinal the index will allocate.",
+            "maximum": 9007199254740991,
+            "minimum": 0
+          },
+          "reorganize_pending": {
+            "type": "boolean",
+            "description": "True while a partitioned segment reorganization is in progress."
           }
         }
       },
@@ -6555,7 +6544,10 @@
         "required": [
           "target_seq",
           "checkpoint_id",
-          "status"
+          "status",
+          "namespace_id",
+          "next_run_ordinal",
+          "reorganize_pending"
         ],
         "properties": {
           "checkpoint_id": {
@@ -6577,6 +6569,21 @@
           "target_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Namespace sequence the pinned checkpoint captured. Reaching it\nis what completes the backfill."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the status describes."
+          },
+          "next_run_ordinal": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Next logical run ordinal the index will allocate.",
+            "maximum": 9007199254740991,
+            "minimum": 0
+          },
+          "reorganize_pending": {
+            "type": "boolean",
+            "description": "True while a partitioned segment reorganization is in progress."
           }
         }
       },
@@ -6585,7 +6592,10 @@
         "description": "The index follows the change feed. Commits at or below the watermark\nare searchable.",
         "required": [
           "built_through_seq",
-          "status"
+          "status",
+          "namespace_id",
+          "next_run_ordinal",
+          "reorganize_pending"
         ],
         "properties": {
           "built_through_seq": {
@@ -6603,6 +6613,21 @@
             "enum": [
               "active"
             ]
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the status describes."
+          },
+          "next_run_ordinal": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Next logical run ordinal the index will allocate.",
+            "maximum": 9007199254740991,
+            "minimum": 0
+          },
+          "reorganize_pending": {
+            "type": "boolean",
+            "description": "True while a partitioned segment reorganization is in progress."
           }
         }
       },
@@ -6751,7 +6776,10 @@
         "description": "Accepting content until its lease passes.",
         "required": [
           "expires_at_ms",
-          "status"
+          "status",
+          "namespace_id",
+          "upload_id",
+          "mode"
         ],
         "properties": {
           "expires_at_ms": {
@@ -6765,6 +6793,18 @@
             "enum": [
               "open"
             ]
+          },
+          "mode": {
+            "$ref": "#/components/schemas/UploadMode",
+            "description": "Transport selected when the session began."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that owns the session."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Session represented by this view."
           }
         }
       },
@@ -6774,7 +6814,10 @@
         "required": [
           "completed_at_ms",
           "content_ref",
-          "status"
+          "status",
+          "namespace_id",
+          "upload_id",
+          "mode"
         ],
         "properties": {
           "completed_at_ms": {
@@ -6796,6 +6839,18 @@
             "enum": [
               "completed"
             ]
+          },
+          "mode": {
+            "$ref": "#/components/schemas/UploadMode",
+            "description": "Transport selected when the session began."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that owns the session."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Session represented by this view."
           }
         }
       },
@@ -6804,7 +6859,10 @@
         "description": "Final: the session selected no content and its object is gone.",
         "required": [
           "aborted_at_ms",
-          "status"
+          "status",
+          "namespace_id",
+          "upload_id",
+          "mode"
         ],
         "properties": {
           "aborted_at_ms": {
@@ -6818,6 +6876,18 @@
             "enum": [
               "aborted"
             ]
+          },
+          "mode": {
+            "$ref": "#/components/schemas/UploadMode",
+            "description": "Transport selected when the session began."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that owns the session."
+          },
+          "upload_id": {
+            "$ref": "#/components/schemas/UploadId",
+            "description": "Session represented by this view."
           }
         }
       },

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -490,8 +490,8 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Fatalf("replay multipart completion: %v", err)
 	}
 	replayedStatus := requireCompletedStatus(t, replayed)
-	if replayed.NamespaceID != first.NamespaceID || replayed.UploadID != first.UploadID || replayed.Mode != first.Mode {
-		t.Errorf("replayed upload identity = %#v, want %#v", replayed, first)
+	if replayedStatus.NamespaceID != firstStatus.NamespaceID || replayedStatus.UploadID != firstStatus.UploadID || replayedStatus.Mode != firstStatus.Mode {
+		t.Errorf("replayed upload identity = %#v, want %#v", replayedStatus, firstStatus)
 	}
 	assertContentRefEqual(t, replayedStatus.ContentRef, firstStatus.ContentRef)
 	if replayedStatus.CompletedAtMs != firstStatus.CompletedAtMs {
@@ -588,17 +588,13 @@ func runAbort(t *testing.T, h *harness, testCase conformanceCase) {
 	if err != nil {
 		t.Fatalf("replay abort: %v", err)
 	}
-	firstStatusEnvelope := uploadSessionStatus(t, first)
-	if firstStatusEnvelope.Status != expected.Status {
-		t.Errorf("upload status = %q, want %q", firstStatusEnvelope.Status, expected.Status)
+	if first.Status != expected.Status {
+		t.Errorf("upload status = %q, want %q", first.Status, expected.Status)
 	}
-	if firstStatusEnvelope.Aborted == nil {
-		t.Fatalf("upload status = %q, want aborted", firstStatusEnvelope.Status)
-	}
-	firstStatus := firstStatusEnvelope.Aborted
+	firstStatus := requireAbortedStatus(t, first)
 	replayedStatus := requireAbortedStatus(t, replayed)
-	if replayed.NamespaceID != first.NamespaceID || replayed.UploadID != first.UploadID || replayed.Mode != first.Mode {
-		t.Errorf("replayed abort identity = %#v, want %#v", replayed, first)
+	if replayedStatus.NamespaceID != firstStatus.NamespaceID || replayedStatus.UploadID != firstStatus.UploadID || replayedStatus.Mode != firstStatus.Mode {
+		t.Errorf("replayed abort identity = %#v, want %#v", replayedStatus, firstStatus)
 	}
 	if replayedStatus.AbortedAtMs != firstStatus.AbortedAtMs {
 		t.Errorf("replayed aborted_at_ms = %d, want %d", replayedStatus.AbortedAtMs, firstStatus.AbortedAtMs)
@@ -728,7 +724,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 	if file.SizeBytes != expected.SizeBytes {
 		t.Errorf("uploaded size_bytes = %d, want %d", file.SizeBytes, expected.SizeBytes)
 	}
-	uploadedInode := stat.InodeID
+	uploadedInode := identityOf(stat).inodeID
 
 	initialListing := listPathEntries(t, h.client, request.NamespaceID, request.Directory)
 	if !listingContainsPath(initialListing, request.UploadPath) {
@@ -825,7 +821,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 	var removedEntry *loonfs.TrashEntry
 	for _, entry := range trash.Results {
-		if entry.InodeID == uploadedInode {
+		if string(entry.InodeID) == uploadedInode {
 			removedEntry = entry
 			break
 		}
@@ -970,10 +966,11 @@ func listedNames(t *testing.T, entries []*loonfs.AuthoritativePathEntry) []strin
 	t.Helper()
 	names := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if entry.DisplayName == nil {
+		name := identityOf(entry).displayName
+		if name == "" {
 			t.Fatal("listed entry has no display_name")
 		}
-		names = append(names, string(*entry.DisplayName))
+		names = append(names, name)
 	}
 	return names
 }
@@ -1599,35 +1596,18 @@ func assertSuccessfulTransfer(t *testing.T, response *http.Response) {
 	t.Fatalf("presigned request returned %s: %s", response.Status, detail)
 }
 
-func uploadSessionStatus(t *testing.T, response *loonfs.UploadSessionResponse) *loonfs.UploadSessionStatus {
-	t.Helper()
-	if response == nil {
-		t.Fatal("upload session response is nil")
-	}
-	if _, ok := response.GetExtraProperties()["status"]; !ok {
-		t.Fatal("upload session response has no status")
-	}
-	data, err := json.Marshal(response.GetExtraProperties())
-	if err != nil {
-		t.Fatalf("encode upload status: %v", err)
-	}
-	var status loonfs.UploadSessionStatus
-	if err := json.Unmarshal(data, &status); err != nil {
-		t.Fatalf("decode upload status: %v", err)
-	}
-	return &status
-}
-
 func requireCompletedStatus(
 	t *testing.T,
 	response *loonfs.UploadSessionResponse,
 ) *loonfs.UploadSessionStatusCompleted {
 	t.Helper()
-	status := uploadSessionStatus(t, response)
-	if status.Completed == nil || status.Completed.ContentRef == nil {
-		t.Fatalf("upload status = %q, want completed", status.Status)
+	if response == nil {
+		t.Fatal("upload session response is nil")
 	}
-	return status.Completed
+	if response.Completed == nil || response.Completed.ContentRef == nil {
+		t.Fatalf("upload status = %q, want completed", response.Status)
+	}
+	return response.Completed
 }
 
 func requireAbortedStatus(
@@ -1635,11 +1615,13 @@ func requireAbortedStatus(
 	response *loonfs.UploadSessionResponse,
 ) *loonfs.UploadSessionStatusAborted {
 	t.Helper()
-	status := uploadSessionStatus(t, response)
-	if status.Aborted == nil {
-		t.Fatalf("upload status = %q, want aborted", status.Status)
+	if response == nil {
+		t.Fatal("upload session response is nil")
 	}
-	return status.Aborted
+	if response.Aborted == nil {
+		t.Fatalf("upload status = %q, want aborted", response.Status)
+	}
+	return response.Aborted
 }
 
 func requireFileProjection(t *testing.T, entry *loonfs.AuthoritativePathEntry) *loonfs.AuthoritativePathEntryFile {
@@ -1647,18 +1629,46 @@ func requireFileProjection(t *testing.T, entry *loonfs.AuthoritativePathEntry) *
 	if entry == nil {
 		t.Fatal("path entry is nil")
 	}
-	data, err := json.Marshal(entry.GetExtraProperties())
-	if err != nil {
-		t.Fatalf("encode path entry projection: %v", err)
+	if entry.File == nil {
+		t.Fatalf("path entry kind = %q, want file", entry.InodeKind)
 	}
-	var projection loonfs.AuthoritativePathEntryKind
-	if err := json.Unmarshal(data, &projection); err != nil {
-		t.Fatalf("decode path entry projection: %v", err)
+	return entry.File
+}
+
+// pathEntryIdentity is the common subset of the generated path-entry variants.
+type pathEntryIdentity struct {
+	path        string
+	inodeID     string
+	displayName string
+}
+
+func identityOf(entry *loonfs.AuthoritativePathEntry) pathEntryIdentity {
+	if entry == nil {
+		return pathEntryIdentity{}
 	}
-	if projection.File == nil {
-		t.Fatalf("path entry kind = %q, want file", projection.InodeKind)
+	if entry.Dir != nil {
+		return pathEntryIdentity{
+			path:        string(entry.Dir.Path),
+			inodeID:     string(entry.Dir.InodeID),
+			displayName: displayNameOf(entry.Dir.DisplayName),
+		}
 	}
-	return projection.File
+	if entry.File != nil {
+		return pathEntryIdentity{
+			path:        string(entry.File.Path),
+			inodeID:     string(entry.File.InodeID),
+			displayName: displayNameOf(entry.File.DisplayName),
+		}
+	}
+	return pathEntryIdentity{}
+}
+
+// displayNameOf returns an empty string for the root entry.
+func displayNameOf(name *loonfs.DisplayName) string {
+	if name == nil {
+		return ""
+	}
+	return string(*name)
 }
 
 func commitCompletedFile(
@@ -1746,7 +1756,7 @@ func listPathEntries(
 
 func listingContainsPath(entries []*loonfs.AuthoritativePathEntry, path string) bool {
 	for _, entry := range entries {
-		if entry != nil && string(entry.Path) == path {
+		if identityOf(entry).path == path {
 			return true
 		}
 	}

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -7,7 +7,7 @@ import re
 import socket
 import threading
 import time
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -21,6 +21,8 @@ import pytest
 import uvicorn
 from loonfs_sdk import (
     ActorRef,
+    AuthoritativePathEntry,
+    AuthoritativePathEntry_File,
     BeginUploadRequest_DirectMultipart,
     BeginUploadRequest_DirectPut,
     BeginUploadRequest_ServiceProxied,
@@ -31,7 +33,6 @@ from loonfs_sdk import (
     CompleteUploadRequest_DirectMultipart,
     CompleteUploadRequest_DirectPut,
     CompletedUploadPart,
-    ContentRef,
     DirectMultipartUploadOptions,
     FilesystemOperation_CreateDirectory,
     FilesystemOperation_DeletePath,
@@ -44,6 +45,8 @@ from loonfs_sdk import (
     UploadContentClaim,
     UploadPartChecksumClaim,
     UploadSessionResponse,
+    UploadSessionResponse_Aborted,
+    UploadSessionResponse_Completed,
 )
 from loonfs_sdk.proxy import LoonFSProxy
 from loonfs_sdk.transfers import get_file, put_file
@@ -468,21 +471,30 @@ def _put_presigned(access: Any, content: bytes) -> httpx.Response:
     return response
 
 
-def _content_ref(value: object) -> ContentRef:
-    if isinstance(value, ContentRef):
-        return value
-    if isinstance(value, Mapping):
-        return ContentRef(**value)
-    raise AssertionError("response has no content reference")
+def _completed_upload(response: UploadSessionResponse) -> UploadSessionResponse_Completed:
+    assert isinstance(
+        response, UploadSessionResponse_Completed
+    ), f"upload {response.upload_id} is {response.status}, not completed"
+    return response
 
 
-def _completed_content(response: Any) -> tuple[ContentRef, str | None, int]:
-    assert response.status == "completed"
-    return (
-        _content_ref(response.content_ref),
-        getattr(response, "content_token", None),
-        response.completed_at_ms,
-    )
+def _aborted_upload(response: UploadSessionResponse) -> UploadSessionResponse_Aborted:
+    assert isinstance(
+        response, UploadSessionResponse_Aborted
+    ), f"upload {response.upload_id} is {response.status}, not aborted"
+    return response
+
+
+def _file_entry(entry: AuthoritativePathEntry) -> AuthoritativePathEntry_File:
+    assert isinstance(
+        entry, AuthoritativePathEntry_File
+    ), f"path {entry.path} is a {entry.inode_kind}, not a file"
+    return entry
+
+
+def _wire(model: pydantic.BaseModel) -> JsonObject:
+    """Render one SDK model back into the JSON the proxy route accepts."""
+    return model.model_dump(mode="json")
 
 
 def _read_proxied(client: LoonFS, namespace_id: str, path: str) -> bytes:
@@ -708,13 +720,9 @@ def test_proxy(
             proxied_complete_response,
             "proxy service-proxied complete response",
         )
-        proxied_complete = UploadSessionResponse(**proxied_complete_data)
-        assert proxied_complete.status == "completed"
-        proxied_content_ref = proxied_complete_data["content_ref"]
-        assert isinstance(proxied_content_ref, dict)
-        assert ContentRef(**proxied_content_ref) == uploaded.content_ref
-        proxied_content_token = proxied_complete_data["content_token"]
-        assert isinstance(proxied_content_token, dict)
+        proxied_complete = UploadSessionResponse_Completed(**proxied_complete_data)
+        assert proxied_complete.content_ref == uploaded.content_ref
+        assert proxied_complete.content_token is not None
         proxied_commit = _proxy_apply_commit(
             client,
             request,
@@ -722,9 +730,9 @@ def test_proxy(
             {
                 "kind": "put_file",
                 "path": request.proxied_path,
-                "content_ref": proxied_content_ref,
+                "content_ref": _wire(proxied_complete.content_ref),
             },
-            proxied_content_token,
+            _wire(proxied_complete.content_token),
         )
         assert proxied_commit.committed_seq == expected.proxied_committed_seq
 
@@ -768,12 +776,9 @@ def test_proxy(
             direct_complete_response,
             "proxy direct-PUT complete response",
         )
-        direct_complete = UploadSessionResponse(**direct_complete_data)
-        assert direct_complete.status == "completed"
-        direct_content_ref = direct_complete_data["content_ref"]
-        assert isinstance(direct_content_ref, dict)
-        direct_content_token = direct_complete_data["content_token"]
-        assert isinstance(direct_content_token, dict)
+        direct_complete = UploadSessionResponse_Completed(**direct_complete_data)
+        assert direct_complete.content_ref.size_bytes == len(payload)
+        assert direct_complete.content_token is not None
         direct_commit = _proxy_apply_commit(
             client,
             request,
@@ -781,9 +786,9 @@ def test_proxy(
             {
                 "kind": "put_file",
                 "path": request.direct_path,
-                "content_ref": direct_content_ref,
+                "content_ref": _wire(direct_complete.content_ref),
             },
-            direct_content_token,
+            _wire(direct_complete.content_token),
         )
         assert direct_commit.committed_seq == expected.direct_committed_seq
 
@@ -868,7 +873,9 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
         begin.upload_id,
         request=CompleteUploadRequest_DirectPut(content=claim),
     )
-    content_ref, content_token, _ = _completed_content(completed)
+    completed = _completed_upload(completed)
+    content_ref = completed.content_ref
+    content_token = completed.content_token
     assert content_ref.size_bytes == expected.size_bytes
     assert content_ref.checksum.algorithm == expected.checksum_algorithm
     assert content_ref.checksum == claim.checksum
@@ -883,8 +890,10 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
         content_tokens=[content_token] if content_token is not None else None,
     )
     assert committed.committed_seq == expected.committed_seq
-    stat = harness.client.filesystem.stat_path(request.namespace_id, path=request.path)
-    assert _content_ref(stat.content_ref) == content_ref
+    stat = _file_entry(
+        harness.client.filesystem.stat_path(request.namespace_id, path=request.path)
+    )
+    assert stat.content_ref == content_ref
     assert _read_proxied(harness.client, request.namespace_id, request.path) == payload
 
 
@@ -956,21 +965,22 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
         begin.upload_id,
         request=completion_request,
     )
-    first_content_ref, _, first_completed_at_ms = _completed_content(first)
+    first_completed = _completed_upload(first)
+    first_content_ref = first_completed.content_ref
     replayed = harness.client.uploads.complete_upload(
         request.namespace_id,
         begin.upload_id,
         request=completion_request,
     )
-    replayed_content_ref, replayed_token, replayed_completed_at_ms = _completed_content(
-        replayed
-    )
+    replayed_completed = _completed_upload(replayed)
+    replayed_content_ref = replayed_completed.content_ref
+    replayed_token = replayed_completed.content_token
 
     assert replayed.namespace_id == first.namespace_id
     assert replayed.upload_id == first.upload_id
     assert replayed.mode == first.mode
     assert replayed_content_ref == first_content_ref
-    assert replayed_completed_at_ms == first_completed_at_ms
+    assert replayed_completed.completed_at_ms == first_completed.completed_at_ms
     assert first_content_ref.size_bytes == expected.size_bytes
     assert first_content_ref.checksum == whole_checksum
     assert first_content_ref.checksum == _checksum(
@@ -1021,9 +1031,11 @@ def test_upload_abort(cases: dict[str, ConformanceCase], harness: Harness) -> No
         request.namespace_id,
         request=BeginUploadRequest_ServiceProxied(),
     )
-    first = harness.client.uploads.abort_upload(request.namespace_id, begin.upload_id)
-    replayed = harness.client.uploads.abort_upload(
-        request.namespace_id, begin.upload_id
+    first = _aborted_upload(
+        harness.client.uploads.abort_upload(request.namespace_id, begin.upload_id)
+    )
+    replayed = _aborted_upload(
+        harness.client.uploads.abort_upload(request.namespace_id, begin.upload_id)
     )
 
     assert first.mode == expected.mode
@@ -1048,13 +1060,15 @@ def test_download(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     )
     assert committed.committed_seq == expected.committed_seq
 
-    stat = harness.client.filesystem.stat_path(request.namespace_id, path=request.path)
+    stat = _file_entry(
+        harness.client.filesystem.stat_path(request.namespace_id, path=request.path)
+    )
     downloaded = get_file(
         harness.client,
         namespace_id=request.namespace_id,
         path=request.path,
     )
-    assert _content_ref(stat.content_ref) == downloaded.content_ref
+    assert stat.content_ref == downloaded.content_ref
     assert downloaded.content_ref.size_bytes == expected.size_bytes
     assert downloaded.content_ref.checksum.algorithm == expected.checksum_algorithm
     assert len(downloaded.content) == downloaded.content_ref.size_bytes

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -239,10 +239,9 @@ interface RunningRecordingServer extends RunningProxy {
 
 type StreamingRequestInit = RequestInit & { duplex?: "half" };
 
-type CompletedUpload = LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
-type AbortedUpload = LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Aborted;
-type FileEntry = LoonFS.AuthoritativePathEntry &
-    LoonFS.AuthoritativePathEntryFile & { kind: "file" };
+type CompletedUpload = Extract<LoonFS.UploadSessionResponse, { status: "completed" }>;
+type AbortedUpload = Extract<LoonFS.UploadSessionResponse, { status: "aborted" }>;
+type FileEntry = Extract<LoonFS.AuthoritativePathEntry, { inode_kind: "file" }>;
 
 
 function jsonObject(value: unknown, label: string): JsonObject {
@@ -707,15 +706,24 @@ async function assertBrowserTransfer(
 }
 
 function completedUpload(response: LoonFS.UploadSessionResponse): CompletedUpload {
-    const completed = response as CompletedUpload;
-    assert.equal(completed.status, "completed");
-    return completed;
+    if (response.status !== "completed") {
+        throw new Error(`upload ${response.upload_id} is ${response.status}, not completed`);
+    }
+    return response;
 }
 
 function abortedUpload(response: LoonFS.UploadSessionResponse): AbortedUpload {
-    const aborted = response as AbortedUpload;
-    assert.equal(aborted.status, "aborted");
-    return aborted;
+    if (response.status !== "aborted") {
+        throw new Error(`upload ${response.upload_id} is ${response.status}, not aborted`);
+    }
+    return response;
+}
+
+function fileEntry(entry: LoonFS.AuthoritativePathEntry): FileEntry {
+    if (entry.inode_kind !== "file") {
+        throw new Error(`path ${entry.path} is a ${entry.inode_kind}, not a file`);
+    }
+    return entry;
 }
 
 function checksum(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): LoonFS.Checksum {
@@ -1342,10 +1350,12 @@ conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
         ),
     );
     assert.equal(committed.committed_seq, expected.committed_seq);
-    const stat = (await activeHarness.client.filesystem.statPath({
-        namespace_id: request.namespace_id,
-        path: request.path,
-    })) as FileEntry;
+    const stat = fileEntry(
+        await activeHarness.client.filesystem.statPath({
+            namespace_id: request.namespace_id,
+            path: request.path,
+        }),
+    );
     assert.deepEqual(stat.content_ref, completed.content_ref);
     assert.deepEqual(
         await readProxied(activeHarness.client, request.namespace_id, request.path),
@@ -1509,10 +1519,12 @@ conformanceTest("download", async (activeHarness, testCase) => {
         commit_id: request.commit_id,
     });
     assert.equal(committed.committed_seq, expected.committed_seq);
-    const stat = (await activeHarness.client.filesystem.statPath({
-        namespace_id: request.namespace_id,
-        path: request.path,
-    })) as FileEntry;
+    const stat = fileEntry(
+        await activeHarness.client.filesystem.statPath({
+            namespace_id: request.namespace_id,
+            path: request.path,
+        }),
+    );
     const download = await getFile(activeHarness.client, {
         namespace_id: request.namespace_id,
         path: request.path,
@@ -1550,10 +1562,12 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
         commit_id: request.commit_ids.upload,
     });
     assert.equal(upload.committed_seq, expected.upload_committed_seq);
-    const stat = (await activeHarness.client.filesystem.statPath({
-        namespace_id: request.namespace_id,
-        path: request.upload_path,
-    })) as FileEntry;
+    const stat = fileEntry(
+        await activeHarness.client.filesystem.statPath({
+            namespace_id: request.namespace_id,
+            path: request.upload_path,
+        }),
+    );
     assert.equal(stat.size_bytes, expected.size_bytes);
     const uploadedInode = stat.inode_id;
 

--- a/sdk/transfers/go/transfers/transfers.go
+++ b/sdk/transfers/go/transfers/transfers.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"hash/crc32"
 	"hash/crc64"
@@ -273,23 +272,15 @@ func getFileProxied(ctx context.Context, c *client.Client, in GetFileInput) (*Ge
 	}, nil
 }
 
-// fileProjection decodes the file fields stored in Fern's extra properties.
+// fileProjection reads the file half of a path entry union.
 func fileProjection(entry *loonfs.AuthoritativePathEntry) (*loonfs.AuthoritativePathEntryFile, error) {
 	if entry == nil {
 		return nil, fmt.Errorf("transfers: path entry is nil")
 	}
-	data, err := json.Marshal(entry.GetExtraProperties())
-	if err != nil {
-		return nil, fmt.Errorf("transfers: encode path entry projection: %w", err)
+	if entry.File == nil {
+		return nil, fmt.Errorf("transfers: path is a %s, not a file", entry.InodeKind)
 	}
-	var projection loonfs.AuthoritativePathEntryKind
-	if err := json.Unmarshal(data, &projection); err != nil {
-		return nil, fmt.Errorf("transfers: decode path entry projection: %w", err)
-	}
-	if projection.File == nil {
-		return nil, fmt.Errorf("transfers: path is a %s, not a file", projection.InodeKind)
-	}
-	return projection.File, nil
+	return entry.File, nil
 }
 
 func beginUploadRequest(
@@ -527,18 +518,10 @@ func completedUploadStatus(response *loonfs.UploadSessionResponse) (*loonfs.Uplo
 	if response == nil {
 		return nil, fmt.Errorf("transfers: upload session response is nil")
 	}
-	data, err := json.Marshal(response.GetExtraProperties())
-	if err != nil {
-		return nil, fmt.Errorf("transfers: encode upload session response: %w", err)
+	if response.Completed == nil || response.Completed.ContentRef == nil {
+		return nil, fmt.Errorf("transfers: upload is %s, not completed", response.Status)
 	}
-	var status loonfs.UploadSessionStatus
-	if err := json.Unmarshal(data, &status); err != nil {
-		return nil, fmt.Errorf("transfers: decode upload status: %w", err)
-	}
-	if status.Completed == nil || status.Completed.ContentRef == nil {
-		return nil, fmt.Errorf("transfers: upload did not complete")
-	}
-	return status.Completed, nil
+	return response.Completed, nil
 }
 
 func splitParts(payload []byte, partSize int) [][]byte {

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -29,6 +29,7 @@ from .types import (
     RevisionNo,
     UploadContentClaim,
     UploadPartChecksumClaim,
+    UploadSessionResponse,
 )
 
 __all__ = ["GetFileResult", "PutFileResult", "get_file", "put_file"]
@@ -195,7 +196,7 @@ def _get_file_proxied(
         entry = client.filesystem.stat_path(namespace_id, path=path)
         if entry.inode_kind != "file":
             raise RuntimeError(f"path {path!r} is a {entry.inode_kind}, not a file")
-        claim = ContentRef(**entry.content_ref)
+        claim = entry.content_ref
         revision_no = entry.revision_no
     else:
         claim = None
@@ -410,14 +411,14 @@ def _send_presigned(
     return response
 
 
-def _completed_content(response) -> _StagedContent:
+def _completed_content(response: UploadSessionResponse) -> _StagedContent:
     if response.status != "completed":
         raise RuntimeError(
             f"upload {response.upload_id!r} completed with status "
             f"{response.status!r}"
         )
     return _StagedContent(
-        content_ref=ContentRef(**response.content_ref),
+        content_ref=response.content_ref,
         content_token=response.content_token,
     )
 

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -128,10 +128,10 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;
     if (revisionNo === undefined) {
-        const entry = (await client.filesystem.statPath({
+        const entry = await client.filesystem.statPath({
             namespace_alias: input.namespace_alias,
             path: input.path,
-        })) as LoonFS.AuthoritativePathEntry & LoonFS.AuthoritativePathEntryKind.File;
+        });
         if (entry.inode_kind !== "file") {
             throw new Error(`path ${input.path} is a ${entry.inode_kind}, not a file`);
         }
@@ -356,13 +356,12 @@ function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
 }
 
 function stagedContent(response: LoonFS.UploadSessionResponse): StagedContent {
-    const completed = response as LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
-    if (completed.status !== "completed") {
-        throw new Error(`upload ${response.upload_id} completed with status ${completed.status}`);
+    if (response.status !== "completed") {
+        throw new Error(`upload ${response.upload_id} completed with status ${response.status}`);
     }
     return {
-        contentRef: completed.content_ref,
-        contentToken: completed.content_token,
+        contentRef: response.content_ref,
+        contentToken: response.content_token,
     };
 }
 

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -125,10 +125,10 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;
     if (revisionNo === undefined) {
-        const entry = (await client.filesystem.statPath({
+        const entry = await client.filesystem.statPath({
             namespace_id: input.namespace_id,
             path: input.path,
-        })) as LoonFS.AuthoritativePathEntry & LoonFS.AuthoritativePathEntryKind.File;
+        });
         if (entry.inode_kind !== "file") {
             throw new Error(`path ${input.path} is a ${entry.inode_kind}, not a file`);
         }
@@ -353,13 +353,12 @@ function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
 }
 
 function stagedContent(response: LoonFS.UploadSessionResponse): StagedContent {
-    const completed = response as LoonFS.UploadSessionResponse & LoonFS.UploadSessionStatus.Completed;
-    if (completed.status !== "completed") {
-        throw new Error(`upload ${response.upload_id} completed with status ${completed.status}`);
+    if (response.status !== "completed") {
+        throw new Error(`upload ${response.upload_id} completed with status ${response.status}`);
     }
     return {
-        contentRef: completed.content_ref,
-        contentToken: completed.content_token,
+        contentRef: response.content_ref,
+        contentToken: response.content_token,
     };
 }
 


### PR DESCRIPTION
`AuthoritativePathEntry`, `UploadSessionResponse`, and `GrepIndexStatusResponse` were rendered as `allOf: [oneOf-union, envelope]`, and Fern's Python and TypeScript generators keep the envelope and drop the union: the generated TypeScript `UploadSessionResponse` had only `mode`, `namespace_id`, and `upload_id`, and the conformance suites carried hand-written casts (one of them checking a `kind` discriminator that does not exist). The OpenAPI postprocessor now merges such composites into top-level discriminated `oneOf` schemas by pushing the envelope fields into every variant, the same shape `BeginUploadResponse` already has; `AuthoritativePathEntryKind`, `UploadSessionStatus`, `GrepIndexLifecycle`, and `AttributesProjection` are no longer referenced and are removed. No wire change. The Go, Python, and TypeScript conformance suites and transfer overlays now consume the real unions.

Rebased onto main. The earlier Go conformance failure (envelope fields read on the union struct instead of its variant) is fixed, and the Go suite was regenerated and run locally through OrbStack: `ok github.com/loonfs/loonfs/sdk/conformance/go`. fmt, clippy (workspace and openapi-gated), loonfs-api, and loonfs-server (openapi) tests pass; both documents regenerate byte-stable.
