### PR TITLE
test(objectstore): simplify object store test coverage

### DIFF
--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -173,8 +173,6 @@ mod tests {
 
     #[test]
     fn http_endpoint_is_allowed_for_emulator() {
-        // Azurite is addressed over plain HTTP, and the scheme check reads the
-        // spelling the operator wrote, so both cases have to build a store.
         for endpoint_url in [
             "http://127.0.0.1:10000/devstoreaccount1",
             "HTTP://127.0.0.1:10000/devstoreaccount1",

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -173,26 +173,24 @@ mod tests {
 
     #[test]
     fn http_endpoint_is_allowed_for_emulator() {
-        AzureAbsStore::new(AzureAbsStoreConfig {
-            account_name: "devstoreaccount1".to_owned(),
-            container_name: "container".to_owned(),
-            access_key: AZURITE_ACCOUNT_KEY.into(),
-            endpoint_url: Some("http://127.0.0.1:10000/devstoreaccount1".to_owned()),
-            key_prefix: None,
-        })
-        .expect("construct azure store with HTTP endpoint");
-    }
-
-    #[test]
-    fn http_endpoint_scheme_is_case_insensitive_for_emulator() {
-        AzureAbsStore::new(AzureAbsStoreConfig {
-            account_name: "devstoreaccount1".to_owned(),
-            container_name: "container".to_owned(),
-            access_key: AZURITE_ACCOUNT_KEY.into(),
-            endpoint_url: Some("HTTP://127.0.0.1:10000/devstoreaccount1".to_owned()),
-            key_prefix: None,
-        })
-        .expect("construct azure store with uppercase HTTP endpoint");
+        // Azurite is addressed over plain HTTP, and the scheme check reads the
+        // spelling the operator wrote, so both cases have to build a store.
+        for endpoint_url in [
+            "http://127.0.0.1:10000/devstoreaccount1",
+            "HTTP://127.0.0.1:10000/devstoreaccount1",
+        ] {
+            let store = AzureAbsStore::new(AzureAbsStoreConfig {
+                account_name: "devstoreaccount1".to_owned(),
+                container_name: "container".to_owned(),
+                access_key: AZURITE_ACCOUNT_KEY.into(),
+                endpoint_url: Some(endpoint_url.to_owned()),
+                key_prefix: None,
+            });
+            assert!(
+                store.is_ok(),
+                "an emulator endpoint spelled {endpoint_url} should build a store"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/loonfs-objectstore/src/aws_credentials.rs
+++ b/crates/loonfs-objectstore/src/aws_credentials.rs
@@ -221,90 +221,14 @@ impl CredentialProvider for ObjectStoreAwsCredentialProvider {
 #[cfg(test)]
 mod tests {
     use super::aws_credentials_source;
+    use crate::test_support::{aws_environment_lock, isolated_aws_environment};
     use crate::{AwsS3Credentials, ObjectStoreError};
     use loonfs_api::SecretString;
-    use std::ffi::OsString;
     use std::fs;
-
-    static ENVIRONMENT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-    struct EnvGuard {
-        name: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let previous = std::env::var_os(name);
-            std::env::set_var(name, value);
-            Self { name, previous }
-        }
-
-        fn unset(name: &'static str) -> Self {
-            let previous = std::env::var_os(name);
-            std::env::remove_var(name);
-            Self { name, previous }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => std::env::set_var(self.name, value),
-                None => std::env::remove_var(self.name),
-            }
-        }
-    }
-
-    fn isolated_aws_environment(
-        tempdir: &tempfile::TempDir,
-        environment_credentials: Option<(&str, &str, Option<&str>)>,
-    ) -> Vec<EnvGuard> {
-        let credentials_file = tempdir.path().join("credentials");
-        let config_file = tempdir.path().join("config");
-        fs::write(&credentials_file, "").expect("write empty credentials file");
-        fs::write(&config_file, "").expect("write empty config file");
-
-        let mut environment = match environment_credentials {
-            Some((access_key_id, secret_access_key, session_token)) => vec![
-                EnvGuard::set("AWS_ACCESS_KEY_ID", access_key_id),
-                EnvGuard::set("AWS_SECRET_ACCESS_KEY", secret_access_key),
-                match session_token {
-                    Some(session_token) => EnvGuard::set("AWS_SESSION_TOKEN", session_token),
-                    None => EnvGuard::unset("AWS_SESSION_TOKEN"),
-                },
-            ],
-            None => vec![
-                EnvGuard::unset("AWS_ACCESS_KEY_ID"),
-                EnvGuard::unset("AWS_SECRET_ACCESS_KEY"),
-                EnvGuard::unset("AWS_SESSION_TOKEN"),
-            ],
-        };
-        environment.extend([
-            EnvGuard::set("AWS_SHARED_CREDENTIALS_FILE", credentials_file),
-            EnvGuard::set("AWS_CONFIG_FILE", config_file),
-            EnvGuard::set("AWS_PROFILE", "loonfs-test"),
-            EnvGuard::set("AWS_REGION", "us-east-1"),
-            EnvGuard::set("AWS_EC2_METADATA_DISABLED", "true"),
-            EnvGuard::unset("AWS_WEB_IDENTITY_TOKEN_FILE"),
-            EnvGuard::unset("AWS_ROLE_ARN"),
-            EnvGuard::unset("AWS_ROLE_SESSION_NAME"),
-            EnvGuard::unset("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),
-            EnvGuard::unset("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
-            EnvGuard::unset("AWS_CONTAINER_AUTHORIZATION_TOKEN"),
-            EnvGuard::unset("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
-        ]);
-        if std::env::var_os("SSL_CERT_FILE").is_none()
-            && std::path::Path::new("/etc/ssl/cert.pem").is_file()
-        {
-            environment.push(EnvGuard::set("SSL_CERT_FILE", "/etc/ssl/cert.pem"));
-        }
-        environment
-    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn environment_pair_resolves_through_the_ambient_source() {
-        let _lock = ENVIRONMENT.lock().await;
+        let _lock = aws_environment_lock().await;
         let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
         let _environment = isolated_aws_environment(
             &tempdir,
@@ -332,7 +256,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn shared_credentials_file_and_profile_resolve_through_the_ambient_source() {
-        let _lock = ENVIRONMENT.lock().await;
+        let _lock = aws_environment_lock().await;
         let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
         let environment = isolated_aws_environment(&tempdir, None);
         fs::write(
@@ -384,7 +308,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn an_empty_chain_reports_only_the_configuration_field() {
-        let _lock = ENVIRONMENT.lock().await;
+        let _lock = aws_environment_lock().await;
         let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
         let _environment = isolated_aws_environment(&tempdir, None);
         let source = aws_credentials_source(&AwsS3Credentials::Ambient {}, "us-east-1")

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -271,8 +271,6 @@ mod tests {
     use std::sync::Arc;
     use std::time::{Duration, UNIX_EPOCH};
 
-    /// Credential-shaped fixture values. AWS publishes this pair in its own
-    /// documentation, so it looks exactly like a real key without being one.
     const FIXTURE_ACCESS_KEY_ID: &str = "AKIAIOSFODNN7EXAMPLE";
     const FIXTURE_SECRET_ACCESS_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
 
@@ -557,9 +555,6 @@ mod tests {
 
     #[test]
     fn configured_object_store_debug_redacts_presigner_credentials() {
-        // The fixture carries credential-shaped values and the assertions
-        // search for those same constants, so a Debug that started printing
-        // either one fails here instead of passing on a spelling mismatch.
         let store = ConfiguredObjectStore::cloudflare_r2(CloudflareR2StoreConfig {
             bucket: "bucket".to_owned(),
             account_id: "account".to_owned(),

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -271,6 +271,11 @@ mod tests {
     use std::sync::Arc;
     use std::time::{Duration, UNIX_EPOCH};
 
+    /// Credential-shaped fixture values. AWS publishes this pair in its own
+    /// documentation, so it looks exactly like a real key without being one.
+    const FIXTURE_ACCESS_KEY_ID: &str = "AKIAIOSFODNN7EXAMPLE";
+    const FIXTURE_SECRET_ACCESS_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
     #[tokio::test]
     async fn configured_local_fs_scopes_optional_key_prefix() {
         let temp_dir = unique_temp_dir("configured-store-local");
@@ -298,15 +303,6 @@ mod tests {
                 .expect("list scoped prefix"),
             vec![head_key]
         );
-    }
-
-    #[test]
-    fn gcs_advertises_the_direct_transfers_its_live_run_proved() {
-        let transfers = gcs_store()
-            .direct_transfers()
-            .expect("a proven provider hands out its bundle");
-        assert!(transfers.put.is_some());
-        assert!(transfers.multipart.is_none());
     }
 
     #[test]
@@ -561,20 +557,23 @@ mod tests {
 
     #[test]
     fn configured_object_store_debug_redacts_presigner_credentials() {
+        // The fixture carries credential-shaped values and the assertions
+        // search for those same constants, so a Debug that started printing
+        // either one fails here instead of passing on a spelling mismatch.
         let store = ConfiguredObjectStore::cloudflare_r2(CloudflareR2StoreConfig {
             bucket: "bucket".to_owned(),
             account_id: "account".to_owned(),
             endpoint_url: "https://account.r2.cloudflarestorage.com".to_owned(),
-            access_key_id: "access".into(),
-            secret_access_key: "debug-secret".into(),
+            access_key_id: FIXTURE_ACCESS_KEY_ID.into(),
+            secret_access_key: FIXTURE_SECRET_ACCESS_KEY.into(),
             key_prefix: Some("tenant-a".to_owned()),
         })
         .expect("construct r2 store");
 
         let rendered = format!("{store:?}");
 
-        assert!(!rendered.contains("debug-secret"));
-        assert!(!rendered.contains("debug-access-key"));
+        assert!(!rendered.contains(FIXTURE_ACCESS_KEY_ID));
+        assert!(!rendered.contains(FIXTURE_SECRET_ACCESS_KEY));
     }
 
     #[tokio::test]

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -358,11 +358,6 @@ mod tests {
         );
     }
 
-    /// The literal key strings themselves are pinned once, by
-    /// `layout_golden_tree_matches_target_paths` in `layout.rs`. What is left
-    /// here is what that test does not cover: the listing prefixes these
-    /// builders answer with, and the parse helper that reads a segment
-    /// identity back out of a key.
     #[test]
     fn listing_prefixes_match_their_keys_and_wal_segment_ids_parse_back() {
         assert_eq!(

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -192,10 +192,9 @@ mod tests {
     use super::{
         checkpoint_record, content_blob, metadata_compaction_lease, metadata_compaction_prefix,
         metadata_compaction_segment, metadata_manifest_object, metadata_root, metadata_segment,
-        metadata_segment_object_key, namespace_prefix, upload_session, wal_floor, wal_head,
-        wal_segment, wal_segment_id_from_key, wal_segment_prefix,
+        metadata_segment_object_key, upload_session, wal_floor, wal_head, wal_segment,
+        wal_segment_id_from_key, wal_segment_prefix,
     };
-    use crate::layout::ObjectLayout;
     use loonfs_api::wire::manifest::{MetadataRowFamily, MetadataSegmentRef};
     use loonfs_api::wire::sst_blocks::BlockHandle;
     use loonfs_api::{
@@ -238,16 +237,6 @@ mod tests {
 
     fn wal_segment_id(value: &str) -> WalSegmentId {
         WalSegmentId::parse(value).expect("valid WAL segment id")
-    }
-
-    #[test]
-    fn namespace_prefix_matches_layout_root_prefix() {
-        let namespace_id = NamespaceId::parse("ns-1").expect("valid namespace id");
-
-        assert_eq!(
-            namespace_prefix(&namespace_id),
-            ObjectLayout::new().namespace_root_prefix(&namespace_id)
-        );
     }
 
     #[test]
@@ -369,17 +358,13 @@ mod tests {
         );
     }
 
+    /// The literal key strings themselves are pinned once, by
+    /// `layout_golden_tree_matches_target_paths` in `layout.rs`. What is left
+    /// here is what that test does not cover: the listing prefixes these
+    /// builders answer with, and the parse helper that reads a segment
+    /// identity back out of a key.
     #[test]
-    fn key_builders_match_spec_examples() {
-        assert_eq!(wal_head(&namespace_id()), "namespaces/ns-1/wal/head.json");
-        assert_eq!(wal_floor(&namespace_id()), "namespaces/ns-1/wal/floor.json");
-        assert_eq!(
-            wal_segment(
-                &namespace_id(),
-                &wal_segment_id("wal_00000000000000000001-0123456789abcdef")
-            ),
-            "namespaces/ns-1/wal/segments/wal_00000000000000000001-0123456789abcdef.wal.zst"
-        );
+    fn listing_prefixes_match_their_keys_and_wal_segment_ids_parse_back() {
         assert_eq!(
             wal_segment_prefix(&namespace_id()),
             "namespaces/ns-1/wal/segments/"
@@ -403,47 +388,8 @@ mod tests {
             None
         );
         assert_eq!(
-            metadata_root(&namespace_id()),
-            "namespaces/ns-1/metadata/root.json"
-        );
-        let manifest_object_id =
-            ManifestObjectId::parse("man_00000000000000000400-0123456789abcdef")
-                .expect("valid manifest object id");
-        assert_eq!(
-            metadata_manifest_object(&namespace_id(), &manifest_object_id),
-            "namespaces/ns-1/metadata/manifests/man_00000000000000000400-0123456789abcdef.manifest.json"
-        );
-        assert_eq!(
-            metadata_segment(&namespace_id(), &metadata_segment_id()),
-            "namespaces/ns-1/metadata/segments/seg_00000000000000000000000000000001.sst.zst"
-        );
-        assert_eq!(
             metadata_compaction_prefix(&namespace_id()),
             "namespaces/ns-1/metadata/compactions/"
-        );
-        assert_eq!(
-            metadata_compaction_segment(
-                &namespace_id(),
-                &metadata_compaction_id(),
-                &metadata_segment_id(),
-            ),
-            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/segments/seg_00000000000000000000000000000001.sst.zst"
-        );
-        assert_eq!(
-            metadata_compaction_lease(&namespace_id(), &metadata_compaction_id()),
-            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/lease.json"
-        );
-        assert_eq!(
-            checkpoint_record(&namespace_id(), &checkpoint_id()),
-            "namespaces/ns-1/checkpoints/chk_00000000000000000000000000000001.json"
-        );
-        assert_eq!(
-            content_blob(&content_store_id(), &content_id()),
-            "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
-        );
-        assert_eq!(
-            upload_session(&namespace_id(), &upload_id()),
-            "namespaces/ns-1/uploads/upl_00000000000000000000000000000001.json"
         );
     }
 
@@ -491,13 +437,5 @@ mod tests {
                 &metadata_segment_id()
             )
         );
-    }
-
-    #[test]
-    fn content_keys_shard_on_the_content_id_prefix() {
-        let id = content_id();
-        let key = content_blob(&content_store_id(), &id);
-        let [first_shard, second_shard] = id.shard_prefixes();
-        assert!(key.ends_with(&format!("/{first_shard}/{second_shard}/{}", id.as_str())));
     }
 }

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_key_prefix_trims_redundant_separators_by_segment_join() {
+    fn a_plain_key_prefix_survives_normalization_and_a_blank_one_becomes_none() {
         assert!(matches!(
             normalize_key_prefix(Some("tenant-a/reports")),
             Ok(Some(prefix)) if prefix == "tenant-a/reports"

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -813,23 +813,6 @@ mod tests {
     use std::sync::Arc;
     use tokio::sync::Barrier;
 
-    #[test]
-    fn construction_requires_atomic_rename_replace_support() {
-        let temp_dir = test_dir("construction-gate");
-        let result = LocalFsStore::new(temp_dir.path());
-
-        #[cfg(unix)]
-        assert!(result.is_ok());
-
-        #[cfg(not(unix))]
-        assert!(matches!(
-            result,
-            Err(ObjectStoreError::Configuration(message))
-                if message.contains("requires atomic rename-replace")
-                    && message.contains("Unix-family")
-        ));
-    }
-
     #[cfg(unix)]
     #[tokio::test]
     async fn listing_tolerates_entries_that_vanish_mid_walk() {
@@ -899,43 +882,6 @@ mod tests {
             .await
             .expect_err("reading a directory is not a missing object");
         assert!(matches!(error, ObjectStoreError::Transport { .. }));
-    }
-
-    #[tokio::test]
-    async fn overwrite_refreshes_head_and_visible_bytes() {
-        let temp_dir = test_dir("overwrite");
-        let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
-        let key = wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
-
-        let first = store
-            .put(
-                &key,
-                Bytes::from_static(br#"{"seq":1}"#),
-                PutMode::Overwrite,
-            )
-            .await
-            .expect("seed first object");
-        let second = store
-            .put(
-                &key,
-                Bytes::from_static(br#"{"seq":2}"#),
-                PutMode::Overwrite,
-            )
-            .await
-            .expect("overwrite object");
-
-        assert_eq!(
-            store.get(&key, None).await.expect("get object"),
-            Some(Bytes::from_static(br#"{"seq":2}"#))
-        );
-        let head = store
-            .head(&key)
-            .await
-            .expect("head object")
-            .expect("head exists");
-        assert_eq!(head.etag, second.etag);
-        assert_eq!(head.size_bytes, second.size_bytes);
-        assert_ne!(first, second);
     }
 
     #[tokio::test]

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -557,6 +557,13 @@ mod tests {
     const CONTENT_KEY: &str =
         "content-stores/cs/objects/01/23/con_0123456789abcdef0123456789abcdef";
 
+    /// Credential-shaped fixture values. AWS publishes this key pair in its
+    /// own documentation, so it looks exactly like a real one without being
+    /// one.
+    const FIXTURE_ACCESS_KEY_ID: &str = "AKIAIOSFODNN7EXAMPLE";
+    const FIXTURE_SECRET_ACCESS_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    const FIXTURE_SESSION_TOKEN: &str = "FwoGZXIvYXdzEBYaDEZJWFRVUkVUT0tFTg==";
+
     #[derive(Debug, Default)]
     struct RotatingCredentialsSource {
         next: AtomicUsize,
@@ -863,6 +870,9 @@ mod tests {
 
     #[test]
     fn presigner_debug_redacts_credentials() {
+        // The fixture carries credential-shaped values and the assertions
+        // search for those same constants, so a Debug that started printing
+        // one fails here instead of passing on a spelling mismatch.
         let config = S3PresignerConfig {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
@@ -872,23 +882,19 @@ mod tests {
             direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
         };
         let credentials = AwsS3Credentials::Static {
-            access_key_id: "debug-access-key".into(),
-            secret_access_key: "debug-secret".into(),
-            session_token: Some("debug-session-token".into()),
+            access_key_id: FIXTURE_ACCESS_KEY_ID.into(),
+            secret_access_key: FIXTURE_SECRET_ACCESS_KEY.into(),
+            session_token: Some(FIXTURE_SESSION_TOKEN.into()),
         };
 
-        let config_debug = format!("{config:?}");
         let credentials_debug = format!("{credentials:?}");
         let signer = S3CompatiblePresigner::new(config, credentials).expect("signer");
         let signer_debug = format!("{signer:?}");
 
-        assert!(!config_debug.contains("debug-secret"));
-        assert!(!config_debug.contains("debug-access-key"));
-        assert!(!config_debug.contains("debug-session-token"));
         for rendered in [credentials_debug, signer_debug] {
-            assert!(!rendered.contains("debug-secret"));
-            assert!(!rendered.contains("debug-access-key"));
-            assert!(!rendered.contains("debug-session-token"));
+            assert!(!rendered.contains(FIXTURE_ACCESS_KEY_ID));
+            assert!(!rendered.contains(FIXTURE_SECRET_ACCESS_KEY));
+            assert!(!rendered.contains(FIXTURE_SESSION_TOKEN));
             assert!(rendered.contains("<redacted>"));
         }
     }

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -557,9 +557,6 @@ mod tests {
     const CONTENT_KEY: &str =
         "content-stores/cs/objects/01/23/con_0123456789abcdef0123456789abcdef";
 
-    /// Credential-shaped fixture values. AWS publishes this key pair in its
-    /// own documentation, so it looks exactly like a real one without being
-    /// one.
     const FIXTURE_ACCESS_KEY_ID: &str = "AKIAIOSFODNN7EXAMPLE";
     const FIXTURE_SECRET_ACCESS_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
     const FIXTURE_SESSION_TOKEN: &str = "FwoGZXIvYXdzEBYaDEZJWFRVUkVUT0tFTg==";
@@ -870,9 +867,6 @@ mod tests {
 
     #[test]
     fn presigner_debug_redacts_credentials() {
-        // The fixture carries credential-shaped values and the assertions
-        // search for those same constants, so a Debug that started printing
-        // one fails here instead of passing on a spelling mismatch.
         let config = S3PresignerConfig {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -1397,55 +1397,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provider_store_range_semantics_match_blocking_contract() {
-        let store = memory_store();
-        let key = "content-stores/cs_0123456789abcdef0123456789abcdef/objects/ab/cd/con_abcdef0123456789abcdef0123456789";
-        store
-            .put_overwrite(key, Bytes::from_static(b"abcdef"))
-            .await
-            .expect("put");
-
-        assert_eq!(
-            store
-                .get(
-                    key,
-                    Some(ByteRange {
-                        start_inclusive: 2,
-                        end_exclusive: 4,
-                    }),
-                )
-                .await
-                .expect("range"),
-            Some(Bytes::from_static(b"cd"))
-        );
-        assert_eq!(
-            store
-                .get(
-                    key,
-                    Some(ByteRange {
-                        start_inclusive: 6,
-                        end_exclusive: 10,
-                    }),
-                )
-                .await
-                .expect("empty"),
-            Some(Bytes::new())
-        );
-        assert!(matches!(
-            store
-                .get(
-                    key,
-                    Some(ByteRange {
-                        start_inclusive: 7,
-                        end_exclusive: 8,
-                    }),
-                )
-                .await,
-            Err(ObjectStoreError::InvalidRange { .. })
-        ));
-    }
-
-    #[tokio::test]
     async fn provider_stream_reports_invalid_prefix() {
         let store = memory_store();
         let mut stream = store.list_prefix_stream("../");

--- a/crates/loonfs-objectstore/src/retry.rs
+++ b/crates/loonfs-objectstore/src/retry.rs
@@ -116,36 +116,3 @@ pub(crate) async fn transport_retry_pause(backoff: Duration) {
     // pacing never feeds protocol state and replay stays deterministic.
     tokio::time::sleep(backoff).await;
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::attempts::counting_attempts;
-
-    #[tokio::test]
-    async fn every_granted_retry_counts_as_an_attempt() {
-        let policy = TransportRetryPolicy {
-            max_retries: 1,
-            initial_backoff: Duration::from_millis(1),
-            max_backoff: Duration::from_millis(1),
-            operation_deadline: Duration::from_secs(1),
-        };
-        let (_, attempts) = counting_attempts(async {
-            let mut retries = 0;
-            assert_eq!(
-                next_retry_backoff(
-                    &policy,
-                    "namespaces/demo/wal/segments/seg_test.wal.zst",
-                    "put_immutable_verified",
-                    7,
-                    &mut retries,
-                    None,
-                ),
-                Some(Duration::from_millis(1))
-            );
-        })
-        .await;
-
-        assert_eq!(attempts, 2);
-    }
-}

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -685,36 +685,19 @@ fn object_store_endpoint_url(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        multipart_error, object_store_endpoint_url, AwsS3StoreConfig, S3CompatibleConfig,
-        S3CompatibleStore, AWS_S3_MAX_DIRECT_PUT_BYTES,
-    };
-    use crate::aws_credentials::static_aws_credentials_source;
+    use super::{multipart_error, object_store_endpoint_url, AwsS3StoreConfig, S3CompatibleStore};
+    use crate::test_support::{aws_environment_lock, isolated_aws_environment};
     use crate::{AwsS3Credentials, ObjectStoreErrorClass};
 
-    fn test_config() -> S3CompatibleConfig {
-        S3CompatibleConfig {
-            provider_name: "test-s3",
-            bucket: "bucket".to_owned(),
-            region: "us-east-1".to_owned(),
-            endpoint_url: Some("http://127.0.0.1:9000".to_owned()),
-            credentials: static_aws_credentials_source("access".into(), "secret".into(), None),
-            key_prefix: Some("tenant-a".to_owned()),
-            force_path_style: true,
-            sha256_upload_checksum: true,
-            direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
-        }
-    }
+    /// The credential chain is emptied first. An eager resolution would then
+    /// have nothing to resolve and would fail, so this only passes when
+    /// construction really does defer the lookup to the first call.
+    #[tokio::test(flavor = "current_thread")]
+    async fn ambient_aws_store_construction_does_not_resolve_credentials() {
+        let _lock = aws_environment_lock().await;
+        let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
+        let _environment = isolated_aws_environment(&tempdir, None);
 
-    #[test]
-    fn s3_compatible_store_builds_without_hidden_runtime() {
-        let store = S3CompatibleStore::new(test_config()).expect("construct store");
-        let debug = format!("{store:?}");
-        assert!(debug.contains("test-s3"));
-    }
-
-    #[test]
-    fn ambient_aws_store_construction_does_not_resolve_credentials() {
         S3CompatibleStore::aws_s3(AwsS3StoreConfig {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -689,9 +689,6 @@ mod tests {
     use crate::test_support::{aws_environment_lock, isolated_aws_environment};
     use crate::{AwsS3Credentials, ObjectStoreErrorClass};
 
-    /// The credential chain is emptied first. An eager resolution would then
-    /// have nothing to resolve and would fail, so this only passes when
-    /// construction really does defer the lookup to the first call.
     #[tokio::test(flavor = "current_thread")]
     async fn ambient_aws_store_construction_does_not_resolve_credentials() {
         let _lock = aws_environment_lock().await;

--- a/crates/loonfs-objectstore/src/test_support.rs
+++ b/crates/loonfs-objectstore/src/test_support.rs
@@ -61,17 +61,15 @@ pub(crate) fn gcs_fixture_service_account_key_file(
     (dir, path)
 }
 
-/// Serializes every test that mutates process-wide AWS environment
-/// variables, which the whole process shares.
+/// Serializes tests that modify AWS environment variables.
 static AWS_ENVIRONMENT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-/// Takes the process-environment lock. Hold the returned guard for as long as
-/// the environment stays mutated.
+/// Locks AWS environment access for a test.
 pub(crate) async fn aws_environment_lock() -> tokio::sync::MutexGuard<'static, ()> {
     AWS_ENVIRONMENT.lock().await
 }
 
-/// Restores one environment variable to what it held before, on drop.
+/// Restores an environment variable when dropped.
 pub(crate) struct EnvGuard {
     name: &'static str,
     previous: Option<std::ffi::OsString>,
@@ -100,12 +98,7 @@ impl Drop for EnvGuard {
     }
 }
 
-/// Empties the AWS credential chain's environment and points its files at a
-/// temporary directory, so a machine with real AWS variables set cannot
-/// decide a test. `environment_credentials` seeds the environment provider.
-///
-/// Hold the returned guards for the length of the test, and take
-/// [`aws_environment_lock`] first.
+/// Replaces ambient AWS credential sources for a test.
 pub(crate) fn isolated_aws_environment(
     tempdir: &tempfile::TempDir,
     environment_credentials: Option<(&str, &str, Option<&str>)>,

--- a/crates/loonfs-objectstore/src/test_support.rs
+++ b/crates/loonfs-objectstore/src/test_support.rs
@@ -60,3 +60,94 @@ pub(crate) fn gcs_fixture_service_account_key_file(
         .expect("the fixture service account should be writable");
     (dir, path)
 }
+
+/// Serializes every test that mutates process-wide AWS environment
+/// variables, which the whole process shares.
+static AWS_ENVIRONMENT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Takes the process-environment lock. Hold the returned guard for as long as
+/// the environment stays mutated.
+pub(crate) async fn aws_environment_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    AWS_ENVIRONMENT.lock().await
+}
+
+/// Restores one environment variable to what it held before, on drop.
+pub(crate) struct EnvGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    pub(crate) fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::set_var(name, value);
+        Self { name, previous }
+    }
+
+    pub(crate) fn unset(name: &'static str) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::remove_var(name);
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(self.name, value),
+            None => std::env::remove_var(self.name),
+        }
+    }
+}
+
+/// Empties the AWS credential chain's environment and points its files at a
+/// temporary directory, so a machine with real AWS variables set cannot
+/// decide a test. `environment_credentials` seeds the environment provider.
+///
+/// Hold the returned guards for the length of the test, and take
+/// [`aws_environment_lock`] first.
+pub(crate) fn isolated_aws_environment(
+    tempdir: &tempfile::TempDir,
+    environment_credentials: Option<(&str, &str, Option<&str>)>,
+) -> Vec<EnvGuard> {
+    let credentials_file = tempdir.path().join("credentials");
+    let config_file = tempdir.path().join("config");
+    std::fs::write(&credentials_file, "").expect("write empty credentials file");
+    std::fs::write(&config_file, "").expect("write empty config file");
+
+    let mut environment = match environment_credentials {
+        Some((access_key_id, secret_access_key, session_token)) => vec![
+            EnvGuard::set("AWS_ACCESS_KEY_ID", access_key_id),
+            EnvGuard::set("AWS_SECRET_ACCESS_KEY", secret_access_key),
+            match session_token {
+                Some(session_token) => EnvGuard::set("AWS_SESSION_TOKEN", session_token),
+                None => EnvGuard::unset("AWS_SESSION_TOKEN"),
+            },
+        ],
+        None => vec![
+            EnvGuard::unset("AWS_ACCESS_KEY_ID"),
+            EnvGuard::unset("AWS_SECRET_ACCESS_KEY"),
+            EnvGuard::unset("AWS_SESSION_TOKEN"),
+        ],
+    };
+    environment.extend([
+        EnvGuard::set("AWS_SHARED_CREDENTIALS_FILE", credentials_file),
+        EnvGuard::set("AWS_CONFIG_FILE", config_file),
+        EnvGuard::set("AWS_PROFILE", "loonfs-test"),
+        EnvGuard::set("AWS_REGION", "us-east-1"),
+        EnvGuard::set("AWS_EC2_METADATA_DISABLED", "true"),
+        EnvGuard::unset("AWS_WEB_IDENTITY_TOKEN_FILE"),
+        EnvGuard::unset("AWS_ROLE_ARN"),
+        EnvGuard::unset("AWS_ROLE_SESSION_NAME"),
+        EnvGuard::unset("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),
+        EnvGuard::unset("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
+        EnvGuard::unset("AWS_CONTAINER_AUTHORIZATION_TOKEN"),
+        EnvGuard::unset("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
+    ]);
+    if std::env::var_os("SSL_CERT_FILE").is_none()
+        && std::path::Path::new("/etc/ssl/cert.pem").is_file()
+    {
+        environment.push(EnvGuard::set("SSL_CERT_FILE", "/etc/ssl/cert.pem"));
+    }
+    environment
+}

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -22,6 +22,17 @@ fn bytes(bytes: &'static [u8]) -> Bytes {
     Bytes::from_static(bytes)
 }
 
+/// A path segment that appears nowhere else, built into the key the leak
+/// checks read back. Searching for a string the fixture does not contain is
+/// how a redaction assertion quietly stops testing anything.
+const SECRET_KEY_SEGMENT: &str = "secret-segment";
+
+/// A key whose own name carries [`SECRET_KEY_SEGMENT`], so a sample that
+/// leaked any part of it fails the checks below.
+fn secret_key() -> String {
+    format!("namespaces/ns-1/wal/{SECRET_KEY_SEGMENT}.wal.zst")
+}
+
 #[tokio::test]
 async fn records_put_success() {
     let temp_dir = tempdir().expect("tempdir");
@@ -131,10 +142,10 @@ async fn records_not_found_without_key_leak() {
     let temp_dir = tempdir().expect("tempdir");
     let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
     let store = instrumented_object_store(temp_dir.path(), recorder.clone());
-    let raw_key = "namespaces/ns-1/wal/seg_secret.wal.zst";
+    let raw_key = secret_key();
 
     assert!(store
-        .get(raw_key, None)
+        .get(&raw_key, None)
         .await
         .expect("get missing")
         .is_none());
@@ -143,8 +154,8 @@ async fn records_not_found_without_key_leak() {
     assert_eq!(sample.operation, ObjectStoreOperation::Get);
     assert_eq!(sample.result, ObjectStoreResultClass::NotFound);
     let encoded = serde_json::to_string(&sample).expect("serialize sample");
-    assert!(!encoded.contains(raw_key));
-    assert!(!encoded.contains("secret-segment"));
+    assert!(!encoded.contains(&raw_key));
+    assert!(!encoded.contains(SECRET_KEY_SEGMENT));
 }
 
 #[tokio::test]
@@ -225,7 +236,7 @@ async fn instrumented_store_forwards_start_after_listing() {
 }
 
 #[tokio::test]
-async fn classifies_wal_and_manifest_key_families() {
+async fn classifies_wal_manifest_segment_and_checkpoint_key_families() {
     let temp_dir = tempdir().expect("tempdir");
     let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
     let store = instrumented_object_store(temp_dir.path(), recorder.clone());
@@ -263,41 +274,6 @@ async fn classifies_wal_and_manifest_key_families() {
         )
         .await
         .expect("put segment");
-
-    let samples = recorder.samples();
-    assert_eq!(samples[0].key_class, KeyClass::WalSegment);
-    assert_eq!(samples[1].key_class, KeyClass::NamespaceManifest);
-    assert_eq!(samples[2].key_class, KeyClass::MetadataSegment);
-}
-
-#[tokio::test]
-async fn classifies_gc_namespace_layout_family() {
-    let temp_dir = tempdir().expect("tempdir");
-    let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
-    let store = instrumented_object_store(temp_dir.path(), recorder.clone());
-
-    store
-        .put_overwrite(
-            &metadata_manifest_object(
-                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
-                &ManifestObjectId::parse("man_00000000000000000001-0123456789abcdef")
-                    .expect("valid manifest object id"),
-            ),
-            bytes(b"manifest"),
-        )
-        .await
-        .expect("put namespace manifest");
-    store
-        .put_overwrite(
-            &metadata_segment(
-                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
-                &loonfs_api::MetadataSegmentId::parse("seg_00000000000000000000000000000001")
-                    .expect("valid metadata segment id"),
-            ),
-            bytes(b"metadata"),
-        )
-        .await
-        .expect("put metadata segment");
     store
         .put_overwrite(
             &checkpoint_record(
@@ -311,9 +287,10 @@ async fn classifies_gc_namespace_layout_family() {
         .expect("put checkpoint record");
 
     let samples = recorder.samples();
-    assert_eq!(samples[0].key_class, KeyClass::NamespaceManifest);
-    assert_eq!(samples[1].key_class, KeyClass::MetadataSegment);
-    assert_eq!(samples[2].key_class, KeyClass::GcControl);
+    assert_eq!(samples[0].key_class, KeyClass::WalSegment);
+    assert_eq!(samples[1].key_class, KeyClass::NamespaceManifest);
+    assert_eq!(samples[2].key_class, KeyClass::MetadataSegment);
+    assert_eq!(samples[3].key_class, KeyClass::GcControl);
 }
 
 #[tokio::test]
@@ -323,7 +300,7 @@ async fn jsonl_recorder_writes_privacy_safe_samples() {
     let recorder =
         Arc::new(JsonlObjectStoreMetricsRecorder::create(&metrics_path).expect("recorder"));
     let store = instrumented_object_store(temp_dir.path(), recorder.clone());
-    let raw_key = "namespaces/ns-1/wal/seg_secret.wal.zst";
+    let raw_key = secret_key();
 
     store
         .put_overwrite(
@@ -333,7 +310,7 @@ async fn jsonl_recorder_writes_privacy_safe_samples() {
         .await
         .expect("put object");
     assert!(store
-        .get(raw_key, None)
+        .get(&raw_key, None)
         .await
         .expect("get missing")
         .is_none());
@@ -342,8 +319,8 @@ async fn jsonl_recorder_writes_privacy_safe_samples() {
     let jsonl = std::fs::read_to_string(metrics_path).expect("read metrics");
     let lines = jsonl.lines().collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
-    assert!(!jsonl.contains(raw_key));
-    assert!(!jsonl.contains("secret-segment"));
+    assert!(!jsonl.contains(&raw_key));
+    assert!(!jsonl.contains(SECRET_KEY_SEGMENT));
 
     let first: serde_json::Value = serde_json::from_str(lines[0]).expect("first sample");
     assert_eq!(first["operation"], "put");

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -22,13 +22,8 @@ fn bytes(bytes: &'static [u8]) -> Bytes {
     Bytes::from_static(bytes)
 }
 
-/// A path segment that appears nowhere else, built into the key the leak
-/// checks read back. Searching for a string the fixture does not contain is
-/// how a redaction assertion quietly stops testing anything.
 const SECRET_KEY_SEGMENT: &str = "secret-segment";
 
-/// A key whose own name carries [`SECRET_KEY_SEGMENT`], so a sample that
-/// leaked any part of it fails the checks below.
 fn secret_key() -> String {
     format!("namespaces/ns-1/wal/{SECRET_KEY_SEGMENT}.wal.zst")
 }

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -7,12 +7,10 @@ use crate::provider_env::{
 };
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
-use loonfs_api::{Checksum, ContentId, ManifestObjectId};
+use loonfs_api::{Checksum, ContentId};
 use loonfs_objectstore::abs::{AzureAbsStore, AzureAbsStoreConfig};
 use loonfs_objectstore::gcs::{GcpGcsStore, GcpGcsStoreConfig};
-use loonfs_objectstore::keys::{
-    content_blob, metadata_manifest_object, metadata_segment, wal_head, wal_segment,
-};
+use loonfs_objectstore::keys::content_blob;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, StoreProbeReport};
 use loonfs_objectstore::s3_compatible::{
@@ -21,61 +19,6 @@ use loonfs_objectstore::s3_compatible::{
 use loonfs_objectstore::ObjectStoreError;
 use loonfs_objectstore::{AwsS3Credentials, ObjectStore};
 use tempfile::TempDir;
-
-#[test]
-fn key_builders_cover_locked_object_families() {
-    assert_eq!(
-        wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id")),
-        "namespaces/ns-1/wal/head.json"
-    );
-    assert_eq!(
-        content_blob(
-            &loonfs_api::ContentStoreId::parse("cs_00000000000000000000000000000001").expect("valid content store id"),
-            &ContentId::parse("con_abcdef0123456789abcdef0123456789").expect("valid content id"),
-        ),
-        "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
-    );
-    assert_eq!(
-        wal_segment(
-            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
-            &loonfs_api::WalSegmentId::parse("wal_00000000000000000001-644e4d336fd4ee33")
-                .expect("valid WAL segment id")
-        ),
-        "namespaces/ns-1/wal/segments/wal_00000000000000000001-644e4d336fd4ee33.wal.zst"
-    );
-    assert_eq!(
-        metadata_manifest_object(
-            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
-            &ManifestObjectId::parse("man_00000000000000000420-0123456789abcdef")
-                .expect("valid manifest object id"),
-        ),
-        "namespaces/ns-1/metadata/manifests/man_00000000000000000420-0123456789abcdef.manifest.json"
-    );
-    assert_eq!(
-        metadata_segment(
-            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
-            &loonfs_api::MetadataSegmentId::parse("seg_00000000000000000000000000000001")
-                .expect("valid metadata segment id")
-        ),
-        "namespaces/ns-1/metadata/segments/seg_00000000000000000000000000000001.sst.zst"
-    );
-    assert_eq!(
-        metadata_segment(
-            &loonfs_api::NamespaceId::parse("source-ns").expect("valid namespace id"),
-            &loonfs_api::MetadataSegmentId::parse("seg_00000000000000000000000000000002")
-                .expect("valid metadata segment id")
-        ),
-        "namespaces/source-ns/metadata/segments/seg_00000000000000000000000000000002.sst.zst"
-    );
-    assert_eq!(
-        metadata_segment(
-            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
-            &loonfs_api::MetadataSegmentId::parse("seg_ffffffffffffffffffffffffffffffff")
-                .expect("valid metadata segment id")
-        ),
-        "namespaces/ns-1/metadata/segments/seg_ffffffffffffffffffffffffffffffff.sst.zst"
-    );
-}
 
 #[test]
 fn provider_env_example_covers_real_provider_contract() {


### PR DESCRIPTION
Removes duplicate and low-value object store tests, combines cases that exercise the same behavior, and strengthens credential-redaction and ambient-credential checks so they cannot pass vacuously.

The remaining tests continue to cover provider conformance, immutable writes, key layout, retry behavior, and live-provider integration. Production behavior is unchanged.