### PR TITLE
test(api): simplify API test coverage

### DIFF
--- a/crates/loonfs-api/src/actor.rs
+++ b/crates/loonfs-api/src/actor.rs
@@ -343,36 +343,4 @@ mod tests {
             serde_json::from_str::<ActorRef>(r#"{"kind":"user","id":"x","name":"Ada"}"#).is_err()
         );
     }
-
-    #[test]
-    fn actor_ref_convenience_constructors_select_the_kind() {
-        let id = ActorId::parse("actor").expect("valid actor id");
-
-        assert_eq!(ActorRef::user(id.clone()).kind, ActorKind::User);
-        assert_eq!(ActorRef::service(id.clone()).kind, ActorKind::Service);
-        assert_eq!(ActorRef::system(id).kind, ActorKind::System);
-        assert_eq!(
-            ActorRef::loonfs_system(),
-            ActorRef::system(ActorId::parse("loonfs").expect("valid bootstrap actor id"))
-        );
-    }
-
-    #[cfg(feature = "openapi")]
-    #[test]
-    fn actor_vocabulary_registers_openapi_schemas() {
-        #[derive(utoipa::OpenApi)]
-        #[openapi(components(schemas(ActorRef, ActorKind, ActorId)))]
-        struct ActorVocabularyOpenApi;
-
-        let document = serde_json::to_value(<ActorVocabularyOpenApi as utoipa::OpenApi>::openapi())
-            .expect("serialize actor vocabulary OpenAPI document");
-        let schemas = document
-            .pointer("/components/schemas")
-            .and_then(serde_json::Value::as_object)
-            .expect("actor vocabulary schemas");
-
-        for name in ["ActorRef", "ActorKind", "ActorId"] {
-            assert!(schemas.contains_key(name), "missing `{name}` schema");
-        }
-    }
 }

--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -783,36 +783,6 @@ mod tests {
     }
 
     #[test]
-    fn checksum_evidence_is_outside_mutation_identity() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let content_ref = ContentRef::blob_v1(
-            ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
-            b"pinned put bytes",
-        );
-        let crc_reference = ContentRef {
-            checksum: Checksum::crc32c(b"pinned put bytes"),
-            ..content_ref.clone()
-        };
-
-        assert_eq!(
-            semantic_commit_fingerprint(
-                &namespace_id,
-                &test_actor(),
-                None,
-                &[put("/docs/report.txt", content_ref)]
-            )
-            .expect("fingerprint"),
-            semantic_commit_fingerprint(
-                &namespace_id,
-                &test_actor(),
-                None,
-                &[put("/docs/report.txt", crc_reference)]
-            )
-            .expect("fingerprint")
-        );
-    }
-
-    #[test]
     fn a_different_content_object_changes_mutation_identity() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let bytes = b"identical bytes, two uploads";
@@ -855,23 +825,6 @@ mod tests {
         .expect("fingerprint");
 
         assert_ne!(without, with);
-    }
-
-    #[test]
-    fn commit_fingerprint_changes_when_logical_inputs_change() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let baseline =
-            semantic_commit_fingerprint(&namespace_id, &test_actor(), None, &[create_dir("/docs")])
-                .expect("baseline");
-        let changed = semantic_commit_fingerprint(
-            &namespace_id,
-            &test_actor(),
-            None,
-            &[create_dir("/drafts")],
-        )
-        .expect("changed");
-
-        assert_ne!(baseline, changed);
     }
 
     #[test]

--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -483,7 +483,7 @@ impl ContentRef {
 mod tests {
     use super::{
         Checksum, ChecksumAlgorithm, ChecksumValidationError, ContentEvidence, ContentRef,
-        ContentRefKind, ContentRefValidationError, Crc32c, Crc64Nvme, StreamingChecksum,
+        ContentRefKind, ContentRefValidationError, StreamingChecksum,
     };
     use crate::ids::ContentId;
 
@@ -514,28 +514,20 @@ mod tests {
     #[test]
     fn every_checksum_algorithm_round_trips() {
         for (algorithm, wire) in [
-            (ChecksumAlgorithm::Sha256, "\"sha256\""),
-            (ChecksumAlgorithm::Crc64nvme, "\"crc64nvme\""),
-            (ChecksumAlgorithm::Crc32c, "\"crc32c\""),
+            (ChecksumAlgorithm::Sha256, "sha256"),
+            (ChecksumAlgorithm::Crc64nvme, "crc64nvme"),
+            (ChecksumAlgorithm::Crc32c, "crc32c"),
         ] {
             let encoded = serde_json::to_string(&algorithm).expect("encode algorithm");
-            assert_eq!(encoded, wire);
+            assert_eq!(encoded, format!("\"{wire}\""));
+            assert_eq!(
+                algorithm.as_str(),
+                wire,
+                "the hand-written spelling must match the serde tag"
+            );
             let decoded: ChecksumAlgorithm =
                 serde_json::from_str(&encoded).expect("decode algorithm");
             assert_eq!(decoded, algorithm);
-        }
-    }
-
-    #[test]
-    fn every_checksum_shape_round_trips() {
-        for checksum in [
-            Checksum::sha256(b"hello"),
-            Checksum::crc64nvme(b"hello"),
-            Checksum::crc32c(b"hello"),
-        ] {
-            let encoded = serde_json::to_string(&checksum).expect("encode checksum");
-            let decoded: Checksum = serde_json::from_str(&encoded).expect("decode checksum");
-            assert_eq!(decoded, checksum);
         }
     }
 
@@ -548,18 +540,6 @@ mod tests {
             "content_id": "con_0123456789abcdef0123456789abcdef",
             "size_bytes": 5,
             "checksum": {"algorithm": "md5", "value": "00000000000000000000000000000000"}
-        }"#;
-        assert!(serde_json::from_str::<ContentRef>(json).is_err());
-    }
-
-    #[test]
-    fn a_content_ref_rejects_unknown_fields() {
-        let json = r#"{
-            "kind": "blob_v1",
-            "content_id": "con_0123456789abcdef0123456789abcdef",
-            "size_bytes": 5,
-            "checksum": {"algorithm": "sha256", "value": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"},
-            "checksum_type": "full_object"
         }"#;
         assert!(serde_json::from_str::<ContentRef>(json).is_err());
     }
@@ -582,7 +562,7 @@ mod tests {
     }
 
     #[test]
-    fn validation_rejects_unsupported_kinds_and_malformed_checksums() {
+    fn validation_rejects_an_unsupported_kind_and_a_malformed_checksum() {
         let mut content_ref = ContentRef::blob_v1(content_id(), b"hello");
         content_ref.kind = ContentRefKind::Unsupported("sparse_file_v9".to_owned());
         assert!(matches!(
@@ -590,6 +570,8 @@ mod tests {
             Err(ContentRefValidationError::UnsupportedKind { .. })
         ));
 
+        // The checksum rules themselves are covered by the sibling test; this
+        // case only proves the reference reports what its checksum refused.
         let mut content_ref = ContentRef::blob_v1(content_id(), b"hello");
         content_ref.checksum = Checksum {
             algorithm: ChecksumAlgorithm::Crc64nvme,
@@ -597,15 +579,8 @@ mod tests {
         };
         assert!(matches!(
             content_ref.validate(),
-            Err(ContentRefValidationError::InvalidChecksum(_))
-        ));
-
-        let mut content_ref = ContentRef::blob_v1(content_id(), b"hello");
-        content_ref.checksum.value = content_ref.checksum.value.to_uppercase();
-        assert!(matches!(
-            content_ref.validate(),
             Err(ContentRefValidationError::InvalidChecksum(
-                ChecksumValidationError::InvalidAlphabet { .. }
+                ChecksumValidationError::InvalidWidth { .. }
             ))
         ));
     }
@@ -669,27 +644,6 @@ mod tests {
             "00000000",
             "the empty payload is the identity"
         );
-    }
-
-    #[test]
-    fn a_streamed_crc64nvme_equals_the_whole_payload_at_once() {
-        let payload: Vec<u8> = (0..4096u32).map(|byte| byte as u8).collect();
-        let mut streamed = Crc64Nvme::new();
-        for chunk in payload.chunks(97) {
-            streamed.update(chunk);
-        }
-
-        assert_eq!(streamed.finish(), Checksum::crc64nvme(&payload));
-    }
-
-    #[test]
-    fn a_crc32c_folded_over_a_prefix_and_the_rest_equals_the_whole_payload() {
-        let payload: Vec<u8> = (0..4096u32).map(|byte| byte as u8).collect();
-        let mut streamed = Crc32c::new();
-        streamed.update(&payload[..1500]);
-        streamed.update(&payload[1500..]);
-
-        assert_eq!(streamed.finish(), Checksum::crc32c(&payload));
     }
 
     #[test]
@@ -764,32 +718,5 @@ mod tests {
         );
         assert!(!crc_reference.matches_evidence(ContentEvidence::ContentRef(&different_size)));
         assert!(sha_reference.matches_evidence(ContentEvidence::ContentRef(&sha_reference)));
-    }
-
-    #[test]
-    fn sha_and_crc_references_round_trip() {
-        for content_ref in [
-            ContentRef::blob_v1(content_id(), b"hello"),
-            ContentRef {
-                kind: ContentRefKind::BlobV1,
-                content_id: content_id(),
-                size_bytes: 11_534_336,
-                checksum: Checksum {
-                    algorithm: ChecksumAlgorithm::Crc64nvme,
-                    value: "bbb7305bdf118bcb".to_owned(),
-                },
-            },
-            ContentRef {
-                kind: ContentRefKind::BlobV1,
-                content_id: content_id(),
-                size_bytes: 5,
-                checksum: Checksum::crc32c(b"hello"),
-            },
-        ] {
-            content_ref.validate().expect("content ref is valid");
-            let encoded = serde_json::to_string(&content_ref).expect("encode");
-            let decoded: ContentRef = serde_json::from_str(&encoded).expect("decode");
-            assert_eq!(decoded, content_ref);
-        }
     }
 }

--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -570,8 +570,6 @@ mod tests {
             Err(ContentRefValidationError::UnsupportedKind { .. })
         ));
 
-        // The checksum rules themselves are covered by the sibling test; this
-        // case only proves the reference reports what its checksum refused.
         let mut content_ref = ContentRef::blob_v1(content_id(), b"hello");
         content_ref.checksum = Checksum {
             algorithm: ChecksumAlgorithm::Crc64nvme,

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -1131,17 +1131,20 @@ mod tests {
     fn head_without_content_store_is_rejected() {
         // The content store is the namespace's addressing-semantics
         // authority; a head that omits it is malformed, never defaulted.
-        let missing = serde_json::json!({
-            "namespace_id": "demo",
-            "seq": 0,
-            "head_commit_id": GENESIS_COMMIT_ID,
-            "writer_epoch": 0,
-            "next_inode_id": 2,
-            "status": { "kind": "active" }
-        });
+        // Every other required field is present, so the named field is the
+        // only reason this can fail.
+        let mut missing = head_json(None, Vec::new());
+        missing
+            .as_object_mut()
+            .expect("head payload object")
+            .remove("content_store_id");
 
-        serde_json::from_value::<HeadState>(missing)
+        let error = serde_json::from_value::<HeadState>(missing)
             .expect_err("head without its immutable identity must be rejected");
+        assert!(
+            error.to_string().contains("content_store_id"),
+            "the rejection should name the missing field: {error}"
+        );
     }
 
     /// One WAL pointer as it appears inside a durable head payload.
@@ -1179,19 +1182,14 @@ mod tests {
     }
 
     #[test]
-    fn head_decodes_with_a_tip_and_no_predecessor_hints() {
+    fn a_head_decodes_its_tip_with_and_without_predecessor_hints() {
         let tip = wal_pointer_json("wal_00000000000000000002-fedcba9876543210", 2, 2);
+        let older = wal_pointer_json("wal_00000000000000000001-0123456789abcdef", 1, 1);
 
-        let head = serde_json::from_value::<HeadState>(head_json(Some(tip), Vec::new()))
+        let head = serde_json::from_value::<HeadState>(head_json(Some(tip.clone()), Vec::new()))
             .expect("the first published segment has no predecessor hints");
         assert!(head.visible_wal_tip.is_some());
         assert!(head.recent_segments.is_empty());
-    }
-
-    #[test]
-    fn predecessor_hints_do_not_repeat_the_tip() {
-        let tip = wal_pointer_json("wal_00000000000000000002-fedcba9876543210", 2, 2);
-        let older = wal_pointer_json("wal_00000000000000000001-0123456789abcdef", 1, 1);
 
         let head = serde_json::from_value::<HeadState>(head_json(Some(tip), vec![older.clone()]))
             .expect("predecessor hints decode independently of the authoritative tip");

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -1131,8 +1131,6 @@ mod tests {
     fn head_without_content_store_is_rejected() {
         // The content store is the namespace's addressing-semantics
         // authority; a head that omits it is malformed, never defaulted.
-        // Every other required field is present, so the named field is the
-        // only reason this can fail.
         let mut missing = head_json(None, Vec::new());
         missing
             .as_object_mut()

--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -291,14 +291,6 @@ mod tests {
     use super::ErrorCode;
 
     #[test]
-    fn error_codes_round_trip_through_their_strings() {
-        for code in ErrorCode::ALL {
-            assert_eq!(ErrorCode::parse(code.as_str()), Some(code));
-        }
-        assert_eq!(ErrorCode::parse("not_a_code"), None);
-    }
-
-    #[test]
     fn error_codes_serde_uses_the_wire_strings() {
         for code in ErrorCode::ALL {
             let value = serde_json::to_value(code).expect("serialize error code");

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -985,15 +985,6 @@ mod tests {
     }
 
     #[test]
-    fn commit_id_parse_uses_same_allowed_grammar() {
-        let parsed = CommitId::parse("c_demo-1").expect("valid commit_id");
-
-        assert_eq!(parsed.as_str(), "c_demo-1");
-        assert!(CommitId::parse("c/demo").is_err());
-        assert!(CommitId::parse("C_demo").is_err());
-    }
-
-    #[test]
     fn identity_try_from_validates_values() {
         assert_eq!(
             NamespaceId::try_from("demo")
@@ -1038,13 +1029,6 @@ mod tests {
         assert!(CheckpointId::try_from("chk_0000000000000000000000000000000g").is_err());
         assert!(NameKey::try_from("a/b").is_err());
         assert!(ManifestObjectId::try_from("42-0123456789abcdef").is_err());
-    }
-
-    #[test]
-    fn identity_from_str_delegates_to_parse() {
-        let namespace_id: NamespaceId = "demo".parse().expect("valid namespace id");
-        assert_eq!(namespace_id.as_str(), "demo");
-        assert!("invalid/name".parse::<NamespaceId>().is_err());
     }
 
     #[test]
@@ -1162,27 +1146,21 @@ mod tests {
     }
 
     #[test]
-    fn generated_wal_segment_ids_are_not_reused_across_samples() {
+    fn generated_positional_ids_are_not_reused_across_samples() {
         // Same position, many proposers: the suffix keeps every proposal
-        // distinct.
-        let mut ids = BTreeSet::new();
+        // distinct. Both positional families draw it from the same source.
+        let mut wal_segment_ids = BTreeSet::new();
+        let mut manifest_object_ids = BTreeSet::new();
         for _ in 0..128 {
-            let id = WalSegmentId::generate(ChangeSeq(412));
+            let wal_segment_id = WalSegmentId::generate(ChangeSeq(412));
             assert!(
-                ids.insert(id.clone()),
-                "generated duplicate WAL segment id {id}"
+                wal_segment_ids.insert(wal_segment_id.clone()),
+                "generated duplicate WAL segment id {wal_segment_id}"
             );
-        }
-    }
-
-    #[test]
-    fn generated_manifest_object_ids_are_not_reused_across_samples() {
-        let mut ids = BTreeSet::new();
-        for _ in 0..128 {
-            let id = ManifestObjectId::generate(ManifestNo(412));
+            let manifest_object_id = ManifestObjectId::generate(ManifestNo(412));
             assert!(
-                ids.insert(id.clone()),
-                "generated duplicate manifest object id {id}"
+                manifest_object_ids.insert(manifest_object_id.clone()),
+                "generated duplicate manifest object id {manifest_object_id}"
             );
         }
     }
@@ -1252,19 +1230,10 @@ mod tests {
     #[test]
     fn content_id_parse_requires_the_generated_id_shape() {
         assert!(ContentId::parse("con_0123456789abcdef0123456789abcdef").is_ok());
-        for value in [
-            "con_",
-            "con_abcdef",
-            "con_0123456789ABCDEF0123456789abcdef",
-            "con_0123456789abcdef0123456789abcde",
-            "upl_0123456789abcdef0123456789abcdef",
-            "0123456789abcdef0123456789abcdef",
-        ] {
-            assert!(
-                ContentId::parse(value).is_err(),
-                "expected invalid content id {value:?}"
-            );
-        }
+        // The body grammar is the shared generated-id validator, covered in
+        // full by the content-store test. What is unique here is the prefix:
+        // another family's well-formed id is not a content id.
+        assert!(ContentId::parse("upl_0123456789abcdef0123456789abcdef").is_err());
     }
 
     fn assert_generated_id_shape(value: &str, prefix: &str) {

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -1147,8 +1147,6 @@ mod tests {
 
     #[test]
     fn generated_positional_ids_are_not_reused_across_samples() {
-        // Same position, many proposers: the suffix keeps every proposal
-        // distinct. Both positional families draw it from the same source.
         let mut wal_segment_ids = BTreeSet::new();
         let mut manifest_object_ids = BTreeSet::new();
         for _ in 0..128 {
@@ -1230,9 +1228,6 @@ mod tests {
     #[test]
     fn content_id_parse_requires_the_generated_id_shape() {
         assert!(ContentId::parse("con_0123456789abcdef0123456789abcdef").is_ok());
-        // The body grammar is the shared generated-id validator, covered in
-        // full by the content-store test. What is unique here is the prefix:
-        // another family's well-formed id is not a content id.
         assert!(ContentId::parse("upl_0123456789abcdef0123456789abcdef").is_err());
     }
 

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -430,8 +430,6 @@ mod tests {
     fn policy_exports_capability_limits() {
         let limits = PaginationPolicy::default().capability_limits();
 
-        // The key strings are what SDKs read, so they are spelled out here
-        // rather than read back from the same constants that wrote them.
         assert_eq!(
             limits.get("pagination.default_limit"),
             Some(&u64::from(DEFAULT_PAGE_LIMIT))

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -430,12 +430,14 @@ mod tests {
     fn policy_exports_capability_limits() {
         let limits = PaginationPolicy::default().capability_limits();
 
+        // The key strings are what SDKs read, so they are spelled out here
+        // rather than read back from the same constants that wrote them.
         assert_eq!(
-            limits.get(LIMIT_PAGINATION_DEFAULT),
+            limits.get("pagination.default_limit"),
             Some(&u64::from(DEFAULT_PAGE_LIMIT))
         );
         assert_eq!(
-            limits.get(LIMIT_PAGINATION_MAX),
+            limits.get("pagination.max_limit"),
             Some(&u64::from(DEFAULT_MAX_PAGE_LIMIT))
         );
     }

--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -493,7 +493,7 @@ impl PathError {
 #[cfg(test)]
 mod tests {
     use super::{AbsolutePath, DisplayName, PathError};
-    use crate::{name_key_for_display_name, NameKey};
+    use crate::NameKey;
 
     #[test]
     fn unportable_names_are_rejected() {
@@ -756,16 +756,5 @@ mod tests {
             AbsolutePath::parse(format!("/docs/{}", "a".repeat(256))),
             Err(PathError::DisplayNameTooLong { .. })
         ));
-    }
-
-    #[test]
-    fn name_key_matches_folding_helper() {
-        let display_name = DisplayName::parse("Cafe\u{301}.TXT").expect("display name");
-        let key = NameKey::for_display_name(&display_name);
-
-        assert_eq!(
-            key.as_str(),
-            name_key_for_display_name(display_name.as_str())
-        );
     }
 }

--- a/crates/loonfs-api/src/public_inode_id.rs
+++ b/crates/loonfs-api/src/public_inode_id.rs
@@ -243,15 +243,4 @@ mod tests {
         );
         assert!(serde_json::from_str::<OptionalField>(r#"{"inode_id":42}"#).is_err());
     }
-
-    #[cfg(feature = "openapi")]
-    #[test]
-    fn openapi_schema_uses_shared_metadata() {
-        let schema = serde_json::to_value(schema()).expect("serialize public inode-id schema");
-
-        assert_eq!(schema["type"], "string");
-        assert_eq!(schema["pattern"], PATTERN);
-        assert_eq!(schema["example"], EXAMPLE);
-        assert_eq!(schema["description"], DESCRIPTION);
-    }
 }

--- a/crates/loonfs-api/src/secret.rs
+++ b/crates/loonfs-api/src/secret.rs
@@ -92,15 +92,6 @@ mod tests {
     }
 
     #[test]
-    fn masked_replaces_the_stored_value() {
-        let secret = SecretString::new("super-secret-value");
-
-        let masked = secret.masked();
-
-        assert_eq!(masked.expose(), "<redacted>");
-    }
-
-    #[test]
     fn serde_round_trips_the_raw_value() {
         let secret = SecretString::new("super-secret-value");
 

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -683,13 +683,8 @@ mod tests {
         builder.finish().expect("finish segment")
     }
 
-    /// Row count of the shared multi-block segment.
     const SHARED_SEGMENT_ROWS: usize = 5_000;
 
-    /// The multi-block segment the index and scan tests read.
-    ///
-    /// Building and encoding it is the most expensive work in this module and
-    /// no reader mutates it, so the three tests share one build.
     fn shared_segment() -> &'static BuiltSegmentBlocks {
         static SEGMENT: std::sync::OnceLock<BuiltSegmentBlocks> = std::sync::OnceLock::new();
         SEGMENT.get_or_init(|| build_segment(SHARED_SEGMENT_ROWS))

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -683,6 +683,18 @@ mod tests {
         builder.finish().expect("finish segment")
     }
 
+    /// Row count of the shared multi-block segment.
+    const SHARED_SEGMENT_ROWS: usize = 5_000;
+
+    /// The multi-block segment the index and scan tests read.
+    ///
+    /// Building and encoding it is the most expensive work in this module and
+    /// no reader mutates it, so the three tests share one build.
+    fn shared_segment() -> &'static BuiltSegmentBlocks {
+        static SEGMENT: std::sync::OnceLock<BuiltSegmentBlocks> = std::sync::OnceLock::new();
+        SEGMENT.get_or_init(|| build_segment(SHARED_SEGMENT_ROWS))
+    }
+
     fn section<'a>(bytes: &'a [u8], handle: &BlockHandle) -> &'a [u8] {
         &bytes[handle.offset as usize..handle.offset as usize + handle.stored_len as usize]
     }
@@ -709,8 +721,8 @@ mod tests {
 
     #[test]
     fn segment_round_trips_every_row_through_index_and_blocks() {
-        let rows = 5_000;
-        let built = build_segment(rows);
+        let rows = SHARED_SEGMENT_ROWS;
+        let built = shared_segment();
         let index =
             decode_index_block(section(&built.bytes, &built.index), &built.index).expect("index");
         assert!(index.len() > 1, "5k inode rows should span several blocks");
@@ -735,7 +747,7 @@ mod tests {
 
     #[test]
     fn index_narrows_point_lookups_to_one_block() {
-        let built = build_segment(5_000);
+        let built = shared_segment();
         let index =
             decode_index_block(section(&built.bytes, &built.index), &built.index).expect("index");
         let (key, _, row) = inode_row(3_217);
@@ -754,7 +766,7 @@ mod tests {
 
     #[test]
     fn key_range_scan_covers_exactly_the_matching_blocks() {
-        let built = build_segment(5_000);
+        let built = shared_segment();
         let index =
             decode_index_block(section(&built.bytes, &built.index), &built.index).expect("index");
         let lower = inode_row(1_000).0;
@@ -954,15 +966,6 @@ mod tests {
         }
         let rate = false_positives as f64 / probes as f64;
         assert!(rate < 0.02, "false positive rate {rate} exceeds 2%");
-    }
-
-    #[test]
-    fn durable_encoding_is_deterministic() {
-        let first = build_segment(300);
-        let second = build_segment(300);
-        assert_eq!(first.bytes, second.bytes);
-        assert_eq!(first.index, second.index);
-        assert_eq!(first.filter, second.filter);
     }
 
     #[test]

--- a/crates/loonfs-api/src/v0/downloads.rs
+++ b/crates/loonfs-api/src/v0/downloads.rs
@@ -117,7 +117,6 @@ mod tests {
         AbsolutePath::parse("/docs/report.txt").expect("absolute path")
     }
 
-    /// A fixed reference, so the grants below can be pinned exactly.
     fn content_ref() -> ContentRef {
         ContentRef::blob_v1(
             ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
@@ -173,8 +172,6 @@ mod tests {
             },
         };
 
-        // Exact equality, not a search for the object key by name: a leaking
-        // field renamed to anything else still has to show up here.
         assert_eq!(
             serde_json::to_value(&response).expect("serialize response"),
             serde_json::json!({
@@ -211,8 +208,6 @@ mod tests {
                 expires_at_ms: 1,
             },
         };
-        // Exact equality again, so the by-inode grant cannot grow a path
-        // field under any spelling.
         assert_eq!(
             serde_json::to_value(&response).expect("serialize response"),
             serde_json::json!({

--- a/crates/loonfs-api/src/v0/downloads.rs
+++ b/crates/loonfs-api/src/v0/downloads.rs
@@ -117,6 +117,26 @@ mod tests {
         AbsolutePath::parse("/docs/report.txt").expect("absolute path")
     }
 
+    /// A fixed reference, so the grants below can be pinned exactly.
+    fn content_ref() -> ContentRef {
+        ContentRef::blob_v1(
+            ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
+            b"hello",
+        )
+    }
+
+    fn content_ref_json() -> serde_json::Value {
+        serde_json::json!({
+            "kind": "blob_v1",
+            "content_id": "con_0123456789abcdef0123456789abcdef",
+            "size_bytes": 5,
+            "checksum": {
+                "algorithm": "sha256",
+                "value": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            }
+        })
+    }
+
     #[test]
     fn a_download_request_names_only_a_path_and_a_revision() {
         let request: BeginDownloadRequest =
@@ -144,7 +164,7 @@ mod tests {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
             path: absolute_path(),
             revision_no: RevisionNo(7),
-            content_ref: ContentRef::blob_v1(ContentId::generate(), b"hello"),
+            content_ref: content_ref(),
             access: ObjectTransferAccess::PresignedUrl {
                 method: "GET".to_owned(),
                 url: "https://bucket.example/object?X-Amz-Signature=abc".to_owned(),
@@ -153,9 +173,23 @@ mod tests {
             },
         };
 
-        let json = serde_json::to_string(&response).expect("serialize response");
-        assert!(json.contains(r#""kind":"presigned_url""#));
-        assert!(!json.contains("object_key"));
+        // Exact equality, not a search for the object key by name: a leaking
+        // field renamed to anything else still has to show up here.
+        assert_eq!(
+            serde_json::to_value(&response).expect("serialize response"),
+            serde_json::json!({
+                "namespace_id": "demo",
+                "path": "/docs/report.txt",
+                "revision_no": 7,
+                "content_ref": content_ref_json(),
+                "access": {
+                    "kind": "presigned_url",
+                    "method": "GET",
+                    "url": "https://bucket.example/object?X-Amz-Signature=abc",
+                    "expires_at_ms": 1
+                }
+            })
+        );
     }
 
     #[test]
@@ -169,7 +203,7 @@ mod tests {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
             inode_id: crate::InodeId(42),
             revision_no: RevisionNo(7),
-            content_ref: ContentRef::blob_v1(ContentId::generate(), b"hello"),
+            content_ref: content_ref(),
             access: ObjectTransferAccess::PresignedUrl {
                 method: "GET".to_owned(),
                 url: "https://bucket.example/object?X-Amz-Signature=abc".to_owned(),
@@ -177,8 +211,22 @@ mod tests {
                 expires_at_ms: 1,
             },
         };
-        let json = serde_json::to_value(response).expect("serialize response");
-        assert_eq!(json["inode_id"], "ino_42");
-        assert!(json.get("path").is_none());
+        // Exact equality again, so the by-inode grant cannot grow a path
+        // field under any spelling.
+        assert_eq!(
+            serde_json::to_value(&response).expect("serialize response"),
+            serde_json::json!({
+                "namespace_id": "demo",
+                "inode_id": "ino_42",
+                "revision_no": 7,
+                "content_ref": content_ref_json(),
+                "access": {
+                    "kind": "presigned_url",
+                    "method": "GET",
+                    "url": "https://bucket.example/object?X-Amz-Signature=abc",
+                    "expires_at_ms": 1
+                }
+            })
+        );
     }
 }

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -469,24 +469,6 @@ mod tests {
     }
 
     #[test]
-    fn serialized_entries_never_nest_attributes_inside_attributes() {
-        let mut projected = entry("/docs", Some(InodeId(1)), Some("docs"));
-        projected.attributes = Some(AttributesProjection {
-            attributes_revision_no: crate::AttributeRevisionNo(1),
-            attributes_updated_by: None,
-            attributes_updated_at_ms: None,
-            attributes: crate::Attributes::new(std::collections::BTreeMap::from([(
-                crate::AttributeKey::parse("owner").expect("attribute key"),
-                crate::AttributeValue::parse("finance").expect("attribute value"),
-            )]))
-            .expect("attributes"),
-        });
-
-        let projected_json = serde_json::to_value(projected).expect("serialize projected entry");
-        assert!(projected_json.pointer("/attributes/attributes").is_none());
-    }
-
-    #[test]
     fn a_trash_entry_nests_the_binding_the_deletion_removed() {
         let trash = TrashEntry {
             inode_id: InodeId(42),

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -321,40 +321,49 @@ mod tests {
     }
 
     #[test]
-    fn grep_index_status_flattens_active_lifecycle() {
-        let response = GrepIndex {
-            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            lifecycle: GrepIndexLifecycle::Active {
-                built_through_seq: ChangeSeq(12),
-                next_event_index: 0,
-            },
-            next_run_no: RunNo(3),
-            reorganize_pending: false,
-        };
-
+    fn grep_index_status_flattens_its_lifecycle() {
         assert_eq!(
-            serde_json::to_string(&response).expect("serialize active status"),
-            r#"{"namespace_id":"demo","status":"active","built_through_seq":12,"next_run_no":3,"reorganize_pending":false}"#
+            serde_json::to_value(GrepIndex {
+                namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+                lifecycle: GrepIndexLifecycle::Active {
+                    built_through_seq: ChangeSeq(12),
+                    next_event_index: 0,
+                },
+                next_run_no: RunNo(3),
+                reorganize_pending: false,
+            })
+            .expect("serialize active status"),
+            serde_json::json!({
+                "namespace_id": "demo",
+                "status": "active",
+                "built_through_seq": 12,
+                "next_run_no": 3,
+                "reorganize_pending": false
+            })
         );
-    }
-
-    #[test]
-    fn grep_index_status_flattens_backfilling_lifecycle() {
-        let response = GrepIndex {
-            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            lifecycle: GrepIndexLifecycle::Backfilling {
-                target_seq: ChangeSeq(12),
-                cursor_inode_id: Some(InodeId(4)),
-                checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000009")
-                    .expect("checkpoint id"),
-            },
-            next_run_no: RunNo(1),
-            reorganize_pending: false,
-        };
 
         assert_eq!(
-            serde_json::to_string(&response).expect("serialize backfilling status"),
-            r#"{"namespace_id":"demo","status":"backfilling","target_seq":12,"cursor_inode_id":"ino_4","checkpoint_id":"chk_00000000000000000000000000000009","next_run_no":1,"reorganize_pending":false}"#
+            serde_json::to_value(GrepIndex {
+                namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+                lifecycle: GrepIndexLifecycle::Backfilling {
+                    target_seq: ChangeSeq(12),
+                    cursor_inode_id: Some(InodeId(4)),
+                    checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000009")
+                        .expect("checkpoint id"),
+                },
+                next_run_no: RunNo(1),
+                reorganize_pending: false,
+            })
+            .expect("serialize backfilling status"),
+            serde_json::json!({
+                "namespace_id": "demo",
+                "status": "backfilling",
+                "target_seq": 12,
+                "cursor_inode_id": "ino_4",
+                "checkpoint_id": "chk_00000000000000000000000000000009",
+                "next_run_no": 1,
+                "reorganize_pending": false
+            })
         );
     }
 

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -485,8 +485,6 @@ mod tests {
         let missing_parts = r#"{"mode":"direct_multipart","content":{"size_bytes":5,"checksum":{"algorithm":"crc64nvme","value":"0123456789abcdef"}}}"#;
         let error = serde_json::from_str::<CompleteUploadRequest>(missing_parts)
             .expect_err("multipart parts are required");
-        // The field name is ours; the rest of the sentence is serde's, so it
-        // is not what this asserts.
         assert!(
             error.to_string().contains("parts"),
             "the rejection should name the missing field: {error}"

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -394,14 +394,6 @@ mod tests {
     use std::collections::BTreeMap;
 
     #[test]
-    fn direct_put_upload_mode_serializes_as_expected() {
-        assert_eq!(
-            serde_json::to_string(&UploadMode::DirectPut).expect("serialize mode"),
-            r#""direct_put""#
-        );
-    }
-
-    #[test]
     fn a_begin_request_without_a_mode_does_not_decode() {
         assert!(serde_json::from_str::<BeginUploadRequest>("{}").is_err());
         assert_eq!(
@@ -493,7 +485,12 @@ mod tests {
         let missing_parts = r#"{"mode":"direct_multipart","content":{"size_bytes":5,"checksum":{"algorithm":"crc64nvme","value":"0123456789abcdef"}}}"#;
         let error = serde_json::from_str::<CompleteUploadRequest>(missing_parts)
             .expect_err("multipart parts are required");
-        assert!(error.to_string().contains("missing field `parts`"));
+        // The field name is ours; the rest of the sentence is serde's, so it
+        // is not what this asserts.
+        assert!(
+            error.to_string().contains("parts"),
+            "the rejection should name the missing field: {error}"
+        );
 
         let multipart = CompleteUploadRequest::DirectMultipart {
             content: UploadContentClaim {
@@ -514,26 +511,6 @@ mod tests {
                 "parts": [],
             })
         );
-    }
-
-    #[test]
-    fn direct_put_response_exposes_the_algorithm_and_presigned_access() {
-        let response = BeginUploadResponse::DirectPut {
-            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            upload_id: UploadId::parse("upl_00000000000000000000000000000001")
-                .expect("valid upload id"),
-            checksum_algorithm: ChecksumAlgorithm::Crc64nvme,
-            access: ObjectTransferAccess::PresignedUrl {
-                method: "PUT".to_owned(),
-                url: "https://bucket.example/object?X-Amz-Signature=abc".to_owned(),
-                headers: BTreeMap::from([("if-none-match".to_owned(), "*".to_owned())]),
-                expires_at_ms: 1,
-            },
-        };
-
-        let json = serde_json::to_string(&response).expect("serialize response");
-        assert!(json.contains(r#""kind":"presigned_url""#));
-        assert!(!json.contains("object_key"));
     }
 
     #[test]
@@ -638,15 +615,6 @@ mod tests {
             .is_err(),
             "a client must not be able to name the content object"
         );
-    }
-
-    #[test]
-    fn an_upload_content_claim_carries_the_operations_required_algorithm() {
-        let claim: UploadContentClaim = serde_json::from_str(
-            r#"{"size_bytes":5,"checksum":{"algorithm":"crc32c","value":"a1b2c3d4"}}"#,
-        )
-        .expect("decode a non-sha256 direct-put claim");
-        assert_eq!(claim.checksum.algorithm, ChecksumAlgorithm::Crc32c);
     }
 
     #[test]

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -2270,24 +2270,6 @@ fn decode_edited_row(row: &ciborium::Value, why: &str) -> MetadataRow {
 }
 
 #[test]
-fn commit_receipt_rows_without_committed_by_are_corrupt() {
-    let mut row = row_cbor(&MetadataRow::CommitReceipt {
-        commit_id: commit_id(),
-        committed_by: actor(),
-        semantic_commit_fingerprint: "v1:sha256:receipt".to_owned(),
-        committed_seq: ChangeSeq(9),
-        committed_at_ms: 9_000,
-        message: None,
-    });
-    cbor_map_of(&mut row).retain(|(key, _)| key.as_text() != Some("committed_by"));
-    let refusal = assert_row_is_corrupt(&row, "a receipt without attribution is corrupt");
-    assert!(
-        refusal.contains("missing field `committed_by`"),
-        "unexpected refusal: {refusal}"
-    );
-}
-
-#[test]
 fn tombstone_rows_reject_a_partial_deleted_direntry() {
     for missing in ["parent_inode_id", "name_key", "display_name"] {
         let mut row = row_cbor(&sample_tombstone_set_row());
@@ -2427,6 +2409,17 @@ fn provenance_rows_reject_every_missing_required_field() {
         (
             sample_populated_attributes_row(),
             &["commit_id", "updated_by", "updated_at_ms"][..],
+        ),
+        (
+            MetadataRow::CommitReceipt {
+                commit_id: commit_id(),
+                committed_by: actor(),
+                semantic_commit_fingerprint: "v1:sha256:receipt".to_owned(),
+                committed_seq: ChangeSeq(9),
+                committed_at_ms: 9_000,
+                message: None,
+            },
+            &["committed_by"][..],
         ),
     ];
 


### PR DESCRIPTION
Removes API tests that duplicate golden fixtures, generated behavior, or stronger nearby coverage. It also shares the expensive segment fixture used by three block tests.

The remaining tests more directly check checksum names, required fields, download response shapes, and grep status JSON. Production code and golden fixtures are unchanged.