### PR TITLE
refactor(format): remove the duplicate WAL floor timestamp

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -94,9 +94,8 @@ pub struct WalFloorState {
     pub namespace_id: NamespaceId,
     /// Earliest sequence at which incremental replay remains promised.
     pub floor_seq: ChangeSeq,
-    /// Unix-millisecond wall-clock time when the referenced manifest basis was last verified.
-    pub verified_at_ms: u64,
-    /// Unix-millisecond wall-clock time stamped by the successful floor update attempt.
+    /// Unix-millisecond stamp of the successful floor update, for
+    /// observability only and never an ordering or validity input.
     pub updated_at_ms: u64,
 }
 

--- a/crates/loonfs-api/tests/golden/control_wal_floor.v1.json
+++ b/crates/loonfs-api/tests/golden/control_wal_floor.v1.json
@@ -1,1 +1,1 @@
-{"kind":"wal_floor","format_version":1,"payload_checksum":"sha256:663c89bbd673e69dab3de873297fd7bf21a587d08e748a11e4c567e1d8ce64c9","payload":{"namespace_id":"demo","floor_seq":1,"verified_at_ms":3000,"updated_at_ms":3000}}
+{"kind":"wal_floor","format_version":1,"payload_checksum":"sha256:99ab5c70f3cfc98e241b7e303797770557a2aa9c0a2aef04503f74c09ffb8930","payload":{"namespace_id":"demo","floor_seq":1,"updated_at_ms":3000}}

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -654,7 +654,6 @@ fn control_objects_match_golden_bytes() {
         WalFloorState {
             namespace_id: namespace_id(),
             floor_seq: ChangeSeq(1),
-            verified_at_ms: 3_000,
             updated_at_ms: 3_000,
         },
     );

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -87,7 +87,6 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         let next = WalFloorState {
             namespace_id: namespace_id.clone(),
             floor_seq: target_floor,
-            verified_at_ms: context.now_ms,
             updated_at_ms: context.now_ms,
         };
         let object_key = loonfs_objectstore::keys::wal_floor(namespace_id);

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -131,7 +131,6 @@ impl FloorRaiseOnCasConflictStore {
             Err(_) => loonfs_api::wire::control::WalFloorState {
                 namespace_id: self.namespace_id.clone(),
                 floor_seq: ChangeSeq(0),
-                verified_at_ms: 1_000,
                 updated_at_ms: 1_000,
             },
         };

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -339,6 +339,10 @@ Six control-object kinds are registered: `wal_head`, `wal_floor`,
 `compaction_lease`. A control-object envelope carrying any other kind string
 is rejected, not skipped.
 
+The WAL floor and the metadata root are the only control objects that carry
+`updated_at_ms`. That field records when the object's last rewrite succeeded,
+and nothing reads it for ordering or validity.
+
 Mutable control-object decoders reject unknown fields in both the envelope and
 the complete nested payload. Otherwise, an older binary could tolerate a
 newer field, erase it during read-modify-write, and still report a successful
@@ -969,8 +973,8 @@ Chain links remain the history authority. The tip plus hints may prefetch or
 count the bounded tail; hints never become GC roots by themselves.
 
 `wal/floor.json` is the symmetrical pair to the head — the earliest retained
-commit boundary next to the latest visible one. It records `floor_seq` and
-verification and update stamps. It is updated only by monotonic compare-and-swap on its
+commit boundary next to the latest visible one. It records `floor_seq` and an
+update stamp. It is updated only by monotonic compare-and-swap on its
 own etag by floor advancement, which is a GC-family operation: it never
 touches the WAL head, so the head changes only when commits land. A missing,
 stale, or unverifiable floor means "retain more history", never less, and the
@@ -1608,7 +1612,7 @@ A namespace with no `metadata/root.json` has nothing to derive a target from,
 so its floor never advances; it retains from its birth sequence until a flush
 publishes a root (section 2.9).
 
-Advancement updates only `wal/floor.json` with compare-and-swap, creating the object on the first advance. The update stores `floor_seq` with its verification stamp and never lowers the floor. `floor_seq <= metadata/root.manifest.manifest_head_seq` must hold. Being below the floor makes an object a deletion candidate, but deletion also requires verification at delete time. If the floor passes an active checkpoint's basis, retention wins ("Garbage collection").
+Advancement updates only `wal/floor.json` with compare-and-swap, creating the object on the first advance. The update stores `floor_seq` and never lowers the floor. `floor_seq <= metadata/root.manifest.manifest_head_seq` must hold. Being below the floor makes an object a deletion candidate, but deletion also requires verification at delete time. If the floor passes an active checkpoint's basis, retention wins ("Garbage collection").
 
 A WAL flush materializes the current durable namespace
 file-set version: if there is no manifest for the current head, the


### PR DESCRIPTION
Removes verified_at_ms from the WAL floor because it always held the same value as updated_at_ms. The WAL floor now stores one timestamp for observability, while ordering and retention decisions continue to use sequence numbers. Updates the durable fixture, tests, and format documentation to match the smaller payload.