### PR TITLE
refactor(client): align Rust method names with API operations

### DIFF
--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -79,10 +79,10 @@ impl PathEntriesPager {
 /// the same error-code registry, which keeps command output consistent.
 impl ResolvedTarget {
     /// Returns the capabilities reported by the selected deployment.
-    pub(crate) async fn capabilities(&self) -> Result<CapabilityDocument, BackendError> {
+    pub(crate) async fn get_capabilities(&self) -> Result<CapabilityDocument, BackendError> {
         match self {
-            Self::Embedded(target) => Ok(target.backend.reader.capabilities()),
-            Self::Remote(target) => Ok(target.client.capabilities().await?),
+            Self::Embedded(target) => Ok(target.backend.reader.get_capabilities()),
+            Self::Remote(target) => Ok(target.client.get_capabilities().await?),
         }
     }
 
@@ -93,7 +93,7 @@ impl ResolvedTarget {
     pub(crate) async fn remote_connectivity(&self) -> Result<(), BackendError> {
         match self {
             Self::Embedded(_) => Ok(()),
-            Self::Remote(target) => match target.client.health().await {
+            Self::Remote(target) => match target.client.get_health().await {
                 Ok(()) | Err(ClientError::Api { .. }) => Ok(()),
                 Err(error) => Err(error.into()),
             },
@@ -104,7 +104,7 @@ impl ResolvedTarget {
     pub(crate) async fn remote_health(&self) -> Result<(), BackendError> {
         match self {
             Self::Embedded(_) => Ok(()),
-            Self::Remote(target) => Ok(target.client.health().await?),
+            Self::Remote(target) => Ok(target.client.get_health().await?),
         }
     }
 
@@ -218,13 +218,16 @@ impl ResolvedTarget {
     }
 
     /// Describes a single path entry, attributes included.
-    pub(crate) async fn stat_path(&self, spec: &NamespacePath) -> Result<PathEntry, BackendError> {
-        self.stat_path_projected(spec, &StatPathOptions::default())
+    pub(crate) async fn get_path_entry(
+        &self,
+        spec: &NamespacePath,
+    ) -> Result<PathEntry, BackendError> {
+        self.get_path_entry_projected(spec, &StatPathOptions::default())
             .await
     }
 
     /// Describes one visible inode, including its attributes.
-    pub(crate) async fn stat_inode(
+    pub(crate) async fn get_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -233,22 +236,22 @@ impl ResolvedTarget {
             Self::Embedded(target) => {
                 target
                     .backend
-                    .stat_inode(namespace_id, inode_id, &StatPathOptions::default())
+                    .get_inode(namespace_id, inode_id, &StatPathOptions::default())
                     .await
             }
             Self::Remote(target) => Ok(target
                 .client
-                .stat_inode(namespace_id, inode_id, &StatPathOptions::default())
+                .get_inode(namespace_id, inode_id, &StatPathOptions::default())
                 .await?),
         }
     }
 
     /// Describes a path without loading its attributes.
-    pub(crate) async fn stat_path_without_attributes(
+    pub(crate) async fn get_path_entry_without_attributes(
         &self,
         spec: &NamespacePath,
     ) -> Result<PathEntry, BackendError> {
-        self.stat_path_projected(
+        self.get_path_entry_projected(
             spec,
             &StatPathOptions {
                 include_attributes: false,
@@ -257,14 +260,14 @@ impl ResolvedTarget {
         .await
     }
 
-    async fn stat_path_projected(
+    async fn get_path_entry_projected(
         &self,
         spec: &NamespacePath,
         options: &StatPathOptions,
     ) -> Result<PathEntry, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.stat_path(spec, options).await,
-            Self::Remote(target) => Ok(target.client.stat_path(spec, options).await?),
+            Self::Embedded(target) => target.backend.get_path_entry(spec, options).await,
+            Self::Remote(target) => Ok(target.client.get_path_entry(spec, options).await?),
         }
     }
 
@@ -297,7 +300,7 @@ impl ResolvedTarget {
     ) -> Result<FileDownload, BackendError> {
         if let (Self::Remote(target), Some(size_bytes)) = (self, size_bytes) {
             if target.client.offers_direct_download(size_bytes).await? {
-                let grant = target.client.begin_download(spec, revision_no).await?;
+                let grant = target.client.create_download(spec, revision_no).await?;
                 return Ok(FileDownload::Direct {
                     stream: Box::new(
                         target
@@ -361,13 +364,13 @@ impl ResolvedTarget {
     }
 
     /// Reads the namespace's grep-index lifecycle (admin plane).
-    pub(crate) async fn get_grep_index_status(
+    pub(crate) async fn get_grep_index(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<GrepIndex, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.get_grep_index_status(namespace_id).await,
-            Self::Remote(target) => Ok(target.client.get_grep_index_status(namespace_id).await?),
+            Self::Embedded(target) => target.backend.get_grep_index(namespace_id).await,
+            Self::Remote(target) => Ok(target.client.get_grep_index(namespace_id).await?),
         }
     }
 
@@ -407,11 +410,7 @@ impl ResolvedTarget {
                 let started_ms = timer.monotonic_now_ms();
                 let mut steps = 0;
                 loop {
-                    let lifecycle = target
-                        .client
-                        .get_grep_index_status(namespace_id)
-                        .await?
-                        .lifecycle;
+                    let lifecycle = target.client.get_grep_index(namespace_id).await?.lifecycle;
                     let reached = lifecycle.is_built_through(target_seq);
                     let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
                     if reached || budget.spent(steps, elapsed_ms) {
@@ -530,17 +529,14 @@ impl ResolvedTarget {
     }
 
     /// Reads what became of an upload session a previous run opened.
-    pub(crate) async fn get_upload_status(
+    pub(crate) async fn get_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
     ) -> Result<UploadSession, BackendError> {
         match self {
             Self::Embedded(_) => Err(upload_sessions_need_a_remote_profile()),
-            Self::Remote(target) => Ok(target
-                .client
-                .get_upload_status(namespace_id, upload_id)
-                .await?),
+            Self::Remote(target) => Ok(target.client.get_upload(namespace_id, upload_id).await?),
         }
     }
 
@@ -738,16 +734,16 @@ impl ResolvedTarget {
     /// reorganization, retention advance, and — when `request.gc` opts in —
     /// one garbage-collection pass. `request.only` restricts it to a single
     /// sub-step.
-    pub(crate) async fn maintenance_step(
+    pub(crate) async fn run_maintenance(
         &self,
         namespace_id: &NamespaceId,
         request: MaintenanceStepRequest,
     ) -> Result<MaintenanceStepResponse, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.maintenance_step(namespace_id, request).await,
+            Self::Embedded(target) => target.backend.run_maintenance(namespace_id, request).await,
             Self::Remote(target) => Ok(target
                 .client
-                .maintenance_step(namespace_id, &request)
+                .run_maintenance(namespace_id, &request)
                 .await?),
         }
     }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -219,13 +219,13 @@ impl EmbeddedBackend {
             .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
     }
 
-    pub(super) async fn stat_path(
+    pub(super) async fn get_path_entry(
         &self,
         spec: &NamespacePath,
         options: &StatPathOptions,
     ) -> Result<PathEntry, BackendError> {
         self.reader
-            .stat_path(
+            .get_path_entry(
                 spec.namespace(),
                 spec.absolute_path().as_str(),
                 options.clone(),
@@ -234,14 +234,14 @@ impl EmbeddedBackend {
             .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
     }
 
-    pub(super) async fn stat_inode(
+    pub(super) async fn get_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
         options: &StatPathOptions,
     ) -> Result<PathEntry, BackendError> {
         self.reader
-            .stat_inode(namespace_id, inode_id, options.clone())
+            .get_inode(namespace_id, inode_id, options.clone())
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
@@ -317,15 +317,15 @@ impl EmbeddedBackend {
         // server. Driving the backfill afterwards is the command's job, not
         // this call's, so an embedded caller and a remote one get the same
         // answer to the same question.
-        self.get_grep_index_status(namespace_id).await
+        self.get_grep_index(namespace_id).await
     }
 
-    pub(super) async fn get_grep_index_status(
+    pub(super) async fn get_grep_index(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<GrepIndex, BackendError> {
         self.grep_worker()
-            .get_grep_index_status(namespace_id)
+            .get_grep_index(namespace_id)
             .await
             .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))
     }
@@ -534,7 +534,7 @@ impl EmbeddedBackend {
             .map_err(grep_error)?
         {
             GrepDisableOutcome::Disabled | GrepDisableOutcome::NotEnabled => {
-                self.get_grep_index_status(namespace_id).await
+                self.get_grep_index(namespace_id).await
             }
             GrepDisableOutcome::Superseded => Err(grep_error(GrepError::PublicationConflict {
                 object_key: loonfs_grep::keyspace::root_key(namespace_id),
@@ -798,7 +798,7 @@ impl EmbeddedBackend {
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
-    pub(super) async fn maintenance_step(
+    pub(super) async fn run_maintenance(
         &self,
         namespace_id: &NamespaceId,
         request: MaintenanceStepRequest,
@@ -808,7 +808,7 @@ impl EmbeddedBackend {
                 .with_invalid_request_param("/metadata/max_wal_tail_segments")
         })?;
         self.admin
-            .maintenance_step_namespace(namespace_id, plan)
+            .run_maintenance(namespace_id, plan)
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
@@ -1099,7 +1099,7 @@ mod tests {
         }
         let indexed_status = target
             .backend
-            .get_grep_index_status(&indexed)
+            .get_grep_index(&indexed)
             .await
             .expect("index status after the drain");
         assert!(
@@ -1187,7 +1187,7 @@ mod tests {
             wait_until(|| async {
                 target
                     .backend
-                    .get_grep_index_status(&namespace)
+                    .get_grep_index(&namespace)
                     .await
                     .expect("index status while hosting")
                     .lifecycle
@@ -1559,7 +1559,7 @@ mod tests {
 
         let missing = rival
             .backend
-            .stat_path(
+            .get_path_entry(
                 &NamespacePath::parse("demo", "/three.txt").expect("namespace path"),
                 &StatPathOptions::default(),
             )

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -94,7 +94,7 @@ async fn run_admin_step(
     };
     let response = context
         .target
-        .maintenance_step(&context.namespace, request)
+        .run_maintenance(&context.namespace, request)
         .await
         .map_err(|error| context.fail(kind, error))?;
 
@@ -128,7 +128,7 @@ async fn run_admin_gc(
     loop {
         let pass = context
             .target
-            .maintenance_step(
+            .run_maintenance(
                 &context.namespace,
                 MaintenanceStepRequest {
                     gc: Some(request.clone()),
@@ -364,7 +364,7 @@ async fn run_admin_flush(
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
-        .maintenance_step(
+        .run_maintenance(
             &context.namespace,
             MaintenanceStepRequest {
                 metadata_maintenance: Some(MetadataMaintenanceRequest {
@@ -392,7 +392,7 @@ async fn run_admin_retention_advance(
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
-        .maintenance_step(
+        .run_maintenance(
             &context.namespace,
             MaintenanceStepRequest {
                 retention: Some(AdvanceRetentionRequest::default()),
@@ -664,7 +664,7 @@ async fn run_admin_index_enable(
     let response = if waited.is_some() {
         context
             .target
-            .get_grep_index_status(&context.namespace)
+            .get_grep_index(&context.namespace)
             .await
             .map_err(|error| context.fail(kind, error))?
     } else {
@@ -692,7 +692,7 @@ async fn run_admin_index_status(
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
-        .get_grep_index_status(&context.namespace)
+        .get_grep_index(&context.namespace)
         .await
         .map_err(|error| context.fail(kind, error))?;
     Ok(CommandOutput {

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -201,12 +201,7 @@ pub(crate) async fn run_filesystem_stat(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let entry = match args.inode {
-        Some(inode_id) => {
-            context
-                .target
-                .stat_inode(&context.namespace, inode_id)
-                .await
-        }
+        Some(inode_id) => context.target.get_inode(&context.namespace, inode_id).await,
         None => {
             let path = args
                 .path
@@ -215,7 +210,7 @@ pub(crate) async fn run_filesystem_stat(
             let allow_root = true;
             let spec = namespace_path(&context.namespace, "path", path, allow_root)
                 .map_err(|error| context.fail(kind, error))?;
-            context.target.stat_path(&spec).await
+            context.target.get_path_entry(&spec).await
         }
     }
     .map_err(|error| context.fail(kind, error))?;
@@ -480,7 +475,7 @@ pub(crate) async fn run_filesystem_get(
         .map_err(|error| context.fail(kind, error))?;
     let entry = context
         .target
-        .stat_path_without_attributes(&spec)
+        .get_path_entry_without_attributes(&spec)
         .await
         .map_err(|error| context.fail(kind, error))?;
     if args.recursive {
@@ -1142,7 +1137,7 @@ async fn commit_a_finished_upload(
     };
     let Ok(status) = context
         .target
-        .get_upload_status(&context.namespace, &resume.upload_id)
+        .get_upload(&context.namespace, &resume.upload_id)
         .await
     else {
         return Ok(None);
@@ -1207,7 +1202,7 @@ pub(crate) async fn run_filesystem_rm(
     // instead of removing (and mis-reporting) a different inode.
     let deleted_inode = context
         .target
-        .stat_path_without_attributes(&spec)
+        .get_path_entry_without_attributes(&spec)
         .await
         .map_err(|error| context.fail(kind, error))?
         .inode_id;
@@ -1369,7 +1364,7 @@ pub(crate) async fn run_filesystem_mkdir(
         Err(error) if args.parents && error.code == ErrorCode::PathConflict.as_str() => {
             let existing = context
                 .target
-                .stat_path_without_attributes(&spec)
+                .get_path_entry_without_attributes(&spec)
                 .await
                 .map_err(|_| context.fail(kind, error.clone()))?;
             if existing.inode_kind() != InodeKind::Directory {
@@ -1445,7 +1440,11 @@ async fn resolve_transfer_destination(
     named: NamespacePath,
     source_leaf: &str,
 ) -> Result<NamespacePath, CliError> {
-    let Ok(existing) = context.target.stat_path_without_attributes(&named).await else {
+    let Ok(existing) = context
+        .target
+        .get_path_entry_without_attributes(&named)
+        .await
+    else {
         // Absent, or unreadable for a reason the transfer itself will
         // report: either way this is not a directory to land inside.
         return Ok(named);
@@ -1525,7 +1524,7 @@ async fn run_filesystem_transfer(
     let result = if transfer_kind == TransferKind::Copy {
         let entry = context
             .target
-            .stat_path_without_attributes(&from)
+            .get_path_entry_without_attributes(&from)
             .await
             .map_err(|error| context.fail(kind, error))?;
         if args.recursive {

--- a/crates/loonfs-cli/src/commands/inspection.rs
+++ b/crates/loonfs-cli/src/commands/inspection.rs
@@ -40,7 +40,7 @@ pub(crate) async fn run_capabilities(
     let mode = resolved.target.mode_str().to_owned();
     let document = resolved
         .target
-        .capabilities()
+        .get_capabilities()
         .await
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
@@ -162,7 +162,7 @@ pub(crate) async fn run_doctor(
         let result = target
             .as_ref()
             .expect("remote provider validation constructs a target")
-            .capabilities()
+            .get_capabilities()
             .await;
         checks.push(match &result {
             Ok(_) => ok(
@@ -211,7 +211,7 @@ pub(crate) async fn run_doctor(
     let capability_result = if remote {
         remote_capabilities.expect("remote auth check records its capability result")
     } else if let Some(target) = &target {
-        target.capabilities().await
+        target.get_capabilities().await
     } else {
         checks.push(skipped(
             DOCTOR_CHECK_NAMES[7],

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -169,7 +169,11 @@ pub(crate) async fn run_put_tree(
         {
             Ok(_) => "created",
             Err(error) if error.code == ErrorCode::PathConflict.as_str() => {
-                match context.target.stat_path_without_attributes(&spec).await {
+                match context
+                    .target
+                    .get_path_entry_without_attributes(&spec)
+                    .await
+                {
                     Ok(entry) if entry.inode_kind() == InodeKind::Directory => "already exists",
                     Ok(_) => {
                         tally.fail(remote, error.into());

--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -144,7 +144,7 @@ impl Client {
     /// names none is rejected. Absent overrides inside a selected action use
     /// the server's defaults.
     /// Retrying this request starts a distinct attempt.
-    pub async fn maintenance_step(
+    pub async fn run_maintenance(
         &self,
         namespace_id: &NamespaceId,
         request: &MaintenanceStepRequest,
@@ -218,7 +218,7 @@ impl Client {
 
     /// Returns whether the namespace's grep index is disabled, being built,
     /// or active. This operation does not change the index.
-    pub async fn get_grep_index_status(&self, namespace_id: &NamespaceId) -> Result<GrepIndex> {
+    pub async fn get_grep_index(&self, namespace_id: &NamespaceId) -> Result<GrepIndex> {
         let url = format!(
             "{}/v0/admin/namespaces/{namespace_id}/grep/index",
             self.base_url

--- a/crates/loonfs-client/src/downloads.rs
+++ b/crates/loonfs-client/src/downloads.rs
@@ -105,7 +105,7 @@ impl Client {
     ///
     /// If the server advertises no proxy limit, this keeps the proxied path.
     pub async fn offers_direct_download(&self, size_bytes: u64) -> Result<bool> {
-        let capabilities = self.capabilities().await?;
+        let capabilities = self.get_capabilities().await?;
         Ok(capabilities.supports(FEATURE_DOWNLOADS_DIRECT_GET)
             && capabilities
                 .limits
@@ -114,7 +114,7 @@ impl Client {
     }
 
     /// Requests short-lived direct access to a file's content object.
-    pub async fn begin_download(
+    pub async fn create_download(
         &self,
         spec: &NamespacePath,
         revision_no: Option<RevisionNo>,
@@ -137,7 +137,7 @@ impl Client {
     }
 
     /// Requests direct access to one retained inode revision.
-    pub async fn begin_download_by_inode(
+    pub async fn create_download_by_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -159,7 +159,7 @@ impl Client {
     /// Feature keys that are not parented by an advertised profile are
     /// dropped rather than trusted, per the spec's client guidance for
     /// malformed documents.
-    pub async fn capabilities(&self) -> Result<CapabilityDocument> {
+    pub async fn get_capabilities(&self) -> Result<CapabilityDocument> {
         if let Some(document) = self.capabilities.get() {
             return Ok(document.clone());
         }
@@ -178,7 +178,7 @@ impl Client {
     }
 
     /// Checks the server's health endpoint.
-    pub async fn health(&self) -> Result<()> {
+    pub async fn get_health(&self) -> Result<()> {
         let url = format!("{}/health", self.base_url);
         self.call_with_transport_retry(&self.get(&url), None)
             .await?;

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -33,7 +33,7 @@ impl Client {
     /// Operations that introduce new external content carry their proofs in
     /// the request's `content_tokens`; stage the bytes with the upload
     /// methods first.
-    pub async fn commit(
+    pub async fn create_commit(
         &self,
         namespace_id: &NamespaceId,
         request: &CommitRequest,
@@ -141,9 +141,9 @@ impl Client {
 
     /// Commits content after an upload completed but its file commit did not.
     ///
-    /// Call [`Self::get_upload_status`] to recover the content reference and
-    /// token. This method then commits the existing content without uploading
-    /// it again.
+    /// Call [`Self::get_upload`] to recover the content reference and token.
+    /// This method then commits the existing content without uploading it
+    /// again.
     pub async fn commit_completed_upload(
         &self,
         spec: &NamespacePath,
@@ -176,7 +176,7 @@ impl Client {
     ) -> Result<ApiCommitResponse> {
         let commit_id = commit_id_or_generated(&options.commit);
         let response = self
-            .commit(
+            .create_commit(
                 spec.namespace(),
                 &CommitRequest {
                     commit_id: commit_id.clone(),
@@ -239,7 +239,7 @@ impl Client {
         spec: &NamespacePath,
         options: &CreateDirectoryOptions,
     ) -> Result<ApiCommitResponse> {
-        self.commit(
+        self.create_commit(
             spec.namespace(),
             &CommitRequest::single(
                 commit_id_or_generated(&options.commit),
@@ -260,7 +260,7 @@ impl Client {
         spec: &NamespacePath,
         options: &DeleteOptions,
     ) -> Result<ApiCommitResponse> {
-        self.commit(
+        self.create_commit(
             spec.namespace(),
             &CommitRequest::single(
                 commit_id_or_generated(&options.commit),
@@ -283,7 +283,7 @@ impl Client {
         spec: &NamespacePath,
         options: &UpdateAttributesOptions,
     ) -> Result<ApiCommitResponse> {
-        self.commit(
+        self.create_commit(
             spec.namespace(),
             &CommitRequest::single(
                 commit_id_or_generated(&options.commit),
@@ -315,7 +315,7 @@ impl Client {
                 to.namespace()
             )));
         }
-        self.commit(
+        self.create_commit(
             from.namespace(),
             &CommitRequest::single(
                 commit_id_or_generated(&options.commit),
@@ -345,7 +345,7 @@ impl Client {
                 to.namespace()
             )));
         }
-        self.commit(
+        self.create_commit(
             from.namespace(),
             &CommitRequest::single(
                 commit_id_or_generated(&options.commit),
@@ -372,7 +372,7 @@ impl Client {
     ) -> Result<ApiCommitResponse> {
         // An absent destination restores in place: the entry re-binds under
         // the parent and name its deletion recorded.
-        self.commit(
+        self.create_commit(
             namespace_id,
             &CommitRequest::single(
                 commit_id_or_generated(&options.commit),
@@ -395,7 +395,7 @@ impl Client {
         source_revision_no: RevisionNo,
         options: &RestoreRevisionOptions,
     ) -> Result<ApiCommitResponse> {
-        self.commit(
+        self.create_commit(
             spec.namespace(),
             &CommitRequest::single(
                 commit_id_or_generated(&options.commit),
@@ -759,7 +759,7 @@ mod tests {
         let (transport, client) = single_attempt_probe();
         assert_single_attempt(
             client
-                .begin_upload(&namespace_id, &BeginUploadRequest::ServiceProxied {})
+                .create_upload(&namespace_id, &BeginUploadRequest::ServiceProxied {})
                 .await,
             &transport,
         );
@@ -768,7 +768,7 @@ mod tests {
         let (transport, client) = single_attempt_probe();
         assert_single_attempt(
             client
-                .begin_direct_put(&namespace_id, Some(b"direct".len() as u64))
+                .create_direct_put_upload(&namespace_id, Some(b"direct".len() as u64))
                 .await,
             &transport,
         );
@@ -807,7 +807,7 @@ mod tests {
         let client = retry_policy_client();
 
         let actual = client
-            .upload_content(&namespace_id, &upload_id, b"content")
+            .put_upload_content(&namespace_id, &upload_id, b"content")
             .await
             .expect("identical content staging should retry");
         assert_eq!(actual, response);

--- a/crates/loonfs-client/src/reads.rs
+++ b/crates/loonfs-client/src/reads.rs
@@ -363,7 +363,7 @@ impl Client {
     }
 
     /// Returns path metadata using the requested projection.
-    pub async fn stat_path(
+    pub async fn get_path_entry(
         &self,
         spec: &NamespacePath,
         options: &StatPathOptions,
@@ -385,7 +385,7 @@ impl Client {
     }
 
     /// Returns the current entry for a visible inode.
-    pub async fn stat_inode(
+    pub async fn get_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,

--- a/crates/loonfs-client/src/uploads/session.rs
+++ b/crates/loonfs-client/src/uploads/session.rs
@@ -5,7 +5,7 @@ use super::staging::presigned_put_request;
 
 impl Client {
     /// Starts an upload session using the transport selected by the request.
-    pub async fn begin_upload(
+    pub async fn create_upload(
         &self,
         namespace_id: &NamespaceId,
         request: &BeginUploadRequest,
@@ -19,12 +19,12 @@ impl Client {
     /// Starts a direct upload of bytes the caller already has.
     ///
     /// A size hint lets the server reject an oversized PUT before signing it.
-    pub async fn begin_direct_put(
+    pub async fn create_direct_put_upload(
         &self,
         namespace_id: &NamespaceId,
         size_bytes: Option<u64>,
     ) -> Result<BeginUploadResponse> {
-        self.begin_upload(namespace_id, &BeginUploadRequest::DirectPut { size_bytes })
+        self.create_upload(namespace_id, &BeginUploadRequest::DirectPut { size_bytes })
             .await
     }
 
@@ -33,12 +33,12 @@ impl Client {
     /// The request does not need a payload length or checksum. The server
     /// returns the part size and checksum algorithm; provider details remain
     /// private and the content reference is returned at completion.
-    pub async fn begin_direct_multipart(
+    pub async fn create_direct_multipart_upload(
         &self,
         namespace_id: &NamespaceId,
         options: DirectMultipartUploadOptions,
     ) -> Result<BeginUploadResponse> {
-        self.begin_upload(
+        self.create_upload(
             namespace_id,
             &BeginUploadRequest::DirectMultipart {
                 part_size_bytes: options.part_size_bytes,
@@ -148,13 +148,13 @@ impl Client {
     }
 
     /// Uploads in-memory bytes through the server for a service-proxied session.
-    pub async fn upload_content(
+    pub async fn put_upload_content(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
         bytes: &[u8],
     ) -> Result<UploadContentResponse> {
-        let request = self.upload_content_request(namespace_id, upload_id);
+        let request = self.put_upload_content_request(namespace_id, upload_id);
         // Proxied uploads are the request most likely to hit the server's
         // concurrency cap; staging the same bytes again is idempotent.
         let response = self
@@ -166,7 +166,7 @@ impl Client {
     /// Stages a payload that arrives in pieces, forwarding it to the server
     /// as it is read.
     ///
-    /// This is [`Self::upload_content`] for a caller that does not hold its
+    /// This is [`Self::put_upload_content`] for a caller that does not hold its
     /// bytes: the payload crosses the client in bounded chunks and the
     /// server hashes it as it forwards it on, so neither side ever holds the
     /// object. A source whose length is unknown is sent with chunked
@@ -175,13 +175,13 @@ impl Client {
     /// Unlike the buffered call this one never resends: a stream is consumed
     /// by the attempt that reads it, so a failure here is the caller's to
     /// handle with a fresh source.
-    pub async fn upload_streamed_content(
+    pub async fn put_upload_content_stream(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
         source: PayloadSource,
     ) -> Result<UploadContentResponse> {
-        let request = self.upload_content_request(namespace_id, upload_id);
+        let request = self.put_upload_content_request(namespace_id, upload_id);
         let (stream, size_bytes) = source.into_stream();
         let response = self
             .call_streamed_once(&request, stream, size_bytes)
@@ -189,7 +189,7 @@ impl Client {
         serde_json::from_slice(&response).map_err(|err| ClientError::Json(err.to_string()))
     }
 
-    fn upload_content_request(
+    fn put_upload_content_request(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
@@ -226,7 +226,7 @@ impl Client {
     /// A completed session returns its content reference and a fresh content
     /// token. A caller that kept the upload id can therefore recover from a
     /// lost completion response without uploading the content again.
-    pub async fn get_upload_status(
+    pub async fn get_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,

--- a/crates/loonfs-client/src/uploads/staging.rs
+++ b/crates/loonfs-client/src/uploads/staging.rs
@@ -336,7 +336,7 @@ impl Client {
     /// Size hints do not cause local rejection. The server checks the final
     /// size for direct PUT and proxied uploads.
     async fn provisional_transport(&self, size_hint: Option<u64>) -> Result<UploadTransport> {
-        let capabilities = self.capabilities().await?;
+        let capabilities = self.get_capabilities().await?;
         Ok(match Self::transport_for(&capabilities, size_hint) {
             Ok(transport) => transport,
             Err(no_fit) if no_fit.direct_put_supported => UploadTransport::DirectPut,
@@ -349,7 +349,7 @@ impl Client {
     /// Returns `UploadTooLarge` before transfer when no transport accepts the
     /// measured size.
     async fn transport_for_measured(&self, size_bytes: u64) -> Result<UploadTransport> {
-        let capabilities = self.capabilities().await?;
+        let capabilities = self.get_capabilities().await?;
         Self::transport_for(&capabilities, Some(size_bytes)).map_err(|no_fit| {
             ClientError::UploadTooLarge {
                 size_bytes,
@@ -430,7 +430,7 @@ impl Client {
         body: DirectPutBody<'_>,
     ) -> Result<StagedContent> {
         let begin = self
-            .begin_direct_put(namespace_id, body.size_hint())
+            .create_direct_put_upload(namespace_id, body.size_hint())
             .await?;
         let BeginUploadResponse::DirectPut {
             upload_id,
@@ -497,7 +497,10 @@ impl Client {
             ),
             None => {
                 let begin = self
-                    .begin_direct_multipart(namespace_id, DirectMultipartUploadOptions::default())
+                    .create_direct_multipart_upload(
+                        namespace_id,
+                        DirectMultipartUploadOptions::default(),
+                    )
                     .await?;
                 let BeginUploadResponse::DirectMultipart {
                     upload_id,
@@ -721,9 +724,9 @@ impl Client {
         bytes: &[u8],
     ) -> Result<StagedContent> {
         let upload = self
-            .begin_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
+            .create_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await?;
-        self.upload_content(namespace_id, upload.upload_id(), bytes)
+        self.put_upload_content(namespace_id, upload.upload_id(), bytes)
             .await?;
         self.complete_staged(namespace_id, upload.upload_id()).await
     }
@@ -739,10 +742,10 @@ impl Client {
         source: PayloadSource,
     ) -> Result<StagedContent> {
         let upload = self
-            .begin_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
+            .create_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await?;
         let staged = self
-            .upload_streamed_content(namespace_id, upload.upload_id(), source)
+            .put_upload_content_stream(namespace_id, upload.upload_id(), source)
             .await;
         if let Err(error) = staged {
             let _ = self.abort_upload(namespace_id, upload.upload_id()).await;

--- a/crates/loonfs-client/src/uploads/staging/tests.rs
+++ b/crates/loonfs-client/src/uploads/staging/tests.rs
@@ -192,7 +192,7 @@ fn capabilities_for(advertised: Advertised) -> Outcome {
     })
 }
 
-fn begin_direct_put(checksum_algorithm: ChecksumAlgorithm) -> Outcome {
+fn create_direct_put_upload(checksum_algorithm: ChecksumAlgorithm) -> Outcome {
     json(&BeginUploadResponse::DirectPut {
         namespace_id: namespace_id(),
         upload_id: upload_id(),
@@ -650,7 +650,7 @@ async fn a_small_payload_past_the_proxy_cap_takes_direct_put() {
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()
         }),
-        begin_direct_put(ChecksumAlgorithm::Sha256),
+        create_direct_put_upload(ChecksumAlgorithm::Sha256),
         Outcome::Success(Vec::new()),
         completed(uploaded),
         commit_landed(),
@@ -689,7 +689,7 @@ async fn an_unknown_length_payload_past_the_proxy_cap_takes_direct_put() {
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024 * 1024),
         }),
-        begin_direct_put(ChecksumAlgorithm::Crc32c),
+        create_direct_put_upload(ChecksumAlgorithm::Crc32c),
         Outcome::Success(Vec::new()),
         completed(uploaded),
         commit_landed(),
@@ -734,7 +734,7 @@ async fn an_unknown_length_payload_takes_direct_put_without_a_preflight_read() {
             proxy_max_bytes: Some(4_096),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024 * 1024),
         }),
-        begin_direct_put(ChecksumAlgorithm::Crc32c),
+        create_direct_put_upload(ChecksumAlgorithm::Crc32c),
         Outcome::Success(Vec::new()),
         completed(uploaded),
         commit_landed(),
@@ -770,7 +770,7 @@ async fn a_direct_put_streams_its_payload_without_ever_holding_it() {
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()
         }),
-        begin_direct_put(ChecksumAlgorithm::Sha256),
+        create_direct_put_upload(ChecksumAlgorithm::Sha256),
         Outcome::Success(Vec::new()),
         completed(uploaded),
         commit_landed(),
@@ -844,7 +844,7 @@ async fn a_file_backed_direct_put_reads_the_file_once_without_spooling_it() {
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()
         }),
-        begin_direct_put(ChecksumAlgorithm::Sha256),
+        create_direct_put_upload(ChecksumAlgorithm::Sha256),
         Outcome::Success(Vec::new()),
         completed(uploaded),
         commit_landed(),
@@ -899,7 +899,7 @@ async fn request_head_for(source: PayloadSource) -> String {
     .expect("valid client config");
     // The response is not the point; the request head is.
     let _ = client
-        .upload_streamed_content(&namespace_id(), &upload_id(), source)
+        .put_upload_content_stream(&namespace_id(), &upload_id(), source)
         .await;
     served.await.expect("probe task")
 }

--- a/crates/loonfs-conformance/tests/reference.rs
+++ b/crates/loonfs-conformance/tests/reference.rs
@@ -259,12 +259,12 @@ async fn run_commit_replay(harness: &Harness, case: &Case) {
     );
     let first = harness
         .client
-        .commit(&namespace, &commit)
+        .create_commit(&namespace, &commit)
         .await
         .expect("first commit");
     let replayed = harness
         .client
-        .commit(&namespace, &commit)
+        .create_commit(&namespace, &commit)
         .await
         .expect("replayed commit");
 
@@ -304,7 +304,7 @@ async fn run_direct_put(harness: &Harness, case: &Case) {
     let payload = request.content_utf8.as_bytes();
     let begin = harness
         .client
-        .begin_direct_put(&namespace, Some(payload.len() as u64))
+        .create_direct_put_upload(&namespace, Some(payload.len() as u64))
         .await
         .expect("begin direct PUT");
     assert_eq!(upload_mode_name(begin.mode()), expected.mode);
@@ -364,7 +364,7 @@ async fn run_direct_put(harness: &Harness, case: &Case) {
     assert_eq!(committed.committed_seq.0, expected.committed_seq);
     let stat = harness
         .client
-        .stat_path(&spec, &StatPathOptions::default())
+        .get_path_entry(&spec, &StatPathOptions::default())
         .await
         .expect("stat direct PUT file");
     assert_eq!(stat.content_ref(), Some(&content_ref));
@@ -419,7 +419,7 @@ async fn run_multipart(harness: &Harness, case: &Case) {
     .expect("valid fixture pattern");
     let begin = harness
         .client
-        .begin_direct_multipart(
+        .create_direct_multipart_upload(
             &namespace,
             DirectMultipartUploadOptions {
                 part_size_bytes: Some(request.part_size_bytes),
@@ -556,7 +556,7 @@ async fn run_abort(harness: &Harness, case: &Case) {
         .expect("create abort namespace");
     let begin = harness
         .client
-        .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin abortable upload");
     assert_eq!(upload_mode_name(begin.mode()), expected.mode);
@@ -638,12 +638,12 @@ async fn run_download(harness: &Harness, case: &Case) {
     assert_eq!(committed.committed_seq.0, expected.committed_seq);
     let stat = harness
         .client
-        .stat_path(&spec, &StatPathOptions::default())
+        .get_path_entry(&spec, &StatPathOptions::default())
         .await
         .expect("stat download file");
     let grant = harness
         .client
-        .begin_download(&spec, None)
+        .create_download(&spec, None)
         .await
         .expect("begin direct download");
     assert_eq!(stat.content_ref(), Some(&grant.content_ref));
@@ -824,7 +824,7 @@ async fn run_changes(harness: &Harness, case: &Case) {
     );
     let committed = harness
         .client
-        .commit(&namespace, &commit)
+        .create_commit(&namespace, &commit)
         .await
         .expect("commit change");
     assert_eq!(committed.committed_seq.0, expected.committed_seq);
@@ -907,7 +907,7 @@ async fn run_end_to_end(harness: &Harness, case: &Case) {
     assert_eq!(upload.committed_seq.0, expected.upload_committed_seq);
     let stat = harness
         .client
-        .stat_path(&upload_path, &StatPathOptions::default())
+        .get_path_entry(&upload_path, &StatPathOptions::default())
         .await
         .expect("stat end-to-end file");
     assert_eq!(stat.size_bytes(), Some(expected.size_bytes));
@@ -925,7 +925,7 @@ async fn run_end_to_end(harness: &Harness, case: &Case) {
 
     let grant = harness
         .client
-        .begin_download(&upload_path, None)
+        .create_download(&upload_path, None)
         .await
         .expect("begin end-to-end download");
     let streamed = stream_grant(&harness.client, &grant).await;

--- a/crates/loonfs-grep/src/reads.rs
+++ b/crates/loonfs-grep/src/reads.rs
@@ -135,7 +135,7 @@ impl<'a> NamespaceReads<'a> {
     pub async fn resolve_path(&self, absolute_path: &AbsolutePath) -> Result<PathEntry> {
         Ok(self
             .reader
-            .stat_path(
+            .get_path_entry(
                 self.namespace_id,
                 absolute_path.as_str(),
                 StatPathOptions {

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -474,7 +474,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     }
 
     /// Returns the grep index's state and maintenance progress.
-    pub async fn get_grep_index_status(&self, namespace_id: &NamespaceId) -> Result<GrepIndex> {
+    pub async fn get_grep_index(&self, namespace_id: &NamespaceId) -> Result<GrepIndex> {
         let root = self.root_state(namespace_id).await?;
         let (lifecycle, next_run_no, reorganize_pending) = match &root {
             Some(root) => (

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -103,7 +103,7 @@ impl GrepHost {
         if let Some(target_seq) = target_seq {
             self.catch_up_grep_index(namespace_id, target_seq).await?;
         }
-        self.get_grep_index_status(namespace_id).await
+        self.get_grep_index(namespace_id).await
     }
 
     /// Runs the index job's bounded steps until the index has built through
@@ -139,7 +139,7 @@ impl GrepHost {
     ) -> Result<GrepIndex, GrepError> {
         match self.worker.disable(namespace_id).await? {
             GrepDisableOutcome::Disabled | GrepDisableOutcome::NotEnabled => {
-                self.get_grep_index_status(namespace_id).await
+                self.get_grep_index(namespace_id).await
             }
             GrepDisableOutcome::Superseded => Err(GrepError::PublicationConflict {
                 object_key: loonfs_grep::keyspace::root_key(namespace_id),
@@ -147,7 +147,7 @@ impl GrepHost {
         }
     }
 
-    pub(crate) async fn get_grep_index_status(
+    pub(crate) async fn get_grep_index(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<GrepIndex, GrepError> {

--- a/crates/loonfs-grep/tests/it/grep_service_differential.rs
+++ b/crates/loonfs-grep/tests/it/grep_service_differential.rs
@@ -241,7 +241,7 @@ async fn planless_scan_returns_exact_materialized_and_wal_boundary_revisions_onc
     let materialized_head = control::head(&fixture.store, &fixture.namespace_id).await;
     fixture
         .admin
-        .maintenance_step_namespace(
+        .run_maintenance(
             &fixture.namespace_id,
             MaintenancePlan {
                 metadata: Some(MetadataMaintenanceOptions {
@@ -322,7 +322,7 @@ async fn planless_scan_deduplicates_an_inode_revised_across_materialization() {
         .expect("write materialized revision");
     fixture
         .admin
-        .maintenance_step_namespace(
+        .run_maintenance(
             &fixture.namespace_id,
             MaintenancePlan {
                 metadata: Some(MetadataMaintenanceOptions {

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -600,7 +600,7 @@ async fn retention_gap_and_vanished_checkpoint_restart_fresh_backfill() {
         .await
         .expect("write after watermark");
     admin
-        .maintenance_step_namespace(
+        .run_maintenance(
             &namespace_id,
             MaintenancePlan {
                 metadata: Some(MetadataMaintenanceOptions {
@@ -612,7 +612,7 @@ async fn retention_gap_and_vanished_checkpoint_restart_fresh_backfill() {
         .await
         .expect("flush wal");
     let floor = admin
-        .maintenance_step_namespace(
+        .run_maintenance(
             &namespace_id,
             MaintenancePlan {
                 advance_retention: true,
@@ -1035,7 +1035,7 @@ async fn a_recursive_delete_hides_matches_and_an_undelete_restores_them() {
     drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
     let segments_before = grep_segment_ids(&store, &namespace_id).await;
     let docs_inode_id = reader
-        .stat_path(&namespace_id, "/docs", Default::default())
+        .get_path_entry(&namespace_id, "/docs", Default::default())
         .await
         .expect("stat the directory")
         .inode_id;

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -84,7 +84,7 @@ pub(super) async fn create_download(
 
     let target = state
         .reader
-        .direct_download_target(&namespace_id, request.path.as_str(), request.revision_no)
+        .create_download(&namespace_id, request.path.as_str(), request.revision_no)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     let access = presigned_access(issuer, &target.object_key).await?;
@@ -141,7 +141,7 @@ pub(super) async fn create_download_by_inode(
     let issuer = direct_get_issuer(&state)?;
     let target = state
         .reader
-        .direct_download_target_by_inode(&namespace_id, inode_id, revision_no)
+        .create_download_by_inode(&namespace_id, inode_id, revision_no)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     let access = presigned_access(issuer, &target.object_key).await?;

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -272,7 +272,7 @@ pub(super) async fn get_path_entry(
     }
     let entry = state
         .reader
-        .stat_path(&namespace_id, &path, options)
+        .get_path_entry(&namespace_id, &path, options)
         .await
         .map_err(|error| {
             ApiResponseError::runtime_for_namespace(&namespace_id, error)
@@ -552,7 +552,7 @@ pub(super) async fn create_commit(
         .instrument(span)
         .await
     } else {
-        state.writer.commit(&namespace_id, request).await
+        state.writer.create_commit(&namespace_id, request).await
     };
     let response = response_result.map_err(|error| {
         ApiResponseError::runtime_for_namespace(&namespace_id, error)

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -86,7 +86,7 @@ pub(super) async fn get_inode(
     }
     let entry = state
         .reader
-        .stat_inode(&namespace_id, inode_id, options)
+        .get_inode(&namespace_id, inode_id, options)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(entry))

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -74,7 +74,7 @@ pub(super) async fn get_capabilities(
 ) -> Result<Json<loonfs_api::CapabilityDocument>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
     query.into_params()?;
-    let mut capabilities = state.reader.capabilities();
+    let mut capabilities = state.reader.get_capabilities();
     // Each direct transport is advertised from the issuer that performs it,
     // so a provider that signs whole-object writes but has no multipart API
     // says exactly that. The read is advertised for the bundle as a whole:
@@ -562,7 +562,7 @@ pub(super) async fn run_maintenance(
         })?;
     let result = state
         .admin
-        .maintenance_step_namespace(&namespace_id, plan)
+        .run_maintenance(&namespace_id, plan)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(result))

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -259,7 +259,7 @@ async fn read_grep_index_status(
 ) -> Result<GrepIndex, ApiResponseError> {
     state
         .grep_worker()
-        .get_grep_index_status(namespace_id)
+        .get_grep_index(namespace_id)
         .await
         .map_err(|error| map_grep_error(namespace_id, error))
 }

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -142,7 +142,7 @@ pub(super) async fn create_upload(
         BeginUploadRequest::ServiceProxied {} => {
             let response = state
                 .writer
-                .begin_upload(&namespace_id, request)
+                .create_upload(&namespace_id, request)
                 .await
                 .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
             Ok(Json(response))
@@ -186,7 +186,7 @@ async fn begin_direct_put_upload(
     let checksum_algorithm = issuer.stored_checksum_algorithm();
     let prepared = state
         .writer
-        .begin_direct_put_upload_target(&namespace_id, checksum_algorithm)
+        .create_direct_put_upload_target(&namespace_id, checksum_algorithm)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     let signed = issuer
@@ -233,7 +233,7 @@ async fn begin_direct_multipart_upload(
     // Use the server's default when no part size is requested.
     let prepared = state
         .writer
-        .begin_direct_multipart_upload_target(
+        .create_direct_multipart_upload_target(
             &namespace_id,
             DirectMultipartUploadOptions { part_size_bytes },
         )
@@ -305,7 +305,7 @@ pub(super) async fn sign_upload_parts(
 
     let targets = state
         .writer
-        .direct_multipart_part_targets(&namespace_id, &upload_id, &request.parts)
+        .sign_upload_parts(&namespace_id, &upload_id, &request.parts)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     let parts = sign_parts(issuer.as_ref(), &targets).await?;
@@ -549,7 +549,7 @@ pub(super) async fn put_upload_content(
     let (stream, outcome) = body.into_stream();
     match state
         .writer
-        .upload_streamed_content(&namespace_id, &upload_id, stream)
+        .put_upload_content_stream(&namespace_id, &upload_id, stream)
         .await
     {
         Ok(response) => Ok(Json(response)),
@@ -818,7 +818,7 @@ pub(super) async fn get_upload(
     let upload_id = parse_upload_id(&upload_id)?;
     let (response, receipt) = state
         .writer
-        .get_upload_status(&namespace_id, &upload_id)
+        .get_upload(&namespace_id, &upload_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(with_content_token(

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1628,7 +1628,7 @@ async fn runtime_created_state_is_readable_through_http() {
     let target = NamespacePath::parse("demo", "/notes/hello.txt").expect("target");
     let stat = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat file");
     assert_eq!(stat.path, "/notes/hello.txt");
@@ -1877,7 +1877,7 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
     assert_api_error(
         harness
             .client
-            .stat_path(&old_child, &Default::default())
+            .get_path_entry(&old_child, &Default::default())
             .await,
         404,
         "path_not_found",
@@ -2303,7 +2303,7 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
     // the proxied content route directly, the way a client that never read
     // the capability document would.
     let session = client
-        .begin_upload(
+        .create_upload(
             &namespace,
             &loonfs_api::v0::BeginUploadRequest::ServiceProxied {},
         )
@@ -2311,7 +2311,7 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
         .expect("begin a proxied upload session");
     assert_api_error(
         client
-            .upload_content(&namespace, session.upload_id(), &[0u8; 4096])
+            .put_upload_content(&namespace, session.upload_id(), &[0u8; 4096])
             .await,
         413,
         "content_too_large",
@@ -2464,7 +2464,7 @@ async fn capability_document_advertises_the_upload_limit() {
 
     let capabilities = harness
         .client
-        .capabilities()
+        .get_capabilities()
         .await
         .expect("fetch capability document");
     assert_eq!(
@@ -2791,7 +2791,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     .await;
     let inode_id = seed_writer
         .reader()
-        .stat_path(&namespace_id("demo"), "/note.txt", Default::default())
+        .get_path_entry(&namespace_id("demo"), "/note.txt", Default::default())
         .await
         .expect("stat seeded file")
         .inode_id;
@@ -2953,13 +2953,13 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
     .await;
     let big_inode_id = seed_writer
         .reader()
-        .stat_path(&namespace_id("demo"), "/big.bin", Default::default())
+        .get_path_entry(&namespace_id("demo"), "/big.bin", Default::default())
         .await
         .expect("stat big file")
         .inode_id;
     let small_inode_id = seed_writer
         .reader()
-        .stat_path(&namespace_id("demo"), "/small.bin", Default::default())
+        .get_path_entry(&namespace_id("demo"), "/small.bin", Default::default())
         .await
         .expect("stat small file")
         .inode_id;
@@ -3813,7 +3813,7 @@ mod direct_download {
             .await
             .expect("seed the oversized file");
         let entry = client
-            .stat_path(&target, &Default::default())
+            .get_path_entry(&target, &Default::default())
             .await
             .expect("stat seeded file");
 
@@ -3827,7 +3827,7 @@ mod direct_download {
         );
 
         let grant = client
-            .begin_download(&target, None)
+            .create_download(&target, None)
             .await
             .expect("download grant");
         assert_eq!(grant.path.as_str(), "/big.bin");
@@ -3850,7 +3850,7 @@ mod direct_download {
             .await
             .expect("delete current binding");
         let inode_grant = client
-            .begin_download_by_inode(&namespace, entry.inode_id, RevisionNo(1))
+            .create_download_by_inode(&namespace, entry.inode_id, RevisionNo(1))
             .await
             .expect("grant retained inode revision");
         assert_eq!(inode_grant.inode_id, entry.inode_id);
@@ -3890,7 +3890,7 @@ mod direct_download {
             .expect("seed revision 1");
 
         let grant = client
-            .begin_download(&target, None)
+            .create_download(&target, None)
             .await
             .expect("grant for revision 1");
         assert_eq!(grant.revision_no, RevisionNo(1));
@@ -3910,7 +3910,7 @@ mod direct_download {
         // And asking for the old revision by number resolves to the same
         // object the earlier grant named.
         let pinned = client
-            .begin_download(&target, Some(RevisionNo(1)))
+            .create_download(&target, Some(RevisionNo(1)))
             .await
             .expect("grant for a prior revision");
         assert_eq!(pinned.revision_no, RevisionNo(1));
@@ -3938,7 +3938,7 @@ mod direct_download {
             .expect("seed a file");
 
         let error = client
-            .begin_download(&target, None)
+            .create_download(&target, None)
             .await
             .expect_err("a deployment with no issuer cannot grant reads");
         match &error {
@@ -3955,12 +3955,12 @@ mod direct_download {
             other => panic!("expected a typed not_supported, got {other:?}"),
         }
         let inode_id = client
-            .stat_path(&target, &Default::default())
+            .get_path_entry(&target, &Default::default())
             .await
             .expect("stat proxied file")
             .inode_id;
         let inode_error = client
-            .begin_download_by_inode(&namespace, inode_id, RevisionNo(1))
+            .create_download_by_inode(&namespace, inode_id, RevisionNo(1))
             .await
             .expect_err("the inode route honors the same provider gate");
         match inode_error {
@@ -3997,7 +3997,7 @@ mod direct_download {
         let transfers = DirectTransferIssuers::read_only(issuer.clone()).with_put(issuer);
         let advertised = start(temp_dir.path(), "put-without-multipart", Some(transfers))
             .await
-            .capabilities()
+            .get_capabilities()
             .await
             .expect("capabilities");
 
@@ -4039,7 +4039,7 @@ mod direct_download {
             .await
             .expect("create namespace");
         let begin = client
-            .begin_direct_put(&namespace_id, Some(5))
+            .create_direct_put_upload(&namespace_id, Some(5))
             .await
             .expect("begin direct put");
 
@@ -4103,7 +4103,7 @@ mod direct_download {
         .await;
 
         // The deployment advertises direct PUT without checksum feature keys.
-        let advertised = client.capabilities().await.expect("capabilities");
+        let advertised = client.get_capabilities().await.expect("capabilities");
         assert!(advertised.supports(FEATURE_UPLOADS_DIRECT_PUT));
         assert!(advertised.supports(FEATURE_DOWNLOADS_DIRECT_GET));
         assert!(
@@ -4129,7 +4129,7 @@ mod direct_download {
             .expect("a large file goes straight to object storage under a crc32c claim");
 
         let grant = client
-            .begin_download(&target, None)
+            .create_download(&target, None)
             .await
             .expect("download grant");
         assert_eq!(
@@ -4154,7 +4154,7 @@ mod direct_download {
         let temp_dir = tempdir().expect("tempdir");
         let advertised = start(temp_dir.path(), "advertises-none", None)
             .await
-            .capabilities()
+            .get_capabilities()
             .await
             .expect("capabilities");
 
@@ -4208,7 +4208,7 @@ mod direct_download {
         // It came home through the grant, byte for byte, which proves the
         // object the presigned write created is the one the commit named.
         let grant = client
-            .begin_download(&target, None)
+            .create_download(&target, None)
             .await
             .expect("download grant");
         assert_eq!(grant.content_ref.size_bytes, payload.len() as u64);

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -394,11 +394,11 @@ pub(crate) mod http_split_support {
         file_bytes: &[u8],
     ) -> StagedUpload {
         let begin = client
-            .begin_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
+            .create_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await
             .expect("begin upload");
         client
-            .upload_content(namespace_id, begin.upload_id(), file_bytes)
+            .put_upload_content(namespace_id, begin.upload_id(), file_bytes)
             .await
             .expect("upload content");
         let complete = client

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -149,7 +149,7 @@ async fn direct_put_round_trip(signed_write: SignedWriteHeaders, config: ServerC
 
     let capabilities = harness
         .client
-        .capabilities()
+        .get_capabilities()
         .await
         .expect("fetch capabilities");
     assert!(capabilities.supports("core.uploads.direct_put"));
@@ -167,7 +167,7 @@ async fn direct_put_round_trip(signed_write: SignedWriteHeaders, config: ServerC
 
     let begin = harness
         .client
-        .begin_direct_put(&namespace_id, Some(bytes.len() as u64))
+        .create_direct_put_upload(&namespace_id, Some(bytes.len() as u64))
         .await
         .expect("begin direct put");
     let (checksum_algorithm, access) = direct_put_of(&begin);
@@ -238,14 +238,14 @@ async fn assert_direct_get_returns_the_written_bytes(
     target: &NamespacePath,
     bytes: &[u8],
 ) {
-    let capabilities = client.capabilities().await.expect("fetch capabilities");
+    let capabilities = client.get_capabilities().await.expect("fetch capabilities");
     assert!(
         capabilities.supports("core.downloads.direct_get"),
         "a provider proven for direct writes must be offered for direct reads"
     );
 
     let grant = client
-        .begin_download(target, None)
+        .create_download(target, None)
         .await
         .expect("begin download");
     let ObjectTransferAccess::PresignedUrl { method, .. } = &grant.access;
@@ -274,7 +274,7 @@ async fn assert_direct_get_capability_serves_ranges(
     bytes: &[u8],
 ) {
     let grant = client
-        .begin_download(target, None)
+        .create_download(target, None)
         .await
         .expect("begin download for ranged reads");
     let ObjectTransferAccess::PresignedUrl { url, headers, .. } = &grant.access;
@@ -322,7 +322,7 @@ async fn assert_wrong_direct_put_bytes_rejected(
     let bytes = b"expected direct put bytes\n";
     let wrong_bytes = b"wrong direct put bytes\n";
     let begin = client
-        .begin_direct_put(namespace_id, Some(bytes.len() as u64))
+        .create_direct_put_upload(namespace_id, Some(bytes.len() as u64))
         .await
         .expect("begin wrong-bytes direct put");
     let (checksum_algorithm, access) = direct_put_of(&begin);
@@ -364,7 +364,7 @@ async fn assert_direct_put_requires_its_signed_headers(
         ),
     ] {
         let begin = client
-            .begin_direct_put(namespace_id, Some(bytes.len() as u64))
+            .create_direct_put_upload(namespace_id, Some(bytes.len() as u64))
             .await
             .expect("begin meddled direct put");
         let (checksum_algorithm, access) = direct_put_of(&begin);
@@ -401,7 +401,7 @@ async fn assert_direct_put_is_no_replace(
 ) {
     let bytes = b"duplicate direct put bytes\n";
     let begin = client
-        .begin_direct_put(namespace_id, Some(bytes.len() as u64))
+        .create_direct_put_upload(namespace_id, Some(bytes.len() as u64))
         .await
         .expect("begin duplicate direct put");
     let (checksum_algorithm, access) = direct_put_of(&begin);
@@ -674,7 +674,7 @@ async fn gcp_gcs_signed_capabilities_are_scoped_bounded_and_single_use() {
 
     let capabilities = harness
         .client
-        .capabilities()
+        .get_capabilities()
         .await
         .expect("fetch capabilities");
     assert!(capabilities.supports("core.uploads.direct_put"));
@@ -701,7 +701,7 @@ async fn assert_gcs_completion_judges_the_object_that_is_there(
 ) {
     let bytes = b"gcs completion reads the object back\n";
     let begin = client
-        .begin_direct_put(namespace_id, Some(bytes.len() as u64))
+        .create_direct_put_upload(namespace_id, Some(bytes.len() as u64))
         .await
         .expect("begin direct put");
     let (checksum_algorithm, access) = direct_put_of(&begin);
@@ -742,7 +742,7 @@ async fn assert_gcs_signed_writes_land_under_the_configured_prefix(
     let bytes = b"gcs prefix scoping\n";
     let begin = harness
         .client
-        .begin_direct_put(&namespace_id, Some(bytes.len() as u64))
+        .create_direct_put_upload(&namespace_id, Some(bytes.len() as u64))
         .await
         .expect("begin direct put");
     let (_, access) = direct_put_of(&begin);
@@ -801,7 +801,7 @@ async fn assert_gcs_read_capability_serves_ranges_and_resumes(
 
     let grant = harness
         .client
-        .begin_download(&target, None)
+        .create_download(&target, None)
         .await
         .expect("begin download");
     let ObjectTransferAccess::PresignedUrl { url, headers, .. } = &grant.access;
@@ -847,7 +847,7 @@ async fn assert_gcs_read_capability_serves_ranges_and_resumes(
 async fn assert_gcs_expired_capability_is_refused(client: &Client, namespace_id: &NamespaceId) {
     let bytes = b"gcs expiry\n";
     let begin = client
-        .begin_direct_put(namespace_id, Some(bytes.len() as u64))
+        .create_direct_put_upload(namespace_id, Some(bytes.len() as u64))
         .await
         .expect("begin direct put");
     let (_, access) = direct_put_of(&begin);
@@ -887,7 +887,7 @@ async fn assert_gcs_cap_bound_object_moves_only_directly(
 
     let grant = harness
         .client
-        .begin_download(&target, None)
+        .create_download(&target, None)
         .await
         .expect("an object past the read cap is served by grant");
     let mut received = Vec::new();
@@ -977,7 +977,7 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
 
     let capabilities = harness
         .client
-        .capabilities()
+        .get_capabilities()
         .await
         .expect("fetch capabilities");
     assert!(capabilities.supports("core.uploads.direct_multipart"));
@@ -1000,7 +1000,7 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
     // not have to: the claim arrives with the completion below.
     let begin = harness
         .client
-        .begin_direct_multipart(&namespace_id, DirectMultipartUploadOptions::default())
+        .create_direct_multipart_upload(&namespace_id, DirectMultipartUploadOptions::default())
         .await
         .expect("begin direct multipart");
     let upload_id = begin.upload_id().clone();
@@ -1145,7 +1145,7 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
     // symmetry this deployment owes.
     let grant = harness
         .client
-        .begin_download(&target, None)
+        .create_download(&target, None)
         .await
         .expect("begin download of the assembled object");
     let mut received = Vec::new();

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -386,7 +386,7 @@ async fn http_admin_maintenance_step_reports_outcomes_not_errors() {
     // Forcing the threshold to one segment flushes the WAL tail, and the
     // named retention and collection actions run behind it.
     let forced: loonfs_api::MaintenanceStepResponse = client
-        .maintenance_step(
+        .run_maintenance(
             &namespace,
             &loonfs_api::MaintenanceStepRequest {
                 metadata_maintenance: Some(loonfs_api::MetadataMaintenanceRequest {
@@ -502,14 +502,17 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
         .await
         .expect("corrupt manifest");
 
-    match cold_client.stat_path(&target, &Default::default()).await {
+    match cold_client
+        .get_path_entry(&target, &Default::default())
+        .await
+    {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "namespace_corrupt"),
         other => panic!("expected namespace_corrupt, got {other:?}"),
     }
     // The warm server keeps serving its pinned pair; the corruption is
     // surfaced by whoever actually consumes the manifest.
     client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("warm server reads from its pinned head-plus-manifest pair");
 

--- a/crates/loonfs-server/tests/it/http_attributes.rs
+++ b/crates/loonfs-server/tests/it/http_attributes.rs
@@ -223,7 +223,7 @@ async fn the_client_round_trips_the_read_options() {
     // this checks: each surface, once, against its own default.
     let stat = harness
         .client
-        .stat_path(&path("/docs/report.txt"), &Default::default())
+        .get_path_entry(&path("/docs/report.txt"), &Default::default())
         .await
         .expect("stat");
     assert_eq!(
@@ -242,7 +242,7 @@ async fn the_client_round_trips_the_read_options() {
 
     let without = harness
         .client
-        .stat_path(
+        .get_path_entry(
             &path("/docs/report.txt"),
             &StatPathOptions {
                 include_attributes: false,
@@ -289,7 +289,7 @@ async fn the_served_capability_document_advertises_attributes() {
 
     let document = harness
         .client
-        .capabilities()
+        .get_capabilities()
         .await
         .expect("read capabilities");
     assert_eq!(

--- a/crates/loonfs-server/tests/it/http_attribution.rs
+++ b/crates/loonfs-server/tests/it/http_attribution.rs
@@ -56,7 +56,7 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
 
     let root = harness
         .client
-        .stat_path(&path("/"), &Default::default())
+        .get_path_entry(&path("/"), &Default::default())
         .await
         .expect("stat root");
     assert_eq!(root.created_by, ActorRef::loonfs_system());
@@ -78,7 +78,7 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
     let create_change = change_at(&harness, create.committed_seq).await;
     let created = harness
         .client
-        .stat_path(&path("/implicit/parent/report.txt"), &Default::default())
+        .get_path_entry(&path("/implicit/parent/report.txt"), &Default::default())
         .await
         .expect("stat created file");
     assert_eq!(created.created_by, creator);
@@ -87,7 +87,7 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
     for parent_path in ["/implicit", "/implicit/parent"] {
         let parent = harness
             .client
-            .stat_path(&path(parent_path), &Default::default())
+            .get_path_entry(&path(parent_path), &Default::default())
             .await
             .expect("stat implicit parent");
         assert_eq!(parent.created_by, creator);
@@ -109,7 +109,7 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
         .expect("replace file");
     let replaced = harness
         .client
-        .stat_path(&path("/implicit/parent/report.txt"), &Default::default())
+        .get_path_entry(&path("/implicit/parent/report.txt"), &Default::default())
         .await
         .expect("stat replaced file");
     assert_eq!(replaced.created_by, creator);
@@ -155,7 +155,7 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
     let copy_change = change_at(&harness, copy.committed_seq).await;
     let copied = harness
         .client
-        .stat_path(&path("/copy.txt"), &Default::default())
+        .get_path_entry(&path("/copy.txt"), &Default::default())
         .await
         .expect("stat copy");
     assert_eq!(copied.created_by, copier);
@@ -174,7 +174,7 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
         .expect("move file");
     let after_move = harness
         .client
-        .stat_path(&path("/moved.txt"), &Default::default())
+        .get_path_entry(&path("/moved.txt"), &Default::default())
         .await
         .expect("stat moved file");
     assert_eq!(after_move.created_by, before_move.created_by);
@@ -199,7 +199,7 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
     let update_change = change_at(&harness, update.committed_seq).await;
     let updated = harness
         .client
-        .stat_path(&path("/moved.txt"), &Default::default())
+        .get_path_entry(&path("/moved.txt"), &Default::default())
         .await
         .expect("stat attributes")
         .attributes

--- a/crates/loonfs-server/tests/it/http_auth.rs
+++ b/crates/loonfs-server/tests/it/http_auth.rs
@@ -374,7 +374,7 @@ async fn puts_with_a_valid_token_reuse_the_ref_and_ignore_irrelevant_tokens() {
     assert_eq!(
         harness
             .client
-            .stat_path(
+            .get_path_entry(
                 &NamespacePath::parse("demo", "/first-copy.txt").expect("path"),
                 &Default::default(),
             )
@@ -421,7 +421,7 @@ async fn bare_operation_body_without_content_tokens_still_parses_and_commits_mkd
     assert_eq!(response.committed_seq, ChangeSeq(1));
     harness
         .client
-        .stat_path(
+        .get_path_entry(
             &NamespacePath::parse("demo", "/docs").expect("path"),
             &Default::default(),
         )
@@ -449,7 +449,7 @@ async fn every_upload_session_route_requires_the_bearer_token() {
         .expect("create namespace");
     let begin = harness
         .client
-        .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
     let upload_id = begin.upload_id().clone();

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -109,7 +109,7 @@ async fn a_batch_commits_once_and_matches_the_same_batch_embedded() {
 
     let committed = harness
         .client
-        .commit(
+        .create_commit(
             &remote_ns,
             &CommitRequest {
                 commit_id: commit_id("batch-one"),
@@ -249,7 +249,7 @@ async fn a_commit_returns_the_change_it_committed_and_replays_it() {
 
     let committed = harness
         .client
-        .commit(&namespace, &request())
+        .create_commit(&namespace, &request())
         .await
         .expect("the put commits");
     assert_eq!(committed.committed_by, loonfs_test_support::test_actor());
@@ -279,7 +279,7 @@ async fn a_commit_returns_the_change_it_committed_and_replays_it() {
     let spec = NamespacePath::parse("demo", ROOT_FILE).expect("path");
     let entry = harness
         .client
-        .stat_path(&spec, &Default::default())
+        .get_path_entry(&spec, &Default::default())
         .await
         .expect("stat the new file");
     assert_eq!(entry.inode_id, created_inode_id);
@@ -303,7 +303,7 @@ async fn a_commit_returns_the_change_it_committed_and_replays_it() {
     // nothing new.
     let replayed = harness
         .client
-        .commit(&namespace, &request())
+        .create_commit(&namespace, &request())
         .await
         .expect("an identical resubmission replays");
     assert_eq!(replayed, committed);
@@ -359,7 +359,7 @@ async fn a_replay_below_the_retention_floor_omits_its_events() {
 
     let committed = harness
         .client
-        .commit(&namespace, &request())
+        .create_commit(&namespace, &request())
         .await
         .expect("the put commits");
     assert!(
@@ -381,7 +381,7 @@ async fn a_replay_below_the_retention_floor_omits_its_events() {
         .expect("create checkpoint");
     let advanced = harness
         .client
-        .maintenance_step(
+        .run_maintenance(
             &namespace,
             &MaintenanceStepRequest {
                 retention: Some(AdvanceRetentionRequest::default()),
@@ -401,7 +401,7 @@ async fn a_replay_below_the_retention_floor_omits_its_events() {
 
     let replayed = harness
         .client
-        .commit(&namespace, &request())
+        .create_commit(&namespace, &request())
         .await
         .expect("an identical resubmission still replays");
     assert_eq!(replayed.committed_seq, committed.committed_seq);
@@ -440,7 +440,7 @@ async fn a_failing_operation_names_its_position_and_commits_nothing() {
     // deletes a path that was never bound.
     let error = harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: commit_id("batch-stops-at-two"),
@@ -496,7 +496,7 @@ async fn a_failing_operation_names_its_position_and_commits_nothing() {
         let spec = NamespacePath::parse("demo", path).expect("path");
         let missing = harness
             .client
-            .stat_path(&spec, &Default::default())
+            .get_path_entry(&spec, &Default::default())
             .await
             .expect_err("the aborted batch wrote nothing");
         match missing {
@@ -538,7 +538,7 @@ async fn an_empty_operation_list_is_rejected() {
 
     let error = harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: commit_id("empty-batch"),
@@ -595,7 +595,7 @@ async fn the_root_path_is_rejected_as_a_mutation_target() {
 
     let alone = harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: commit_id("root-alone"),
@@ -635,7 +635,7 @@ async fn the_root_path_is_rejected_as_a_mutation_target() {
 
     let in_batch = harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: commit_id("root-in-batch"),
@@ -698,7 +698,7 @@ async fn the_root_path_is_rejected_as_a_mutation_target() {
     // namespace that does not answers for the namespace instead.
     let unknown = harness
         .client
-        .commit(
+        .create_commit(
             &namespace_id("missing"),
             &CommitRequest {
                 commit_id: commit_id("root-unknown-namespace"),
@@ -763,12 +763,12 @@ async fn a_batch_replays_under_its_commit_id() {
 
     let first = harness
         .client
-        .commit(&namespace, &batch(operations.clone()))
+        .create_commit(&namespace, &batch(operations.clone()))
         .await
         .expect("batch commits");
     let replayed = harness
         .client
-        .commit(&namespace, &batch(operations.clone()))
+        .create_commit(&namespace, &batch(operations.clone()))
         .await
         .expect("identical resubmission replays");
     assert_eq!(replayed, first);
@@ -787,7 +787,7 @@ async fn a_batch_replays_under_its_commit_id() {
     // id, so the id is spent.
     let conflict = harness
         .client
-        .commit(&namespace, &batch(operations[..1].to_vec()))
+        .create_commit(&namespace, &batch(operations[..1].to_vec()))
         .await
         .expect_err("a different batch cannot reuse the id");
     match conflict {
@@ -843,7 +843,7 @@ async fn a_commit_id_used_embedded_replays_over_http() {
             .await
             .expect("create namespace");
         let receipt = writer
-            .commit(
+            .create_commit(
                 &namespace,
                 CoreCommitRequest {
                     commit_id: commit_id("crosses-transports"),
@@ -886,7 +886,7 @@ async fn a_commit_id_used_embedded_replays_over_http() {
     ];
     let replayed = harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: commit_id("crosses-transports"),
@@ -914,7 +914,7 @@ async fn a_commit_id_used_embedded_replays_over_http() {
     // fails over HTTP on a receipt the embedded runtime wrote.
     let conflict = harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: commit_id("crosses-transports"),
@@ -963,7 +963,7 @@ async fn a_misspelled_commit_guard_is_rejected_rather_than_dropped() {
 
     harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: commit_id("guarded-create"),
@@ -1016,7 +1016,7 @@ async fn a_misspelled_commit_guard_is_rejected_rather_than_dropped() {
     // create published.
     let unchanged = harness
         .client
-        .stat_path(
+        .get_path_entry(
             &NamespacePath::parse("demo", FIRST_FILE).expect("path"),
             &Default::default(),
         )
@@ -1035,7 +1035,7 @@ async fn a_misspelled_commit_guard_is_rejected_rather_than_dropped() {
     .expect("the guard spelled correctly commits");
     let replaced = harness
         .client
-        .stat_path(
+        .get_path_entry(
             &NamespacePath::parse("demo", FIRST_FILE).expect("path"),
             &Default::default(),
         )

--- a/crates/loonfs-server/tests/it/http_inodes.rs
+++ b/crates/loonfs-server/tests/it/http_inodes.rs
@@ -63,14 +63,14 @@ async fn http_stat_inode_tracks_renames_and_revision_reads_survive_deletion() {
 
     let by_path = harness
         .client
-        .stat_path(&before, &Default::default())
+        .get_path_entry(&before, &Default::default())
         .await
         .expect("stat path");
     let inode_id = by_path.inode_id;
     assert_eq!(
         harness
             .client
-            .stat_inode(&namespace, inode_id, &Default::default())
+            .get_inode(&namespace, inode_id, &Default::default())
             .await
             .expect("stat inode before rename"),
         by_path
@@ -91,7 +91,7 @@ async fn http_stat_inode_tracks_renames_and_revision_reads_survive_deletion() {
         .expect("rename file");
     let renamed = harness
         .client
-        .stat_inode(&namespace, inode_id, &Default::default())
+        .get_inode(&namespace, inode_id, &Default::default())
         .await
         .expect("stat inode after rename");
     assert_eq!(renamed.inode_id, inode_id);
@@ -100,7 +100,7 @@ async fn http_stat_inode_tracks_renames_and_revision_reads_survive_deletion() {
         renamed,
         harness
             .client
-            .stat_path(&after, &Default::default())
+            .get_path_entry(&after, &Default::default())
             .await
             .expect("stat renamed path")
     );
@@ -136,7 +136,7 @@ async fn http_stat_inode_tracks_renames_and_revision_reads_survive_deletion() {
     assert_api_code(
         harness
             .client
-            .stat_inode(&namespace, inode_id, &Default::default())
+            .get_inode(&namespace, inode_id, &Default::default())
             .await,
         404,
         ErrorCode::InodeNotFound,
@@ -181,7 +181,7 @@ async fn http_inode_read_errors_use_identity_codes_and_root_is_nameless() {
         .expect("create namespace");
     let root = harness
         .client
-        .stat_inode(&namespace, InodeId(1), &Default::default())
+        .get_inode(&namespace, InodeId(1), &Default::default())
         .await
         .expect("stat root inode");
     assert_eq!(root.path.as_str(), "/");
@@ -196,7 +196,7 @@ async fn http_inode_read_errors_use_identity_codes_and_root_is_nameless() {
         .expect("create directory");
     let directory_id = harness
         .client
-        .stat_path(&directory, &Default::default())
+        .get_path_entry(&directory, &Default::default())
         .await
         .expect("stat directory")
         .inode_id;
@@ -211,7 +211,7 @@ async fn http_inode_read_errors_use_identity_codes_and_root_is_nameless() {
     for result in [
         harness
             .client
-            .stat_inode(&namespace, InodeId(u64::MAX), &Default::default())
+            .get_inode(&namespace, InodeId(u64::MAX), &Default::default())
             .await
             .map(|_| ()),
         harness
@@ -231,7 +231,7 @@ async fn http_inode_read_errors_use_identity_codes_and_root_is_nameless() {
         .expect("put file");
     let file_id = harness
         .client
-        .stat_path(&file, &Default::default())
+        .get_path_entry(&file, &Default::default())
         .await
         .expect("stat file")
         .inode_id;
@@ -258,7 +258,7 @@ async fn http_inode_read_errors_use_identity_codes_and_root_is_nameless() {
     assert_api_code(
         harness
             .client
-            .stat_inode(&deleted_namespace, InodeId(1), &Default::default())
+            .get_inode(&deleted_namespace, InodeId(1), &Default::default())
             .await,
         410,
         ErrorCode::NamespaceDeleted,
@@ -284,7 +284,7 @@ async fn http_inode_read_errors_use_identity_codes_and_root_is_nameless() {
     assert_api_code(
         harness
             .client
-            .begin_download_by_inode(&namespace, file_id, RevisionNo(1))
+            .create_download_by_inode(&namespace, file_id, RevisionNo(1))
             .await,
         501,
         ErrorCode::NotSupported,
@@ -324,7 +324,7 @@ async fn inode_routes_reject_invalid_ids_after_authorization() {
     assert_eq!(
         harness
             .client
-            .stat_path(&inode_27_path, &Default::default())
+            .get_path_entry(&inode_27_path, &Default::default())
             .await
             .expect("stat ino_27")
             .inode_id,

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -380,7 +380,7 @@ async fn http_restore_revision_appends_new_head_and_reports_change() {
         .expect("create file");
     let created = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat created file");
     let inode_id = created.inode_id;
@@ -430,7 +430,7 @@ async fn http_restore_revision_appends_new_head_and_reports_change() {
 
     let entry = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat restored file");
     assert_eq!(entry.inode_id, inode_id);
@@ -534,7 +534,7 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
 
     let entry = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat file");
     let revisions = harness

--- a/crates/loonfs-server/tests/it/http_paths.rs
+++ b/crates/loonfs-server/tests/it/http_paths.rs
@@ -119,12 +119,12 @@ async fn http_put_no_replace_and_copy_preserve_cli_semantics() {
 
     let source_entry = harness
         .client
-        .stat_path(&source, &Default::default())
+        .get_path_entry(&source, &Default::default())
         .await
         .expect("source stat");
     let dest_entry = harness
         .client
-        .stat_path(&destination, &Default::default())
+        .get_path_entry(&destination, &Default::default())
         .await
         .expect("dest stat");
     assert_ne!(source_entry.inode_id, dest_entry.inode_id);
@@ -249,7 +249,11 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
         )
         .await
         .expect("recursive delete succeeds");
-    match harness.client.stat_path(&child, &Default::default()).await {
+    match harness
+        .client
+        .get_path_entry(&child, &Default::default())
+        .await
+    {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
         other => panic!("expected path_not_found after recursive delete, got {other:?}"),
     }

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -133,7 +133,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
 
     let first = harness
         .client
-        .commit(
+        .create_commit(
             &namespace_id("demo"),
             &commit_request(staged.content_ref.clone(), token.clone()),
         )
@@ -143,7 +143,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
 
     let repeated = harness
         .client
-        .commit(
+        .create_commit(
             &namespace_id("demo"),
             &commit_request(staged.content_ref.clone(), token),
         )
@@ -178,7 +178,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
 
     let entry = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat path");
     assert_eq!(entry.head_seq, first.committed_seq);
@@ -330,7 +330,7 @@ async fn http_put_conflict_stands_when_only_the_message_changed() {
     );
     let entry = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat path");
     assert_eq!(
@@ -401,7 +401,7 @@ async fn http_put_conflict_stands_when_only_the_path_changed() {
 
     match harness
         .client
-        .stat_path(&second_target, &Default::default())
+        .get_path_entry(&second_target, &Default::default())
         .await
     {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
@@ -409,7 +409,7 @@ async fn http_put_conflict_stands_when_only_the_path_changed() {
     }
     let entry = harness
         .client
-        .stat_path(&first_target, &Default::default())
+        .get_path_entry(&first_target, &Default::default())
         .await
         .expect("stat path");
     assert_eq!(
@@ -491,7 +491,7 @@ async fn http_put_conflict_stands_when_only_a_guard_changed() {
 
     let entry = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat path");
     assert_eq!(
@@ -527,7 +527,7 @@ async fn http_single_put_does_not_replay_a_multi_operation_commit() {
     let staged = stage_uploaded_content(&harness.client, &namespace, b"stable bytes\n").await;
     let first = harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: commit_id.clone(),
@@ -574,7 +574,7 @@ async fn http_single_put_does_not_replay_a_multi_operation_commit() {
 
     let entry = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat path");
     assert_eq!(
@@ -623,18 +623,18 @@ async fn http_commit_and_mkdir_conflict_when_only_the_message_changed() {
     };
     let first = harness
         .client
-        .commit(&namespace, &commit_request("one"))
+        .create_commit(&namespace, &commit_request("one"))
         .await
         .expect("first commit");
     let replay = harness
         .client
-        .commit(&namespace, &commit_request("one"))
+        .create_commit(&namespace, &commit_request("one"))
         .await
         .expect("an identical retry replays");
     assert_eq!(replay, first);
     match harness
         .client
-        .commit(&namespace, &commit_request("two"))
+        .create_commit(&namespace, &commit_request("two"))
         .await
     {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
@@ -727,7 +727,7 @@ async fn http_put_conflict_stands_when_retention_trimmed_the_committed_seq() {
         .expect("create checkpoint");
     let advanced = harness
         .client
-        .maintenance_step(
+        .run_maintenance(
             &namespace,
             &MaintenanceStepRequest {
                 retention: Some(AdvanceRetentionRequest::default()),
@@ -831,12 +831,12 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
     assert_eq!(copy_repeated, copy_first);
     let source_entry = harness
         .client
-        .stat_path(&source, &Default::default())
+        .get_path_entry(&source, &Default::default())
         .await
         .expect("source stat");
     let copied_entry = harness
         .client
-        .stat_path(&copied, &Default::default())
+        .get_path_entry(&copied, &Default::default())
         .await
         .expect("copied stat");
     assert_ne!(source_entry.inode_id, copied_entry.inode_id);
@@ -876,13 +876,17 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         .await
         .expect("move repeat");
     assert_eq!(move_repeated, move_first);
-    match harness.client.stat_path(&copied, &Default::default()).await {
+    match harness
+        .client
+        .get_path_entry(&copied, &Default::default())
+        .await
+    {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
         other => panic!("expected path_not_found for moved-from path, got {other:?}"),
     }
     let moved_entry = harness
         .client
-        .stat_path(&moved, &Default::default())
+        .get_path_entry(&moved, &Default::default())
         .await
         .expect("moved stat");
     assert_eq!(moved_entry.inode_id, copied_entry.inode_id);
@@ -918,7 +922,11 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         .await
         .expect("delete repeat");
     assert_eq!(delete_repeated, delete_first);
-    match harness.client.stat_path(&moved, &Default::default()).await {
+    match harness
+        .client
+        .get_path_entry(&moved, &Default::default())
+        .await
+    {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
         other => panic!("expected path_not_found for deleted path, got {other:?}"),
     }
@@ -1020,7 +1028,7 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
 
     // Fencing gates writes only; server A still reads the moved file.
     let host_b_entry = client_a
-        .stat_path(&host_b_target, &Default::default())
+        .get_path_entry(&host_b_target, &Default::default())
         .await
         .expect("stat host b file");
     assert_eq!(host_b_entry.head_seq.0, moved.committed_seq.0);

--- a/crates/loonfs-server/tests/it/http_smoke.rs
+++ b/crates/loonfs-server/tests/it/http_smoke.rs
@@ -145,7 +145,7 @@ async fn capabilities_endpoint_advertises_capabilities() {
 
     let capabilities = harness
         .client
-        .capabilities()
+        .get_capabilities()
         .await
         .expect("fetch capabilities");
     assert_eq!(capabilities.protocol_version, "v0");
@@ -213,7 +213,7 @@ async fn capabilities_endpoint_advertises_capabilities() {
 
     let cached = harness
         .client
-        .capabilities()
+        .get_capabilities()
         .await
         .expect("cached capabilities");
     assert_eq!(cached, capabilities);
@@ -248,7 +248,7 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
         .expect("create directory");
     let directory_entry = harness
         .client
-        .stat_path(&directory, &Default::default())
+        .get_path_entry(&directory, &Default::default())
         .await
         .expect("stat directory");
     assert_eq!(directory_entry.inode_kind(), InodeKind::Directory);
@@ -277,7 +277,7 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
 
     let entry = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat path");
     assert_eq!(entry.size_bytes(), Some(16));
@@ -381,12 +381,12 @@ async fn http_namespace_fork_shares_content_and_diverges() {
 
     let source_entry = harness
         .client
-        .stat_path(&source_path, &Default::default())
+        .get_path_entry(&source_path, &Default::default())
         .await
         .expect("source stat");
     let clone_entry = harness
         .client
-        .stat_path(&clone_path, &Default::default())
+        .get_path_entry(&clone_path, &Default::default())
         .await
         .expect("clone stat");
     assert_eq!(source_entry.content_ref(), clone_entry.content_ref());

--- a/crates/loonfs-server/tests/it/http_tls.rs
+++ b/crates/loonfs-server/tests/it/http_tls.rs
@@ -39,7 +39,7 @@ async fn a_client_trusting_the_server_certificate_round_trips_over_tls() {
 
     let stat = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat file");
     assert_eq!(

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -126,7 +126,7 @@ async fn stored_proxied_mode_rejects_other_tags_and_retired_completion_fields_pr
         .expect("create namespace");
     let begin = harness
         .client
-        .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
 
@@ -172,7 +172,7 @@ async fn stored_proxied_mode_rejects_other_tags_and_retired_completion_fields_pr
 
     harness
         .client
-        .upload_content(&namespace, begin.upload_id(), b"hello")
+        .put_upload_content(&namespace, begin.upload_id(), b"hello")
         .await
         .expect("stage content");
     harness
@@ -204,12 +204,12 @@ async fn completion_body_one_under_reaches_session_validation_and_one_over_answe
         .expect("create namespace");
     let begin = harness
         .client
-        .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
     let limit = harness
         .client
-        .capabilities()
+        .get_capabilities()
         .await
         .expect("fetch capabilities")
         .limits
@@ -292,23 +292,23 @@ async fn completion_content_token_passes_unchanged_into_http_commit() {
 
     let begin = harness
         .client
-        .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
     let first_content = harness
         .client
-        .upload_content(&namespace, begin.upload_id(), file_bytes)
+        .put_upload_content(&namespace, begin.upload_id(), file_bytes)
         .await
         .expect("upload content");
     let repeated_content = harness
         .client
-        .upload_content(&namespace, begin.upload_id(), file_bytes)
+        .put_upload_content(&namespace, begin.upload_id(), file_bytes)
         .await
         .expect("repeat upload content");
     assert_eq!(first_content, repeated_content);
     match harness
         .client
-        .upload_content(&namespace, begin.upload_id(), b"different bytes")
+        .put_upload_content(&namespace, begin.upload_id(), b"different bytes")
         .await
     {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "upload_content_conflict"),
@@ -349,7 +349,7 @@ async fn completion_content_token_passes_unchanged_into_http_commit() {
 
     let stat = harness
         .client
-        .stat_path(&target, &Default::default())
+        .get_path_entry(&target, &Default::default())
         .await
         .expect("stat committed file");
     assert_eq!(stat.inode_id, InodeId(2));
@@ -421,10 +421,10 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     // An open session reports itself and mints nothing.
     let open = harness
         .client
-        .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
-    let status = get_upload_status(&harness.server_url, open.upload_id());
+    let status = get_upload(&harness.server_url, open.upload_id());
     assert_eq!(status.namespace_id, namespace);
     assert_eq!(&status.upload_id, open.upload_id());
     assert_eq!(status.mode, UploadMode::ServiceProxied);
@@ -443,7 +443,7 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     else {
         panic!("abort reports an aborted session")
     };
-    let status = get_upload_status(&harness.server_url, open.upload_id());
+    let status = get_upload(&harness.server_url, open.upload_id());
     assert_eq!(status.mode, UploadMode::ServiceProxied);
     let UploadSessionStatus::Aborted { aborted_at_ms } = status.status else {
         panic!("an aborted session reports itself aborted");
@@ -469,7 +469,7 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     // the read hands back, without sending a byte of content again.
     let (upload_id, content_ref, completed_at_ms) =
         complete_upload_session(&harness, &namespace, b"status re-mint").await;
-    let status = get_upload_status(&harness.server_url, &upload_id);
+    let status = get_upload(&harness.server_url, &upload_id);
     assert_eq!(status.mode, UploadMode::ServiceProxied);
     let UploadSessionStatus::Completed {
         completed_at_ms: reported_completed_at_ms,
@@ -542,7 +542,7 @@ async fn client_reads_a_completed_upload_back_and_commits_what_it_names() {
 
     let status = harness
         .client
-        .get_upload_status(&namespace, &upload_id)
+        .get_upload(&namespace, &upload_id)
         .await
         .expect("read the upload session back");
     assert_eq!(status.namespace_id, namespace);
@@ -561,7 +561,7 @@ async fn client_reads_a_completed_upload_back_and_commits_what_it_names() {
 
     let commit = harness
         .client
-        .commit(
+        .create_commit(
             &namespace,
             &CommitRequest {
                 commit_id: CommitId::parse("client-read-back-put").expect("valid commit id"),
@@ -599,12 +599,12 @@ async fn complete_upload_session(
 ) -> (loonfs_api::UploadId, ContentRef, u64) {
     let begin = harness
         .client
-        .begin_upload(namespace, &BeginUploadRequest::ServiceProxied {})
+        .create_upload(namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
     harness
         .client
-        .upload_content(namespace, begin.upload_id(), bytes)
+        .put_upload_content(namespace, begin.upload_id(), bytes)
         .await
         .expect("upload content");
     let completed = harness
@@ -628,7 +628,7 @@ async fn complete_upload_session(
     (begin.upload_id().clone(), content_ref, completed_at_ms)
 }
 
-fn get_upload_status(server_url: &str, upload_id: &loonfs_api::UploadId) -> UploadSession {
+fn get_upload(server_url: &str, upload_id: &loonfs_api::UploadId) -> UploadSession {
     let response = raw_agent()
         .get(&format!(
             "{server_url}/v0/namespaces/demo/uploads/{upload_id}"

--- a/crates/loonfs-server/tests/logging.rs
+++ b/crates/loonfs-server/tests/logging.rs
@@ -267,7 +267,7 @@ async fn expected_typed_errors_use_debug_or_warn_and_keep_completion_fields() {
         .await
         .expect("create namespace");
     let upload = writer
-        .begin_upload(&namespace, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace, BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
 

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -187,7 +187,7 @@ impl ReadCore {
     /// this document before serving it. Callers should still gate on the
     /// document rather than on the backend kind, so the same logic works
     /// against remote deployments that implement more or less.
-    pub(crate) fn capabilities(&self) -> CapabilityDocument {
+    pub(crate) fn get_capabilities(&self) -> CapabilityDocument {
         CapabilityDocument {
             protocol_version: PROTOCOL_VERSION.to_owned(),
             profiles: vec![PROFILE_CORE_V0.to_owned(), PROFILE_ADMIN_V0.to_owned()],

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -187,7 +187,7 @@ impl FsAdmin {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn maintenance_step_namespace(
+    pub async fn run_maintenance(
         &self,
         namespace_id: &NamespaceId,
         mut plan: MaintenancePlan,
@@ -469,11 +469,11 @@ impl FsAdmin {
     /// caller's own task.
     ///
     /// This is the whole of metadata maintenance for a deployment that
-    /// schedules none: bounded steps run through
-    /// [`Self::maintenance_step_namespace`], and the one piece of upkeep that
-    /// does not fit a step runs here. It plans exactly as a step does, so a
-    /// step reporting [`ReorganizeStepOutcome::CompactionRequired`] is what
-    /// says a call here has work to do.
+    /// schedules none: bounded steps run through [`Self::run_maintenance`],
+    /// and the one piece of upkeep that does not fit a step runs here. It
+    /// plans exactly as a step does, so a step reporting
+    /// [`ReorganizeStepOutcome::CompactionRequired`] is what says a call here
+    /// has work to do.
     ///
     /// The job is the same one background work runs: the same executor, the
     /// same finalizer, and no durable record that it is running. Dropping the
@@ -815,13 +815,12 @@ impl FsAdmin {
     /// Advances the namespace retention floor when a verified checkpoint
     /// makes it safe.
     ///
-    /// One name over the one step path: exactly
-    /// [`Self::maintenance_step_namespace`] with a retention-only plan. It
-    /// keeps a name of its own because of what it costs — advancing the
-    /// floor abandons the replay history below it, which is a decision
-    /// rather than upkeep. Nothing schedules it: no maintenance job exists
-    /// for retention, so an unattended deployment keeps its whole history
-    /// until a call arrives here.
+    /// One name over the one step path: exactly [`Self::run_maintenance`]
+    /// with a retention-only plan. It keeps a name of its own because of what
+    /// it costs — advancing the floor abandons the replay history below it,
+    /// which is a decision rather than upkeep. Nothing schedules it: no
+    /// maintenance job exists for retention, so an unattended deployment keeps
+    /// its whole history until a call arrives here.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.maintenance.advance_retention_floor",
@@ -840,7 +839,7 @@ impl FsAdmin {
     ) -> Result<AdvanceRetentionResponse> {
         self.core.record_trace_context(&tracing::Span::current());
         let step = self
-            .maintenance_step_namespace(
+            .run_maintenance(
                 namespace_id,
                 MaintenancePlan {
                     advance_retention: true,

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -114,7 +114,7 @@ async fn an_admin_gc_step_records_the_pass_counters_once() {
 
     assert_eq!(counter(&recorder.snapshot(), "loonfs.gc.retained", &[]), 0);
     let step = admin
-        .maintenance_step_namespace(
+        .run_maintenance(
             &namespace,
             MaintenancePlan {
                 gc: Some(GcConfig::default()),
@@ -373,7 +373,7 @@ async fn explicit_compaction_runs_the_job_while_a_delta_merge_is_still_available
     // shape, publishes the delta merge. That is what proves the merge was
     // there to take.
     let step = scheduled
-        .maintenance_step_namespace(&automatic, metadata_plan())
+        .run_maintenance(&automatic, metadata_plan())
         .await
         .expect("run a writer-scheduled step");
     assert_eq!(
@@ -461,7 +461,7 @@ async fn a_standalone_step_reports_the_compaction_the_explicit_call_runs() {
     sustained_writes(&writer, &standalone, &namespace).await;
 
     let step = standalone
-        .maintenance_step_namespace(&namespace, metadata_plan())
+        .run_maintenance(&namespace, metadata_plan())
         .await
         .expect("run a standalone step");
     assert_eq!(

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -312,7 +312,7 @@ impl FsReader {
             cache_path = tracing::field::Empty,
         )
     )]
-    pub async fn stat_path(
+    pub async fn get_path_entry(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -342,7 +342,7 @@ impl FsReader {
             cache_path = tracing::field::Empty,
         )
     )]
-    pub async fn stat_inode(
+    pub async fn get_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -543,7 +543,7 @@ impl FsReader {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn direct_download_target(
+    pub async fn create_download(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -571,7 +571,7 @@ impl FsReader {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn direct_download_target_by_inode(
+    pub async fn create_download_by_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -55,13 +55,13 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "begin_upload",
-            method = "begin_upload",
+            method = "create_upload",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn begin_upload(
+    pub async fn create_upload(
         &self,
         namespace_id: &NamespaceId,
         request: BeginUploadRequest,
@@ -81,13 +81,13 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "begin_upload",
-            method = "begin_direct_put_upload_target",
+            method = "create_direct_put_upload_target",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn begin_direct_put_upload_target(
+    pub async fn create_direct_put_upload_target(
         &self,
         namespace_id: &NamespaceId,
         checksum_algorithm: ChecksumAlgorithm,
@@ -111,13 +111,13 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "begin_upload",
-            method = "begin_direct_multipart_upload_target",
+            method = "create_direct_multipart_upload_target",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn begin_direct_multipart_upload_target(
+    pub async fn create_direct_multipart_upload_target(
         &self,
         namespace_id: &NamespaceId,
         options: DirectMultipartUploadOptions,
@@ -144,7 +144,7 @@ impl FsWriter {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn direct_multipart_part_targets(
+    pub async fn sign_upload_parts(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
@@ -165,14 +165,14 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "upload_content",
-            method = "upload_content",
+            method = "put_upload_content",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = tracing::field::Empty,
         )
     )]
-    pub async fn upload_content(
+    pub async fn put_upload_content(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
@@ -194,7 +194,7 @@ impl FsWriter {
     /// object's length. Everything after this point — the reference it
     /// produces, completion, publication — is identical to the buffered
     /// path's; callers that already hold their bytes should stay on
-    /// [`Self::upload_content`].
+    /// [`Self::put_upload_content`].
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.upload_content",
@@ -202,14 +202,14 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "upload_content",
-            method = "upload_streamed_content",
+            method = "put_upload_content_stream",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = "streamed",
         )
     )]
-    pub async fn upload_streamed_content(
+    pub async fn put_upload_content_stream(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
@@ -432,7 +432,7 @@ impl FsWriter {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn get_upload_status(
+    pub async fn get_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -820,13 +820,13 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
-            method = "commit",
+            method = "create_commit",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn commit(
+    pub async fn create_commit(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -46,8 +46,8 @@ impl FsReader {
 
     /// Returns the capability document for this embedded build (API spec,
     /// "Capability discovery").
-    pub fn capabilities(&self) -> CapabilityDocument {
-        self.core.capabilities()
+    pub fn get_capabilities(&self) -> CapabilityDocument {
+        self.core.get_capabilities()
     }
 
     /// Snapshots the runtime cache counters.

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -118,8 +118,8 @@ impl FsWriter {
 
     /// Returns the capability document for this embedded build (API spec,
     /// "Capability discovery").
-    pub fn capabilities(&self) -> CapabilityDocument {
-        self.core.capabilities()
+    pub fn get_capabilities(&self) -> CapabilityDocument {
+        self.core.get_capabilities()
     }
 
     /// Snapshots the runtime cache counters.

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -115,7 +115,7 @@ impl MaintenanceJob for MetadataJob {
         // Upkeep alone: no retention, no garbage collection. Both are other
         // decisions, and one of them is another job.
         match admin
-            .maintenance_step_namespace(namespace_id, MaintenancePlan::metadata())
+            .run_maintenance(namespace_id, MaintenancePlan::metadata())
             .await
         {
             Ok(step) => {
@@ -201,7 +201,7 @@ impl MaintenanceJob for GcJob {
             }),
             ..MaintenancePlan::default()
         };
-        let step = match admin.maintenance_step_namespace(namespace_id, plan).await {
+        let step = match admin.run_maintenance(namespace_id, plan).await {
             Ok(step) => step,
             Err(error) if error.code() == ErrorCode::NamespaceNotFound => {
                 // A deleted namespace still owns reclaimable state, so only

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -887,7 +887,7 @@ async fn upload_paths_plant_the_collection_deadlines_they_create() {
         .expect("create namespace");
 
     let begun = writer
-        .begin_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
     assert_eq!(
@@ -900,7 +900,7 @@ async fn upload_paths_plant_the_collection_deadlines_they_create() {
     );
 
     writer
-        .upload_content(&namespace_id, begun.upload_id(), b"body")
+        .put_upload_content(&namespace_id, begun.upload_id(), b"body")
         .await
         .expect("upload content");
     writer

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -72,7 +72,7 @@ impl MaintenancePlan {
     /// Resolves a wire-level step request into the plan it selects.
     ///
     /// A request that selects nothing resolves to an empty plan, which
-    /// [`FsAdmin::maintenance_step_namespace`](crate::FsAdmin::maintenance_step_namespace)
+    /// [`FsAdmin::run_maintenance`](crate::FsAdmin::run_maintenance)
     /// then refuses — one gate, wherever the plan came from.
     pub fn from_request(request: MaintenanceStepRequest) -> Result<Self> {
         Ok(Self {

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -1521,11 +1521,11 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
         .await
         .expect("bootstrap");
     let upload = writer
-        .begin_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
     let staged = writer
-        .upload_content(&namespace_id, upload.upload_id(), b"hello")
+        .put_upload_content(&namespace_id, upload.upload_id(), b"hello")
         .await
         .expect("stage content");
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&shared, &namespace_id)

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -207,7 +207,7 @@ fn read_options_project_grouped_attributes_or_none() {
         .expect("stat");
     assert!(default_stat.attributes.is_some());
 
-    let opted_out = block_on(fs.reader.stat_path(
+    let opted_out = block_on(fs.reader.get_path_entry(
         &namespace_id,
         "/docs/report.txt",
         StatPathOptions {
@@ -262,7 +262,7 @@ fn read_options_project_grouped_attributes_or_none() {
 fn the_embedded_capability_document_advertises_attributes() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "attributes-capability");
-    let document = fs.reader.capabilities();
+    let document = fs.reader.get_capabilities();
     assert_eq!(
         document.features.get(loonfs::FEATURE_ATTRIBUTES),
         Some(&true)

--- a/crates/loonfs/tests/it/attribution_rows.rs
+++ b/crates/loonfs/tests/it/attribution_rows.rs
@@ -254,7 +254,7 @@ fn attributes_root_forks_and_trash_report_their_row_attribution() {
 
     fs.create_checkpoint_blocking(&source_id)
         .expect("checkpoint deletion rows");
-    block_on(fs.admin.maintenance_step_namespace(
+    block_on(fs.admin.run_maintenance(
         &source_id,
         MaintenancePlan {
             advance_retention: true,

--- a/crates/loonfs/tests/it/bulk_file_reads.rs
+++ b/crates/loonfs/tests/it/bulk_file_reads.rs
@@ -190,7 +190,7 @@ async fn build_mixed_namespace(fs: &TestRuntime, namespace_id: &NamespaceId) {
 
     // An undeleted file: visible again, at a new path.
     let recovered_inode_id = fs
-        .stat_path(namespace_id, "/notes/recovered.txt")
+        .get_path_entry(namespace_id, "/notes/recovered.txt")
         .await
         .expect("stat before delete")
         .inode_id;
@@ -605,7 +605,7 @@ async fn resolve_current_files_answers_the_whole_matrix_in_input_order() {
         let fs = &fs;
         let namespace_id = &namespace_id;
         async move {
-            fs.stat_path(namespace_id, path)
+            fs.get_path_entry(namespace_id, path)
                 .await
                 .expect("stat path")
                 .inode_id
@@ -773,7 +773,7 @@ async fn resolve_current_files_refuses_a_batch_over_the_cap() {
     .await
     .expect("put file");
     let alpha = fs
-        .stat_path(&namespace_id, "/docs/alpha.txt")
+        .get_path_entry(&namespace_id, "/docs/alpha.txt")
         .await
         .expect("stat file")
         .inode_id;
@@ -825,7 +825,7 @@ async fn read_content_ref_answers_bytes_and_refuses_over_budget_before_fetching(
     .await
     .expect("put file");
     let content_ref = fs
-        .stat_path(&namespace_id, "/docs/alpha.txt")
+        .get_path_entry(&namespace_id, "/docs/alpha.txt")
         .await
         .expect("stat file")
         .content_ref()
@@ -877,7 +877,7 @@ async fn read_content_ref_refuses_bytes_that_do_not_match_the_reference() {
     .await
     .expect("put file");
     let content_ref = fs
-        .stat_path(&namespace_id, "/docs/alpha.txt")
+        .get_path_entry(&namespace_id, "/docs/alpha.txt")
         .await
         .expect("stat file")
         .content_ref()

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -478,7 +478,7 @@ async fn concurrent_materialized_stat_and_list_share_async_store() {
         .expect("checkpoint");
 
     let (stat, list) = tokio::join!(
-        fs.stat_path(&namespace_id, "/docs/file.txt"),
+        fs.get_path_entry(&namespace_id, "/docs/file.txt"),
         fs.list_path(&namespace_id, "/docs"),
     );
     let stat = stat.expect("stat file");

--- a/crates/loonfs/tests/it/capability_conformance.rs
+++ b/crates/loonfs/tests/it/capability_conformance.rs
@@ -28,7 +28,7 @@ fn embedded_capabilities() -> CapabilityDocument {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let reader = block_on(FsReader::builder_with_store(store).build()).expect("build reader");
-    reader.capabilities()
+    reader.get_capabilities()
 }
 
 /// The composed grep extension, dropped from a document so what remains is

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -129,7 +129,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         }
         publish_candidates(&writer, &namespace_id, candidates).await;
         admin
-            .maintenance_step_namespace(
+            .run_maintenance(
                 &namespace_id,
                 MaintenancePlan {
                     metadata: Some(MetadataMaintenanceOptions {
@@ -203,7 +203,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .expect("build reader");
     let _ = log.take_gets();
     let entry = reader
-        .stat_path(
+        .get_path_entry(
             &namespace_id,
             "/tree/dir-000000/file-000000042.txt",
             Default::default(),

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -209,14 +209,14 @@ async fn the_same_bytes_at_a_different_path_still_conflict() {
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
     assert_eq!(
         runtime
-            .stat_path(&namespace_id, "/b.txt")
+            .get_path_entry(&namespace_id, "/b.txt")
             .await
             .expect_err("the refused rerun wrote nothing")
             .code(),
         ErrorCode::PathNotFound
     );
     let entry = runtime
-        .stat_path(&namespace_id, "/a.txt")
+        .get_path_entry(&namespace_id, "/a.txt")
         .await
         .expect("stat path");
     assert_eq!(
@@ -255,7 +255,7 @@ async fn a_changed_behavior_under_a_used_commit_id_still_conflicts() {
 
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
     let entry = runtime
-        .stat_path(&namespace_id, PATH)
+        .get_path_entry(&namespace_id, PATH)
         .await
         .expect("stat path");
     assert_eq!(
@@ -293,7 +293,7 @@ async fn a_changed_expected_revision_under_a_used_commit_id_still_conflicts() {
 
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
     let entry = runtime
-        .stat_path(&namespace_id, PATH)
+        .get_path_entry(&namespace_id, PATH)
         .await
         .expect("stat path");
     assert_eq!(
@@ -352,7 +352,7 @@ async fn a_single_put_does_not_replay_a_multi_operation_commit() {
 
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
     let entry = runtime
-        .stat_path(&namespace_id, PATH)
+        .get_path_entry(&namespace_id, PATH)
         .await
         .expect("stat path");
     assert_eq!(
@@ -448,7 +448,7 @@ async fn a_changed_message_under_a_used_commit_id_still_conflicts() {
         "the refused rerun did not rewrite the annotation that landed"
     );
     let entry = runtime
-        .stat_path(&namespace_id, PATH)
+        .get_path_entry(&namespace_id, PATH)
         .await
         .expect("stat path");
     assert_eq!(
@@ -557,19 +557,19 @@ async fn a_changed_message_on_a_direct_commit_still_conflicts() {
 
     let first = runtime
         .writer
-        .commit(&namespace_id, request("one"))
+        .create_commit(&namespace_id, request("one"))
         .await
         .expect("first commit");
     let replay = runtime
         .writer
-        .commit(&namespace_id, request("one"))
+        .create_commit(&namespace_id, request("one"))
         .await
         .expect("an identical retry replays");
     assert_eq!(replay, first);
 
     let error = runtime
         .writer
-        .commit(&namespace_id, request("two"))
+        .create_commit(&namespace_id, request("two"))
         .await
         .expect_err("a changed message is a different commit");
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
@@ -602,7 +602,7 @@ async fn a_retention_trimmed_commit_seq_leaves_the_conflict_standing() {
         .expect("create checkpoint");
     let advanced = runtime
         .admin
-        .maintenance_step_namespace(
+        .run_maintenance(
             &namespace_id,
             MaintenancePlan {
                 advance_retention: true,
@@ -684,7 +684,7 @@ async fn a_retry_past_the_receipt_horizon_commits_again() {
     }
     let advanced = runtime
         .admin
-        .maintenance_step_namespace(
+        .run_maintenance(
             &namespace_id,
             MaintenancePlan {
                 advance_retention: true,
@@ -710,7 +710,7 @@ async fn a_retry_past_the_receipt_horizon_commits_again() {
     for _ in 0..32 {
         let step = runtime
             .admin
-            .maintenance_step_namespace(&namespace_id, MaintenancePlan::metadata())
+            .run_maintenance(&namespace_id, MaintenancePlan::metadata())
             .await
             .expect("upkeep step")
             .metadata_maintenance

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -175,13 +175,13 @@ impl TestRuntime {
             .await
     }
 
-    pub(crate) async fn stat_path(
+    pub(crate) async fn get_path_entry(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<PathEntry> {
         self.reader
-            .stat_path(namespace_id, absolute_path, Default::default())
+            .get_path_entry(namespace_id, absolute_path, Default::default())
             .await
     }
 
@@ -242,13 +242,13 @@ impl TestRuntime {
             .await
     }
 
-    pub(crate) async fn begin_direct_put_upload_target(
+    pub(crate) async fn create_direct_put_upload_target(
         &self,
         namespace_id: &NamespaceId,
         checksum_algorithm: ChecksumAlgorithm,
     ) -> loonfs::Result<loonfs::uploads::BeginDirectPutUploadTargetResponse> {
         self.writer
-            .begin_direct_put_upload_target(namespace_id, checksum_algorithm)
+            .create_direct_put_upload_target(namespace_id, checksum_algorithm)
             .await
     }
 
@@ -417,7 +417,7 @@ impl RuntimeTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         plan: MaintenancePlan,
     ) -> loonfs::Result<MaintenanceStepResponse> {
-        block_on(self.admin.maintenance_step_namespace(namespace_id, plan))
+        block_on(self.admin.run_maintenance(namespace_id, plan))
     }
 
     fn flush_wal_blocking(
@@ -434,7 +434,7 @@ impl RuntimeTestExt for TestRuntime {
     ) -> loonfs::Result<PathEntry> {
         block_on(
             self.reader
-                .stat_path(namespace_id, absolute_path, Default::default()),
+                .get_path_entry(namespace_id, absolute_path, Default::default()),
         )
     }
 
@@ -528,7 +528,7 @@ impl RuntimeTestExt for TestRuntime {
     ) -> loonfs::Result<BeginUploadResponse> {
         block_on(
             self.writer
-                .begin_upload(namespace_id, BeginUploadRequest::ServiceProxied {}),
+                .create_upload(namespace_id, BeginUploadRequest::ServiceProxied {}),
         )
     }
 
@@ -538,7 +538,10 @@ impl RuntimeTestExt for TestRuntime {
         upload_id: &UploadId,
         bytes: &[u8],
     ) -> loonfs::Result<UploadContentResponse> {
-        block_on(self.writer.upload_content(namespace_id, upload_id, bytes))
+        block_on(
+            self.writer
+                .put_upload_content(namespace_id, upload_id, bytes),
+        )
     }
 
     fn complete_upload_blocking(
@@ -554,7 +557,7 @@ impl RuntimeTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> loonfs::Result<CommitResponse> {
-        block_on(self.writer.commit(namespace_id, request))
+        block_on(self.writer.create_commit(namespace_id, request))
     }
 
     fn mutate_batch_blocking(

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -490,14 +490,14 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
     let bytes = b"service proxied upload";
     let begin = harness
         .writer
-        .begin_upload(&harness.namespace_id, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&harness.namespace_id, BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
     harness.recording.reset();
 
     harness
         .writer
-        .upload_content(&harness.namespace_id, begin.upload_id(), bytes)
+        .put_upload_content(&harness.namespace_id, begin.upload_id(), bytes)
         .await
         .expect("upload content");
     let upload_counts = harness.recording.snapshot();
@@ -549,7 +549,7 @@ async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_cont
     let bytes = b"direct provider upload";
     let begin = harness
         .writer
-        .begin_direct_put_upload_target(
+        .create_direct_put_upload_target(
             &harness.namespace_id,
             loonfs_api::ChecksumAlgorithm::Sha256,
         )
@@ -648,7 +648,7 @@ async fn writer_mutate_with_external_ref_fails_typed_without_content_io() {
     // content I/O, and the caller still receives a typed core error.
     let error = harness
         .writer
-        .commit(
+        .create_commit(
             &harness.namespace_id,
             put_request("mutate-create", "/file.txt", content_ref.clone()),
         )
@@ -808,7 +808,7 @@ async fn restore_revision_uses_retained_metadata_without_content_io() {
     // re-downloading the retained blob would prove nothing.
     harness
         .writer
-        .commit(
+        .create_commit(
             &harness.namespace_id,
             CommitRequest::single(
                 CommitId::parse("restore-first-revision").expect("valid commit id"),

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -103,7 +103,7 @@ fn direct_put_upload_flow_validates_durable_object_on_complete() {
         .expect("create namespace");
     let claim = direct_put_claim(bytes);
     let begin =
-        block_on(fs.begin_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
+        block_on(fs.create_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
             .expect("begin direct put");
     // The target is minted here, before a byte is written, and the key it
     // names is derived from that identity alone.
@@ -156,7 +156,7 @@ fn direct_put_completion_proves_upload_without_reading_content() {
         .expect("create namespace");
     let claim = direct_put_claim(bytes);
     let begin =
-        block_on(fs.begin_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
+        block_on(fs.create_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
             .expect("begin direct put");
 
     // Stands in for the provider-verified presigned upload.
@@ -196,7 +196,7 @@ fn direct_put_completion_rejects_a_mis_declared_size() {
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let begin =
-        block_on(fs.begin_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
+        block_on(fs.create_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
             .expect("begin direct put");
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
     block_on(direct_store.put_if_absent(&begin.object_key, Bytes::copy_from_slice(bytes)))
@@ -226,7 +226,7 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
         .expect("create namespace");
     let claim = direct_put_claim(promised);
     let begin =
-        block_on(fs.begin_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
+        block_on(fs.create_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
             .expect("begin direct put");
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
     block_on(direct_store.put_if_absent(&begin.object_key, Bytes::copy_from_slice(delivered)))
@@ -267,7 +267,7 @@ fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
         .expect("create namespace");
     let claim = direct_put_claim(bytes);
     let begin =
-        block_on(fs.begin_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
+        block_on(fs.create_direct_put_upload_target(&namespace_id, ChecksumAlgorithm::Sha256))
             .expect("begin direct put");
 
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
@@ -285,8 +285,8 @@ fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
             .is_some(),
         "a store failure must not delete the client's object"
     );
-    let (status, _) = block_on(fs.writer.get_upload_status(&namespace_id, &begin.upload_id))
-        .expect("get upload status");
+    let (status, _) =
+        block_on(fs.writer.get_upload(&namespace_id, &begin.upload_id)).expect("get upload status");
     assert!(
         matches!(status.status, UploadSessionStatus::Open { .. }),
         "a store failure must not end the session"
@@ -425,7 +425,7 @@ fn path_mutations_return_the_commit_id_they_committed_under() {
         // attaches, so the retry reuses the reference the first put landed.
         let landed = fs
             .reader
-            .stat_path(&namespace_id, "/docs/a.txt", Default::default())
+            .get_path_entry(&namespace_id, "/docs/a.txt", Default::default())
             .await
             .expect("stat the committed file")
             .content_ref()
@@ -531,11 +531,11 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         for bytes in [b"alpha" as &[u8], b"beta", b"gamma", b"delta"] {
             let begin = fs
                 .writer
-                .begin_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
+                .create_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
                 .await
                 .expect("begin upload");
             fs.writer
-                .upload_content(&namespace_id, begin.upload_id(), bytes)
+                .put_upload_content(&namespace_id, begin.upload_id(), bytes)
                 .await
                 .expect("upload content");
             let completed = fs

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -498,7 +498,7 @@ fn standalone_reader_builds_without_writer_identity() {
             .expect("build standalone reader");
         // The reader serves the full read surface without an identity.
         let stat = reader
-            .stat_path(&namespace_id, "/docs/hello.txt", Default::default())
+            .get_path_entry(&namespace_id, "/docs/hello.txt", Default::default())
             .await
             .expect("stat through standalone reader");
         assert_eq!(stat.size_bytes(), Some(5));
@@ -569,7 +569,7 @@ fn admin_over_writer_core_invalidates_shared_caches() {
         // Reads and writes on the writer's own runtime see the state the
         // step left behind, with no stale-cache error in between.
         reader
-            .stat_path(&namespace_id, "/docs/file-0.txt", Default::default())
+            .get_path_entry(&namespace_id, "/docs/file-0.txt", Default::default())
             .await
             .expect("read after maintenance is served from revalidated caches");
         writer
@@ -582,7 +582,7 @@ fn admin_over_writer_core_invalidates_shared_caches() {
             .await
             .expect("writes continue against the post-maintenance head");
         reader
-            .stat_path(
+            .get_path_entry(
                 &namespace_id,
                 "/docs/after-maintenance.txt",
                 Default::default(),
@@ -641,11 +641,11 @@ fn put_file_bytes_and_prepare_then_put_commit_equivalent_state() {
 
         let reader = writer.reader();
         let simple_stat = reader
-            .stat_path(&simple_namespace, "/file.txt", Default::default())
+            .get_path_entry(&simple_namespace, "/file.txt", Default::default())
             .await
             .expect("stat simple put");
         let prepared_stat = reader
-            .stat_path(&prepared_namespace, "/file.txt", Default::default())
+            .get_path_entry(&prepared_namespace, "/file.txt", Default::default())
             .await
             .expect("stat prepared put");
         assert_eq!(simple_stat.revision_no(), prepared_stat.revision_no());
@@ -709,7 +709,7 @@ fn manual_only_writer_never_schedules_maintenance() {
 
         // Explicit admin maintenance bounds the tail the writer left.
         let step = admin
-            .maintenance_step_namespace(&namespace_id, MaintenancePlan::metadata())
+            .run_maintenance(&namespace_id, MaintenancePlan::metadata())
             .await
             .expect("explicit maintenance step")
             .metadata_maintenance
@@ -981,7 +981,7 @@ fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
             .expect("create checkpoint");
         assert!(checkpoint.manifest_no > ManifestNo(0));
         let retention = admin
-            .maintenance_step_namespace(
+            .run_maintenance(
                 &namespace_id,
                 MaintenancePlan {
                     advance_retention: true,

--- a/crates/loonfs/tests/it/immutable_view_inputs.rs
+++ b/crates/loonfs/tests/it/immutable_view_inputs.rs
@@ -46,7 +46,7 @@ async fn build_namespace(store: &SharedObjectStore, namespace_id: &NamespaceId) 
             .expect("seed file");
     }
     admin
-        .maintenance_step_namespace(
+        .run_maintenance(
             namespace_id,
             MaintenancePlan {
                 metadata: Some(MetadataMaintenanceOptions {
@@ -75,7 +75,7 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
         .await
         .expect("build reader");
     reader
-        .stat_path(&namespace_id, "/docs/file-0.txt", Default::default())
+        .get_path_entry(&namespace_id, "/docs/file-0.txt", Default::default())
         .await
         .expect("first stat");
     let warmup = immutable_input_gets(&recording.take_get_keys());
@@ -85,7 +85,7 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
     );
 
     reader
-        .stat_path(&namespace_id, "/docs/file-1.txt", Default::default())
+        .get_path_entry(&namespace_id, "/docs/file-1.txt", Default::default())
         .await
         .expect("second stat");
     let repeats = immutable_input_gets(&recording.take_get_keys());

--- a/crates/loonfs/tests/it/inode_reads.rs
+++ b/crates/loonfs/tests/it/inode_reads.rs
@@ -51,13 +51,13 @@ async fn stat_inode_tracks_a_rename_and_retained_revisions_keep_the_same_identit
 
     let path_entry = fs
         .reader
-        .stat_path(&namespace_id, "/before.txt", StatPathOptions::default())
+        .get_path_entry(&namespace_id, "/before.txt", StatPathOptions::default())
         .await
         .expect("stat path before rename");
     let inode_id = path_entry.inode_id;
     let inode_entry = fs
         .reader
-        .stat_inode(&namespace_id, inode_id, StatPathOptions::default())
+        .get_inode(&namespace_id, inode_id, StatPathOptions::default())
         .await
         .expect("stat inode before rename");
     assert_eq!(inode_entry, path_entry);
@@ -80,7 +80,7 @@ async fn stat_inode_tracks_a_rename_and_retained_revisions_keep_the_same_identit
         .expect("rename file");
     let after = fs
         .reader
-        .stat_inode(&namespace_id, inode_id, StatPathOptions::default())
+        .get_inode(&namespace_id, inode_id, StatPathOptions::default())
         .await
         .expect("stat inode after rename");
     assert_eq!(after.inode_id, inode_id);
@@ -88,7 +88,7 @@ async fn stat_inode_tracks_a_rename_and_retained_revisions_keep_the_same_identit
     assert_eq!(
         after,
         fs.reader
-            .stat_path(&namespace_id, "/after.txt", StatPathOptions::default())
+            .get_path_entry(&namespace_id, "/after.txt", StatPathOptions::default())
             .await
             .expect("stat renamed path")
     );
@@ -113,7 +113,7 @@ async fn stat_inode_tracks_a_rename_and_retained_revisions_keep_the_same_identit
         .expect("delete file");
     let hidden = fs
         .reader
-        .stat_inode(&namespace_id, inode_id, StatPathOptions::default())
+        .get_inode(&namespace_id, inode_id, StatPathOptions::default())
         .await
         .expect_err("deleted inode is not current");
     assert_eq!(hidden.code(), ErrorCode::InodeNotFound);
@@ -148,7 +148,7 @@ async fn stat_inode_preserves_the_nameless_root_and_revision_error_conventions()
 
     let root = fs
         .reader
-        .stat_inode(&namespace_id, InodeId(1), StatPathOptions::default())
+        .get_inode(&namespace_id, InodeId(1), StatPathOptions::default())
         .await
         .expect("stat root inode");
     assert_eq!(root.path.as_str(), "/");
@@ -157,7 +157,7 @@ async fn stat_inode_preserves_the_nameless_root_and_revision_error_conventions()
     assert_eq!(
         root,
         fs.reader
-            .stat_path(&namespace_id, "/", StatPathOptions::default())
+            .get_path_entry(&namespace_id, "/", StatPathOptions::default())
             .await
             .expect("stat root path")
     );
@@ -168,7 +168,7 @@ async fn stat_inode_preserves_the_nameless_root_and_revision_error_conventions()
         .expect("create directory");
     let directory = fs
         .reader
-        .stat_path(&namespace_id, "/docs", StatPathOptions::default())
+        .get_path_entry(&namespace_id, "/docs", StatPathOptions::default())
         .await
         .expect("stat directory");
     let directory_error = fs
@@ -180,7 +180,7 @@ async fn stat_inode_preserves_the_nameless_root_and_revision_error_conventions()
 
     for error in [
         fs.reader
-            .stat_inode(&namespace_id, InodeId(u64::MAX), StatPathOptions::default())
+            .get_inode(&namespace_id, InodeId(u64::MAX), StatPathOptions::default())
             .await
             .expect_err("unknown inode stat"),
         fs.reader
@@ -222,7 +222,7 @@ async fn stat_inode_and_stat_path_have_the_same_point_lookup_request_count() {
         .expect("put file");
     let inode_id = fs
         .reader
-        .stat_path(&namespace_id, "/file.txt", StatPathOptions::default())
+        .get_path_entry(&namespace_id, "/file.txt", StatPathOptions::default())
         .await
         .expect("discover inode")
         .inode_id;
@@ -234,7 +234,7 @@ async fn stat_inode_and_stat_path_have_the_same_point_lookup_request_count() {
         .await
         .expect("build path reader");
     path_reader
-        .stat_path(&namespace_id, "/file.txt", StatPathOptions::default())
+        .get_path_entry(&namespace_id, "/file.txt", StatPathOptions::default())
         .await
         .expect("cold path stat");
     let path_gets = recorded.take_gets();
@@ -245,7 +245,7 @@ async fn stat_inode_and_stat_path_have_the_same_point_lookup_request_count() {
         .await
         .expect("build inode reader");
     inode_reader
-        .stat_inode(&namespace_id, inode_id, StatPathOptions::default())
+        .get_inode(&namespace_id, inode_id, StatPathOptions::default())
         .await
         .expect("cold inode stat");
     let inode_gets = recorded.take_gets();

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -497,7 +497,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
             .expect("warmup put");
     }
     reader
-        .stat_path(&namespace_id, "/docs/warm-0.txt", Default::default())
+        .get_path_entry(&namespace_id, "/docs/warm-0.txt", Default::default())
         .await
         .expect("warmup stat");
 
@@ -539,7 +539,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
     );
 
     reader
-        .stat_path(&namespace_id, "/docs/fresh.txt", Default::default())
+        .get_path_entry(&namespace_id, "/docs/fresh.txt", Default::default())
         .await
         .expect("read after write");
     let read_gets = recording.take_get_keys();

--- a/crates/loonfs/tests/it/publication.rs
+++ b/crates/loonfs/tests/it/publication.rs
@@ -64,11 +64,11 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
     // callers start being cancelled, the only work still in flight is
     // publication, the thing under test.
     let upload = writer
-        .begin_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
     let staged = writer
-        .upload_content(&namespace_id, upload.upload_id(), b"b")
+        .put_upload_content(&namespace_id, upload.upload_id(), b"b")
         .await
         .expect("stage second put content");
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -193,7 +193,7 @@ async fn warm_phase_request_accounting() {
         publish_candidates(&writer, &namespace_id, candidates).await;
         if (index / BATCH) % STEP_EVERY_BATCHES == 0 {
             admin
-                .maintenance_step_namespace(
+                .run_maintenance(
                     &namespace_id,
                     MaintenancePlan {
                         metadata: Some(MetadataMaintenanceOptions {
@@ -250,7 +250,7 @@ async fn warm_phase_request_accounting() {
     report("warm full list", &log.take_gets(), &segments);
 
     reader
-        .stat_path(&namespace_id, "/hot/file-04999.txt", Default::default())
+        .get_path_entry(&namespace_id, "/hot/file-04999.txt", Default::default())
         .await
         .expect("stat");
     report("warm stat", &log.take_gets(), &segments);

--- a/crates/loonfs/tests/it/runtime_config.rs
+++ b/crates/loonfs/tests/it/runtime_config.rs
@@ -161,7 +161,7 @@ async fn async_runtime_methods_are_the_engine_boundary() {
     .await
     .expect("put file");
 
-    let async_stat = FsReader::stat_path(
+    let async_stat = FsReader::get_path_entry(
         &fs.reader,
         &namespace_id,
         "/docs/hello.txt",

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -174,7 +174,7 @@ async fn a_published_put_keeps_its_content_and_loses_only_the_session_record() {
         .expect("published put");
     let content_ref = runtime
         .reader
-        .stat_path(&namespace_id, "/docs/kept.txt", Default::default())
+        .get_path_entry(&namespace_id, "/docs/kept.txt", Default::default())
         .await
         .expect("stat file")
         .content_ref()
@@ -230,7 +230,7 @@ async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survi
         .expect("first put");
     let committed_content_ref = runtime
         .reader
-        .stat_path(&namespace_id, "/docs/retry.txt", Default::default())
+        .get_path_entry(&namespace_id, "/docs/retry.txt", Default::default())
         .await
         .expect("stat file")
         .content_ref()

--- a/crates/loonfs/tests/it/streamed_read.rs
+++ b/crates/loonfs/tests/it/streamed_read.rs
@@ -163,7 +163,7 @@ async fn a_streamed_read_rejects_content_that_stopped_matching_its_reference() {
     // Same length, different bytes: nothing but the digest can tell, which
     // is the case the read exists to catch.
     let entry = reader
-        .stat_path(&namespace_id, PATH, Default::default())
+        .get_path_entry(&namespace_id, PATH, Default::default())
         .await
         .expect("stat file");
     let content_ref = entry.content_ref().cloned().expect("a file has content");

--- a/crates/loonfs/tests/operation_spans.rs
+++ b/crates/loonfs/tests/operation_spans.rs
@@ -73,7 +73,7 @@ fn every_handle_emits_an_operation_span_with_its_namespace() {
 
         let reader = writer.reader();
         reader
-            .stat_path(&namespace_id, "/", Default::default())
+            .get_path_entry(&namespace_id, "/", Default::default())
             .await
             .expect("stat namespace root");
         reader

--- a/crates/loonfs/tests/read_tracing_capture.rs
+++ b/crates/loonfs/tests/read_tracing_capture.rs
@@ -84,11 +84,11 @@ fn reads_name_their_anchor_and_the_lookup_that_came_back_empty() {
             .expect("put file");
         let reader = writer.reader();
         reader
-            .stat_path(&namespace_id, "/docs/report.txt", Default::default())
+            .get_path_entry(&namespace_id, "/docs/report.txt", Default::default())
             .await
             .expect("stat the file that was just written");
         let missing = reader
-            .stat_path(&namespace_id, "/docs/missing.txt", Default::default())
+            .get_path_entry(&namespace_id, "/docs/missing.txt", Default::default())
             .await;
         assert!(missing.is_err(), "a path that was never written is absent");
     });

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -341,10 +341,11 @@ An inode ID is only unique within its namespace. Use `namespace_id` and
 opaque value and MUST NOT create IDs or infer ordering from the numeric suffix.
 
 - The embedded handles (`loonfs::FsWriter`, `loonfs::FsReader`) and the
-  remote client (`loonfs_client::Client`) expose the same operations and the
-  same `capabilities()` accessor returning the capability document of
-  section 2.1. For the remote client the document is fetched from
-  `GET /v0/capabilities` and cached; for the embedded handles it is a constant.
+  remote client (`loonfs_client::Client`) expose the same operations under the
+  same names, including the `get_capabilities()` accessor that returns the
+  capability document of section 2.1. For the remote client the document is
+  fetched from `GET /v0/capabilities` and cached; for the embedded handles it
+  is a constant.
 - The two surfaces stay aligned by sharing one definition of every option
   struct they both take (`PutFileOptions`, `CreateDirectoryOptions`,
   `DeleteOptions` live in `loonfs-api` and are re-exported by both), not by a


### PR DESCRIPTION
Renames Rust client and embedded filesystem methods to use the same operation names as the HTTP API and generated SDKs. For example, stat_path becomes get_path_entry, commit becomes create_commit, and begin_upload becomes create_upload. HTTP routes, request and response types, CLI commands, and durable formats are unchanged.