### PR TITLE
docs(code): simplify comments and rustdoc

### DIFF
--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -476,10 +476,6 @@ mod tests {
         }
     }
 
-    /// Pins the exact stored fingerprint for a guarded attribute update.
-    ///
-    /// The literal covers the frozen preimage: the variant name, the field
-    /// order, the canonical attribute-value spelling, and both guards.
     #[test]
     fn update_attributes_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -503,8 +499,6 @@ mod tests {
         );
     }
 
-    /// The set is a map, so the order the caller wrote its keys in is not
-    /// part of what was asked for.
     #[test]
     fn json_map_order_does_not_change_attribute_update_identity() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -527,10 +521,6 @@ mod tests {
         );
     }
 
-    /// Removing two keys asks for the same thing whichever order they are
-    /// listed in, and asking twice for one removal asks for the same thing
-    /// as asking once. Canonicalization inside the translation is what makes
-    /// both true.
     #[test]
     fn remove_order_and_repeats_do_not_change_attribute_update_identity() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -556,7 +546,6 @@ mod tests {
         }
     }
 
-    /// Everything the update asks for is inside the value.
     #[test]
     fn attribute_update_fingerprint_changes_with_every_request_field() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -605,12 +594,6 @@ mod tests {
         }
     }
 
-    /// Pins the exact stored fingerprint for a fixed one-operation request.
-    ///
-    /// If this fails, the canonical preimage changed (format spec, "Commit
-    /// identity fingerprints") and every persisted fingerprint would disagree
-    /// with recomputed ones, breaking retry idempotency across versions. Do
-    /// not update the literal without bumping the fingerprint scheme tag.
     #[test]
     fn commit_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -646,7 +629,6 @@ mod tests {
         assert_ne!(fingerprint(&user_x), fingerprint(&service_x));
     }
 
-    /// Pins the exact stored fingerprint encoding for a guarded delete.
     #[test]
     fn guarded_delete_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -669,12 +651,6 @@ mod tests {
         );
     }
 
-    /// Pins the exact stored fingerprint for an undelete with a destination
-    /// path.
-    ///
-    /// This literal is what proves the in-place form was preimage-additive:
-    /// the path became optional and this value did not move, because a
-    /// present path serializes as the bare string it always was.
     #[test]
     fn undelete_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -704,9 +680,6 @@ mod tests {
         );
     }
 
-    /// Pins the exact stored fingerprint for an in-place undelete, whose
-    /// absent path serializes as `null` — a distinct preimage from every
-    /// pathed form.
     #[test]
     fn in_place_undelete_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -729,13 +702,6 @@ mod tests {
         );
     }
 
-    /// Pins the exact stored fingerprint for a put, which is the only
-    /// operation whose preimage embeds a content reference.
-    ///
-    /// The literal covers the canonical content-ref form — kind, content id,
-    /// size, and nothing else. Adding a checksum to that form, or reordering
-    /// it, would change this value and silently break replay for every
-    /// already-published put.
     #[test]
     fn put_file_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -762,15 +728,6 @@ mod tests {
         );
     }
 
-    /// The retry leg, over the pinned value above: whatever algorithm the
-    /// original commit's reference landed with, a retry reading it back
-    /// recomputes the same fingerprint.
-    ///
-    /// This is what lets a retry prove sameness in two independent steps —
-    /// the fingerprint says the two requests are the same mutation, and the
-    /// digest evidence says the two payloads are the same bytes. A checksum
-    /// inside the preimage would collapse them into one weaker check and
-    /// make a CRC-only commit unreplayable.
     #[test]
     fn a_put_retry_reaches_the_pinned_fingerprint_under_every_checksum_algorithm() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -825,9 +782,6 @@ mod tests {
         }
     }
 
-    /// Two references to the same object with different checksum evidence
-    /// are the same mutation: identity is which object a put attaches, and
-    /// the checksum is pinned to that object by verification elsewhere.
     #[test]
     fn checksum_evidence_is_outside_mutation_identity() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -858,8 +812,6 @@ mod tests {
         );
     }
 
-    /// A different content object is a different mutation, which is what
-    /// makes a re-upload under a used commit id conflict instead of replay.
     #[test]
     fn a_different_content_object_changes_mutation_identity() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -922,8 +874,6 @@ mod tests {
         assert_ne!(baseline, changed);
     }
 
-    /// Operation order is part of the request: reordering is a different
-    /// logical mutation, so it must not replay the first one's receipt.
     #[test]
     fn operation_order_changes_mutation_identity() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -946,9 +896,6 @@ mod tests {
         );
     }
 
-    /// The retry helper is not a second spelling of the preimage: it builds
-    /// the same single-put request a caller would have sent and hands it to
-    /// the same function.
     #[test]
     fn put_retry_fingerprint_matches_the_equivalent_single_operation_request() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -986,9 +933,6 @@ mod tests {
         );
     }
 
-    /// Everything a put can ask for beyond its content is inside the value,
-    /// which is what makes comparing the whole fingerprint a complete proof
-    /// rather than a partial one.
     #[test]
     fn put_retry_fingerprint_changes_with_every_request_field() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1075,8 +1019,6 @@ mod tests {
         }
     }
 
-    /// Tests the shared retry logic without using the HTTP or embedded-runtime
-    /// adapters.
     #[test]
     fn put_retry_reconciliation_agrees_on_receipt_mismatch_and_unavailable_evidence() {
         #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -539,12 +539,6 @@ mod tests {
         }
     }
 
-    /// Unknown checksum algorithms are rejected during decoding.
-    ///
-    /// Content kinds may be preserved by readers without interpretation, but a
-    /// checksum is accepted only when this build can verify it. This guarantees
-    /// that every decoded `ChecksumAlgorithm` is supported by buffered, streamed,
-    /// and resumed verification.
     #[test]
     fn an_unknown_checksum_algorithm_fails_to_decode() {
         assert!(serde_json::from_str::<ChecksumAlgorithm>("\"md5\"").is_err());
@@ -657,10 +651,6 @@ mod tests {
         }
     }
 
-    /// The catalog check value for CRC-64/NVME. This is the one thing that
-    /// has to agree with the provider bit for bit: a completion compares our
-    /// value against the one S3 computed over the assembled object, so a
-    /// wrong polynomial or byte order would fail every multipart upload.
     #[test]
     fn crc64nvme_matches_its_catalog_check_value() {
         assert_eq!(Checksum::crc64nvme(b"123456789").value, "ae8b14860a799888");
@@ -671,12 +661,6 @@ mod tests {
         );
     }
 
-    /// The catalog check value for CRC-32C (Castagnoli), the one the RFC
-    /// 3720 iSCSI CRC and Google Cloud Storage both mean by "crc32c". Like
-    /// the CRC-64/NVME vector above it is an external anchor: it fixes the
-    /// polynomial and the big-endian byte order of the canonical hex against
-    /// a published value rather than against whatever this build happens to
-    /// compute, so a GCS-minted reference and one produced here agree.
     #[test]
     fn crc32c_matches_its_catalog_check_value() {
         assert_eq!(Checksum::crc32c(b"123456789").value, "e3069283");
@@ -687,9 +671,6 @@ mod tests {
         );
     }
 
-    /// The streaming form exists so parts can be hashed on the way past
-    /// without the whole object ever being held, so it must agree with the
-    /// one-shot form over the same bytes.
     #[test]
     fn a_streamed_crc64nvme_equals_the_whole_payload_at_once() {
         let payload: Vec<u8> = (0..4096u32).map(|byte| byte as u8).collect();
@@ -701,9 +682,6 @@ mod tests {
         assert_eq!(streamed.finish(), Checksum::crc64nvme(&payload));
     }
 
-    /// A resumed read folds a prefix it already holds and then the bytes it
-    /// fetches, so a CRC has to close over the two halves exactly as it
-    /// closes over the whole.
     #[test]
     fn a_crc32c_folded_over_a_prefix_and_the_rest_equals_the_whole_payload() {
         let payload: Vec<u8> = (0..4096u32).map(|byte| byte as u8).collect();
@@ -714,10 +692,6 @@ mod tests {
         assert_eq!(streamed.finish(), Checksum::crc32c(&payload));
     }
 
-    /// A verifying reader folds the same checksum the one-shot check
-    /// computes, for every algorithm the vocabulary has — a reader that
-    /// disagreed with [`Checksum::matches`] would accept or reject
-    /// objects the buffered read would not.
     #[test]
     fn a_streamed_checksum_agrees_with_the_whole_payload_at_once() {
         let payload: Vec<u8> = (0..4096u32).map(|byte| byte as u8).collect();
@@ -734,8 +708,6 @@ mod tests {
         }
     }
 
-    /// Every algorithm in the vocabulary is comparable, so a checksum in
-    /// hand is always a question with an answer.
     #[test]
     fn every_algorithm_compares_bytes_against_the_checksum_they_produce() {
         for algorithm in [

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -1201,8 +1201,6 @@ mod tests {
         );
     }
 
-    /// The mutable head rejects pointer fields that it cannot preserve during
-    /// a rewrite.
     #[test]
     fn head_rejects_a_pointer_field_it_does_not_define() {
         let mut tip = wal_pointer_json("wal_00000000000000000002-fedcba9876543210", 2, 2);
@@ -1218,7 +1216,6 @@ mod tests {
             .expect_err("the head rejects a field a predecessor hint does not define");
     }
 
-    /// WAL pointers reject ids that do not encode their start sequence.
     #[test]
     fn wal_pointers_reject_an_id_that_disagrees_with_its_start_seq() {
         let agreeing = wal_pointer_json("wal_00000000000000000002-fedcba9876543210", 2, 2);
@@ -1236,7 +1233,6 @@ mod tests {
         );
     }
 
-    /// The strict head decoder applies the same check to its tip and hints.
     #[test]
     fn the_head_rejects_a_pointer_whose_id_disagrees_with_its_start_seq() {
         let tip = wal_pointer_json("wal_00000000000000000003-aaaaaaaaaaaaaaaa", 3, 3);
@@ -1267,8 +1263,6 @@ mod tests {
         assert!(genesis.recent_segments.is_empty());
     }
 
-    /// A head with no predecessor hints writes an empty list, so a head that
-    /// omits the field is not a head this format wrote.
     #[test]
     fn a_head_that_omits_its_predecessor_hints_does_not_decode() {
         let mut head = head_json(None, Vec::new());

--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -1,18 +1,9 @@
-//! The durable envelope layout, decided once.
+//! Shared encoding and validation for durable envelopes.
 //!
-//! Every durable LoonFS object is an envelope document with the same leading
-//! fields — `kind`, `format_version`, `payload_checksum` —
-//! followed by the payload as an opaque sub-document. This module owns the
-//! whole contract: the probe, the one error vocabulary, the kind/version/
-//! checksum validation rules, and the generic JSON codec that control
-//! objects and namespace manifests parameterize. The WAL segment codec keeps
-//! its CBOR-plus-zstd transport but validates through the same rules and
-//! reports through the same errors, so no envelope family can drift from
-//! the others.
-//!
-//! `payload_checksum` is always computed over the exact payload bytes as
-//! stored, never over a re-encoding, so checksum failures mean corruption
-//! and version skew surfaces as a version error.
+//! Durable objects declare `kind`, `format_version`, and `payload_checksum`
+//! before their payload. Checksums cover the stored payload bytes rather than
+//! a re-encoding. JSON control objects and CBOR WAL segments use the same
+//! validation rules and errors.
 
 use crate::digest::sha256_digest;
 use serde::de::DeserializeOwned;

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -1,26 +1,8 @@
 //! Wire types and durable-format codecs for LoonFS.
 //!
-//! Everything that crosses a process or storage boundary is defined here:
-//! validated identifier and path types at the crate root, the versioned HTTP
-//! protocol shapes in [`v0`], and the durable storage formats in [`wire`]
-//! (WAL segments, metadata segments, namespace manifests, and control objects).
-//! Other LoonFS crates depend on this one for vocabulary; it depends on none
-//! of them.
-//!
-//! One module here is deliberately not a boundary format: [`options`] holds
-//! the per-operation argument structs that the embedded runtime and the HTTP
-//! client both expose. They parameterize the same semantic operations on both
-//! surfaces, so this crate — the shared vocabulary — owns the single
-//! definition rather than each surface keeping its own copy to drift.
-//!
-//! The `commit_identity` module contains shared logic rather than wire types.
-//! It computes durable mutation fingerprints and verifies retried PUT requests
-//! against existing commit receipts. Keeping this logic here ensures that the
-//! embedded runtime and HTTP client apply the same identity and content checks.
-//!
-//! Module rule: v0 HTTP shapes live in [`v0`]; the crate root keeps the
-//! ids/paths/errors/wire-format modules and re-exports the common v0
-//! surface as a curated explicit list below.
+//! The crate defines validated identifiers and paths, HTTP protocol shapes in
+//! [`v0`], durable storage formats in [`wire`], and shared operation options in
+//! [`options`].
 
 #![warn(missing_docs)]
 
@@ -69,13 +51,7 @@ pub mod wire {
     }
 
     pub mod envelope {
-        //! The shared durable envelope codec: probe, validation rules, JSON
-        //! codec, and the one error vocabulary every family reports through.
-        //!
-        //! Published so a durable format outside this crate — a first-party
-        //! extension's own objects — parameterizes the same codec instead of
-        //! copying it and drifting from the rules in section 4 of the format
-        //! spec.
+        //! Shared durable envelope codec and validation errors.
 
         pub use crate::envelope::*;
     }

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -1076,9 +1076,6 @@ mod tests {
         assert_eq!(decoded.payload.segments[0].run_seq, ChangeSeq(10));
     }
 
-    /// A fork target's first own manifest keeps referencing the source's
-    /// metadata objects: ownership travels with each file reference, not
-    /// with the manifest.
     #[test]
     fn namespace_manifest_codec_round_trips_inherited_source_segments() {
         let envelope = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
@@ -1128,7 +1125,6 @@ mod tests {
         );
     }
 
-    /// Compaction segments include a job id; flushed segments omit it.
     #[test]
     fn namespace_manifest_codec_round_trips_a_compaction_job_segment() {
         let compaction_job_id = MetadataCompactionId::parse("cmp_0123456789abcdef0123456789abcdef")
@@ -1249,9 +1245,6 @@ mod tests {
         );
     }
 
-    /// The attribute family's durable order is newest revision first within
-    /// one inode, and the row key a writer stores must be the exact key a
-    /// reader's prefix selects.
     #[test]
     fn attributes_row_keys_sort_newest_revision_first_under_the_inode_prefix() {
         let row_of =
@@ -1295,8 +1288,6 @@ mod tests {
             .starts_with(&super::lookup_keys::attributes_prefix(InodeId(43))));
     }
 
-    /// Compaction groups rows using the components after each family prefix.
-    /// This test keeps those prefixes consistent with the generated row keys.
     #[test]
     fn row_key_prefixes_match_the_row_keys_they_front() {
         let name_key = NameKey::parse("report.txt").expect("valid name key");

--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -521,9 +521,6 @@ mod tests {
         }
     }
 
-    /// The characters Windows reserves are rejected the same way its
-    /// trailing dots and device names already were, and the diagnostic names
-    /// the one to fix.
     #[test]
     fn windows_reserved_characters_are_rejected() {
         for (name, character) in [

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -1,39 +1,23 @@
 //! Block-granular encoding for metadata and derived-index segments.
 //!
-//! A segment object is a sequence of independently readable sections:
-//! data blocks, then one filter block, then one index block. There is no
-//! footer — the manifest's segment descriptor carries the index and filter
-//! handles, so the descriptor is the only entry point into the object.
-//! Readers fetch the byte range a handle names, verify its CRC32C, and
-//! decode just that section; nothing here performs IO.
+//! A segment contains data blocks followed by one filter block and one index
+//! block. The manifest descriptor stores the index and filter handles. Each
+//! handle identifies a byte range and its CRC32C.
 //!
-//! The block grammar is row-payload-agnostic: the builder and decoders
-//! carry any CBOR row type, and the segment's descriptor family says which
-//! one to expect — [`MetadataRow`] for metadata segments, `IndexRow` for gram
-//! index segments. The section framing, key compression, filter hashing,
-//! and checksums are identical either way.
-//!
-//! Durable layout, frozen by this module:
+//! The block format supports any CBOR row type, including [`MetadataRow`] and
+//! grep index rows. The durable layout is:
 //!
 //! - A **data block** holds prefix-compressed entries: each entry stores
 //!   `(shared_prefix_len, key_suffix_len)` as LEB128 varints, the key
-//!   suffix bytes, then the row as a CBOR-encoded payload length-
-//!   prefixed with a varint. Every [`RESTART_INTERVAL`]th entry is a
-//!   restart point storing its full key (shared prefix length zero). The
-//!   block ends with the restart offsets as little-endian `u32`s and their
-//!   count. The block payload is zstd-compressed.
+//!   suffix, and a length-prefixed CBOR row. Every [`RESTART_INTERVAL`]th
+//!   entry stores its full key. Restart offsets and their count end the
+//!   zstd-compressed block.
 //! - The **index block** is a zstd-compressed CBOR list with one entry per
 //!   data block: the block's last row key and its [`BlockHandle`].
 //! - The **filter block** is a bloom filter over caller-chosen filter keys
-//!   (per-family lookup prefixes): `n_hashes` as a little-endian `u32`,
-//!   the bit length as a little-endian `u64`, then the bit bytes. Filter
-//!   bits do not compress, so the payload is stored raw.
-//! - Every section's CRC32C is computed over its stored bytes and lives in
-//!   the handle that names it (index entries for data blocks; the segment
-//!   descriptor for the index and filter), never inside the section.
-//! - Bloom hashing is two xxh64 passes with fixed seeds combined by double
-//!   hashing. The seeds, like the CRC and hash algorithm choices, are
-//!   frozen durable-format constants.
+//!   and is stored without compression.
+//! - Every section's CRC32C is stored in its handle.
+//! - Bloom hashing uses two xxh64 hashes with fixed seeds.
 
 use crate::wire::manifest::MetadataRow;
 use serde::{Deserialize, Serialize};
@@ -42,12 +26,7 @@ use std::num::NonZeroUsize;
 use thiserror::Error;
 use xxhash_rust::xxh64::xxh64;
 
-/// Target uncompressed size of one data block, in bytes. Sized for direct
-/// object-store reads: request round-trips dominate transfer time at this
-/// scale, so bulk read paths (directory listings read most rows of several
-/// families) want few large ranged GETs, and a lookup fetching one block
-/// still moves trivial bytes. Benchmarked over 8 KiB, which priced a full
-/// listing at one GET per tiny block.
+/// Target uncompressed size of one data block.
 pub const DEFAULT_TARGET_BLOCK_BYTES: usize = 64 * 1024;
 /// Number of level-zero runs that triggers reorganization.
 pub const DEFAULT_MAX_DELTA_RUNS: usize = 8;
@@ -70,9 +49,7 @@ pub const FILTER_HASH_COUNT: u32 = 7;
 
 const FILTER_HASH_SEED_ONE: u64 = 0;
 const FILTER_HASH_SEED_TWO: u64 = 0x9e37_79b9_7f4a_7c15;
-/// One compression level for every zstd-compressed durable artifact (SST
-/// blocks and WAL segment envelopes). 3 is also the library default, so
-/// this pins in a name what an implicit `0` would choose silently.
+/// Compression level for every zstd-compressed durable artifact.
 pub(crate) const ZSTD_LEVEL: i32 = 3;
 
 /// Where one stored section lives inside a segment object, and how to
@@ -816,11 +793,6 @@ mod tests {
         assert!(matches!(error, SstBlockCodecError::EmptySegment));
     }
 
-    /// The builder closes a data block from inside `push` as soon as the
-    /// block reaches its target size, so the last row of a segment can be
-    /// the row that closes one. The segment's max row key must survive that:
-    /// an empty max row key sorts below every bound, so a keyed scan would
-    /// prune the whole segment away and report the rows missing.
     #[test]
     fn max_key_survives_a_last_row_that_closes_its_block() {
         // Calibrate the target so the crossing lands on the final row.
@@ -859,8 +831,6 @@ mod tests {
         assert_eq!(index[0].last_row_key, expected_max);
     }
 
-    /// A segment's key range describes its rows, not its block geometry, so
-    /// the same rows must report the same range at every target size.
     #[test]
     fn block_geometry_does_not_change_the_segment_key_range() {
         let rows = 400usize;
@@ -905,9 +875,6 @@ mod tests {
         }
     }
 
-    /// Closing a block clears the prefix anchor, so the order guard has to
-    /// read the last accepted row key instead. Every push closes a block
-    /// here, which puts the offered row first in a fresh block.
     #[test]
     fn a_descending_row_after_a_block_boundary_is_rejected() {
         let mut builder = SegmentBlocksBuilder::new(NonZeroUsize::MIN);

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -347,7 +347,6 @@ mod tests {
         );
     }
 
-    /// A receipt-only replay has no retained events.
     #[test]
     fn a_commit_response_omits_absent_events_and_message() {
         let response = CommitResponse {

--- a/crates/loonfs-api/src/v0/downloads.rs
+++ b/crates/loonfs-api/src/v0/downloads.rs
@@ -117,8 +117,6 @@ mod tests {
         AbsolutePath::parse("/docs/report.txt").expect("absolute path")
     }
 
-    /// A download request names a path, never an object. Identity belongs
-    /// to the server on the way out exactly as it does on the way in.
     #[test]
     fn a_download_request_names_only_a_path_and_a_revision() {
         let request: BeginDownloadRequest =

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -1600,9 +1600,6 @@ mod tests {
         }
     }
 
-    /// A guard the server never saw must fail the request, not the
-    /// precondition. Every guard is optional, so a misspelled one used to
-    /// decode to `None` and let the write apply unguarded.
     #[test]
     fn a_misspelled_guard_does_not_decode() {
         let put = |guard: &str| {
@@ -1674,8 +1671,6 @@ mod tests {
         );
     }
 
-    /// The whole commit request tree is strict, not just its root: a typo one
-    /// level down hides the same guards.
     #[test]
     fn a_commit_request_rejects_unknown_fields_at_every_level() {
         let valid = || {
@@ -1819,9 +1814,6 @@ mod tests {
         );
     }
 
-    /// The maintenance bodies are optional selectors and overrides all the
-    /// way down, so a typo would run a different step than the caller asked
-    /// for and report the difference as "nothing to do".
     #[test]
     fn maintenance_request_bodies_reject_unknown_fields() {
         serde_json::from_value::<MaintenanceStepRequest>(serde_json::json!({

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -401,8 +401,6 @@ mod tests {
         );
     }
 
-    /// A begin request says how it means to move its bytes, or it is not a
-    /// request. Nothing is inferred from what the body left out.
     #[test]
     fn a_begin_request_without_a_mode_does_not_decode() {
         assert!(serde_json::from_str::<BeginUploadRequest>("{}").is_err());
@@ -413,8 +411,6 @@ mod tests {
         );
     }
 
-    /// The combinations a flat begin request could spell are refused where
-    /// the body is read, not by a handler comparing fields afterwards.
     #[test]
     fn a_begin_request_carrying_another_modes_fields_does_not_decode() {
         for body in [
@@ -432,8 +428,6 @@ mod tests {
         }
     }
 
-    /// Multipart options are fields beside `mode`; an omitted part size uses
-    /// the server default.
     #[test]
     fn a_multipart_begin_names_its_part_size_beside_the_mode() {
         assert_eq!(
@@ -461,7 +455,6 @@ mod tests {
         );
     }
 
-    /// Each completion request includes only the fields for its upload mode.
     #[test]
     fn completion_requests_are_tagged_and_mode_specific() {
         assert_eq!(
@@ -543,7 +536,6 @@ mod tests {
         assert!(!json.contains("object_key"));
     }
 
-    /// Pins the response shape for each upload mode.
     #[test]
     fn a_begin_response_carries_only_its_transports_fields() {
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -607,8 +599,6 @@ mod tests {
         );
     }
 
-    /// The request refuses fields it does not know; the response must not.
-    /// A reader that rejected them could not talk to a later server.
     #[test]
     fn a_begin_response_carrying_a_later_servers_field_still_decodes() {
         assert_eq!(
@@ -624,7 +614,6 @@ mod tests {
         );
     }
 
-    /// A direct-put begin may carry an advisory length but no content claim.
     #[test]
     fn an_upload_content_claim_names_only_size_and_checksum() {
         let request: BeginUploadRequest =
@@ -651,8 +640,6 @@ mod tests {
         );
     }
 
-    /// The claim names its algorithm, so a provider that enforces something
-    /// other than SHA-256 is expressible without a wire change.
     #[test]
     fn an_upload_content_claim_carries_the_operations_required_algorithm() {
         let claim: UploadContentClaim = serde_json::from_str(

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -157,13 +157,6 @@ fn sample_crc_content_ref() -> ContentRef {
     }
 }
 
-/// Pins the durable JSON of a content reference for every checksum algorithm
-/// the format defines.
-///
-/// One reference per algorithm in the vocabulary, so the durable bytes of
-/// each are pinned independently of which write path happens to mint it: a
-/// producer arriving for one of them must need no format change, and this
-/// fixture is what fails if someone reshapes the reference on the way.
 #[test]
 fn content_ref_matches_golden_bytes_for_every_checksum_algorithm() {
     let references = [
@@ -190,8 +183,6 @@ fn content_ref_matches_golden_bytes_for_every_checksum_algorithm() {
     }
 }
 
-/// The reference rejects fields it does not define: an unexpected key is
-/// corruption, not a newer writer's extension.
 #[test]
 fn content_ref_decode_rejects_unknown_fields() {
     let mut document: serde_json::Value =
@@ -455,10 +446,6 @@ fn wal_segment_golden_decodes_to_sample() {
     assert_eq!(decoded, sample_wal_envelope());
 }
 
-/// The 20 digits after `wal_` in a segment id are the segment's start
-/// sequence, and reclamation reads them back out of the object key. A stored
-/// segment whose id disagrees with the sequence beside it does not decode,
-/// and neither does one carrying a chain link that disagrees with itself.
 #[test]
 fn wal_segments_reject_an_id_that_disagrees_with_its_start_seq() {
     let agreeing = encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("encode wal");
@@ -596,8 +583,6 @@ fn head_status_reading_is_fail_closed_on_unknown_statuses() {
     assert!(deleted.contains("\"status\":{\"kind\":\"deleted\"}"));
 }
 
-/// The field is required. A head that omits it is malformed, exactly like a
-/// head that omits its content store, and nothing defaults it to active.
 #[test]
 fn head_without_a_status_is_rejected() {
     let mut document =
@@ -615,8 +600,6 @@ fn head_without_a_status_is_rejected() {
     );
 }
 
-/// The status object holds a tag and nothing else, so a stray field inside
-/// it is corruption a guarded rewrite must not erase.
 #[test]
 fn head_status_rejects_unknown_fields_as_corruption() {
     let mut document =
@@ -853,12 +836,6 @@ fn control_objects_match_golden_bytes() {
     );
 }
 
-/// Every durable record with a lifecycle spells that field `status` and
-/// writes a `kind`-tagged object into it.
-///
-/// The fixtures are the durable bytes, so this reads the committed payloads
-/// rather than a re-encoding. The fifth family, the grep manifest, is
-/// checked the same way in `loonfs-grep`, which owns those bytes.
 #[test]
 fn every_durable_status_is_a_kind_tagged_object() {
     let fixtures = [
@@ -1006,9 +983,6 @@ fn mutable_control_nested_structs_reject_unknown_fields_as_corruption() {
     );
 }
 
-/// The checkpoint status is a tagged object over two variants. A bare
-/// string is not one of them, whatever it spells, and neither is a tag this
-/// format does not define.
 #[test]
 fn checkpoint_records_reject_an_untagged_or_unknown_status() {
     for untagged in ["active", "released", "condemned"] {
@@ -1041,9 +1015,6 @@ fn active_checkpoint_records_reject_release_stamps() {
     );
 }
 
-/// A fork-owned record is the lease over one fork attempt, and its shape
-/// requires the expiry that makes an abandoned attempt collectable. A user
-/// pin without an expiry remains an ordinary permanent pin.
 #[test]
 fn fork_checkpoint_records_reject_a_missing_lease_expiry() {
     let message = assert_control_payload_edit_is_corrupt::<CheckpointRecordState>(
@@ -1064,10 +1035,6 @@ fn fork_checkpoint_records_reject_a_missing_lease_expiry() {
     );
 }
 
-/// The upload status is a tagged object over three variants, each carrying
-/// the instant its own transition happened. A bare string is not one of
-/// them, an undefined tag is not one of them, and neither is a defined tag
-/// without its stamp.
 #[test]
 fn upload_sessions_reject_an_untagged_or_incomplete_status() {
     for untagged in ["open", "condemned"] {
@@ -1120,7 +1087,6 @@ fn mutable_control_enums_fail_closed_on_unknown_variants() {
     );
 }
 
-/// Upload sessions reject mode fields outside the tagged `mode` object.
 #[test]
 fn upload_sessions_reject_the_pre_mode_flat_encoding() {
     // Reject a string mode and mode-specific fields at the top level.
@@ -1172,9 +1138,6 @@ fn upload_sessions_reject_the_pre_mode_flat_encoding() {
     );
 }
 
-/// Every reference a record holds names the object the session owns. A
-/// record that disagrees with itself describes two objects and could
-/// publish one while verifying the other, so it is refused at load.
 #[test]
 fn upload_sessions_reject_a_reference_to_another_content_object() {
     let other = serde_json::Value::from("con_99999999999999999999999999999999");
@@ -1230,7 +1193,6 @@ fn completed_direct_put_sessions_require_the_session_algorithm() {
     );
 }
 
-/// Rejects upload sessions that omit required mode fields.
 #[test]
 fn upload_sessions_reject_a_mode_missing_its_own_fields() {
     assert_control_payload_edit_is_corrupt::<UploadSessionState>(
@@ -1267,7 +1229,6 @@ fn upload_sessions_reject_a_mode_missing_its_own_fields() {
     );
 }
 
-/// Multipart sessions reject a part size of zero.
 #[test]
 fn upload_sessions_reject_a_zero_multipart_part_size() {
     assert_control_payload_edit_is_corrupt::<UploadSessionState>(
@@ -1582,7 +1543,6 @@ fn wal_decode_tolerates_additive_payload_fields() {
     assert_eq!(decoded.payload, envelope.payload);
 }
 
-/// Immutable WAL segments accept unknown predecessor-pointer fields.
 #[test]
 fn wal_decode_tolerates_an_additive_field_inside_the_predecessor_pointer() {
     let envelope = sample_wal_envelope();
@@ -1595,7 +1555,6 @@ fn wal_decode_tolerates_an_additive_field_inside_the_predecessor_pointer() {
     assert_eq!(decoded.payload, envelope.payload);
 }
 
-/// Immutable WAL segments accept unknown fields nested in tombstone deltas.
 #[test]
 fn wal_decode_tolerates_additive_fields_inside_tombstone_deltas() {
     let envelope = wal_envelope_with_deltas(vec![
@@ -1634,8 +1593,6 @@ fn wal_decode_tolerates_additive_fields_inside_tombstone_deltas() {
     assert_eq!(decoded.payload, envelope.payload);
 }
 
-/// Actor references reject unknown fields in every context because the same
-/// type is also used in request bodies.
 #[test]
 fn wal_decode_rejects_an_additive_field_inside_the_commit_attribution() {
     let document = wal_document_with_payload_edit(&sample_wal_envelope(), |payload| {
@@ -2155,10 +2112,6 @@ fn sst_block_data_payload_matches_golden_bytes() {
     );
 }
 
-/// The active-deletion family sorts ahead of every other prefix, so both of
-/// its rows — the listing and the removal that cancels it — sit inside the
-/// block the fixture above pins. This says so, the way the guards below say
-/// the same for the attribute and tombstone families.
 #[test]
 fn sst_block_data_first_block_covers_the_active_deletion_prefix() {
     let built = sample_segment_blocks();
@@ -2178,9 +2131,6 @@ fn sst_block_data_first_block_covers_the_active_deletion_prefix() {
     );
 }
 
-/// The fixture above pins the block's bytes. This test names the rows those
-/// bytes hold, so a regeneration that changed the sample cannot pass
-/// unnoticed.
 #[test]
 fn sst_block_data_golden_decodes_to_sample_rows() {
     let block = decode_golden_data_block("sst_block_data.v1.bin");
@@ -2219,7 +2169,6 @@ fn sst_block_data_revision_golden_decodes_to_sample_rows() {
     assert_eq!(block.rows, sample_revision_rows());
 }
 
-/// Covers the encodings for both populated and cleared attribute maps.
 #[test]
 fn sst_block_data_attribute_rows_match_golden_bytes() {
     assert_rows_match_single_block_golden(
@@ -2257,8 +2206,6 @@ fn sst_block_data_commit_receipt_golden_decodes_to_sample_row() {
     assert_eq!(block.rows, [sample_commit_receipt_row()]);
 }
 
-/// Checks the stable encoding of a tombstone and its matching revoke. A
-/// separate fixture keeps block splitting from separating the pair.
 #[test]
 fn sst_block_data_tombstone_rows_match_golden_bytes() {
     assert_rows_match_single_block_golden(
@@ -2340,9 +2287,6 @@ fn commit_receipt_rows_without_committed_by_are_corrupt() {
     );
 }
 
-/// The deleted binding is one value with three required parts. Two of the
-/// three is not a binding anyone can restore or render, and the decoder says
-/// so rather than filling the gap in with a default.
 #[test]
 fn tombstone_rows_reject_a_partial_deleted_direntry() {
     for missing in ["parent_inode_id", "name_key", "display_name"] {
@@ -2357,7 +2301,6 @@ fn tombstone_rows_reject_a_partial_deleted_direntry() {
     }
 }
 
-/// Immutable metadata rows accept unknown tombstone fields at every level.
 #[test]
 fn tombstone_rows_tolerate_additive_fields_at_every_level() {
     let expected = sample_tombstone_set_row();
@@ -2385,7 +2328,6 @@ fn tombstone_rows_tolerate_additive_fields_at_every_level() {
     }
 }
 
-/// A `revoke` ignores `deleted_direntry`, which is valid only for `set`.
 #[test]
 fn tombstone_revoke_rows_ignore_a_deleted_direntry() {
     let expected = sample_tombstone_revoke_row();
@@ -2401,10 +2343,6 @@ fn tombstone_revoke_rows_ignore_a_deleted_direntry() {
     );
 }
 
-/// The pre-grouping layout, exactly as it was written before the generation
-/// and the binding each became a shape of their own: `tombstone_seq` and
-/// `tombstone_delta_index` beside three optional binding fields, and a `set`
-/// with nothing in it.
 #[test]
 fn tombstone_rows_reject_the_pre_grouping_flat_encoding() {
     let row = row_cbor(&sample_tombstone_set_row());
@@ -2433,10 +2371,6 @@ fn tombstone_rows_reject_the_pre_grouping_flat_encoding() {
     );
 }
 
-/// A listed row copies the binding from the tombstone it derives from, so the
-/// same two rules hold on this side: the binding is one value with three
-/// required parts, and a `listed` states the field even when the deletion
-/// recorded no name.
 #[test]
 fn active_deletion_rows_reject_a_partial_or_absent_deleted_direntry() {
     for missing in ["parent_inode_id", "name_key", "display_name"] {
@@ -2461,8 +2395,6 @@ fn active_deletion_rows_reject_a_partial_or_absent_deleted_direntry() {
     );
 }
 
-/// Version-one provenance rows require a commit ID, actor, and timestamp.
-/// Decoding fails when any required field is missing.
 #[test]
 fn provenance_rows_reject_every_missing_required_field() {
     let cases = [
@@ -2524,8 +2456,6 @@ fn provenance_rows_reject_every_missing_required_field() {
 // Attribute rows: the retired tagged value is not a value
 // ---------------------------------------------------------------------------
 
-/// Attribute values are strings in this format. The retired tagged object is
-/// corruption rather than a shape the reader translates.
 #[test]
 fn attribute_rows_reject_the_retired_tagged_value_shape() {
     let mut row = row_cbor(&MetadataRow::AttributesRevision {
@@ -2554,8 +2484,6 @@ fn attribute_rows_reject_the_retired_tagged_value_shape() {
     );
 }
 
-/// The map's limits are enforced on the way in, so a stored row that breaks
-/// one fails to decode instead of decoding to something within the limits.
 #[test]
 fn attribute_rows_reject_a_map_over_its_limits() {
     let mut row = row_cbor(&MetadataRow::AttributesRevision {

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -1026,8 +1026,6 @@ mod tests {
         (config, store)
     }
 
-    /// Verifies that a drain settles every assigned job and namespace. One
-    /// namespace has an index to build, and the other does not.
     #[tokio::test]
     async fn a_drain_settles_every_assigned_key_and_does_the_work_it_finds() {
         let temp_dir = tempdir().expect("create temp dir");
@@ -1109,9 +1107,6 @@ mod tests {
         );
     }
 
-    /// A budget that runs out mid-assignment reports where every key got to
-    /// — including the ones it never reached — instead of claiming the
-    /// assignment is caught up.
     #[tokio::test]
     async fn a_spent_drain_budget_reports_the_keys_it_left_unsettled() {
         let temp_dir = tempdir().expect("create temp dir");
@@ -1156,9 +1151,6 @@ mod tests {
         assert!(!collection.settled());
     }
 
-    /// Hosting is the other half: the runner runs the steps, the assignment
-    /// is what admits them, and the signal is what stops it. Nothing here
-    /// discovered the namespace — the assignment did.
     #[tokio::test]
     async fn hosting_an_assignment_maintains_a_cold_namespace_until_the_signal() {
         let temp_dir = tempdir().expect("create temp dir");

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -791,9 +791,6 @@ mod tests {
     use crate::progress::ProgressMode;
     use loonfs_api::{GcResponse, NamespaceId, RetainedReason};
 
-    /// The multi-pass summary folds every counter and keeps the soonest
-    /// reclamation obligation any pass reported: a later pass with nothing
-    /// deferred does not erase an earlier pass's pending horizon.
     #[test]
     fn the_summary_folds_expired_releases_and_keeps_the_soonest_horizon() {
         let namespace = NamespaceId::parse("demo").expect("namespace id");
@@ -829,9 +826,6 @@ mod tests {
         }
     }
 
-    /// A run that finishes in one pass has nothing to report progress about:
-    /// its summary is the whole story, and a stray "pass 1" line before it
-    /// would be noise on every quiet invocation.
     #[test]
     fn a_single_pass_run_reports_no_progress() {
         let mut progress = PassProgress::new(runtime(false));
@@ -840,9 +834,6 @@ mod tests {
             .is_empty());
     }
 
-    /// Once a second pass proves the run is a long one, the first pass's line
-    /// is written too — so a multi-pass run accounts for every pass, in
-    /// order, rather than starting the story at pass two.
     #[test]
     fn a_multi_pass_run_reports_every_pass_in_order() {
         let mut progress = PassProgress::new(runtime(false));
@@ -859,8 +850,6 @@ mod tests {
         );
     }
 
-    /// `--json` promises one machine-readable envelope and nothing else, so
-    /// however many passes a run takes, it says nothing on the way.
     #[test]
     fn json_output_stays_silent_across_passes() {
         let mut progress = PassProgress::new(runtime(true));
@@ -871,8 +860,6 @@ mod tests {
         }
     }
 
-    /// A progress line answers what an operator watching a sweep asks: what
-    /// went, what stayed and mostly why, and when to expect the rest.
     #[test]
     fn a_pass_line_names_what_stayed_and_mostly_why() {
         let mut pass = GcResponse::empty(NamespaceId::parse("demo").expect("namespace id"));
@@ -891,8 +878,6 @@ mod tests {
         );
     }
 
-    /// A pass that kept nothing says so plainly rather than inventing a
-    /// reason for zero candidates.
     #[test]
     fn a_pass_line_that_kept_nothing_names_no_reason() {
         let pass = GcResponse::empty(NamespaceId::parse("demo").expect("namespace id"));

--- a/crates/loonfs-cli/src/commands/partial.rs
+++ b/crates/loonfs-cli/src/commands/partial.rs
@@ -1,12 +1,4 @@
-//! The file a download writes into before it is installed, and the note
-//! beside it saying which content it holds.
-//!
-//! Both are named from the destination rather than randomly, because a
-//! rerun has to find them: that is the whole of how an interrupted download
-//! picks up where it stopped. Both are deleted once the download reaches a
-//! verdict — installed at the destination, or failed and reported — so the
-//! only run that leaves bytes behind is one that never got to clean up,
-//! which is exactly the run worth resuming.
+//! Partial files and metadata used to resume interrupted downloads.
 
 use crate::backend::FileDownload;
 use crate::error::CliError;
@@ -15,26 +7,14 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
-/// Suffix of the file a download's bytes land in.
+/// Suffix for partial download files.
 const PARTIAL_SUFFIX: &str = ".loonfs-partial";
-/// Suffix of the note beside it.
+/// Suffix for partial download metadata.
 const META_SUFFIX: &str = ".loonfs-partial.meta";
-/// How much of a partial file is read at a time when its bytes are folded
-/// back into a resumed download's verification. Bounded for the same reason
-/// the download itself is: a resumed 50 GiB file must not cost 50 GiB.
+/// Chunk size used to checksum an existing partial file.
 const FOLD_CHUNK_BYTES: usize = 1024 * 1024;
 
-/// What the bytes in a partial file are, so a rerun can tell whether they
-/// are still the bytes it wants.
-///
-/// The content id settles it on its own: content objects are immutable and
-/// randomly identified, so the same id is the same bytes and a different id
-/// is a different file. The rest is recorded because a partial disagreeing
-/// with any of it is not worth resuming either, and because a note this
-/// build cannot read at all is the same answer — start over.
-///
-/// The checksum is the reference's complete-payload evidence whatever
-/// produced it.
+/// Identifies the content stored in a partial download.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct PartialMeta {
@@ -65,11 +45,7 @@ impl PartialMeta {
     }
 }
 
-/// How much of a destination's partial file a fresh download of `meta` may
-/// pick up, which is none of it unless everything agrees.
-///
-/// Every disagreement answers zero and says nothing: a stale partial is not
-/// a failure, it is a download that starts over.
+/// Returns the number of reusable bytes when the partial file matches `meta`.
 pub(super) fn resumable_bytes(destination: &Path, meta: &PartialMeta) -> u64 {
     let (Some(partial_path), Some(meta_path)) = (
         sibling(destination, PARTIAL_SUFFIX),
@@ -129,8 +105,6 @@ impl PartialDownload {
                 let encoded = serde_json::to_vec(meta).map_err(std::io::Error::other)?;
                 std::fs::write(&meta_path, encoded)?;
             }
-            // A stale note from an earlier run must not outlive the bytes it
-            // described.
             None => drop(std::fs::remove_file(&meta_path)),
         }
         let meta = tempfile::TempPath::try_from_path(&meta_path)?;
@@ -184,12 +158,7 @@ impl PartialDownload {
         self.file.write_all(bytes)
     }
 
-    /// Installs the completed download at its destination with one rename,
-    /// and takes the note away with it.
-    ///
-    /// Only a download that finished — and, when it was streamed, verified
-    /// — reaches this, so the file at the destination is never a truncated
-    /// or unverified one.
+    /// Installs the completed download with an atomic rename.
     pub(super) fn install(mut self, destination: &Path, force: bool) -> std::io::Result<()> {
         self.file.flush()?;
         let persisted = if force {
@@ -201,9 +170,7 @@ impl PartialDownload {
     }
 }
 
-/// The sibling of `destination` carrying `suffix`, as a hidden file in the
-/// destination's own directory so the rename that installs it never crosses
-/// a filesystem.
+/// Returns a hidden sibling of `destination` with the given suffix.
 fn sibling(destination: &Path, suffix: &str) -> Option<PathBuf> {
     let file_name = destination.file_name()?;
     let mut name = std::ffi::OsString::from(".");
@@ -212,8 +179,7 @@ fn sibling(destination: &Path, suffix: &str) -> Option<PathBuf> {
     Some(parent_of(destination).join(name))
 }
 
-/// The directory a destination's partial file is created in — its own, and
-/// the working directory for a bare file name.
+/// Returns the destination directory, or the working directory for a bare name.
 pub(super) fn parent_of(destination: &Path) -> &Path {
     destination
         .parent()
@@ -230,8 +196,6 @@ mod tests {
         PartialMeta::describe(&ContentRef::blob_v1(ContentId::generate(), bytes), None)
     }
 
-    /// A reference whose only full-object evidence is a CRC-32C, as a direct
-    /// transfer to Google Cloud Storage leaves behind.
     fn crc32c_content_ref(bytes: &[u8]) -> ContentRef {
         ContentRef {
             kind: ContentRefKind::BlobV1,
@@ -241,8 +205,6 @@ mod tests {
         }
     }
 
-    /// A partial whose note matches the content being fetched is picked up
-    /// at exactly the length on disk.
     #[test]
     fn a_matching_note_resumes_at_what_is_on_disk() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -265,9 +227,6 @@ mod tests {
         );
     }
 
-    /// The note is what makes bytes resumable, and it has to describe the
-    /// content this run resolved: a different file, a different revision, or
-    /// a note this build cannot read all start over.
     #[test]
     fn a_note_that_does_not_match_starts_over() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -301,10 +260,6 @@ mod tests {
         assert_eq!(resumable_bytes(&destination, &meta), 0);
     }
 
-    /// A file whose only evidence is a CRC-32C is described and resumed like
-    /// any other: the note carries the reference's own checksum, so content
-    /// nobody hashed for us is still identified on disk rather than being
-    /// content a rerun has to start over on.
     #[test]
     fn a_crc32c_note_describes_and_resumes_its_partial() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -1,13 +1,8 @@
 //! Client-side recursive transfers: `put -r`, `get -r`, and `cp -r`.
 //!
-//! Traversal is client-side and unpinned (API spec, section 9.3): remote
-//! walks read each directory at its own head through drift-tolerant
-//! listings, and every file rides the same per-file operation its singular
-//! command uses, as its own independent commit. One process holds one
-//! writer session, so concurrent submissions coalesce into batched WAL
-//! segments; the transfer runs with bounded concurrency and reports
-//! per-file outcomes, so a partial failure reruns per file instead of
-//! aborting a giant transaction.
+//! Traversal is unpinned and tolerates directory changes between pages. Each
+//! file uses the corresponding single-file operation and commits independently.
+//! Transfers use bounded concurrency and report failures per file.
 
 use super::context::CommandContext;
 use super::output::{
@@ -25,26 +20,16 @@ use loonfs_client::{CommitOptions, CreateDirectoryOptions, NamespacePath, PutFil
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-/// How many per-file operations run at once. Matches the reference server's
-/// default upload concurrency; deliberately a constant, not a flag, until a
-/// real workload needs tuning.
+/// Maximum number of concurrent file operations.
 const TREE_TRANSFER_CONCURRENCY: usize = 8;
 
-/// One file or directory job, as namespace-absolute remote path plus the
-/// local half when one exists.
+/// One file or directory in a recursive transfer.
 struct FileJob {
     local: PathBuf,
     remote: String,
-    /// The file's length, when the walk that found it stated one. On a
-    /// download it also decides how the bytes travel — past the
-    /// deployment's proxy cap they come straight from object storage — and
-    /// on either transfer it is what lets the whole tree be measured before
-    /// the first byte moves.
+    /// File length, used for transfer selection and progress totals.
     size_bytes: Option<u64>,
-    /// What the remote file's content is, when a listing named it. It rides
-    /// along so a download interrupted part way can tell whether the bytes
-    /// it left behind are still the bytes it wants. An upload's jobs come
-    /// from a local walk and name no remote content.
+    /// Remote content identity used to resume downloads.
     content_ref: Option<loonfs_api::ContentRef>,
 }
 
@@ -71,9 +56,7 @@ impl TreeTally {
     }
 }
 
-/// What the whole tree weighs, or nothing at all when even one file's
-/// length is unknown: a total that is missing some files would misreport
-/// every percentage derived from it.
+/// Returns the total size when every file length is known.
 fn tree_bytes(files: &[FileJob]) -> Option<u64> {
     files
         .iter()
@@ -753,10 +736,6 @@ mod tests {
         (context, watched)
     }
 
-    /// A tree's largest file is never held whole. Each file travels the way
-    /// a single `put` of it would, so the payload of one too large to hold
-    /// crosses the store boundary in transfer parts — and the measurement is
-    /// retention at that boundary, not a reading of the process.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_recursive_put_never_holds_a_whole_file() {
         let store_dir = tempfile::tempdir().expect("tempdir");

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -831,8 +831,6 @@ secret_access_key = "secret"
         assert_eq!(error.message, "missing `cloud.store.bucket`");
     }
 
-    /// Every CLI example config must keep parsing into [`CliConfig`]
-    /// (including under `deny_unknown_fields`) and passing validation.
     #[test]
     fn cli_example_configs_parse_and_validate() {
         let configs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("config");
@@ -859,8 +857,6 @@ secret_access_key = "secret"
         );
     }
 
-    /// Loading a config preserves its credential source. Environment
-    /// credentials are read only when the object store is constructed.
     #[test]
     fn the_loader_preserves_the_serialized_credential_source() {
         let store = loonfs_objectstore::StoreConfig::AwsS3 {
@@ -970,8 +966,6 @@ secret_access_key = "secret"
         );
     }
 
-    /// Strict decoding is only safe while a rejected file can be stepped
-    /// around, so every way of failing to load one offers both hatches.
     #[test]
     fn every_unreadable_config_offers_both_escape_hatches() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/loonfs-cli/src/payload.rs
+++ b/crates/loonfs-cli/src/payload.rs
@@ -1,10 +1,4 @@
-//! Where a `put` reads its bytes, and how each transport is handed them.
-//!
-//! One description of the payload serves all three transports. It has to be
-//! opened once per transport rather than shared, because the two runtimes
-//! spell a stream differently — the embedded runtime in the object store's
-//! terms, the client in its own — but what is read, and how much of it is
-//! held at a time, is the same either way.
+//! Payload sources shared by embedded and remote `put` operations.
 
 use crate::backend_error::BackendError;
 use crate::error::CliError;
@@ -21,10 +15,9 @@ pub(crate) const STDIN_PATH: &str = "-";
 /// Where one `put` reads its payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum LocalPayload {
-    /// A file on disk, whose length is known before the first byte moves.
+    /// A file with a known length.
     File { path: PathBuf, size_bytes: u64 },
-    /// Standard input: bytes of no knowable length, which is why it can
-    /// only be uploaded by a path that never needs to know one.
+    /// Standard input, whose length is unknown.
     Stdin,
 }
 
@@ -37,13 +30,7 @@ impl LocalPayload {
         }
     }
 
-    /// The file this payload names, when it is small enough to hold whole.
-    ///
-    /// This is the one decision about how a put travels. A payload under
-    /// the threshold takes the buffered path it always took; anything at or
-    /// past it, and anything whose length nobody knows, is read once
-    /// instead — and a source with no length can never answer here, which
-    /// is exactly right, because it cannot be held.
+    /// Returns the file when it is small enough to buffer completely.
     pub(crate) fn holdable_file(&self) -> Option<&Path> {
         match self {
             Self::File { path, size_bytes } if *size_bytes < STREAMING_PUT_MIN_BYTES => Some(path),
@@ -51,14 +38,7 @@ impl LocalPayload {
         }
     }
 
-    /// The local file an interrupted upload of this payload could pick up
-    /// from, when there is one.
-    ///
-    /// Two things have to hold. The payload must travel in parts — a
-    /// smaller one is a single request, which either happened or did not —
-    /// and its source must be openable a second time, because a resumed
-    /// upload reads every byte again to fold the checksum the assembly is
-    /// verified against. A pipe fails the second on its own.
+    /// Returns a source that may be reopened to resume a multipart upload.
     pub(crate) fn resumable_source(&self) -> Option<&Path> {
         match self {
             Self::File { path, size_bytes } if *size_bytes >= STREAMING_PUT_MIN_BYTES => Some(path),
@@ -76,12 +56,8 @@ impl LocalPayload {
 
     /// Opens the payload for the HTTP client.
     ///
-    /// The source counts itself as it is read, which is the one place an
-    /// upload's bytes are observable without reaching into a transport: past
-    /// here they belong to the runtime that is staging them. That puts the
-    /// count slightly ahead of the wire — a direct multipart upload holds a
-    /// few parts in flight — so what it reports is payload read, which is
-    /// what a caller watching their own file wants to know.
+    /// Progress measures bytes read from the source and may be slightly ahead
+    /// of bytes sent when multipart uploads have parts in flight.
     pub(crate) async fn open_source(
         &self,
         progress: &Arc<ProgressReporter>,
@@ -96,19 +72,11 @@ impl LocalPayload {
     }
 }
 
-/// Wraps a source so every byte read off it is counted, and the end of the
-/// payload announces the phase that follows it.
-///
-/// The commit is the part a finished upload waits on with no bytes moving,
-/// so the transition is reported where it actually happens: when the source
-/// runs dry.
+/// Counts bytes read from a source and reports the commit phase at EOF.
 fn counted_source(source: PayloadSource, progress: Arc<ProgressReporter>) -> PayloadSource {
     if !progress.enabled() {
         return source;
     }
-    // Counting is all this adds, so the source keeps everything else it knew
-    // — including that a file-backed payload can simply be re-opened if the
-    // transport has to read it twice.
     source.map_stream(|stream| {
         futures::stream::unfold((stream, progress), |(mut stream, progress)| async move {
             match stream.next().await {
@@ -127,12 +95,7 @@ fn counted_source(source: PayloadSource, progress: Arc<ProgressReporter>) -> Pay
     })
 }
 
-/// Restates a source in the object store's terms, which is how the embedded
-/// runtime's staging path takes a payload.
-///
-/// A read failure becomes a transport error against the same "upload body"
-/// name the server's own streaming path uses, so a truncated local read and
-/// a truncated request body read alike.
+/// Converts a client payload source into an object-store byte stream.
 fn as_object_store_stream(source: PayloadSource) -> ByteStream {
     let (stream, _) = source.into_stream();
     stream
@@ -153,8 +116,6 @@ pub(crate) async fn read_whole_file(path: &Path) -> Result<Vec<u8>, CliError> {
 mod tests {
     use super::*;
 
-    /// The threshold is a property of the payload, not of the transport:
-    /// the same file streams or does not regardless of which arm takes it.
     #[test]
     fn only_large_or_unmeasured_payloads_stream() {
         assert!(LocalPayload::file("/tmp/small", 0)

--- a/crates/loonfs-cli/src/progress.rs
+++ b/crates/loonfs-cli/src/progress.rs
@@ -1,41 +1,30 @@
-//! Live progress for the transfers that take human time.
+//! Progress output for file transfers.
 //!
-//! Two audiences, one accounting. A terminal gets a single line redrawn in
-//! place; `--json` gets one JSON object per line. Both go to standard error,
-//! because standard output already carries either the result document or the
-//! file's own bytes. Neither is produced when standard error is not a
-//! terminal and nobody asked for events, which is how `curl` behaves and why
-//! a piped `loonfs get` stays silent.
-//!
-//! The event names and field names are a contract: agents parse them.
+//! Human-readable and JSON progress are written to standard error so standard
+//! output remains available for results or file content. Event and field names
+//! are part of the CLI contract.
 
 use crate::args::RuntimeBehavior;
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::io::{IsTerminal, Write};
 use std::sync::Mutex;
 
-/// The shortest gap between two reports of one operation.
-///
-/// Four a second is live enough for a terminal and few enough that an agent
-/// parsing the stream reads less progress than transfer.
+/// Minimum interval between progress reports.
 const MIN_REPORT_INTERVAL_MS: u64 = 250;
 
 /// How a running transfer is described, decided once per invocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProgressMode {
-    /// One line on a terminal's standard error, redrawn in place.
+    /// Redraw one line on standard error.
     Human,
-    /// One JSON object per line on standard error, beside the result
-    /// document on standard output.
+    /// Write one JSON object per line to standard error.
     Events,
-    /// Nothing at all.
+    /// Disable progress output.
     Off,
 }
 
 impl ProgressMode {
-    /// Reads the mode off the invocation: `--no-progress` silences it,
-    /// `--json` asks for events, and a terminal on standard error is what
-    /// makes the human line worth drawing.
+    /// Selects the progress mode from CLI flags and terminal detection.
     pub(crate) fn detect(no_progress: bool, json: bool) -> Self {
         if no_progress {
             Self::Off
@@ -71,33 +60,27 @@ impl ProgressOp {
     }
 }
 
-/// What the accounting knows right now.
+/// Current progress counters.
 #[derive(Debug)]
 struct ProgressState {
     bytes_done: u64,
-    /// Bytes this run actually moved, which is what a rate is about. It
-    /// trails `bytes_done` by whatever an interrupted run left behind.
+    /// Bytes transferred during this run, excluding resumed bytes.
     bytes_moved: u64,
     bytes_total: Option<u64>,
     files_done: u64,
     files_total: Option<u64>,
-    /// The file of a tree that started most recently, which is what a
-    /// terminal line names.
+    /// Most recently started file in a recursive transfer.
     current: Option<String>,
-    /// Byte count of the last report, so a report that would say exactly
-    /// what the last one said is skipped.
+    /// Byte count included in the last report.
     reported_bytes: Option<u64>,
     reported_ms: u64,
     reported_percent: Option<u64>,
-    /// Width of the human line currently on screen, so the next one can
-    /// erase what it does not cover.
+    /// Width of the current terminal line.
     drawn_width: usize,
 }
 
 impl ProgressState {
-    /// Whether a report is due: no more often than the interval allows,
-    /// unless the whole-number percentage moved, and never a repeat of what
-    /// the last report already said.
+    /// Returns whether progress changed enough to report.
     fn due(&self, now_ms: u64) -> bool {
         if self.reported_bytes == Some(self.bytes_done) {
             return false;
@@ -116,9 +99,7 @@ impl ProgressState {
         })
     }
 
-    /// Whether this operation covers more than one file — a tree, or an
-    /// operation that never said how many. What one file's progress means
-    /// for the whole depends on it.
+    /// Returns whether this operation may cover more than one file.
     fn many_files(&self) -> bool {
         self.files_total.is_none_or(|total| total > 1)
     }
@@ -558,8 +539,6 @@ mod tests {
         assert_eq!(eta_seconds(10, None, 1_000), None);
     }
 
-    /// One file states what it is and how far along; a tree adds the file
-    /// count and names the file that started last.
     #[test]
     fn a_terminal_line_says_what_a_watcher_needs() {
         let one_file = silent_reporter(ProgressOp::Get, "/docs/big.bin");

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -380,9 +380,6 @@ mod tests {
             .to_owned()
     }
 
-    /// Attribute values are the first user-written text this CLI prints. A
-    /// newline in one must not forge an output line, and an escape sequence
-    /// must not reach the terminal as a command.
     #[test]
     fn human_stat_escapes_control_characters_in_attribute_values() {
         let newline = stat_with_attribute(
@@ -408,8 +405,6 @@ mod tests {
         assert_eq!(attribute_line(&tabbed), "attr.note: a\\tb\\rc");
     }
 
-    /// Only control characters are rewritten, so ordinary text prints as
-    /// itself.
     #[test]
     fn human_stat_leaves_ordinary_unicode_alone() {
         let unicode = stat_with_attribute(
@@ -418,8 +413,6 @@ mod tests {
         assert_eq!(attribute_line(&unicode), "attr.note: café ☃ 日本語 🙂");
     }
 
-    /// JSON output needs no escaping of its own: serde emits an escaped
-    /// string, and the value round-trips through a decode unchanged.
     #[test]
     fn json_stat_flattens_the_attribute_projection_and_preserves_values() {
         let newline =

--- a/crates/loonfs-cli/src/uploads.rs
+++ b/crates/loonfs-cli/src/uploads.rs
@@ -1,15 +1,4 @@
-//! Where an interrupted upload's bookkeeping lives between runs.
-//!
-//! An upload session records the geometry it was opened with and nothing
-//! per part — parts are the uploading client's own account, deliberately —
-//! so the only record of what landed is the one this CLI keeps. It keeps it
-//! under the user's state directory, keyed by the upload it describes, and
-//! deletes it the moment the upload commits or is abandoned.
-//!
-//! Only a remote profile's direct multipart upload has anything to record.
-//! An embedded profile stages through its own runtime with no session to
-//! rejoin, and a payload small enough to travel in one request has no parts
-//! to have half-finished.
+//! Local journals used to resume interrupted multipart uploads.
 
 use loonfs_api::v0::CompletedUploadPart;
 use loonfs_api::{Checksum, ChecksumAlgorithm, UploadId};
@@ -20,13 +9,12 @@ use std::sync::Mutex;
 
 /// Directory under `$XDG_STATE_HOME`.
 const XDG_STATE_SUBDIR: &str = "loonfs";
-/// Directory under `$HOME`, matching where a config file lives when XDG
-/// says nothing.
+/// Legacy state directory under `$HOME`.
 const LEGACY_STATE_SUBDIR: &str = ".loonfs/state";
-/// Directory both roots hold the per-upload files in.
+/// Per-upload journal directory.
 const UPLOADS_SUBDIR: &str = "uploads";
 
-/// What one interrupted upload got through.
+/// State required to resume one upload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct UploadState {
@@ -37,7 +25,7 @@ struct UploadState {
     source: SourceIdentity,
 }
 
-/// One part already in object storage, as the provider acknowledged it.
+/// A completed multipart upload part.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct StatePart {
@@ -46,13 +34,7 @@ struct StatePart {
     checksum: Checksum,
 }
 
-/// Enough of the local file to notice it is not the same file any more.
-///
-/// A payload that changed under a half-finished upload cannot be resumed
-/// into: the parts already in object storage came from bytes that no longer
-/// exist, and completing the assembly would produce an object matching
-/// neither version. Length and modification time are what a filesystem
-/// offers cheaply, and disagreeing on either is enough to start over.
+/// File properties used to detect changes before resuming an upload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct SourceIdentity {
@@ -62,9 +44,7 @@ pub(crate) struct SourceIdentity {
 }
 
 impl SourceIdentity {
-    /// Reads a local file's identity. A modification time the filesystem
-    /// will not state leaves the length as the whole check, which is weaker
-    /// and still better than nothing.
+    /// Reads a file's length and optional modification time.
     pub(crate) fn of(path: &Path) -> std::io::Result<Self> {
         let metadata = std::fs::metadata(path)?;
         let modified_ms = metadata.modified().ok().and_then(|modified| {
@@ -80,28 +60,17 @@ impl SourceIdentity {
     }
 }
 
-/// The record of one upload, and where it is kept.
-///
-/// Named by a digest of everything that decides which upload this is: two
-/// puts of different files, to different paths, in different namespaces, or
-/// through different profiles are different uploads and never share a
-/// record.
+/// Local journal for one upload.
 #[derive(Debug)]
 pub(crate) struct UploadJournal {
     path: PathBuf,
     source: SourceIdentity,
-    /// What this run has been told, held until it is written down. Every
-    /// change is flushed immediately: a record that lags the object store
-    /// makes a rerun send parts that already landed, which is wasteful, and
-    /// a record that leads it makes a rerun claim parts that did not, which
-    /// fails the assembly.
+    /// Latest state, flushed after every change.
     state: Mutex<Option<UploadState>>,
 }
 
 impl UploadJournal {
-    /// The journal for one upload, or nothing when there is nowhere to keep
-    /// it. A resume nobody can record is not a failure; it is an upload that
-    /// starts over if it is interrupted.
+    /// Returns a journal when a writable state directory is available.
     pub(crate) fn for_upload(
         profile: &str,
         namespace: &str,
@@ -124,12 +93,7 @@ impl UploadJournal {
         })
     }
 
-    /// What an earlier run of this upload got through, when its record is
-    /// still about the same bytes.
-    ///
-    /// Every disagreement answers nothing and takes the record away with
-    /// it: a stale record is not a failure, it is an upload that starts
-    /// over.
+    /// Returns valid state from an earlier run, deleting stale state.
     pub(crate) fn resume(&self) -> Option<MultipartUploadResume> {
         let recorded = std::fs::read(&self.path).ok()?;
         let recorded: UploadState = serde_json::from_slice(&recorded).ok().or_else(|| {
@@ -158,9 +122,7 @@ impl UploadJournal {
                 })
                 .collect(),
         };
-        // The run that picks this up appends to it: a resumed upload that is
-        // itself interrupted must leave a record of everything that landed,
-        // not only of what landed before it started.
+        // Preserve earlier parts when this run appends new ones.
         *self.lock() = Some(recorded);
         Some(resume)
     }
@@ -172,8 +134,7 @@ impl UploadJournal {
         *self.lock() = None;
     }
 
-    /// Writes the record down. Nothing surfaces a failure: an upload that
-    /// cannot be recorded still uploads, it just cannot be resumed.
+    /// Writes the journal. Failure only disables future resumption.
     fn flush(&self, state: &UploadState) {
         let Some(parent) = self.path.parent() else {
             return;
@@ -277,8 +238,6 @@ mod tests {
         UploadId::parse("upl_00000000000000000000000000000001").expect("valid upload id")
     }
 
-    /// What a run records is exactly what the next one picks up, part by
-    /// part, and committing takes the record away.
     #[test]
     fn a_record_hands_the_next_run_the_parts_that_landed() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -325,8 +284,6 @@ mod tests {
         assert_eq!(journal.resume(), None, "a committed upload keeps nothing");
     }
 
-    /// A payload that changed under a half-finished upload cannot be
-    /// resumed into: the parts already stored came from bytes that are gone.
     #[test]
     fn a_source_that_changed_invalidates_its_record() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -345,8 +302,6 @@ mod tests {
         assert_eq!(resized.resume(), None, "a longer file is a different file");
     }
 
-    /// A record this build cannot read is no record at all, and does not
-    /// survive to confuse the next run either.
     #[test]
     fn an_unreadable_record_is_discarded() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -373,8 +328,6 @@ mod tests {
         assert!(!journal.path.exists());
     }
 
-    /// Two uploads are the same upload only when everything that names one
-    /// agrees.
     #[test]
     fn the_record_is_named_by_what_decides_which_upload_it_is() {
         let source = identity(1024, 7);

--- a/crates/loonfs-cli/tests/it/admin.rs
+++ b/crates/loonfs-cli/tests/it/admin.rs
@@ -228,8 +228,6 @@ fn index_enable_leaves_core_maintenance_decoupled() {
     assert!(json_data(&retried).get("backfill_step").is_none());
 }
 
-/// The index reports its lifecycle status, and statuses do not share a
-/// field: a backfill names its target, an active index names its watermark.
 #[test]
 fn index_status_reports_each_lifecycle_status_in_its_own_terms() {
     let harness = Harness::new();
@@ -279,8 +277,6 @@ fn index_status_reports_each_lifecycle_status_in_its_own_terms() {
     assert_eq!(json_data(&disabled_again)["status"], "disabled");
 }
 
-/// The wait stops at the sequence it captured, even while a writer keeps
-/// committing past it.
 #[test]
 fn index_enable_waits_to_its_captured_target_and_not_the_live_head() {
     let harness = Harness::new();
@@ -321,8 +317,6 @@ fn index_enable_waits_to_its_captured_target_and_not_the_live_head() {
     );
 }
 
-/// A wait that runs out of budget reports where the index got to and exits
-/// nonzero — real progress, not an error-shaped lie.
 #[test]
 fn index_enable_budgets_exit_nonzero_and_report_progress() {
     let harness = Harness::new();
@@ -354,8 +348,6 @@ fn index_enable_budgets_exit_nonzero_and_report_progress() {
     assert_success(&found);
 }
 
-/// Remote and embedded profiles report the same index state. Remote waiting
-/// polls status while the server runs index maintenance.
 #[test]
 fn index_status_and_enable_answer_the_same_over_the_remote_transport() {
     let harness = Harness::new();
@@ -412,7 +404,6 @@ fn index_status_and_enable_answer_the_same_over_the_remote_transport() {
     assert_eq!(json_data(&collected)["namespace_reaped"], false);
 }
 
-/// Verifies that `index gc` follows every page and reports aggregate totals.
 #[test]
 fn index_gc_loops_its_cursor_and_accumulates() {
     let harness = Harness::new();
@@ -464,8 +455,6 @@ fn index_gc_loops_its_cursor_and_accumulates() {
     );
 }
 
-/// Verifies that `admin maintenance run --drain` completes its assignments
-/// and persists the resulting work.
 #[test]
 fn admin_run_drains_an_assignment_and_leaves_the_work_done() {
     let harness = Harness::new();
@@ -538,8 +527,6 @@ fn admin_run_drains_an_assignment_and_leaves_the_work_done() {
     }
 }
 
-/// A drain that runs out of budget reports where every key got to — the one
-/// it stopped inside and the ones it never reached — and exits nonzero.
 #[test]
 fn admin_run_budgets_exit_nonzero_and_report_per_key_progress() {
     let harness = Harness::new();
@@ -592,8 +579,6 @@ fn admin_run_budgets_exit_nonzero_and_report_per_key_progress() {
     assert!(rendered.contains("gave up"), "{rendered}");
 }
 
-/// The assignment is explicit and the job names are a closed set: neither is
-/// something the command guesses at.
 #[test]
 fn admin_run_requires_an_assignment_and_names_the_jobs_it_hosts() {
     let harness = Harness::new();
@@ -626,8 +611,6 @@ fn admin_run_requires_an_assignment_and_names_the_jobs_it_hosts() {
     }
 }
 
-/// Hosted runs accept a poll interval with a minimum value. Drains do not
-/// wait between assignments, so the setting does not affect them.
 #[test]
 fn admin_run_takes_a_poll_interval_with_a_floor_that_a_drain_ignores() {
     let harness = Harness::new();
@@ -696,8 +679,6 @@ fn admin_run_takes_a_poll_interval_with_a_floor_that_a_drain_ignores() {
     );
 }
 
-/// The store probe is store-scoped: it needs no namespace, renders every
-/// returned check, and exits zero only because they all passed.
 #[test]
 fn admin_store_probe_renders_the_profile_stores_report() {
     let harness = Harness::new();
@@ -737,9 +718,6 @@ fn admin_store_probe_renders_the_profile_stores_report() {
     );
 }
 
-/// A remote profile's server hosts its own runner. Hosting another one here
-/// would be a second scheduler over the same namespaces, so the command
-/// refuses instead of pretending it can.
 #[test]
 fn admin_run_refuses_a_remote_profile() {
     let harness = Harness::new();
@@ -773,8 +751,6 @@ fn admin_run_refuses_a_remote_profile() {
         .contains("requires an embedded profile"));
 }
 
-/// Verifies matching JSON fields and errors for admin and change-feed
-/// commands through embedded and remote profiles.
 #[test]
 fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
     let harness = Harness::new();

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -450,9 +450,6 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
     );
 }
 
-/// A large file and a pipe both round-trip through an embedded profile,
-/// and the retry contract holds for them exactly as it does for a payload
-/// small enough to hold.
 #[test]
 fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
     let harness = Harness::new();
@@ -529,8 +526,6 @@ fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
     assert_eq!(json_error(&no_destination)["code"], "invalid_request");
 }
 
-/// A file many chunks long round-trips through an embedded profile to a
-/// local file and to standard output, byte for byte.
 #[test]
 fn a_multi_chunk_file_round_trips_to_a_file_and_to_stdout() {
     let harness = Harness::new();
@@ -557,10 +552,6 @@ fn a_multi_chunk_file_round_trips_to_a_file_and_to_stdout() {
     );
 }
 
-/// Content that no longer matches its reference fails the download, and
-/// fails it without leaving anything at the destination: no file, and no
-/// partial file beside it. A verified-looking local copy of unverified bytes
-/// is the outcome the temp-file-then-rename order exists to prevent.
 #[test]
 fn a_download_of_corrupted_content_leaves_nothing_at_the_destination() {
     let harness = Harness::new();
@@ -604,9 +595,6 @@ fn a_download_of_corrupted_content_leaves_nothing_at_the_destination() {
     );
 }
 
-/// A download that stopped part way is picked up rather than started over:
-/// the bytes already on disk are fetched again by nobody, and the file that
-/// lands is still verified as a whole.
 #[test]
 fn an_interrupted_download_resumes_from_what_it_already_has() {
     let harness = Harness::new();
@@ -651,9 +639,6 @@ fn an_interrupted_download_resumes_from_what_it_already_has() {
     assert!(!meta.exists(), "and takes its note with it");
 }
 
-/// The note is what makes leftover bytes resumable. Bytes belonging to
-/// other content, and bytes with nothing vouching for them, are dropped
-/// without a word and the download starts over.
 #[test]
 fn a_partial_that_does_not_describe_this_file_is_started_over() {
     let harness = Harness::new();
@@ -701,10 +686,6 @@ fn a_partial_that_does_not_describe_this_file_is_started_over() {
     assert!(events_of_kind(&get, "phase").is_empty());
 }
 
-/// The same two payloads over the remote transport. This deployment stores
-/// to a local filesystem, so it cannot authorize direct part uploads and
-/// the payload streams through the server instead — the fallback the client
-/// picks from the capability document rather than from a guess.
 #[test]
 fn large_and_piped_puts_round_trip_over_the_remote_transport() {
     let harness = Harness::new();
@@ -741,9 +722,6 @@ fn large_and_piped_puts_round_trip_over_the_remote_transport() {
     assert_eq!(download(&harness, "/piped.bin", "piped-back.bin"), payload);
 }
 
-/// Every mutating command takes `-m`, and each one lands its annotation on
-/// its own commit. Reading the feed back through `loonfs changes` covers the
-/// flag, the threading, and the rendering in a single pass.
 #[test]
 fn every_mutating_command_records_its_message() {
     let harness = Harness::new();
@@ -810,8 +788,6 @@ fn every_mutating_command_records_its_message() {
     );
 }
 
-/// The remote arm has to hand the message to the client's mutation options,
-/// not just the embedded arm. Same flag, same feed rows, over HTTP.
 #[test]
 fn commit_messages_ride_the_feed_over_the_remote_transport() {
     let harness = Harness::new();
@@ -972,9 +948,6 @@ fn naming_strictness_and_directory_intent_hold_end_to_end() {
     }
 }
 
-/// One file into a directory that does not exist fails, exactly as `cp` into
-/// a missing parent fails: only `-r`, which owns the destination tree it is
-/// asked to build, creates directories.
 #[test]
 fn single_file_get_refuses_a_missing_parent_directory() {
     let harness = Harness::new();
@@ -1410,10 +1383,6 @@ fn rm_reports_the_inode_and_undelete_recovers_it() {
     assert_eq!(json_error(&again)["code"], "not_deleted");
 }
 
-/// A pathless undelete restores in place: it re-binds under the parent
-/// inode and name the deletion recorded. Renaming the parent between the
-/// delete and the recovery is the proof that the anchor is identity, not a
-/// remembered path — the entry comes back inside the parent's new name.
 #[test]
 fn an_undelete_without_a_path_restores_in_place() {
     let harness = Harness::new();
@@ -1639,8 +1608,6 @@ fn namespace_delete_without_yes_fails_cleanly_when_not_interactive() {
     assert_success(&deleted);
 }
 
-/// A refused precondition has to say what it wanted and what it found, or
-/// the caller cannot tell a raced delete from a mistyped sequence.
 #[test]
 fn namespace_delete_reports_both_head_sequences_when_the_precondition_fails() {
     let harness = Harness::new();
@@ -1686,8 +1653,6 @@ fn namespace_delete_reports_both_head_sequences_when_the_precondition_fails() {
     assert_success(&harness.run(&["--json", "ls", "/"]));
 }
 
-/// `annotate` writes and removes attributes, and `stat` shows what the inode
-/// holds — over both transports, from the same command line.
 #[test]
 fn annotate_writes_and_removes_attributes_in_both_modes() {
     let harness = Harness::new();
@@ -1826,8 +1791,6 @@ fn annotate_writes_and_removes_attributes_in_both_modes() {
     }
 }
 
-/// The argument errors `annotate` reports about its own flags, before it
-/// commits anything.
 #[test]
 fn annotate_rejects_a_set_without_an_equals_and_a_document_beside_the_flags() {
     let harness = Harness::new();
@@ -1886,8 +1849,6 @@ fn annotate_rejects_a_set_without_an_equals_and_a_document_beside_the_flags() {
     assert_eq!(error["param"], "--attributes-json");
 }
 
-/// `mkdir -p` on a directory that is already there succeeds, the way Unix
-/// does, and still fails on a file — in both profile modes.
 #[test]
 fn mkdir_parents_is_idempotent_over_an_existing_directory_in_both_modes() {
     let harness = Harness::new();
@@ -1948,8 +1909,6 @@ fn mkdir_parents_is_idempotent_over_an_existing_directory_in_both_modes() {
     }
 }
 
-/// `cp` and `mv` land inside a destination that is already a directory, the
-/// way Unix does; a destination that is a file keeps its overwrite rules.
 #[test]
 fn cp_and_mv_land_inside_an_existing_directory_in_both_modes() {
     let harness = Harness::new();

--- a/crates/loonfs-cli/tests/it/output.rs
+++ b/crates/loonfs-cli/tests/it/output.rs
@@ -2,9 +2,6 @@
 
 use super::common::*;
 
-/// A download that takes real time says where it has got to, in events an
-/// agent can tell apart from a hang, and says so without disturbing the
-/// result document on standard output.
 #[test]
 fn a_download_reports_its_progress_to_an_agent() {
     let harness = Harness::new();
@@ -52,8 +49,6 @@ fn a_download_reports_its_progress_to_an_agent() {
     assert_eq!(finished[0]["path"], "/big.bin");
 }
 
-/// An upload counts the payload as it is read and then names the commit,
-/// which is the stretch where time passes and no bytes move.
 #[test]
 fn an_upload_reports_bytes_read_and_then_the_commit() {
     let harness = Harness::new();
@@ -97,9 +92,6 @@ fn an_upload_reports_bytes_read_and_then_the_commit() {
     );
 }
 
-/// Nobody asked, so nobody is told: a run whose standard error is a pipe
-/// and which asked for no events says nothing about the transfer, and
-/// --no-progress silences the agent stream too.
 #[test]
 fn progress_is_silent_unless_someone_is_watching() {
     let harness = Harness::new();
@@ -143,8 +135,6 @@ fn progress_is_silent_unless_someone_is_watching() {
     assert_eq!(json_error(&clash)["code"], "path_conflict");
 }
 
-/// The printed recovery commands are meant to be pasted, so they name the
-/// namespace they belong to and quote a path a shell would otherwise split.
 #[test]
 fn recovery_hints_name_their_namespace_and_quote_the_path() {
     let harness = Harness::new();
@@ -195,9 +185,6 @@ fn recovery_hints_name_their_namespace_and_quote_the_path() {
     assert_eq!(cat.stdout, b"body");
 }
 
-/// A hint that leaves out a profile or a config file a bare invocation would
-/// not find again sends the paste at some other filesystem, so both are
-/// spelled whenever this run did not reach them the default way.
 #[test]
 fn recovery_hints_name_a_profile_and_config_a_bare_invocation_would_miss() {
     let harness = Harness::new();
@@ -335,9 +322,6 @@ fn human_output_shows_dates_and_event_names() {
     assert!(entry["created_at_ms"].as_u64().expect("creation time") > 0);
 }
 
-/// A command line the parser rejected is a failure like any other under
-/// `--json`, and keeps clap's own exit status so a script can still tell a
-/// command that never ran from one that ran and failed.
 #[test]
 fn json_covers_command_lines_the_parser_rejects() {
     let harness = Harness::new();
@@ -440,9 +424,6 @@ fn json_all_is_invalid_usage_even_with_a_limit() {
     }
 }
 
-/// Embedded and remote profiles must report the same `code` for the same
-/// failure: registry codes pass through verbatim in both modes instead of
-/// being rewritten to CLI-local codes on one side.
 #[test]
 fn embedded_and_remote_profiles_emit_the_same_error_codes() {
     let harness = Harness::new();
@@ -533,8 +514,6 @@ fn help_lists_the_context_commands() {
     assert!(stdout.contains("use"));
 }
 
-/// The default listing stops after one real server page, while the explicit
-/// streaming modes cross that boundary and a cursor resumes at the next row.
 #[test]
 fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     let harness = Harness::new();
@@ -655,9 +634,6 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     assert_eq!(second_entries[0]["path"], "/listing/f1000.txt");
 }
 
-/// A two-page wire fixture makes the otherwise racy between-page commit
-/// deterministic while still exercising the CLI process, client, command,
-/// JSON envelope, and standard-error rendering together.
 #[test]
 fn ls_surfaces_head_drift_from_paged_responses() {
     let harness = Harness::new();

--- a/crates/loonfs-cli/tests/it/profile.rs
+++ b/crates/loonfs-cli/tests/it/profile.rs
@@ -207,9 +207,6 @@ root = "{}"
     );
 }
 
-/// The resolution chain, first match wins: `--config`, then
-/// `LOONFS_CONFIG`, then `$XDG_CONFIG_HOME/loonfs/config.toml`, then
-/// `~/.loonfs/config.toml`.
 #[test]
 fn config_resolution_prefers_the_flag_then_the_environment_then_xdg_then_legacy() {
     let harness = Harness::new();
@@ -292,8 +289,6 @@ fn config_resolution_prefers_the_flag_then_the_environment_then_xdg_then_legacy(
     }
 }
 
-/// `config path` is the command that answers "which file is this build even
-/// looking at", so it never reads that file.
 #[test]
 fn config_path_answers_while_the_config_file_is_unreadable() {
     let harness = Harness::new();
@@ -320,8 +315,6 @@ fn config_path_answers_while_the_config_file_is_unreadable() {
     assert!(shown.contains("default location"), "{shown}");
 }
 
-/// The recovery path: an override reaches a config file of its own while
-/// the default file is one this build refuses to read.
 #[test]
 fn profile_create_runs_through_an_override_while_the_default_config_is_unreadable() {
     let harness = Harness::new();
@@ -381,8 +374,6 @@ fn profile_create_runs_through_an_override_while_the_default_config_is_unreadabl
     );
 }
 
-/// A file this build will not read names itself, what in it went wrong, and
-/// the two ways past it.
 #[test]
 fn unreadable_config_errors_name_the_file_the_field_and_the_way_out() {
     let harness = Harness::new();

--- a/crates/loonfs-cli/tests/it/recursive.rs
+++ b/crates/loonfs-cli/tests/it/recursive.rs
@@ -2,8 +2,6 @@
 
 use super::common::*;
 
-/// A tree is measured as a tree: one operation's bytes and files, plus a
-/// start and a finish for every file inside it.
 #[test]
 fn a_recursive_transfer_counts_files_and_bytes_for_the_whole_tree() {
     let harness = Harness::new();
@@ -65,10 +63,6 @@ fn a_recursive_transfer_counts_files_and_bytes_for_the_whole_tree() {
     assert_eq!(last["files_total"], 3);
 }
 
-/// A tree's large file is read once, a piece at a time, exactly as a single
-/// `put` of it is. So the tree's byte count moves through that file rather
-/// than jumping over it once the whole thing has been read — which is what
-/// an upload that held each file whole could only ever report.
 #[test]
 fn a_recursive_put_counts_a_large_file_as_it_is_read() {
     let harness = Harness::new();
@@ -115,10 +109,6 @@ fn a_recursive_put_counts_a_large_file_as_it_is_read() {
     );
 }
 
-/// The same tree over the remote transport, where a large file is the one
-/// upload with parts to lose. Each file keeps its own resume record, named
-/// by the profile, namespace, remote path, and local file that decide which
-/// upload it is — and a run that committed leaves none of them behind.
 #[test]
 fn a_recursive_put_streams_a_large_file_over_the_remote_transport() {
     let harness = Harness::new();
@@ -179,9 +169,6 @@ fn a_recursive_put_streams_a_large_file_over_the_remote_transport() {
     );
 }
 
-/// What a tree holds that is neither a file nor a directory is named and
-/// skipped rather than silently dropped, and the walk carries on around it.
-/// Unix only: nothing else in the suite can make one.
 #[cfg(unix)]
 #[test]
 fn a_recursive_put_names_what_it_will_not_transfer() {
@@ -421,10 +408,6 @@ fn recursive_put_reuses_existing_directories_but_rejects_files() {
     assert_eq!(data["failures"][0]["error"]["code"], "path_conflict");
 }
 
-/// A recursive get creates the destination it was handed, parents included,
-/// the way `cp -r` creates its target. The shape that used to fail on every
-/// file is a remote directory holding nothing but files: no subdirectory
-/// existed to create the root as a side effect of its own `mkdir`.
 #[test]
 fn recursive_get_creates_an_absent_destination_root_in_both_modes() {
     let harness = Harness::new();
@@ -525,9 +508,6 @@ fn recursive_get_creates_an_absent_destination_root_in_both_modes() {
     }
 }
 
-/// One unwritable destination path fails alone. A local file sitting where a
-/// directory has to go takes down that directory and the files under it —
-/// each named on its own — while every sibling still lands.
 #[test]
 fn recursive_get_names_only_the_paths_it_could_not_write_in_both_modes() {
     let harness = Harness::new();

--- a/crates/loonfs-client/src/downloads/tests.rs
+++ b/crates/loonfs-client/src/downloads/tests.rs
@@ -38,7 +38,6 @@ fn capabilities(direct_get: bool, proxy_cap_bytes: Option<u64>) -> Outcome {
     Outcome::Success(serde_json::to_vec(&document).expect("serialize capability document"))
 }
 
-/// Files above the proxy limit use direct access; smaller files remain proxied.
 #[tokio::test]
 async fn a_file_past_the_default_proxy_cap_takes_the_grant() {
     let client = client();
@@ -59,7 +58,6 @@ async fn a_file_past_the_default_proxy_cap_takes_the_grant() {
         .expect("cached capabilities"));
 }
 
-/// Without direct-read support, every file remains on the proxied path.
 #[tokio::test]
 async fn a_deployment_without_the_capability_never_takes_the_grant() {
     let client = client();
@@ -71,7 +69,6 @@ async fn a_deployment_without_the_capability_never_takes_the_grant() {
         .expect("capabilities"));
 }
 
-/// Without an advertised proxy limit, the client keeps the proxied path.
 #[tokio::test]
 async fn a_deployment_that_advertises_no_cap_stays_proxied() {
     let client = client();
@@ -109,9 +106,6 @@ fn grant(content_ref: ContentRef, url: &str) -> BeginDownloadResponse {
     }
 }
 
-/// A grant's reference is the check on the bytes, not a description of
-/// them: an object store that answers with anything else fails the
-/// download rather than reaching the caller's sink as if it were the file.
 #[tokio::test]
 async fn a_streamed_read_is_refused_when_the_bytes_are_not_what_the_grant_named() {
     let payload = b"the bytes the grant described".to_vec();
@@ -145,9 +139,6 @@ fn crc32c_content_ref(bytes: &[u8]) -> ContentRef {
     }
 }
 
-/// An object nobody hashed for us is described only by the provider's own
-/// CRC, and that is what the download checks it against. A grant carrying
-/// one is not a grant whose bytes go unchecked.
 #[tokio::test]
 async fn a_crc32c_only_grant_verifies_the_bytes_it_receives() {
     let payload = b"transferred straight to the provider".to_vec();
@@ -185,9 +176,6 @@ async fn a_crc32c_only_grant_verifies_the_bytes_it_receives() {
     );
 }
 
-/// A CRC folds forward from a running value, so a resumed download of a
-/// CRC-32C-only grant closes over the prefix it never received exactly as a
-/// hashed one does.
 #[tokio::test]
 async fn a_resumed_crc32c_download_folds_the_prefix_into_the_same_verdict() {
     let payload = b"the first half and then the second half".to_vec();
@@ -232,8 +220,6 @@ async fn a_resumed_crc32c_download_folds_the_prefix_into_the_same_verdict() {
     );
 }
 
-/// The successful path through the same transport: the declared length and
-/// digest both hold, every byte reaches the sink, and the count comes back.
 #[tokio::test]
 async fn a_streamed_read_writes_the_granted_object_and_reports_its_length() {
     let payload = b"exactly the bytes the grant described".to_vec();
@@ -254,9 +240,6 @@ async fn a_streamed_read_writes_the_granted_object_and_reports_its_length() {
     assert_eq!(sink, payload);
 }
 
-/// A resumed download uses `Range` with the existing grant. The signature
-/// does not cover that header, and checksum verification includes the prefix
-/// already held by the caller.
 #[tokio::test]
 async fn a_resumed_download_asks_for_the_rest_and_verifies_the_whole_file() {
     let payload = b"the first half and then the second half".to_vec();
@@ -292,8 +275,6 @@ async fn a_resumed_download_asks_for_the_rest_and_verifies_the_whole_file() {
     );
 }
 
-/// Complete downloads omit `Range`. Resumed downloads require their prefix
-/// before reading new bytes.
 #[tokio::test]
 async fn a_resume_is_refused_until_it_accounts_for_what_it_holds() {
     let payload = b"a whole object".to_vec();
@@ -328,8 +309,6 @@ async fn a_resume_is_refused_until_it_accounts_for_what_it_holds() {
     );
 }
 
-/// A capability is a URL and a method, and this client sends the method it
-/// was given rather than assuming one.
 #[tokio::test]
 async fn a_grant_that_does_not_authorize_a_read_is_refused_before_any_request() {
     let payload = b"unused".to_vec();

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -1,16 +1,9 @@
 //! Async HTTP client for a LoonFS server.
 //!
-//! Use this crate when your process should talk to a hosted LoonFS runtime
-//! instead of embedding the runtime directly. The client keeps paths simple:
-//! pass a [`NamespacePath`] for filesystem operations and use explicit commit
-//! helpers when you need retry control.
-//!
-//! The public surface is [`Client`] and the values it takes: [`ClientConfig`],
-//! [`ClientError`], [`NamespacePath`], and the per-operation option structs
-//! re-exported below. There is no transport abstraction to implement — a
-//! process that wants the runtime in-process uses the `loonfs` crate instead,
-//! and the two surfaces share one definition of every option struct (they
-//! live in `loonfs-api`) so their arguments cannot drift apart.
+//! Use [`Client`] with [`ClientConfig`] and [`NamespacePath`] to access a
+//! hosted LoonFS server. Applications that embed the runtime directly should
+//! use the `loonfs` crate. Both crates share operation options from
+//! `loonfs-api`.
 
 #![warn(missing_docs)]
 #![allow(

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -424,8 +424,6 @@ mod tests {
         ContentRef::blob_v1(ContentId::generate(), bytes)
     }
 
-    /// `Client::new` runs the same validation as `ClientConfig::load`, so a
-    /// directly built config cannot bypass it.
     #[test]
     fn construction_validates_config_like_load_does() {
         let error = super::Client::new(super::ClientConfig {
@@ -469,9 +467,6 @@ mod tests {
         assert!(client_debug.contains("<redacted>"), "{client_debug}");
     }
 
-    /// A CA bundle that cannot be read or is not PEM fails at construction,
-    /// naming the path. Falling back to the platform roots would move the
-    /// failure to the first request and blame the server for it.
     #[test]
     fn an_unusable_ca_bundle_fails_construction_and_names_the_path() {
         let dir = tempdir().expect("tempdir");
@@ -502,9 +497,6 @@ mod tests {
         }
     }
 
-    /// Configs are strict like everywhere else in the workspace: a typo'd
-    /// key fails decode instead of silently producing an unauthenticated
-    /// client.
     #[test]
     fn client_config_rejects_unknown_keys() {
         let error = toml::from_str::<ClientConfig>(
@@ -517,10 +509,6 @@ mod tests {
             toml::from_str("server_url = \"http://localhost:1\"\n").expect("minimal config");
         assert!(config.auth_token.is_none());
     }
-    /// The retry policy in one place: network-level transport failures and
-    /// the retryable-unavailability codes resend; everything else — including
-    /// a served status whose body was not the error envelope — surfaces
-    /// immediately.
     #[test]
     fn retryable_transport_failure_covers_transport_and_unavailability_only() {
         let api = |code: &str| ClientError::Api {
@@ -564,8 +552,6 @@ mod tests {
         ));
     }
 
-    /// A network-level transport failure resends up to the attempt cap when
-    /// retry is enabled; with it disabled the first failure surfaces.
     #[tokio::test]
     async fn transport_failures_resend_up_to_the_attempt_cap() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -897,9 +883,6 @@ mod tests {
         }
     }
 
-    /// An intermediary answering with a non-envelope body (a load balancer's
-    /// HTML 502) must keep its status in the surfaced error — the status is
-    /// the only signal the response carried.
     #[test]
     fn status_errors_keep_the_status_when_the_body_is_not_the_envelope() {
         let error = crate::transport::map_status_error(502, b"<html>upstream error</html>");
@@ -1013,9 +996,6 @@ auth_token = "   "
         }
     }
 
-    /// Construction is the only door: the fields are private, so a bad id
-    /// or a bad path fails `parse` with the same error the string-shuttling
-    /// client surfaced before the fields were typed.
     #[test]
     fn namespace_path_parse_rejects_invalid_paths() {
         for path in ["notes.txt", "", "/docs/../a.txt", "/docs/./a.txt"] {

--- a/crates/loonfs-client/src/payload.rs
+++ b/crates/loonfs-client/src/payload.rs
@@ -196,8 +196,6 @@ mod tests {
         parts
     }
 
-    /// Source chunks and part boundaries are unrelated: a chunk that
-    /// straddles a boundary is split, and its tail opens the next part.
     #[tokio::test]
     async fn parts_are_cut_regardless_of_how_the_source_chunked_them() {
         let mut reader = PartReader::new(source(vec![b"abcde", b"fg", b"hijkl"]), 4);
@@ -207,8 +205,6 @@ mod tests {
         );
     }
 
-    /// A source that ends exactly on a boundary produces no trailing empty
-    /// part, and one that does not ends with a short one.
     #[tokio::test]
     async fn the_last_part_is_whatever_is_left() {
         let mut reader = PartReader::new(source(vec![b"abcdef"]), 4);
@@ -221,8 +217,6 @@ mod tests {
         assert_eq!(cut(&mut reader).await, vec![b"abcd".to_vec()]);
     }
 
-    /// An empty source produces no parts at all, which is what tells a
-    /// one-pass uploader that it has nothing to assemble.
     #[tokio::test]
     async fn an_empty_source_produces_no_parts() {
         let mut reader = PartReader::new(source(vec![]), 4);
@@ -247,8 +241,6 @@ mod tests {
         assert!(reader.next_part().await.expect("cut").is_none());
     }
 
-    /// A reader-backed source declares no length, which is exactly the
-    /// case a pipe presents.
     #[tokio::test]
     async fn a_reader_source_declares_no_length() {
         let source = PayloadSource::reader(std::io::Cursor::new(vec![1u8; 100]));

--- a/crates/loonfs-client/src/uploads/staging/tests.rs
+++ b/crates/loonfs-client/src/uploads/staging/tests.rs
@@ -385,10 +385,6 @@ fn resumed_script(missing: &[u32], uploaded: ContentRef) -> Vec<Outcome> {
     script
 }
 
-/// An upload interrupted after some parts landed picks the session back up
-/// and sends only what is missing. Every byte is still read — the assembly
-/// is verified against a checksum over the whole object — but the parts
-/// already in object storage are not sent a second time.
 #[tokio::test]
 async fn a_resumed_multipart_put_uploads_only_the_parts_that_are_missing() {
     let payload = payload(TEST_PAYLOAD_BYTES);
@@ -471,9 +467,6 @@ async fn a_resumed_multipart_put_uploads_only_the_parts_that_are_missing() {
     assert_eq!(transport.attempts(), 1 + 1 + missing.len() + 2);
 }
 
-/// A resumed upload obeys the algorithm recorded beside its durable session,
-/// even when it differs from the algorithm a new multipart session receives
-/// today. The payload is still read once while that recorded digest is folded.
 #[tokio::test]
 async fn a_resumed_multipart_put_uses_the_recorded_checksum_algorithm() {
     let payload = payload(TEST_PAYLOAD_BYTES);
@@ -515,8 +508,6 @@ async fn a_resumed_multipart_put_uses_the_recorded_checksum_algorithm() {
     assert_eq!(transport.attempts(), 1 + signing_waves + missing.len() + 2);
 }
 
-/// A large put reads its source once and never holds more of it than the
-/// window it uploads in.
 #[tokio::test]
 async fn a_direct_multipart_put_holds_only_its_window() {
     let payload = payload(TEST_PAYLOAD_BYTES);
@@ -551,8 +542,6 @@ async fn a_direct_multipart_put_holds_only_its_window() {
     );
 }
 
-/// A deployment that cannot authorize part uploads gets the same source as
-/// a request body, and the client accumulates none of it.
 #[tokio::test]
 async fn a_proxied_put_streams_its_body() {
     let payload = payload(TEST_PAYLOAD_BYTES);
@@ -592,10 +581,6 @@ async fn a_proxied_put_streams_its_body() {
     );
 }
 
-/// A small source goes through the server — but because the deployment's
-/// advertised cap says it fits, not because the client assumed it would.
-/// The document is read once and cached, so the round trip is paid at most
-/// once per client however many puts follow.
 #[tokio::test]
 async fn a_small_streamed_source_proxies_against_the_advertised_cap() {
     let payload = payload(1_000);
@@ -637,7 +622,6 @@ async fn a_small_streamed_source_proxies_against_the_advertised_cap() {
     );
 }
 
-/// A payload above the proxy limit uses direct PUT when multipart is absent.
 #[tokio::test]
 async fn a_small_payload_past_the_proxy_cap_takes_direct_put() {
     let payload = payload(1_025);
@@ -673,7 +657,6 @@ async fn a_small_payload_past_the_proxy_cap_takes_direct_put() {
     assert_eq!(object_write.body_bytes(), payload.len());
 }
 
-/// An unknown-length payload can use direct PUT without multipart support.
 #[tokio::test]
 async fn an_unknown_length_payload_past_the_proxy_cap_takes_direct_put() {
     let payload = payload(64 * 1024);
@@ -718,8 +701,6 @@ async fn an_unknown_length_payload_past_the_proxy_cap_takes_direct_put() {
     );
 }
 
-/// An unknown length cannot be routed by its eventual size. Direct PUT is
-/// selected without a preflight read and observes the size during transfer.
 #[tokio::test]
 async fn an_unknown_length_payload_takes_direct_put_without_a_preflight_read() {
     let payload = payload(1_000);
@@ -757,7 +738,6 @@ async fn an_unknown_length_payload_takes_direct_put_without_a_preflight_read() {
     assert_eq!(object_write.body_bytes(), payload.len());
 }
 
-/// Direct PUT streams, counts, and hashes a payload in one pass.
 #[tokio::test]
 async fn a_direct_put_streams_its_payload_without_ever_holding_it() {
     let payload = payload(TEST_PAYLOAD_BYTES);
@@ -826,8 +806,6 @@ async fn a_capability_failure_does_not_downgrade_a_measured_upload_to_the_proxy(
     assert_eq!(transport.attempts(), 1);
 }
 
-/// A file-backed direct PUT reads the source once without copying it to a
-/// spool file.
 #[tokio::test]
 async fn a_file_backed_direct_put_reads_the_file_once_without_spooling_it() {
     let payload = payload(TEST_PAYLOAD_BYTES);
@@ -904,8 +882,6 @@ async fn request_head_for(source: PayloadSource) -> String {
     served.await.expect("probe task")
 }
 
-/// A source that knows its length declares it, so the server can refuse an
-/// oversized body before reading it.
 #[tokio::test]
 async fn a_sized_source_frames_its_body_with_a_content_length() {
     let directory = tempfile::tempdir().expect("tempdir");
@@ -921,8 +897,6 @@ async fn a_sized_source_frames_its_body_with_a_content_length() {
     );
 }
 
-/// A source with unknown length uses chunked transfer encoding so the server
-/// can enforce its incremental size limit.
 #[tokio::test]
 async fn an_unsized_source_frames_its_body_chunked() {
     let stream = futures::stream::iter(vec![Ok(Bytes::from_static(b"0123456789"))]).boxed();

--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -1,36 +1,12 @@
-//! The lease one streaming metadata compaction holds over its own output.
+//! Lease for a streaming compaction's staged output.
 //!
-//! A job writes every output segment under `metadata/compactions/{job_id}/`
-//! and writes this object beside them. It carries lifecycle ownership and
-//! nothing else — job, namespace, owner, status, start, last heartbeat —
-//! because the one question it answers is who owns the objects under its
-//! prefix. There is no cursor here, no output descriptor, no offset, and no
-//! progress: a crashed job still loses its work, exactly as the design says
-//! it does.
+//! A job creates and refreshes an `Active` lease with compare-and-swap.
+//! Garbage collection may claim an expired lease by changing it to `Reaping`.
+//! A failed heartbeat then prevents the job from publishing.
 //!
-//! The lease is a fence, not a timestamp. Every write after the first is a
-//! compare-and-swap on the etag the writer last observed, so the job and the
-//! collector cannot both believe they own the prefix. The job creates the
-//! lease with `put_if_absent` and refreshes it by compare-and-swap; garbage
-//! collection claims an expired lease by compare-and-swapping it from
-//! `Active` to `Reaping` and only then treats the prefix as orphaned (format
-//! spec, "Garbage collection", rule 12). Exactly one of those two
-//! compare-and-swaps can win:
-//!
-//! - the job's heartbeat wins, so the collector keeps the prefix; or
-//! - the collector's claim wins, so the job is fenced, aborts, and publishes
-//!   nothing.
-//!
-//! A published job stops heartbeating and leaves its final lease in place. It
-//! is not deleted, because deleting it would open the one hole a lease exists
-//! to close: a collection pass that captured its live set before the
-//! publication would find output objects far older than any grace window and
-//! no lease saying who owns them. The lease expires on its own, and the pass
-//! that finds it expired reads a root that already names the segments.
-//!
-//! A malformed lease is corruption rather than evidence that its prefix is
-//! unowned; collection stops before it can race a job whose fence it cannot
-//! verify.
+//! Completed jobs leave the lease in place so a collection pass that started
+//! before publication cannot mistake old output for garbage. Malformed leases
+//! stop collection because ownership cannot be verified.
 
 use crate::control_object::{
     core_control_load_error, expect_identity_field, expect_namespace, load_control_object,
@@ -67,17 +43,14 @@ pub(crate) enum CompactionPrefixOwner {
     NoOne,
 }
 
-/// Reads the lease of one job and says who owns that job's prefix, claiming
-/// an expired lease on the way.
+/// Returns the current prefix owner, claiming an expired lease when possible.
 ///
 /// A collector parses `metadata_compaction_id` from the key it is deciding.
 /// A lease naming a different job or namespace is corrupt because the key
 /// and embedded fence disagree.
 ///
-/// The claim is the whole point of reading it. An expired `Active` lease
-/// alone proves nothing — the job may be resuming from a long stall right
-/// now — so the prefix is orphaned only once this compare-and-swap has landed
-/// and the job's next heartbeat is guaranteed to fail.
+/// An expired lease is not collectable until the compare-and-swap succeeds;
+/// the job may still resume and refresh it first.
 pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/compaction_merge.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_merge.rs
@@ -1,10 +1,4 @@
-//! Reading a merge's input: one iterator per run per family, merged in row-key
-//! order, refilled a bounded wave at a time.
-//!
-//! This is what makes a merge's input residency a fixed number rather than a
-//! function of what it merges. An iterator holds the blocks it has not
-//! consumed and nothing else, a refill wave is bounded, and the selection
-//! that decides which iterator goes next compares borrowed key slices.
+//! Streams rows from multiple runs in row-key order with bounded buffering.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::block_load::SessionBlockMemo;
@@ -28,29 +22,11 @@ const BLOCKS_PER_ITERATOR_FETCH: usize = 2;
 /// this is the width of its fan-out at the store.
 const ITERATOR_FETCH_CONCURRENCY: usize = 8;
 
-/// Which rows a retention rule has to see together, and therefore how the
-/// merge interleaves the families of one cluster.
+/// Defines which adjacent rows a retention rule processes together.
 ///
-/// The rules that drop a row read its neighbours, and every one of them reads
-/// neighbours that share a row-key prefix: an unbind cancels the bind of its
-/// own generation, a removal marker repeats its deletion's sequence and root,
-/// and an attribute revision supersedes revisions of its own inode. So the
-/// grouping is read straight off the row-key grammar in
-/// `MetadataRow::row_key_for_family`, and it is the shortest prefix each rule
-/// needs rather than the whole partition the rows happen to share:
-///
-/// | families | grouped by | key components after the family prefix |
-/// | --- | --- | --- |
-/// | binds, unbinds | one binding generation | `{parent}-{name}-{bind_seq}-{bind_delta}` |
-/// | active deletions | one deletion | `{deletion_seq}-{root}` |
-/// | attributes | one inode | `{inode}` |
-/// | everything else | one row | — |
-///
-/// A generation rather than a name slot is what keeps the bindings group
-/// bounded: a slot has no limit on how many times a name is created and
-/// deleted, and a generation holds one bind and the unbind that retires it.
-/// A bind's whole row key *is* its generation, and an unbind's key leads with
-/// the generation it retires, so both families name the same group.
+/// Groups use the shortest shared row-key prefix required by the rule: a
+/// binding generation, deletion identity, inode, or single row. Binding
+/// generations keep memory bounded when a name is reused many times.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum LocalityGrouping {
     /// Every row is judged on its own.
@@ -63,8 +39,7 @@ pub(super) enum LocalityGrouping {
     LeadingKeyComponents(usize),
 }
 
-/// Returns the row's locality group after removing the family prefix. Bind
-/// and unbind rows for the same parent and name therefore share a group.
+/// Returns the row's locality group after removing the family prefix.
 pub(super) fn locality_of(
     family: MetadataRowFamily,
     row_key: &str,
@@ -305,10 +280,6 @@ mod tests {
     /// The grouping the bindings cluster merges by.
     const GENERATION: LocalityGrouping = LocalityGrouping::LeadingKeyComponents(4);
 
-    /// A bind and the unbind that retires it must name the same locality
-    /// group, because the drop rule reads one from the other. They live in
-    /// different families with different row-key prefixes, so this holds only
-    /// because the grouping is read behind the prefix.
     #[test]
     fn a_bind_and_its_unbind_name_one_locality_group() {
         let bound = bind(7, "report.txt", 11);
@@ -344,9 +315,6 @@ mod tests {
         );
     }
 
-    /// Rows of one locality group are contiguous in row-key order, and
-    /// grouping order is row-key order. Without both, a merge would reopen a
-    /// group it had already judged and written.
     #[test]
     fn locality_order_follows_row_key_order() {
         let mut keys: Vec<String> = ["a", "ab", "b", "a-b"]

--- a/crates/loonfs-core/src/checkpoint/compaction_retention.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_retention.rs
@@ -1,27 +1,8 @@
-//! The frozen floor's rules as streaming operators: one row in, at most one
-//! row out, and a fixed amount of state in between.
+//! Applies retention rules while rows are streamed in key order.
 //!
-//! Holding every row of a family and deciding them together is not available
-//! to a merge: one inode may hold any number of attribute revisions and one
-//! parent-and-name slot any number of binding generations, so holding "the
-//! rows a rule reads together" is holding an unbounded set. These operators
-//! hold the *answer* a rule is building instead, which is a fixed number of
-//! fields per family and at most one row.
-//!
-//! What makes that possible is the row-key grammar. Rows arrive in row-key
-//! order, and every rule reads neighbours that share a key prefix, so the rows
-//! a rule needs arrive together and in the order the rule wants them:
-//!
-//! | family | grouped by | arrives |
-//! | --- | --- | --- |
-//! | attributes | one inode | newest revision first |
-//! | active deletions | one deletion | the removal before the row it removes |
-//! | binds, unbinds | one binding generation | the bind before its unbinds |
-//!
-//! The reverse bind index is the one family no grouping can serve: it is
-//! keyed by child while the unbind that retires a bind is keyed by parent, so
-//! its rows are decided one at a time by a point read into the merge's snapshot
-//! ([`super::streaming_compaction`]) and it holds no state here at all.
+//! Each operator keeps bounded state for its current key group. Reverse bind
+//! rows require point reads because binds and unbinds use different key
+//! prefixes; [`super::streaming_compaction`] handles those reads.
 
 use super::frozen_floor::{bind_survives_frozen_floor, BindingGeneration};
 use crate::error::{CoreError, Result};
@@ -32,22 +13,17 @@ use std::collections::BTreeSet;
 /// One row a retention operator kept, and the family it belongs to.
 pub(super) type KeptRow = (MetadataRowFamily, MetadataRow);
 
-/// Which rule decides a cluster's rows, as the cluster table names it.
-///
-/// The table is `const`, so it names the rule; [`Self::operator`] is what
-/// turns one into the state that runs it.
+/// Retention rule assigned to a row cluster.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RetentionRule {
-    /// Nothing is ever dropped: revision history, inode rows, and tombstone
-    /// rows are retained whatever the floor says.
+    /// Retain every row in the group.
     KeepEveryRow,
     /// A receipt is decided by its own sequence against the floor.
     Receipts,
     /// Every revision above the floor, plus the newest at or below it, per
     /// inode.
     Attributes,
-    /// A cancelled deletion's pair leaves together; a live listing stays
-    /// however far the floor advances.
+    /// Retain active deletions and remove completed deletion pairs.
     ActiveDeletions,
     /// A bind and the unbinds of its own generation, decided together.
     ForwardBindings,
@@ -66,10 +42,8 @@ impl RetentionRule {
                 RetentionOperator::ActiveDeletions(ActiveDeletionRetention::default())
             }
             Self::ForwardBindings => RetentionOperator::ForwardBindings(Box::default()),
-            // The reverse index is decided one row at a time by the merge,
-            // which is the only thing that can read the snapshot, so this
-            // rule has no state of its own to run. The merge still opens and
-            // closes groups over it, and both are nothing to do.
+            // The merge checks reverse bind rows against its snapshot, so
+            // this operator has no state to maintain.
             Self::ReverseBindProbe => RetentionOperator::KeepEveryRow,
         }
     }
@@ -86,11 +60,8 @@ pub(super) enum RetentionOperator {
 }
 
 impl RetentionOperator {
-    /// Judges one row and answers with what survives it.
-    ///
-    /// A `None` means the row was dropped or is being held for a verdict the
-    /// rest of its group has not delivered yet; [`Self::close_group`] is where
-    /// anything held comes back.
+    /// Returns the retained row, or `None` when the row is dropped or held
+    /// until [`Self::close_group`].
     pub(super) fn push(
         &mut self,
         family: MetadataRowFamily,
@@ -107,8 +78,7 @@ impl RetentionOperator {
         Ok(kept.map(|row| (family, row)))
     }
 
-    /// Closes the locality group that just ended and answers with the row it
-    /// was holding, if it was holding one.
+    /// Finishes the current key group and returns any retained row.
     pub(super) fn close_group(&mut self, floor_seq: ChangeSeq) -> Result<Option<KeptRow>> {
         match self {
             Self::KeepEveryRow | Self::Receipts => Ok(None),
@@ -126,11 +96,7 @@ impl RetentionOperator {
         }
     }
 
-    /// How many rows this operator is holding right now.
-    ///
-    /// This is the number the merge's peak counter tracks, and the thing the
-    /// resource tests assert stays small however many revisions one inode has
-    /// or however many generations one name slot has.
+    /// Number of rows currently held by this operator.
     pub(super) fn held_rows(&self) -> usize {
         match self {
             Self::KeepEveryRow
@@ -406,9 +372,6 @@ mod tests {
         }
     }
 
-    /// One inode's revisions arrive newest first, so the operator keeps
-    /// everything above the floor plus the first row at or below it, and its
-    /// state never grows with the history.
     #[test]
     fn one_inode_keeps_the_newest_row_at_the_floor_and_holds_nothing() {
         let mut operator = RetentionRule::Attributes.operator();
@@ -443,8 +406,6 @@ mod tests {
         assert_eq!(kept[2], attribute_row(7, 100_000, 50));
     }
 
-    /// The rule refuses a history where "the newest at the floor" is
-    /// ambiguous.
     #[test]
     fn two_attribute_rows_at_one_revision_below_the_floor_are_refused() {
         let mut operator = RetentionRule::Attributes.operator();
@@ -465,8 +426,6 @@ mod tests {
         assert!(error.to_string().contains("two attribute rows at revision"));
     }
 
-    /// A cancelled deletion's pair leaves together, and a live one stays
-    /// whatever the floor says.
     #[test]
     fn a_cancelled_deletion_leaves_and_a_live_one_stays() {
         let mut operator = RetentionRule::ActiveDeletions.operator();
@@ -506,8 +465,6 @@ mod tests {
         );
     }
 
-    /// One name slot with a hundred thousand generations streams through
-    /// holding at most one row.
     #[test]
     fn one_name_slot_of_many_generations_holds_at_most_one_row() {
         let mut operator = RetentionRule::ForwardBindings.operator();
@@ -543,9 +500,6 @@ mod tests {
         );
     }
 
-    /// A bind that survives the floor is remembered by identity alone, and a
-    /// second surviving bind in the same slot is the invariant violation the
-    /// rule refuses.
     #[test]
     fn a_second_unretired_bind_in_one_slot_is_refused() {
         let mut operator = RetentionRule::ForwardBindings.operator();

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -65,25 +65,13 @@ pub struct CheckpointFilesPage {
     pub next_cursor: Option<CheckpointFilesPageCursor>,
 }
 
-/// Reads one page of the files visible in the state `checkpoint_id` pins.
+/// Lists files visible in the state pinned by `checkpoint_id`.
 ///
-/// The checkpoint's own manifest is the only state read: no WAL tail is
-/// replayed over it, and no later manifest is consulted, so the answer is
-/// the namespace exactly as of `checkpoint_seq`. Visibility is the same rule
-/// every read applies — the inode exists, and no subtree tombstone covers it
-/// or any of its ancestors — evaluated against that manifest. Directories
-/// are not returned.
-///
-/// A record that is missing or released answers `checkpoint_unavailable`,
-/// and so does a pinned manifest that is already gone. There is no fallback
-/// to current state: a consumer that lost its checkpoint takes a new one and
-/// starts over.
-///
-/// Release is the whole authority here — no clock. An active record whose
-/// expiry has passed still pins its basis and still serves: garbage
-/// collection is what turns a passed expiry into a release, and until it
-/// does, the record is a root, so answering from it is answering from state
-/// that is provably still there.
+/// The checkpoint manifest is read without replaying later WAL entries.
+/// Visibility rules match current reads, and directories are omitted. Missing
+/// or released records and missing pinned manifests return
+/// `checkpoint_unavailable` without falling back to current state. Expiry is
+/// enforced when garbage collection releases the record, not during reads.
 pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
     store: &S,
     segment_cache: Option<&MetadataSegmentCache>,

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -1,14 +1,6 @@
-//! Checkpoint inventory: every active record a namespace still carries.
+//! Lists active checkpoint records for a namespace.
 //!
-//! A checkpoint record is a garbage-collection root, and the creation
-//! response is the only place its id ever appears. An operator who lost that
-//! response — or who never saw it, because a duplicate label produced a
-//! second record under a second id — has no other way to find the pin and
-//! release it. This enumeration is that way.
-//!
-//! It reads the `checkpoints/` prefix and nothing else. Records that were
-//! released are gone from the answer: a release is what stops a record
-//! pinning anything, and a released record awaiting its reap pins nothing.
+//! The listing reads the `checkpoints/` prefix and excludes released records.
 
 use super::record::load_checkpoint_record_at_key;
 use crate::control_object::{core_control_load_error, ControlObjectLoadError};

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -3,21 +3,6 @@
 //! A namespace manifest references the immutable metadata segment runs for one
 //! namespace state. A checkpoint pins a manifest for retention, forks, stable
 //! reads, or restore.
-//!
-//! The submodules cover these areas:
-//! - Building and publishing manifests: [`build`], [`flush`], [`create`], and
-//!   [`publish`].
-//! - Managing checkpoint records: [`record`], [`list`], [`release`], and
-//!   [`files`].
-//! - Loading, validating, and scanning metadata: [`load`], [`validate`],
-//!   [`scan`], and [`row`].
-//! - Planning and running metadata merges: [`reorganize`],
-//!   [`streaming_compaction`], [`compaction_merge`],
-//!   [`compaction_retention`], [`compaction_output`], [`compaction_lease`],
-//!   and [`frozen_floor`].
-//! - Advancing the retention floor: [`retention`].
-//! - Describing run layout and caching: [`runs`], [`cache`], and
-//!   [`stored_block_cache`].
 
 mod block_fetch;
 mod block_load;

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -1,14 +1,9 @@
 //! Checkpoint records stored under `checkpoints/`.
 //!
-//! A checkpoint record pins one metadata manifest (its "basis") so that
-//! garbage collection keeps everything the manifest references. Creation is
-//! write-then-verify: the record is written as `active`, then the basis is
-//! checked against the live retention floor, and the record flips to
-//! `released` if the check fails. Release is the one state change a record
-//! ever makes and it is one-way; garbage collection deletes the released
-//! record outright once it has aged. Records never decide what readers see
-//! as latest, and they are stored as standalone objects, never inside
-//! manifests.
+//! A checkpoint record pins one metadata manifest for garbage collection.
+//! Creation writes an active record and then verifies its basis against the
+//! retention floor. Failed verification releases the record. Release is
+//! one-way, and garbage collection later removes aged released records.
 
 use super::load::load_namespace_manifest_envelope;
 use super::ManifestLoadError;
@@ -355,7 +350,6 @@ mod tests {
         ));
     }
 
-    /// A checkpoint record cannot pin another namespace's manifest.
     #[tokio::test]
     async fn loader_rejects_a_record_pinning_another_namespaces_manifest() {
         let (_directory, store) = local_store();

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -1,28 +1,12 @@
 //! Plans and publishes bounded metadata merges.
 //!
-//! Checkpoint publication appends delta runs. Each maintenance step selects
-//! one metadata family group and either merges a budgeted, contiguous set of
-//! complete runs or returns a plan for a background compaction of the entire
-//! group. Bounded steps and background jobs use the same merge engine.
+//! Each step selects one family group and either merges a bounded run window
+//! or requests a full background compaction. Base merges may apply retention;
+//! delta merges preserve every row. Both paths use the same merge engine.
 //!
-//! A merge that includes the group's oldest run writes a base-tier run and may
-//! remove rows below the retention floor. A merge that starts above the base
-//! writes a delta-tier run at its newest input sequence and preserves every
-//! row. These rules keep at most one base run per family group and preserve
-//! run ordering.
-//!
-//! Each bounded merge publishes a durable manifest, so no separate progress
-//! record is required. After interruption, the next step reloads the current
-//! manifest and selects another group. If a concurrent publication wins the
-//! root compare-and-swap, the merge output remains unreferenced for garbage
-//! collection and a later step retries from the new manifest.
-//!
-//! When the oldest run prevents a useful bounded merge, [`FrozenBasePolicy`]
-//! determines whether the step may merge newer delta runs or must request a
-//! full compaction. Writer maintenance permits a limited number of delta
-//! merges before requesting the background job. Explicit compaction requests
-//! select the job immediately. [`MetadataCompactionView`] identifies any group
-//! already being compacted so a bounded step does not select it again.
+//! Every successful merge publishes a new manifest. Interrupted or losing
+//! publications leave unreferenced output for garbage collection.
+//! [`FrozenBasePolicy`] decides when a blocked base requires full compaction.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::error::ManifestLoadError;
@@ -51,46 +35,20 @@ use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Delta merges that may publish over a frozen base before the planner
-/// insists on the job that unfreezes it.
-///
-/// Delta merges between jobs are how a stuck group amortizes: a job rereads
-/// the whole group, so running one for every eight delta runs would reread
-/// megabytes to fold in a sliver. Two merges is the smallest count that still
-/// lets the ordinary merge do that work, and it bounds how long retention for
-/// the group can stay stopped — the job starts within two published delta
-/// merges of the block, whatever the write rate is.
+/// Delta merges allowed over a frozen base before full compaction.
 pub(super) const DELTA_MERGES_OVER_A_FROZEN_BASE: u32 = 2;
 
 /// How planning treats a family group whose base run is frozen.
 ///
-/// A group whose bottom-anchored window is blocked still has delta runs above
-/// that base to merge, and under sustained writes there is always another pair
-/// of them. So the planner has to be told what to do about that, and the two
-/// answers are genuinely different work.
+/// Selects immediate or amortized compaction for a frozen base.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FrozenBasePolicy {
-    /// Amortize the rebuild: keep taking the delta merge above the frozen
-    /// base until `DELTA_MERGES_OVER_A_FROZEN_BASE` of them have published
-    /// for the group, then plan the job. This is what a writer's own
-    /// maintenance runs under, because upkeep that rebuilt the whole group
-    /// for every eight delta runs would reread megabytes to fold in a sliver.
-    ///
-    /// The counts are per family group, keyed by the group itself: a group's
-    /// block is its own, and one step reorganizes one group. A group absent
-    /// from the map has published none.
-    ///
-    /// They are in-memory process state and safe to lose: a restart forgets
-    /// them and the next two merges rebuild them, which delays one cycle.
+    /// Merge newer delta runs before requesting a full compaction.
+    /// Counts are per family group and may be rebuilt after restart.
     Amortized {
         published_delta_merges_over_frozen_base: BTreeMap<MetadataFamilyGroup, u32>,
     },
-    /// Plan the job as soon as the bottom-anchored window is blocked. This is
-    /// what an explicit compaction request runs under, and what a bounded step
-    /// with nowhere to run background work runs under: the first reports the
-    /// operation its caller asked for, and the second reports that the
-    /// namespace needs one promptly instead of publishing delta merges that
-    /// never reach it.
+    /// Request full compaction as soon as the base is blocked.
     CompactImmediately,
 }
 
@@ -535,21 +493,13 @@ fn over_budget_run(
 /// Selects bounded merge input or plans a full compaction for one family
 /// group.
 ///
-/// Runs are ordered oldest first. Base-tier runs sort before delta-tier runs
-/// regardless of `run_seq`; within a tier, lower sequences are older. The
-/// selector first tries a contiguous window beginning at the oldest run. If
-/// that cannot make progress, it may try a window beginning at the oldest
-/// delta run. It never skips a delta run.
+/// Base runs sort before delta runs, with older runs first in each tier. The
+/// selector tries a window from the oldest run, then a delta-only window. It
+/// never skips a delta run. If neither bounded window can make progress, it
+/// plans a full compaction.
 ///
-/// A bottom-anchored merge makes progress when it moves at least one delta run
-/// into the base tier. A delta-only merge must combine at least two runs. If
-/// neither bounded window works, or `frozen_base` requires a full compaction,
-/// the result contains a plan covering every run in the group.
-///
-/// Block indexes are read before row data so the row and decoded-byte budgets
-/// can be enforced without partially including a run. A bounded merge resolves
-/// the current retention floor before applying retention. A full-compaction
-/// plan records `frozen_floor_seq` so the background job uses one fixed floor.
+/// Indexes are read before row data so each run either fits the row and byte
+/// budgets completely or is excluded.
 pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
     segments: &VerifiedMetadataSegments<'_, S>,
     group: MetadataFamilyGroup,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -1,44 +1,13 @@
-//! The merge engine both reorganization paths run, and the background job
-//! that is one of them.
+//! Streaming metadata merge engine.
 //!
-//! [`GroupMerge`] merges one family group. It opens one iterator per run per
-//! family and merges them in row-key order ([`super::compaction_merge`]),
-//! feeds the merged rows through streaming retention operators
-//! ([`super::compaction_retention`]), and writes each output segment as it
-//! fills ([`super::compaction_output`]). What it holds at any instant is a
-//! fixed number of decoded input blocks per iterator, the fixed state of one
-//! retention operator, and one segment builder per family of the group. No
-//! family, no partition, no directory, no inode's history, and no name slot's
-//! generations are ever collected whole, so nothing it holds follows the size
-//! of what it merges.
+//! [`GroupMerge`] merges runs in row-key order, applies retention rules, and
+//! writes bounded output segments. It buffers only input blocks, retention
+//! state, and one segment builder per family.
 //!
-//! Rows are dropped when, and only when, the merge's [`MergePlacement`] is
-//! `Base`. That is the placement rule already: a window that starts at the
-//! group's oldest run holds every row a drop could need to read, and a window
-//! above the base does not, so a merge above the base is a pure rewrite.
-//!
-//! Two callers drive the engine, and they differ in orchestration rather than
-//! in merging.
-//!
-//! [`merge_group_in_step`] runs it synchronously inside one maintenance step.
-//! The step's budgets chose the window and the step publishes the result, so
-//! the segments go to `metadata/segments/` and there is no lease, no job, no
-//! registry, and no admission.
-//!
-//! [`run_metadata_compaction_job`] runs it as a background task the
-//! maintenance runner owns, for a group whose bottom-anchored window no longer
-//! fits one step's budgets — a group whose base is frozen and whose retention
-//! has stopped ([`super::reorganize`] reports that, loudly). Nothing paces that
-//! work, so it needs everything the step-contained merge does not: admission, a
-//! staging prefix, and a lease over what it writes there. Its segments go to
-//! the job's own prefix (format spec, "Compaction") because a job outlives the
-//! collector's grace window, so its output would otherwise look exactly like
-//! the unreferenced aged objects the collector reaps; the lease beside them
-//! ([`super::compaction_lease`]) is what tells the collector the difference. It
-//! publishes nothing until it is finished, and a cancelled or crashed job
-//! leaves staged objects nothing references and the old manifest still valid.
-//! The step that plans it starts it and returns; the runner cancels it on
-//! shutdown and joins it with the rest of its background work.
+//! [`merge_group_in_step`] runs within a bounded maintenance step.
+//! [`run_metadata_compaction_job`] handles full background compactions using a
+//! staging prefix and lease. Only base merges may remove rows below the
+//! retention floor; delta merges preserve every row.
 
 use super::block_fetch::{load_segment_filter, segment_object_len};
 use super::block_load::SessionBlockMemo;
@@ -111,9 +80,8 @@ const MAX_FINALIZATION_ATTEMPTS: usize = 4;
 /// the same durable state produces the same rows, which is what makes a
 /// cancelled attempt free to throw away.
 ///
-/// The runtime holds one of these per running job and hands it back to
-/// [`super::reorganize_metadata_step`], which is how a step knows not to
-/// merge the group a job is rebuilding.
+/// The runtime holds one per running job so maintenance steps skip the group
+/// being rebuilt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataCompactionSpec {
     /// This job's identity, and the prefix its output and its lease live
@@ -605,27 +573,13 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
 
 /// Swaps the rebuilt run in for the snapshot it replaces.
 ///
-/// Reload the root and manifest, check that every segment the job read is
-/// still exactly what the manifest holds for the group in those runs, replace
-/// those descriptors with the output run's, keep everything else — including
-/// the runs that arrived while the job ran — and publish through the ordinary
-/// compare-and-swap. An unrelated publication winning that race is a reload
-/// and another attempt; a snapshot that moved is an abandon, because this
-/// output no longer stands in for what the manifest holds.
+/// The current manifest must still contain the segments used by the job. New
+/// runs are preserved. Unrelated compare-and-swap conflicts are retried, while
+/// changes to the job's input abandon the output.
 ///
-/// The publication budget covers this publication and not the job: what it
-/// protects against is a root compare-and-swap landing after the objects it
-/// names could have aged into the collector's window, which is a property of
-/// the last few seconds and not of however long the rebuild took. That is the
-/// same span the lease has to cover, so both are measured off the lease's own
-/// clock.
-///
-/// The root is stamped with the wall clock each attempt reads rather than the
-/// one the job started under. A job that ran for hours would otherwise stamp
-/// the root with its start time, and a job rebasing over a newer flush would
-/// move the root's `updated_at_ms` backwards. The job's identity is the other
-/// half of what a publication carries, and that stays frozen: the writer this
-/// job runs as is the writer that planned it.
+/// The publication budget starts during finalization rather than at the start
+/// of the potentially long rebuild. Each attempt uses a current wall-clock
+/// timestamp so `updated_at_ms` cannot move backward.
 pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -637,19 +591,12 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
 ) -> Result<Finalization> {
     let timer = lease.timer();
     for attempt in 1..=MAX_FINALIZATION_ATTEMPTS {
-        // Checked at the top of every attempt, not only the first: the
-        // attempts after a lost race are exactly the wait a shutdown must not
-        // sit through.
+        // Check cancellation again after every publication conflict.
         if cancellation.is_cancelled() {
             return Ok(Finalization::Cancelled);
         }
-        // The claim is refreshed at the top of every attempt, and losing that
-        // compare-and-swap ends the job here. This is the check that makes
-        // the fence complete: the span from here to the root compare-and-swap
-        // below is one publication budget, which is shorter than the lease
-        // expiry, so a job that gets past this line cannot have its prefix
-        // claimed before the swap that makes its output referenced
-        // (`limits::METADATA_COMPACTION_LEASE_EXPIRY_MS`).
+        // Refresh the lease before publishing. Its expiry exceeds the
+        // publication budget, so GC cannot claim the prefix before the CAS.
         if lease.heartbeat(store).await? == LeaseHold::Fenced {
             return Ok(Finalization::Fenced);
         }
@@ -801,46 +748,15 @@ pub(super) fn snapshot_segment_keys<S: ObjectStore + ?Sized>(
     Some(keys)
 }
 
-/// How a merge decides whether a reverse bind row survives the frozen floor.
+/// Source used to determine whether a reverse bind survives the frozen floor.
 ///
-/// The reverse index is keyed by child while the unbind that retires a bind is
-/// keyed by parent, so no grouping of the merged stream holds a reverse row
-/// together with its unbind. Both answers below come from the same rule
-/// ([`bind_survives_frozen_floor`]) against the same set
-/// ([`unbinding_at_or_below_floor`]); they differ only in where the set comes
-/// from, because the two orchestrations have different resource contracts.
-///
-/// This parameterizes the lookup and nothing else. Iteration, retention,
-/// segment writing, parity, and publication are the same code either way.
+/// Reverse binds and unbinds have different key prefixes. Background jobs use
+/// point reads to keep memory bounded. Step-contained merges reuse a bounded
+/// set collected while processing forward binds.
 enum ReverseBindResolution {
-    /// Read the unbinds of one binding out of the snapshot, one probe per
-    /// reverse row at or below the floor.
-    ///
-    /// What a background job uses. A job has no bound on the group it
-    /// rebuilds, so it must not hold a set that follows the group's size; a
-    /// bounded cache in front of the reads is the most it can keep.
+    /// Probe the snapshot for each reverse row, with a bounded cache.
     PointProbeSnapshot,
-    /// Consult the below-floor unbound generations the forward cluster already
-    /// streamed past.
-    ///
-    /// What a merge inside a maintenance step uses. Its input is capped by the
-    /// step's row and decoded-byte budgets, so this set is capped by the same
-    /// budgets — it holds one generation identity per below-floor unbind in
-    /// the window, and never more than the window itself.
-    ///
-    /// The alternative costs one store round trip per reverse row once the
-    /// probe cache can no longer hold the window's unbind family. The row
-    /// budget admits about 43,000 unbind rows, which reaches the 16 MiB cache
-    /// at an ordinary name length, and the decoded-byte budget allows four
-    /// times that. Measured on a window whose unbind family just fills the
-    /// cache, with the reverse index walking it out of order: 65,536 reverse
-    /// rows cost 27,427 data reads and 309 MB transferred for 16 MB of priced
-    /// input, and doubling the family doubled both. This set is also the
-    /// smaller resident structure — one identity per below-floor unbind, well
-    /// under the cache it replaces.
-    ///
-    /// This is filled by the forward cluster, which
-    /// [`BINDINGS_CLUSTERS`] runs first for exactly that reason.
+    /// Use unbound generations collected from the bounded forward-bind input.
     CollectedUnbinds(BTreeSet<BindingGeneration>),
 }
 
@@ -1096,29 +1012,10 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         Ok(Ok(self.result))
     }
 
-    /// Refuses a family that hands the merge one row key twice, and refuses a
-    /// merge that hands itself a family out of order.
+    /// Rejects duplicate or out-of-order input keys within a family.
     ///
-    /// A metadata row key identifies one row. Nothing downstream re-checks
-    /// that: reads concatenate runs rather than deduplicating them, and the
-    /// segment builder rejects only a descending key, so two equal adjacent
-    /// keys travel into a published run and make the same logical event
-    /// answerable twice.
-    ///
-    /// This runs over the merge's input rather than its output, which is what
-    /// makes it see a duplicate retention would otherwise drop, a duplicate
-    /// split across two runs, and a duplicate split across two segments.
-    ///
-    /// It stands beside the output digests
-    /// ([`Self::refuse_a_run_whose_index_disagrees`]) because the two prove
-    /// different things. The digests say the two families of an index pair hold
-    /// the same rows as each other; a duplicate present on both sides passes
-    /// them, because both multisets still match. This says no family holds one
-    /// row key twice, whatever the other family holds.
-    ///
-    /// A key that goes backwards is not corruption in the store — the k-way
-    /// merge emits one family in row-key order — so that case is an internal
-    /// error against the merge itself.
+    /// This checks input before retention can drop a duplicate. Output parity
+    /// digests cannot detect duplicates present in both paired families.
     fn refuse_a_repeated_input_key(
         &mut self,
         family: MetadataRowFamily,
@@ -1613,9 +1510,6 @@ mod tests {
         }
     }
 
-    /// The digest compares two families written in different orders and, for
-    /// the bind pair, in different passes. So it must ignore order and still
-    /// notice one row differing in one field.
     #[test]
     fn the_row_digest_ignores_order_and_notices_one_changed_field() {
         let rows = [

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -760,12 +760,6 @@ async fn a_trash_page_costs_the_page_not_the_namespaces_deletion_history() {
     );
 }
 
-/// Pins what nesting means for the trash, because it is the case the family
-/// most easily gets wrong. Deletions are per root, not per subtree: a child
-/// deleted before its parent keeps its own entry while the parent's deletion
-/// covers it, and recovering the parent leaves the child's own deletion
-/// listed. The differential test is the authority that this equals the old
-/// walk; this names the behavior.
 #[tokio::test]
 async fn nested_deletions_each_keep_their_own_entry() {
     let temp = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/attributes.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/attributes.rs
@@ -72,8 +72,6 @@ fn kept_revisions(
         .collect()
 }
 
-/// Rows for one inode sort newest revision first, which is what makes the
-/// first row of a prefix scan the answer.
 #[test]
 fn attribute_rows_sort_newest_first_per_inode() {
     let state = state_from_attributes(vec![
@@ -113,9 +111,6 @@ fn the_fold_keeps_every_revision_above_the_floor_and_the_newest_at_it() {
     );
 }
 
-/// A cleared map is the state a caller asked for. Dropping its row would let
-/// the older non-empty map become the newest one and resurrect attributes the
-/// clear removed.
 #[test]
 fn the_fold_keeps_a_latest_empty_revision() {
     let state = state_from_attributes(vec![
@@ -156,8 +151,6 @@ fn the_fold_keeps_a_latest_empty_revision() {
     );
 }
 
-/// A deleted inode keeps its attributes, which is what makes an undelete give
-/// back the map the inode had.
 #[test]
 fn the_fold_never_drops_attributes_for_being_unreachable() {
     let state = state_from_attributes(vec![attributes_record(
@@ -179,9 +172,6 @@ fn the_fold_never_drops_attributes_for_being_unreachable() {
     assert_eq!(kept_revisions(&rows_by_family), vec![(7, 1)]);
 }
 
-/// One inode's revisions are numbered without repeats, so two rows sharing a
-/// number make "the newest at the floor" arbitrary. Refuse to compact rather
-/// than pick one.
 #[test]
 fn the_fold_refuses_to_compact_repeated_revision_numbers() {
     let state = state_from_attributes(vec![
@@ -205,10 +195,6 @@ fn the_fold_refuses_to_compact_repeated_revision_numbers() {
     assert!(error.to_string().contains("two attribute rows"), "{error}");
 }
 
-/// The published family answers a read at the sequence it asks for: a row
-/// committed after that sequence is skipped, and the newest one at or below
-/// it is the answer. This is what a checkpoint-basis or fork-basis read
-/// depends on.
 #[tokio::test]
 async fn a_published_segment_answers_at_the_sequence_the_read_asks_for() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -873,9 +873,6 @@ async fn warm_local_block_cache(
         .expect("warm the index")
 }
 
-/// A cold local cache is probed, answers nothing, and is then offered every
-/// section the one fetch produced: the filter that was asked for, the index
-/// beside it, and the data blocks a small segment brings along.
 #[tokio::test]
 async fn a_cold_local_block_cache_takes_every_section_one_fetch_produced() {
     let (_temp_dir, store, descriptor) = checkpointed_direntry_segment().await;
@@ -950,9 +947,6 @@ async fn a_cold_local_block_cache_takes_every_section_one_fetch_produced() {
     }
 }
 
-/// A warm local cache answers both sections with no segment bytes read: the
-/// decoded cache and the view memo are fresh, as a restarted process's are,
-/// so only the local tier can be answering.
 #[tokio::test]
 async fn a_warm_local_block_cache_answers_index_and_filter_without_the_store() {
     let (_temp_dir, store, descriptor) = checkpointed_direntry_segment().await;
@@ -997,9 +991,6 @@ async fn a_warm_local_block_cache_answers_index_and_filter_without_the_store() {
     }
 }
 
-/// A local entry that no longer decodes is dropped and refetched exactly
-/// once. What it held was a copy; object storage still holds the authority,
-/// so the read succeeds rather than reporting a corrupt segment.
 #[tokio::test]
 async fn a_local_block_cache_entry_that_does_not_decode_is_dropped_and_refetched() {
     let (_temp_dir, store, descriptor) = checkpointed_direntry_segment().await;
@@ -1039,7 +1030,6 @@ async fn a_local_block_cache_entry_that_does_not_decode_is_dropped_and_refetched
     );
 }
 
-/// A closed cache is a miss, and a miss is only ever a fetch.
 #[tokio::test]
 async fn a_closed_local_block_cache_reads_as_a_miss() {
     let (_temp_dir, store, descriptor) = checkpointed_direntry_segment().await;
@@ -1254,9 +1244,6 @@ async fn wide_read(
     (blocks, store.count(OperationClass::Read))
 }
 
-/// A narrow data-block load probes the local cache, misses, pays one fetch,
-/// and offers what it fetched. A second load whose decoded caches are fresh
-/// — a restarted process's shape — is answered without reading the store.
 #[tokio::test]
 async fn a_narrow_data_block_load_fills_the_local_cache_and_then_reads_from_it() {
     let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
@@ -1328,7 +1315,6 @@ async fn a_narrow_data_block_load_fills_the_local_cache_and_then_reads_from_it()
     );
 }
 
-/// Decoded blocks split a wide selection into coalesced spans around them.
 #[tokio::test]
 async fn a_wide_read_coalesces_the_blocks_the_decoded_cache_did_not_answer() {
     let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
@@ -1348,8 +1334,6 @@ async fn a_wide_read_coalesces_the_blocks_the_decoded_cache_did_not_answer() {
     );
 }
 
-/// A span load ignores the local stored-block tier in both directions, even
-/// when that tier already holds every selected block.
 #[tokio::test]
 async fn a_span_load_never_reads_or_writes_the_local_block_cache() {
     let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
@@ -1373,8 +1357,6 @@ async fn a_span_load_never_reads_or_writes_the_local_block_cache() {
     );
 }
 
-/// A corrupt local entry on the narrow path is dropped and refetched once.
-/// What it held was a copy; object storage still holds the authority.
 #[tokio::test]
 async fn a_corrupt_local_entry_on_a_narrow_load_is_dropped_and_refetched() {
     let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -1457,13 +1457,6 @@ async fn unreferenced_manifest_run_is_ignored_by_current_projection_load() {
     ));
 }
 
-/// A data block closes from inside the builder's `push` as soon as it
-/// reaches its target size, so a segment's last row can be the row that
-/// closes its block. The descriptor's max key must still describe the rows
-/// the segment holds: a keyed scan prunes a segment whose max key sorts
-/// below the scan's lower bound, so an empty max key hides every row from
-/// every point and prefix lookup while reorganization, which scans from the
-/// empty bound, still reads them.
 #[tokio::test]
 async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1649,7 +1642,6 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
     }
 }
 
-/// A manifest with two base-tier runs for one family group does not load.
 #[tokio::test]
 async fn a_manifest_whose_group_base_fragmented_does_not_load() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1689,7 +1681,6 @@ async fn a_manifest_whose_group_base_fragmented_does_not_load() {
     );
 }
 
-/// Two segments in the same family and run cannot have the same index.
 #[tokio::test]
 async fn a_manifest_that_numbers_one_family_twice_in_one_run_does_not_load() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1721,8 +1712,6 @@ async fn a_manifest_that_numbers_one_family_twice_in_one_run_does_not_load() {
     );
 }
 
-/// Two segments in the same family and run cannot have overlapping key
-/// ranges. This test gives the second segment the first segment's full range.
 #[tokio::test]
 async fn a_manifest_whose_run_segments_overlap_in_key_range_does_not_load() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/inventory.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inventory.rs
@@ -57,8 +57,6 @@ async fn pin_named<S: ObjectStore + ?Sized>(
     .checkpoint_id
 }
 
-/// One label over two calls is two records, and the listing is where their
-/// two ids can be read back — the whole reason it exists.
 #[tokio::test]
 async fn two_pins_under_one_label_list_as_two_records() {
     let temp_dir = tempdir().expect("tempdir");
@@ -106,10 +104,6 @@ async fn two_pins_under_one_label_list_as_two_records() {
     assert_ne!(after_release.checkpoints[0].checkpoint_id, first);
 }
 
-/// A record whose expiry has passed is still active, still roots its basis,
-/// and is still listed. Garbage collection is what turns a passed expiry
-/// into a release; until it does, hiding the record would hide a live root
-/// from the operation whose job is to find live roots.
 #[tokio::test]
 async fn an_expired_record_is_listed_with_its_expiry_until_it_is_released() {
     let temp_dir = tempdir().expect("tempdir");
@@ -138,8 +132,6 @@ async fn an_expired_record_is_listed_with_its_expiry_until_it_is_released() {
     assert_eq!(listed.checkpoints[0].expires_at_ms, Some(expires_at_ms));
 }
 
-/// An inventory that answered "no checkpoints" for a namespace that does not
-/// exist would be indistinguishable from one with none.
 #[tokio::test]
 async fn a_namespace_that_does_not_exist_is_not_a_namespace_without_checkpoints() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1647,9 +1647,6 @@ async fn checkpoints_chain_delta_runs_past_the_default_cap() {
     assert_eq!(appended.manifest.payload.base_seq, ChangeSeq(0));
 }
 
-/// A created namespace writes no floor object at all, and its absence
-/// reads as "retain from the namespace's birth sequence", which for a
-/// created namespace is genesis.
 #[tokio::test]
 async fn a_missing_floor_reads_as_retain_everything() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1678,9 +1675,6 @@ async fn a_missing_floor_reads_as_retain_everything() {
     assert_eq!(floor, ChangeSeq(0));
 }
 
-/// An over-budget WAL flush aborts before the root compare-and-swap:
-/// the root keeps its previous basis, the orphan outputs are harmless GC
-/// candidates, and an in-budget retry succeeds.
 #[tokio::test]
 async fn over_budget_wal_flush_aborts_without_publishing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1737,8 +1731,6 @@ async fn over_budget_wal_flush_aborts_without_publishing() {
     assert!(advanced.manifest_no > root_before.manifest.manifest_no);
 }
 
-/// An over-budget reorganization unit aborts the same way: no root motion,
-/// orphan segments left for garbage collection.
 #[tokio::test]
 async fn over_budget_reorganization_aborts_without_publishing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1886,22 +1878,6 @@ fn policy_that_cannot_fold_the_base(base_rows: u64) -> MetadataLsmPolicy {
     }
 }
 
-/// A group whose base run alone busts the per-step row budget used to park
-/// immediately: selection broke on the first candidate, chose nothing, and
-/// reported the group blocked on every step after that while delta runs
-/// piled up behind it with nothing saying why.
-///
-/// The step skips the base run it cannot read whole, merges the delta runs
-/// above it into one bigger delta run, and says out loud that the base has
-/// outgrown the budget. The merged output is a delta run at its newest
-/// input's identity, so the base stays exactly one run: minting a second
-/// base run here is what hid the over-budget bottom from the report.
-///
-/// Once the delta runs are down to one the group has nothing left to merge,
-/// and the step hands the whole group to a streaming compaction. That job
-/// rebuilds the group under no budget, so the base is folded again, its
-/// segments are replaced, and the group ends in one run. There is no state
-/// where the group is stuck.
 #[tokio::test]
 async fn a_base_run_over_the_step_budget_merges_the_delta_runs_then_compacts_the_group() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2086,19 +2062,6 @@ async fn a_base_run_over_the_step_budget_merges_the_delta_runs_then_compacts_the
     ));
 }
 
-/// A merge that skipped older runs must carry every row its inputs held, and
-/// must leave the group's base alone.
-///
-/// The retention drop rules read across the merged rows: an unbind cancels
-/// the bind it names, and both have to leave together. A window that starts
-/// above the base cannot see the bind at all, so dropping the unbind there
-/// would put a deleted file back. The step merges without dropping instead.
-///
-/// The output is a delta run at the newest input's sequence, so it stands
-/// where that run stood and the group keeps exactly one base run. Writing it
-/// at the base tier instead is what fragmented the base, and stamping it at
-/// the manifest head is what made two merges of one quiet namespace collide
-/// at one identity.
 #[tokio::test]
 async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2259,12 +2222,6 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     ));
 }
 
-/// Skipping is only ever legal at the recency bottom.
-///
-/// A run in the middle that busts the budget stops the window. The selector
-/// refuses to reach past it for a newer run that would have fit, because the
-/// merged output stands where the window stood and reaching past a run would
-/// move rows past it.
 #[tokio::test]
 async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2374,24 +2331,6 @@ async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
     );
 }
 
-/// The soak's end state, as a test.
-///
-/// Four cycles of writes, deletions, and a retention floor that moves past
-/// them, folded under budgets too small to take a group whole. The old level
-/// rule turned every merge above the base into another base-tier run, so the
-/// bases fragmented: a live S3 soak ended with six base-tier runs — direntry
-/// binds split across three of them, revisions across four — and one run
-/// identity carrying the output of several publications. Nothing then
-/// reported any group as too large to fold from its oldest run, because every
-/// fragment fit one step on its own, and the rows below the retention floor
-/// could never be dropped.
-///
-/// What is pinned here is that neither happens. No group's base fragments,
-/// whatever the budgets do; every step leaves reads answering exactly what
-/// they answered before; a group whose bottom stops fitting one step is
-/// handed to a streaming compaction rather than minting another base run;
-/// and every cycle settles with nothing left to fold. There is no run of
-/// steps that ends with a group nothing can fold.
 #[tokio::test]
 async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -33,8 +33,6 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 // The family-group mapping
 // -------------------------------------------------------------------------
 
-/// Every family compacts in exactly one group. A family in none would never
-/// be folded; a family in two would be rewritten twice at one identity.
 #[test]
 fn every_family_belongs_to_exactly_one_reorganization_group() {
     for family in CHECKPOINT_ROW_FAMILIES {
@@ -831,9 +829,6 @@ async fn fold_group_whole<S: ObjectStore + ?Sized>(
 // The plan split
 // -------------------------------------------------------------------------
 
-/// A group whose bottom-anchored window fits the budgets is a bounded merge;
-/// the same group under budgets no window can satisfy is a streaming
-/// compaction over every run it holds.
 #[tokio::test]
 async fn the_planner_answers_with_a_merge_or_with_a_compaction() {
     let temp_dir = tempdir().expect("tempdir");
@@ -896,8 +891,6 @@ async fn the_planner_answers_with_a_merge_or_with_a_compaction() {
     );
 }
 
-/// A step that plans a compaction publishes nothing and stages nothing: it
-/// hands the plan back, and the runtime starts the job.
 #[tokio::test]
 async fn a_step_that_plans_a_compaction_publishes_nothing_itself() {
     let temp_dir = tempdir().expect("tempdir");
@@ -931,10 +924,6 @@ async fn a_step_that_plans_a_compaction_publishes_nothing_itself() {
     );
 }
 
-/// While a job rebuilds one group, steps leave that group alone and fold the
-/// others. Without this a step would keep re-planning the running job: the
-/// group's delta rows are frozen in the job's snapshot, so its count never falls
-/// while every other group's does.
 #[tokio::test]
 async fn a_step_leaves_the_group_a_running_job_is_rebuilding_alone() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1007,16 +996,6 @@ async fn a_step_leaves_the_group_a_running_job_is_rebuilding_alone() {
     );
 }
 
-/// A group whose bottom-anchored window is blocked still merges the delta
-/// runs above the frozen base — and under sustained writes there is always
-/// another pair of them, so a planner reading one step's view alone would take
-/// that merge forever and never start the job.
-///
-/// An amortizing runtime counts those published merges, and after
-/// `DELTA_MERGES_OVER_A_FROZEN_BASE` of them the planner starts the job
-/// regardless of what delta window is available. Here every step publishes a
-/// fresh delta run before the next one plans, which is the write pattern that
-/// used to postpone the job indefinitely.
 #[tokio::test]
 async fn sustained_delta_runs_cannot_postpone_a_blocked_groups_job() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1093,12 +1072,6 @@ async fn sustained_delta_runs_cannot_postpone_a_blocked_groups_job() {
     );
 }
 
-/// Between jobs, the ordinary delta merge is what consolidates new runs.
-///
-/// Starting a job for every batch of delta runs would reread the whole group
-/// to fold in a sliver, which is the amortization the counter exists to keep.
-/// A group whose base is not frozen never counts a merge at all, and a group
-/// whose base is frozen spends its budget on merges first.
 #[tokio::test]
 async fn small_delta_batches_are_consolidated_by_merges_rather_than_by_jobs() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1184,19 +1157,6 @@ async fn small_delta_batches_are_consolidated_by_merges_rather_than_by_jobs() {
 // The oracle
 // -------------------------------------------------------------------------
 
-/// A background compaction and a synchronous merge inside a maintenance step
-/// with the budgets raised must land in the same place: the same surviving rows
-/// in every family of the group, the same materialized namespace, and the same
-/// rows dropped.
-///
-/// Both paths run one engine, so this no longer bridges two implementations of
-/// the merge. What it guards now is the orchestration split. The background job
-/// resolves its input from a spec captured before it started, stages its output
-/// under its own prefix behind a lease, and swaps it in with a separate
-/// publication much later; the step chooses its window from the manifest it
-/// just read, writes at ordinary segment keys, and publishes in the same step.
-/// Those are different enough that a change to either one can move the rows a
-/// reader ends up with, and this is what says it did not.
 #[tokio::test]
 async fn a_background_compaction_and_a_step_contained_merge_reach_the_same_rows() {
     let job_dir = tempdir().expect("tempdir");
@@ -1329,9 +1289,6 @@ async fn a_background_compaction_and_a_step_contained_merge_reach_the_same_rows(
     }
 }
 
-/// The oracle has teeth only if the retention rules are what make the two
-/// rebuilds agree. A floor of zero is above nothing, so every rule that reads
-/// the floor keeps every row, and the job must then disagree with the step.
 #[tokio::test]
 async fn a_compaction_that_drops_nothing_fails_the_oracle() {
     let job_dir = tempdir().expect("tempdir");
@@ -1376,8 +1333,6 @@ async fn a_compaction_that_drops_nothing_fails_the_oracle() {
     );
 }
 
-/// A group with no drop rule at all is a straight rewrite: revisions are
-/// durable history, so the job's output must hold every row it read.
 #[tokio::test]
 async fn a_compaction_of_the_revisions_group_rewrites_every_row_it_reads() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1466,16 +1421,6 @@ async fn rewrite_base_segment(
     .await;
 }
 
-/// A run whose canonical family and secondary index both hold the same row
-/// twice is refused by both orchestration paths, and neither publishes.
-///
-/// The duplicate has to be on both sides. The output digests compare the two
-/// families against each other, so a one-sided duplicate only re-proves what
-/// the digests already catch; a duplicate present on both sides leaves both
-/// multisets equal and passes them. The segment builder does not catch it
-/// either — it refuses a descending row key, not a repeated one — so without
-/// the input-key guard the duplicate reaches a published run, where reads that
-/// concatenate runs would answer the same revision twice.
 #[tokio::test]
 async fn a_row_key_repeated_in_both_families_of_an_index_pair_is_refused() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1912,28 +1857,6 @@ async fn install_synthetic_bindings_base(
     unbind_decoded_bytes
 }
 
-/// A merge inside a maintenance step reads its window once, whatever order the
-/// reverse index walks the unbind keyspace in.
-///
-/// This is the total-work half of the resource contract. The other resource
-/// tests bound what a merge holds and how wide it fans out at any instant;
-/// neither of them sees a merge that reads the same block over and over.
-///
-/// The window here is the shape that used to cost the most: every reverse bind
-/// row is below the floor, so every one needs a verdict, and the names are
-/// scrambled against the child ids so consecutive reverse rows land in
-/// unrelated parts of the parent-ordered unbind family. Resolving those from
-/// the store costs one round trip per row once the probe cache can no longer
-/// hold the window's unbind family, which the step's budgets allow. Measured on
-/// a window whose unbind family just fills the cache, 65,536 reverse rows cost
-/// 27,427 data reads and 309 MB transferred against 16 MB of priced input, and
-/// doubling the family doubled both; the same window resolved from the
-/// collected set costs 386 data reads and 3.7 MB.
-///
-/// So the assertion is the contract rather than a number: the step reads each
-/// segment's index once and its data once, and makes no probe at all. A
-/// background job keeps the probes, because its memory must not follow the
-/// group it rebuilds, and this pins that split too.
 #[tokio::test]
 async fn a_step_contained_merge_reads_its_window_once() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2101,10 +2024,6 @@ impl ObjectStore for CancelAfterReadsStore {
     }
 }
 
-/// A cancelled job costs its work and nothing else. The manifest never moved,
-/// so a reader answers exactly as before; the segments the attempt wrote are
-/// staged and unreferenced; and running the same spec again lands where an
-/// uninterrupted job would have landed.
 #[tokio::test]
 async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_would_have() {
     let straight_dir = tempdir().expect("tempdir");
@@ -2259,14 +2178,6 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
 // The job's claim on its own output
 // -------------------------------------------------------------------------
 
-/// A job writes its lease before its first output object and leaves it in
-/// place after publishing, and the segments it published stay where they are.
-///
-/// The lease is what tells a collector who owns an unreferenced staged
-/// object. Deleting it at publication would open the one hole it exists to
-/// close: a collection pass that captured its live set a moment earlier would
-/// find segments far older than any grace window and nothing saying who wrote
-/// them. So the job stops heartbeating and lets the lease expire instead.
 #[tokio::test]
 async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_when_it_publishes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2321,8 +2232,6 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
     );
 }
 
-/// A cancelled job leaves its lease behind, which is what keeps a collector
-/// off the segments it had written until the lease expires.
 #[tokio::test]
 async fn a_cancelled_job_leaves_its_claim_standing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2367,15 +2276,6 @@ async fn a_cancelled_job_leaves_its_claim_standing() {
     );
 }
 
-/// A worker whose lease expired and was claimed cannot take its prefix back,
-/// and cannot publish.
-///
-/// This is the revival a timestamp-only lease allowed. A job that stalled long
-/// enough for its lease to expire — a suspended process, a starved runtime —
-/// used to be able to resume, overwrite the lease with a fresh heartbeat, and
-/// go on to publish descriptors naming segments the collector had already
-/// decided to reap. The claim is a compare-and-swap, so the worker's next
-/// heartbeat finds an etag it does not hold and stops there.
 #[tokio::test]
 async fn a_worker_whose_expired_lease_was_claimed_is_fenced_and_publishes_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2454,16 +2354,6 @@ impl MonotonicTimer for SteppingTimer {
     }
 }
 
-/// The heartbeat and the reaping claim are the same compare-and-swap on the
-/// same object, so whichever lands first wins and the other is refused.
-///
-/// The interesting order is the collector reading an expired lease and the
-/// worker heartbeating before the claim lands — the exact window in which a
-/// timestamp-only lease would have let both parties believe they owned the
-/// prefix. Here the claim is gated at its compare-and-swap, the worker's
-/// heartbeat goes through underneath it, and the claim is refused. The other
-/// order follows on the same store: once the claim wins, the heartbeat behind
-/// it is the one refused.
 #[tokio::test]
 async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2530,9 +2420,6 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
 // Resource discipline
 // -------------------------------------------------------------------------
 
-/// A merge's reads never overlap wider than its fetch bound, and the decoded
-/// blocks it holds never follow the size of what it is merging. Both hold for
-/// the background job and for the same engine run inside a maintenance step.
 #[tokio::test]
 async fn a_merge_keeps_its_reads_and_its_decoded_blocks_bounded() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2657,10 +2544,6 @@ async fn a_merge_keeps_its_reads_and_its_decoded_blocks_bounded() {
     );
 }
 
-/// One directory far past the old per-step row budget streams through with
-/// the same bounded state. The case that needed a durable offset inside a
-/// partition needs nothing now: the operators hold one row at most, whatever
-/// the directory holds.
 #[tokio::test]
 async fn one_directory_far_past_the_row_budget_streams_a_row_at_a_time() {
     let job_dir = tempdir().expect("tempdir");
@@ -2745,14 +2628,6 @@ async fn one_directory_far_past_the_row_budget_streams_a_row_at_a_time() {
     );
 }
 
-/// Every group of a namespace whose churn all lands on one hot locality
-/// rebuilds to the same rows a step-contained merge reaches, while its
-/// operators hold at most one row.
-///
-/// The wide-directory case above proves that distinct localities do not
-/// accumulate together. This proves the other half: one inode's attribute
-/// history, one name slot's binding generations, and one deletion's markers
-/// are each decided by fixed state rather than by holding the locality.
 #[tokio::test]
 async fn one_hot_locality_of_each_kind_rebuilds_with_fixed_operator_state() {
     let job_dir = tempdir().expect("tempdir");
@@ -2910,17 +2785,6 @@ async fn referenced_segment_keys<S: ObjectStore + ?Sized>(
         .collect()
 }
 
-/// The whole arc, driven through the entry point the maintenance runner
-/// calls.
-///
-/// A group past the budgets with churn below the floor is handed to a job.
-/// The runner starts that job and goes on stepping; here the steps and the job
-/// run in one task, which is the same interleaving with the timing taken out.
-/// While the job is in flight the other groups keep folding, no step touches
-/// the job's group, a run arrives above the job's snapshot and survives its
-/// publication, the loader accepts the manifest every step leaves, and a read
-/// answers the same thing throughout. The job then publishes, the group ends
-/// in one base run, and the churn the floor covered is gone.
 #[tokio::test]
 async fn an_over_budget_group_is_rebuilt_by_a_job_while_maintenance_carries_on() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3111,14 +2975,6 @@ async fn step_until_a_compaction_is_planned<S: ObjectStore + ?Sized>(
     panic!("no step handed a group to a job")
 }
 
-/// The crash variant of the same arc: the job dies mid-run, and the next step
-/// plans it again.
-///
-/// Nothing durable records that a job was running, so a process that dies —
-/// or a shutdown that cancels — costs the work and nothing else. What a read
-/// answers has not moved, the manifest has not moved, the segments the attempt
-/// wrote are staged and named by nothing, and the step after it plans the
-/// group again and the second attempt finishes.
 #[tokio::test]
 async fn a_job_that_dies_mid_run_leaves_orphans_and_the_next_step_plans_it_again() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3270,12 +3126,6 @@ impl ObjectStore for FlushDuringFinalizationStore {
     }
 }
 
-/// A flush that lands while a job is finalizing does not cost the job.
-///
-/// The finalizer reloads, checks that its input is still exactly what it read,
-/// and publishes on top of the flush. The flush's own run survives, because it
-/// arrived above the job's snapshot and the swap replaces only what the
-/// snapshot held.
 #[tokio::test]
 async fn a_flush_landing_during_finalization_is_retried_over() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3387,13 +3237,6 @@ async fn root_updated_at_ms<S: ObjectStore + ?Sized>(store: &S, namespace_id: &N
         .updated_at_ms
 }
 
-/// The root's timestamp says when the publication landed, not when the job
-/// that produced it started.
-///
-/// A job holds its writer identity for as long as it runs, and a long one
-/// finishes hours after the context it was planned under was built. Stamping
-/// the root with that context would make a job that rebases over a newer
-/// flush move the namespace's `updated_at_ms` backwards.
 #[tokio::test]
 async fn a_rebased_publication_never_moves_the_root_timestamp_backward() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3451,11 +3294,6 @@ async fn a_rebased_publication_never_moves_the_root_timestamp_backward() {
     );
 }
 
-/// A token set after the last row costs the job its publication.
-///
-/// The executor finished, so there is a whole rebuilt group in memory and
-/// staged output on the store. None of it lands: the manifest stays where it
-/// was, and the staged segments stay orphans a later pass reclaims.
 #[tokio::test]
 async fn a_cancellation_after_the_last_row_publishes_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3580,12 +3418,6 @@ impl ObjectStore for CancelAtTheFirstPublicationStore {
     }
 }
 
-/// A shutdown during finalization does not wait out the attempts it has left.
-///
-/// The first attempt loses its race and the token is set while it does. The
-/// attempts after it are exactly the wait a shutdown must not sit through, so
-/// the job stops at the top of the next one rather than building three more
-/// manifests to lose three more races with.
 #[tokio::test]
 async fn a_cancelled_finalization_does_not_take_the_races_it_has_left() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/commit/identity.rs
+++ b/crates/loonfs-core/src/commit/identity.rs
@@ -1,14 +1,8 @@
-//! Commit identity fingerprints (format spec, "Commit identity
-//! fingerprints"): a stable digest over a mutation's semantic content, used
-//! to decide whether a reused commit id carries the same mutation or a
-//! conflicting one.
+//! Core representation of a commit identity fingerprint.
 //!
-//! The digest itself is computed by
-//! [`loonfs_api::semantic_commit_fingerprint`], because the HTTP client has
-//! to compute the same value and does not depend on this crate. What stays
-//! here is core's name for one: a value that reached this crate through
-//! [`crate::path::write::commit_fingerprint`] and is therefore comparable
-//! against a stored receipt.
+//! [`loonfs_api::semantic_commit_fingerprint`] computes the shared client and
+//! runtime digest. This module wraps a validated fingerprint for comparison
+//! with stored commit receipts.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/loonfs-core/src/commit/metadata_overlay.rs
+++ b/crates/loonfs-core/src/commit/metadata_overlay.rs
@@ -335,8 +335,6 @@ mod tests {
         );
     }
 
-    /// A clear is a real revision carrying the empty map, so the overlay and
-    /// replay must both hold a row for it.
     #[test]
     fn cleared_attributes_overlay_rows_match_replayed_wal_deltas() {
         assert_overlay_matches_replay(

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -566,10 +566,6 @@ mod tests {
         encode_control_object(&envelope).expect("encode head").len()
     }
 
-    /// The head is the one control object whose size grows with the tail it
-    /// describes, so raising the accelerator's cap is a claim about how big
-    /// the head gets. This measures it at the cap, from both ends of what
-    /// the identifier grammars allow.
     #[test]
     fn a_head_at_the_accelerator_cap_stays_a_small_object() {
         const CEILING_BYTES: usize = 256 * 1024;

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -272,9 +272,6 @@ async fn build_commit_plan(
     .finish(resulting_next_inode_id))
 }
 
-/// Every attribute update carries its own revision guard, whether or not the
-/// caller stated an expectation. A plan built against a revision that is no
-/// longer current is rejected here, not merged.
 #[tokio::test]
 async fn a_stale_attribute_base_revision_is_rejected_by_the_updates_own_guard() {
     let metadata_state = metadata_state_after(&[
@@ -310,8 +307,6 @@ async fn a_stale_attribute_base_revision_is_rejected_by_the_updates_own_guard() 
     );
 }
 
-/// An inode with no attribute row is at revision 0, so a first write states
-/// zero — and a second first write of the same inode conflicts.
 #[tokio::test]
 async fn a_first_attribute_write_states_revision_zero() {
     let metadata_state = metadata_state_after(&[wal_create_directory(
@@ -348,8 +343,6 @@ async fn a_first_attribute_write_states_revision_zero() {
     );
 }
 
-/// Attributes belong to the resource, so an inode nothing binds has none to
-/// write.
 #[tokio::test]
 async fn an_attribute_update_of_a_missing_inode_is_rejected() {
     let metadata_state = metadata_state_after(&[]);
@@ -407,9 +400,6 @@ async fn stale_revision_precondition_is_rejected() {
     ));
 }
 
-/// The validator independently refuses a create whose name is already
-/// bound, whatever compiled it: the check does not lean on planning having
-/// looked first.
 #[tokio::test]
 async fn a_create_for_a_bound_name_is_rejected() {
     let metadata_state = metadata_state_after(&[wal_create_directory(
@@ -438,8 +428,6 @@ async fn a_create_for_a_bound_name_is_rejected() {
     ));
 }
 
-/// A `BindingIs` race check whose observed binding no longer exists is
-/// refused before the operation that carries it runs.
 #[tokio::test]
 async fn a_binding_precondition_for_an_unbound_name_is_rejected() {
     let metadata_state = metadata_state_after(&[wal_create_directory(
@@ -517,12 +505,6 @@ async fn failed_multi_op_plan_uses_preview_without_mutating_base_metadata() {
         .is_none());
 }
 
-/// The rows here are deliberately corrupt: the tombstone lands without the
-/// unbind a real delete emits with it, so `readme.txt` stays bound under a
-/// tombstoned directory. No client history produces that — planning resolves
-/// through visible bindings, and a visible inode is one no tombstone covers
-/// — so the guards fire only on self-contradicting stored state and classify
-/// as corruption.
 #[tokio::test]
 async fn create_and_replace_under_ancestor_tombstone_report_corruption() {
     let metadata_state = metadata_state_after(&[
@@ -786,9 +768,6 @@ async fn restore_revision_can_reference_restore_created_earlier_in_same_request(
     ));
 }
 
-/// Same corrupt shape as the create/replace guards above: a tombstone with
-/// no matching unbind leaves a live binding under it, which is the only way
-/// this guard can fire.
 #[tokio::test]
 async fn restore_revision_under_tombstoned_ancestor_reports_corruption() {
     let metadata_state = metadata_state_after(&[

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -664,8 +664,6 @@ mod tests {
             .expect("message limits must not affect identity");
     }
 
-    /// A batch past the operation ceiling is refused before it can occupy
-    /// the publisher.
     #[test]
     fn a_batch_past_the_operation_ceiling_is_rejected() {
         let oversized = CommitCandidate::new(CommitRequest {
@@ -703,8 +701,6 @@ mod tests {
             .expect("a batch at the ceiling is admitted");
     }
 
-    /// A message past the byte ceiling is refused before it can enter the
-    /// durable record or the fingerprint path.
     #[test]
     fn a_message_past_the_byte_ceiling_is_rejected() {
         let operations = vec![FilesystemOperation::CreateDirectory {
@@ -811,9 +807,6 @@ mod tests {
         assert_eq!(head.writer.expect("writer block").writer_id, "writer-b");
     }
 
-    /// A takeover that lands while the loser is mid-load is still a fence,
-    /// not a head race. The loser must be told so — `stale_head` would send a
-    /// permanently fenced session back to retry.
     #[tokio::test]
     async fn fencing_during_publish_view_load_still_reports_writer_fenced() {
         use loonfs_test_support::stores::{BlockingStore, KeyPredicate};

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -1090,9 +1090,6 @@ mod tests {
         assert!(CoreError::Internal("boom".to_owned()).details().is_none());
     }
 
-    /// Provider authorization failures map to
-    /// `storage_permission_denied`. Other store failures map to
-    /// `server_error`.
     #[test]
     fn store_permission_denied_classifies_to_its_wire_code() {
         let denied = ObjectStoreError::PermissionDenied {

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -1,10 +1,8 @@
-//! What `max_objects` meters, and what a pass does when it runs out.
+//! Work limits for a garbage-collection pass.
 
-/// The work one garbage-collection pass is allowed to do, from its first
-/// read to its last. Marking is inside the bound, not before it.
+/// Limits object-store work performed by one garbage-collection pass.
 ///
-/// One unit is one object the pass reads or decides on a candidate's
-/// behalf:
+/// One unit is charged for:
 ///
 /// * the head and the metadata root together — one unit for the pair,
 ///   because they are read concurrently and neither is a root without the
@@ -15,23 +13,13 @@
 /// * one manifest opened, whether to mark its segments or by the content
 ///   reference scan;
 /// * one page of revision rows read out of an opened manifest;
-/// * the retained WAL chain, charged as one block of one unit per request
-///   the load issued for a segment body — a failed request included, since
-///   the store was asked. The pass caps that load at what it has left, so
-///   the chain cannot read past the bound either;
+/// * each request used to read the retained WAL chain, including failed
+///   requests;
 /// * one enumerated candidate key, decided — the original meaning of
 ///   `max_objects`.
 ///
-/// Prefix listing is the one thing not metered: it is how a family finds
-/// candidates at all, and the cursor is what resumes it. Everything else a
-/// pass touches is charged, so no pass can do work proportional to the
-/// namespace while asking for a small budget.
-///
-/// The rule is deliberately coarse — it is a bound, not a cost model. A
-/// page of rows costs more than a manifest header and both count as one.
-/// What matters is that every store round trip inside the pass has a
-/// charge attached to it, and that running out stops the pass instead of
-/// letting it finish "just this one thing" unboundedly.
+/// Prefix listings are not charged. This is a coarse upper bound on store
+/// operations, not a cost model.
 #[derive(Debug)]
 pub struct PassBudget {
     max_objects: Option<u64>,
@@ -47,9 +35,7 @@ impl PassBudget {
         }
     }
 
-    /// True once nothing further may be charged: the caller stops where it
-    /// stands. The sweep returns its cursor; the content reference scan
-    /// gives up on collecting and the pass defers that reclamation.
+    /// Returns `true` when no more work may be charged.
     pub fn exhausted(&self) -> bool {
         self.remaining() == 0
     }
@@ -66,16 +52,13 @@ impl PassBudget {
         self.spent = self.spent.saturating_add(1);
     }
 
-    /// What has been charged so far. Tests price a namespace's roots with
-    /// this, so a bounded case can ask for a budget in candidates rather
-    /// than in a number that has to be kept true by hand.
+    /// Returns the number of charged units.
     #[cfg(test)]
     pub(super) fn spent(&self) -> u64 {
         self.spent
     }
 
-    /// Charges one unit for work about to be done. `false` means the
-    /// budget is spent and the caller must not do it.
+    /// Reserves one unit, returning `false` if the budget is exhausted.
     pub(super) fn try_charge(&mut self) -> bool {
         if self.exhausted() {
             return false;
@@ -84,10 +67,7 @@ impl PassBudget {
         true
     }
 
-    /// Charges `units` for one block of work already done — the requests
-    /// one chain load issued. The caller sizes that load by what
-    /// [`PassBudget::remaining`] reports, so a block never charges more
-    /// than the budget had left.
+    /// Charges several units for completed work.
     pub(super) fn charge_block(&mut self, units: u64) {
         self.spent = self.spent.saturating_add(units);
     }

--- a/crates/loonfs-core/src/gc/compaction_staging.rs
+++ b/crates/loonfs-core/src/gc/compaction_staging.rs
@@ -1,23 +1,9 @@
-//! Determines whether staged output from a streaming compaction can be collected.
+//! Determines whether streaming-compaction output may be collected.
 //!
-//! A job writes its output under `metadata/compactions/{job_id}/` and refreshes
-//! its lease with compare-and-swap while it runs (format spec, "Garbage
-//! collection", rule 12). A current lease means every object under the job's
-//! prefix must be retained. An expired lease is not sufficient evidence for
-//! collection because the job may resume. The collector must first change the
-//! lease from `Active` to `Reaping` with compare-and-swap. After that succeeds,
-//! the job's next heartbeat fails and it can no longer publish the staged
-//! output, so those objects can be treated as unreferenced.
-//!
-//! A job's lease sorts before its `segments/` directory. The collector reads the
-//! lease first and deletes it only after processing the staged segments. If the
-//! pass stops midway through the prefix, the `Reaping` lease remains so a
-//! later pass can safely continue.
-//!
-//! Objects for one job are contiguous in key order. The pass caches the
-//! confirmed ownership result for the current job, reducing lease reads from
-//! one per object to one per job. It caches only a current `Active` lease or a
-//! successful claim, never an expired lease that was only observed.
+//! A current lease protects every object under a compaction job's prefix. To
+//! collect an expired job, the collector first changes its lease from `Active`
+//! to `Reaping` with compare-and-swap. This fences the job from publishing and
+//! lets later passes safely resume collection.
 
 use crate::checkpoint::{claim_compaction_prefix, CompactionPrefixOwner};
 use crate::error::{CoreError, Result};

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -175,9 +175,6 @@ mod tests {
         assert!(GcCursor::decode(&wrong_family_prefix, &namespace_id).is_err());
     }
 
-    /// Core and grep collect the same namespace under two cursors of the
-    /// same shape. The kind is what stops one job resuming the other's
-    /// position.
     #[test]
     fn a_cursor_from_another_job_is_refused() {
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");

--- a/crates/loonfs-core/src/gc/mod.rs
+++ b/crates/loonfs-core/src/gc/mod.rs
@@ -1,18 +1,9 @@
 //! Mark-and-sweep garbage collection (format spec, "Garbage collection").
 //!
-//! GC, floor advancement, and explicit namespace repair are the only code
-//! paths that list the store. Nothing sweeps by default: callers opt in
-//! through the admin endpoint or an explicit maintenance-step option.
-//! Writers never coordinate with GC, so a sweep can race an in-flight
-//! publish or checkpoint creation. The grace window, delete-time
-//! re-verification, and retain-on-ambiguity defaults close those races. When
-//! in doubt, this module retains.
-//!
-//! Readers do not coordinate with it either. A read pins a head and the
-//! basis manifest under it and then keeps reading through that pair, so the
-//! grace window has to run from the moment an object stopped being
-//! referenced rather than from the moment it was written. The reference
-//! anchor in `live_set.rs` is what dates that moment.
+//! Garbage collection does not coordinate with readers or writers. Grace
+//! periods, delete-time reference checks, and retain-on-error behavior protect
+//! concurrent publications and pinned reads. Collection only runs when
+//! explicitly requested or scheduled.
 
 mod budget;
 mod compaction_staging;

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -1,15 +1,8 @@
 //! Reaping: age-gated deletion of unreachable objects.
 //!
-//! Immutable families age by provider timestamp — nothing else records when
-//! they were written. Checkpoint records do not: their lifecycle instants
-//! (`created_at_ms`, `expires_at_ms`, `released_at_ms`) live in the record,
-//! so no checkpoint state transition depends on object metadata.
-//!
-//! A write time is when an object appeared, not when it stopped being
-//! referenced, and those are the same instant only for an object nothing
-//! ever referenced. The namespace sweep therefore asks this module for the
-//! age and decides the rest itself, from the reference anchor in
-//! `gc/live_set.rs`.
+//! Immutable objects use provider timestamps for age checks. Checkpoints use
+//! lifecycle timestamps stored in their records. The namespace sweep combines
+//! object age with the reference anchor from `gc/live_set.rs`.
 
 use crate::checkpoint::record::{encode_checkpoint_record, load_checkpoint_record_at_key};
 use crate::context::MutationContext;

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -326,8 +326,6 @@ impl<S: ObjectStore> ObjectStore for ListingCursorStore<S> {
     }
 }
 
-/// The derived floor is enforced at validation: a pass configured below
-/// it is rejected as an invalid request before touching the store.
 #[tokio::test]
 async fn gc_rejects_grace_windows_below_the_derived_minimum() {
     let temp_dir = tempdir().expect("tempdir");
@@ -692,9 +690,6 @@ async fn fork_protected_bases_survive_source_deletion_until_the_target_dies() {
     assert!(!report.retention_degraded);
 }
 
-/// The whole upload arm end to end: a lease that passes turns into a
-/// durable abort with its provider object gone, and the record itself
-/// survives one more grace so the abort is observable before it is reaped.
 #[tokio::test]
 async fn upload_gc_aborts_an_expired_session_then_reaps_it() {
     let temp_dir = tempdir().expect("tempdir");
@@ -761,10 +756,6 @@ async fn upload_gc_aborts_an_expired_session_then_reaps_it() {
     assert_eq!(report.deleted.upload_sessions, 0);
 }
 
-/// A pass knows when the things it retained stop being retained, because
-/// it compared every one of them against its own clock to decide. Saying so
-/// is what lets a scheduler come back exactly once, for exactly that
-/// namespace, with nothing else having to remember.
 #[tokio::test]
 async fn a_pass_reports_the_soonest_deadline_it_retained() {
     let temp_dir = tempdir().expect("tempdir");
@@ -804,10 +795,6 @@ async fn a_pass_reports_the_soonest_deadline_it_retained() {
     );
 }
 
-/// The abort gap, closed at the source: nothing plants a deadline when a
-/// session is aborted, so the pass that observes the abort reports the one
-/// the abort created. A restart loses every in-memory deadline the same
-/// way, and is covered by the same sentence.
 #[tokio::test]
 async fn an_aborted_session_is_reclaimed_from_the_deadline_the_pass_reported() {
     let temp_dir = tempdir().expect("tempdir");
@@ -869,8 +856,6 @@ async fn complete_staged_upload<S: ObjectStore + ?Sized>(
     .expect("complete upload");
 }
 
-/// A session record written straight into the store, never touched by an
-/// upload, still ages out on nothing but its own recorded lease.
 #[tokio::test]
 async fn upload_gc_reaps_a_session_that_never_staged_anything() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1070,9 +1055,6 @@ async fn publish_completed_content<S: ObjectStore>(
         .expect("published");
 }
 
-/// Inside the derived grace a completed session's content is untouchable,
-/// because a receipt could still be minted for it and a commit carrying that
-/// receipt could still be in flight.
 #[tokio::test]
 async fn content_gc_retains_completed_content_inside_its_grace() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1100,9 +1082,6 @@ async fn content_gc_retains_completed_content_inside_its_grace() {
         .is_some());
 }
 
-/// Past the grace, content no metadata references is provably nobody's: no
-/// receipt survives that could admit a commit for it, so the set of
-/// references can no longer grow.
 #[tokio::test]
 async fn content_gc_reclaims_completed_content_nothing_references() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1134,10 +1113,6 @@ async fn content_gc_reclaims_completed_content_nothing_references() {
         .is_none());
 }
 
-/// Published content is metadata's now. The session record still ages out —
-/// it has nothing left to say — but the object it named stays, whether the
-/// commit that referenced it is still only in the WAL or already
-/// materialized into a manifest.
 #[tokio::test]
 async fn content_gc_never_reclaims_published_content() {
     for materialize in [false, true] {
@@ -1363,9 +1338,6 @@ async fn content_reference_scan_retains_content_when_metadata_rows_do_not_read()
         .is_some());
 }
 
-/// If the reference scan exceeds the remaining budget, the pass retains the
-/// session and content, sets `content_reclamation_deferred`, and advances its
-/// cursor. A later pass with enough budget completes the decision.
 #[tokio::test]
 async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1447,12 +1419,6 @@ async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
         .is_none());
 }
 
-/// Marking spends out of the same budget as everything else, and it spends
-/// first. One unit buys the head and the metadata root beside it and
-/// nothing more: no floor, no manifest, and above all no retained WAL
-/// chain, which is where the unmetered reading used to be. The pass says it
-/// ran out rather than reporting an empty pass, which is what an operator
-/// would otherwise read as a clean namespace.
 #[tokio::test]
 async fn a_budget_below_the_roots_reads_no_chain_and_says_it_ran_out() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1493,10 +1459,6 @@ async fn a_budget_below_the_roots_reads_no_chain_and_says_it_ran_out() {
     );
 }
 
-/// A pass with nothing left does not start a chain load at all. A budget
-/// sized to everything before the chain stops at that gate. It fetches no
-/// segment and decides no candidate, and a rerun with room does the whole
-/// job.
 #[tokio::test]
 async fn a_budget_that_dies_at_the_chain_gate_sweeps_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1541,11 +1503,6 @@ async fn a_budget_that_dies_at_the_chain_gate_sweeps_nothing() {
         .is_none());
 }
 
-/// The chain can be longer than the budget has room for. The pass caps the
-/// load at what it has left, so the loader issues no more requests than the
-/// pass may pay for, and it issues all of them: the head names the whole
-/// tail, and a hint list longer than the cap is cut down to the cap rather
-/// than refused. The pass then decides nothing and reports that it ran out.
 #[tokio::test]
 async fn a_chain_longer_than_the_budget_is_not_read_past_the_budget() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1596,17 +1553,6 @@ async fn a_chain_longer_than_the_budget_is_not_read_past_the_budget() {
     );
 }
 
-/// A collection that reaches the chain with less budget than the chain
-/// costs used to charge nothing for it. The head names every segment of the
-/// retained tail, that hint list was longer than the cap the pass handed
-/// the loader, and the loader refused up front rather than reading the part
-/// the cap covered. The pass then reported that it ran out while its budget
-/// still showed unspent units, which is the wrong account of where the
-/// budget went.
-///
-/// Now every unit the collection has left at the chain is spent on the
-/// chain, at every budget from one unit up to the whole chain, and a budget
-/// that covers the chain collects it.
 #[tokio::test]
 async fn a_chain_the_budget_cannot_cover_still_spends_what_the_budget_had_left() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1655,9 +1601,6 @@ async fn a_chain_the_budget_cannot_cover_still_spends_what_the_budget_had_left()
     );
 }
 
-/// A budget that covers the roots exactly reads the whole chain. The cap on
-/// the load is what the budget has left, and that is the chain's own size,
-/// so nothing is truncated. One more unit than that lets the walk begin.
 #[tokio::test]
 async fn a_budget_that_covers_the_roots_exactly_finishes_marking() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1702,9 +1645,6 @@ async fn a_budget_that_covers_the_roots_exactly_finishes_marking() {
     );
 }
 
-/// A pass whose roots cost the whole budget decides nothing. It returns the
-/// token it was given, byte for byte, so the runner can tell that the pass
-/// made no progress and park it.
 #[tokio::test]
 async fn a_pass_that_decides_nothing_echoes_its_cursor_verbatim() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1751,11 +1691,6 @@ async fn a_pass_that_decides_nothing_echoes_its_cursor_verbatim() {
     );
 }
 
-/// Marking decodes and validates every retained segment already, so the
-/// content those commits name is read off the same bodies rather than by a
-/// second pass over the same objects. One complete pass, one fetch per
-/// segment — and the reference that only exists in a retained WAL record
-/// still protects its bytes, because that harvest is where it comes from.
 #[tokio::test]
 async fn a_complete_pass_fetches_each_retained_segment_once() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1814,10 +1749,6 @@ async fn a_complete_pass_fetches_each_retained_segment_once() {
         .is_none());
 }
 
-/// Checkpoint records are read one at a time while marking, and each one
-/// costs a unit like everything else. A budget that covers the head-and-root
-/// pair, the floor, and exactly one of six records stops inside that loop:
-/// one record read, nothing marked, nothing decided.
 #[tokio::test]
 async fn a_budget_that_dies_among_the_checkpoint_records_decides_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1861,17 +1792,6 @@ async fn a_budget_that_dies_among_the_checkpoint_records_decides_nothing() {
     );
 }
 
-/// The only reference keeping this content alive lives in the newest WAL
-/// segment, the very last root the scan reads. A pass that stopped short
-/// and answered from what it had collected would call the content
-/// unreferenced and delete it. The budgets below run from one candidate a
-/// pass up to sixteen, each walk to its end, which leaves no interleaving
-/// where a partial reference set decides anything. The budgets that can
-/// afford the scan still reach the right verdict.
-///
-/// Every budget is priced from what marking this namespace costs, because
-/// marking spends out of the same purse. A budget below that cost buys no
-/// walk at all, which would prove nothing here.
 #[tokio::test]
 async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2062,14 +1982,6 @@ async fn fold_metadata<S: ObjectStore + ?Sized>(
     assert!(folded, "the fold must reach a steady state");
 }
 
-/// The whole point of the reference anchor: a read that pinned its anchor
-/// before a fold is still reading through it afterwards, and the grace
-/// window is what that read is owed.
-///
-/// The segments here are old by write time and unreferenced by the fold, which
-/// is exactly the pair that used to make them collectable on the spot. They
-/// stay until a grace window has passed since the fold, and then they go —
-/// protecting a reader must not turn into never reclaiming.
 #[tokio::test]
 async fn a_read_pinned_before_a_fold_still_reads_after_the_sweep() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2231,12 +2143,6 @@ fn test_metadata_compaction_id() -> loonfs_api::MetadataCompactionId {
         .expect("valid metadata compaction id")
 }
 
-/// A running job's output survives however old it is, because its lease says
-/// the job that wrote it is still running.
-///
-/// This is the case a fixed window could not express: a job publishes nothing
-/// until it finishes and is paced by no budget, so its first segment can be
-/// arbitrarily older than any window a collector applies to it.
 #[tokio::test]
 async fn a_live_jobs_staged_output_survives_however_old_it_is() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2276,8 +2182,6 @@ async fn a_live_jobs_staged_output_survives_however_old_it_is() {
     }
 }
 
-/// A job whose lease went stale loses its prefix: the segments and the lease
-/// are ordinary orphans once the staging window has passed on them.
 #[tokio::test]
 async fn a_dead_jobs_staged_output_is_reclaimed_after_the_staging_window() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2335,8 +2239,6 @@ async fn a_dead_jobs_staged_output_is_reclaimed_after_the_staging_window() {
     }
 }
 
-/// A job that died before writing a lease at all leaves output no lease
-/// claims, and the same window reclaims it.
 #[tokio::test]
 async fn staged_output_with_no_lease_at_all_is_reclaimed() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2362,8 +2264,6 @@ async fn staged_output_with_no_lease_at_all_is_reclaimed() {
         .is_none());
 }
 
-/// A lease that does not decode is corruption, not evidence that the staged
-/// prefix is unowned. The pass stops before deleting either object.
 #[tokio::test]
 async fn a_lease_that_does_not_decode_fails_the_pass() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2399,9 +2299,6 @@ async fn a_lease_that_does_not_decode_fails_the_pass() {
     }
 }
 
-/// Once a pass claims a stale compaction lease, every exit owes that lease a
-/// deletion. A later candidate failure must not strand the claim in `Reaping`
-/// just because the normal end of the prefix was never reached.
 #[tokio::test]
 async fn a_candidate_error_still_finishes_the_claimed_compaction_lease() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2459,9 +2356,6 @@ async fn a_candidate_error_still_finishes_the_claimed_compaction_lease() {
     );
 }
 
-/// A budget stop uses the same settlement boundary as an error. Once the
-/// lease candidate has been decided, the lookahead that notices an empty
-/// budget must close the claim before returning its cursor.
 #[tokio::test]
 async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2525,8 +2419,6 @@ async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
     );
 }
 
-/// A published job produces normal referenced segments. Their manifest keeps
-/// them from being collected.
 #[tokio::test]
 async fn a_published_compactions_staged_segments_are_referenced_and_kept() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2582,17 +2474,6 @@ async fn a_published_compactions_staged_segments_are_referenced_and_kept() {
     }
 }
 
-/// A publication that lands mid-pass does not cost the job its output.
-///
-/// This is the handoff a fixed grace window cannot express. A pass collects
-/// its live set, the compaction publishes a manifest naming its staged
-/// segments, and the pass reaches the compaction prefix still holding the
-/// older live set — in which those segments are referenced by nothing and are
-/// older than any window a collector applies. The lease the job leaves behind
-/// is what the pass reads instead, and it says the objects are owned.
-///
-/// The pass is gated at the first listing it makes after collecting its roots,
-/// which is where the whole job runs underneath it on a second store handle.
 #[tokio::test]
 async fn a_publication_during_a_pass_never_costs_the_job_its_segments() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2665,13 +2546,6 @@ async fn a_publication_during_a_pass_never_costs_the_job_its_segments() {
     }
 }
 
-/// A published job's lease outlives it, and the pass that finds it expired
-/// removes the lease and nothing else.
-///
-/// The job stops heartbeating at publication rather than deleting the object,
-/// so a later pass is the one that cleans it up. By then that pass reads a
-/// root that names every staged segment, so the reap it performs has nothing
-/// to take but the lease.
 #[tokio::test]
 async fn a_published_jobs_lease_expires_and_the_pass_removes_only_the_lease() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2751,10 +2625,6 @@ async fn a_published_jobs_lease_expires_and_the_pass_removes_only_the_lease() {
     }
 }
 
-/// The write-time arm is what covers an object the reference manifest
-/// predates: it was written after the anchor, so the anchor cannot be asked
-/// about it, and only its own age says anything. Once that age passes and
-/// neither anchor names it, it goes.
 #[tokio::test]
 async fn an_object_the_anchor_predates_is_kept_by_its_own_age_alone() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2806,10 +2676,6 @@ async fn an_object_the_anchor_predates_is_kept_by_its_own_age_alone() {
         .is_none());
 }
 
-/// A namespace whose manifests are all younger than the window has nothing
-/// that says what it referenced when the window opened. The pass keeps every
-/// aged candidate and names the reason, rather than reaping against evidence
-/// it does not have.
 #[tokio::test]
 async fn a_pass_with_no_aged_manifest_reaps_nothing_and_says_why() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2864,9 +2730,6 @@ async fn a_pass_with_no_aged_manifest_reaps_nothing_and_says_why() {
     assert_eq!(report.retained.no_reference_manifest, 0);
 }
 
-/// A budget that runs out while the anchor is still being established buys
-/// nothing at all. Reaping needs both anchors, and half a root set is not a
-/// smaller answer, it is no answer.
 #[tokio::test]
 async fn a_budget_that_dies_before_the_anchor_sweeps_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2921,9 +2784,6 @@ async fn a_budget_that_dies_before_the_anchor_sweeps_nothing() {
     assert_eq!(report.deleted.wal_segments, 1);
 }
 
-/// A pass that keeps a checkpoint record says so as a checkpoint decision,
-/// not as an anonymous count — which is the difference between an operator
-/// knowing to look at their pins and knowing nothing.
 #[tokio::test]
 async fn a_pass_names_a_checkpoint_record_it_could_not_advance() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2987,9 +2847,6 @@ async fn gc_never_deletes_the_live_replay_chain() {
         .expect("tail commit stays readable");
 }
 
-/// A released record whose basis has aged out loses the record first,
-/// and the basis only on the following pass — never the other way
-/// around.
 #[tokio::test]
 async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3068,8 +2925,6 @@ async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
     stat_root(&store, &namespace_id).await;
 }
 
-/// Objects whose keys do not name a valid manifest are not proven GC
-/// candidates, so the pass retains their exact bytes.
 #[tokio::test]
 async fn gc_retains_unrecognized_manifest_keys() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3114,9 +2969,6 @@ async fn gc_retains_unrecognized_manifest_keys() {
     }
 }
 
-/// Repeated WAL flushes leave superseded manifests unpinned, so GC
-/// reclaims them once aged. This is what keeps retained metadata
-/// bounded when maintenance runs continuously.
 #[tokio::test]
 async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3210,8 +3062,6 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
     }
 }
 
-/// The user release lifecycle end to end: release flips the record,
-/// the record reaps first, and the basis follows one pass later.
 #[tokio::test]
 async fn gc_reaps_released_checkpoints_before_their_basis_across_passes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3260,10 +3110,6 @@ async fn gc_reaps_released_checkpoints_before_their_basis_across_passes() {
     stat_root(&store, &namespace_id).await;
 }
 
-/// Release runs one way to one end state, so a caller and a
-/// garbage-collection pass asking for it at the same moment converge.
-/// Whichever compare-and-swap lands writes the stamp; the other side sees
-/// the end state it wanted and reports success without touching the record.
 #[tokio::test]
 async fn caller_release_and_expiry_release_converge_on_the_winners_stamp() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3343,9 +3189,6 @@ async fn caller_release_and_expiry_release_converge_on_the_winners_stamp() {
     );
 }
 
-/// The same convergence with the two compare-and-swaps genuinely in flight:
-/// the pass's release is held mid-write while the caller's lands, so the
-/// pass loses its etag. Losing is retention, never an error.
 #[tokio::test]
 async fn a_release_that_loses_its_etag_retains_without_erroring() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3401,9 +3244,6 @@ async fn a_release_that_loses_its_etag_retains_without_erroring() {
     );
 }
 
-/// A released record waits out the grace window measured from its own
-/// release stamp — not from any provider timestamp — and is deleted after
-/// it, its basis following on the pass after that.
 #[tokio::test]
 async fn gc_deletes_a_released_record_only_after_its_release_ages() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3467,8 +3307,6 @@ async fn gc_deletes_a_released_record_only_after_its_release_ages() {
     .is_none());
 }
 
-/// An expiring pin protects until its expiry, then is released by the pass
-/// that observes the expiry and follows the ordinary released cascade.
 #[tokio::test]
 async fn gc_reaps_expired_checkpoints_before_their_basis_across_passes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3557,8 +3395,6 @@ async fn gc_reaps_expired_checkpoints_before_their_basis_across_passes() {
     stat_root(&store, &namespace_id).await;
 }
 
-/// Two owners of one basis hold two records: releasing one leaves the
-/// other rooting the shared basis.
 #[tokio::test]
 async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3635,8 +3471,6 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
     );
 }
 
-/// Fork checkpoints cannot be released through the user operation. Garbage
-/// collection releases them after their target namespace is gone.
 #[tokio::test]
 async fn fork_owned_checkpoints_reject_user_release() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3735,10 +3569,6 @@ async fn read_fork_record(store: &LocalFsStore, source: &NamespaceId) -> Checkpo
     panic!("fork leaves one fork-owned record");
 }
 
-/// The fork-record cascade: a live target keeps the record a root; a
-/// terminal target delete releases the record by compare-and-swap; the
-/// record reaps a grace window after that release, and its basis on the
-/// pass after that.
 #[tokio::test]
 async fn gc_releases_fork_checkpoints_of_terminally_deleted_targets_across_passes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3878,10 +3708,6 @@ async fn gc_retains_a_fork_checkpoint_when_the_target_head_does_not_read() {
     );
 }
 
-/// A finished fork owns its source pin for as long as the target lives.
-/// The lease bounds the attempt, not the result: once the target head is
-/// there, no number of passes at any clock past the lease can release the
-/// record or reach the basis behind it.
 #[tokio::test]
 async fn gc_never_releases_a_fork_record_while_its_target_lives() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3941,10 +3767,6 @@ async fn gc_never_releases_a_fork_record_while_its_target_lives() {
         .expect("forked file readable");
 }
 
-/// The abandoned-fork arm: an attempt that never installed its target head
-/// is proven abandoned by its own lease, and by nothing else. The source's
-/// basis is safe for the whole lease, and the record then follows the
-/// ordinary released cascade.
 #[tokio::test]
 async fn gc_releases_abandoned_fork_checkpoints_once_the_lease_expires() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4032,9 +3854,6 @@ async fn gc_releases_abandoned_fork_checkpoints_once_the_lease_expires() {
     stat_root(&store, &source).await;
 }
 
-/// A fork retry after an abandoned attempt is simply another attempt: it
-/// takes its own record under its own id, and the abandoned one is left to
-/// age out on its own schedule.
 #[tokio::test]
 async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4080,10 +3899,6 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
         .expect("forked file readable");
 }
 
-/// Only checkpoint records live under the checkpoints prefix, so bytes
-/// there that do not decode as one are corruption. The pass reports it and
-/// stops. It does not retain the object and suppress reclamation on every
-/// pass after this one.
 #[tokio::test]
 async fn gc_fails_the_pass_on_a_corrupt_checkpoint_record() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4128,8 +3943,6 @@ async fn gc_fails_the_pass_on_a_corrupt_checkpoint_record() {
     );
 }
 
-/// A store read failure is retryable and differs from an invalid record. The
-/// error includes the object key and a retryable error code.
 #[tokio::test]
 async fn gc_fails_the_pass_when_a_checkpoint_record_does_not_read() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4243,8 +4056,6 @@ async fn unreadable_reference_anchor_manifest_remains_conservative() {
     assert!(matches!(anchor, ReferenceAnchor::Missing));
 }
 
-/// The manifest arm of the same split: a rooted manifest that reads but
-/// does not decode is corruption, and the pass says so.
 #[tokio::test]
 async fn gc_fails_the_pass_on_a_corrupt_root_manifest() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4293,10 +4104,6 @@ async fn gc_fails_the_pass_on_a_corrupt_root_manifest() {
     );
 }
 
-/// The other half of the manifest arm: a rooted manifest the store will
-/// not hand over says nothing about the bytes, so the pass keeps its old
-/// behavior. It degrades, reclaims no manifests or segments, and counts what
-/// it kept under `degraded_roots`.
 #[tokio::test]
 async fn gc_degrades_when_a_root_manifest_does_not_read() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4337,8 +4144,6 @@ async fn gc_degrades_when_a_root_manifest_does_not_read() {
     );
 }
 
-/// Rule 1's timestamp arm: an object without a provider timestamp reads
-/// as young, so a store that reports none never deletes anything.
 #[tokio::test]
 async fn gc_retains_everything_without_provider_timestamps() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4376,9 +4181,6 @@ async fn gc_retains_everything_without_provider_timestamps() {
     stat_root(&store, &namespace_id).await;
 }
 
-/// The chunked delete-time re-verification path (rule 3) must reach the
-/// same outcomes as a whole-batch sweep; chunk size one re-collects the
-/// live set before every candidate.
 #[tokio::test]
 async fn gc_sweep_reverification_chunks_preserve_outcomes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4414,9 +4216,6 @@ async fn gc_sweep_reverification_chunks_preserve_outcomes() {
     stat_root(&store, &namespace_id).await;
 }
 
-/// A namespace with no head does not exist, so the pass lists nothing and
-/// deletes nothing: the head is every installation's first and only write,
-/// so nothing can be under the prefix without it.
 #[tokio::test]
 async fn gc_of_an_absent_namespace_lists_and_deletes_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4436,9 +4235,6 @@ async fn gc_of_an_absent_namespace_lists_and_deletes_nothing() {
     assert_eq!(store.deletes.load(Ordering::SeqCst), 0);
 }
 
-/// The same rule with a fork pin in the way: a corrupt record is corrupt
-/// whoever owns it. The source's pass fails and the basis the target reads
-/// through is left exactly as it was.
 #[tokio::test]
 async fn gc_fails_the_pass_when_a_fork_pin_record_is_corrupt() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -302,23 +302,10 @@ impl ContentReferences {
 /// checkpoints. Other namespaces cannot reference these content IDs because
 /// each namespace publishes content created by its own upload sessions.
 ///
-/// Only the manifest half is read here. The chain's references were
-/// harvested off the bodies marking already decoded, so this half is a set
-/// union rather than a second pass over the same objects.
-///
-/// Every manifest root read costs a budget unit — one per manifest opened,
-/// one per page of revision rows — so this scan is part of the pass's bound
-/// rather than an exception to it. Running out stops the scan where it
-/// stands and reports [`CollectedReferences::Deferred`]; the caller retains
-/// the session that triggered it, marks the pass as having deferred content
-/// reclamation, and carries on. A namespace whose scan never fits therefore
-/// keeps its completed content — `max_objects` has to be at least the
-/// scan's size for content reclamation to happen at all — but the sweep
-/// around it still advances, which is the difference between leaking
-/// content for a while and not collecting anything ever.
-///
-/// Every return is a verdict the memo can hold: an attempt that has run
-/// never comes back as [`CollectedReferences::NotYet`].
+/// WAL references were collected while marking the chain. Manifest reads and
+/// revision pages consume the pass budget. If the budget runs out, the scan
+/// returns [`CollectedReferences::Deferred`] and completed content is retained
+/// until a later pass can finish the scan.
 pub(super) async fn collect_referenced_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -1,12 +1,7 @@
 //! Core LoonFS namespace operations.
 //!
-//! `loonfs-core` is the low-level API for building directly on the LoonFS
-//! metadata protocol. Most callers should start with [`NamespaceEngine`].
-//!
-//! A namespace is one durable filesystem history. File bytes are written to
-//! object storage first, then metadata is published as a committed namespace
-//! mutation. Reads rebuild or reuse a verified view of the namespace before
-//! walking paths.
+//! Most callers should use the higher-level `loonfs` crate. Use
+//! [`NamespaceEngine`] when working directly with the metadata protocol.
 //!
 //! # Example
 //!
@@ -57,14 +52,6 @@
 //! );
 //! ```
 
-// This crate has two supported consumers:
-// - `loonfs`, which wraps the core API with runtime caching and batching.
-// - `loonfs-core` integration tests, which inspect durable layout and replay.
-//
-// Application code should depend on `loonfs`, not `loonfs-core`. Modules are
-// private unless one of these consumers needs them to be public.
-
-// Internal engine modules. Public APIs below expose the supported entry points.
 mod checkpoint;
 mod commit_engine;
 mod context;
@@ -80,7 +67,6 @@ mod recency;
 mod storage;
 mod wal;
 
-// Public modules required by `loonfs` or this crate's integration tests.
 /// Commit planning, validation, and materialization. Consumed by the `loonfs`
 /// publisher and by this crate's commit-validation integration tests.
 pub mod commit;

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -107,96 +107,44 @@ pub const GC_SAFETY_MARGIN_MS: u64 = 3 * 60 * 1000;
 /// Default candidate budget for one step-driven garbage-collection pass.
 pub const DEFAULT_GC_MAX_OBJECTS: u64 = 1024;
 
-/// How often a running streaming compaction rewrites its lease (format spec,
-/// "Garbage collection", rule 12).
+/// Interval between streaming-compaction lease heartbeats.
 ///
-/// A job's staged output is unreferenced for as long as the job runs, and a
-/// job has no time budget at all, so the collector cannot tell a running
-/// job's output from a dead one's by age. The lease is what tells it: the
-/// job rewrites it on this interval, and a prefix whose lease is fresh is
-/// retained whole.
-///
-/// One small overwrite per interval is nothing beside the reads the job is
-/// already making, so the interval is set by the other side of the trade:
-/// it has to be long enough that a heartbeat spending its whole provider
-/// budget still lands before the next one is due, and short enough that a
-/// dead job's output is reclaimable in a sensible time. Five minutes is
-/// twice the provider bound below it and leaves the reclamation window
-/// under an hour.
+/// The interval must exceed one provider operation bound so a healthy job can
+/// refresh its lease before the next heartbeat is due.
 pub const METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS: u64 = 5 * 60 * 1000;
 
-/// Heartbeats a lease may miss before the collector reads its job as gone.
+/// Heartbeats a lease may miss before its job is considered inactive.
 pub const METADATA_COMPACTION_LEASE_MISSED_HEARTBEATS: u64 = 5;
 
-/// How long after its last heartbeat an `active` lease still says its job owns
-/// its prefix.
+/// Time after the last heartbeat before a compaction lease expires.
 ///
-/// Two things have to fit inside it. A running job must never lose its
-/// prefix, so the window covers several missed heartbeats rather than one.
-/// And a job's last heartbeat before it publishes is at the top of a
-/// finalization attempt, so the window must also outlast one publication.
-///
-/// That second requirement is what makes the fence complete, and it is an
-/// inequality over the constants here:
-///
-/// ```text
-/// one finalization attempt   <= METADATA_PUBLICATION_BUDGET_MS
-///                                  (enforced: `ensure_metadata_publication_budget`)
-///                             < GC_MIN_GRACE_WINDOW_MS
-///                                  (that budget plus provider bounds and skew)
-///                            <= METADATA_COMPACTION_LEASE_EXPIRY_MS
-///                                  (asserted below)
-/// ```
-///
-/// So a job that heartbeats at the top of an attempt cannot have its lease
-/// expire before that attempt's root compare-and-swap: garbage collection
-/// cannot claim the prefix underneath it mid-attempt, and a job that got past
-/// the heartbeat is the only party that can publish the segments it named.
+/// This must outlast one publication so garbage collection cannot claim a
+/// job's prefix while its final compare-and-swap is in progress.
 pub const METADATA_COMPACTION_LEASE_EXPIRY_MS: u64 =
     METADATA_COMPACTION_LEASE_MISSED_HEARTBEATS * METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS;
 
-/// Grace a streaming compaction's staged segments get, once their job's
-/// lease is stale or gone, before garbage collection may reap one as an
-/// orphan (format spec, "Garbage collection", rule 12).
-///
-/// Derived, not tuned. A job owns its prefix while its lease is fresh, so
-/// what remains to cover is the gap between the last heartbeat and the moment
-/// the objects become referenced: the lease's own expiry, plus the bound on
-/// the publication that names them, which is what `GC_MIN_GRACE_WINDOW_MS`
-/// bounds for every other publication in the system.
-///
-/// This is the window that replaced a fixed day. A day was a guess at how
-/// long a job might run, which is exactly the thing the streaming design
-/// refuses to bound; the lease measures it instead, and this window only has
-/// to cover what happens after a lease stops being refreshed.
+/// Minimum age of staged compaction output before it may be collected after
+/// its lease expires.
 pub const METADATA_COMPACTION_STAGING_GRACE_MS: u64 =
     METADATA_COMPACTION_LEASE_EXPIRY_MS + GC_MIN_GRACE_WINDOW_MS;
 
-/// The heartbeat's inequality, shared by the compile-time assertion below
-/// and the test that proves the assertion has teeth.
+/// Returns whether a heartbeat can complete before the next is due.
 const fn heartbeats_land_before_the_next_one_is_due(interval_ms: u64) -> bool {
     interval_ms > PROVIDER_OPERATION_DEADLINE_MS + PROVIDER_ATTEMPT_TIMEOUT_MS
 }
 
-// A heartbeat is one small overwrite, and one provider operation's total wall
-// time is its deadline plus one attempt timeout. An interval below that would
-// make a healthy job fall behind its own lease under nothing worse than a
-// slow provider, so the two constants have to move together.
+// Keep the heartbeat interval above the maximum provider operation time.
 const _: () = assert!(
     heartbeats_land_before_the_next_one_is_due(METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS),
     "a heartbeat that spends its whole provider budget must still land before the next is due"
 );
 
-/// The lease's inequality, shared by the compile-time assertion below and the
-/// test that proves the assertion has teeth.
+/// Returns whether a lease can cover one metadata publication.
 const fn outlasts_one_publication(expiry_ms: u64) -> bool {
     expiry_ms >= GC_MIN_GRACE_WINDOW_MS
 }
 
-// A job's last heartbeat before its output becomes referenced is at the top
-// of a finalization attempt, and that attempt's compare-and-swap lands within
-// one publication bound of it. A lease shorter than that bound would expire
-// while the publication naming its output was still in flight.
+// The lease must remain valid through a final publication attempt.
 const _: () = assert!(
     outlasts_one_publication(METADATA_COMPACTION_LEASE_EXPIRY_MS),
     "a compaction lease must outlast the publication that ends the job holding it"
@@ -210,15 +158,9 @@ const fn max_u64(left: u64, right: u64) -> u64 {
     }
 }
 
-/// The derived minimum GC grace window and explicit namespace-repair safety
-/// window (format spec, "Garbage collection", rule 1). Every acknowledged
-/// publication starts its final compare-and-swap within a publication budget
-/// measured from its first object write, and that compare-and-swap completes
-/// within one provider operation bound. So an object older than this window
-/// that is still unreachable at delete time cannot belong to a publication
-/// that might yet succeed. `GcConfig::validate` rejects smaller windows, and
-/// namespace repair uses the same bound before reaping non-completable install
-/// debris.
+/// Minimum age of an unreachable object before garbage collection or repair
+/// may remove it. The value covers the longest publication budget, provider
+/// operation time, and clock skew.
 pub const GC_MIN_GRACE_WINDOW_MS: u64 = max_u64(
     max_u64(WAL_PUBLISH_BUDGET_MS, CHECKPOINT_VERIFY_BUDGET_MS),
     METADATA_PUBLICATION_BUDGET_MS,
@@ -244,57 +186,24 @@ pub const MAX_MULTIPART_PART_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 /// one upload.
 pub const MAX_SIGNED_PARTS_PER_REQUEST: usize = 1_000;
 
-/// Lease every fork attempt takes on the fork-owned source checkpoint it
-/// creates. An attempt that never installs its target head lets the lease
-/// pass, and garbage collection releases the record on that alone — no
-/// provider timestamp, no fork-specific age rule.
+/// Lease for the source checkpoint created by a fork attempt.
 ///
-/// Two grace floors, because a fork attempt is two of the things that floor
-/// already bounds. The first covers creating the record: the WAL flush and
-/// manifest publication it may perform, the post-write basis verification,
-/// and the provider bounds and clock skew around them — which is exactly
-/// what `GC_MIN_GRACE_WINDOW_MS` is the bound for. The second covers
-/// everything after: reading the pinned manifest and the source head,
-/// installing the target head, and the guard read below. Each half is one
-/// publication plus provider bounds plus skew, so each is one floor.
+/// Two GC grace windows cover checkpoint creation followed by target-head
+/// installation and verification.
 pub const FORK_CHECKPOINT_LEASE_MS: u64 = 2 * GC_MIN_GRACE_WINDOW_MS;
 
-/// Lease an upload session takes when it opens. A session is the only place
-/// retry idempotency lives, so the lease has to outlast any single transfer a
-/// client may reasonably be in the middle of — a proxied body, or a presigned
-/// direct write and the completion call after it. Once it passes, the session
-/// is abandoned by definition and upload garbage collection aborts it: unlike
-/// a namespace, a session is a lease, so reclaiming one on age alone is the
-/// correct reading and not a guess about the client.
+/// Lease duration for an upload session.
 pub const UPLOAD_SESSION_LEASE_MS: u64 = 24 * 60 * 60 * 1000;
 
-/// How long one minted content receipt admits the content it names at commit.
-///
-/// Short on purpose: durability lives in the completed upload session, which
-/// is durable and re-mints, so the receipt only has to cover the gap between
-/// finishing an upload and committing the metadata that references it.
+/// Time during which a content receipt may be used in a commit.
 pub const CONTENT_RECEIPT_TTL_MS: u64 = 60 * 60 * 1000;
 
-/// How long a completed session goes on minting receipts for its content.
-///
-/// This is the "a lost publish response never costs a retransfer" promise
-/// expressed as a number: for this long after completion, reading the
-/// session's status hands back a fresh receipt for bytes that are already
-/// durable. After it, the content is either referenced by metadata — which
-/// protects it on its own — or reclaimable.
+/// Time during which a completed upload may issue new content receipts.
 pub const COMPLETED_UPLOAD_RECEIPT_WINDOW_MS: u64 = 7 * 24 * 60 * 60 * 1000;
 
-/// Grace a completed upload's content object gets before content garbage
-/// collection may reclaim it as unreferenced. Derived, not tuned.
-///
-/// Three spans have to be over before "no metadata references this" can be
-/// trusted to stay true. The session may mint a receipt at any point in its
-/// receipt window; the last such receipt admits a commit for one more receipt
-/// TTL; and a commit admitted at that last instant still has a publication
-/// budget plus provider bounds and clock skew to land its root — which is
-/// exactly what `GC_MIN_GRACE_WINDOW_MS` bounds. Past their sum no new
-/// reference can appear, so a reference set collected earlier in the pass is
-/// still sound at delete time.
+/// Minimum age of unreferenced content from a completed upload before
+/// collection. The value covers the receipt window, receipt lifetime, and a
+/// final publication.
 pub const CONTENT_RECLAMATION_GRACE_MS: u64 =
     COMPLETED_UPLOAD_RECEIPT_WINDOW_MS + CONTENT_RECEIPT_TTL_MS + GC_MIN_GRACE_WINDOW_MS;
 
@@ -343,9 +252,6 @@ mod tests {
     use super::*;
     use crate::gc::GcConfig;
 
-    /// The compile-time assertion above is only worth having if its
-    /// predicate can fail, so the predicate is exercised from both sides
-    /// here: one millisecond below the derivation is rejected.
     #[test]
     fn the_content_grace_floor_rejects_a_window_one_receipt_short() {
         assert!(outlasts_every_receipt(CONTENT_RECLAMATION_GRACE_MS));
@@ -358,9 +264,6 @@ mod tests {
         assert_eq!(CONTENT_RECLAMATION_GRACE_MS, 608_400_000 + 1_230_000);
     }
 
-    /// Same bargain as above: the head-coverage assertion is only worth
-    /// having if its predicate can fail, so one pointer short of the legal
-    /// tail is exercised too.
     #[test]
     fn the_head_coverage_floor_rejects_a_list_one_segment_short() {
         assert!(covers_every_unflushed_segment(RECENT_SEGMENTS_LIMIT));
@@ -391,9 +294,6 @@ mod tests {
         );
     }
 
-    /// The staging window is derived from the lease, not from a guess at how
-    /// long a job runs. A running job holds its prefix through its lease, so
-    /// this window only has to cover what follows the last heartbeat.
     #[test]
     fn the_compaction_staging_grace_is_the_lease_plus_one_publication() {
         // 25 minutes of lease + 20.5 minutes of publication.
@@ -411,8 +311,6 @@ mod tests {
         assert!(!outlasts_one_publication(GC_MIN_GRACE_WINDOW_MS - 1));
     }
 
-    /// Same bargain as the other derived floors: the heartbeat assertion is
-    /// only worth having if its predicate can fail.
     #[test]
     fn the_heartbeat_interval_floor_rejects_an_interval_one_provider_bound_short() {
         assert!(heartbeats_land_before_the_next_one_is_due(

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -400,9 +400,6 @@ mod tests {
         }
     }
 
-    /// A bind that is older than the child's active binding must not evict
-    /// it. WAL apply never produces this order; the guard covers a future
-    /// caller that does.
     #[test]
     fn an_out_of_order_bind_does_not_evict_the_childs_newer_binding() {
         let mut indexes = MetadataIndexes::default();
@@ -430,8 +427,6 @@ mod tests {
             .is_none());
     }
 
-    /// A stale bind must mutate nothing: rejecting it after evicting the
-    /// name slot would orphan whichever child currently holds that name.
     #[test]
     fn a_stale_bind_does_not_orphan_the_name_slots_current_child() {
         let mut indexes = MetadataIndexes::default();

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -1,25 +1,8 @@
-//! Materialized namespace metadata: append-only row families plus derived
-//! indexes that answer reads over them.
+//! Materialized namespace metadata.
 //!
-//! [`MetadataState`] is one namespace's metadata materialized at one WAL
-//! sequence: committed WAL deltas append immutable rows, and every read is
-//! answered from those rows. Submodules follow that lifecycle:
-//!
-//! - `rows` defines the row records and the append/accounting plumbing that
-//!   keeps the derived indexes and decoded-size totals in step with every
-//!   appended row.
-//! - `apply` maps committed WAL deltas onto row appends — the only WAL-delta
-//!   to metadata-row mapping in the crate, shared by durable replay and
-//!   commit-validation previews.
-//! - `queries` answers seq-gated reads: record lookups, visibility checks,
-//!   and path resolution, routed to the indexes at head and to historical
-//!   row scans below it.
-//! - `indexes` maintains the at-head lookup structures behind those fast
-//!   paths.
-//! - `visibility` holds the single authoritative statement of the
-//!   direntry-visibility rules (binding identity, active bindings, tombstone
-//!   coverage, path resolution) that every storage shape above decides
-//!   through.
+//! `MetadataState` stores append-only rows at a WAL sequence. Derived indexes
+//! accelerate current reads, while historical reads scan the retained rows.
+//! The `visibility` module applies shared direntry rules to every storage view.
 
 mod apply;
 mod durable_cache;
@@ -41,10 +24,7 @@ pub use self::rows::{
 };
 
 pub(crate) use self::durable_cache::DurableVisibilityCache;
-/// The newest-event-wins tombstone rule. Every production reader reaches it
-/// through `metadata::visibility`; the trash listing's differential test
-/// reaches it directly, to model the walk the active-deletions family
-/// replaced.
+/// Newest-event-wins tombstone selection used by differential tests.
 #[cfg(test)]
 pub(crate) use self::rows::active_tombstone_from_records;
 pub(crate) use self::rows::content_ref_evidence_bytes;

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -441,9 +441,6 @@ fn find_commit_receipt_returns_latest_matching_receipt() {
     assert_eq!(receipt.semantic_commit_fingerprint, "new");
 }
 
-/// Revision rows keep no in-memory index — reads scan the tail-sized rows —
-/// but they must still advance the indexed-seq watermark that gates at-head
-/// query routing.
 #[test]
 fn revisions_advance_watermark_and_receipt_index() {
     let receipt_commit_id = CommitId::parse("indexed-commit").expect("valid commit id");
@@ -546,8 +543,6 @@ fn append_attributes(
     }
 }
 
-/// Several attribute updates at one sequence replay in delta order, and a
-/// clear is a row like any other.
 #[test]
 fn attribute_deltas_replay_in_delta_order_and_a_clear_keeps_its_row() {
     let mut metadata_state = MetadataState::default();
@@ -580,10 +575,6 @@ fn attribute_deltas_replay_in_delta_order_and_a_clear_keeps_its_row() {
     assert_eq!(metadata_state.indexed_seq(), ChangeSeq(4));
 }
 
-/// A read at a sequence below the head answers with the map that sequence
-/// saw, not with the newest one. Attributes are current state rather than
-/// history, so a leg that let a later row through would answer with a map
-/// the reading sequence never had.
 #[tokio::test]
 async fn attribute_reads_answer_at_the_sequence_they_ask_for() {
     let mut state = MetadataState::default();
@@ -647,8 +638,6 @@ async fn attribute_reads_answer_at_the_sequence_they_ask_for() {
     );
 }
 
-/// The tail's row accounting counts an attribute map's key and value bytes,
-/// so a namespace that writes large maps is charged for them.
 #[test]
 fn attribute_row_accounting_counts_key_and_value_bytes() {
     let small = MetadataState::default().apply_committed_wal_deltas(
@@ -867,8 +856,6 @@ fn incremental_and_rebuilt_indexes_agree_on_latest_binds() {
     }
 }
 
-/// Queries above `indexed_seq()` are at-head queries: commit validation
-/// probes the materialization at the next assigned seq and must hit the indexes.
 #[test]
 fn queries_above_indexed_seq_match_at_head_results() {
     let state = churned_binding_state();
@@ -894,9 +881,6 @@ fn queries_above_indexed_seq_match_at_head_results() {
     );
 }
 
-/// The directory-empty checks probe existence through the bounded
-/// [`MetadataView::has_visible_children`]; a directory whose every child
-/// binding was unbound must read as empty again.
 #[test]
 fn has_visible_children_sees_through_unbinds() {
     let dir = InodeId(1);
@@ -969,8 +953,6 @@ fn has_visible_children_sees_through_unbinds() {
     );
 }
 
-/// The leg names land in log records that operators grep for. They are fixed
-/// strings, and no two legs share one.
 #[test]
 fn every_absent_visibility_leg_has_its_own_stable_name() {
     use visibility::AbsentVisibilityLeg;

--- a/crates/loonfs-core/src/metadata/visibility.rs
+++ b/crates/loonfs-core/src/metadata/visibility.rs
@@ -1,32 +1,9 @@
-//! The single authoritative implementation of direntry visibility.
+//! Shared direntry visibility rules.
 //!
-//! "Which binding is visible/active" is the most safety-critical rule in the
-//! system, and it must be decided identically no matter which storage shape
-//! answers the underlying lookups (in-memory rows, at-head indexes, paged
-//! manifest segments merged with a WAL tail, or commit-preview overlays). This
-//! module expresses each composite rule exactly once:
-//!
-//! - [`BindingIdentity`] is the identity key of a binding event; every
-//!   binding-identity comparison in the crate goes through it (via
-//!   [`DirentryBindRecord::same_binding`] or [`unbind_matches_binding`]).
-//! - [`MetadataVisibilityReads`] is the storage contract: five primitive
-//!   lookups a storage shape must answer, plus provided composite methods
-//!   that implementors may override only to reuse a cache or an index fast
-//!   path — never to re-derive the rules.
-//! - The free functions ([`active_child_binding`],
-//!   [`current_parent_binding_for_child`], [`covering_subtree_tombstone`],
-//!   [`visible_inode`], [`visible_child`],
-//!   [`would_create_directory_cycle`], [`resolve_visible_path`]) are the
-//!   canonical rule bodies that both the provided trait methods and every
-//!   caching/gating override delegate to.
-//! - [`AbsentVisibilityLeg`] names the lookup a walk stopped on when it
-//!   answers "no child". The rules decide nothing differently for it; it
-//!   only makes an absence say which of the agreeing lookups was empty.
-//!
-//! The at-head indexes ([`super::MetadataState`]'s `indexes`) are a
-//! materialization of these same rules, maintained incrementally. The
-//! metadata unit tests and the mutation-guard suite check that they always
-//! agree with the scan implementations.
+//! [`MetadataVisibilityReads`] defines the required storage lookups. The
+//! composite methods and free functions apply the same visibility rules to
+//! in-memory state, manifest-backed views, and mutation previews.
+//! [`BindingIdentity`] provides the common bind/unbind comparison.
 
 use super::queries::{ResolvedVisiblePath, VisiblePathError};
 use super::{
@@ -91,16 +68,11 @@ pub(crate) fn unbind_matches_binding(
     BindingIdentity::from(unbind) == BindingIdentity::from(direntry)
 }
 
-/// The storage lookups the visibility rules are decided over, all scoped to
-/// one read sequence chosen by the implementor (a `base_seq`, a head, or a
-/// preview overlay's view of either).
+/// Storage lookups scoped to one read sequence.
 ///
-/// The `find_*` primitives are required and answer raw questions about the
-/// stored rows; they apply no visibility policy beyond "latest at the read
-/// seq". The provided methods are the composite rules; implementors override
-/// them only to route through a cache or an equivalent index fast path, and
-/// every such override must delegate back to the canonical free functions in
-/// this module on the slow path.
+/// Required `find_*` methods return raw rows. Provided methods apply
+/// visibility rules and may be overridden only for equivalent cached or
+/// indexed paths.
 pub(crate) trait MetadataVisibilityReads {
     type Error;
 

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -1,18 +1,9 @@
-//! Where a namespace's materialized metadata starts.
+//! Resolves the metadata basis for a namespace.
 //!
-//! A namespace publishes `metadata/root.json` at its first flush, not at
-//! creation, so the basis is resolved from the head plus that root when it
-//! exists (format spec, "Resolving the metadata basis"):
-//!
-//! 1. `metadata/root.json` present: the basis is the manifest it names,
-//!    under this namespace's own prefix.
-//! 2. Root absent, head carries no fork basis: the basis is the built-in
-//!    genesis state — one root-inode row at sequence zero. No manifest
-//!    object exists, and none was ever written.
-//! 3. Root absent, head carries a fork basis: the basis is the source
-//!    namespace's manifest, read under the source's prefix and validated
-//!    against the identity and checksum the head recorded. A mismatch is
-//!    corruption, never a fallback.
+//! The basis is the namespace's metadata root when present, its fork source
+//! manifest when recorded in the head, or the built-in genesis state before
+//! the first flush. A fork basis must match the identity and checksum stored
+//! in the head.
 
 use crate::control_object::ControlObjectLoadError;
 use crate::error::CoreError;

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -151,9 +151,7 @@ pub async fn load_namespace_metadata_root_control<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Loads the head together with the metadata basis it authorizes, as one
-/// consistent read anchor (see [`load_head_and_metadata_root_if_present`]
-/// for the race rule).
+/// Loads the head and authorized metadata basis as one consistent read anchor.
 pub async fn load_namespace_read_anchor<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
@@ -232,7 +230,6 @@ mod tests {
             .expect("write control object");
     }
 
-    /// A metadata root cannot reference another namespace's manifest.
     #[tokio::test]
     async fn root_loader_rejects_a_manifest_owned_by_another_namespace() {
         let (_directory, store) = local_store();
@@ -261,7 +258,6 @@ mod tests {
         ));
     }
 
-    /// A fork basis cannot reference the target namespace's own manifest.
     #[tokio::test]
     async fn head_loader_rejects_a_fork_basis_owned_by_the_namespace_itself() {
         let (_directory, store) = local_store();
@@ -298,7 +294,6 @@ mod tests {
         );
     }
 
-    /// A fork basis may reference its source namespace.
     #[tokio::test]
     async fn head_loader_accepts_a_fork_basis_owned_by_the_source() {
         let (_directory, store) = local_store();

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -11,33 +11,12 @@ use loonfs_api::wire::control::{
 use loonfs_api::{DeleteNamespaceResponse, NamespaceId};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError, PutMode};
 
-/// Deletes a namespace by compare-and-swapping its head into the terminal
-/// `deleted` state (format spec, "Tombstones and deletion").
+/// Marks a namespace as deleted with a compare-and-swap on its head.
 ///
-/// `acquired_writer` is the deleting session's writer epoch, so no stale
-/// writer session can publish past the delete. The caller owns acquisition —
-/// [`NamespaceCommitEngine`](crate::publish::NamespaceCommitEngine), which
-/// refuses outright when the session is already fenced. Every retry that
-/// still has a swap to make re-checks that epoch against the reloaded head,
-/// so a writer takeover between acquisition and the swap aborts the delete
-/// instead of deleting a namespace another writer now owns.
-/// The delete linearizes at that swap: commits whose
-/// head advance serialized before it stay committed and durable; everything
-/// that observes the deleted head afterward fails with `namespace_deleted`.
-///
-/// A reload that finds the head already deleted answers before the fence,
-/// because there is no swap left to fence. The namespace is in the terminal
-/// state this call was asking for, so the answer is the same whoever owns
-/// the writer epoch now: `namespace_deleted` when this call never swapped
-/// (API spec, "DELETE /v0/namespaces/{ns}"), and success when it did. Every
-/// acquisition bumps the epoch, so checking the fence first would report a
-/// concurrent deleter's tombstone as `writer_fenced` and, worse, would fence
-/// this session for good over a delete that landed.
-///
-/// Because `deleted` is terminal, a lost acknowledgment is self-resolving:
-/// if a reload after an ambiguous swap shows the head deleted, the delete
-/// succeeded (ours or a concurrent deleter's — indistinguishable and
-/// equivalent). Only an unreachable store surfaces an unknown outcome.
+/// Each retry verifies the writer epoch before attempting the swap. A deleted
+/// head is checked first because no further write is required: it indicates
+/// success after an ambiguous swap, or `namespace_deleted` if this call never
+/// attempted one.
 pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -51,13 +30,10 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
             .map_err(|error| CoreError::MetadataProjection(error.into()))?;
         let head = loaded.state.clone();
 
-        // Terminal state first, ahead of the fence and the precondition
-        // below: both of those decide whether this call may swap, and there
-        // is nothing left to swap. See the fence paragraph above.
+        // Check the terminal state before the writer fence because a deleted
+        // namespace requires no further write.
         if head.status == (NamespaceStatus::Deleted {}) {
-            // If we already sent a swap, the delete is done regardless of
-            // whose swap landed; if we never sent one, the namespace was
-            // already deleted when we arrived.
+            // A deleted head resolves an earlier ambiguous swap as success.
             if attempted_swap {
                 return Ok(DeleteNamespaceResponse {
                     namespace_id: namespace_id.clone(),

--- a/crates/loonfs-core/src/path/mutation_path.rs
+++ b/crates/loonfs-core/src/path/mutation_path.rs
@@ -11,9 +11,8 @@ pub(crate) fn parse_absolute_path_for_core(absolute_path: &str) -> Result<Absolu
 /// [`CommitRequest`](crate::path::write::CommitRequest) carries:
 /// absolute, normalized, and not the root.
 ///
-/// This is the one named home for the invariant. Every surface that accepts
-/// a raw mutation path parses through it exactly once; planning re-asserts
-/// only the root guard ([`ensure_mutation_path`]) and never re-parses.
+/// Every surface that accepts a raw mutation path parses it here. Planning
+/// checks only the root guard and does not parse it again.
 pub fn parse_mutation_path(absolute_path: &str) -> Result<AbsolutePath> {
     let path = parse_absolute_path_for_core(absolute_path)?;
     ensure_mutation_path(&path)?;

--- a/crates/loonfs-core/src/path/read/current_files.rs
+++ b/crates/loonfs-core/src/path/read/current_files.rs
@@ -1,10 +1,6 @@
-//! Answering "where is this inode now?" for a batch of inode ids.
+//! Resolves the current state and path of a batch of inode IDs.
 //!
-//! A consumer that holds inode ids from an earlier enumeration asks this
-//! what became of them: whether each is still visible, which revision it
-//! carries now, and where it currently sits. Stale ids are ordinary input —
-//! a candidate generator routinely holds ids that were deleted since — so
-//! an unknown id is answered, not refused.
+//! Stale or unknown IDs are returned as not visible rather than rejected.
 
 use super::materialized_view::LoadedMetadataView;
 use crate::error::{CoreError, Result};
@@ -13,31 +9,19 @@ use loonfs_api::{AbsolutePath, InodeId, InodeKind, RevisionNo, ROOT_INODE_ID};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{HashMap, HashSet};
 
-/// The most inode ids [`resolve_current_files`] answers in one call.
-///
-/// One item costs about what one row of a listing page costs, so the batch
-/// is bounded by the same number: the pagination policy's maximum page limit
-/// ([`loonfs_api::DEFAULT_MAX_PAGE_LIMIT`]).
+/// Maximum number of inode IDs accepted by a batch resolution.
 pub const MAX_RESOLVE_CURRENT_FILES: usize = loonfs_api::DEFAULT_MAX_PAGE_LIMIT as usize;
 
-/// What one inode looks like in the namespace's current state.
-///
-/// The shape is file-oriented but tolerant of anything an id can name: a
-/// directory answers `visible` with a path and no revision, and an id that
-/// names nothing answers not visible with nothing else filled in.
+/// Current namespace state for one inode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CurrentFileState {
-    /// The inode this answer is about, echoed so batched answers stay
-    /// self-describing.
+    /// Requested inode ID.
     pub inode_id: InodeId,
-    /// Whether the inode is currently visible: it exists, no subtree
-    /// tombstone covers it or an ancestor, and its bindings still reach the
-    /// namespace root.
+    /// Whether the inode exists and has a visible path from the root.
     pub visible: bool,
-    /// The current revision number — `Some` only for a visible file that
-    /// has one.
+    /// Current revision number for a visible file.
     pub current_revision_no: Option<RevisionNo>,
-    /// Where the inode currently sits — `Some` exactly when `visible`.
+    /// Current path when visible.
     pub current_path: Option<AbsolutePath>,
 }
 
@@ -54,14 +38,9 @@ pub(crate) fn ensure_resolve_batch_within_cap(requested: usize) -> Result<()> {
     Ok(())
 }
 
-/// Resolves every inode id against one loaded view, in input order.
+/// Resolves inode IDs against one loaded view in input order.
 ///
-/// The whole batch reads one view, so every answer describes the same
-/// namespace state. Ancestor walks are shared: the batch memoizes each
-/// ancestor directory's path the first time a walk passes through it, so
-/// files under one directory pay for that chain once — the walking cost is
-/// bounded by the number of distinct ancestors in the batch, not by the
-/// number of items.
+/// The batch shares one namespace state and caches paths for common ancestors.
 pub(crate) async fn resolve_current_files<S: ObjectStore + ?Sized>(
     view: &LoadedMetadataView<'_, S>,
     inode_ids: &[InodeId],
@@ -151,14 +130,9 @@ fn missing(inode_id: InodeId) -> CurrentFileState {
     }
 }
 
-/// Derives the inode's current path by following parent bindings up to the
-/// root, then spelling the chain back out.
+/// Derives an inode's path by following parent bindings to the root.
 ///
-/// This is the same binding relation a path resolution walks downward, read
-/// from the other end. `None` means the chain never reaches the root — a
-/// binding cycle, or a dead end — which commit validation prevents; the walk
-/// reports it as "not visible" rather than inventing a path for state it
-/// cannot name.
+/// Returns `None` for a cycle or a chain that does not reach the root.
 async fn current_path<S: ObjectStore + ?Sized>(
     session: &mut MetadataViewSession<'_, '_, S>,
     ancestor_paths: &mut HashMap<InodeId, AbsolutePath>,
@@ -184,9 +158,7 @@ async fn current_path<S: ObjectStore + ?Sized>(
         climbed.push(binding);
     };
 
-    // `climbed` runs leaf-first; spelling it out from the known base
-    // downward names every directory passed on the way, which is what the
-    // next item under the same directory reuses.
+    // Cache each path reconstructed from the known ancestor to the leaf.
     let mut path = base;
     for binding in climbed.iter().rev() {
         path = path.join(&binding.display_name);

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -987,9 +987,6 @@ mod tests {
         (temp_dir, store, namespace_id)
     }
 
-    /// A stat-shaped build with the projection on carries the grouped
-    /// attribute state; with it off it carries none. The empty map is a
-    /// projected answer, not an absent one.
     #[tokio::test]
     async fn an_entry_build_projects_grouped_attributes_or_none() {
         let (_temp_dir, store, namespace_id) = namespace_with_annotated_children().await;
@@ -1038,9 +1035,6 @@ mod tests {
         assert!(omitted.attributes.is_none());
     }
 
-    /// The listing pays for attributes only when it was asked to. The session
-    /// counter is the evidence: an omitted projection never calls the lookup,
-    /// so a wide listing cannot quietly grow a per-entry read.
     #[tokio::test]
     async fn a_listing_reads_attributes_only_when_it_projects_them() {
         let (_temp_dir, store, namespace_id) = namespace_with_annotated_children().await;
@@ -1083,9 +1077,6 @@ mod tests {
         }
     }
 
-    /// A projected listing reads every entry's attributes in one wave, so the
-    /// per-entry build runs over cache hits and the page costs one round of
-    /// lookups rather than one per entry.
     #[tokio::test]
     async fn a_projected_listing_reads_its_attributes_in_one_wave() {
         let (_temp_dir, store, namespace_id) = namespace_with_annotated_children().await;

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -240,9 +240,6 @@ mod tests {
         }
     }
 
-    /// The commit id is the key, not the identity: two requests that differ
-    /// only in the id they are filed under are the same mutation, which is
-    /// what makes a reused id comparable against a receipt at all.
     #[test]
     fn commit_fingerprint_is_stable_for_canonical_paths() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -270,8 +267,6 @@ mod tests {
         assert_eq!(left, right);
     }
 
-    /// A one-operation convenience call and a one-element batch are the same
-    /// request, so they cannot fingerprint differently.
     #[test]
     fn one_operation_request_and_one_element_batch_share_identity() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -458,9 +453,6 @@ mod tests {
         .expect("recreating a deleted subtree plans as fresh state");
     }
 
-    /// A batch resolves each operation against what the earlier ones did:
-    /// the put walks into a directory that only exists because of the
-    /// create ahead of it, and both land in one commit.
     #[tokio::test]
     async fn later_operations_resolve_against_earlier_ones() {
         let (_temp_dir, store, namespace_id, _context) = setup_namespace().await;
@@ -511,8 +503,6 @@ mod tests {
         assert_eq!(planned.allocation.resulting_next_inode_id(), InodeId(4));
     }
 
-    /// A batch that deletes a path and recreates it resolves the create
-    /// against the delete, not against the state the request started from.
     #[tokio::test]
     async fn delete_then_create_resolves_against_the_delete() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
@@ -564,8 +554,6 @@ mod tests {
         ));
     }
 
-    /// The first failing operation aborts the request and names its own
-    /// position.
     #[tokio::test]
     async fn a_failing_operation_names_its_position() {
         let (_temp_dir, store, namespace_id, _context) = setup_namespace().await;

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -210,9 +210,6 @@ mod tests {
         CommitFingerprint::new_unchecked("v1:sha256:test".to_owned())
     }
 
-    /// Two plans through one session share the durable-layer memo: the
-    /// second plan's path walk answers from cache instead of re-scanning
-    /// the manifest for the components both paths share.
     #[tokio::test]
     async fn second_plan_in_a_session_hits_the_durable_cache() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
@@ -300,9 +297,6 @@ mod tests {
         );
     }
 
-    /// The first candidate implicitly creates `/wide`; the second must plan
-    /// against the session state that already contains it, or its own
-    /// duplicate `CreateDirectory` would fail child-name-absent validation.
     #[tokio::test]
     async fn batch_creates_under_one_new_parent_share_session_state() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -321,8 +321,6 @@ mod tests {
         );
     }
 
-    /// The mapper still refuses a pattern the reducer never produces, rather
-    /// than reading past the delta it recognizes.
     #[test]
     fn a_delta_pattern_the_reducer_never_produces_is_rejected() {
         let first = append_attributes(0);

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -1,25 +1,6 @@
-//! Namespace protocol operations: upload sessions, publish batches, and the
-//! change feed.
-//!
-//! These are the object-store implementations behind
-//! [`NamespaceEngine`](crate::engine::NamespaceEngine) calls; the module tree
-//! is crate-internal, so callers reach every operation through the re-exports
-//! below. Submodules follow the life of a mutation:
-//!
-//! - [`uploads`] stages content before metadata can reference it: begin,
-//!   stage, and complete durable upload sessions, including direct-put
-//!   targets that move bytes past the server and the in-process staging
-//!   writes that are both ends of an upload at once.
-//! - [`publish_view`] loads the publish-time metadata view: the current head
-//!   plus the WAL tail replayed over the manifest, with head-etag freshness
-//!   checks against concurrent publishers.
-//! - [`candidates`] admits one batch candidate at a time: request conversion,
-//!   commit-id validation, and duplicate resolution against durable receipts
-//!   and same-batch primaries.
-//! - [`batch`] publishes admitted candidates as one WAL segment plus one head
-//!   compare-and-swap, then fans outcomes back to every candidate slot.
-//! - [`changes`] reads committed changes after a sequence number and converts
-//!   durable WAL deltas to API deltas.
+//! Object-store implementations for uploads, commit publication, and the
+//! change feed. [`NamespaceEngine`](crate::engine::NamespaceEngine) exposes
+//! the supported entry points.
 
 mod batch;
 mod candidates;

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -1625,8 +1625,6 @@ mod tests {
         .await
     }
 
-    /// The durable session decision, rather than today's process default,
-    /// governs both part signing and completion after a restart.
     #[test]
     fn multipart_validation_uses_the_algorithm_frozen_in_the_session() {
         let session = UploadSessionState {
@@ -1777,10 +1775,6 @@ mod tests {
         assert_eq!(replay, first);
     }
 
-    /// An aborted session is logically absent: it will never select content,
-    /// which is the same thing the eventual physical deletion says. A
-    /// completion arriving afterwards must not resurrect it — and must not
-    /// touch the object the abort already cleaned up.
     #[tokio::test]
     async fn a_completion_after_an_abort_fails_terminally_and_touches_nothing() {
         let temp_dir = tempdir().expect("tempdir");
@@ -1901,9 +1895,6 @@ mod tests {
         assert!(matches!(retry, CoreError::UploadNotFound { .. }));
     }
 
-    /// Completion is terminal in the other direction. An abort cannot
-    /// quietly succeed over it, because by then the content may already be
-    /// published and deleting it would break a live reference.
     #[tokio::test]
     async fn an_abort_after_completion_is_refused_and_keeps_the_content() {
         let temp_dir = tempdir().expect("tempdir");
@@ -1937,8 +1928,6 @@ mod tests {
         );
     }
 
-    /// Aborting twice is a success that reports the abort that stands, so a
-    /// client retrying a lost response learns the same thing both times.
     #[tokio::test]
     async fn a_repeated_abort_reports_the_first_stamp() {
         let temp_dir = tempdir().expect("tempdir");
@@ -1976,7 +1965,6 @@ mod tests {
         assert_eq!(second, first);
     }
 
-    /// Bytes may only be staged into the one live state.
     #[tokio::test]
     async fn staging_into_a_terminal_session_is_refused() {
         let temp_dir = tempdir().expect("tempdir");
@@ -2021,8 +2009,6 @@ mod tests {
         assert!(matches!(error, CoreError::UploadNotFound { .. }));
     }
 
-    /// A receipt exists for exactly one state. An open session has nothing
-    /// durable to attest yet, and an aborted one never will.
     #[tokio::test]
     async fn only_a_completed_session_mints_a_receipt() {
         let temp_dir = tempdir().expect("tempdir");
@@ -2094,10 +2080,6 @@ mod tests {
         assert!(receipt.is_none(), "an aborted session attests nothing");
     }
 
-    /// Re-minting is what makes a lost publish response cheap, and its
-    /// window is what makes content reclamation decidable: the session hands
-    /// out fresh receipts for as long as its content is protected, then
-    /// stops.
     #[tokio::test]
     async fn a_completed_session_keeps_its_content_ref_after_token_minting_closes() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/recency.rs
+++ b/crates/loonfs-core/src/recency.rs
@@ -124,8 +124,6 @@ mod tests {
         assert_eq!(evicted, "a", "the stale position for a must not evict b");
     }
 
-    /// An eviction loop asks for a key it can drop; a queue holding only
-    /// ghosts has none, and saying so is what stops the loop spinning.
     #[test]
     fn eviction_reports_a_queue_of_ghosts_as_empty() {
         let mut recency = Recency::default();

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -229,69 +229,40 @@ pub(crate) async fn abort_unpublished_multipart_upload<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Bytes one ranged read of a content object fetches, and therefore the most
-/// of that object a streaming read holds at once.
-///
-/// The same 8 MiB the write path moves a large payload in
-/// ([`loonfs_objectstore::PROVIDER_MULTIPART_PART_BYTES`]): one transfer unit
-/// for both directions, large enough that per-request overhead disappears
-/// against the payload on a large object, small enough that a read's memory
-/// is a fixed few megabytes whatever the object's size.
+/// Bytes fetched by each ranged content read.
 pub const CONTENT_READ_CHUNK_BYTES: u64 = 8 * 1024 * 1024;
 
-/// One file's current content, read as fixed-size ranged chunks.
+/// Reads file content in fixed-size chunks while verifying its size and
+/// checksum.
 ///
-/// This is the streaming twin of the buffered content read, for a reader that
-/// must not hold what it reads: chunks are fetched one range at a time and
-/// the verifying digest is folded as they go, so a 50 GiB object costs one
-/// chunk of memory rather than 50 GiB. It verifies exactly what the buffered
-/// read verifies: the declared size and the reference's full-object checksum.
-///
-/// The object is immutable and named by a random content id, so nothing can
-/// rewrite it under a reader: chunk *n* and chunk *n+1* are always from the
-/// same object, and no revalidation between them is needed or done.
-///
-/// Verification lands on the final [`Self::next_chunk`] call — the one that
-/// reports the end of the content. A caller that stops early stops with
-/// unverified bytes, which is what streaming means and why the buffered read
-/// stays for callers that want the whole answer or none of it.
+/// Verification completes when [`Self::next_chunk`] returns `None`. A caller
+/// that stops earlier has not verified the complete object.
 pub struct FileContentStream<S> {
     store: S,
     entry: PathEntry,
     object_key: String,
     content_ref: ContentRef,
     chunk_bytes: NonZeroU64,
-    /// Offset the next ranged read starts at; also how much has been read.
+    /// Start offset of the next ranged read.
     next_offset: u64,
-    /// Offset this stream was opened at. Zero for a read of the whole
-    /// object, and the length of what the caller already holds for a
-    /// resumed one.
+    /// Offset where this stream started.
     resumed_from: u64,
-    /// How much of that head start the caller has folded in so far. The
-    /// stream fetches nothing until this reaches `resumed_from`, because
-    /// the verdict is over the whole object either way.
+    /// Number of bytes before `resumed_from` included in the checksum.
     prefix_folded: u64,
-    /// The checksum the complete object must produce, folded so far.
+    /// Checksum state for bytes processed so far.
     digest: StreamingChecksum,
-    /// The value `digest` is closed against.
+    /// Expected checksum.
     expected: Checksum,
-    /// The verdict on the complete object, once there is one. Kept because a
-    /// digest can only be closed once: without it, asking again after the end
-    /// would fold a second, empty digest and report a mismatch that is not
-    /// one.
+    /// Cached result because the checksum can only be finalized once.
     completion: Option<Result<(), DurableContentValidationError>>,
 }
 
 impl<S: ObjectStore> FileContentStream<S> {
     /// Opens a streaming read of the object `content_ref` names.
     ///
-    /// One `HeadObject` proves the object exists and is exactly as long as
-    /// the reference claims before any payload moves, which is what lets a
-    /// wrong-sized object fail without a partial answer having been handed
-    /// out.
-    /// `start_offset` is where the caller already is: bytes below it are
-    /// never fetched, and [`Self::fold_resumed_prefix`] is how they still
-    /// reach the digest.
+    /// The object size is validated before content is returned. For resumed
+    /// reads, `start_offset` skips bytes that the caller supplies through
+    /// [`Self::fold_resumed_prefix`].
     pub(crate) async fn open(
         store: S,
         content_store_id: &ContentStoreId,
@@ -319,20 +290,10 @@ impl<S: ObjectStore> FileContentStream<S> {
         })
     }
 
-    /// Hands the stream part of what the caller already holds, in order,
-    /// from the object's first byte.
+    /// Adds already-downloaded prefix bytes to a resumed read's checksum.
     ///
-    /// A resumed read still reports on the whole object, so the bytes it
-    /// will never fetch have to be folded into the same digest that closes
-    /// over the ones it does. Feeding the wrong bytes fails verification at
-    /// the end, which is exactly right: the reference is the authority on
-    /// what the object holds, not the partial copy on the caller's disk.
-    ///
-    /// Feeding the wrong *number* of bytes, or feeding them at the wrong
-    /// time, is refused here instead. A digest is order-dependent and closes
-    /// once, so those could only ever surface as a corruption verdict at the
-    /// end — a report about the object, for a mistake that was never the
-    /// object's.
+    /// Bytes must be supplied in order before fetching new chunks. Incorrect
+    /// bytes cause checksum verification to fail at the end of the stream.
     pub fn fold_resumed_prefix(&mut self, bytes: &[u8]) -> Result<(), CoreError> {
         if self.completion.is_some() {
             return Err(CoreError::Internal(format!(
@@ -377,12 +338,8 @@ impl<S: ObjectStore> FileContentStream<S> {
     /// arrive in order from wherever the stream started, and every one but
     /// the last is exactly the chunk size this stream was opened with.
     ///
-    /// This is the method callers outside this crate hold, so it speaks the
-    /// crate's error type: a content object that disagrees with its reference
-    /// is namespace corruption, and it is classified as such here rather than
-    /// at every call site. A resumed stream that has not been told what it
-    /// skipped is the caller's own mistake instead, and says so before
-    /// anything is fetched.
+    /// A resumed stream must receive its complete prefix before this method is
+    /// called.
     pub async fn next_chunk(&mut self) -> Result<Option<Bytes>, CoreError> {
         if self.prefix_folded != self.resumed_from {
             return Err(CoreError::ResumePrefixIncomplete {
@@ -612,44 +569,20 @@ pub(crate) async fn store_bytes_as_content_with_store_id<S: ObjectStore + ?Sized
     stage_bytes_under_content_id(store, content_store_id, ContentId::generate(), bytes).await
 }
 
-/// What a streamed staging write established about the content object.
+/// Result of staging streamed content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StagedStream {
-    /// Identity, length, and the digest folded over the payload on its way
-    /// through. The digest is always over the complete stream: the store
-    /// consumes the body before it evaluates any precondition.
+    /// Identity, length, and checksum of the complete payload.
     pub content_ref: ContentRef,
-    /// Whether the key was already occupied when the write tried to create
-    /// it. Only this session can have written there — the identity is
-    /// random and belongs to one session — so the caller decides whether
-    /// this is its own earlier attempt replayed or a conflicting one, by
-    /// comparing `content_ref` against what the session recorded.
+    /// Whether the object existed before this write.
     pub already_present: bool,
 }
 
-/// Stages a payload that arrives as a stream, hashing it on the way through.
+/// Stages and hashes a payload without buffering the complete stream.
 ///
-/// The bytes are never held whole: the digest is folded chunk by chunk as
-/// they are forwarded to the store, and the reference is built from that
-/// digest and the length the store reports back. The constructor guarantees
-/// that the checksum covers the complete payload.
-///
-/// The write is create-only, exactly like the buffered staging write. Past
-/// the store's multipart threshold the store cannot make that condition part
-/// of the write — a provider assembles a multipart object unconditionally —
-/// so it reads the key instead, immediately before the assembly. That read
-/// is not atomic with the assembly, so `already_present` answers for a key
-/// that was occupied before this write started and not for one occupied
-/// during it.
-///
-/// The only writer that could occupy the key during the write is another
-/// request against the same upload session, because the key is named by 128
-/// random bits one session owns. The staging claim in
-/// [`crate::protocol::upload_streamed_content`] is what keeps that writer
-/// away: exactly one request holds the claim, so `already_present` is exact
-/// for every caller that takes it. A caller that stages under a freshly
-/// minted identity nobody else holds — [`crate::protocol::stage_owned_stream`]
-/// — needs no claim for the same reason.
+/// The write is create-only. Multipart providers may check for an existing
+/// object immediately before assembly rather than atomically with it. Upload
+/// session claims prevent concurrent writes to the same random content ID.
 pub(crate) async fn stage_streamed_under_content_id<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: ContentStoreId,
@@ -683,8 +616,7 @@ pub(crate) async fn stage_streamed_under_content_id<S: ObjectStore + ?Sized>(
             )))
         }
         Ok(_) => false,
-        // The key is occupied. Only this session can name it, so the caller
-        // decides from the digest whether that was its own earlier attempt.
+        // The caller compares the checksum with the session's recorded value.
         Err(ObjectStoreError::PreconditionFailed { .. }) => true,
         Err(err) => return Err(CoreError::store(&object_key, &err)),
     };
@@ -695,12 +627,7 @@ pub(crate) async fn stage_streamed_under_content_id<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Reads a payload without writing it anywhere, and reports what it was.
-///
-/// This is how a session that has already staged content answers a repeated
-/// upload: the only way to tell "the same bytes again" from "different
-/// bytes" is to hash them, and the object it already owns must not be
-/// touched while that is decided.
+/// Reads and hashes a stream without storing it.
 pub(crate) async fn identify_streamed_payload(
     content_id: ContentId,
     mut body: ByteStream,
@@ -718,7 +645,7 @@ pub(crate) async fn identify_streamed_payload(
     ))
 }
 
-/// What a streamed payload amounted to, folded as it passed through.
+/// Size and checksum state for a streamed payload.
 #[derive(Debug, Default)]
 struct StreamedPayload {
     digest: Sha256,
@@ -873,9 +800,6 @@ mod tests {
         ));
     }
 
-    /// A direct transfer to Google Cloud Storage produces a reference whose
-    /// only evidence is the CRC-32C that provider computed. Reads verify it
-    /// like any other full-object evidence, and a wrong object fails on it.
     #[tokio::test]
     async fn read_verifies_a_reference_whose_only_evidence_is_a_crc32c() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -908,10 +832,6 @@ mod tests {
         ));
     }
 
-    /// A direct multipart upload produces a reference whose only evidence is
-    /// the CRC-64/NVME the provider computed over the assembly. Reads must
-    /// verify it — the alternative is a whole write path whose bytes are
-    /// never checked on the way back out.
     #[tokio::test]
     async fn read_verifies_a_reference_whose_only_evidence_is_a_crc64nvme() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1017,8 +937,6 @@ mod tests {
         ));
     }
 
-    /// Two writers staging the same bytes get two objects. There is no
-    /// shared key to coalesce on, so neither can observe the other.
     #[tokio::test]
     async fn staging_identical_bytes_twice_mints_two_distinct_objects() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1112,8 +1030,6 @@ mod tests {
         .await
     }
 
-    /// A streamed read hands back the object in chunks of the size it was
-    /// opened with, in order, and ends only after verifying the whole thing.
     #[tokio::test]
     async fn a_streamed_read_returns_the_object_one_chunk_at_a_time() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1137,9 +1053,6 @@ mod tests {
         assert_eq!(chunks.concat(), bytes, "the object arrives byte-identical");
     }
 
-    /// The end is an answer, not an event: a caller that asks again after it
-    /// gets the same verdict rather than a digest closed a second time over
-    /// nothing.
     #[tokio::test]
     async fn a_finished_stream_repeats_its_verdict() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1155,8 +1068,6 @@ mod tests {
         assert!(stream.next_chunk().await.expect("verified end").is_none());
     }
 
-    /// A resumed read fetches only what it does not already have, and still
-    /// closes its verdict over the whole object.
     #[tokio::test]
     async fn a_resumed_read_fetches_only_the_rest_and_verifies_all_of_it() {
         let (_temp_dir, inner, content_store_id) = test_store();
@@ -1189,9 +1100,6 @@ mod tests {
         );
     }
 
-    /// The prefix is part of the verdict, not a formality: bytes that are
-    /// not the object's fail the read at its end, and a stream driven before
-    /// it has them refuses to fetch anything at all.
     #[tokio::test]
     async fn a_resumed_read_holds_the_prefix_to_the_same_verdict() {
         let (_temp_dir, inner, content_store_id) = test_store();
@@ -1249,9 +1157,6 @@ mod tests {
         );
     }
 
-    /// A prefix handed over in pieces is the ordinary case, and the fold
-    /// accepts every one of them: the digest only cares that the bytes
-    /// arrive in order.
     #[tokio::test]
     async fn a_resumed_prefix_may_be_folded_in_pieces() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1273,9 +1178,6 @@ mod tests {
         assert_eq!(fetched, bytes[held..]);
     }
 
-    /// A partial longer than the content it claims to resume is the caller's
-    /// own file being wrong, and it is refused where that is still visible
-    /// — not folded in to reappear as a corruption verdict about the object.
     #[tokio::test]
     async fn a_prefix_longer_than_the_content_is_refused() {
         let (_temp_dir, inner, content_store_id) = test_store();
@@ -1306,9 +1208,6 @@ mod tests {
         assert_eq!(store.count(OperationClass::Read), 0, "nothing was fetched");
     }
 
-    /// The digest folds in one direction, so a prefix offered after the
-    /// stream has already fetched content could only ever land in the wrong
-    /// place. Saying so beats folding it and blaming the object.
     #[tokio::test]
     async fn a_prefix_offered_after_a_fetch_is_refused() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1329,8 +1228,6 @@ mod tests {
         );
     }
 
-    /// The verdict is closed once. A prefix offered after it exists cannot
-    /// change it, so the fold refuses rather than pretending to.
     #[tokio::test]
     async fn a_prefix_offered_after_the_end_is_refused() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1352,8 +1249,6 @@ mod tests {
         );
     }
 
-    /// An empty file has nothing to fetch and still verifies: the digest of
-    /// no bytes is the digest its reference carries.
     #[tokio::test]
     async fn a_streamed_read_of_an_empty_object_verifies_without_fetching() {
         let (_temp_dir, inner, content_store_id) = test_store();
@@ -1373,10 +1268,6 @@ mod tests {
         );
     }
 
-    /// A CRC-32C-only reference is what a direct transfer to Google Cloud
-    /// Storage leaves behind, and a streamed read of one is verified like any
-    /// other: folded chunk by chunk, closed at the end, and failed when the
-    /// object is not what the reference says.
     #[tokio::test]
     async fn a_streamed_read_verifies_a_reference_whose_only_evidence_is_a_crc32c() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1426,16 +1317,11 @@ mod tests {
         );
     }
 
-    /// A CRC folds forward from a running value, so a resumed read of a
-    /// CRC-32C-only reference closes over the prefix it never fetched
-    /// exactly as a hashed one does.
     #[tokio::test]
     async fn a_resumed_crc32c_read_folds_the_prefix_into_the_same_verdict() {
         assert_resumed_checksum_verification(Checksum::crc32c).await;
     }
 
-    /// A multipart CRC obeys the same resumed-read contract: the retained
-    /// prefix and fetched suffix close one CRC-64/NVME verdict.
     #[tokio::test]
     async fn a_resumed_crc64nvme_read_folds_the_prefix_into_the_same_verdict() {
         assert_resumed_checksum_verification(Checksum::crc64nvme).await;
@@ -1499,9 +1385,6 @@ mod tests {
         );
     }
 
-    /// The same evidence the buffered read holds bytes to, folded chunk by
-    /// chunk: a provider-assembled object carries only a CRC, and a streamed
-    /// read verifies it rather than waving it through.
     #[tokio::test]
     async fn a_streamed_read_verifies_a_reference_whose_only_evidence_is_a_crc64nvme() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1524,10 +1407,6 @@ mod tests {
         assert_eq!(read, bytes);
     }
 
-    /// Bytes that disagree with the reference fail the read at the call that
-    /// reports the end, after the chunks have been handed out. That is what
-    /// streaming costs, and why a caller that installs a file installs it
-    /// only once this call has returned.
     #[tokio::test]
     async fn a_streamed_read_rejects_an_object_that_does_not_match_its_reference() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1560,8 +1439,6 @@ mod tests {
         ));
     }
 
-    /// An object that is not there fails when the stream is opened, so a
-    /// caller learns it before it has written anything anywhere.
     #[tokio::test]
     async fn a_streamed_read_reports_a_missing_object_when_it_opens() {
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1576,9 +1453,6 @@ mod tests {
         ));
     }
 
-    /// An object longer or shorter than its reference claims is caught
-    /// before any of it is handed out, by the same size check the buffered
-    /// read makes over the bytes it downloaded.
     #[tokio::test]
     async fn a_streamed_read_rejects_an_object_of_the_wrong_length() {
         let (_temp_dir, store, content_store_id) = test_store();

--- a/crates/loonfs-core/src/test_support.rs
+++ b/crates/loonfs-core/src/test_support.rs
@@ -1,9 +1,7 @@
-//! Test doubles for this crate's public seams.
+//! Test helpers and recording implementations.
 
-// Path-mutation wrappers that drive the production commit pipeline one
-// operation at a time. They are `#[cfg(test)]`-only rather than part of the
-// `test-support` feature surface: they lean on this crate's dev-dependencies,
-// and their consumers (checkpoint and planner tests) are in-crate.
+// These path-mutation helpers use dev-dependencies and are only needed by
+// in-crate checkpoint and planner tests.
 #[cfg(test)]
 mod content_write;
 #[cfg(test)]
@@ -17,16 +15,15 @@ use bytes::Bytes;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-/// One call made against a [`RecordingStoredMetadataBlockCache`], in the
-/// form that says what the caller asked for.
+/// A call recorded by [`RecordingStoredMetadataBlockCache`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecordedStoredMetadataBlockCall {
-    /// A lookup, with whether it was answered from the map.
+    /// A lookup and whether it hit the cache.
     Get {
         key: StoredMetadataBlockKey,
         hit: bool,
     },
-    /// An insert, with the length of the bytes offered.
+    /// An insert and its byte length.
     Insert {
         key: StoredMetadataBlockKey,
         bytes: usize,
@@ -92,12 +89,7 @@ impl RecordingStoredMetadataBlockCache {
         self.state().closed
     }
 
-    /// Replaces what is held for `key` with the same number of bytes that no
-    /// longer checksum, the way a lost write or a bad sector leaves an
-    /// entry. Does nothing for a key the cache is not holding.
-    ///
-    /// The replacement is not recorded: it is the test arranging the world,
-    /// not a call the code under test made.
+    /// Corrupts an existing entry without recording a cache operation.
     pub fn corrupt(&self, key: &StoredMetadataBlockKey) {
         let mut state = self.state();
         if let Some(held) = state.entries.get_mut(key) {

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -596,9 +596,6 @@ async fn write_linked_chain(
     pointers
 }
 
-/// A caller that meters its own reads caps the load, and the loader stops
-/// once it has read that many segment bodies. It reports how many it read
-/// so the caller can charge for exactly those.
 #[tokio::test]
 async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
     let temp_dir = tempdir().expect("tempdir");
@@ -668,8 +665,6 @@ async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
     );
 }
 
-/// A limit that covers the chain exactly does not truncate it. The load
-/// completes and matches what an unbounded load returns.
 #[tokio::test]
 async fn a_limit_that_covers_the_chain_loads_all_of_it() {
     let temp_dir = tempdir().expect("tempdir");
@@ -711,11 +706,6 @@ async fn a_limit_that_covers_the_chain_loads_all_of_it() {
     assert_eq!(store.count(OperationClass::Get), 5);
 }
 
-/// A prefetch request that fails is a request the store answered, so it
-/// counts like any other. The walk fetches that segment itself and the
-/// chain still loads. The number the load reports is the number of requests
-/// it issued: one failed prefetch and one walk fetch for each of the three
-/// segments, which is what the counting wrapper saw.
 #[tokio::test]
 async fn a_failed_prefetch_costs_its_own_request_and_the_walk_loads_the_chain() {
     let temp_dir = tempdir().expect("tempdir");
@@ -775,9 +765,6 @@ async fn a_failed_prefetch_costs_its_own_request_and_the_walk_loads_the_chain() 
     }
 }
 
-/// The limit bounds every request the load issues, prefetch included. A
-/// store that fails every prefetch cannot make the load exceed it: the walk
-/// stops once the failures have spent the limit.
 #[tokio::test]
 async fn failed_prefetch_requests_count_against_the_limit() {
     let temp_dir = tempdir().expect("tempdir");
@@ -940,9 +927,6 @@ fn tail_count_request<'a>(
     }
 }
 
-/// The count takes no store at all, so "reads no bodies" is the signature
-/// rather than an assertion — and it holds at the longest tail a landed
-/// publish can leave behind, which is what the head is sized to describe.
 #[test]
 fn tail_count_from_contiguous_hints_covers_the_longest_legal_tail() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1019,9 +1003,6 @@ fn tail_count_at_genesis_is_zero_without_tip_or_hints() {
     assert_eq!(count, 0);
 }
 
-/// A head that does not name its whole tail is corrupted. The count says so
-/// instead of walking chain links one round trip at a time on an inspection
-/// call.
 #[test]
 fn tail_count_rejects_a_head_that_does_not_describe_its_tail() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1068,8 +1049,6 @@ fn tail_count_rejects_a_head_that_does_not_describe_its_tail() {
     ));
 }
 
-/// The two readers diverge on purpose: replay walks chain links for history
-/// the head no longer names, and the count refuses to.
 #[tokio::test]
 async fn tail_count_and_chain_load_agree_where_the_head_describes_the_tail() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1099,8 +1078,6 @@ async fn tail_count_and_chain_load_agree_where_the_head_describes_the_tail() {
     assert_eq!(loaded.segments().len(), 3);
 }
 
-/// The change feed reads history below the accelerator window, so the chain
-/// loader keeps its predecessor walk.
 #[tokio::test]
 async fn chain_load_walks_predecessor_links_past_the_hinted_window() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1129,8 +1106,6 @@ async fn chain_load_walks_predecessor_links_past_the_hinted_window() {
     assert_eq!(loaded.segments()[0].records()[0].seq, ChangeSeq(1));
 }
 
-/// A boundary-length replay is one wave shape: every segment arrives from
-/// the hints, none is fetched twice, and the width is the prefetch bound.
 #[tokio::test]
 async fn boundary_length_replay_fetches_every_segment_once_in_bounded_waves() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1172,7 +1147,6 @@ async fn boundary_length_replay_fetches_every_segment_once_in_bounded_waves() {
     assert_eq!(reads.peak_in_flight, RECENT_SEGMENT_PREFETCH_CONCURRENCY);
 }
 
-/// The prefetch fetches only the segments the replay gap intersects.
 #[tokio::test]
 async fn prefetch_fetches_only_the_segments_the_gap_intersects() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1211,8 +1185,6 @@ async fn prefetch_fetches_only_the_segments_the_gap_intersects() {
     assert_eq!(fetched, expected);
 }
 
-/// Prefetching moves where the bytes come from, not what is checked: every
-/// chain validation runs in the sequential pass either way.
 #[tokio::test]
 async fn a_corrupt_segment_inside_the_hinted_set_is_still_rejected() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -356,9 +356,6 @@ async fn an_update_rejects_a_request_that_does_not_describe_one_change() {
     }
 }
 
-/// An update that leaves the map exactly as it was publishes nothing. This is
-/// the rule that differs from put: an identical-content put appends a
-/// revision because a file's revisions are its history.
 #[tokio::test]
 async fn an_update_that_changes_nothing_is_rejected() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -414,8 +411,6 @@ async fn an_update_that_changes_nothing_is_rejected() {
     );
 }
 
-/// The limits are checked against the map the update produces, not against
-/// what it carries: one small value can push an already-large map over a cap.
 #[tokio::test]
 async fn an_update_is_rejected_when_the_resulting_map_breaks_a_limit() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -530,8 +525,6 @@ async fn a_caller_supplied_stale_expectation_reports_expected_and_actual() {
     );
 }
 
-/// A caller that names the inode it means gets the same protection without
-/// waiting for the commit guards.
 #[tokio::test]
 async fn a_wrong_expected_inode_is_rejected() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -569,8 +562,6 @@ async fn a_wrong_expected_inode_is_rejected() {
 // Multi-operation requests
 // ---------------------------------------------------------------------------
 
-/// The update resolves against what the put in the same request did, and both
-/// land at one sequence.
 #[tokio::test]
 async fn a_put_and_an_update_of_the_new_path_commit_together() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -608,8 +599,6 @@ async fn a_put_and_an_update_of_the_new_path_commit_together() {
     );
 }
 
-/// Two updates of one key in one request advance the counter twice, so the
-/// second observed what the first wrote.
 #[tokio::test]
 async fn two_updates_in_one_request_advance_the_revision_twice() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -711,9 +700,6 @@ async fn a_request_that_stops_at_a_bad_update_publishes_nothing() {
 // Durability: across a flush, and across a fork
 // ---------------------------------------------------------------------------
 
-/// After a flush the attributes live in metadata segments rather than in the
-/// replayed WAL tail. The next update's revision number is what says the
-/// write path read them from there: a lost map would restart the counter.
 #[tokio::test]
 async fn attributes_survive_a_flush_and_the_counter_keeps_going() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -786,8 +772,6 @@ async fn attributes_survive_a_flush_and_the_counter_keeps_going() {
     );
 }
 
-/// A fork reads its source's basis until it publishes a manifest of its own,
-/// and its first flush carries the inherited rows forward.
 #[tokio::test]
 async fn a_fork_reads_the_sources_attributes_before_and_after_its_first_flush() {
     let (_temp_dir, store, source, context) = setup().await;
@@ -880,8 +864,6 @@ async fn a_fork_reads_the_sources_attributes_before_and_after_its_first_flush() 
 // What every other operation does to attributes
 // ---------------------------------------------------------------------------
 
-/// Attributes travel with inode identity, so nothing that moves an inode or
-/// changes its content touches them.
 #[tokio::test]
 async fn move_rename_replace_and_restore_preserve_attributes() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -955,8 +937,6 @@ async fn move_rename_replace_and_restore_preserve_attributes() {
     );
 }
 
-/// A delete hides an inode without touching its attributes, and an undelete
-/// gives back the same map at the same revision.
 #[tokio::test]
 async fn a_delete_keeps_attributes_and_an_undelete_gives_them_back() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -1039,9 +1019,6 @@ async fn a_delete_keeps_attributes_and_an_undelete_gives_them_back() {
     assert!(no_op.to_string().contains("unchanged"), "{no_op}");
 }
 
-/// A copy to a vacant destination is a new resource standing for the source,
-/// so it starts with the source's attributes — as its own internal operation
-/// with its own event.
 #[tokio::test]
 async fn a_copy_to_a_vacant_destination_inherits_the_sources_attributes() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -1109,7 +1086,6 @@ async fn a_copy_to_a_vacant_destination_inherits_the_sources_attributes() {
     assert_eq!(copy_events, vec!["file_created", "attributes_changed"]);
 }
 
-/// A copy with nothing to inherit publishes no attribute event at all.
 #[tokio::test]
 async fn a_copy_of_a_file_without_attributes_publishes_no_attribute_event() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -1145,8 +1121,6 @@ async fn a_copy_of_a_file_without_attributes_publishes_no_attribute_event() {
     );
 }
 
-/// Copying over an existing file changes its content and nothing else: the
-/// destination is a resource that already exists and keeps what it holds.
 #[tokio::test]
 async fn a_copy_over_an_existing_file_leaves_its_attributes_alone() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
@@ -1207,8 +1181,6 @@ async fn a_copy_over_an_existing_file_leaves_its_attributes_alone() {
     );
 }
 
-/// Removing every key is a real update publishing the empty map, and the
-/// counter advances for it.
 #[tokio::test]
 async fn clearing_every_attribute_publishes_the_empty_map() {
     let (_temp_dir, store, namespace_id, context) = setup().await;

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -700,13 +700,6 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
     );
 }
 
-/// A batch where the WAL write fails must report that failure for every
-/// outcome that depended on the batch publishing: the accepted candidate and
-/// the rejection decided against its speculative in-batch state. Before this
-/// contract the speculative rejection surfaced as a definitive `PathConflict`
-/// derived from a create that never became durable, so its client gave up
-/// instead of retrying. Rejections decided against the durable materialization alone
-/// stand regardless of the batch outcome.
 #[tokio::test]
 async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
     let temp_dir = tempdir().expect("tempdir");
@@ -827,10 +820,6 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
     );
 }
 
-/// Same contract when the batch dies at the head CAS instead of the WAL
-/// write: the stale-head error replaces the rejection decided against the
-/// accepted candidate's speculative state, while the materialization-decided rejection
-/// stands.
 #[tokio::test]
 async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -294,8 +294,6 @@ async fn valid_content_admission_skips_durable_content_validation() {
     assert_eq!(store.count(OperationClass::Read), 0);
 }
 
-/// A later candidate in one batch resolves against what the earlier one did,
-/// so a delete of a path the earlier candidate renamed away finds nothing.
 #[tokio::test]
 async fn a_later_batch_candidate_observes_the_earlier_one() {
     let temp_dir = tempdir().expect("tempdir");
@@ -359,8 +357,6 @@ async fn a_later_batch_candidate_observes_the_earlier_one() {
     assert_eq!(error.code(), ErrorCode::PathNotFound);
 }
 
-/// The directory-empty rule is evaluated against what the earlier candidate
-/// did, so a delete of a directory a earlier candidate just filled fails.
 #[tokio::test]
 async fn a_directory_delete_observes_an_earlier_batch_candidate() {
     let temp_dir = tempdir().expect("tempdir");
@@ -414,8 +410,6 @@ async fn a_directory_delete_observes_an_earlier_batch_candidate() {
     assert_eq!(error.code(), ErrorCode::DirectoryNotEmpty);
 }
 
-/// A rejected candidate returns any inode IDs it reserved, so the next
-/// accepted candidate can use them.
 #[tokio::test]
 async fn a_rejected_batch_candidate_does_not_consume_inode_ids() {
     let temp_dir = tempdir().expect("tempdir");
@@ -581,9 +575,6 @@ async fn metadata_only_mutation_does_not_validate_content_store_refs() {
     );
 }
 
-/// Validation runs before content coverage. A put with both a stale revision
-/// guard and missing content proof returns the stale revision without reading
-/// from the content store.
 #[tokio::test]
 async fn a_guarded_put_reports_the_stale_revision_before_missing_content_without_content_reads() {
     let temp_dir = tempdir().expect("tempdir");
@@ -674,9 +665,6 @@ async fn restore_revision_missing_source_is_revision_not_found() {
     assert_eq!(error.code(), ErrorCode::RevisionNotFound);
 }
 
-/// A directory and the files under it land in one commit: the puts resolve
-/// against the directory the first operation creates, and the change feed
-/// reports one committed change whose events follow operation order.
 #[tokio::test]
 async fn a_batch_creates_a_directory_and_writes_into_it_in_one_commit() {
     let temp_dir = tempdir().expect("tempdir");
@@ -739,9 +727,6 @@ async fn a_batch_creates_a_directory_and_writes_into_it_in_one_commit() {
     assert_eq!(names, vec!["reports", "a.txt", "b.txt"]);
 }
 
-/// A request stops at its first failing operation and nothing it would have
-/// written becomes visible. The same commit id then commits a corrected
-/// batch, because the failed attempt left no receipt behind.
 #[tokio::test]
 async fn a_batch_that_stops_commits_nothing_and_names_the_operation() {
     let temp_dir = tempdir().expect("tempdir");
@@ -800,9 +785,6 @@ async fn a_batch_that_stops_commits_nothing_and_names_the_operation() {
     assert_eq!(response.committed_seq, ChangeSeq(1));
 }
 
-/// Reusing a commit id replays the original receipt for the same request and
-/// conflicts for a different one, and a one-operation request is the same
-/// request as a one-element batch.
 #[tokio::test]
 async fn a_reused_commit_id_replays_the_receipt_or_conflicts() {
     let temp_dir = tempdir().expect("tempdir");
@@ -870,8 +852,6 @@ async fn a_reused_commit_id_replays_the_receipt_or_conflicts() {
     assert_eq!(as_batch.committed_seq, convenience.committed_seq);
 }
 
-/// Operation order is the contract: creating then deleting a path leaves it
-/// gone, and deleting then creating leaves it present.
 #[tokio::test]
 async fn operation_order_decides_the_outcome() {
     let temp_dir = tempdir().expect("tempdir");
@@ -930,9 +910,6 @@ async fn operation_order_decides_the_outcome() {
         .expect("the create ran after the delete");
 }
 
-/// A caller's revision guard is evaluated against the state its own
-/// operation sees, which includes the revision an earlier operation of the
-/// same request wrote.
 #[tokio::test]
 async fn a_revision_guard_observes_an_earlier_operation_of_the_same_request() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1014,11 +991,6 @@ async fn a_revision_guard_observes_an_earlier_operation_of_the_same_request() {
     );
 }
 
-/// The end-to-end promise: a client that lost its commit response reads the
-/// session again, gets a fresh receipt for bytes that never moved, and
-/// publishes with it. The receipt it was holding is refused at admission
-/// first, so the re-mint is doing real work rather than papering over a
-/// token that would have been accepted anyway.
 #[tokio::test]
 async fn a_re_minted_receipt_publishes_after_the_first_one_expired() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/tests/it/differential.rs
+++ b/crates/loonfs-core/tests/it/differential.rs
@@ -413,8 +413,6 @@ fn metadata_apply_matches_model_for_attribute_writes_and_removals() {
     ]);
 }
 
-/// A clear is a real revision carrying the empty map, and both sides must
-/// record it rather than dropping the row.
 #[test]
 fn metadata_apply_matches_model_for_a_cleared_attribute_map() {
     assert_states_match(&[
@@ -424,9 +422,6 @@ fn metadata_apply_matches_model_for_a_cleared_attribute_map() {
     ]);
 }
 
-/// The copy path emits the create and the inherited attributes as two
-/// internal operations of one commit, so both sides see them at one sequence
-/// in delta order.
 #[test]
 fn metadata_apply_matches_model_for_copy_attribute_inheritance() {
     assert_states_match(&[
@@ -457,8 +452,6 @@ fn metadata_apply_matches_model_for_copy_attribute_inheritance() {
     ]);
 }
 
-/// A delete keeps the attribute rows and an undelete reveals them again, so
-/// neither side may drop or rewrite a row for an inode that went away.
 #[test]
 fn metadata_apply_matches_model_for_delete_then_undelete_with_attributes() {
     assert_states_match(&[

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -92,9 +92,6 @@ fn metadata_segment_counting_store(root: impl AsRef<Path>) -> CountingStore<Loca
     )
 }
 
-/// A created namespace is exactly one object. It serves reads and accepts
-/// writes with no root, no floor, and no manifest anywhere; the first flush
-/// is what publishes a root.
 #[tokio::test]
 async fn a_created_namespace_is_one_object_until_its_first_flush() {
     let temp_dir = tempdir().expect("tempdir");
@@ -187,8 +184,6 @@ async fn a_created_namespace_is_one_object_until_its_first_flush() {
     assert_eq!(status.current_manifest_no, Some(ManifestNo(1)));
 }
 
-/// Exactly one of two concurrent creates of the same id wins; the loser is
-/// told the id is taken.
 #[tokio::test]
 async fn concurrent_creates_of_one_id_leave_exactly_one_winner() {
     let temp_dir = tempdir().expect("tempdir");
@@ -216,11 +211,6 @@ async fn concurrent_creates_of_one_id_leave_exactly_one_winner() {
     );
 }
 
-/// A create retry after a lost acknowledgment answers `namespace_exists`,
-/// whoever made the namespace, and leaves the landed head untouched. The
-/// namespace it names is complete and usable, which is the whole point: the
-/// old protocol answered this case with a partial namespace nobody could
-/// use. A caller that wants the retry to succeed asks for that.
 #[tokio::test]
 async fn a_create_retry_after_a_lost_acknowledgment_reports_the_id_as_taken() {
     let temp_dir = tempdir().expect("tempdir");
@@ -260,8 +250,6 @@ async fn a_create_retry_after_a_lost_acknowledgment_reports_the_id_as_taken() {
     );
 }
 
-/// The same one-winner rule covers two forks racing for one target, and a
-/// create racing a fork for the same id.
 #[tokio::test]
 async fn concurrent_installs_of_one_target_leave_exactly_one_winner() {
     let temp_dir = tempdir().expect("tempdir");
@@ -316,8 +304,6 @@ async fn concurrent_installs_of_one_target_leave_exactly_one_winner() {
     }
 }
 
-/// A fork target is one object too: it reads through the source's manifest
-/// until it flushes, and it never copies content or metadata.
 #[tokio::test]
 async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     let temp_dir = tempdir().expect("tempdir");
@@ -520,8 +506,6 @@ async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     );
 }
 
-/// The fork target keeps reading after the source namespace is deleted: the
-/// pinned basis and the source-owned segments it names both survive.
 #[tokio::test]
 async fn fork_clone_survives_source_delete() {
     let temp_dir = tempdir().expect("tempdir");
@@ -550,9 +534,6 @@ async fn fork_clone_survives_source_delete() {
     );
 }
 
-/// The head authorizes the foreign basis and nothing else does: a recorded
-/// checksum that disagrees with the manifest is corruption, never a
-/// fallback to some other basis.
 #[tokio::test]
 async fn a_fork_basis_checksum_mismatch_is_corruption() {
     let temp_dir = tempdir().expect("tempdir");
@@ -588,9 +569,6 @@ async fn a_fork_basis_checksum_mismatch_is_corruption() {
     assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
 }
 
-/// Checkpointing a fork target that has never flushed materializes its
-/// first own manifest, because a checkpoint record can only pin a manifest
-/// of its own namespace.
 #[tokio::test]
 async fn checkpointing_an_unflushed_fork_materializes_its_first_manifest() {
     let temp_dir = tempdir().expect("tempdir");
@@ -649,9 +627,6 @@ async fn checkpointing_an_unflushed_fork_materializes_its_first_manifest() {
     );
 }
 
-/// A fork that loses its source checkpoint after the target head lands
-/// deletes the target it just created, rather than leaving a namespace
-/// whose basis nothing protects.
 #[tokio::test]
 async fn a_fork_whose_source_pin_is_released_deletes_its_own_target() {
     let temp_dir = tempdir().expect("tempdir");
@@ -680,10 +655,6 @@ async fn a_fork_whose_source_pin_is_released_deletes_its_own_target() {
     assert_eq!(retry.code(), ErrorCode::NamespaceDeleted);
 }
 
-/// The guard is a margin, not a bare re-read. A source record that is still
-/// active but has only the guard margin of lease left could be released by
-/// a pass at any moment, so the fork refuses it and deletes the target it
-/// just published rather than leaving a basis nothing protects.
 #[tokio::test]
 async fn a_fork_whose_source_lease_runs_out_deletes_its_own_target() {
     let temp_dir = tempdir().expect("tempdir");
@@ -710,9 +681,6 @@ async fn a_fork_whose_source_lease_runs_out_deletes_its_own_target() {
     );
 }
 
-/// The other side of the guard: a fork with its whole lease ahead of it
-/// stands, even with a garbage-collection pass running against the source
-/// at the same time.
 #[tokio::test]
 async fn a_fork_with_lease_to_spare_survives_a_concurrent_gc_pass() {
     let temp_dir = tempdir().expect("tempdir");
@@ -741,8 +709,6 @@ async fn a_fork_with_lease_to_spare_survives_a_concurrent_gc_pass() {
     );
 }
 
-/// A source manifest that no longer validates blocks the fork before any
-/// target object exists.
 #[tokio::test]
 async fn fork_namespace_rejects_corrupt_source_manifest_descriptors() {
     let temp_dir = tempdir().expect("tempdir");
@@ -798,8 +764,6 @@ async fn fork_namespace_rejects_corrupt_source_manifest_descriptors() {
     );
 }
 
-/// A source checkpoint that cannot be written aborts the fork before the
-/// target exists at all.
 #[tokio::test]
 async fn fork_source_checkpoint_failure_leaves_target_namespace_absent() {
     let temp_dir = tempdir().expect("tempdir");
@@ -836,8 +800,6 @@ async fn fork_source_checkpoint_failure_leaves_target_namespace_absent() {
     );
 }
 
-/// A create that loses its conditional write to an unrelated namespace
-/// reports the id as taken, and leaves that namespace alone.
 #[tokio::test]
 async fn a_create_losing_to_a_foreign_head_reports_the_id_as_taken() {
     let temp_dir = tempdir().expect("tempdir");
@@ -968,9 +930,6 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
     );
 }
 
-/// A namespace with no root of its own is still a legal garbage-collection
-/// subject: it roots its WAL from birth and nothing else, and a later
-/// deleted namespace reclaims down to its tombstone.
 #[tokio::test]
 async fn gc_handles_a_namespace_with_no_root_and_then_its_tombstone() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -64,9 +64,6 @@ async fn put_file<S: ObjectStore + ?Sized>(
         .expect("put file");
 }
 
-/// Nothing correct depends on listing: reads, commits, and the change feed
-/// complete without a single LIST, even with junk parked in the segment
-/// collection (chain traversal never sees it).
 #[tokio::test]
 async fn reads_commits_and_change_feed_never_list() {
     let temp_dir = tempdir().expect("tempdir");
@@ -153,9 +150,6 @@ async fn reads_commits_and_change_feed_never_list() {
     );
 }
 
-/// The head changes only when commits land: checkpoint creation, root
-/// publication, floor advancement, garbage collection, and the upload
-/// workflow leave `wal/head.json` byte-identical.
 #[tokio::test]
 async fn maintenance_never_touches_the_wal_head() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -1724,11 +1724,6 @@ async fn no_replace_put_rejects_casefold_and_normalization_equivalent_name() {
     assert_eq!(error.code(), ErrorCode::PathConflict);
 }
 
-/// Listings decide visibility during child enumeration and then look up
-/// revision heads without re-deriving it, so this pins both halves of that
-/// contract: a recursively deleted subtree stays out of listings and
-/// resolution entirely, while entries the enumeration does admit still
-/// surface their real revision data (revision_no, size, content ref).
 #[tokio::test]
 async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -84,8 +84,6 @@ fn replay_read_guard_store(root: impl AsRef<Path>, namespace: &str) -> FailStore
     store
 }
 
-/// Upload admission is exactly the head: absent means the namespace was
-/// never created, and the deletion tombstone refuses.
 #[tokio::test]
 async fn begin_upload_rejects_missing_and_deleted_namespaces() {
     let temp_dir = tempdir().expect("tempdir");
@@ -121,8 +119,6 @@ async fn begin_upload_rejects_missing_and_deleted_namespaces() {
     assert_eq!(deleted_error.code(), ErrorCode::NamespaceDeleted);
 }
 
-/// The server, not the client, names the object a direct upload writes,
-/// and it names it before any byte moves.
 #[tokio::test]
 async fn begin_direct_put_mints_the_target_object_up_front() {
     let temp_dir = tempdir().expect("tempdir");
@@ -228,13 +224,6 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     assert_eq!(store.count(OperationClass::Read), 0);
 }
 
-/// A direct-put session that never recorded the reference its write was
-/// signed against used to be a record this test could write and complete
-/// against. The transport variant carries that reference, so there is no
-/// such record to write any more — in Rust or on the wire. What is left of
-/// this case lives where the durable bytes are read: see
-/// `upload_sessions_reject_a_transport_missing_its_own_fields` in
-/// loonfs-api's golden format tests.
 #[tokio::test]
 async fn upload_content_rejects_invalid_upload_id_before_key_construction() {
     let temp_dir = tempdir().expect("tempdir");
@@ -292,9 +281,6 @@ mod streamed_content {
             .await
     }
 
-    /// A streamed upload produces exactly the reference the buffered one
-    /// would, because the same digest is computed over the same bytes — the
-    /// only difference is that they were never all in memory at once.
     #[tokio::test]
     async fn a_streamed_upload_produces_the_reference_the_buffered_one_would() {
         let temp_dir = tempdir().expect("tempdir");
@@ -327,10 +313,6 @@ mod streamed_content {
         assert_eq!(completed.content_ref(), Some(&staged.content_ref));
     }
 
-    /// Re-sending a body is the case that forces the shape: the digest only
-    /// exists once the payload has been read, so the decision comes after
-    /// the read — and the object the session already owns must survive it
-    /// either way.
     #[tokio::test]
     async fn a_repeated_body_replays_and_a_different_one_conflicts_without_rewriting() {
         let temp_dir = tempdir().expect("tempdir");
@@ -381,19 +363,6 @@ mod streamed_content {
         );
     }
 
-    /// Two staging requests against one session, overlapped so the second
-    /// starts while the first is still writing the object.
-    ///
-    /// This is the shape that used to corrupt the session. Both requests
-    /// would find the key absent, both would assemble over it, and the one
-    /// that lost the record compare-and-swap would leave its bytes behind
-    /// under the winner's digest. The payloads here are the same length and
-    /// different bytes, which is exactly the pair a size comparison cannot
-    /// tell apart, so nothing downstream could have caught it.
-    ///
-    /// The staging claim is what settles it: exactly one request writes, the
-    /// other is refused before it touches the object, and the reference the
-    /// session recorded describes the object byte for byte.
     #[tokio::test]
     async fn one_session_admits_one_writer_and_records_what_that_writer_wrote() {
         let temp_dir = tempdir().expect("tempdir");
@@ -623,9 +592,6 @@ mod direct_multipart {
             .await
     }
 
-    /// The whole point of the transport: parts go straight to the provider,
-    /// the server assembles them, and it believes the assembly only after
-    /// reading the object's own checksum back.
     #[tokio::test]
     async fn a_multipart_upload_completes_against_the_assembled_object() {
         let temp_dir = tempdir().expect("tempdir");
@@ -701,8 +667,6 @@ mod direct_multipart {
         assert!(error.to_string().contains("at least one uploaded part"));
     }
 
-    /// Re-uploading a part is how a client retries one. The last write wins
-    /// and the assembled object follows it.
     #[tokio::test]
     async fn a_re_uploaded_part_is_the_one_that_lands() {
         let temp_dir = tempdir().expect("tempdir");
@@ -736,10 +700,6 @@ mod direct_multipart {
         );
     }
 
-    /// A completion whose response was lost. The provider has consumed the
-    /// upload, so replaying it reports an upload nobody has heard of — but
-    /// the durable session says what was promised and the object says what
-    /// landed, and those two settle it on every provider identically.
     #[tokio::test]
     async fn a_lost_completion_reconciles_from_the_session_and_the_object() {
         let temp_dir = tempdir().expect("tempdir");
@@ -781,10 +741,6 @@ mod direct_multipart {
         );
     }
 
-    /// An assembly that is not what was promised. There are no parts left to
-    /// retry against — completion consumed them — so the session ends rather
-    /// than waiting for a retry that could never work, and the wrong object
-    /// goes with it.
     #[tokio::test]
     async fn a_completion_that_does_not_verify_ends_the_session_and_deletes_the_object() {
         let temp_dir = tempdir().expect("tempdir");
@@ -852,13 +808,6 @@ mod direct_multipart {
         assert_eq!(error.code(), ErrorCode::UploadNotFound);
     }
 
-    /// A provider that treats the whole-object checksum as a precondition
-    /// refuses the assembly outright. A refusal and a completion whose
-    /// response was lost arrive as the same transport failure, so the first
-    /// attempt reports the store failure and leaves the session open. The
-    /// object ends the session instead: the retry finds the upload consumed
-    /// and nothing at the key, and the completion contract already calls
-    /// that terminal.
     #[tokio::test]
     async fn a_refused_assembly_is_a_store_failure_and_the_retry_is_terminal() {
         let temp_dir = tempdir().expect("tempdir");
@@ -922,11 +871,6 @@ mod direct_multipart {
             .is_none());
     }
 
-    /// A read-back the store refuses to answer says nothing about the object
-    /// the provider assembled. The completion reports the store failure, and
-    /// the object and the session survive it. The retry then completes from
-    /// the object: the provider reports an upload it no longer knows, and
-    /// the read-back settles the rest.
     #[tokio::test]
     async fn a_verification_the_store_refuses_leaves_the_completion_retryable() {
         let temp_dir = tempdir().expect("tempdir");
@@ -990,9 +934,6 @@ mod direct_multipart {
         );
     }
 
-    /// A session abandoned mid-upload leaves parts sitting at the provider.
-    /// Upload collection abandons them along with the object, because the
-    /// session record is where the provider's upload id lives.
     #[tokio::test]
     async fn upload_collection_abandons_the_provider_upload_of_an_expired_session() {
         let temp_dir = tempdir().expect("tempdir");
@@ -1040,9 +981,6 @@ mod direct_multipart {
             .is_none());
     }
 
-    /// The geometry is the one thing a begin request may choose, and it is
-    /// bounded by what every supported provider accepts for a non-final
-    /// part. The size it settles on is what bounds the object, too.
     #[tokio::test]
     async fn a_multipart_session_takes_a_part_size_inside_the_providers_bounds() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-grep/src/codec.rs
+++ b/crates/loonfs-grep/src/codec.rs
@@ -481,11 +481,6 @@ mod tests {
         );
     }
 
-    /// The index segment builder is the shared `SegmentBlocksBuilder`, so a
-    /// lost `max_row_key` would surface here as a segment whose row range
-    /// descends — which `GrepManifestState` rejects, parking the reorganize
-    /// step on `InvalidSegmentRange`. Target 1 closes a data block on every
-    /// push, the final one included, which is the case that once lost the key.
     #[test]
     fn segment_max_row_key_survives_a_full_final_block() {
         use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -1,62 +1,17 @@
-//! LoonFS full-text grep subsystem, and the reference derived projection.
+//! LoonFS full-text grep subsystem and reference derived projection.
 //!
-//! Grep is a first-party extension, not part of the runtime: it depends on
-//! `loonfs` and `loonfs` knows nothing about it. Anything else that derives
-//! its own data from a namespace — an embedding index, a symbol graph — can
-//! be built the same way, from the same public surfaces. The shape:
+//! Grep uses only public runtime APIs. Enabling it pins a checkpoint and
+//! backfills files in bounded pages. Once active, it consumes the semantic
+//! change feed from the checkpoint sequence.
 //!
-//! **Bootstrap from a checkpoint.** Enabling grep pins a checkpoint and
-//! publishes a `Backfilling` root that names it. The backfill walks the
-//! files that checkpoint pins, in inode order, a bounded page at a time,
-//! remembering the last inode it consumed. The checkpoint is what makes
-//! that walk resumable across steps and processes: it answers the same
-//! state every time, whatever commits land meanwhile.
+//! Each step publishes the segment list and watermark with one root
+//! compare-and-swap. Failed publications leave unreferenced derived data for
+//! grep garbage collection. A retention gap causes a new checkpoint and
+//! backfill.
 //!
-//! **Semantic changes after it.** Once the walk finishes, the lifecycle
-//! changes to `Active` and indexing continues from the checkpoint's sequence.
-//! The feed reports what happened, not which bytes moved, so grep indexes
-//! only the events that publish content and ignores moves, deletes, and
-//! undeletes outright — the index is keyed by durable `(inode_id,
-//! revision_no)`, which those events do not change.
-//!
-//! **Watermark by root publication.** Every step ends in one compare-and-swap
-//! on grep's own root object, which advances the watermark and the segment
-//! list together. Nothing is indexed until that CAS lands, so a crashed
-//! step leaves unreferenced segments rather than a half-advanced cursor,
-//! and a lost race is an outcome the caller retries.
-//!
-//! **Rebootstrap on a retention gap.** If the feed cursor falls below the
-//! namespace's retention floor, or the pinned checkpoint stops pinning its
-//! basis, the history the projection needs is gone. Grep does not guess: it
-//! discards the incomplete projection, pins a fresh checkpoint, and starts
-//! over.
-//!
-//! **Queries generate candidates; current state verifies them.** The index
-//! narrows, it never decides. A query turns gram postings and the unindexed
-//! tail into candidate inodes, then resolves each against current state and
-//! runs the real pattern over the bytes that path publishes now. That is
-//! what lets the index lag, hold postings for revisions that were replaced,
-//! or miss a rename without ever returning a wrong match — and it is why
-//! per-call reads suffice where a pinned snapshot once seemed necessary.
-//!
-//! [`GrepMaintenanceJob`] can run in a server or in a dedicated
-//! `loonfs admin maintenance run` process. The CLI's `index enable` command
-//! can also run it until the index reaches a captured sequence. All three use
-//! the same durable state and update protocol.
-//!
-//! **An extension owns its keyspace and its garbage.** Grep's durable state
-//! lives under each namespace's `extensions/grep/` prefix and is
-//! independent of the namespace manifest; a missing or corrupt grep root
-//! disables grep for that namespace and never affects filesystem operation.
-//! Grep collects that prefix itself
-//! ([`GrepWorker::garbage_collect_namespace`]), because only grep knows
-//! which of its objects are still reachable.
-//!
-//! Everything grep knows about the filesystem it learns through public
-//! runtime calls, collected in [`NamespaceReads`]: the files a checkpoint
-//! pins, the semantic change feed after it, current state for a batch of
-//! inodes, directory pages, and content by reference. Wire vocabulary stays
-//! in `loonfs-api`, and the filesystem stays in `loonfs`.
+//! Queries combine indexed postings with the unindexed tail, then verify each
+//! candidate against current file contents. Grep state is stored under
+//! `extensions/grep/` and does not affect filesystem availability.
 
 mod cache;
 pub mod codec;

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -354,9 +354,6 @@ mod tests {
         );
     }
 
-    /// Where the enumeration got to is the whole conclusion, so a pass that
-    /// hands back the position it was given has nothing to gain from being
-    /// run again at once.
     #[test]
     fn a_collection_pass_concludes_on_where_its_enumeration_reached() {
         let stopped = grep_gc_step_result(
@@ -382,8 +379,6 @@ mod tests {
         );
     }
 
-    /// A finished walk reports what it freed, and a namespace it could not
-    /// read parks rather than passing for idle.
     #[test]
     fn a_finished_pass_separates_reclamation_from_an_unreadable_namespace() {
         assert_eq!(

--- a/crates/loonfs-grep/src/query.rs
+++ b/crates/loonfs-grep/src/query.rs
@@ -1,21 +1,9 @@
-//! Gram query planning: turns a pattern into the grams any match must
-//! contain — the classic code-search transformation, conservatively.
+//! Converts a search pattern into grams that every match must contain.
 //!
-//! The plan is an AND of OR-sets over case-folded grams. Soundness is the
-//! only obligation: every true match satisfies the plan, so dropping a
-//! constraint (a complex subexpression, a wide alternation, a non-ASCII
-//! case pair) costs candidates, never correctness — verification runs the
-//! real pattern over every candidate. A pattern that yields no constraint
-//! at all is unindexable and the caller decides between rejection and a
-//! capped scan.
-//!
-//! The analysis walks the parsed pattern tracking runs of fixed bytes.
-//! Case-insensitive patterns parse into character classes; a class whose
-//! members fold to one ASCII byte extends the run (matching the index's
-//! ASCII-folded tokenizer), anything wider breaks it. Zero-width
-//! constructs (anchors, look-around the dialect permits) pass through;
-//! optional or repeated subexpressions contribute their inner constraints
-//! only when they must occur.
+//! The plan contains required sets of alternative, case-folded grams. The
+//! index may omit a constraint when it cannot prove that every match contains
+//! it; the full pattern still verifies each candidate. Patterns without any
+//! proven grams are unindexable.
 
 use crate::codec::{extract_grams, Gram, GRAM_LEN};
 use regex_syntax::hir::{Class, Hir, HirKind, Look, Repetition};
@@ -78,9 +66,7 @@ pub(crate) fn plan_pattern(
 struct Analysis {
     /// Gram constraints every match of this subexpression satisfies.
     sets: Vec<BTreeSet<Gram>>,
-    /// When the subexpression matches exactly one folded byte string, that
-    /// string — so concatenation can join runs across children before
-    /// extracting grams.
+    /// A fixed folded byte string, when the subexpression has exactly one.
     run: Option<Vec<u8>>,
 }
 

--- a/crates/loonfs-grep/src/reads.rs
+++ b/crates/loonfs-grep/src/reads.rs
@@ -1,16 +1,7 @@
-//! Every filesystem read grep performs, as calls on a runtime read handle.
+//! Filesystem reads used by grep indexing and query verification.
 //!
-//! Grep owns an index, not a filesystem: it learns what to index from the
-//! checkpointed file enumeration and the semantic change feed, and it
-//! verifies query candidates against current state — resolving inodes,
-//! paths, directories, and content by reference. Every one of those is a
-//! published [`FsReader`] operation any consumer could call, and this module
-//! is the one place grep calls them, so the surface it depends on stays
-//! countable.
-//!
-//! Reads of grep's own durable state (segments, manifests, the root
-//! pointer, all under `namespaces/{namespace}/extensions/grep/`) do not come
-//! through here: that keyspace is grep's, and it reads it directly.
+//! Grep reads filesystem state through [`FsReader`] and reads its own index
+//! objects directly from the extension keyspace.
 
 use crate::{GrepError, Result};
 use loonfs::{
@@ -24,16 +15,11 @@ use loonfs_api::{
     PathEntry, RevisionNo, MAX_PUBLIC_INTEGER,
 };
 
-/// One namespace's filesystem reads, borrowed from a reader handle.
+/// Filesystem reads for one namespace.
 ///
-/// Each call is its own internally-consistent read: the runtime pins a
-/// snapshot per call, so a page of checkpoint files, a batch of resolved
-/// inodes, and the content read that follows them may observe different
-/// heads. The verification model already tolerates that — a query treats
-/// index and feed output as candidates and re-verifies every one against
-/// current state before emitting a match, and the worker keys postings by
-/// durable `(inode_id, revision_no)` — so nothing here needs a snapshot
-/// held across calls.
+/// Each call uses an internally consistent snapshot, but consecutive calls
+/// may observe different heads. Query candidates are reverified against
+/// current state, so a snapshot does not need to span calls.
 pub struct NamespaceReads<'a> {
     reader: &'a FsReader,
     namespace_id: &'a NamespaceId,
@@ -91,9 +77,8 @@ impl<'a> NamespaceReads<'a> {
 
     /// Reads committed changes after `after_seq` as semantic events.
     ///
-    /// A cursor below the namespace's retention floor answers
-    /// `rebootstrap_required`: the history grep would need to catch up is
-    /// gone, so it rebuilds from a fresh checkpoint instead.
+    /// Returns `rebootstrap_required` when `after_seq` is below the retention
+    /// floor.
     pub async fn list_changes_after(
         &self,
         after_seq: ChangeSeq,
@@ -111,11 +96,9 @@ impl<'a> NamespaceReads<'a> {
             .await?)
     }
 
-    /// Answers what each inode looks like now: visible, its current
-    /// revision, and its current path, in input order.
+    /// Resolves current visibility, revision, and path in input order.
     ///
-    /// At most [`MAX_RESOLVE_CURRENT_FILES`] ids per call; callers chunk
-    /// with [`resolve_batch_size`].
+    /// At most [`MAX_RESOLVE_CURRENT_FILES`] IDs are accepted per call.
     pub async fn resolve_current_files(
         &self,
         inode_ids: &[InodeId],

--- a/crates/loonfs-grep/src/root/mod.rs
+++ b/crates/loonfs-grep/src/root/mod.rs
@@ -1,16 +1,9 @@
 //! The atomic grep root pointer, immutable manifests, and publication boundary.
 //!
-//! One immutable manifest pairs the query-visible segment set with its
-//! `(built_through_seq, next_event_index)` cursor, lifecycle, in-progress
-//! reorganization, and run number allocation. Publication writes that manifest
-//! create-if-absent, then updates its pointer with one object-store
-//! compare-and-swap. Readers therefore see the cursor and its segments
-//! together.
-//!
-//! Segment and manifest objects are immutable derived data written before
-//! the pointer CAS. A CAS loser therefore leaks only unreachable derived
-//! objects; it never changes visible grep state. [`crate::GrepWorker`]
-//! garbage collection reclaims those objects after its grace window.
+//! A manifest stores the visible segment set, change cursor, lifecycle state,
+//! and run allocation. Publication writes an immutable manifest and then
+//! updates the root pointer with compare-and-swap. Failed publications leave
+//! only unreachable derived objects for grep garbage collection.
 
 mod codec;
 mod error;

--- a/crates/loonfs-grep/tests/it/golden_formats.rs
+++ b/crates/loonfs-grep/tests/it/golden_formats.rs
@@ -324,9 +324,6 @@ fn grep_root_golden_decodes_to_sample() {
     assert_eq!(decoded, expected);
 }
 
-/// The pointer fixture names the manifest fixture: the digest it promises is
-/// that manifest envelope's own `payload_checksum`. A regeneration that moved
-/// one file without the other breaks the pair.
 #[test]
 fn grep_root_golden_carries_the_manifest_golden_checksum() {
     let pointer =
@@ -390,9 +387,6 @@ fn grep_segment_gram_postings_matches_golden_bytes() {
     );
 }
 
-/// The fixture above pins the block's bytes. This names the rows, the keys,
-/// and the postings those bytes hold, so a decoder that stopped reading them
-/// fails even while the encoder still writes the same block.
 #[test]
 fn grep_segment_gram_postings_golden_decodes_to_sample_rows() {
     let rows = sample_gram_postings_rows();

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -201,8 +201,6 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// Runtime background maintenance is metadata-only: a small publish leaves
-/// grep backfilling until an explicit worker step runs.
 #[tokio::test]
 async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
     let temp_dir = tempdir().expect("tempdir");
@@ -276,13 +274,6 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// A policy passed to the worker bounds each explicit build step: with
-/// `max_files_per_step: 3`, one step consumes
-/// exactly three of the five pending file commits — the watermark lands on
-/// the third put's committed seq — and the next step consumes the rest.
-/// Under the default 256-file budget the first step would have caught up
-/// to the head outright, so the intermediate watermark is exactly the
-/// configured budget observed in effect.
 #[tokio::test]
 async fn a_worker_policy_bounds_each_build_step() {
     let temp_dir = tempdir().expect("tempdir");
@@ -343,10 +334,6 @@ async fn a_worker_policy_bounds_each_build_step() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// A single legal commit can carry thousands of file revisions. The content
-/// budget must split that one WAL record at a durable delta cursor, queries
-/// must combine the indexed prefix with only its unindexed suffix, and a new
-/// worker must resume without reading the prefix again.
 #[tokio::test]
 async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumable() {
     const FILES: usize = 1_000;
@@ -591,8 +578,6 @@ async fn collect_grep_paths(
     }
 }
 
-/// Verifies that reorganizing delta segments into a mid-level run does not
-/// change grep results.
 #[tokio::test]
 async fn grep_answers_identically_across_tiered_reorganizations() {
     let temp_dir = tempdir().expect("tempdir");
@@ -668,9 +653,6 @@ fn index_segment_keys() -> KeyPredicate {
     KeyPredicate::new(|key| key.contains("/extensions/grep/segments/") && key.ends_with(".sst.zst"))
 }
 
-/// Index segment blocks are immutable and keyed by payload checksum, so the
-/// grep-private decoded-block cache must serve a repeated query's posting
-/// probes without re-fetching the segments it already decoded.
 #[tokio::test]
 async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
     let temp_dir = tempdir().expect("tempdir");
@@ -744,10 +726,6 @@ async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// Concurrent candidate content reads keep the serial loop's error
-/// positions: a failed read surfaces only when the in-order walk reaches
-/// that candidate, so a page that fills first still returns its full
-/// matches and a cursor, and the error waits for the next page.
 #[tokio::test]
 async fn a_failed_candidate_read_surfaces_in_traversal_order() {
     let temp_dir = tempdir().expect("tempdir");
@@ -857,10 +835,6 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// An unindexed-tail candidate larger than the index eligibility cap can
-/// never pass verification, so grep must skip it on its declared size
-/// alone: no content GET for it, unchanged page budgets, and a cursor
-/// that resumes past it.
 #[tokio::test]
 async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
     let temp_dir = tempdir().expect("tempdir");
@@ -985,8 +959,6 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// Verifies that the service reuses blocks loaded by a partial worker
-/// reorganization instead of decoding a second copy.
 #[tokio::test]
 async fn worker_and_service_share_decoded_index_blocks() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1077,11 +1049,6 @@ async fn worker_and_service_share_decoded_index_blocks() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// Verifies that a cold reorganization opens segment cursors concurrently
-/// without exceeding the maintenance I/O limit.
-///
-/// The test adds delta runs until reorganization begins. Because it performs
-/// no queries, every observed segment read belongs to that reorganization.
 #[tokio::test]
 async fn a_cold_reorganization_fans_out_its_segment_opens_within_the_io_cap() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -666,11 +666,6 @@ async fn retention_gap_and_vanished_checkpoint_restart_fresh_backfill() {
     writer.shutdown().await.expect("shutdown");
 }
 
-/// A backfill whose pin has outlived its ttl but has not been released
-/// keeps enumerating. Nothing on the checkpoint read path consults a clock:
-/// the record is still a garbage-collection root, so the state it pins is
-/// still there. The worker only starts over when a pass actually releases
-/// it — which the suite above covers.
 #[tokio::test]
 async fn an_expired_but_unreleased_backfill_pin_keeps_enumerating() {
     let temp_dir = tempdir().expect("tempdir");
@@ -824,10 +819,6 @@ fn matched_paths(response: &GrepResponse) -> Vec<String> {
         .collect()
 }
 
-/// A backfill of a populated namespace while commits keep landing: the
-/// checkpoint enumeration answers the state it pinned, the change feed
-/// answers everything after it, and the two phases neither miss a file nor
-/// index one twice.
 #[tokio::test]
 async fn commits_during_backfill_are_indexed_once_by_the_feed_phase() {
     let temp_dir = tempdir().expect("tempdir");
@@ -937,9 +928,6 @@ async fn commits_during_backfill_are_indexed_once_by_the_feed_phase() {
     writer.shutdown().await.expect("shutdown");
 }
 
-/// A move changes no content, so it changes no posting: the index is left
-/// exactly as it was and the query answers the file's new path because
-/// verification reads current state.
 #[tokio::test]
 async fn a_move_reindexes_nothing_and_answers_the_new_path() {
     let temp_dir = tempdir().expect("tempdir");
@@ -999,9 +987,6 @@ async fn a_move_reindexes_nothing_and_answers_the_new_path() {
     writer.shutdown().await.expect("shutdown");
 }
 
-/// A recursive delete hides every match under it and an undelete brings
-/// them back, both without touching the index: verification against current
-/// state is what decides whether a posting can still produce a match.
 #[tokio::test]
 async fn a_recursive_delete_hides_matches_and_an_undelete_restores_them() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1103,9 +1088,6 @@ async fn a_recursive_delete_hides_matches_and_an_undelete_restores_them() {
     writer.shutdown().await.expect("shutdown");
 }
 
-/// Grep is a projection beside the filesystem, not inside it: a worker step
-/// that fails against unreadable grep state must not disturb a commit
-/// running at the same time.
 #[tokio::test]
 async fn a_failing_worker_step_never_blocks_a_concurrent_commit() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1742,14 +1724,6 @@ async fn checkpoint_backfill_matches_incremental_worker_results() {
     writer.shutdown().await.expect("shutdown");
 }
 
-/// A collection pass that lands in the middle of a publication leaves the
-/// candidate manifest alone.
-///
-/// The grace window is the whole argument: the candidate was written
-/// moments ago under an id nothing has used before, and grep bounds its own
-/// publications by the same budget the runtime bounds its own by, which is
-/// what the derived grace floor is built from. So a pass that examines the
-/// key before the pointer moves must retain it.
 #[tokio::test]
 async fn a_publication_in_flight_keeps_its_candidate_through_a_collection_pass() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2170,14 +2144,6 @@ fn orphan_keys(namespace_id: &NamespaceId) -> Vec<String> {
         .collect()
 }
 
-/// A budgeted, resumed collection reaches everything one unbudgeted pass
-/// would.
-///
-/// Two identically seeded stores are collected two ways: one whole-prefix
-/// pass, and a cursor loop with a budget small enough that a page cannot
-/// even finish deciding one key. The counters and the surviving keys must
-/// agree — that is what makes the cursor an enumeration shortcut rather
-/// than a second opinion about what is live.
 #[tokio::test]
 async fn a_budgeted_grep_collection_walks_everything_an_unbudgeted_one_does() {
     let namespace_id = NamespaceId::parse("gc-budget").expect("namespace id");
@@ -2282,13 +2248,6 @@ async fn a_budgeted_grep_collection_walks_everything_an_unbudgeted_one_does() {
     }
 }
 
-/// The budget counts reads, not listed keys.
-///
-/// Deciding one key costs three: its listing, the liveness or root re-read
-/// that authorizes the decision, and the age probe. A deleted namespace is
-/// where that is countable — every key there is decided and deleted — so a
-/// budget of seven reaps exactly two keys, where a budget that only counted
-/// listings would have reaped seven.
 #[tokio::test]
 async fn the_collection_budget_charges_each_key_the_reads_it_costs() {
     let namespace_id = NamespaceId::parse("gc-charge").expect("namespace id");
@@ -2340,8 +2299,6 @@ async fn the_collection_budget_charges_each_key_the_reads_it_costs() {
     );
 }
 
-/// However small the budget, a pass examines one key — otherwise a caller
-/// looping the cursor would never finish.
 #[tokio::test]
 async fn a_budget_too_small_for_one_key_still_advances_the_cursor() {
     let namespace_id = NamespaceId::parse("gc-progress").expect("namespace id");
@@ -2378,8 +2335,6 @@ async fn a_budget_too_small_for_one_key_still_advances_the_cursor() {
     );
 }
 
-/// A cursor is bound to the namespace that minted it and to grep's own
-/// prefix; anything else is refused as an invalid request.
 #[tokio::test]
 async fn a_collection_cursor_is_refused_outside_the_namespace_that_minted_it() {
     let namespace_id = NamespaceId::parse("gc-cursor").expect("namespace id");
@@ -2420,8 +2375,6 @@ async fn a_collection_cursor_is_refused_outside_the_namespace_that_minted_it() {
     }
 }
 
-/// A backfilling root has no watermark, and nothing on the way out invents
-/// one for it.
 #[tokio::test]
 async fn a_backfilling_root_never_reports_a_built_through_sequence() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -99,9 +99,6 @@ async fn a_tombstoned_namespace_concludes_not_enabled() {
     );
 }
 
-/// Disabling the index is one durable compare-and-swap, and the next step
-/// is where a scheduler finds out — with the conclusion that makes the
-/// runner forget the namespace.
 #[tokio::test]
 async fn a_disabled_root_concludes_not_enabled_on_the_next_step() {
     let temp_dir = tempdir().expect("tempdir");
@@ -128,8 +125,6 @@ async fn a_disabled_root_concludes_not_enabled_on_the_next_step() {
     );
 }
 
-/// The runner is what turns a nudge into an indexed namespace, and a
-/// poisoned root must not stop the namespaces beside it.
 #[tokio::test]
 async fn a_nudge_indexes_a_namespace_while_a_poisoned_sibling_backs_off() {
     let temp_dir = tempdir().expect("tempdir");
@@ -178,9 +173,6 @@ async fn a_nudge_indexes_a_namespace_while_a_poisoned_sibling_backs_off() {
     host.shutdown().await.expect("settle host maintenance");
 }
 
-/// One writer, one permit pool: the runner's cap is what bounds grep steps
-/// now, so blocking each namespace's sole backfill content read makes the
-/// number of simultaneously executing steps directly visible.
 #[tokio::test]
 async fn the_runners_one_permit_pool_caps_grep_steps_across_namespaces() {
     const NAMESPACES: usize = 8;
@@ -267,8 +259,6 @@ async fn catch_up<S: ObjectStore + Clone + Send + Sync + 'static>(
     panic!("the grep job did not catch up");
 }
 
-/// The collection job is the reclaiming half the index job deliberately
-/// leaves undone, and a nudge is what asks for it.
 #[tokio::test]
 async fn a_nudge_collects_what_indexing_left_behind() {
     let temp_dir = tempdir().expect("tempdir");
@@ -304,9 +294,6 @@ async fn a_nudge_collects_what_indexing_left_behind() {
     host.shutdown().await.expect("settle host maintenance");
 }
 
-/// A resume position the collector refuses restarts the pass instead of
-/// failing the key: every pass rebuilds its own safety proof, so starting
-/// over is always sound.
 #[tokio::test]
 async fn a_refused_resume_position_restarts_the_collection_pass() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-grep/tests/it/root_format.rs
+++ b/crates/loonfs-grep/tests/it/root_format.rs
@@ -48,8 +48,6 @@ fn edited_document(
     .into_bytes()
 }
 
-/// A manifest's identity is minted, never read out of its bytes, so two
-/// candidates over identical state are two distinct objects.
 #[test]
 fn identical_manifest_state_mints_distinct_ids() {
     let first = GrepManifestObjectId::generate();
@@ -63,9 +61,6 @@ fn identical_manifest_state_mints_distinct_ids() {
     );
 }
 
-/// Every phase survives a round trip carrying exactly its own fields, and
-/// the encoded bytes never name the other phase's sequence. The active case
-/// rides at event index zero, which the format writes like any other value.
 #[test]
 fn every_status_round_trips_carrying_only_its_own_position() {
     for (state, absent_field) in [
@@ -93,9 +88,6 @@ fn every_status_round_trips_carrying_only_its_own_position() {
     }
 }
 
-/// The manifest spells its lifecycle field `status` and writes a
-/// `kind`-tagged object into it, exactly as every durable control object
-/// does. The control families are checked the same way in `loonfs-api`.
 #[test]
 fn the_manifest_status_is_a_kind_tagged_object() {
     for fixture in [
@@ -121,9 +113,6 @@ fn the_manifest_status_is_a_kind_tagged_object() {
     }
 }
 
-/// A manifest is immutable, so nothing rewrites its bytes and this reader
-/// keeps decoding one a later version wrote. The probe adds a field at every
-/// level the payload nests, and one beside the payload itself.
 #[test]
 fn immutable_manifest_decoder_reads_frozen_bytes_with_additive_fields() {
     let additive = edited_document(ACTIVE_MANIFEST_FIXTURE, UNKNOWN_ENVELOPE_FIELD, |payload| {
@@ -167,9 +156,6 @@ fn mutable_pointer_envelope_rejects_unknown_fields_as_corruption() {
     ));
 }
 
-/// The envelope version is a number, like every other durable family's.
-/// The string spelling grep used to write is not an older version to be
-/// tolerated. It is not a version at all, and the probe says so.
 #[test]
 fn decoder_rejects_the_string_format_version_without_a_shim() {
     let manifest = String::from_utf8(read_golden(DISABLED_MANIFEST_FIXTURE))
@@ -194,8 +180,6 @@ fn decoder_rejects_the_string_format_version_without_a_shim() {
     ));
 }
 
-/// An `active` status writes `next_event_index` at every position, zero
-/// included, so bytes that omit it are not bytes this format wrote.
 #[test]
 fn decoder_rejects_an_active_status_that_omits_its_event_index() {
     let edited = edited_document(ACTIVE_MANIFEST_FIXTURE, "", |payload| {

--- a/crates/loonfs-grep/tests/it/root_store.rs
+++ b/crates/loonfs-grep/tests/it/root_store.rs
@@ -91,10 +91,6 @@ async fn seed_succeeds_once_and_second_seed_conflicts() {
     ));
 }
 
-/// Republishing identical state writes a new object rather than adopting the
-/// one an earlier publication left behind. Nothing about a manifest's key
-/// derives from its bytes, which is what stops collection of an old
-/// candidate from ever reaching a new publication's manifest.
 #[tokio::test]
 async fn identical_state_publishes_a_fresh_manifest_object() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
@@ -132,9 +128,6 @@ async fn identical_state_publishes_a_fresh_manifest_object() {
     );
 }
 
-/// A manifest key is claimed create-only, so an occupant carrying other
-/// bytes is corruption rather than something to overwrite. A random id
-/// cannot collide, so only a foreign writer or a damaged object gets here.
 #[tokio::test]
 async fn a_manifest_key_occupied_by_other_bytes_is_corrupt() {
     let temp_dir = tempfile::tempdir().expect("temp dir");

--- a/crates/loonfs-objectstore/src/attempts.rs
+++ b/crates/loonfs-objectstore/src/attempts.rs
@@ -1,18 +1,7 @@
-//! Counting the provider attempts one measured object-store call made.
+//! Counts provider attempts for instrumented object-store calls.
 //!
-//! [`InstrumentedObjectStore`](crate::metrics::InstrumentedObjectStore)
-//! wraps above the bounded retry loops in
-//! [`provider_object_store`](crate::provider_object_store), so a sample's
-//! elapsed time already covers every retry while the count itself is
-//! invisible from up there — a slow call and a call that was retried nine
-//! times read the same. This task-local tally is the one channel between
-//! the two: the wrapper opens a tally around the call it is timing, the
-//! retry gate below counts each attempt it grants, and the wrapper reads
-//! the total back when it builds the sample.
-//!
-//! A retry gate outside a measured call finds no tally and counts nothing,
-//! so an uninstrumented store pays one failed task-local lookup per granted
-//! retry and nothing on any other path.
+//! A task-local counter connects the retry loop to the outer metrics wrapper.
+//! Retries outside an instrumented call are ignored.
 
 use std::future::Future;
 use std::sync::atomic::{AtomicU32, Ordering};

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -300,17 +300,6 @@ mod tests {
         );
     }
 
-    /// GCS advertises no direct transfer until a credentialed conformance
-    /// run has proven the provider enforces what the signatures bind.
-    ///
-    /// This is the same bar the S3-compatible providers cleared before their
-    /// domains went into the allowlists above. Trusting a signed precondition
-    /// that nothing has watched the provider honour is exactly the failure
-    /// the whole gate exists to prevent, and an implementation passing its
-    /// own unit tests is not that evidence.
-    ///
-    /// Flipping [`GCS_DIRECT_TRANSFERS_PROVEN`] fails this test, which is the
-    /// point: the flip and the run that justifies it land together.
     #[test]
     fn gcs_advertises_the_direct_transfers_its_live_run_proved() {
         let transfers = gcs_store()
@@ -320,10 +309,6 @@ mod tests {
         assert!(transfers.multipart.is_none());
     }
 
-    /// What the live-conformance flip turns on: reads and whole-object
-    /// writes, and no multipart, because this adapter signs none for GCS.
-    /// The checksum and the ceiling come from the issuer, which is the only
-    /// thing that knows them.
     #[test]
     fn a_proven_gcs_deployment_signs_puts_and_gets_and_offers_no_multipart() {
         let transfers = proven_gcs_store()
@@ -339,7 +324,6 @@ mod tests {
         assert_eq!(put.max_content_bytes(), GCP_GCS_MAX_DIRECT_PUT_BYTES);
     }
 
-    /// GCS signs the configured prefix and create-only precondition.
     #[tokio::test]
     async fn the_gcs_bundle_signs_native_generation_preconditions() {
         let issuer = proven_gcs_store()
@@ -375,8 +359,6 @@ mod tests {
         assert!(!signed.url.contains("X-Amz-"));
     }
 
-    /// Only a provider that can presign, on an endpoint the live conformance
-    /// suite has run against, offers direct transfers at all.
     #[test]
     fn configured_object_store_offers_direct_transfers_only_on_proven_endpoints() {
         let temp_dir = unique_temp_dir("configured-store-kind");
@@ -421,9 +403,6 @@ mod tests {
         assert!(azure.direct_transfers().is_none());
     }
 
-    /// A presigned URL is a bearer capability, so a proven domain reached
-    /// over plain `http` earns no bundle: the capability and its signed
-    /// headers would go out in cleartext.
     #[test]
     fn a_proven_domain_without_tls_offers_no_direct_transfers() {
         assert!(aws_s3_store(Some("http://bucket.s3.amazonaws.com"))
@@ -441,8 +420,6 @@ mod tests {
             .is_some());
     }
 
-    /// The S3-compatible providers sign every direction, and each names its
-    /// own documented single-request ceiling.
     #[test]
     fn s3_compatible_stores_offer_all_three_directions() {
         let s3 = aws_s3_store(None).direct_transfers().expect("s3 transfers");
@@ -469,8 +446,6 @@ mod tests {
         );
     }
 
-    /// A store that signs reads and whole-object writes but has no multipart
-    /// API is expressible: absence is a missing field, not a failing call.
     #[test]
     fn a_bundle_can_offer_put_and_get_without_multipart() {
         let presigner = Arc::new(

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -367,9 +367,6 @@ mod tests {
         ));
     }
 
-    /// The store signs its own checksum readback, so a key that cannot sign
-    /// stops the store from being built at all rather than surfacing as a
-    /// failure on the first completion.
     #[test]
     fn a_service_account_key_that_cannot_sign_stops_the_store_from_being_built() {
         let (key_dir, _key_path) = gcs_fixture_service_account_key_file("gcs-unsignable");
@@ -390,10 +387,6 @@ mod tests {
         ));
     }
 
-    /// GCS spells its hash report two ways and orders it however it likes, so
-    /// the readback finds the crc32c in each of them. Reading only the first
-    /// header line would complete an upload on an md5 it cannot check, or
-    /// fail one whose crc32c was simply second.
     #[test]
     fn the_stored_crc32c_is_found_however_gcs_spells_its_hash_header() {
         let crc32c_of_hello = "9a71bb4c";

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -250,12 +250,6 @@ mod tests {
         );
     }
 
-    /// Pins every standard key pattern in the format spec's "Durable object
-    /// families" table to the key this crate actually builds for that family.
-    ///
-    /// The table is normative: a new family must be added to the table and to
-    /// this test together, and neither the spec pattern nor the builder can
-    /// change without the other.
     #[test]
     fn standard_key_patterns_match_format_spec_table() {
         let spec = std::fs::read_to_string(concat!(
@@ -483,7 +477,6 @@ mod tests {
         }
     }
 
-    /// Segment descriptors derive standard and compaction object keys.
     #[test]
     fn segment_descriptors_derive_published_and_staging_keys() {
         assert_eq!(
@@ -500,8 +493,6 @@ mod tests {
         );
     }
 
-    /// Content keys shard on the id's own leading characters, so both shard
-    /// directories are derivable from the id and nothing else.
     #[test]
     fn content_keys_shard_on_the_content_id_prefix() {
         let id = content_id();

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -439,8 +439,6 @@ mod tests {
             .starts_with(&prefix));
     }
 
-    /// Staged compaction segments use a separate prefix so metadata segment
-    /// garbage collection does not treat active job output as unreferenced.
     #[test]
     fn staged_compaction_segments_live_outside_the_segment_listing_prefix() {
         let layout = ObjectLayout::new();
@@ -470,7 +468,6 @@ mod tests {
             .starts_with(&staging));
     }
 
-    /// Sorting places a job's lease before its staged segments.
     #[test]
     fn a_jobs_lease_sorts_before_its_staged_segments() {
         let layout = ObjectLayout::new();
@@ -488,7 +485,6 @@ mod tests {
         );
     }
 
-    /// Recognized lease and segment keys return their compaction job id.
     #[test]
     fn compaction_keys_report_the_job_that_owns_them() {
         let layout = ObjectLayout::new();
@@ -632,8 +628,6 @@ mod tests {
         assert!(parse_object_key("namespaces/ns-1/unknown/file").is_none());
     }
 
-    /// One content layout exists. Anything else under `content-stores/`
-    /// classifies as nothing at all rather than as content.
     #[test]
     fn parser_admits_exactly_one_content_layout() {
         for foreign in [

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -938,9 +938,6 @@ mod tests {
         assert_ne!(first, second);
     }
 
-    /// The range contract a chunked reader depends on: ranges answer their
-    /// own bytes, an end past the object is truncated rather than refused,
-    /// and a start past the object or a descending range is refused.
     #[tokio::test]
     async fn ranged_reads_answer_their_range_and_refuse_impossible_ones() {
         let temp_dir = test_dir("ranged-reads");
@@ -1000,7 +997,6 @@ mod tests {
             .is_none());
     }
 
-    /// Readers race each overwrite rename to exercise replacement visibility across runtime workers.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_readers_observe_complete_replacement_generations() {
         const PAYLOAD_BYTES: usize = 16 * 1024;

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -362,19 +362,14 @@ pub trait ObjectStore: Send + Sync + Debug {
     /// Reads size and the stored full-object checksum for one key, returning
     /// `None` when the object is absent.
     ///
-    /// This is exactly one metadata request. S3-family stores issue
-    /// `HeadObject` with checksum mode enabled; `GetObjectAttributes` is
-    /// never used anywhere, because Cloudflare R2 answers it with 501 and
-    /// code that reaches for it passes its tests against S3 and fails in
-    /// production.
+    /// This uses one metadata request. S3-compatible stores use `HeadObject`
+    /// with checksum mode because some providers do not support
+    /// `GetObjectAttributes`.
     ///
-    /// Stores that cannot perform checksum readback return
-    /// [`ObjectStoreError::Unsupported`]. A store that can ask but finds an
-    /// existing object with no stored checksum returns
-    /// [`ObjectStoreError::StoredChecksumMissing`]. That is the same
-    /// capability line as presigned direct uploads: a deployment whose
-    /// provider cannot show the checksum back also cannot offer `direct_put`,
-    /// because completion would have nothing to verify against.
+    /// Stores without checksum readback return [`ObjectStoreError::Unsupported`].
+    /// Existing objects without a stored checksum return
+    /// [`ObjectStoreError::StoredChecksumMissing`]. Direct uploads require
+    /// this capability for completion verification.
     async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
         let _ = key;
         Err(ObjectStoreError::Unsupported(
@@ -448,45 +443,17 @@ pub trait ObjectStore: Send + Sync + Debug {
     /// failed conditions, permission failures, and ambiguous transport failures are returned.
     async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata>;
 
-    /// Writes a payload of unknown length without holding it whole, and
-    /// reports how many bytes were stored.
+    /// Writes a stream and returns the number of bytes stored.
     ///
-    /// This is for immutable objects at uniquely-named keys — content
-    /// blobs. Two properties define it:
+    /// Implementations consume the complete stream before reporting a failed
+    /// precondition, allowing callers to finish checksums. Multipart providers
+    /// may check `mode` immediately before assembly rather than atomically with
+    /// it, so this method is only safe for immutable, uniquely named keys.
+    /// Failed multipart writes must be aborted.
     ///
-    /// - **Bounded memory.** A store that can write incrementally holds at
-    ///   most one internal buffer at a time, whatever the payload's length.
-    ///   The default implementation cannot, and says so below.
-    /// - **The body is consumed before any precondition is evaluated.** A
-    ///   caller folding a digest over the stream as it forwards it therefore
-    ///   always ends up with a digest over the complete payload, even when
-    ///   the write is refused — which is what lets it tell "these are the
-    ///   same bytes again" from "these are different bytes".
-    ///
-    /// `mode` is enforced by the provider, as part of the write, while the
-    /// payload fits inside one internal part. Beyond that, an implementation
-    /// that uses a provider multipart upload cannot enforce it that way,
-    /// because providers assemble a multipart upload unconditionally. Such
-    /// an implementation evaluates the condition against a separate
-    /// observation of the key, taken after the payload has been consumed and
-    /// immediately before the assembly. A key that was already occupied is
-    /// still refused with [`ObjectStoreError::PreconditionFailed`]; a writer
-    /// that lands between that observation and the assembly is not, and this
-    /// write assembles over it.
-    ///
-    /// That is why this operation is for immutable keys only: on a key whose
-    /// bytes are fixed by its name, the condition is a corruption tripwire
-    /// rather than a concurrency control. A caller that must also detect the
-    /// concurrent case has to check the object again before it relies on it.
-    ///
-    /// A failed or abandoned write leaves no provider state behind: an
-    /// implementation that opened a multipart upload aborts it.
-    ///
-    /// The default implementation **buffers the whole stream** and delegates
-    /// to [`Self::put`]. It exists so a provider without an incremental
-    /// write is honest rather than absent: its memory cost is exactly what
-    /// buffering the payload and calling `put` costs today, and it is
-    /// bounded only by whatever bounds the caller puts on the stream.
+    /// The default implementation buffers the complete stream before calling
+    /// [`Self::put`]. Providers should override it to provide bounded-memory
+    /// streaming.
     async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
         let bytes = collect_stream(body).await?;
         let size_bytes = bytes.len() as u64;

--- a/crates/loonfs-objectstore/src/presign/gcs.rs
+++ b/crates/loonfs-objectstore/src/presign/gcs.rs
@@ -446,7 +446,6 @@ mod tests {
             .expect("presign put")
     }
 
-    /// The signature covers the object path and create-only precondition.
     #[tokio::test]
     async fn presigned_put_binds_the_scoped_path_and_create_only_precondition() {
         let signed = presign_put(&presigner(Some("tenant-a"))).await;
@@ -474,9 +473,6 @@ mod tests {
         );
     }
 
-    /// The read capability signs `host` and nothing else, which is what
-    /// leaves `Range` outside the signature: one issued URL serves ranged,
-    /// resumed, and parallel reads without another round trip to the server.
     #[tokio::test]
     async fn presigned_get_signs_only_the_host_so_range_stays_unsigned() {
         let signed = presigner(Some("tenant-a"))
@@ -505,8 +501,6 @@ mod tests {
         );
     }
 
-    /// The checksum readback needs no request header, so it signs the same
-    /// header set a read does and differs only in method.
     #[test]
     fn presigned_head_reads_the_object_back_with_host_signed_alone() {
         let signed = presigner(Some("tenant-a"))
@@ -524,9 +518,6 @@ mod tests {
         );
     }
 
-    /// The key prefix is part of what is signed, not decoration on the URL:
-    /// dropping it produces a different signature, so a capability issued for
-    /// one tenant's prefix cannot be replayed against another's.
     #[tokio::test]
     async fn the_key_prefix_is_inside_the_signature() {
         let unprefixed = presign_put(&presigner(None)).await;
@@ -545,15 +536,6 @@ mod tests {
         );
     }
 
-    /// The signer and the provider client resolve an object key to the same
-    /// string, whatever spelling of a prefix the deployment configured.
-    ///
-    /// A whitespace-only prefix is the case that used to split them: the
-    /// store normalizes it away and works in the unprefixed keyspace, while
-    /// the signer kept it raw and addressed `%20%20%20/...`. An object
-    /// written through such a capability is committed and then invisible to
-    /// every read, listing, and collection the store performs — durable
-    /// nowhere anything looks.
     #[tokio::test]
     async fn the_signer_and_the_store_resolve_a_key_to_the_same_string() {
         for raw_prefix in [None, Some("   "), Some(""), Some("tenant-a")] {
@@ -586,8 +568,6 @@ mod tests {
         }
     }
 
-    /// A prefix the store would refuse is refused here too, at construction,
-    /// rather than producing capabilities the store cannot address.
     #[test]
     fn an_unusable_key_prefix_fails_construction() {
         for raw_prefix in ["tenant-a//bad", "../escape"] {
@@ -604,9 +584,6 @@ mod tests {
         }
     }
 
-    /// Path segments are percent-encoded, and the separators between them are
-    /// not. Getting either wrong signs a different object than the one the
-    /// URL addresses.
     #[tokio::test]
     async fn path_segments_are_percent_encoded_and_separators_are_not() {
         let signed = presigner(Some("tenant-a"))
@@ -630,8 +607,6 @@ mod tests {
         );
     }
 
-    /// Reads and writes of the same object address the same URL, so a
-    /// deployment cannot sign a write it is unable to sign a read of.
     #[tokio::test]
     async fn presigned_get_addresses_the_same_object_the_write_did() {
         let signer = presigner(Some("tenant-a"));
@@ -709,8 +684,6 @@ mod tests {
         }
     }
 
-    /// A signing key is a bearer credential for the whole bucket, so nothing
-    /// about it reaches a log through the store that holds it.
     #[test]
     fn presigner_debug_redacts_the_service_account_and_its_key() {
         let signer = presigner(Some("tenant-a"));
@@ -723,8 +696,6 @@ mod tests {
         assert!(rendered.contains("bucket"));
     }
 
-    /// GCS lists hashes in an unspecified order and may name algorithms this
-    /// format does not, so the CRC-32C is selected rather than positioned.
     #[test]
     fn stored_crc32c_selects_its_algorithm_out_of_the_hash_header() {
         assert_eq!(

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -698,8 +698,6 @@ mod tests {
             .contains("X-Amz-Security-Token=temporary-session-token"));
     }
 
-    /// The checksum readback rides the signature the same way the write's
-    /// checksum does, so an operator cannot strip it in flight.
     #[tokio::test]
     async fn presigned_head_signs_the_checksum_mode_header() {
         let signed = presigner(Some("tenant-a"), None)
@@ -727,10 +725,6 @@ mod tests {
             .starts_with("https://bucket.s3.us-east-1.amazonaws.com/tenant-a/content-stores/"));
     }
 
-    /// The read capability signs `host` and nothing else, which is what
-    /// leaves `Range` outside the signature: one issued URL serves ranged,
-    /// resumed, and parallel reads without another round trip to the
-    /// server. The live suite proves the provider agrees.
     #[tokio::test]
     async fn presigned_get_signs_only_the_host_so_range_stays_unsigned() {
         let signed = presigner(Some("tenant-a"), None)
@@ -757,10 +751,6 @@ mod tests {
         assert!(!signed.url.contains("secret"));
     }
 
-    /// Reads and writes of the same object address the same URL: whatever
-    /// the key prefix and endpoint style resolve to for one, they resolve
-    /// to for the other, so a deployment cannot sign a write it is unable
-    /// to sign a read of.
     #[tokio::test]
     async fn presigned_get_addresses_the_same_object_the_write_did() {
         let signer = presigner(
@@ -793,14 +783,6 @@ mod tests {
         assert_eq!(object_of(&read.url), object_of(&written.url));
     }
 
-    /// The signer and the provider client resolve an object key to the same
-    /// string, whatever spelling of a prefix the deployment configured.
-    ///
-    /// A whitespace-only prefix is the case that used to split them: the
-    /// store normalizes it away and works in the unprefixed keyspace, while
-    /// the signer kept it raw and addressed `%20%20%20/...`. An object
-    /// written through such a capability is committed and then invisible to
-    /// every read, listing, and collection the store performs.
     #[tokio::test]
     async fn the_signer_and_the_store_resolve_a_key_to_the_same_string() {
         for raw_prefix in [None, Some("   "), Some(""), Some("tenant-a")] {
@@ -833,8 +815,6 @@ mod tests {
         }
     }
 
-    /// A prefix the store would refuse is refused here too, at construction,
-    /// rather than producing capabilities the store cannot address.
     #[test]
     fn an_unusable_key_prefix_fails_construction() {
         for raw_prefix in ["tenant-a//bad", "../escape"] {

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -1189,9 +1189,6 @@ mod tests {
         .expect("provider store")
     }
 
-    /// The epoch stamp an AWS-compatible client synthesizes for a response
-    /// with no `Last-Modified` header is not an age, and grace protection is
-    /// exactly what reading it as one would cost.
     #[test]
     fn a_synthesized_epoch_stamp_reads_as_no_timestamp_at_all() {
         assert_eq!(last_modified_ms(0), None);
@@ -2091,8 +2088,6 @@ mod tests {
         assert!(store.head(transient_key).await.expect("head").is_none());
     }
 
-    /// The metrics wrapper sits above this store's retry loops, so without
-    /// the attempt tally a retried call and a slow one make the same sample.
     #[tokio::test]
     async fn a_retried_call_reports_its_attempts_to_the_metrics_wrapper() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2283,9 +2278,6 @@ mod tests {
         );
     }
 
-    /// Cancellation has no error arm to run. The upload id must therefore
-    /// be guarded from the instant creation returns, including for the
-    /// buffered multipart path.
     #[tokio::test]
     async fn dropping_a_buffered_multipart_write_aborts_its_provider_upload() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2342,9 +2334,6 @@ mod tests {
         assert_eq!(flaky.puts.load(Ordering::SeqCst), 1);
     }
 
-    /// Conditional modes never ride multipart: providers complete multipart
-    /// uploads as unconditional overwrites, so create-if-absent keeps its
-    /// real provider precondition on the single-request path at any size.
     #[tokio::test]
     async fn large_create_if_absent_stays_single_request() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2380,8 +2369,6 @@ mod tests {
         stream::iter(chunks.into_iter().map(Ok)).boxed()
     }
 
-    /// The streamed write's whole job: regroup whatever arrives into fixed
-    /// parts, upload them one at a time, and assemble exactly the payload.
     #[tokio::test]
     async fn a_streamed_put_cuts_the_stream_into_parts_and_preserves_bytes() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2417,9 +2404,6 @@ mod tests {
         );
     }
 
-    /// A payload that ends inside the first buffered part is an ordinary
-    /// put, with the caller's mode intact — the same size line `put` itself
-    /// draws, so a small streamed write behaves like a small buffered one.
     #[tokio::test]
     async fn a_short_streamed_put_is_one_request_that_keeps_its_precondition() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2452,10 +2436,6 @@ mod tests {
         );
     }
 
-    /// Create-only means the same thing past one part as it does inside
-    /// one. The provider assembles a multipart upload unconditionally, so
-    /// the store evaluates the condition itself, and the object already at
-    /// the key survives.
     #[tokio::test]
     async fn a_streamed_multipart_put_refuses_an_occupied_key() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2496,7 +2476,6 @@ mod tests {
         );
     }
 
-    /// An overwrite has no condition to evaluate, so it costs no read.
     #[tokio::test]
     async fn a_streamed_multipart_overwrite_reads_nothing() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2512,8 +2491,6 @@ mod tests {
         assert_eq!(flaky.gets.load(Ordering::SeqCst), 0);
     }
 
-    /// An empty stream still writes an object, and still writes it the way
-    /// its mode asks for.
     #[tokio::test]
     async fn an_empty_streamed_put_writes_an_empty_object() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2536,9 +2513,6 @@ mod tests {
         );
     }
 
-    /// A payload that stops mid-transfer leaves nothing behind: the
-    /// provider upload is abandoned rather than left holding parts, and no
-    /// object appears at the key.
     #[tokio::test]
     async fn a_streamed_put_that_fails_mid_stream_abandons_its_upload() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2705,10 +2679,6 @@ mod tests {
         assert!(store.head(MULTIPART_KEY).await.expect("head").is_none());
     }
 
-    /// The regression this fix exists for: an unproven completion must
-    /// never adopt a pre-existing object of the same size. The pre-fix code
-    /// reconciled by size identity and reported success for bytes that were
-    /// never written.
     #[tokio::test]
     async fn multipart_complete_rejects_stale_same_size_object() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2745,10 +2715,6 @@ mod tests {
         );
     }
 
-    /// The content-addressed re-put shape: when the object already holds
-    /// exactly the payload bytes, byte identity proves the put's
-    /// postcondition even though this upload's completion never landed —
-    /// and the dangling upload is reclaimed rather than stranded.
     #[tokio::test]
     async fn multipart_complete_accepts_identical_object_and_aborts() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2775,9 +2741,6 @@ mod tests {
         );
     }
 
-    /// The lifecycle-abort race: the upload vanishes while the completion's
-    /// outcome is ambiguous and a stale object sits at the key. The stale
-    /// object is never accepted as this write.
     #[tokio::test]
     async fn multipart_complete_gone_upload_with_stale_object_fails_as_transport() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2802,8 +2765,6 @@ mod tests {
         );
     }
 
-    /// A first-attempt refusal is definite: nothing can have landed, so no
-    /// read-back runs and the refusal surfaces directly.
     #[tokio::test]
     async fn multipart_complete_first_attempt_rejection_skips_verification() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2821,9 +2782,6 @@ mod tests {
         assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
     }
 
-    /// When the read-back itself fails, the outcome stays unknown and
-    /// surfaces as a transport error carrying both failures — never as a
-    /// success the store cannot prove.
     #[tokio::test]
     async fn multipart_complete_unverifiable_outcome_surfaces_both_failures() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2850,9 +2808,6 @@ mod tests {
         assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
     }
 
-    /// Multipart transfers carry no whole-operation clock: with a stepping
-    /// timer that would spend the single-request deadline almost instantly,
-    /// part retries still run to their full count budget.
     #[tokio::test]
     async fn multipart_part_retries_are_count_bounded_not_clock_bounded() {
         let flaky = Arc::new(FlakyStore::default());

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -635,10 +635,6 @@ access_key = "key"
         }
     }
 
-    /// A provider's own endpoint on plain `http` is a misconfiguration, and
-    /// the message says what to do about it. Any other host is left alone —
-    /// a private gateway on `http` is a legitimate setup that simply earns
-    /// no direct transfers.
     #[test]
     fn a_provider_endpoint_without_tls_is_rejected_by_name() {
         for (contents, host) in [

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -140,10 +140,6 @@ async fn aws_s3_real_provider_conformance() {
     assert_provider_conformance(&store, true).await;
 }
 
-/// The streamed write against live AWS S3. Separate from the conformance
-/// sweep because it moves 24 MiB: it is the one exercise where the
-/// provider's real multipart rules — non-final part sizes, completion,
-/// assembly — meet a payload the server never held.
 #[tokio::test]
 #[ignore = "requires real AWS S3 credentials"]
 async fn aws_s3_streamed_write_round_trips() {
@@ -165,8 +161,6 @@ async fn aws_s3_streamed_write_round_trips() {
     assert_streamed_write_round_trips(&store).await;
 }
 
-/// The same streamed write against live Cloudflare R2, whose fixed
-/// non-final part size rule is the one this geometry has to satisfy.
 #[tokio::test]
 #[ignore = "requires real Cloudflare R2 credentials"]
 async fn cloudflare_r2_streamed_write_round_trips() {

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -628,7 +628,6 @@ mod tests {
         }
     }
 
-    /// Loading a config preserves its credential source without resolving it.
     #[test]
     fn ambient_credential_sources_survive_loading_with_environment_credentials_set() {
         let path = write_config(
@@ -1716,9 +1715,6 @@ root = "/tmp/loonfs-server"
         }
     }
 
-    /// A disk tier smaller than one block holds nothing on disk, and foyer
-    /// says so in a warning rather than an error. The config check is what
-    /// makes it a startup failure with a number in it.
     #[test]
     fn a_local_cache_disk_tier_has_a_floor() {
         let with_disk_bytes = |disk_bytes: u64| {
@@ -2023,8 +2019,6 @@ root = "/tmp/loonfs-server"
         }
     }
 
-    /// Every server example config must keep parsing into [`ServerConfig`]
-    /// (including under `deny_unknown_fields`) and passing field validation.
     #[test]
     fn server_example_configs_parse_and_validate() {
         let configs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("config");

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -426,22 +426,11 @@ impl<const MAX_BYTES: usize> FromRequest<AppState> for UploadBodyBytes<MAX_BYTES
     }
 }
 
-/// The proxied-upload body as a stream, plus the admission permit that
-/// bounds how many such transfers run at once.
+/// Proxied upload stream and its concurrency permit.
 ///
-/// Extraction runs the admission sequence in bounded-cost order:
-/// authorization first (an unauthenticated caller must not occupy a
-/// transfer slot), then a permit — or 503 `server_busy`. The body itself is
-/// not read here at all. It is handed on as a stream so the write path can
-/// hash it and forward it a piece at a time, which is what keeps a large
-/// upload's memory cost independent of its size. The permit rides with the
-/// stream and frees its slot when the handler drops it.
-///
-/// Two things end a transfer early, and neither can be reported through the
-/// stream itself — a store sees only "the payload stopped". So the reason
-/// is recorded beside it and read back by [`Self::into_rejection`] once the
-/// write has failed: a body past `upload.max_content_bytes` answers 413
-/// `content_too_large`, an unreadable one 400.
+/// Authorization occurs before acquiring a permit. The body remains streamed
+/// so memory use does not grow with payload size. Abort state distinguishes an
+/// oversized body (`413 content_too_large`) from an unreadable body (`400`).
 pub(super) struct UploadBodyStream {
     body: axum::body::Body,
     max_bytes: u64,

--- a/crates/loonfs-server/src/http/metrics/tests.rs
+++ b/crates/loonfs-server/src/http/metrics/tests.rs
@@ -42,8 +42,6 @@ fn a_gauge_renders_without_a_suffix() {
     );
 }
 
-/// Prometheus buckets are cumulative and must end at `+Inf`; the runtime's
-/// are per-bucket, so this is where the running sum happens.
 #[test]
 fn a_histogram_renders_cumulative_buckets_ending_at_infinity() {
     const BOUNDARIES: &[f64] = &[1.0, 2.0];
@@ -70,7 +68,6 @@ fn a_histogram_renders_cumulative_buckets_ending_at_infinity() {
     );
 }
 
-/// One name, one header pair, however many label sets it carries.
 #[test]
 fn label_sets_of_one_name_share_a_single_header_pair() {
     let recorder = DefaultMetricsRecorder::new();
@@ -96,8 +93,6 @@ fn label_sets_of_one_name_share_a_single_header_pair() {
     );
 }
 
-/// A scrape that reads the same numbers twice must produce the same bytes,
-/// or a diffing operator sees changes that did not happen.
 #[test]
 fn rendering_the_same_readings_twice_produces_the_same_bytes() {
     let recorder = DefaultMetricsRecorder::new();
@@ -166,8 +161,6 @@ fn a_scrape_reports_positive_process_resident_bytes() {
     assert!(resident_bytes > 0);
 }
 
-/// The whole reason the label is the matched template: a route seen twice is
-/// one label, and a path that matched nothing never becomes one.
 #[test]
 fn route_labels_intern_once_and_refuse_to_grow_without_bound() {
     let mut routes = RouteLabels::default();

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -182,10 +182,6 @@ fn replace_file_options() -> PutFileOptions {
     }
 }
 
-/// The compile-time forcing function for new error codes moved here when
-/// `ErrorCode` became `#[non_exhaustive]`: every registered code must
-/// appear in the api.md error table, and the status this server serves
-/// must be the status the table documents.
 #[test]
 fn error_status_mapping_matches_the_api_spec_table() {
     let spec = std::fs::read_to_string(concat!(
@@ -832,9 +828,6 @@ async fn every_deadline_exemption_names_a_served_route() {
     }
 }
 
-/// The `[local_cache]` table is the whole switch: without it nothing is
-/// built, and a scrape says nothing about a tier this deployment does not
-/// have.
 #[tokio::test]
 async fn a_server_without_the_table_builds_no_local_cache() {
     let temp_dir = tempdir().expect("tempdir");
@@ -896,8 +889,6 @@ async fn runtime_and_grep_cache_metrics_render_from_the_recorder() {
     assert!(!rendered.contains("loonfs_cache_metadata_segment_cache_hits"));
 }
 
-/// A configured cache is built at startup and reports itself on every
-/// scrape.
 #[tokio::test]
 async fn a_configured_local_cache_is_built_and_scraped() {
     let temp_dir = tempdir().expect("tempdir");
@@ -919,8 +910,6 @@ async fn a_configured_local_cache_is_built_and_scraped() {
     local_cache.close().await.expect("close local cache");
 }
 
-/// The graceful path closes the cache, and closes it after the writer has
-/// settled.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn graceful_shutdown_closes_the_local_cache() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1170,21 +1159,6 @@ impl MaintenanceJob for StepCountingJob {
     }
 }
 
-/// `FsWriter::shutdown` closes maintenance admission before it starts
-/// draining publications, under a real deployment rather than a bare
-/// writer: this server registers the grep index job and runs the publish
-/// observer that nudges it.
-///
-/// The drain is a wait, and it is the whole window: while it runs, the
-/// runner's timer is still promoting deadlines and every publication that
-/// lands still fires the observer that nudges the grep index. A nudge that
-/// arrives in that window must find the door already shut, or the shutdown
-/// spends it starting work it is about to throw away — and then waits for
-/// that work to finish.
-///
-/// The observation is behavioral rather than a flag read, and it is pinned
-/// on the shutdown's first poll rather than on wall-clock timing: nudge
-/// after that poll, and no step may follow.
 #[tokio::test]
 async fn shutdown_closes_maintenance_admission_before_draining_publications() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2350,14 +2324,6 @@ fn distinct_bytes(len: usize) -> Vec<u8> {
 const MEMORY_BOUND_PART_BYTES: u64 = loonfs_objectstore::PROVIDER_MULTIPART_PART_BYTES;
 const MEMORY_BOUND_PAYLOAD_BYTES: usize = 3 * MEMORY_BOUND_PART_BYTES as usize + 4_096;
 
-/// The proxied upload route must not materialize its request body.
-///
-/// This is measured, not asserted about the process: the store is wrapped in
-/// a watcher that records every payload buffer handed across the object-store
-/// boundary and, exactly, how many bytes of them are alive at any instant. A
-/// route that buffered its body would hand the store one buffer the size of
-/// the whole payload; a streaming one hands it a series of chunks and never
-/// holds more than a part's worth.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn the_proxied_upload_route_never_holds_the_whole_payload() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2403,9 +2369,6 @@ async fn the_proxied_upload_route_never_holds_the_whole_payload() {
     harness.server.abort();
 }
 
-/// The same bound one layer down, on the primitive the route depends on.
-/// Driving `put_streamed` directly separates "the route streams" from "the
-/// store writes incrementally", so a regression in either is attributable.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn put_streamed_writes_a_multi_part_payload_one_part_at_a_time() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3788,9 +3751,6 @@ mod direct_download {
         }
     }
 
-    /// The audit's case in miniature: a file this deployment will not
-    /// buffer for one response comes home through a download grant, byte
-    /// for byte, checked against the reference the grant carried.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_file_past_the_proxy_cap_round_trips_through_a_download_grant() {
         let temp_dir = tempdir().expect("tempdir");
@@ -3866,9 +3826,6 @@ mod direct_download {
         assert_eq!(inode_received, payload);
     }
 
-    /// A grant names one immutable object, so a commit that replaces the
-    /// file afterwards changes neither what it reads nor whether it works —
-    /// and a grant asked for one revision reads that revision.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_grant_keeps_reading_the_revision_it_was_issued_for() {
         let temp_dir = tempdir().expect("tempdir");
@@ -3917,10 +3874,6 @@ mod direct_download {
         assert_eq!(pinned.content_ref, grant.content_ref);
     }
 
-    /// A deployment that cannot presign refuses the grant the same way it
-    /// refuses a direct upload — one typed `not_supported` naming the
-    /// capability a client would have gated on — rather than 404ing a route
-    /// that exists everywhere.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_deployment_that_cannot_presign_refuses_the_grant_by_capability() {
         let temp_dir = tempdir().expect("tempdir");
@@ -3987,9 +3940,6 @@ mod direct_download {
         );
     }
 
-    /// A provider that signs whole-object writes and reads but has no
-    /// multipart API advertises exactly that: each transport comes from its
-    /// own issuer, and the read comes from the bundle existing at all.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_provider_without_multipart_advertises_put_and_get_and_denies_multipart() {
         let temp_dir = tempdir().expect("tempdir");
@@ -4076,14 +4026,6 @@ mod direct_download {
         }
     }
 
-    /// The GCS shape, end to end, with no GCS-specific code anywhere above
-    /// the object-store adapter.
-    ///
-    /// A bundle that signs reads and CRC-32C whole-object writes and no
-    /// multipart is served by the same handler, carried by the same client
-    /// ladder, and completed by the same rule as the S3-compatible one. The client learns `crc32c` from the capability document, folds
-    /// exactly that digest over the payload in its one measuring pass, and
-    /// the ref the commit records carries that full-object checksum.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_crc32c_provider_without_multipart_carries_a_file_end_to_end() {
         let temp_dir = tempdir().expect("tempdir");
@@ -4148,7 +4090,6 @@ mod direct_download {
         assert_eq!(received, payload);
     }
 
-    /// A store that authorizes nothing directly advertises none of the three.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_deployment_without_a_bundle_advertises_no_direct_transfer() {
         let temp_dir = tempdir().expect("tempdir");
@@ -4170,10 +4111,6 @@ mod direct_download {
             .contains_key(LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES));
     }
 
-    /// The ladder's whole point: with no multipart API to open, a payload
-    /// too large for the proxy still reaches object storage — through one
-    /// presigned whole-object write, chosen by the client from what the
-    /// deployment advertised.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_large_file_takes_direct_put_where_multipart_is_not_offered() {
         let temp_dir = tempdir().expect("tempdir");
@@ -4220,9 +4157,6 @@ mod direct_download {
         assert_eq!(received, payload);
     }
 
-    /// A payload no transport can carry is refused before any byte moves,
-    /// naming the caps it passed, rather than being pushed into the capped
-    /// proxy to fail there.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_payload_past_every_transport_is_refused_with_the_caps_named() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-server/src/local_cache/tests.rs
+++ b/crates/loonfs-server/src/local_cache/tests.rs
@@ -90,12 +90,6 @@ fn key(offset: u64) -> StoredMetadataBlockKey {
     }
 }
 
-/// The cache keeps what it is given and finds it again after a restart.
-///
-/// The reopen is the point. An insert reaches disk, closing flushes what the
-/// memory tier still held, and a fresh cache over the same directory serves
-/// both; without that this would be an in-memory cache with a directory
-/// beside it.
 #[tokio::test]
 async fn a_kept_block_survives_a_reopen() {
     let temp_dir = tempdir().expect("tempdir");
@@ -128,7 +122,6 @@ async fn a_kept_block_survives_a_reopen() {
     reopened.close().await.expect("close reopened cache");
 }
 
-/// One directory belongs to one server.
 #[tokio::test]
 async fn a_second_open_of_one_directory_is_refused() {
     let temp_dir = tempdir().expect("tempdir");
@@ -148,7 +141,6 @@ async fn a_second_open_of_one_directory_is_refused() {
     held.close().await.expect("close local cache");
 }
 
-/// A closed cache is inert, and closing it again is not an error.
 #[tokio::test]
 async fn a_closed_cache_answers_nothing_and_keeps_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -174,7 +166,6 @@ async fn a_closed_cache_answers_nothing_and_keeps_nothing() {
         .expect("closing a closed cache does nothing further and succeeds");
 }
 
-/// A root the process cannot make a directory of fails startup.
 #[tokio::test]
 async fn an_unusable_path_fails_startup() {
     let temp_dir = tempdir().expect("tempdir");
@@ -191,14 +182,6 @@ async fn an_unusable_path_fails_startup() {
     }
 }
 
-/// The disk tier writes beneath the versioned directory, in one open file
-/// per block.
-///
-/// The file count is what bounds [`DISK_BLOCK_BYTES`] from below: the tier
-/// claims the whole capacity as blocks at startup and holds every block file
-/// open, so a smaller block means proportionally more descriptors for the
-/// same `disk_bytes`. The assertion is here so that relationship cannot
-/// change without someone noticing.
 #[tokio::test]
 async fn the_disk_tier_claims_the_capacity_as_block_files() {
     let temp_dir = tempdir().expect("tempdir");
@@ -226,13 +209,6 @@ async fn the_disk_tier_claims_the_capacity_as_block_files() {
     );
 }
 
-/// A tier that shrinks starts over rather than leaving blocks behind.
-///
-/// foyer names block files from a counter and never reads the directory, so
-/// a smaller capacity would reopen the low-numbered files and abandon the
-/// rest: cached bytes on disk that nothing opens, nothing counts, and
-/// nothing reclaims, holding the tier above the size it was configured for.
-/// The file count is the assertion because it is the thing that leaks.
 #[tokio::test]
 async fn a_shrunk_disk_tier_starts_over() {
     let temp_dir = tempdir().expect("tempdir");
@@ -268,12 +244,6 @@ async fn a_shrunk_disk_tier_starts_over() {
     reopened.close().await.expect("close reopened cache");
 }
 
-/// A tier that grows keeps what it had.
-///
-/// The files foyer already wrote are the ones it reopens, so a bigger
-/// capacity is the one geometry change that costs nothing: it adds files
-/// above the ones that are there. Discarding here would throw away a warm
-/// cache for no reason.
 #[tokio::test]
 async fn a_grown_disk_tier_keeps_what_it_had() {
     let temp_dir = tempdir().expect("tempdir");
@@ -307,12 +277,6 @@ async fn a_grown_disk_tier_keeps_what_it_had() {
     reopened.close().await.expect("close reopened cache");
 }
 
-/// A directory whose marker says nothing readable is discarded.
-///
-/// The marker is the only account of how many block files are down there.
-/// One this process cannot parse is no account at all, and a directory of
-/// unknown geometry is exactly the one that leaks, so it is treated like a
-/// shrink rather than trusted.
 #[tokio::test]
 async fn an_unreadable_geometry_marker_starts_over() {
     let temp_dir = tempdir().expect("tempdir");
@@ -352,17 +316,6 @@ async fn an_unreadable_geometry_marker_starts_over() {
     reopened.close().await.expect("close reopened cache");
 }
 
-/// A marker that exists and cannot be read fails startup.
-///
-/// The recovery for an unreadable marker is to delete the directory it
-/// describes, so the two cases have to stay apart: a marker that is not
-/// there says the directory is new, while one that is there and answers an
-/// error says nothing at all about how many block files are below it. The
-/// second is a permission or device problem, and deleting on the strength of
-/// it would discard a warm cache — or fail to — for a reason nobody could
-/// see. The path is made a directory here because that produces a real
-/// read error on every platform these tests run on, without depending on
-/// which user is running them.
 #[tokio::test]
 async fn an_unreadable_geometry_marker_fails_startup() {
     let temp_dir = tempdir().expect("tempdir");
@@ -391,12 +344,6 @@ async fn an_unreadable_geometry_marker_fails_startup() {
     );
 }
 
-/// foyer's overflow counters reach this process's numbers.
-///
-/// The bridge is one metric name and two label values agreed with foyer, and
-/// nothing in the type system holds the agreement together, so it is
-/// asserted here: the registry hands back the counters foyer increments, and
-/// what foyer increments is what a scrape reads.
 #[test]
 fn the_registry_keeps_foyers_two_overflow_counters() {
     let counters = FoyerOverflowCounters::default();

--- a/crates/loonfs-server/src/trace.rs
+++ b/crates/loonfs-server/src/trace.rs
@@ -80,8 +80,6 @@ fn trace_config_from_env(
 mod tests {
     use super::{trace_config_from_env, DEFAULT_TRACE_FILTER};
 
-    /// An unset or blank `LOONFS_TRACE` logs, and logs exactly what `json`
-    /// logs.
     #[test]
     fn tracing_is_enabled_without_env() {
         let unset = trace_config_from_env(None, None)
@@ -110,9 +108,6 @@ mod tests {
             .is_none());
     }
 
-    /// `off` silences the output whatever `RUST_LOG` says, because the two
-    /// answer different questions: one turns logging off and the other picks
-    /// the filter.
     #[test]
     fn off_wins_over_rust_log() {
         assert!(trace_config_from_env(
@@ -134,8 +129,6 @@ mod tests {
         assert_eq!(config.filter, "loonfs_core=debug");
     }
 
-    /// `RUST_LOG` still picks the filter when `LOONFS_TRACE` is unset, which
-    /// is the mode most deployments run in.
     #[test]
     fn default_tracing_uses_rust_log_when_present() {
         let config = trace_config_from_env(None, Some("loonfs_core=debug".to_owned()))

--- a/crates/loonfs-server/tests/it/check_config.rs
+++ b/crates/loonfs-server/tests/it/check_config.rs
@@ -236,10 +236,6 @@ root = "/tmp/loonfs-check-config-unused"
     );
 }
 
-/// The check loads the TLS identity, so an identity a start could not use
-/// fails the check too. Field validation passes both configs below: each one
-/// names two non-empty paths, which is all the config file can say about
-/// them.
 #[test]
 fn check_config_reports_a_tls_identity_it_cannot_load() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -291,9 +287,6 @@ fn check_config_reports_a_tls_identity_it_cannot_load() {
     );
 }
 
-/// The check opens the local block cache, so a directory a start could not
-/// own fails the check too. A plain file where the directory belongs is one
-/// way to be unable to own it, and it fails whichever user runs the test.
 #[test]
 fn check_config_reports_a_local_cache_it_cannot_open() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -323,12 +316,6 @@ fn check_config_reports_a_local_cache_it_cannot_open() {
     );
 }
 
-/// A configured identity and a configured cache both pass, and the check
-/// leaves the cache directory the way the start that follows it needs to
-/// find it.
-///
-/// The second run is what proves the release: it calls the same open a start
-/// calls, so a lock the first run still held would fail it.
 #[test]
 fn check_config_opens_the_local_cache_and_leaves_it_openable() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -373,8 +360,6 @@ fn check_config_opens_the_local_cache_and_leaves_it_openable() {
     );
 }
 
-/// Holding the configured port during the check proves the check never binds
-/// it: a server that bound would fail with the address already in use.
 #[test]
 fn check_config_does_not_bind_the_port() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -630,7 +630,6 @@ fn direct_put_prefix(provider: &str, base_prefix: Option<String>) -> String {
     )
 }
 
-/// Runs the direct PUT round trip through native GCS V4 signed URLs.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires real GCP GCS credentials"]
 async fn gcp_gcs_direct_put_real_provider_round_trip() {
@@ -647,7 +646,6 @@ async fn gcp_gcs_direct_put_real_provider_round_trip() {
     .await;
 }
 
-/// Tests GCS capability scope, replay protection, expiry, and ranged reads.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "requires real GCP GCS credentials"]
 async fn gcp_gcs_signed_capabilities_are_scoped_bounded_and_single_use() {

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -554,9 +554,6 @@ async fn maintain_only_keeps_the_index_built_without_serving_searches() {
     server.shutdown().await.expect("settle the server writer");
 }
 
-/// `maintenance = "manual"` registers no automatic job — the grep index's
-/// included, whatever the grep mode says — and changes nothing an operator
-/// may ask for. Who schedules is the only difference.
 #[tokio::test]
 async fn manual_maintenance_registers_no_index_job_and_still_administers_one() {
     let temp_dir = tempdir().expect("store tempdir");

--- a/crates/loonfs-server/tests/it/http_attributes.rs
+++ b/crates/loonfs-server/tests/it/http_attributes.rs
@@ -86,8 +86,6 @@ fn assert_projection(entry: &serde_json::Value, projected: bool) {
     );
 }
 
-/// Stat projects attributes by default and drops the siblings on request;
-/// listing does the opposite.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_reads_project_flat_attribute_siblings_together() {
     let temp_dir = tempdir().expect("tempdir");
@@ -148,8 +146,6 @@ async fn http_reads_project_flat_attribute_siblings_together() {
     }
 }
 
-/// The parameter accepts the two spellings it documents and rejects the rest,
-/// on both read endpoints.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_include_attributes_accepts_true_and_false_and_nothing_else() {
     let temp_dir = tempdir().expect("tempdir");
@@ -204,8 +200,6 @@ async fn http_include_attributes_accepts_true_and_false_and_nothing_else() {
     );
 }
 
-/// The client sends the options it was given, and its defaults are the
-/// server's.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn the_client_round_trips_the_read_options() {
     let temp_dir = tempdir().expect("tempdir");
@@ -275,8 +269,6 @@ async fn the_client_round_trips_the_read_options() {
         .all(|entry| entry.attributes.is_some()));
 }
 
-/// A served deployment advertises attributes as a core feature, the way the
-/// embedded runtime does.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn the_served_capability_document_advertises_attributes() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -83,8 +83,6 @@ fn batch(first: &ContentRef, second: &ContentRef) -> Vec<FilesystemOperation> {
     ]
 }
 
-/// One batch, two transports: the same three operations submitted over HTTP
-/// and embedded produce the same single commit and the same ordered events.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_batch_commits_once_and_matches_the_same_batch_embedded() {
     let temp_dir = tempdir().expect("tempdir");
@@ -214,9 +212,6 @@ async fn a_batch_commits_once_and_matches_the_same_batch_embedded() {
     harness.server.abort();
 }
 
-/// A commit answers with the change it committed, so a caller reads the
-/// inode id its put created out of the response instead of stating the path
-/// afterward. A replay of the same request answers with that same row.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_commit_returns_the_change_it_committed_and_replays_it() {
     let temp_dir = tempdir().expect("tempdir");
@@ -321,10 +316,6 @@ async fn a_commit_returns_the_change_it_committed_and_replays_it() {
     harness.server.abort();
 }
 
-/// Retirement is the one case where a replay cannot report events. Once the
-/// retention floor passes a commit, the record holding its events is no
-/// longer readable while the commit receipt still is, so the replay answers
-/// from the receipt and omits `events`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_replay_below_the_retention_floor_omits_its_events() {
     let temp_dir = tempdir().expect("tempdir");
@@ -416,8 +407,6 @@ async fn a_replay_below_the_retention_floor_omits_its_events() {
     harness.server.abort();
 }
 
-/// A batch is all-or-nothing: the operation that stops it names its own
-/// position, and nothing the batch would have written is visible.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_failing_operation_names_its_position_and_commits_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -517,8 +506,6 @@ async fn a_failing_operation_names_its_position_and_commits_nothing() {
     harness.server.abort();
 }
 
-/// An empty operation list is the one shape the language does not accept;
-/// the wire surfaces core's own classification for it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn an_empty_operation_list_is_rejected() {
     let temp_dir = tempdir().expect("tempdir");
@@ -570,12 +557,6 @@ async fn an_empty_operation_list_is_rejected() {
     harness.server.abort();
 }
 
-/// The root is readable but never a mutation target, alone or inside a
-/// batch, and rejecting it commits nothing.
-///
-/// The planners own the rule, so the rejection is attributed exactly like
-/// every other planning failure: a batch names the operation that stopped
-/// it, a one-operation request names nothing, and both echo the commit id.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn the_root_path_is_rejected_as_a_mutation_target() {
     let temp_dir = tempdir().expect("tempdir");
@@ -724,8 +705,6 @@ async fn the_root_path_is_rejected_as_a_mutation_target() {
     harness.server.abort();
 }
 
-/// Replay over the wire: the same id with the same batch returns the
-/// original receipt, and the same id with a different batch conflicts.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_batch_replays_under_its_commit_id() {
     let temp_dir = tempdir().expect("tempdir");
@@ -800,9 +779,6 @@ async fn a_batch_replays_under_its_commit_id() {
     harness.server.abort();
 }
 
-/// One fingerprint domain across transports: a batch committed embedded
-/// replays over HTTP under the same commit id, and a different batch under
-/// that id conflicts over HTTP just as it would embedded.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_commit_id_used_embedded_replays_over_http() {
     let temp_dir = tempdir().expect("tempdir");
@@ -936,12 +912,6 @@ async fn a_commit_id_used_embedded_replays_over_http() {
     harness.server.abort();
 }
 
-/// A misspelled guard fails the request rather than the precondition.
-///
-/// Every optimistic-concurrency guard on a commit is an optional field, so
-/// before the commit body rejected unknown fields a typo decoded to `None`
-/// and the write applied unguarded — a lost update reported as a 200. The two
-/// bodies below differ only in how `expected_revision_no` is spelled.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_misspelled_commit_guard_is_rejected_rather_than_dropped() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-server/tests/it/http_metrics.rs
+++ b/crates/loonfs-server/tests/it/http_metrics.rs
@@ -17,8 +17,6 @@ fn object_store_calls(scrape: &BTreeMap<String, f64>) -> f64 {
         .sum()
 }
 
-/// The route reports what the process is doing, not whether it is up, so it
-/// authorizes like every other route — unlike `/health` and `/readiness`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn scraping_metrics_without_a_token_is_unauthorized() {
     let temp_dir = tempdir().expect("tempdir");
@@ -38,9 +36,6 @@ async fn scraping_metrics_without_a_token_is_unauthorized() {
     harness.server.abort();
 }
 
-/// One scrape has to show all three layers moving: the requests this server
-/// served, the object-store calls they made, and the runtime caches those
-/// reads warmed.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_scrape_reports_requests_object_store_calls_and_cache_metrics() {
     let temp_dir = tempdir().expect("tempdir");
@@ -136,8 +131,6 @@ async fn a_scrape_reports_requests_object_store_calls_and_cache_metrics() {
     harness.server.abort();
 }
 
-/// A path outside the served surface must not become a label of its own, or
-/// one scanner turns the request metric into a cardinality bomb.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn unmatched_paths_share_one_route_label() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -299,9 +299,6 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
     harness.server.abort();
 }
 
-/// The client aggregates pages without re-ordering: mixed-case names must come
-/// back in the server's canonical casefolded name-key order, not in raw
-/// display-name byte order (`B.txt` sorts after `a.txt`, not before).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_client_listing_preserves_canonical_name_key_order() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -243,11 +243,6 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
     harness.server.abort();
 }
 
-/// The message is part of a commit's identity, so re-uploading the same
-/// bytes under a changed message is a different mutation and the conflict
-/// stands. The bytes matching is exactly what makes this worth pinning:
-/// content evidence alone would call this a successful retry and quietly
-/// keep the original annotation.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_conflict_stands_when_only_the_message_changed() {
     let temp_dir = tempdir().expect("tempdir");
@@ -341,10 +336,6 @@ async fn http_put_conflict_stands_when_only_the_message_changed() {
     harness.server.abort();
 }
 
-/// The same bytes written somewhere else are a different mutation, and no
-/// amount of matching payload makes them the same one. Content evidence
-/// alone would call this a successful retry and leave `/b.txt` unwritten
-/// forever, which is why the client proves the whole request fingerprint.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_conflict_stands_when_only_the_path_changed() {
     let temp_dir = tempdir().expect("tempdir");
@@ -420,9 +411,6 @@ async fn http_put_conflict_stands_when_only_the_path_changed() {
     harness.server.abort();
 }
 
-/// The replacement behavior and the expected-revision guard are part of
-/// what the caller asked for, so the same bytes at the same path under
-/// either one changed are different mutations.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_conflict_stands_when_only_a_guard_changed() {
     let temp_dir = tempdir().expect("tempdir");
@@ -502,9 +490,6 @@ async fn http_put_conflict_stands_when_only_a_guard_changed() {
     harness.server.abort();
 }
 
-/// A commit that did more than one thing is not the commit a single put
-/// makes, however well its put half lines up. The operation list is inside
-/// the fingerprint, so the count alone settles this.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_single_put_does_not_replay_a_multi_operation_commit() {
     let temp_dir = tempdir().expect("tempdir");
@@ -585,11 +570,6 @@ async fn http_single_put_does_not_replay_a_multi_operation_commit() {
     harness.server.abort();
 }
 
-/// The mutations that upload nothing reconcile nothing — the server's own
-/// identity check is the whole answer — so a changed message conflicts
-/// there whatever the put path does. These anchor that the client-side
-/// reconciliation is not the only thing keeping the contract: one commit
-/// built by the caller, and one `mkdir`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_commit_and_mkdir_conflict_when_only_the_message_changed() {
     let temp_dir = tempdir().expect("tempdir");
@@ -674,11 +654,6 @@ async fn http_commit_and_mkdir_conflict_when_only_the_message_changed() {
     harness.server.abort();
 }
 
-/// The client reconciles by reading the feed at the sequence the conflict
-/// reported. Once retention has surrendered incremental replay below that
-/// sequence, the feed cannot answer for it, so there is nothing to compare
-/// and the conflict stands — identical bytes included. A comparison that
-/// cannot be made is never reported as success.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_conflict_stands_when_retention_trimmed_the_committed_seq() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -55,10 +55,6 @@ async fn http_upload_content_rejects_invalid_upload_id() {
     harness.server.abort();
 }
 
-/// A begin body that mixes two transports, or names none, is refused where
-/// it is read. These used to reach a handler that compared the fields back
-/// against the mode; the tagged request means there is nothing to compare,
-/// and the standard 400 envelope is what the client sees either way.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_begin_upload_rejects_a_body_that_mixes_transports() {
     let temp_dir = tempdir().expect("tempdir");
@@ -399,9 +395,6 @@ async fn completion_content_token_passes_unchanged_into_http_commit() {
     harness.server.abort();
 }
 
-/// The two new surfaces over HTTP: reading a session, and ending one
-/// without content. The status read is what re-mints, so a client that lost
-/// its commit response gets a usable token back without sending a byte.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_upload_status_re_mints_and_abort_is_terminal() {
     let temp_dir = tempdir().expect("tempdir");
@@ -516,10 +509,6 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     harness.server.abort();
 }
 
-/// Cross-process recovery through the Rust client alone: the upload id is
-/// the only thing that has to survive. Reading the session back names the
-/// exact content that landed and hands over a token that admits it, so the
-/// retry commits without re-uploading anything.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn client_reads_a_completed_upload_back_and_commits_what_it_names() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-server/tests/it/local_cache.rs
+++ b/crates/loonfs-server/tests/it/local_cache.rs
@@ -44,13 +44,6 @@ fn test_config_with_local_cache(
     }
 }
 
-/// A restarted server uses the local cache for point-shaped section loads,
-/// while a directory scan skips it for data blocks.
-///
-/// The second server starts with empty in-memory caches, so the only thing
-/// carried over is the cache directory the first one closed. Its index read
-/// hits that tier. Its data span performs no local-cache operation because
-/// the store path can coalesce the selected blocks.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
     let store_dir = tempdir().expect("store tempdir");

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -138,8 +138,6 @@ fn every_one_of_is_a_discriminated_non_null_union() {
     }
 }
 
-/// Checks success and error response schemas, including components used only
-/// by `ApiError` and `ErrorDetails`.
 #[test]
 fn no_schema_a_response_reaches_admits_null() {
     let spec: Value = serde_json::from_str(
@@ -1084,10 +1082,6 @@ const UNION_COMPOSITE_ENVELOPES: &[(&str, &[&str])] = &[
     ),
 ];
 
-/// A response that flattens an enum is one discriminated union, never an
-/// `allOf` wrapped around one. SDK generators keep the envelope half of such
-/// an `allOf` and drop the union half, so the generated type would lose every
-/// field the variants carry.
 #[test]
 fn no_openapi_schema_wraps_an_all_of_around_a_one_of() {
     for document_path in [OPENAPI_JSON_PATH, PROXY_OPENAPI_JSON_PATH] {

--- a/crates/loonfs-test-support/src/stores/blocking_store.rs
+++ b/crates/loonfs-test-support/src/stores/blocking_store.rs
@@ -335,10 +335,6 @@ mod tests {
     use std::time::Duration;
     use tempfile::tempdir;
 
-    /// The gate carries no wall-clock budget of its own: a parked operation
-    /// waits for the release however long the test takes to reach it. Time is
-    /// paused, so the hold below costs nothing to run while being longer than
-    /// any deadline this helper could plausibly have carried.
     #[tokio::test(start_paused = true)]
     async fn a_parked_operation_waits_for_the_release_however_long_it_takes() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -1,6 +1,4 @@
-//! Runtime configuration: read-side limits and cache sizing, plus the
-//! writer-identity validation the write-capable builders apply, with the
-//! defaults the rest of the crate advertises.
+//! Runtime limits, cache sizing, and writer identity validation.
 
 use crate::trace::{TraceMode, TraceStoreKind};
 use crate::{MetadataSegmentCacheConfig, Result, RuntimeError};
@@ -27,11 +25,7 @@ pub(crate) const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 15;
 /// dropped: it takes the next one that frees.
 pub const DEFAULT_MAX_CONCURRENT_MAINTENANCE: usize = 2;
 
-/// Configuration for one read core, assembled by the handle builders.
-///
-/// Everything here governs reading and caching, so every handle carries it.
-/// Writer-side settings — the actor identity and publication pacing — belong
-/// to the write-capable handles and never reach a reader.
+/// Read and cache configuration shared by all handles.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ReadConfig {
     /// Largest file content the buffered read APIs will materialize for one
@@ -51,20 +45,11 @@ pub(crate) struct ReadConfig {
 /// same way: a zero budget.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCacheConfig {
-    /// Maximum namespaces each entry-counted runtime cache retains: the
-    /// head anchors, the read-side WAL-tail projection entries, and the tail
-    /// projections a writer's namespace publishers hold. Setting this to
-    /// zero disables those caches — a diagnostic mode that trades speed for
-    /// re-reads. Cache settings never change behavior: maintenance
-    /// scheduling is controlled only by
-    /// [`FsBackgroundWork`](crate::FsBackgroundWork).
+    /// Maximum namespaces retained by entry-counted runtime caches. Zero
+    /// disables those caches. This does not affect maintenance scheduling.
     ///
-    /// It does not bound what a writer keeps per namespace it has mutated.
-    /// One writer session — the epoch it acquired and its terminal fencing
-    /// record — and the empty publisher around it are retained for every
-    /// live namespace, at a few dozen bytes each. That is deliberate:
-    /// nothing in the store can rebuild "this session was fenced", so
-    /// evicting it would let a fenced writer reacquire the epoch (see
+    /// Writer session state is retained separately because an evicted fenced
+    /// session could otherwise reacquire the epoch (see
     /// [`WriterSessionState`](loonfs_core::publish::WriterSessionState)).
     pub max_cached_namespaces: usize,
     /// Maximum metadata rows retained across WAL-tail projections. The read

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -1,6 +1,4 @@
-//! [`ReadCore`]: the read-side runtime state every handle shares, and the
-//! writer-side state — actor identity, background work, publish observer —
-//! that only a write-capable handle owns on top of it.
+//! Shared read state and additional state used by writers.
 
 use crate::cache::{RuntimeCacheStatsInner, RuntimeControlCache};
 use crate::config::{validate_writer_id, ReadConfig};
@@ -30,14 +28,7 @@ use loonfs_core::{MutationContext, NamespaceReaderEngine, NamespaceWriterEngine}
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-/// Shared read-side runtime state: the object-store client and the read
-/// caches. [`FsWriter`](crate::FsWriter), [`FsReader`](crate::FsReader), and
-/// [`FsAdmin`](crate::FsAdmin) each hold one; handles built from the same
-/// core share its caches and store.
-///
-/// A read core carries no actor identity, owns no publisher, and starts no
-/// background work — it is what a read needs and nothing more. `ReadCore` is
-/// cheap to clone.
+/// Shared object-store client, read configuration, caches, and metrics.
 #[derive(Clone)]
 pub(crate) struct ReadCore {
     pub(crate) inner: Arc<ReadCoreInner>,
@@ -50,28 +41,20 @@ pub(crate) struct ReadCoreInner {
     pub(crate) metadata_segment_cache: Arc<MetadataSegmentCache>,
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
     pub(crate) cache_stats: RuntimeCacheStatsInner,
-    /// Where this runtime's publication, maintenance, and collection
-    /// numbers go. Reports nothing unless the handle was built with a
-    /// metrics recorder.
+    /// Publication, maintenance, and collection metrics.
     pub(crate) instruments: Arc<RuntimeInstruments>,
 }
 
-/// The actor identity a write-capable handle publishes under: immutable
-/// plain data, minted once when the handle is built.
+/// Actor identity used by a writer.
 #[derive(Clone)]
 pub(crate) struct WriterIdentity {
     pub(crate) writer_id: String,
 }
 
-/// What a publisher worker needs from the writer that owns it, in one
-/// allocation the worker can hold weakly: dropping the writer drops these,
-/// and admitted work then settles as `shutting_down` instead of publishing
-/// under an identity nobody owns any more.
+/// Writer state shared weakly with the publisher worker.
 pub(crate) struct WriterBits {
     pub(crate) identity: WriterIdentity,
-    /// Admission for every background maintenance step this writer
-    /// schedules. Write paths reach it through a nudge-only handle; only
-    /// the writer shuts it down.
+    /// Background maintenance owned by this writer.
     pub(crate) maintenance: MaintenanceRunner,
     /// Optional synchronous notification after a mutation batch durably
     /// advances a namespace. Callers promise that it does not block.
@@ -177,16 +160,9 @@ impl ReadCore {
         span.record("store_kind", self.trace_store_kind());
     }
 
-    /// Returns the capability document for this embedded build (API spec,
-    /// "Capability discovery").
+    /// Returns capabilities implemented by the embedded runtime.
     ///
-    /// The runtime implements the core and admin planes, so the answer is a
-    /// constant. It describes this crate and nothing else: a host that
-    /// composes an extension — the reference server composing `loonfs-grep`,
-    /// for one — merges that extension's profile, features, and limits into
-    /// this document before serving it. Callers should still gate on the
-    /// document rather than on the backend kind, so the same logic works
-    /// against remote deployments that implement more or less.
+    /// A host may add extension capabilities before serving this document.
     pub(crate) fn get_capabilities(&self) -> CapabilityDocument {
         CapabilityDocument {
             protocol_version: PROTOCOL_VERSION.to_owned(),

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -465,30 +465,13 @@ impl FsAdmin {
         }
     }
 
-    /// Runs one planned streaming metadata compaction to its end, in the
-    /// caller's own task.
+    /// Runs one streaming metadata compaction in the caller's task.
     ///
-    /// This is the whole of metadata maintenance for a deployment that
-    /// schedules none: bounded steps run through [`Self::run_maintenance`],
-    /// and the one piece of upkeep that does not fit a step runs here. It
-    /// plans exactly as a step does, so a step reporting
-    /// [`ReorganizeStepOutcome::CompactionRequired`] is what says a call here
-    /// has work to do.
-    ///
-    /// The job is the same one background work runs: the same executor, the
-    /// same finalizer, and no durable record that it is running. Dropping the
-    /// returned future stops it, at the cost of the work it had done. A
-    /// handle attached to a writer's background work shares that writer's
-    /// namespace slots and compaction permits, so this waits its turn beside
-    /// the writer's own jobs and is cancelled by that writer's shutdown. A
-    /// standalone handle has neither, and the caller's own call rate is the
-    /// only limit on how many of these run at once.
-    ///
-    /// Planning here does not amortize. A caller who asks for this asked for
-    /// the long rebuild, so a family group whose base no bounded window can
-    /// reach is compacted on this call rather than after two more delta
-    /// merges have published over it — which, under sustained writes, is a
-    /// wait with no end.
+    /// Use this when automatic maintenance is disabled or
+    /// [`ReorganizeStepOutcome::CompactionRequired`] is reported. Dropping the
+    /// returned future cancels the compaction. Handles connected to a writer
+    /// share that writer's compaction limits and shutdown signal; standalone
+    /// handles rely on the caller to limit concurrency.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.maintenance.compact_metadata",
@@ -520,8 +503,7 @@ impl FsAdmin {
             ReorganizationStep::Concluded(_) => return Ok(MetadataCompactionOutcome::NoWork),
         };
         let Some(compactions) = &self.compactions else {
-            // No runner behind this handle, so there is no slot to claim and
-            // no permit to wait for.
+            // Standalone handles have no shared concurrency limit.
             let cancellation = loonfs_core::MetadataCompactionCancellation::default();
             let outcome = self
                 .run_streaming_compaction(namespace_id, &spec, &cancellation)

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -342,16 +342,6 @@ async fn bindings_runs<S: ObjectStore + ?Sized>(
         })
 }
 
-/// An explicit compaction runs the long job while a delta-only merge is still
-/// available, and a writer's own upkeep takes that merge instead.
-///
-/// The two policies are the whole point. Automatic upkeep amortizes: it takes
-/// the delta merge because it will run the job itself soon enough, and
-/// rebuilding a whole group for every batch of delta runs would reread
-/// megabytes to fold in a sliver. An explicit call cannot amortize against
-/// anything — under sustained writes there is always another pair of delta
-/// runs, so a call that took the merge would postpone the rebuild its caller
-/// asked for forever.
 #[tokio::test]
 async fn explicit_compaction_runs_the_job_while_a_delta_merge_is_still_available() {
     let temp_dir = tempdir().expect("tempdir");
@@ -443,12 +433,6 @@ async fn explicit_compaction_runs_the_job_while_a_delta_merge_is_still_available
     }
 }
 
-/// A standalone bounded step reports the compaction it cannot run, and the
-/// explicit call runs it.
-///
-/// Those are the two halves of a `ManualOnly` deployment's metadata upkeep. A
-/// step reports promptly rather than publishing delta merges that never reach
-/// the rebuild, and the operator's answer to that report is one call.
 #[tokio::test]
 async fn a_standalone_step_reports_the_compaction_the_explicit_call_runs() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/src/fs/mod.rs
+++ b/crates/loonfs/src/fs/mod.rs
@@ -1,6 +1,4 @@
-//! The read core every handle shares, the writer-side state a write-capable
-//! handle owns on top of it, and the operation surface — each method a thin,
-//! cache-aware delegation to `loonfs-core`.
+//! Filesystem operations and shared handle state.
 
 mod core;
 mod maintenance;

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -472,23 +472,13 @@ impl FsReader {
 
     /// Reads a file's current content as bounded chunks instead of one buffer.
     ///
-    /// This is [`Self::get_file_bytes`] for a caller that should not hold what
-    /// it reads: the content arrives one ranged read at a time with the
-    /// verifying digest folded over it, so a 50 GiB file costs one chunk of
-    /// memory rather than 50 GiB. The verification is the buffered read's,
-    /// unweakened — declared size plus the reference's full-object checksum,
-    /// recomputed using the algorithm the reference names — and it lands on the final
-    /// [`FileContentStream::next_chunk`] call. A caller that stops early
-    /// stops with unverified bytes; a caller that wants the whole answer or
-    /// none of it uses [`Self::get_file_bytes`].
+    /// Each ranged read uses bounded memory. Size and checksum verification
+    /// complete when [`FileContentStream::next_chunk`] returns `None`; stopping
+    /// early leaves the content unverified. The buffered-read size limit does
+    /// not apply.
     ///
-    /// The deployment's buffered-read cap does not apply here. That cap
-    /// bounds what one call materializes, and this call materializes a chunk.
-    ///
-    /// [`ReadFileStreamOptions::start_offset`] resumes a read the caller
-    /// already began. Verification stays over the whole object, so a
-    /// resumed stream refuses to fetch anything until it has been handed
-    /// the bytes below its start through
+    /// [`ReadFileStreamOptions::start_offset`] resumes a read. The caller must
+    /// supply earlier bytes for whole-object verification through
     /// [`FileContentStream::fold_resumed_prefix`].
     #[tracing::instrument(
         level = "debug",
@@ -585,21 +575,11 @@ impl FsReader {
         Ok(target)
     }
 
-    /// Reads one page of the files visible in the state a checkpoint pins,
-    /// in ascending inode-id order.
+    /// Lists files visible at a checkpoint in ascending inode-ID order.
     ///
-    /// The checkpoint's pinned manifest is the whole answer: no WAL is
-    /// replayed over it, so a commit landing mid-enumeration changes
-    /// nothing a consumer sees, and everything after
-    /// [`CheckpointFilesPage::checkpoint_seq`] is what
-    /// [`Self::list_changes`] reports. Directories are not returned.
-    ///
-    /// A released, expired, or reaped checkpoint returns
-    /// `checkpoint_unavailable`. The caller must create a new checkpoint and
-    /// restart instead of silently reading current state.
-    ///
-    /// This does not increment the latest-metadata-view metric because it
-    /// reads a checkpoint snapshot.
+    /// The pinned manifest is read without replaying later WAL entries.
+    /// Directories are omitted. An unavailable checkpoint returns
+    /// `checkpoint_unavailable` rather than falling back to current state.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.list_checkpoint_files_page",
@@ -625,14 +605,10 @@ impl FsReader {
             .await?)
     }
 
-    /// Answers, for each inode id, what it looks like right now: whether it
-    /// is visible, its current revision, and its current path.
+    /// Resolves the current state of each inode ID.
     ///
-    /// One pinned read serves the batch, so every answer describes the same
-    /// state, and answers come back in input order. Ids that name nothing
-    /// answer `visible: false` instead of failing — a consumer holding ids
-    /// from an earlier enumeration routinely holds stale ones. A directory
-    /// id answers visible with a path and no revision.
+    /// Results use one pinned read and preserve input order. Unknown IDs return
+    /// `visible: false`. Directories have a path but no revision.
     ///
     /// At most [`MAX_RESOLVE_CURRENT_FILES`](crate::MAX_RESOLVE_CURRENT_FILES)
     /// ids per call; a larger batch is refused with `invalid_request`

--- a/crates/loonfs/src/handle/mod.rs
+++ b/crates/loonfs/src/handle/mod.rs
@@ -1,22 +1,10 @@
-//! Purpose-specific runtime handles.
+//! Purpose-specific filesystem handles.
 //!
-//! One handle per job, each opened asynchronously inside the Tokio runtime
-//! that will drive it:
-//!
-//! - [`FsWriter`] mutates namespaces and optionally schedules non-destructive
-//!   maintenance after writes, controlled by
-//!   [`FsBackgroundWork`](crate::FsBackgroundWork).
-//! - [`FsReader`] serves namespace state and latest-view reads. It owns no
-//!   writer session and starts no maintenance.
-//! - [`FsAdmin`] runs explicit maintenance: diagnostics, checkpoints,
-//!   retention advancement, and garbage collection, always as one-shot
-//!   calls in the caller's task.
-//!
-//! Builders prefer [`StoreConfig`](crate::StoreConfig) so the object-store
-//! client is constructed inside the handle's runtime ownership domain. The
-//! `builder_with_store` escape hatches are for callers who know the store is
-//! safe in that domain — do not use them to share one provider client across
-//! unrelated runtimes; open another handle from config instead.
+//! [`FsWriter`] mutates namespaces, [`FsReader`] serves reads, and [`FsAdmin`]
+//! runs explicit maintenance. Each handle must be opened in the Tokio runtime
+//! where it will be used. Prefer builders that accept
+//! [`StoreConfig`](crate::StoreConfig); use `builder_with_store` only when the
+//! supplied store is safe to use from that runtime.
 
 mod admin;
 mod builder_core;

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -163,18 +163,11 @@ impl FsWriter {
         self.bits.maintenance.job(job)
     }
 
-    /// Waits for currently scheduled maintenance to finish without closing
-    /// admission.
+    /// Waits for scheduled maintenance to reach a quiet point.
     ///
-    /// New work may still be scheduled while this method runs, so it waits for a
-    /// quiet point rather than performing terminal shutdown. Task panics are
-    /// returned as runtime errors.
-    ///
-    /// One task this waits for is not a bounded step. A family group that has
-    /// outgrown one step is rebuilt by a streaming compaction paced by no
-    /// budget, and this waits for that to finish rather than stopping it.
-    /// [`Self::shutdown`] cancels it instead, which is what makes a shutdown
-    /// short.
+    /// Admission remains open, so new work may be scheduled while this method
+    /// runs. Streaming compactions are allowed to finish; [`Self::shutdown`]
+    /// cancels them. Task panics are returned as runtime errors.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.flush_background",
@@ -193,25 +186,13 @@ impl FsWriter {
         self.bits.maintenance.drain().await
     }
 
-    /// Gracefully shuts down writer-owned background work.
+    /// Stops publication and writer-owned background work.
     ///
-    /// Shutdown closes maintenance admission before its first await, then
-    /// closes publication admission, drains accepted publications, and waits
-    /// for maintenance tasks that were already running. Closing maintenance
-    /// first prevents completed publications from scheduling new work during
-    /// the drain. Maintenance jobs publish through [`FsAdmin`](crate::FsAdmin),
-    /// not the publication service, so the publication queue can only shrink.
-    ///
-    /// Closing maintenance admission also cancels streaming metadata
-    /// compactions. These jobs check for cancellation between block reads and
-    /// publish only after the complete merge finishes, so cancellation leaves
-    /// the current manifest unchanged. A later maintenance step can plan the
-    /// compaction again.
-    ///
-    /// After shutdown, mutations return `shutting_down`, maintenance nudges
-    /// are ignored, and reads continue to work. The method is idempotent and
-    /// may be called from any clone because all clones share the same shutdown
-    /// state. Task panics are returned as runtime errors.
+    /// Accepted publications and running maintenance steps are drained.
+    /// Streaming metadata compactions are cancelled before publication, so a
+    /// later step may safely plan them again. After shutdown, mutations return
+    /// `shutting_down`, maintenance triggers are ignored, and reads continue.
+    /// This method is idempotent across clones.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.shutdown",
@@ -328,17 +309,10 @@ impl FsWriterBuilder {
         self
     }
 
-    /// Installs a node-local cache of encoded metadata blocks beneath this
-    /// writer's decoded block cache.
+    /// Installs a node-local encoded-block cache beneath the decoded cache.
     ///
-    /// The handle rides on the decoded cache, so every handle built from
-    /// this writer's cache reaches the same local cache — the reader this
-    /// writer derives, and an admin handle sharing the cache through
-    /// [`FsAdminBuilder::shared_metadata_segment_cache`]. Nothing else
-    /// reaches it: paths that carry no decoded cache carry neither tier.
-    ///
-    /// Unset by default. The host owns the cache and closes it, and object
-    /// storage stays the authority for every read either way.
+    /// Handles that share this writer's decoded cache also share this local
+    /// cache. The host owns and closes it; object storage remains authoritative.
     ///
     /// [`FsAdminBuilder::shared_metadata_segment_cache`]: crate::FsAdminBuilder::shared_metadata_segment_cache
     pub fn stored_metadata_block_cache(
@@ -494,10 +468,6 @@ mod tests {
             .is_none());
     }
 
-    /// The handle rides on the decoded block cache, which is what puts the
-    /// two tiers in the same places: every handle built from this cache
-    /// reaches the local cache, and every path that carries no decoded cache
-    /// reaches neither tier.
     #[tokio::test]
     async fn the_builder_installs_the_stored_block_cache_on_the_decoded_cache() {
         let temp_dir = tempdir().expect("tempdir");
@@ -546,13 +516,6 @@ mod tests {
         (writer, blocking)
     }
 
-    /// Both admissions must close on the shutdown's first poll, before it
-    /// starts draining publications. The drain is a wait, and the runner
-    /// stays live across it: a queue still open here lets a nudge landing in
-    /// that window be admitted, and lets a finishing step hand its slot on
-    /// and spawn work the shutdown already decided to drop. Asserting on the
-    /// first poll pins the order on every machine; the integration coverage
-    /// in `tests/it/handles.rs` only loses the race on some.
     #[tokio::test]
     async fn shutdown_closes_both_admissions_before_draining_publications() {
         let temp_dir = tempdir().expect("tempdir");
@@ -622,9 +585,6 @@ mod tests {
         shutdown.await.expect("shut down the writer");
     }
 
-    /// Shutdown is a state of the shared runtime, not a token one handle
-    /// holds: a clone that shuts down is observable from every other clone,
-    /// and a second shutdown settles rather than panicking or wedging.
     #[tokio::test]
     async fn a_clone_observes_a_shutdown_and_may_repeat_it() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -1,17 +1,8 @@
 //! Embedded LoonFS runtime.
 //!
-//! `loonfs` is the ergonomic runtime layer. It wraps `loonfs-core` with caching,
-//! upload helpers, maintenance hooks, and an optional [`metrics`] surface. Use
-//! it when you want LoonFS in-process, or when building the reference server.
-//!
-//! The runtime is opened through purpose-specific handles, each built
-//! asynchronously inside the Tokio runtime that will own it:
-//!
-//! - [`FsWriter`] for writes, with [`FsBackgroundWork`] controlling whether
-//!   the writer schedules non-destructive maintenance after writes.
-//! - [`FsReader`] for namespace state and read-only latest views.
-//! - [`FsAdmin`] for explicit maintenance: diagnostics, checkpoints,
-//!   retention, and garbage collection.
+//! Use [`FsWriter`] for mutations, [`FsReader`] for reads, and [`FsAdmin`] for
+//! explicit maintenance. [`FsBackgroundWork`] controls whether a writer also
+//! schedules non-destructive maintenance.
 //!
 //! ```no_run
 //! # async fn open(store_config: loonfs::StoreConfig) -> loonfs::Result<()> {
@@ -60,12 +51,9 @@
 //! assert_eq!(options.set.len(), 1);
 //! ```
 //!
-//! A writer owns publication and any automatically scheduled maintenance.
-//! One [`MaintenanceJob`] runner schedules work for namespaces touched or
-//! explicitly assigned to this process; it does not discover namespaces.
-//! Jobs run on the writer's Tokio runtime and re-read durable state before
-//! acting. [`FsWriter::shutdown`] drains this work. Readers and admins do not
-//! start background tasks.
+//! Writers schedule maintenance only for namespaces touched by or assigned to
+//! the process. [`FsWriter::shutdown`] drains that work. Readers and admins do
+//! not start background tasks.
 #![warn(missing_docs)]
 
 mod cache;

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -1,21 +1,8 @@
 //! Scheduler for bounded background maintenance.
 //!
-//! A [`MaintenanceJob`] performs one bounded unit of work for one namespace.
-//! Each step reloads durable state, performs at most one update, and returns a
-//! [`MaintenanceStepReport`]. The runner decides when jobs run.
-//!
-//! [`MaintenanceRunner`] owns scheduling. It tracks pending `(job, namespace)`
-//! keys, concurrency permits, retry backoff, earliest run times, per-job
-//! continuations, and reconciliation progress. Triggers are hints only; every
-//! step validates current durable state before acting.
-//!
-//! Continuations are in-memory performance hints. Losing one restarts the
-//! pass but does not change correctness.
-//!
-//! Automatic maintenance covers namespaces touched by this process or
-//! explicitly assigned to it. The runner never discovers namespaces.
-//! Maintenance tasks run on the writer's runtime and are included in writer
-//! shutdown. Readers and admin handles do not own a runner.
+//! Each [`MaintenanceJob`] performs one unit of work for one namespace. The
+//! runner manages concurrency, retries, deadlines, and continuations. It only
+//! maintains namespaces used by this process or explicitly assigned to it.
 
 mod admission;
 mod compaction;
@@ -52,33 +39,22 @@ const RECONCILE_INTERVAL_MS: u64 = 60_000;
 /// one long one.
 const MAX_RECONCILE_PROBES_PER_SWEEP: usize = 64;
 
-/// Writer-initiated background maintenance policy.
+/// Controls background maintenance started by a writer.
 ///
-/// The policy governs only maintenance a write-capable handle schedules for
-/// itself: the non-destructive metadata steps that keep read cost bounded
-/// once the WAL tail crosses its threshold, and the garbage-collection
-/// passes that reclaim what the upload sessions this writer opened leave
-/// behind once their leases pass. It never advances the retention floor —
-/// surrendering replay history stays an explicit
-/// [`FsAdmin`](crate::FsAdmin) operation with no scheduler behind it.
+/// Background work may compact metadata and collect expired uploads. It never
+/// advances the retention floor; that remains an explicit
+/// [`FsAdmin`](crate::FsAdmin) operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FsBackgroundWork {
-    /// The writer may schedule non-destructive maintenance for itself,
-    /// spawned on the writer's owning runtime.
-    ///
-    /// The namespaces it covers are the ones this process touches and the
-    /// ones a host explicitly assigns to it — never a discovered set.
+    /// Run maintenance for namespaces used or explicitly assigned to this
+    /// process.
     Enabled,
-    /// The writer never auto-schedules maintenance. Jobs may still be
-    /// registered, and explicit [`FsAdmin`](crate::FsAdmin) maintenance
-    /// calls still work.
+    /// Disable automatic maintenance. Explicit admin operations remain
+    /// available.
     ManualOnly,
 }
 
-/// Stable identity of a registered maintenance job.
-///
-/// The name is part of the admission key and of every trace the job's steps
-/// emit, so it outlives any one registration and must not drift.
+/// Stable identifier for a registered maintenance job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MaintenanceJobId(&'static str);
 
@@ -113,21 +89,15 @@ impl fmt::Display for MaintenanceJobId {
 /// the key again.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MaintenanceStepConclusion {
-    /// Durable state advanced. The key is eligible again at once — behind
-    /// whatever else is waiting, so a long backlog stays fair to its peers.
+    /// Durable state advanced. The job may run again immediately.
     Progressed,
-    /// Nothing to do. The key parks until something nudges it or a
-    /// reconciliation sweep finds work.
+    /// No work was available. The job waits for a trigger or reconciliation.
     Idle,
-    /// There is work, and this step's policy cannot make progress on it —
-    /// an input that does not fit the per-step budget, for one. Parks like
-    /// [`Self::Idle`]: requeueing zero-progress work would only spin.
+    /// Work exists, but this step cannot process it within its limits.
     Blocked,
-    /// Another writer won the race this step was in. The key is eligible
-    /// again at once, to take the race against what actually landed.
+    /// Concurrent work changed the state. The job may retry immediately.
     Superseded,
-    /// This job has nothing to maintain for this namespace at all. The
-    /// runner forgets the key.
+    /// This job is not enabled for the namespace.
     NotEnabled,
 }
 
@@ -153,8 +123,7 @@ impl MaintenanceStepConclusion {
 pub struct MaintenanceStepReport {
     /// What the step accomplished.
     pub conclusion: MaintenanceStepConclusion,
-    /// Where this step stopped, for the next one to resume from. Opaque to
-    /// the runner, which stores it and hands it straight back.
+    /// Opaque state that lets the next step resume this job.
     ///
     /// The runner keeps it while the key is making progress or waiting for
     /// room to work, clears it on [`MaintenanceStepConclusion::Idle`], and
@@ -171,8 +140,7 @@ pub struct MaintenanceStepReport {
 }
 
 impl MaintenanceStepReport {
-    /// A conclusion with nothing to resume from and no deadline observed —
-    /// what a job whose whole position is durable returns.
+    /// Creates a report without a continuation or deadline.
     pub fn concluded(conclusion: MaintenanceStepConclusion) -> Self {
         Self {
             conclusion,
@@ -182,17 +150,12 @@ impl MaintenanceStepReport {
     }
 }
 
-/// What a reconciliation probe found.
-///
-/// A probe is the cheapest question a job can answer — one status read, or
-/// no read at all — and it exists so a sweep can re-admit forgotten work
-/// without running a step to find out there was none.
+/// Result of checking whether a maintenance job has work to do.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MaintenanceProbe {
-    /// Durable state shows work waiting. The runner re-nudges the key.
+    /// Work is waiting.
     Due,
-    /// Nothing waiting. With no timed obligation left, the runner forgets
-    /// the key until something nudges it again.
+    /// No work is waiting.
     Idle,
 }
 
@@ -219,8 +182,8 @@ pub trait MaintenanceJob: Send + Sync + 'static {
         continuation: Option<&str>,
     ) -> Result<MaintenanceStepReport>;
 
-    /// Answers whether `namespace_id` has work waiting, as cheaply as this
-    /// job can. Called only by reconciliation, never on the hot path.
+    /// Checks whether `namespace_id` has work waiting. Called only during
+    /// reconciliation.
     async fn probe(&self, namespace_id: &NamespaceId) -> Result<MaintenanceProbe>;
 
     /// Returns whether successful publications should nudge this job.
@@ -242,12 +205,7 @@ pub(crate) trait MaintenanceClock: fmt::Debug + Send + Sync {
     /// Unix milliseconds.
     fn now_ms(&self) -> u64;
 
-    /// A draw uniform in `0..span_ms`, and `0` when `span_ms` is zero.
-    ///
-    /// The error backoff jitters with this. It rides on the clock because
-    /// it answers the same kind of question — when to look again — and
-    /// because a test that substitutes one has to be able to name the
-    /// delays it asserts on.
+    /// Returns a value in `0..span_ms`, or `0` when `span_ms` is zero.
     fn jitter_below_ms(&self, span_ms: u64) -> u64;
 }
 
@@ -263,10 +221,7 @@ const JITTER_GAMMA: u64 = 0x9E37_79B9_7F4A_7C15;
 
 impl Default for SystemMaintenanceClock {
     fn default() -> Self {
-        // Seeded per instance, so two hosts riding out one provider outage
-        // do not draw the same retry sequence. The standard library's own
-        // randomly keyed hasher is the seed: this decides when to look
-        // again and nothing else, so it needs spread rather than secrecy.
+        // Use a per-instance random seed so hosts retry at different times.
         use std::hash::{BuildHasher, Hasher};
         let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
         hasher.write_u64(JITTER_GAMMA);
@@ -296,10 +251,7 @@ impl MaintenanceClock for SystemMaintenanceClock {
     }
 }
 
-/// SplitMix64's finalizer: three xor-shift-multiply rounds over a counter.
-///
-/// Two keys that fail in the same millisecond draw consecutive counters,
-/// and this is what makes those two draws land far apart.
+/// Applies the SplitMix64 finalizer to the jitter counter.
 fn split_mix_64(counter: u64) -> u64 {
     let mut mixed = counter;
     mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
@@ -335,8 +287,8 @@ impl MaintenanceHandle {
         }
     }
 
-    /// Asks for `job` to run against `namespace_id` as soon as a permit is
-    /// free. Repeated asks coalesce into one run.
+    /// Schedules `job` for `namespace_id` when a permit is available.
+    /// Repeated calls coalesce.
     pub fn nudge(&self, job: MaintenanceJobId, namespace_id: &NamespaceId) {
         let Some(inner) = self.inner.upgrade() else {
             return;
@@ -344,13 +296,8 @@ impl MaintenanceHandle {
         nudge_key(&inner, job, namespace_id, None);
     }
 
-    /// Asks for `job` to run against `namespace_id` once `not_before_ms`
-    /// passes, whether or not anything else asks in the meantime.
-    ///
-    /// This is how a wall-clock obligation — an upload lease that will
-    /// expire, content whose reclamation grace will pass — becomes admitted
-    /// work instead of something only the next unrelated write would notice.
-    /// Repeated asks keep the soonest time.
+    /// Schedules `job` for `namespace_id` at or after `not_before_ms`.
+    /// Repeated calls keep the earliest time.
     pub fn nudge_not_before(
         &self,
         job: MaintenanceJobId,
@@ -484,38 +431,24 @@ impl MaintenanceRunner {
         }
     }
 
-    /// A cloneable nudge-only view. Every trigger holds one of these; only
-    /// this runner can shut admission down.
+    /// Returns a cloneable scheduling handle that cannot shut down admission.
     pub(crate) fn handle(&self) -> MaintenanceHandle {
         MaintenanceHandle {
             inner: Arc::downgrade(&self.inner),
         }
     }
 
-    /// A cloneable view of the streaming compactions this runner is running.
-    ///
-    /// Every handle whose maintenance steps may plan one holds this, which is
-    /// what makes the runner's own steps and an operator's explicit step see
-    /// the same jobs and share the same permits.
+    /// Returns a shared view of running streaming compactions.
     pub(crate) fn compactions(&self) -> BackgroundCompactions {
         BackgroundCompactions::new(&self.inner)
     }
 
-    /// The executor registered under `id`.
-    ///
-    /// For a host that drives bounded steps itself instead of through
-    /// admission — a catch-up command with a caller's budget on it. The
-    /// steps are the same bounded, compare-and-swap-published units this
-    /// runner admits; they simply have no scheduler in front of them.
+    /// Returns the job registered under `id`.
     pub(crate) fn job(&self, id: MaintenanceJobId) -> Option<Arc<dyn MaintenanceJob>> {
         self.inner.job(id)
     }
 
-    /// Registers an executor under its own id.
-    ///
-    /// Registration is accepted under either policy: with
-    /// [`FsBackgroundWork::ManualOnly`] the runner simply never nudges what
-    /// it knows about.
+    /// Registers a job. Manual-only runners retain jobs for explicit use.
     pub(crate) fn register(&self, job: Arc<dyn MaintenanceJob>) -> Result<MaintenanceJobId> {
         let id = job.id();
         let mut jobs = self.inner.lock_jobs();
@@ -528,16 +461,11 @@ impl MaintenanceRunner {
         Ok(id)
     }
 
-    /// Rejects further scheduling and discards work still waiting for a
-    /// permit, and tells every running streaming compaction to stop. Running
-    /// steps and cancelled compactions stay visible to [`Self::drain`].
+    /// Stops admission, discards queued work, and cancels compactions.
     ///
-    /// Synchronous on purpose: a shutdown has to close admission before its
-    /// first await, or a step finishing during the publication drain hands
-    /// its slot to work the shutdown already decided to drop. Cancelling the
-    /// compactions here rather than in the drain is the same reasoning — a
-    /// job checks its token between block fetches, so the earlier it is set
-    /// the less of the drain it spends finishing work nobody will publish.
+    /// Running steps and cancelled compactions remain visible to
+    /// [`Self::drain`]. This method is synchronous so admission closes before
+    /// any shutdown await can allow another job to start.
     pub(crate) fn close_admission(&self) {
         self.inner.lock_state().admission.close();
         self.compactions().cancel_all();
@@ -596,9 +524,7 @@ impl MaintenanceRunner {
     /// the write path does not need job-specific wiring. Nudges are non-blocking,
     /// coalesced, and ignored when automatic maintenance is disabled or closed.
     pub(crate) fn nudge_publication_subscribers(&self, namespace_id: &NamespaceId) {
-        // The subscriber list is read out from under the job lock before
-        // any nudge takes the scheduling lock: the two are never held
-        // together anywhere, and this is the one place that would.
+        // Release the job lock before acquiring scheduling state.
         let subscribers: Vec<MaintenanceJobId> = self
             .inner
             .lock_jobs()
@@ -937,9 +863,8 @@ async fn wait_for_deadline(delay: Duration, wake: &Notify) {
     }
 }
 
-/// How long the timer may sleep: until the soonest deadline, and never past
-/// the reconciliation interval — which also bounds how long the task
-/// outlives a runner nobody holds any more. `None` means admission closed.
+/// Returns the delay until the next deadline or reconciliation sweep.
+/// `None` means admission is closed.
 fn next_wake_delay(inner: &Arc<RunnerInner>) -> Option<Duration> {
     let now_ms = inner.clock.now_ms();
     let state = inner.lock_state();

--- a/crates/loonfs/src/maintenance_runner/admission.rs
+++ b/crates/loonfs/src/maintenance_runner/admission.rs
@@ -761,8 +761,6 @@ mod tests {
         backoff_window_ms(consecutive_failures) - 1
     }
 
-    /// Ported from the previous scheduler: a request arriving during an
-    /// active step defers and reruns exactly once.
     #[test]
     fn a_request_during_an_active_step_defers_and_reruns_exactly_once() {
         let mut admission = book(8);
@@ -795,7 +793,6 @@ mod tests {
         );
     }
 
-    /// Ported: shutdown wins over a deferred rerun.
     #[test]
     fn shutdown_wins_over_a_deferred_rerun() {
         let mut admission = book(8);
@@ -812,9 +809,6 @@ mod tests {
         );
     }
 
-    /// The fairness rule has no exception for the key that just finished: a
-    /// request that arrived mid-step holds the newest ticket there is, so a
-    /// peer that was already waiting runs first.
     #[test]
     fn a_waiting_peer_outranks_a_rerun_asked_for_later() {
         let mut admission = book(1);
@@ -837,9 +831,6 @@ mod tests {
         );
     }
 
-    /// A job that subscribes to publications is renudged inside every step
-    /// it runs, and a busy namespace publishes without pause. Its reruns
-    /// must not add up to a permit it never gives back.
     #[test]
     fn a_key_renudged_on_every_run_cannot_hold_the_permit_past_a_peer() {
         let mut admission = book(1);
@@ -867,7 +858,6 @@ mod tests {
         );
     }
 
-    /// Losing the handoff is not losing the request.
     #[test]
     fn a_rerun_that_loses_the_handoff_runs_when_a_permit_frees() {
         let mut admission = book(1);
@@ -895,8 +885,6 @@ mod tests {
         );
     }
 
-    /// The other half of a claim: what the step it dispatches is told about
-    /// the wait it ended.
     #[test]
     fn a_claim_reports_how_long_its_run_waited() {
         let mut admission = book(1);
@@ -924,7 +912,6 @@ mod tests {
         );
     }
 
-    /// Ported: claims are singleflight and refused after close.
     #[test]
     fn claims_are_singleflight_and_refused_after_close() {
         let mut admission = book(8);
@@ -950,7 +937,6 @@ mod tests {
         );
     }
 
-    /// Ported: a freed slot claims the next key waiting at the global cap.
     #[test]
     fn a_freed_slot_claims_the_next_key_at_the_global_cap() {
         let mut admission = book(2);
@@ -973,7 +959,6 @@ mod tests {
         );
     }
 
-    /// Ported: repeated requests for one queued key coalesce to one run.
     #[test]
     fn repeated_requests_for_one_queued_key_coalesce_to_one_run() {
         let mut admission = book(1);
@@ -1001,7 +986,6 @@ mod tests {
         );
     }
 
-    /// Ported: shutdown clears keys waiting at the global cap.
     #[test]
     fn shutdown_clears_keys_waiting_at_the_global_cap() {
         let mut admission = book(1);
@@ -1115,10 +1099,6 @@ mod tests {
         );
     }
 
-    /// The whole continuation contract in one place: a progressing step's
-    /// position is stored and handed to the next one, a blocked step's is
-    /// kept for a retry with room to work, an idle step's is spent, and an
-    /// evicted key takes its position with it.
     #[test]
     fn the_runner_carries_a_continuation_between_steps() {
         let mut admission = book(1);
@@ -1238,8 +1218,6 @@ mod tests {
         );
     }
 
-    /// A deadline the step itself observed is planted the same way a
-    /// trigger's is, and merges with what is already there.
     #[test]
     fn a_step_can_report_its_own_next_eligible_time() {
         let mut admission = book(1);
@@ -1416,8 +1394,6 @@ mod tests {
         }
     }
 
-    /// The property a provider outage depends on: keys that failed in the
-    /// same millisecond must not all come back in the same millisecond.
     #[test]
     fn a_burst_of_failures_does_not_come_back_synchronized() {
         let mut admission = Admission::new(8, TestClock::walking());
@@ -1971,14 +1947,6 @@ mod tests {
         }
     }
 
-    /// The properties the book holds whatever order its callers arrive in:
-    /// one step per key, permits accounted for, ticket order, nothing
-    /// dispatched after a close, and an obligation only its own deadline or
-    /// a close may clear.
-    ///
-    /// The book is synchronous under one lock, so a seeded sequence of calls
-    /// is the whole concurrency story — there is no interleaving these
-    /// sequences cannot produce.
     #[test]
     fn a_seeded_action_sequence_holds_every_admission_invariant() {
         for (index, seed) in MODEL_SEEDS.into_iter().enumerate() {

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -1,38 +1,12 @@
-//! The streaming metadata compactions this process is running, and the
-//! pressure that decides when one has to start.
+//! Tracks background metadata compactions.
 //!
-//! A maintenance step that plans one starts it here. The job is a background
-//! task the runner owns — it takes no admission permit, because it is not a
-//! bounded step and holding one for hours would starve every key behind it —
-//! and it is registered for the same drain every other spawned task is, so a
-//! shutdown cancels it and then waits for it.
+//! Each namespace may have one queued or running compaction. A process-wide
+//! semaphore limits total concurrency. Jobs do not consume bounded-step
+//! permits and are cancelled and joined during writer shutdown.
 //!
-//! Two things admit a job, and they answer different questions. A namespace
-//! slot stops two jobs rebuilding one namespace at once, which would waste
-//! one of them at finalization. A process-wide semaphore stops this process
-//! running one job per namespace it serves: each job holds a probe cache,
-//! decoded blocks for its iterators, and a segment builder per family, so the
-//! aggregate is what has to be capped whatever the per-namespace rule says. A
-//! job claims its slot first and then waits for a permit, and it is queued
-//! rather than refused while it waits.
-//!
-//! What this holds, per namespace, is two things. The one job claiming it:
-//! the plan, so the steps that follow know not to merge the group underneath
-//! it, and the cancellation token, so a shutdown can stop it. The plan is
-//! recorded when the slot is claimed rather than when the job starts reading,
-//! so a queued job's group is left alone exactly as a running job's is — and
-//! because it is left alone, no merge is published for it, so the count below
-//! neither climbs nor resets while the job waits. And a count per family
-//! group of the delta merges that have published over that group's frozen
-//! base, which is the one thing a single step cannot see: under sustained
-//! writes there is always another pair of delta runs to merge, so a planner
-//! deciding from one step's view would take that merge forever and never
-//! start the job that unfreezes the group's base.
-//!
-//! Both are in-memory and single-writer, and both are safe to lose. A restart
-//! forgets the running job, and a later step plans it again. A restart
-//! forgets the counts, and the next two published merges rebuild them, which
-//! delays one cycle and nothing else.
+//! The in-memory state also counts delta merges over each frozen base so the
+//! planner eventually requests a full compaction. Losing this state only
+//! delays replanning after restart.
 
 use super::{MaintenanceJobId, RunnerInner};
 use crate::{FsAdmin, NamespaceId};
@@ -44,16 +18,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, Weak};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-/// Streaming compactions this process runs at once, across every namespace it
-/// serves.
-///
-/// Small and fixed. A job is unpaced by design and holds real memory while it
-/// runs, so the useful question is how many of them a process may hold at
-/// once, and two is enough to keep one namespace's job from stalling every
-/// other namespace while still bounding the total. It is deliberately not a
-/// configuration knob: an operator's lever over maintenance is how often it
-/// runs, and a second concurrency number would only let a deployment raise
-/// this one until its memory answered for it.
+/// Maximum concurrent streaming compactions in one process.
 pub(crate) const MAX_CONCURRENT_COMPACTIONS: usize = 2;
 
 /// The one job a namespace may have, from the moment it claims the slot to
@@ -80,13 +45,7 @@ impl NamespaceCompactions {
     }
 }
 
-/// A handle on this process's running compactions, cloned into every handle
-/// whose maintenance steps may start one.
-///
-/// The map and the permits are held strongly and the runner weakly, which is
-/// the same shape [`super::MaintenanceHandle`] has and for the same reason: a
-/// step may consult the map at any time, and a step that outlives the writer
-/// that owns the runner starts nothing.
+/// Shared access to this process's background compactions.
 #[derive(Clone)]
 pub(crate) struct BackgroundCompactions {
     namespaces: Arc<Mutex<BTreeMap<NamespaceId, NamespaceCompactions>>>,
@@ -311,22 +270,11 @@ impl CompactionClaim {
         &self.cancellation
     }
 
-    /// Gives the claim back and puts the namespace's metadata maintenance
-    /// back in the queue, which is what a job ending is: the moment the
-    /// condition that blocked that maintenance changed.
+    /// Releases the claim and reschedules metadata maintenance.
     ///
-    /// A publication means the group is rebuilt and whatever arrived while
-    /// the job ran can fold now, so the key is nudged at once. Any other
-    /// ending means the job is to be planned again, and immediately would
-    /// only start the same long job again, so the key waits one
-    /// reconciliation interval. The sweep remains the net under both: these
-    /// nudges are hints like every other, and a lost one costs the delay to
-    /// the next sweep.
-    ///
-    /// The claim goes back before the nudge, and that order is the whole
-    /// reason this is one call. A step that reached the planner while the
-    /// slot was still held would leave alone the very group the job just
-    /// rebuilt, and then park.
+    /// Successful publication reschedules immediately. Other outcomes wait
+    /// one reconciliation interval before replanning. The claim is released
+    /// before scheduling so the next step can inspect the group.
     pub(crate) fn finished(self, published: bool) {
         let runner = Weak::clone(&self.slot.runner);
         let namespace_id = self.slot.namespace_id.clone();

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -252,22 +252,16 @@ fn metadata_has_nothing_to_maintain(error: &RuntimeError) -> bool {
     )
 }
 
-/// Combines WAL-flush and reorganization outcomes into one scheduling
-/// conclusion.
+/// Combines WAL flush and reorganization results for scheduling.
 ///
 /// Progress takes precedence over a lost race, and a lost race takes
 /// precedence over a budget block. A step that changed durable state should
 /// run again even when its second operation was blocked.
 ///
-/// Starting a streaming compaction is progress of the useful kind: the step
-/// that started it did no folding, and the steps behind it now have the
-/// group's peers to fold while the job runs. A job queued behind the process
-/// compaction limit reads the same way — the group is claimed, so the steps
-/// behind it have the same peers to fold, and nothing is needed to make the
-/// job run. A group waiting on a job already running, and a group needing one
-/// this handle cannot run at all, are blocks: there is work and this step
-/// cannot make it, so the key parks and comes back on the next nudge or
-/// sweep. The job's own ending nudges the key back when it lands.
+/// Starting or queueing a streaming compaction counts as progress because the
+/// group is claimed and other groups may still be merged. Waiting for an
+/// existing compaction, or requiring one that this handle cannot run, is
+/// blocked.
 fn metadata_conclusion(step: &MetadataMaintenanceResponse) -> MaintenanceStepConclusion {
     let flush = match step.wal_flush {
         WalFlushStepOutcome::Flushed { .. } => Some(MaintenanceStepConclusion::Progressed),
@@ -438,10 +432,6 @@ mod tests {
         );
     }
 
-    /// Starting a background rebuild is progress: the step that started it
-    /// folded nothing, and the steps behind it have the group's peers to fold
-    /// while the job runs. A job queued behind the process limit reads the
-    /// same way, because the group is claimed either way.
     #[test]
     fn a_started_or_queued_compaction_progresses_and_the_other_two_block() {
         let started = step_response(
@@ -549,9 +539,6 @@ mod tests {
         );
     }
 
-    /// A budget that ran out before the pass finished is a park, not an
-    /// idle: idle clears the stored continuation, and a pass that never got
-    /// to the keyspace has nothing to show for itself but that.
     #[test]
     fn a_pass_that_ran_out_of_budget_parks_unless_it_got_somewhere_first() {
         let namespace = namespace_id("demo");
@@ -591,8 +578,6 @@ mod tests {
         );
     }
 
-    /// The runner owns the cursor. The step receives it as its continuation
-    /// and returns it in the result without storing a job-local copy.
     #[test]
     fn a_collection_pass_hands_its_cursor_back_to_the_runner() {
         let mut walked = GcResponse::empty(namespace_id("demo"));
@@ -627,8 +612,6 @@ mod tests {
         );
     }
 
-    /// The deadline a pass reports for what it retained becomes the key's
-    /// own, which is what makes a pass schedule its own successor.
     #[test]
     fn a_collection_pass_hands_its_soonest_retained_deadline_to_the_runner() {
         let mut retained = GcResponse::empty(namespace_id("demo"));

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -361,9 +361,6 @@ async fn progressed_requeues_immediately_and_stays_fair_at_the_cap() {
     );
 }
 
-/// The continuation round trip over a live runner: what a step hands back
-/// is what the next step is handed, without the job holding a map of its
-/// own.
 #[tokio::test]
 async fn a_progressing_job_resumes_from_where_its_last_step_stopped() {
     let job = TestJob::scripted(
@@ -402,8 +399,6 @@ async fn a_progressing_job_resumes_from_where_its_last_step_stopped() {
     );
 }
 
-/// A step that ran out of budget keeps its position, so the retry picks up
-/// there instead of walking the same ground again.
 #[tokio::test]
 async fn a_blocked_job_resumes_from_where_it_parked() {
     let job = TestJob::scripted(
@@ -428,8 +423,6 @@ async fn a_blocked_job_resumes_from_where_it_parked() {
     );
 }
 
-/// An evicted key takes its position with it: nothing survives the job
-/// saying it has nothing to maintain here.
 #[tokio::test]
 async fn a_not_enabled_conclusion_drops_the_continuation() {
     let job = TestJob::scripted(
@@ -566,10 +559,6 @@ async fn a_key_planted_in_the_future_does_not_fire_early() {
     );
 }
 
-/// The other end of the same mechanism: a step that reports a deadline
-/// arms its own key with it. This is what makes a pass self-scheduling —
-/// reclamation nothing planted a deadline for, and deadlines a restart
-/// forgot, both come back through the next pass over the namespace.
 #[tokio::test]
 async fn a_step_that_reports_a_deadline_re_arms_its_own_key() {
     let clock = ManualClock::at(1_000_000);
@@ -607,8 +596,6 @@ async fn a_step_that_reports_a_deadline_re_arms_its_own_key() {
     );
 }
 
-/// Publications reach the jobs that asked for them and no others, so a
-/// host wires nothing into the write path on any job's behalf.
 #[tokio::test]
 async fn a_publication_nudges_only_the_jobs_that_subscribe_to_it() {
     let quiet = TestJob::idle();
@@ -811,10 +798,6 @@ async fn drain_surfaces_a_panicked_step() {
     );
 }
 
-/// The interleaving a shutdown must win, ported from the previous
-/// scheduler: work claims its slot, a whole shutdown-and-drain completes
-/// while the registry is still empty, and only then does the claimed work
-/// reach spawn.
 #[tokio::test]
 async fn work_claimed_before_a_shutdown_is_refused_and_gives_its_permit_back() {
     let job = TestJob::idle();
@@ -872,9 +855,6 @@ async fn upload_writer(root: &std::path::Path, clock: Arc<dyn MaintenanceClock>)
         .expect("build writer")
 }
 
-/// The lease-expiry admission decision, end to end: opening a session and
-/// completing one each plant the collection deadline they create, at the
-/// time the collector's own predicate will allow.
 #[tokio::test]
 async fn upload_paths_plant_the_collection_deadlines_they_create() {
     let temp_dir = tempfile::tempdir().expect("tempdir");
@@ -942,8 +922,6 @@ async fn upload_paths_plant_the_collection_deadlines_they_create() {
     );
 }
 
-/// The runtime registers exactly the two jobs it owns, under the ids every
-/// write path nudges.
 #[tokio::test]
 async fn the_runtime_registers_its_metadata_and_gc_jobs() {
     let temp_dir = tempfile::tempdir().expect("tempdir");
@@ -992,13 +970,6 @@ fn claim_all(
         .collect()
 }
 
-/// The process limit is what bounds compactions, not the namespace count.
-///
-/// Every namespace that plans one claims its own slot, so the map cannot
-/// bound them: a process serving a hundred namespaces would run a hundred
-/// jobs. The permits are what stop that, and a job that cannot have one is
-/// queued rather than refused — its group is claimed either way, so nothing
-/// re-plans it and nothing merges it underneath.
 #[tokio::test]
 async fn at_most_the_process_limit_of_compactions_run_however_many_namespaces_plan_one() {
     let runner = enabled_runner(TestJob::idle());
@@ -1054,11 +1025,6 @@ async fn at_most_the_process_limit_of_compactions_run_however_many_namespaces_pl
     }
 }
 
-/// One namespace, one job — whether the job is running or still queued.
-///
-/// The plan is in the map from the claim, which is also what leaves the
-/// group alone: a step that read a queued job's group and merged it would
-/// waste that job at finalization.
 #[tokio::test]
 async fn a_queued_job_still_holds_its_namespace_and_still_excludes_its_group() {
     let runner = enabled_runner(TestJob::idle());
@@ -1089,11 +1055,6 @@ async fn a_queued_job_still_holds_its_namespace_and_still_excludes_its_group() {
     );
 }
 
-/// A shutdown stops a job that is waiting for a permit, not only one that is
-/// reading rows.
-///
-/// A queued job has no block fetch to check its token between, so without
-/// this the drain would wait for a permit it is trying to stop needing.
 #[tokio::test]
 async fn cancellation_reaches_a_job_that_is_still_waiting_for_a_permit() {
     let runner = enabled_runner(TestJob::idle());
@@ -1137,16 +1098,6 @@ async fn cancellation_reaches_a_job_that_is_still_waiting_for_a_permit() {
     );
 }
 
-/// A published job puts its namespace's metadata maintenance back in the
-/// queue at once, and gives its slot back first.
-///
-/// A delta run that arrived while the job ran is exactly what a group blocked
-/// behind that job could not fold. Nothing durable reports that it can now,
-/// so without this nudge the fold waits for the next reconciliation sweep —
-/// and a nudge that arrived while the slot was still held would wake a step
-/// that leaves that group alone. A job that ended without publishing is
-/// planned again instead, and waits a sweep's worth of time so it does not
-/// start the same long job at once.
 #[tokio::test]
 async fn a_job_that_ends_frees_its_slot_and_requeues_its_namespace() {
     let job = TestJob::gated([], ScriptedStep::Conclude(MaintenanceStepConclusion::Idle));

--- a/crates/loonfs/src/metrics.rs
+++ b/crates/loonfs/src/metrics.rs
@@ -1,52 +1,12 @@
-//! The runtime's metrics surface: a push-based recorder the embedder
-//! implements, and the instruments the runtime registers against it.
+//! Runtime metrics API.
 //!
-//! LoonFS defines instruments and reports values. It does not export them,
-//! and it depends on no metrics crate to do so. An embedder that already
-//! has a metrics pipeline implements [`MetricsRecorder`] over its own
-//! registry and the runtime's numbers land there directly; an embedder that
-//! has none installs [`DefaultMetricsRecorder`], which aggregates in atomics
-//! and hands back a [`MetricsSnapshot`] to render however the host likes.
-//! Installing nothing costs nothing: with no recorder configured the runtime
-//! registers no instruments and no hot path touches this module at all.
+//! Embedders can implement [`MetricsRecorder`] for an existing registry or
+//! use [`DefaultMetricsRecorder`] to collect a [`MetricsSnapshot`]. Without a
+//! recorder, the runtime does not register or update instruments.
 //!
-//! The reference server is LoonFS's own first embedder — it installs the
-//! default recorder and serves its snapshot as Prometheus text on
-//! `GET /metrics`.
-//!
-//! ## Names and labels
-//!
-//! Metric names are `loonfs.<subsystem>.<metric>` — `loonfs.gc.reclaimed`,
-//! `loonfs.maintenance.steps`. The subsystem is the part of the runtime that
-//! owns the number, and it is the same word the module that reports it is
-//! called.
-//!
-//! Every name, description, label key, and label value in this API is
-//! `&'static str`, and that is the whole cardinality policy expressed in the
-//! type system: a namespace id, a commit id, a path, or a request id cannot
-//! be borrowed for `'static`, so it cannot become a label. Label values come
-//! from closed enumerations' `as_str` methods and from nowhere else. There
-//! is no escape hatch, deliberately — a metrics backend does not survive one
-//! unbounded label, and "we will be careful" is not a mechanism.
-//!
-//! ## Object-store metrics
-//!
-//! This module also re-exports the object-store sampling vocabulary from
-//! [`loonfs_objectstore::metrics`]. The two surfaces compose rather than
-//! compete: a handle given a [`MetricsRecorder`] bridges every object-store
-//! sample into the instruments below, and a handle given an
-//! [`ObjectStoreMetricsRecorder`] as well receives the raw samples too.
-//!
-//! ## Deviations from the model this follows
-//!
-//! The design is SlateDB's (their RFC 0021), with two deliberate omissions:
-//!
-//! - **No up-down counter.** Nothing in the v1 instrument set needs one — a
-//!   quantity that falls is a gauge here. Adding the instrument later is
-//!   purely additive.
-//! - **No metric levels.** SlateDB filters instruments by verbosity because
-//!   it has enough of them for that to matter. This set is small enough to
-//!   read whole, and a level knob nobody turns is a knob that rots.
+//! Metric names use `loonfs.<subsystem>.<metric>`. Names and labels are static
+//! strings so request IDs, paths, and other unbounded values cannot become
+//! labels. This module also re-exports the object-store metrics API.
 
 mod instruments;
 
@@ -64,33 +24,24 @@ use std::sync::{Arc, Mutex};
 
 /// Bucket upper bounds for a latency histogram, in seconds.
 ///
-/// Twelve buckets from a millisecond to two minutes, stepping by roughly
-/// three: that spans a warm cache hit at one end and a provider call about
-/// to spend its whole operation deadline at the other, and no two adjacent
-/// buckets are so close that a shifted distribution hides between them.
+/// Covers latencies from one millisecond to two minutes.
 pub const LATENCY_SECONDS_BOUNDARIES: &[f64] = &[
     0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 60.0, 120.0,
 ];
 
-/// Bucket upper bounds for a histogram over small counts — how many
-/// candidates a publication batched, and the like.
+/// Bucket upper bounds for histograms over small counts.
 pub const SMALL_COUNT_BOUNDARIES: &[f64] = &[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0];
 
-/// Where the runtime reports its instruments.
+/// Registers instruments used by the runtime.
 ///
-/// An embedder implements this over whatever registry it already has. The
-/// runtime registers each instrument once, at handle construction, and then
-/// only ever calls the handle it was given — so an implementation may do
-/// real work in the `register_*` methods and must do as little as possible
-/// in the handles', which run on hot paths.
+/// Embedders may adapt this trait to an existing metrics registry. The runtime
+/// registers each instrument once and uses the returned handles on hot paths.
 ///
 /// Registering the same `(name, labels)` pair twice returns a handle to the
-/// same underlying value. Two parts of the runtime reporting the same
-/// instrument are reporting one number, not two.
+/// same underlying value.
 ///
-/// Everything here is `&'static str` on purpose: it makes a runtime id
-/// impossible to use as a name or a label value, which is the cardinality
-/// policy this crate enforces in the type system rather than by convention.
+/// Static names and labels prevent unbounded runtime values from increasing
+/// metric cardinality.
 pub trait MetricsRecorder: Send + Sync + 'static {
     /// Registers a monotonically increasing count.
     fn register_counter(
@@ -207,13 +158,7 @@ impl InstrumentKey {
     }
 }
 
-/// The in-process recorder: every instrument is a few atomics, and
-/// [`Self::snapshot`] reads them all.
-///
-/// This is what an embedder installs when it has no metrics pipeline of its
-/// own and wants one anyway. Reporting is lock-free — registration takes a
-/// lock, the handles never do — so hot paths pay an atomic add and nothing
-/// else.
+/// In-process metrics recorder backed by atomic values.
 #[derive(Debug, Default)]
 pub struct DefaultMetricsRecorder {
     registry: Mutex<BTreeMap<InstrumentKey, RegisteredInstrument>>,
@@ -234,10 +179,8 @@ impl DefaultMetricsRecorder {
 
     /// Reads every registered instrument's current value.
     ///
-    /// The read is per instrument, not a stop-the-world barrier: two
-    /// instruments in one snapshot may have been read a few nanoseconds
-    /// apart. Nothing an operator asks of these numbers needs them to agree
-    /// to that resolution.
+    /// Instruments are read independently, so a snapshot is not atomic across
+    /// all values.
     pub fn snapshot(&self) -> MetricsSnapshot {
         let registry = self.lock_registry();
         MetricsSnapshot {

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -1,18 +1,8 @@
-//! The instruments the runtime reports, and the bridge that turns
-//! object-store samples into them.
+//! Runtime instruments and object-store metric reporting.
 //!
-//! One [`RuntimeInstruments`] is built per handle and reaches the reporting
-//! sites through the read core. Without a configured recorder it holds
-//! nothing and every report returns on a null check, which is what makes
-//! "no recorder" cost nothing rather than cost a no-op registration for
-//! every instrument in the set.
-//!
-//! Instruments whose label value is only known when the first report
-//! arrives — the object-store operation that just finished, the id an
-//! extension registered its maintenance job under — are memoized here, so a
-//! recorder still sees exactly one registration per label set as
-//! [`MetricsRecorder`] promises. The memo costs one uncontended lock on
-//! paths whose unit of work is a provider round trip.
+//! Each handle has one [`RuntimeInstruments`] instance. Instruments with
+//! dynamic labels are cached so each label set is registered once. Reporting
+//! returns immediately when no recorder is configured.
 
 use super::{
     CounterHandle, GaugeHandle, HistogramHandle, MetricsRecorder, ObjectStoreMetricSample,
@@ -1179,9 +1169,6 @@ mod tests {
         }
     }
 
-    /// Outcomes share one operation's latency and byte instruments and get a
-    /// counter each, so a failing operation is visible without splitting its
-    /// timing in two.
     #[test]
     fn outcomes_of_one_operation_count_separately() {
         let recorder = Arc::new(DefaultMetricsRecorder::new());
@@ -1258,8 +1245,6 @@ mod tests {
         );
     }
 
-    /// What the null check buys: a handle built without a recorder installs
-    /// no wrapper at all, and reporting through it is a returned call.
     #[test]
     fn a_handle_with_no_recorder_installs_nothing() {
         let instruments = RuntimeInstruments::new(None);
@@ -1336,10 +1321,6 @@ mod tests {
         }
     }
 
-    /// A probe that cannot answer leaves the key admitted and says nothing
-    /// else, so this counter is the only standing record that a namespace's
-    /// reconciliation is stuck. It is counted per job, beside the step
-    /// failures, and it is not filed as one: a probe ran no step.
     #[test]
     fn a_failed_reconciliation_probe_counts_against_its_job() {
         let recorder = Arc::new(DefaultMetricsRecorder::new());

--- a/crates/loonfs/src/metrics/tests.rs
+++ b/crates/loonfs/src/metrics/tests.rs
@@ -52,8 +52,6 @@ fn a_gauge_reports_only_its_latest_value() {
     );
 }
 
-/// Boundaries are inclusive upper bounds, and the bucket past the last one
-/// catches everything above it.
 #[test]
 fn histogram_observations_land_in_the_bucket_their_boundary_names() {
     const BOUNDARIES: &[f64] = &[1.0, 2.0, 4.0];
@@ -101,7 +99,6 @@ fn registering_one_name_and_label_set_twice_shares_one_value() {
     assert_eq!(counter_value(&snapshot, "loonfs.test.calls"), 2);
 }
 
-/// The label set is the identity, not the order it was written in.
 #[test]
 fn label_order_does_not_split_an_instrument_in_two() {
     let recorder = DefaultMetricsRecorder::new();
@@ -144,7 +141,6 @@ fn distinct_label_sets_are_distinct_instruments() {
     assert_eq!(entries[1].value, MetricValue::Counter(4));
 }
 
-/// A snapshot renders in a fixed order so a host does not have to sort it.
 #[test]
 fn a_snapshot_orders_entries_by_name_then_labels() {
     let recorder = DefaultMetricsRecorder::new();

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -227,8 +227,6 @@ mod tests {
         );
     }
 
-    /// Selection is presence, so a body that names nothing resolves to a
-    /// plan the step refuses rather than one that quietly does nothing.
     #[test]
     fn a_request_that_selects_nothing_is_an_empty_plan() {
         assert!(plan(MaintenanceStepRequest::default()).is_empty());

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1,25 +1,12 @@
 //! Runtime publication service for namespace mutations.
 //!
-//! Each namespace has one publisher and one worker queue. The publisher:
+//! Each namespace has one queue. Concurrent commits may share a WAL segment
+//! and head update. Duplicate commit IDs join in flight, conflicting reuse is
+//! rejected, and namespace deletion is ordered with other mutations.
 //!
-//! - batches concurrent commits into one WAL segment and one head CAS,
-//! - joins duplicate in-flight commit IDs and rejects conflicting reuse,
-//! - orders namespace deletion after earlier work and before later work,
-//! - retries stale or unknown CAS outcomes with the same commit IDs, and
-//! - enforces the configured minimum interval between head CAS attempts.
-//!
-//! A publisher keeps one commit engine and writer session for its lifetime.
-//! The writer session is small and cannot be reconstructed after fencing.
-//! The WAL-tail projection is rebuildable, so the registry evicts projections
-//! when the shared cache budget is exceeded.
-//!
-//! The first request for an idle namespace publishes immediately. Requests
-//! that arrive during a publish or its pacing interval join the next batch.
-//! Cancelling a caller does not cancel admitted work.
-//!
-//! Shutdown first closes admission and then drains admitted work. Use
-//! [`FsWriter::shutdown`](crate::FsWriter::shutdown), which also coordinates
-//! shutdown with the maintenance runner.
+//! Admitted work continues if its caller is cancelled. Shutdown closes
+//! admission and drains the queues through
+//! [`FsWriter::shutdown`](crate::FsWriter::shutdown).
 
 use crate::fs::{ReadCore, WriterBits};
 use crate::metrics::PublishOutcome;
@@ -31,7 +18,6 @@ use futures::FutureExt;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::{CommitId, NamespaceId};
 use loonfs_core::commit::{CommitFingerprint, CommitHeadPublishError};
-// Publisher head-CAS races use the core-wide bounded contention retry limit.
 use loonfs_core::limits::CONTENTION_RETRY_LIMIT;
 use loonfs_core::publish::{NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState};
 use std::collections::{HashMap, VecDeque};

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -640,7 +640,6 @@ async fn ready_duplicate_joins_rejected_in_flight_primary() {
     assert_eq!(duplicate_error.to_string(), primary_error.to_string());
 }
 
-/// Admission races a blocked active publication with a pending batch.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_admits_pending_batch_while_active_publish_blocks() {
     let temp_dir = tempdir().expect("tempdir");
@@ -685,7 +684,6 @@ async fn publisher_admits_pending_batch_while_active_publish_blocks() {
     assert_eq!(wal_keys.len(), 2);
 }
 
-/// Duplicate and conflicting admissions race an active publication.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
     let temp_dir = tempdir().expect("tempdir");
@@ -731,7 +729,6 @@ async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
     assert_eq!(duplicate_response.committed_seq, ChangeSeq(1));
 }
 
-/// Distinct and duplicate admissions race a full pending batch.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
     let temp_dir = tempdir().expect("tempdir");
@@ -802,9 +799,6 @@ async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
     );
 }
 
-/// A cold namespace takes whatever has batched — here a full batch
-/// admitted before the publish task first runs — immediately, with no
-/// coalescing wait in front of the first publication.
 #[tokio::test(flavor = "current_thread")]
 async fn publisher_takes_a_cold_full_batch_immediately() {
     let temp_dir = tempdir().expect("tempdir");
@@ -840,9 +834,6 @@ async fn publisher_takes_a_cold_full_batch_immediately() {
     }
 }
 
-/// A submission to a cold namespace is taken immediately: after one
-/// poll of the publish task there is no open batch parked behind a
-/// timer, so a lone candidate never waits out a coalescing window.
 #[tokio::test(flavor = "current_thread")]
 async fn cold_submission_publishes_without_a_coalescing_delay() {
     let temp_dir = tempdir().expect("tempdir");
@@ -866,9 +857,6 @@ async fn cold_submission_publishes_without_a_coalescing_delay() {
     assert_eq!(response.committed_seq, ChangeSeq(1));
 }
 
-/// Follow-up submissions inside the pacing interval coalesce and
-/// publish no earlier than the interval boundary — the timer gives a
-/// deterministic lower bound.
 #[tokio::test]
 async fn hot_submissions_wait_out_the_pacing_interval() {
     tokio::time::pause();
@@ -915,7 +903,6 @@ async fn hot_submissions_wait_out_the_pacing_interval() {
         .expect("hot commit");
 }
 
-/// Receipt replay races a lost head compare-and-swap acknowledgement.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_resolves_unknown_head_outcome_by_replaying_receipt() {
     let temp_dir = tempdir().expect("tempdir");
@@ -956,7 +943,6 @@ async fn publisher_resolves_unknown_head_outcome_by_replaying_receipt() {
     assert_eq!(response.committed_seq, ChangeSeq(2));
 }
 
-/// Queued publication races a publication whose panic the worker contains.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_survives_publish_panic_and_keeps_serving() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1008,7 +994,6 @@ async fn publisher_survives_publish_panic_and_keeps_serving() {
     );
 }
 
-/// Delete admission races active, pending, and later mutation work.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn delete_barrier_publishes_admitted_work_and_rejects_later_work() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1083,12 +1068,6 @@ async fn delete_barrier_publishes_admitted_work_and_rejects_later_work() {
     assert!(matches!(fast_fail, Err(CoreError::NamespaceDeleted { .. })));
 }
 
-/// A second delete races the first one's head compare-and-swap.
-///
-/// Both callers must be answered. The second delete is a queue item of its
-/// own, so the tombstone sweep settles it exactly like any other work that
-/// queued behind a landed delete — where the sealed-batch design stranded
-/// its waiters forever.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn second_delete_during_inflight_delete_settles_both() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1160,8 +1139,6 @@ async fn second_delete_during_inflight_delete_settles_both() {
     assert_eq!(orphan_error.code(), ErrorCode::NamespaceDeleted);
 }
 
-/// Two deletes pending at the queue tail with equal options are one
-/// request: one queue item, and both callers share its outcome.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn identical_pending_deletes_coalesce_into_one_outcome() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1217,8 +1194,6 @@ async fn identical_pending_deletes_coalesce_into_one_outcome() {
     assert_eq!(second.head_seq, ChangeSeq(2));
 }
 
-/// Deletes with different preconditions are different requests: each is
-/// its own queue item, and each settles against its own options.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pending_deletes_with_different_preconditions_settle_separately() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1274,8 +1249,6 @@ async fn pending_deletes_with_different_preconditions_settle_separately() {
     assert_eq!(deleted.head_seq, ChangeSeq(2));
 }
 
-/// A stale delete queued behind a valid one settles as
-/// `namespace_deleted` — it never inherits the other delete's success.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_stale_pending_delete_does_not_share_the_first_deletes_success() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1331,8 +1304,6 @@ async fn a_stale_pending_delete_does_not_share_the_first_deletes_success() {
     assert_eq!(stale_error.code(), ErrorCode::NamespaceDeleted);
 }
 
-/// Commit admission races a delete already queued behind an in-flight
-/// publication.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mutations_admitted_after_a_queued_delete_wait_behind_it() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1383,7 +1354,6 @@ async fn mutations_admitted_after_a_queued_delete_wait_behind_it() {
     assert_eq!(after_error.code(), ErrorCode::NamespaceDeleted);
 }
 
-/// Concurrent submissions race to share one pending publication batch.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1507,8 +1477,6 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
     assert_eq!(feed_actors.get("req-b"), Some(&actor_b));
 }
 
-/// A content-free submission and a submission carrying prepared content
-/// race to share one publication batch.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_batches_plain_and_prepared_mutations_together() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1635,7 +1603,6 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
     assert_eq!(record_counts, vec![1, 2]);
 }
 
-/// Admission closure races an already-blocked publication draining.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn registry_close_admission_refuses_new_work_while_admitted_work_drains() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1707,7 +1674,6 @@ async fn registry_close_admission_refuses_new_work_while_admitted_work_drains() 
         .all(|publisher| publisher_state(publisher).worker.is_none()));
 }
 
-/// Registry drain races a contained panic and the queue behind it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn worker_survives_panic_and_processes_later_queue_items() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1783,7 +1749,6 @@ async fn worker_survives_panic_and_processes_later_queue_items() {
     );
 }
 
-/// Publisher eviction races the delete barrier's terminal transition.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn successful_delete_evicts_the_namespace_publisher() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1854,10 +1819,6 @@ async fn close_admission_refuses_without_creating_publishers() {
     registry.drain().await.expect("nothing to drain");
 }
 
-/// A delete admitted before the shutdown sweep is the worker's to finish, so
-/// it still lands after admission closes — and it lands terminally. Deleted
-/// outranks closed: the publisher answers later work with the namespace's
-/// tombstone, not with the shutdown that raced it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_delete_admitted_before_close_admission_lands_terminal() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2043,11 +2004,6 @@ async fn delete_queued_mid_publish_waits_behind_admitted_work() {
     registry.drain().await.expect("drain settles both units");
 }
 
-/// Retained publish-tail projections are bounded across namespaces, not only
-/// one at a time: a writer that publishes to far more namespaces than the
-/// budget admits keeps a projection for the most recently published ones and
-/// nothing for the rest. The publishers stay — each one carries the writer
-/// session that nothing may evict — but they carry no tail.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn retained_tail_projections_stay_within_the_namespace_count_cap() {
     const NAMESPACES: usize = 12;
@@ -2107,10 +2063,6 @@ async fn retained_tail_projections_stay_within_the_namespace_count_cap() {
         .expect("drain settles every publisher");
 }
 
-/// The row and decoded-byte budgets bound the publish side in aggregate, the
-/// same meaning the read-side projection cache gives them. A projection that
-/// fits the per-projection ceiling on its own is still evicted once the
-/// namespaces together outgrow the budget.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn retained_tail_projections_stay_within_the_shared_byte_budget() {
     const NAMESPACES: usize = 8;
@@ -2167,9 +2119,6 @@ async fn one_projection_decoded_bytes() -> usize {
     totals.decoded_bytes
 }
 
-/// Caches off is the one mode that keeps nothing: every publish drops its
-/// projection where it was built, so the registry has none to account for
-/// and none to evict.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn disabled_runtime_caches_retain_no_tail_projections() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2201,9 +2150,6 @@ async fn disabled_runtime_caches_retain_no_tail_projections() {
         .expect("drain settles every publisher");
 }
 
-/// A landed delete takes its namespace's projection out of the accounting
-/// with the publisher itself: nothing stays charged to an id that can never
-/// rebind.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_landed_delete_forgets_the_namespace_projection() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2236,10 +2182,6 @@ async fn a_landed_delete_forgets_the_namespace_projection() {
         .expect("drain settles every publisher");
 }
 
-/// A namespace that is publishing keeps its engine, so a sweep skips it —
-/// and must keep it accounted rather than record an eviction that never
-/// happened. The next publish sweeps again and the skipped namespace loses
-/// its projection then.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_skipped_eviction_leaves_the_namespace_accounted() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -23,8 +23,6 @@ fn owner_update() -> UpdateAttributesOptions {
     options
 }
 
-/// The convenience call and the hand-built one-operation commit are the same
-/// request, so they cannot fingerprint differently.
 #[test]
 fn the_write_convenience_matches_a_hand_built_one_operation_commit() {
     let temp_dir = tempdir().expect("tempdir");
@@ -111,8 +109,6 @@ fn the_write_convenience_matches_a_hand_built_one_operation_commit() {
     ));
 }
 
-/// Writing through the convenience and reading back through stat: the map is
-/// there, at the revision the write produced.
 #[test]
 fn a_write_is_visible_to_the_next_stat() {
     let temp_dir = tempdir().expect("tempdir");
@@ -178,7 +174,6 @@ fn a_write_is_visible_to_the_next_stat() {
     );
 }
 
-/// The read options decide whether the grouped projection is present.
 #[test]
 fn read_options_project_grouped_attributes_or_none() {
     let temp_dir = tempdir().expect("tempdir");
@@ -257,7 +252,6 @@ fn read_options_project_grouped_attributes_or_none() {
     }
 }
 
-/// The embedded document advertises attributes as a core feature.
 #[test]
 fn the_embedded_capability_document_advertises_attributes() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -455,7 +455,6 @@ fn stat_and_list_use_materialized_segments_after_checkpoint_without_content_read
     assert_eq!(raw_store.count(OperationClass::Read), 0);
 }
 
-/// Concurrent stat and list race through the shared async metadata-view cache.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn concurrent_materialized_stat_and_list_share_async_store() {
     let temp_dir = tempdir().expect("tempdir");
@@ -700,9 +699,6 @@ fn separate_runtime_instances_share_object_store_state() {
     assert_eq!(file.bytes, b"shared");
 }
 
-/// A runtime fills the stored-block cache while reading. A second runtime with
-/// an empty decoded cache then reads a segment section from the stored cache.
-/// The decoded-cache assertion confirms that both reads use this cache path.
 #[test]
 fn an_installed_stored_block_cache_is_filled_and_then_serves_a_later_runtime() {
     let temp_dir = tempdir().expect("tempdir");
@@ -787,11 +783,6 @@ fn an_installed_stored_block_cache_is_filled_and_then_serves_a_later_runtime() {
     );
 }
 
-/// Maintenance reads through no metadata segment cache, so the local tier
-/// beneath it never sees a maintenance read. Reorganization is the widest
-/// read maintenance has — it decodes every row of the runs it folds — and
-/// this pins the structural argument end to end: not one block offered, and
-/// not one probe either.
 #[test]
 fn metadata_maintenance_offers_nothing_to_the_local_block_cache() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -109,9 +109,6 @@ async fn restart_replays_the_commit_actor_from_the_wal() {
     assert_eq!(change.committed_by, actor);
 }
 
-/// The retry that motivates all of this: the same command run twice with
-/// the same `--commit-id`. The second run uploads again, conflicts, and
-/// then reconciles to the commit that already landed.
 #[tokio::test]
 async fn rerunning_a_put_with_the_same_commit_id_replays_on_identical_bytes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -140,8 +137,6 @@ async fn rerunning_a_put_with_the_same_commit_id_replays_on_identical_bytes() {
     );
 }
 
-/// Different bytes under the same commit id are a different operation, not
-/// a retry, and the conflict stands.
 #[tokio::test]
 async fn different_bytes_under_a_used_commit_id_still_conflict() {
     let temp_dir = tempdir().expect("tempdir");
@@ -176,10 +171,6 @@ async fn different_bytes_under_a_used_commit_id_still_conflict() {
     );
 }
 
-/// The same bytes written somewhere else are a different mutation, and no
-/// amount of matching payload makes them the same one. Content evidence
-/// alone would call this a successful retry and leave `/b.txt` unwritten
-/// forever, which is why the proof is the whole request fingerprint.
 #[tokio::test]
 async fn the_same_bytes_at_a_different_path_still_conflict() {
     let temp_dir = tempdir().expect("tempdir");
@@ -225,10 +216,6 @@ async fn the_same_bytes_at_a_different_path_still_conflict() {
     );
 }
 
-/// The replacement behavior is part of what the caller asked for: the same
-/// bytes at the same path under a changed `behavior` is a different
-/// mutation, and a create-only rerun must not report a replacing commit's
-/// success.
 #[tokio::test]
 async fn a_changed_behavior_under_a_used_commit_id_still_conflicts() {
     let temp_dir = tempdir().expect("tempdir");
@@ -264,9 +251,6 @@ async fn a_changed_behavior_under_a_used_commit_id_still_conflicts() {
     );
 }
 
-/// The expected revision is a race guard, and a rerun that adds one asked a
-/// question the original never asked. Replaying the unguarded commit would
-/// answer it without ever checking it.
 #[tokio::test]
 async fn a_changed_expected_revision_under_a_used_commit_id_still_conflicts() {
     let temp_dir = tempdir().expect("tempdir");
@@ -302,10 +286,6 @@ async fn a_changed_expected_revision_under_a_used_commit_id_still_conflicts() {
     );
 }
 
-/// A commit that did more than one thing is not the commit a single put
-/// makes, however well its put half lines up. The operation list is inside
-/// the fingerprint, so the count alone settles this — no comparison of the
-/// other operations is needed or attempted.
 #[tokio::test]
 async fn a_single_put_does_not_replay_a_multi_operation_commit() {
     let temp_dir = tempdir().expect("tempdir");
@@ -361,9 +341,6 @@ async fn a_single_put_does_not_replay_a_multi_operation_commit() {
     );
 }
 
-/// Same length, different bytes. Size alone cannot tell these apart, so
-/// this is the case that proves the comparison reaches the content's
-/// checksum rather than stopping at its length.
 #[tokio::test]
 async fn same_length_different_bytes_conflict() {
     let temp_dir = tempdir().expect("tempdir");
@@ -383,9 +360,6 @@ async fn same_length_different_bytes_conflict() {
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
 }
 
-/// The same bytes under the same message are the same commit, so the rerun
-/// replays the sequence that already landed — the message being present
-/// changes nothing about that.
 #[tokio::test]
 async fn rerunning_a_put_with_the_same_message_replays_on_identical_bytes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -410,11 +384,6 @@ async fn rerunning_a_put_with_the_same_message_replays_on_identical_bytes() {
     );
 }
 
-/// The message is part of a commit's identity, so the same bytes under a
-/// changed message are a different mutation and the conflict stands. The
-/// bytes matching is exactly what makes this worth pinning: content
-/// evidence alone would call this a successful retry and quietly keep the
-/// original annotation.
 #[tokio::test]
 async fn a_changed_message_under_a_used_commit_id_still_conflicts() {
     let temp_dir = tempdir().expect("tempdir");
@@ -457,10 +426,6 @@ async fn a_changed_message_under_a_used_commit_id_still_conflicts() {
     );
 }
 
-/// Absent and empty are different messages: the fingerprint serializes the
-/// annotation as given, so `null` and `""` are different commits. The
-/// reconciliation compares them the same way rather than folding both into
-/// "no message".
 #[tokio::test]
 async fn an_empty_message_does_not_replay_an_absent_one() {
     let temp_dir = tempdir().expect("tempdir");
@@ -494,11 +459,6 @@ async fn an_empty_message_does_not_replay_an_absent_one() {
     );
 }
 
-/// The mutations that never uploaded anything reconcile nothing — the
-/// publisher's own identity check is the whole answer — so a changed
-/// message conflicts there whatever the put path does. This anchors that
-/// the reconciliation added for put did not become the only thing keeping
-/// the contract.
 #[tokio::test]
 async fn a_changed_message_on_mkdir_still_conflicts() {
     let temp_dir = tempdir().expect("tempdir");
@@ -534,9 +494,6 @@ async fn a_changed_message_on_mkdir_still_conflicts() {
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
 }
 
-/// The same anchor one layer down, where the caller builds the commit
-/// itself: the request that reaches the publisher is identical apart from
-/// its message, and that alone conflicts.
 #[tokio::test]
 async fn a_changed_message_on_a_direct_commit_still_conflicts() {
     let temp_dir = tempdir().expect("tempdir");
@@ -575,11 +532,6 @@ async fn a_changed_message_on_a_direct_commit_still_conflicts() {
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
 }
 
-/// Reconciliation reads the feed at the sequence the conflict reported, so
-/// once retention has surrendered the replay promise below that sequence
-/// there is no committed content left to compare against. Identical bytes
-/// and all, the conflict stands: a comparison that cannot be made is never
-/// reported as success.
 #[tokio::test]
 async fn a_retention_trimmed_commit_seq_leaves_the_conflict_standing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -638,14 +590,6 @@ async fn a_retention_trimmed_commit_seq_leaves_the_conflict_standing() {
     );
 }
 
-/// The idempotency horizon, pinned end to end: once the retention floor
-/// passes a commit AND reorganization drops its receipt, the id no longer
-/// replays — a late retry commits again as a new mutation. That is the
-/// documented contract (api spec, "safe retry"): replay is guaranteed only
-/// while the receipt lives, and receipts live exactly as long as retained
-/// history. This test exists so the behavior stays deliberate; if it ever
-/// starts failing because a late retry replays or errors instead, the spec
-/// and this pin must move together.
 #[tokio::test]
 async fn a_retry_past_the_receipt_horizon_commits_again() {
     let temp_dir = tempdir().expect("tempdir");
@@ -760,8 +704,6 @@ async fn a_retry_past_the_receipt_horizon_commits_again() {
     );
 }
 
-/// A commit id that never committed anything is not a retry of anything,
-/// so a rerun against an unrelated id behaves like a first run.
 #[tokio::test]
 async fn an_unused_commit_id_is_an_ordinary_commit() {
     let temp_dir = tempdir().expect("tempdir");
@@ -790,10 +732,6 @@ async fn an_unused_commit_id_is_an_ordinary_commit() {
     assert!(second.committed_seq > first.committed_seq);
 }
 
-/// The same reconciliation for a payload nobody held: rerunning a streamed
-/// put with the same commit id and the same bytes replays the commit that
-/// already landed. The evidence is what the pass measured and hashed,
-/// because the bytes themselves are long gone.
 #[tokio::test]
 async fn rerunning_a_streamed_put_with_the_same_commit_id_replays_on_identical_bytes() {
     let temp_dir = tempdir().expect("tempdir");
@@ -838,9 +776,6 @@ async fn rerunning_a_streamed_put_with_the_same_commit_id_replays_on_identical_b
     );
 }
 
-/// Different bytes under the same commit id are a different operation
-/// whether or not anyone held them. Same length, too, so only the digest
-/// can tell them apart.
 #[tokio::test]
 async fn different_streamed_bytes_under_a_used_commit_id_still_conflict() {
     let temp_dir = tempdir().expect("tempdir");
@@ -882,9 +817,6 @@ async fn different_streamed_bytes_under_a_used_commit_id_still_conflict() {
     );
 }
 
-/// A streamed put and a buffered put of the same bytes are the same
-/// operation and reconcile against each other: both hash the whole payload
-/// themselves, so both produce the same trusted digest.
 #[tokio::test]
 async fn a_streamed_rerun_reconciles_against_a_buffered_first_run() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -710,7 +710,6 @@ async fn replacing_put_fails_unprepared_without_content_io() {
     assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
-/// The spawned preparations exercise concurrent use of one cloned writer before one commit.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn prepared_commit_after_concurrent_preparations_uses_no_publication_content_io() {
     let harness = TestHarness::new("prepared-explicit-many").await;
@@ -953,7 +952,6 @@ async fn new_rejected_preparation_fails_before_path_planning_without_content_ope
     assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
-/// Exercises duplicate admission while the primary publication is stalled at its head CAS.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn in_flight_duplicate_performs_no_additional_content_operations() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1062,8 +1060,6 @@ async fn stale_head_retry_preserves_content_admission() {
     assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
 }
 
-/// Holds one publication at its head CAS so the next two candidates are
-/// deterministically collected into the same batch.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_content_io() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -210,9 +210,6 @@ fn direct_put_completion_rejects_a_mis_declared_size() {
     );
 }
 
-/// Bytes that do not match the claim are refused at completion and the
-/// object is removed. The id was never published, so nothing can reference
-/// what gets deleted.
 #[test]
 fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim() {
     let temp_dir = tempdir().expect("tempdir");
@@ -251,9 +248,6 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
     );
 }
 
-/// A read-back that could not run is not evidence about the bytes. The
-/// completion reports the store failure it hit, keeps the object the client
-/// uploaded and the session that owns it, and the retry completes.
 #[test]
 fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
     let temp_dir = tempdir().expect("tempdir");
@@ -758,8 +752,6 @@ fn begin_upload_validates_controls_without_replay_reads() {
     assert_eq!(raw_store.manifest_get_count(), 0);
 }
 
-/// Upload admission is the head: absent means the namespace was never
-/// created, and an unreadable head is corruption, not absence.
 #[test]
 fn begin_upload_rejects_missing_and_unreadable_namespaces() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -470,8 +470,6 @@ fn writer_reader_and_admin_share_a_namespace_through_store_config() {
     });
 }
 
-/// A standalone reader carries no actor identity at all: its engines are
-/// reader-built, so there is no writer id on a handle that never mutates.
 #[test]
 fn standalone_reader_builds_without_writer_identity() {
     let temp_dir = tempdir().expect("tempdir");
@@ -524,11 +522,6 @@ fn standalone_reader_builds_without_writer_identity() {
     });
 }
 
-/// Writer-scheduled maintenance runs as an admin over the writer's own
-/// runtime, so its invalidations land on the caches the writer reads
-/// through: after the scheduled step rewrites the namespace's metadata
-/// root, a read on the same runtime observes post-maintenance state
-/// instead of failing on a cached view of reaped objects.
 #[test]
 fn admin_over_writer_core_invalidates_shared_caches() {
     let temp_dir = tempdir().expect("tempdir");
@@ -995,14 +988,6 @@ fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
     });
 }
 
-/// Threshold crossings with background work enabled must both bound the
-/// WAL tail and drain the reorganization backlog. The first crossing
-/// publishes the namespace's first manifest as one base run; the next
-/// eight chain one delta run each, and the last of them reaches the fold
-/// trigger (eight delta runs). The writer's own background step then folds
-/// every family group — no admin involvement. Before the drain, background
-/// steps folded at most one unit per crossing, so fold debt outlived the
-/// burst that created it.
 #[test]
 fn enabled_writer_drains_reorganization_backlog_without_admin() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -86,11 +86,6 @@ async fn head_state(store: &SharedObjectStore, namespace_id: &NamespaceId) -> He
         .state
 }
 
-/// A fenced writer session must stay fenced: before this fix, the runtime
-/// dropped the commit engine after every successful publish and maintenance
-/// pass, so a superseded writer forgot its fencing and silently re-acquired
-/// the epoch — two live writers would fence each other back and forth
-/// instead of one surfacing `writer_fenced`.
 #[tokio::test]
 async fn fenced_writer_stays_fenced_instead_of_reacquiring() {
     let temp_dir = tempdir().expect("tempdir");
@@ -170,10 +165,6 @@ async fn fenced_writer_stays_fenced_instead_of_reacquiring() {
         .expect("live writer is not fenced back");
 }
 
-/// Deleting is a head-advancing write, so a fenced session must be refused
-/// there too. Before this fix the delete acquired an epoch of its own,
-/// bypassing the session entirely: a superseded writer could bump the epoch
-/// back and delete a namespace the live writer owned.
 #[tokio::test]
 async fn fenced_session_cannot_delete_namespace() {
     let temp_dir = tempdir().expect("tempdir");
@@ -244,13 +235,6 @@ async fn fenced_session_cannot_delete_namespace() {
         .expect("live writer keeps publishing after the refused delete");
 }
 
-/// Fencing must survive the eviction that bounds retained publish state.
-/// A writer's publishers hold one WAL-tail projection per namespace, and the
-/// projection budget drops the least recently published of them; only the
-/// projection goes. The epoch this session acquired belongs to the session,
-/// which nothing evicts — before that split, capacity pressure took the
-/// engine whole, and the rebuilt engine's first publish silently re-acquired
-/// the epoch, fencing the legitimate writer back.
 #[tokio::test]
 async fn fenced_writer_stays_fenced_after_its_tail_projection_is_evicted() {
     let temp_dir = tempdir().expect("tempdir");
@@ -384,11 +368,6 @@ async fn fenced_writer_stays_fenced_after_its_tail_projection_is_evicted() {
         .expect("live writer is not fenced back");
 }
 
-/// With runtime caches disabled the publisher's engine still carries the
-/// session's epoch and fencing: no cache configuration disables the
-/// publication service. Before this fix, cache-disabled runs never kept
-/// fencing at all: a superseded writer re-acquired the epoch on every
-/// publish and the two writers fenced each other back and forth.
 #[tokio::test]
 async fn fenced_writer_stays_fenced_with_runtime_caches_disabled() {
     let temp_dir = tempdir().expect("tempdir");
@@ -465,10 +444,6 @@ async fn fenced_writer_stays_fenced_with_runtime_caches_disabled() {
         .expect("live writer is not fenced back");
 }
 
-/// A landed publish seeds the read caches with the state it just produced,
-/// so read-after-write on the same core issues no store GETs at all: the
-/// anchor, catalog, manifest, tail projection, and segment blocks are all in
-/// memory.
 #[tokio::test]
 async fn read_after_write_is_served_from_seeded_caches() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -124,9 +124,6 @@ fn truncate_recent_segments(store: &SharedObjectStore, namespace_id: &NamespaceI
     block_on(store.put_overwrite(&key, bytes::Bytes::from(encoded))).expect("rewrite head");
 }
 
-/// The documented escape for a namespace whose WAL tail already outran the
-/// pointer window the head was published with: status refuses to answer,
-/// and an explicit flush is what repairs it.
 #[test]
 fn a_head_that_under_describes_its_tail_is_repaired_by_an_explicit_flush() {
     let temp_dir = tempdir().expect("tempdir");
@@ -202,8 +199,6 @@ fn namespace_diagnostics_and_step_reject_missing_namespace() {
     );
 }
 
-/// A namespace whose head is gone is a namespace that does not exist:
-/// there is no third answer between present and absent.
 #[test]
 fn namespace_diagnostics_and_step_reject_a_namespace_whose_head_is_gone() {
     let temp_dir = tempdir().expect("tempdir");
@@ -379,7 +374,6 @@ fn maintenance_step_advances_the_floor_only_when_retention_opts_in() {
     );
 }
 
-/// A plan that names nothing is not a step, whichever surface built it.
 #[test]
 fn a_plan_that_names_nothing_is_rejected() {
     let temp_dir = tempdir().expect("tempdir");
@@ -401,9 +395,6 @@ fn a_plan_that_names_nothing_is_rejected() {
     }
 }
 
-/// The typed names are one name each over the one step path: what they do
-/// is exactly the step with that one action named, and what they report
-/// agrees with it.
 #[test]
 fn the_typed_wrappers_are_single_action_steps() {
     let temp_dir = tempdir().expect("tempdir");
@@ -564,13 +555,6 @@ fn maintenance_step_after_existing_manifest_writes_delta_manifest() {
         .any(|descriptor| descriptor.run_seq == ChangeSeq(2)));
 }
 
-/// A handle with no background work behind it can still run the one piece of
-/// upkeep a bounded step cannot do itself.
-///
-/// This is the manual deployment story: an operator drives bounded steps and
-/// then drives this, and neither needs a scheduler. The call plans exactly as
-/// a step does — including folding one bounded unit when that is what the
-/// namespace needs — and reports what it ran.
 #[test]
 fn a_standalone_admin_drives_metadata_compaction_itself() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -37,9 +37,6 @@ fn histogram_count(snapshot: &MetricsSnapshot, name: &str) -> u64 {
         .sum()
 }
 
-/// One writer's ordinary work has to reach the recorder through three
-/// separate paths: the store wrapper the builder installed, the publisher,
-/// and the maintenance runner.
 #[test]
 fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
     let temp_dir = tempdir().expect("tempdir");
@@ -140,8 +137,6 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
     assert!(histogram_count(&snapshot, "loonfs.maintenance.queue_wait_seconds") > 0);
 }
 
-/// The automatic collection path reads a pass as one conclusion; these are
-/// the counts that would otherwise be dropped with the response.
 #[test]
 fn a_collection_step_reports_what_the_pass_retained() {
     let temp_dir = tempdir().expect("tempdir");
@@ -181,8 +176,6 @@ fn a_collection_step_reports_what_the_pass_retained() {
     );
 }
 
-/// A handle built without a recorder must be exactly the handle it was
-/// before: no wrapper on its store, and nothing registered anywhere.
 #[test]
 fn a_writer_without_a_recorder_registers_nothing() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/publication.rs
+++ b/crates/loonfs/tests/it/publication.rs
@@ -137,9 +137,6 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
     }
 }
 
-/// Cancelling the caller whose publication is mid-flight abandons only its
-/// result: the publication lands, and the caller queued behind it gets its
-/// own durable result.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn cancelled_caller_does_not_cancel_admitted_publication() {
     let temp_dir = tempdir().expect("tempdir");
@@ -166,8 +163,6 @@ async fn cancelled_caller_does_not_cancel_admitted_publication() {
         .expect("the queued publication landed");
 }
 
-/// Even with every caller gone, admitted publications land and a drain
-/// settles their tasks.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn all_callers_cancelled_publication_still_lands() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -98,9 +98,6 @@ async fn session_keys(store: &SharedObjectStore, namespace_id: &NamespaceId) -> 
         .expect("list upload sessions")
 }
 
-/// A prepared reference that never reaches a commit is not a leak. It is a
-/// completed session's content that no metadata names, which is the one
-/// thing content collection exists to reclaim.
 #[tokio::test]
 async fn content_prepared_and_never_published_is_reclaimed_with_its_session() {
     let temp_dir = tempdir().expect("tempdir");
@@ -154,8 +151,6 @@ async fn content_prepared_and_never_published_is_reclaimed_with_its_session() {
     assert!(session_keys(&store, &namespace_id).await.is_empty());
 }
 
-/// Published content answers to metadata from then on. Its session record
-/// still ages out, and taking that record must not take the bytes with it.
 #[tokio::test]
 async fn a_published_put_keeps_its_content_and_loses_only_the_session_record() {
     let temp_dir = tempdir().expect("tempdir");
@@ -206,10 +201,6 @@ async fn a_published_put_keeps_its_content_and_loses_only_the_session_record() {
     );
 }
 
-/// Re-running a put under a commit id that already committed stages a
-/// second object and then reconciles against the first. The duplicate is
-/// referenced by nothing, and this is what "not a leak" has to mean: it
-/// goes, and the object the commit actually named stays.
 #[tokio::test]
 async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survives() {
     let temp_dir = tempdir().expect("tempdir");
@@ -280,10 +271,6 @@ async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survi
     );
 }
 
-/// The session record is durable before the content write is attempted, so
-/// a staging write that dies mid-flight leaves an owner behind rather than
-/// nothing. What the owner buys is the expiry sweep: the record ages out of
-/// its lease and takes whatever it was writing with it.
 #[tokio::test]
 async fn staging_that_fails_leaves_a_session_the_expiry_sweep_reclaims() {
     let temp_dir = tempdir().expect("tempdir");
@@ -336,10 +323,6 @@ async fn staging_that_fails_leaves_a_session_the_expiry_sweep_reclaims() {
     assert!(session_keys(&store, &namespace_id).await.is_empty());
 }
 
-/// What ownership costs, pinned so it stays deliberate: one create-if-absent
-/// for the record that claims the content id, and one compare-and-swap to
-/// freeze what was written under it. Reading the record for that swap's etag
-/// is the third and last control operation a put adds.
 #[tokio::test]
 async fn a_put_pays_two_control_writes_for_the_session_that_owns_its_content() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/streamed_put.rs
+++ b/crates/loonfs/tests/it/streamed_put.rs
@@ -48,8 +48,6 @@ async fn namespace(runtime: &TestRuntime) -> NamespaceId {
     namespace_id
 }
 
-/// A streamed put never holds more of its payload than one transfer part,
-/// and every byte crosses the store boundary exactly once.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_streamed_put_holds_one_part_of_its_payload() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/streamed_read.rs
+++ b/crates/loonfs/tests/it/streamed_read.rs
@@ -81,8 +81,6 @@ async fn written_file(
     (namespace_id, watched, reader)
 }
 
-/// A streamed read never holds more of the file than one chunk, and every
-/// byte crosses the store boundary exactly once.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_streamed_read_holds_one_chunk_of_its_file() {
     let temp_dir = tempdir().expect("tempdir");
@@ -130,8 +128,6 @@ async fn a_streamed_read_holds_one_chunk_of_its_file() {
     );
 }
 
-/// The control the number above is measured against: the buffered read is
-/// supposed to hold the whole file, and does.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_buffered_read_holds_the_whole_file() {
     let temp_dir = tempdir().expect("tempdir");
@@ -151,9 +147,6 @@ async fn a_buffered_read_holds_the_whole_file() {
     );
 }
 
-/// Content that disagrees with its reference fails the read, and fails it at
-/// the end — after the chunks are out, which is exactly why a caller that
-/// installs a file installs it only once the stream has ended cleanly.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_streamed_read_rejects_content_that_stopped_matching_its_reference() {
     let temp_dir = tempdir().expect("tempdir");


### PR DESCRIPTION
Simplifies code comments and rustdoc across the workspace.