### PR TITLE
test(runtime): simplify runtime test coverage

### DIFF
--- a/crates/loonfs/src/metrics/tests.rs
+++ b/crates/loonfs/src/metrics/tests.rs
@@ -165,7 +165,10 @@ fn a_snapshot_orders_entries_by_name_then_labels() {
 }
 
 #[test]
-fn the_noop_recorder_keeps_nothing() {
+fn registering_on_the_noop_recorder_does_not_panic() {
+    // The noop recorder exposes nothing to read back, so not panicking is
+    // the whole of its contract. This is the smoke test that keeps a
+    // `todo!()` out of the path a host takes when it installs no recorder.
     let recorder = NoopMetricsRecorder;
     recorder
         .register_counter("loonfs.test.calls", "Calls", &[])

--- a/crates/loonfs/src/metrics/tests.rs
+++ b/crates/loonfs/src/metrics/tests.rs
@@ -166,9 +166,6 @@ fn a_snapshot_orders_entries_by_name_then_labels() {
 
 #[test]
 fn registering_on_the_noop_recorder_does_not_panic() {
-    // The noop recorder exposes nothing to read back, so not panicking is
-    // the whole of its contract. This is the smoke test that keeps a
-    // `todo!()` out of the path a host takes when it installs no recorder.
     let recorder = NoopMetricsRecorder;
     recorder
         .register_counter("loonfs.test.calls", "Calls", &[])

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -513,7 +513,6 @@ fn publisher_trace_labels_are_low_cardinality() {
         .as_str(),
         "error"
     );
-    assert_eq!(usize_to_u64(7), 7);
 }
 
 #[tokio::test]

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -251,17 +251,3 @@ fn read_options_project_grouped_attributes_or_none() {
         }
     }
 }
-
-#[test]
-fn the_embedded_capability_document_advertises_attributes() {
-    let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "attributes-capability");
-    let document = fs.reader.get_capabilities();
-    assert_eq!(
-        document.features.get(loonfs::FEATURE_ATTRIBUTES),
-        Some(&true)
-    );
-    document
-        .validate()
-        .expect("`core.attributes` is parented by the advertised core plane");
-}

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -128,9 +128,6 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
 
 #[test]
 fn runtime_publish_and_read_allow_multi_segment_wal_tail() {
-    // Both directions over a tail of more than one WAL segment, each from a
-    // handle that did not seed it, so the projection is built rather than
-    // reused. Pins that the old segment limit is gone.
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -127,13 +127,17 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
 }
 
 #[test]
-fn runtime_publish_allows_multi_segment_wal_tail() {
+fn runtime_publish_and_read_allow_multi_segment_wal_tail() {
+    // Both directions over a tail of more than one WAL segment, each from a
+    // handle that did not seed it, so the projection is built rather than
+    // reused. Pins that the old segment limit is gone.
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let setup = open_runtime(object_store.clone(), "publish-tail");
-    let measured = open_runtime(object_store, "publish-tail");
+    let measured_read = open_runtime(object_store.clone(), "publish-tail");
+    let measured_publish = open_runtime(object_store, "publish-tail");
 
     setup
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -153,7 +157,10 @@ fn runtime_publish_allows_multi_segment_wal_tail() {
         )
         .expect("seed second WAL segment");
 
-    measured
+    measured_read
+        .stat_path_blocking(&namespace_id, "/seed-a")
+        .expect("read projects the visible WAL tail without a segment limit");
+    measured_publish
         .create_directory_blocking(
             &namespace_id,
             "/should-succeed",
@@ -323,31 +330,6 @@ fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
     assert_eq!(stats.wal_tail_projection_cache_hits, 0);
     assert_eq!(stats.wal_tail_projection_cache_uncacheable_count, 2);
     assert_eq!(stats.wal_tail_projection_cache_cached_rows, 0);
-}
-
-#[test]
-fn runtime_read_allows_multi_segment_wal_tail() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("demo");
-    let fs = open_runtime(store(temp_dir.path()), "tail-read-test");
-
-    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
-        .expect("create namespace");
-    fs.create_directory_blocking(
-        &namespace_id,
-        "/docs",
-        CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
-    )
-    .expect("create docs");
-    fs.create_directory_blocking(
-        &namespace_id,
-        "/more",
-        CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
-    )
-    .expect("create another WAL segment");
-
-    fs.stat_path_blocking(&namespace_id, "/docs")
-        .expect("read projects the visible WAL tail without a segment limit");
 }
 
 #[test]

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -613,101 +613,69 @@ async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_cont
     assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
-#[tokio::test]
-async fn plain_path_put_fails_unprepared_without_content_io() {
-    let harness = TestHarness::new("plain-path-unprepared").await;
-    let content_ref = harness.stage_content(b"unprepared path content").await;
-    harness.recording.reset();
-
-    let error = harness
-        .writer
-        .publisher()
-        .submit_candidate(
-            harness.namespace_id.clone(),
-            CommitCandidate::new(put_request(
-                "plain-unprepared-put",
-                "/file.txt",
-                content_ref.clone(),
-            )),
-        )
-        .await
-        .expect_err("plain path put must require prepared content");
-
-    assert_content_not_prepared(error, &content_ref);
-    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+/// The two ways a caller hands an external content ref to publication.
+#[derive(Debug, Clone, Copy)]
+enum UnpreparedEntryPoint {
+    Publisher,
+    WriterCreateCommit,
 }
 
 #[tokio::test]
-async fn writer_mutate_with_external_ref_fails_typed_without_content_io() {
-    let harness = TestHarness::new("create-unprepared").await;
-    let content_ref = harness.stage_content(b"unprepared create content").await;
-    harness.recording.reset();
+async fn an_unprepared_external_ref_fails_typed_without_content_io() {
+    // Publication never rescues an unprepared ref by reading the blob. That
+    // holds at both entry points, and an existing destination file does not
+    // change the proof coverage a replacement needs.
+    for entry_point in [
+        UnpreparedEntryPoint::Publisher,
+        UnpreparedEntryPoint::WriterCreateCommit,
+    ] {
+        for behavior in [DestinationBehavior::NoReplace, DestinationBehavior::Replace] {
+            let harness = TestHarness::new("unprepared-ref").await;
+            if behavior == DestinationBehavior::Replace {
+                harness
+                    .writer
+                    .put_file_bytes(
+                        &harness.namespace_id,
+                        "/file.txt",
+                        b"first revision",
+                        PutFileOptions::new(loonfs_test_support::test_actor()),
+                    )
+                    .await
+                    .expect("seed file");
+            }
+            let content_ref = harness.stage_content(b"unprepared content").await;
+            harness.recording.reset();
 
-    // The writer surface wraps the same in-memory proof coverage the
-    // publisher applies; publication never rescues an unprepared ref with
-    // content I/O, and the caller still receives a typed core error.
-    let error = harness
-        .writer
-        .create_commit(
-            &harness.namespace_id,
-            put_request("mutate-create", "/file.txt", content_ref.clone()),
-        )
-        .await
-        .expect_err("unprepared create must fail");
-
-    assert!(
-        matches!(error, RuntimeError::Core(_)),
-        "expected typed core error, got {error:?}"
-    );
-    let RuntimeError::Core(error) = error else {
-        return;
-    };
-    assert_content_not_prepared(error, &content_ref);
-    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
-}
-
-#[tokio::test]
-async fn replacing_put_fails_unprepared_without_content_io() {
-    let harness = TestHarness::new("replace-unprepared").await;
-    harness
-        .writer
-        .put_file_bytes(
-            &harness.namespace_id,
-            "/file.txt",
-            b"first revision",
-            PutFileOptions::new(loonfs_test_support::test_actor()),
-        )
-        .await
-        .expect("seed file");
-    let content_ref = harness
-        .stage_content(b"unprepared replacement content")
-        .await;
-    harness.recording.reset();
-
-    // The existing file does not change proof coverage: a replacement's
-    // external ref must already be prepared before publication.
-    let error = harness
-        .writer
-        .publisher()
-        .submit_candidate(
-            harness.namespace_id.clone(),
-            CommitCandidate::new(CommitRequest::single(
-                CommitId::parse("unprepared-replace").expect("valid commit id"),
+            let request = CommitRequest::single(
+                CommitId::parse("unprepared-put").expect("valid commit id"),
                 loonfs_test_support::test_actor(),
                 None,
                 FilesystemOperation::PutFile {
                     path: parse_mutation_path("/file.txt").expect("valid mutation path"),
                     content_ref: content_ref.clone(),
-                    behavior: DestinationBehavior::Replace,
+                    behavior,
                     expected_revision_no: None,
                 },
-            )),
-        )
-        .await
-        .expect_err("unprepared replacement must fail");
+            );
+            // Both entry points answer with the crate's typed error.
+            let error: RuntimeError = match entry_point {
+                UnpreparedEntryPoint::Publisher => harness
+                    .writer
+                    .publisher()
+                    .submit_candidate(harness.namespace_id.clone(), CommitCandidate::new(request))
+                    .await
+                    .expect_err("an unprepared ref must not publish"),
+                UnpreparedEntryPoint::WriterCreateCommit => harness
+                    .writer
+                    .create_commit(&harness.namespace_id, request)
+                    .await
+                    .expect_err("an unprepared ref must not publish"),
+            };
 
-    assert_content_not_prepared(error, &content_ref);
-    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+            assert_content_not_prepared(error, &content_ref);
+            assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -613,7 +613,6 @@ async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_cont
     assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
-/// The two ways a caller hands an external content ref to publication.
 #[derive(Debug, Clone, Copy)]
 enum UnpreparedEntryPoint {
     Publisher,
@@ -622,9 +621,6 @@ enum UnpreparedEntryPoint {
 
 #[tokio::test]
 async fn an_unprepared_external_ref_fails_typed_without_content_io() {
-    // Publication never rescues an unprepared ref by reading the blob. That
-    // holds at both entry points, and an existing destination file does not
-    // change the proof coverage a replacement needs.
     for entry_point in [
         UnpreparedEntryPoint::Publisher,
         UnpreparedEntryPoint::WriterCreateCommit,
@@ -657,7 +653,6 @@ async fn an_unprepared_external_ref_fails_typed_without_content_io() {
                     expected_revision_no: None,
                 },
             );
-            // Both entry points answer with the crate's typed error.
             let error: RuntimeError = match entry_point {
                 UnpreparedEntryPoint::Publisher => harness
                     .writer

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -204,9 +204,10 @@ fn direct_put_completion_rejects_a_mis_declared_size() {
 
     let error = block_on(fs.complete_direct_put(&namespace_id, &begin.upload_id, claim))
         .expect_err("mis-declared size must fail completion");
-    assert!(
-        error.to_string().contains("content length mismatch"),
-        "completion names the size mismatch: {error}"
+    assert_eq!(
+        error.code(),
+        ErrorCode::InvalidRequest,
+        "a size the caller declared and the object contradicts is a bad request: {error}"
     );
 }
 
@@ -235,10 +236,6 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
         error.code(),
         ErrorCode::InvalidRequest,
         "a read-back that ran and disagreed is reported against the content: {error}"
-    );
-    assert!(
-        error.to_string().contains("content checksum mismatch"),
-        "completion names the checksum mismatch: {error}"
     );
     assert!(
         block_on(direct_store.head(&begin.object_key))
@@ -412,79 +409,6 @@ fn path_mutations_return_the_commit_id_they_committed_under() {
             .expect("first put");
         assert_eq!(first.namespace_id, namespace_id);
         assert_eq!(first.commit_id, commit_id);
-
-        // Resubmitting the identical mutation with the same commit id
-        // replays the original commit instead of committing again. Identical
-        // means the same content object: a put's identity is which object it
-        // attaches, so the retry reuses the reference the first put landed.
-        let landed = fs
-            .reader
-            .get_path_entry(&namespace_id, "/docs/a.txt", Default::default())
-            .await
-            .expect("stat the committed file")
-            .content_ref()
-            .cloned()
-            .expect("a file revision carries a content ref");
-        let replay = fs
-            .put_file_content_ref(
-                &namespace_id,
-                "/docs/a.txt",
-                landed,
-                PutFileOptions {
-                    commit: loonfs_api::options::CommitOptions {
-                        actor: loonfs_test_support::test_actor(),
-                        commit_id: Some(commit_id.clone()),
-                        message: None,
-                    },
-                    ..PutFileOptions::new(loonfs_test_support::test_actor())
-                },
-            )
-            .await
-            .expect("identical resubmission replays the original commit");
-        assert_eq!(replay.commit_id, first.commit_id);
-        assert_eq!(replay.committed_seq, first.committed_seq);
-
-        // Re-uploading the same bytes under the same commit id stages a
-        // fresh content object, so the publisher sees a different mutation
-        // and refuses it. What makes the rerun safe is the comparison that
-        // follows: the commit id's committed content is read back, its
-        // bytes match, and the original commit is reported.
-        let reuploaded = fs
-            .put_file_bytes(
-                &namespace_id,
-                "/docs/a.txt",
-                b"alpha",
-                PutFileOptions {
-                    commit: loonfs_api::options::CommitOptions {
-                        actor: loonfs_test_support::test_actor(),
-                        commit_id: Some(commit_id.clone()),
-                        message: None,
-                    },
-                    ..PutFileOptions::new(loonfs_test_support::test_actor())
-                },
-            )
-            .await
-            .expect("re-uploading identical bytes under a used commit id is idempotent");
-        assert_eq!(reuploaded.committed_seq, first.committed_seq);
-
-        // Different bytes are a different operation and still conflict.
-        let conflict = fs
-            .put_file_bytes(
-                &namespace_id,
-                "/docs/a.txt",
-                b"omega",
-                PutFileOptions {
-                    commit: loonfs_api::options::CommitOptions {
-                        actor: loonfs_test_support::test_actor(),
-                        commit_id: Some(commit_id.clone()),
-                        message: None,
-                    },
-                    ..PutFileOptions::new(loonfs_test_support::test_actor())
-                },
-            )
-            .await
-            .expect_err("different bytes under a used commit id must conflict");
-        assert_eq!(conflict.code(), ErrorCode::CommitIdReuseConflict);
 
         // Without a caller-supplied id, the generated one is still returned,
         // so every caller holds a reconciliation handle.

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -729,9 +729,6 @@ fn manual_only_writer_never_schedules_maintenance() {
 
 #[test]
 fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
-    // Once with the caches on and once with them off. Cache configuration
-    // is performance-only, so the Enabled policy schedules the same
-    // post-publish maintenance either way.
     for runtime_cache in [
         RuntimeCacheConfig::default(),
         RuntimeCacheConfig::disabled(),
@@ -867,7 +864,6 @@ fn builders_require_identity_and_a_runtime() {
         Err(other) => panic!("expected config error for missing writer_id, got {other:?}"),
         Ok(_) => panic!("writer_id must be required"),
     }
-    // A writer_id of only whitespace is as absent as no writer_id at all.
     match block_on(
         FsWriter::builder(store_config(temp_dir.path()))
             .writer_id("   ")

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -729,86 +729,56 @@ fn manual_only_writer_never_schedules_maintenance() {
 
 #[test]
 fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("demo");
-    block_on(async {
-        let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
-        writer
-            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
-            .await
-            .expect("create namespace");
-        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
-        writer
-            .flush_background()
-            .await
-            .expect("background maintenance quiesces");
+    // Once with the caches on and once with them off. Cache configuration
+    // is performance-only, so the Enabled policy schedules the same
+    // post-publish maintenance either way.
+    for runtime_cache in [
+        RuntimeCacheConfig::default(),
+        RuntimeCacheConfig::disabled(),
+    ] {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = namespace_id("demo");
+        block_on(async {
+            let writer = FsWriter::builder(store_config(temp_dir.path()))
+                .writer_id("handle-test-writer")
+                .background_work(FsBackgroundWork::Enabled)
+                .runtime_cache(runtime_cache)
+                .build()
+                .await
+                .expect("build writer");
+            writer
+                .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+                .await
+                .expect("create namespace");
+            fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+            writer
+                .flush_background()
+                .await
+                .expect("background maintenance quiesces");
 
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
-            .build()
-            .await
-            .expect("build admin");
-        let status = admin
-            .get_namespace_diagnostics(&namespace_id)
-            .await
-            .expect("status after auto step");
-        assert!(
-            status.current_manifest_no.is_some(),
-            "auto step should have published a manifest: {status:?}"
-        );
-        assert!(
-            status.wal_tail_segments < wal_tail_segment_threshold(),
-            "auto step should have bounded the tail: {status:?}"
-        );
-        writer
-            .shutdown()
-            .await
-            .expect("shut down writer background work");
-    });
-}
-
-#[test]
-fn enabled_writer_schedules_maintenance_with_caches_disabled() {
-    // Cache configuration is performance-only: with the caches off, the
-    // Enabled policy still schedules the same post-publish maintenance.
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("demo");
-    block_on(async {
-        let writer = FsWriter::builder(store_config(temp_dir.path()))
-            .writer_id("handle-test-writer")
-            .background_work(FsBackgroundWork::Enabled)
-            .runtime_cache(RuntimeCacheConfig::disabled())
-            .build()
-            .await
-            .expect("build writer");
-        writer
-            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
-            .await
-            .expect("create namespace");
-        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
-        writer
-            .flush_background()
-            .await
-            .expect("background maintenance quiesces");
-
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
-            .build()
-            .await
-            .expect("build admin");
-        let status = admin
-            .get_namespace_diagnostics(&namespace_id)
-            .await
-            .expect("status after auto step");
-        assert!(
-            status.wal_tail_segments < wal_tail_segment_threshold(),
-            "auto step should have bounded the tail: {status:?}"
-        );
-        writer
-            .shutdown()
-            .await
-            .expect("shut down writer background work");
-    });
+            let admin = FsAdmin::builder(store_config(temp_dir.path()))
+                .actor_id("handle-test-admin")
+                .build()
+                .await
+                .expect("build admin");
+            let status = admin
+                .get_namespace_diagnostics(&namespace_id)
+                .await
+                .expect("status after auto step");
+            assert!(
+                status.current_manifest_no.is_some(),
+                "auto step should have published a manifest: {status:?}"
+            );
+            assert!(
+                status.wal_tail_segments < wal_tail_segment_threshold(),
+                "auto step should have bounded the tail: {status:?}"
+            );
+            writer
+                .shutdown()
+                .await
+                .expect("shut down writer background work");
+        });
+    }
 }
 
 #[test]
@@ -897,6 +867,16 @@ fn builders_require_identity_and_a_runtime() {
         Err(other) => panic!("expected config error for missing writer_id, got {other:?}"),
         Ok(_) => panic!("writer_id must be required"),
     }
+    // A writer_id of only whitespace is as absent as no writer_id at all.
+    match block_on(
+        FsWriter::builder(store_config(temp_dir.path()))
+            .writer_id("   ")
+            .build(),
+    ) {
+        Err(RuntimeError::Config(_)) => {}
+        Err(other) => panic!("expected config error for a blank writer_id, got {other:?}"),
+        Ok(_) => panic!("a whitespace-only writer_id must be rejected"),
+    }
     match block_on(FsAdmin::builder(store_config(temp_dir.path())).build()) {
         Err(RuntimeError::Config(_)) => {}
         Err(other) => panic!("expected config error for missing actor_id, got {other:?}"),
@@ -933,7 +913,6 @@ fn writer_builder_rejects_zero_maintenance_concurrency() {
             Ok(_) => panic!("zero maintenance concurrency must be rejected"),
         };
         assert_eq!(error.code(), ErrorCode::InvalidRequest);
-        assert!(error.to_string().contains("`max_concurrent_maintenance`"));
     }
 }
 

--- a/crates/loonfs/tests/it/immutable_view_inputs.rs
+++ b/crates/loonfs/tests/it/immutable_view_inputs.rs
@@ -1,7 +1,4 @@
-//! A namespace's immutable view input — the manifest object its head
-//! resolves to — is loaded once per handle, not once per operation. This
-//! test pins that a warm handle stops re-fetching it entirely, on both the
-//! read and the write path.
+//! Immutable view inputs are cached once per handle.
 
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenancePlan,
@@ -71,8 +68,6 @@ async fn warm_handles_stop_fetching_immutable_view_inputs() {
     let namespace_id = NamespaceId::parse("pins").expect("valid namespace id");
     build_namespace(&store, &namespace_id).await;
 
-    // The read path first. Each handle owns its own copy of the inputs, so
-    // the recorded keys are drained between the two halves.
     let reader = FsReader::builder_with_store(store.clone())
         .build()
         .await
@@ -99,7 +94,6 @@ async fn warm_handles_stop_fetching_immutable_view_inputs() {
          content-store descriptor, or the manifest object"
     );
 
-    // The write path, on a handle of its own.
     let writer = FsWriter::builder_with_store(store.clone())
         .writer_id("warm-writer")
         .min_publish_interval_ms(0)

--- a/crates/loonfs/tests/it/immutable_view_inputs.rs
+++ b/crates/loonfs/tests/it/immutable_view_inputs.rs
@@ -1,6 +1,7 @@
 //! A namespace's immutable view input — the manifest object its head
-//! resolves to — is loaded once per handle, not once per operation. These
-//! tests pin that a warm handle stops re-fetching it entirely.
+//! resolves to — is loaded once per handle, not once per operation. This
+//! test pins that a warm handle stops re-fetching it entirely, on both the
+//! read and the write path.
 
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenancePlan,
@@ -60,7 +61,7 @@ async fn build_namespace(store: &SharedObjectStore, namespace_id: &NamespaceId) 
 }
 
 #[tokio::test]
-async fn warm_reader_stops_fetching_immutable_view_inputs() {
+async fn warm_handles_stop_fetching_immutable_view_inputs() {
     let temp_dir = tempdir().expect("tempdir");
     let recording = Arc::new(RecordingStore::new(
         LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
@@ -70,6 +71,8 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
     let namespace_id = NamespaceId::parse("pins").expect("valid namespace id");
     build_namespace(&store, &namespace_id).await;
 
+    // The read path first. Each handle owns its own copy of the inputs, so
+    // the recorded keys are drained between the two halves.
     let reader = FsReader::builder_with_store(store.clone())
         .build()
         .await
@@ -95,19 +98,8 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
         "a warm handle must not re-fetch the namespace config, the \
          content-store descriptor, or the manifest object"
     );
-}
 
-#[tokio::test]
-async fn warm_writer_stops_fetching_immutable_view_inputs() {
-    let temp_dir = tempdir().expect("tempdir");
-    let recording = Arc::new(RecordingStore::new(
-        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-        KeyPredicate::any(),
-    ));
-    let store: SharedObjectStore = recording.clone();
-    let namespace_id = NamespaceId::parse("pins").expect("valid namespace id");
-    build_namespace(&store, &namespace_id).await;
-
+    // The write path, on a handle of its own.
     let writer = FsWriter::builder_with_store(store.clone())
         .writer_id("warm-writer")
         .min_publish_interval_ms(0)

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -147,12 +147,10 @@ fn a_head_that_under_describes_its_tail_is_repaired_by_an_explicit_flush() {
     let error = fs
         .namespace_diagnostics_blocking(&namespace_id)
         .expect_err("a head that does not describe its tail cannot be counted");
-    assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
-    assert!(
-        error
-            .to_string()
-            .contains("does not reach the tail boundary"),
-        "unexpected message: {error}"
+    assert_eq!(
+        error.code(),
+        ErrorCode::NamespaceCorrupt,
+        "a head that under-describes its tail is corruption, not absence: {error}"
     );
 
     let flushed = fs
@@ -693,31 +691,6 @@ fn maintenance_step_treats_metadata_root_cas_loss_as_benign_race() {
         .expect("status after lost race");
     assert_eq!(status.current_manifest_no, None);
     assert_eq!(status.wal_tail_segments, 1);
-}
-
-#[test]
-fn checkpoint_and_retention_hooks_are_available() {
-    let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "maintenance-test");
-    let namespace_id = namespace_id("demo");
-
-    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
-        .expect("create namespace");
-    fs.put_file_bytes_blocking(
-        &namespace_id,
-        "/docs/hello.txt",
-        b"hello",
-        PutFileOptions::new(loonfs_test_support::test_actor()),
-    )
-    .expect("put file");
-
-    let checkpoint = fs
-        .create_checkpoint_blocking(&namespace_id)
-        .expect("create checkpoint");
-    let retention = fs
-        .advance_retention_floor_blocking(&namespace_id)
-        .expect("advance retention");
-    assert_eq!(retention.retention_floor_seq, checkpoint.checkpoint_seq);
 }
 
 #[test]

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -176,18 +176,6 @@ fn a_collection_step_reports_what_the_pass_retained() {
     );
 }
 
-#[test]
-fn a_writer_without_a_recorder_registers_nothing() {
-    let temp_dir = tempdir().expect("tempdir");
-    let recorder = Arc::new(DefaultMetricsRecorder::new());
-    let fs = runtime(temp_dir.path(), "unmetered-writer");
-
-    fs.create_namespace_blocking(&namespace_id("demo"), CreateNamespaceOptions::default())
-        .expect("create namespace");
-
-    assert!(recorder.snapshot().all().is_empty());
-}
-
 /// The five conclusions a metadata step can settle on, as label values.
 struct MetadataConclusions;
 

--- a/crates/loonfs/tests/it/publish_observer.rs
+++ b/crates/loonfs/tests/it/publish_observer.rs
@@ -1,5 +1,4 @@
-//! Publish-observer delivery: what a registered observer is handed, and
-//! which calls do not reach it.
+//! Publish-observer delivery.
 
 use loonfs::{CreateNamespaceOptions, FsWriter, PutFileOptions, SharedObjectStore};
 use loonfs_api::{ChangeSeq, NamespaceId};

--- a/crates/loonfs/tests/it/publish_observer.rs
+++ b/crates/loonfs/tests/it/publish_observer.rs
@@ -1,4 +1,5 @@
-//! Publish-observer delivery and opt-in behavior.
+//! Publish-observer delivery: what a registered observer is handed, and
+//! which calls do not reach it.
 
 use loonfs::{CreateNamespaceOptions, FsWriter, PutFileOptions, SharedObjectStore};
 use loonfs_api::{ChangeSeq, NamespaceId};
@@ -51,35 +52,5 @@ async fn registered_observer_sees_namespace_and_sequence_after_publish() {
         *observed.lock().expect("observer values lock poisoned"),
         vec![(namespace_id, ChangeSeq(1))]
     );
-    writer.shutdown().await.expect("shutdown");
-}
-
-#[tokio::test]
-async fn unregistered_writer_publishes_with_the_existing_result_shape() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
-    let writer = FsWriter::builder_with_store(store)
-        .writer_id("plain-writer")
-        .min_publish_interval_ms(0)
-        .build()
-        .await
-        .expect("writer");
-    let namespace_id = NamespaceId::parse("plain").expect("namespace id");
-    writer
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
-        .await
-        .expect("create namespace");
-
-    let response = writer
-        .put_file_bytes(
-            &namespace_id,
-            "/note.txt",
-            b"plain publish\n",
-            PutFileOptions::new(loonfs_test_support::test_actor()),
-        )
-        .await
-        .expect("publish without observer");
-    assert_eq!(response.namespace_id, namespace_id);
-    assert_eq!(response.committed_seq, ChangeSeq(1));
     writer.shutdown().await.expect("shutdown");
 }

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -119,6 +119,8 @@ async fn publish_candidates(
 #[allow(clippy::print_stdout)]
 #[tokio::test]
 #[ignore = "diagnostic: prints warm-phase request accounting"]
+// This is a diagnostic tool, not coverage: it prints a breakdown for a human
+// to read, and its one assertion only checks that the fixture was built.
 async fn warm_phase_request_accounting() {
     let temp_dir = tempdir().expect("tempdir");
     let log = Arc::new(RecordingStore::new(

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -119,8 +119,6 @@ async fn publish_candidates(
 #[allow(clippy::print_stdout)]
 #[tokio::test]
 #[ignore = "diagnostic: prints warm-phase request accounting"]
-// This is a diagnostic tool, not coverage: it prints a breakdown for a human
-// to read, and its one assertion only checks that the fixture was built.
 async fn warm_phase_request_accounting() {
     let temp_dir = tempdir().expect("tempdir");
     let log = Arc::new(RecordingStore::new(

--- a/crates/loonfs/tests/it/runtime_config.rs
+++ b/crates/loonfs/tests/it/runtime_config.rs
@@ -1,48 +1,18 @@
-//! Runtime builder validation and public handle boundary behavior.
+//! Public handle boundary behavior: the object-store metrics seam, the
+//! filesystem operations, and fork isolation.
 
 #![allow(clippy::panic)]
 // Runtime integration tests use panic in helper assertions for precise diagnostics.
 
 use crate::common::*;
 use loonfs::{
-    CopyOptions, CreateNamespaceOptions, DestinationBehavior, FsReader, FsWriter, MoveOptions,
-    NamespaceId, PutFileOptions, RuntimeError, TraceStoreKind,
+    CopyOptions, CreateNamespaceOptions, DestinationBehavior, MoveOptions, NamespaceId,
+    PutFileOptions, TraceStoreKind,
 };
 use loonfs_objectstore::metrics::{ObjectStoreOperation, VecObjectStoreMetricsRecorder};
-use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use std::sync::Arc;
 use tempfile::tempdir;
-
-fn assert_config_error<T>(result: loonfs::Result<T>, expected: &str) {
-    match result {
-        Err(RuntimeError::Config(message)) => assert!(
-            message.contains(expected),
-            "expected {message:?} to contain {expected:?}"
-        ),
-        Err(error) => panic!("expected config error, got {error:?}"),
-        Ok(_) => panic!("expected config error"),
-    }
-}
-
-#[test]
-fn open_validates_runtime_config() {
-    let temp_dir = tempdir().expect("tempdir");
-    let object_store = store(temp_dir.path());
-
-    assert_config_error(
-        block_on(FsWriter::builder_with_store(object_store.clone()).build()),
-        "writer_id",
-    );
-    assert_config_error(
-        block_on(
-            FsWriter::builder_with_store(object_store.clone())
-                .writer_id("   ")
-                .build(),
-        ),
-        "writer_id",
-    );
-}
 
 #[test]
 fn builder_object_store_metrics_recorder_instruments_object_store() {
@@ -140,38 +110,6 @@ fn filesystem_operations_match_core_semantics() {
             .bytes,
         b"updated"
     );
-}
-
-#[tokio::test]
-async fn async_runtime_methods_are_the_engine_boundary() {
-    let temp_dir = tempdir().expect("tempdir");
-    let fs = open_runtime_async(store(temp_dir.path()), "async-runtime-test").await;
-    let namespace_id = namespace_id("demo");
-
-    FsWriter::create_namespace(&fs.writer, &namespace_id, CreateNamespaceOptions::default())
-        .await
-        .expect("create namespace");
-    FsWriter::put_file_bytes(
-        &fs.writer,
-        &namespace_id,
-        "/docs/hello.txt",
-        b"hello",
-        PutFileOptions::new(loonfs_test_support::test_actor()),
-    )
-    .await
-    .expect("put file");
-
-    let async_stat = FsReader::get_path_entry(
-        &fs.reader,
-        &namespace_id,
-        "/docs/hello.txt",
-        Default::default(),
-    )
-    .await
-    .expect("async stat");
-
-    assert_eq!(async_stat.path, "/docs/hello.txt");
-    assert_eq!(async_stat.size_bytes(), Some(5));
 }
 
 #[test]

--- a/crates/loonfs/tests/it/runtime_config.rs
+++ b/crates/loonfs/tests/it/runtime_config.rs
@@ -1,5 +1,4 @@
-//! Public handle boundary behavior: the object-store metrics seam, the
-//! filesystem operations, and fork isolation.
+//! Public handle behavior and fork isolation.
 
 #![allow(clippy::panic)]
 // Runtime integration tests use panic in helper assertions for precise diagnostics.


### PR DESCRIPTION
Removes duplicate and low-value runtime tests, combines cases that exercise the same behavior, and replaces fragile error-message checks with typed error codes.

The remaining tests continue to cover cache behavior, maintenance scheduling, unprepared content, immutable views, and commit retries. Production code is unchanged.