### PR TITLE
test(core): drop verified duplicates, fold repeated fixtures, and assert typed errors instead of sentences

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -822,7 +822,6 @@ mod tests {
             "a failed fetch should leave nothing behind for the next caller"
         );
 
-        // This loader fails if called, so success confirms a cache hit.
         let cached: Result<_, String> = cache
             .get_or_load(&key("a"), || async {
                 Err("a populated key must not re-fetch".to_owned())

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -808,7 +808,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_or_load_retries_after_a_failed_load() {
+    async fn get_or_load_retries_a_failed_load_and_then_stops_loading() {
         let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig::default());
         let failed: Result<_, String> = cache
             .get_or_load(&key("a"), || async { Err("transport".to_owned()) })
@@ -821,25 +821,14 @@ mod tests {
             recovered.is_ok(),
             "a failed fetch should leave nothing behind for the next caller"
         );
-    }
 
-    #[tokio::test]
-    async fn get_or_load_counts_one_miss_and_populates_for_later_hits() {
-        let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig::default());
-        let fetched: Result<_, String> = cache
-            .get_or_load(&key("a"), || async { Ok(block(1)) })
-            .await;
-        assert!(fetched.is_ok());
+        // The loader below fails if it runs at all, so a successful answer
+        // is proof the populated key served the access on its own.
         let cached: Result<_, String> = cache
             .get_or_load(&key("a"), || async {
                 Err("a populated key must not re-fetch".to_owned())
             })
             .await;
         assert!(cached.is_ok(), "the cached block should answer the access");
-
-        let stats = cache.stats();
-        assert_eq!(stats.misses, 1);
-        assert_eq!(stats.inserts, 1);
-        assert_eq!(stats.hits, 1);
     }
 }

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -822,8 +822,7 @@ mod tests {
             "a failed fetch should leave nothing behind for the next caller"
         );
 
-        // The loader below fails if it runs at all, so a successful answer
-        // is proof the populated key served the access on its own.
+        // This loader fails if called, so success confirms a cache hit.
         let cached: Result<_, String> = cache
             .get_or_load(&key("a"), || async {
                 Err("a populated key must not re-fetch".to_owned())

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -351,8 +351,6 @@ mod tests {
         ));
     }
 
-    /// A record has to describe the key it is stored under. Each case forges
-    /// one half of that identity and the loader has to refuse it.
     #[tokio::test]
     async fn listed_loader_validates_the_record_against_its_key() {
         enum Mismatch {

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -327,30 +327,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn listed_loader_validates_embedded_namespace_against_the_key() {
-        let (_directory, store) = local_store();
-        let key_namespace_id = namespace("demo");
-        let embedded_namespace_id = namespace("other");
-        let checkpoint_id = checkpoint("chk_00000000000000000000000000000001");
-        let object_key = checkpoint_record(&key_namespace_id, &checkpoint_id);
-        let bytes = encode_checkpoint_record(&record(embedded_namespace_id, checkpoint_id))
-            .expect("record bytes");
-        store
-            .put_overwrite(&object_key, bytes)
-            .await
-            .expect("write record");
-
-        let error = load_checkpoint_record_at_key(&store, &object_key)
-            .await
-            .expect_err("namespace mismatch should fail");
-
-        assert!(matches!(
-            error,
-            ControlObjectLoadError::NamespaceMismatch { .. }
-        ));
-    }
-
-    #[tokio::test]
     async fn loader_rejects_a_record_pinning_another_namespaces_manifest() {
         let (_directory, store) = local_store();
         let namespace_id = namespace("demo");
@@ -375,28 +351,60 @@ mod tests {
         ));
     }
 
+    /// A record has to describe the key it is stored under. Each case forges
+    /// one half of that identity and the loader has to refuse it.
     #[tokio::test]
-    async fn listed_loader_validates_embedded_checkpoint_id_against_the_key() {
+    async fn listed_loader_validates_the_record_against_its_key() {
+        enum Mismatch {
+            Namespace,
+            CheckpointId,
+        }
+
         let (_directory, store) = local_store();
-        let namespace_id = namespace("demo");
+        let key_namespace_id = namespace("demo");
         let key_checkpoint_id = checkpoint("chk_00000000000000000000000000000001");
-        let embedded_checkpoint_id = checkpoint("chk_00000000000000000000000000000002");
-        let object_key = checkpoint_record(&namespace_id, &key_checkpoint_id);
-        let bytes = encode_checkpoint_record(&record(namespace_id, embedded_checkpoint_id))
-            .expect("record bytes");
-        store
-            .put_overwrite(&object_key, bytes)
-            .await
-            .expect("write record");
+        let object_key = checkpoint_record(&key_namespace_id, &key_checkpoint_id);
 
-        let error = load_checkpoint_record_at_key(&store, &object_key)
-            .await
-            .expect_err("checkpoint mismatch should fail");
+        let cases = [
+            (
+                "embedded namespace",
+                record(namespace("other"), key_checkpoint_id.clone()),
+                Mismatch::Namespace,
+            ),
+            (
+                "embedded checkpoint id",
+                record(
+                    key_namespace_id.clone(),
+                    checkpoint("chk_00000000000000000000000000000002"),
+                ),
+                Mismatch::CheckpointId,
+            ),
+        ];
 
-        assert!(matches!(
-            error,
-            ControlObjectLoadError::IdentityMismatch { field, .. }
-                if field == "checkpoint id"
-        ));
+        for (label, forged, expected) in cases {
+            let bytes = encode_checkpoint_record(&forged).expect("record bytes");
+            store
+                .put_overwrite(&object_key, bytes)
+                .await
+                .expect("write record");
+
+            let error = load_checkpoint_record_at_key(&store, &object_key)
+                .await
+                .expect_err("a record that does not describe its key should fail");
+            match expected {
+                Mismatch::Namespace => assert!(
+                    matches!(error, ControlObjectLoadError::NamespaceMismatch { .. }),
+                    "for `{label}`: {error:?}"
+                ),
+                Mismatch::CheckpointId => assert!(
+                    matches!(
+                        error,
+                        ControlObjectLoadError::IdentityMismatch { ref field, .. }
+                            if field == "checkpoint id"
+                    ),
+                    "for `{label}`: {error:?}"
+                ),
+            }
+        }
     }
 }

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -2,9 +2,7 @@
 
 use super::*;
 
-/// Eight files checkpointed and reorganized at one row per segment, so any
-/// scan over them has to visit more segments than the small-scan limit
-/// admits. Returns the manifest the reorganization published.
+/// Builds eight one-row segments and returns the reorganized manifest.
 async fn eight_files_one_row_per_segment<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -83,9 +81,7 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
     );
     assert!(after_repeat.hits > after_first.hits);
 
-    // The list preload path is the other entry point onto the same cache: a
-    // page-shaped range scan over a directory whose bind rows span more
-    // segments than the small-scan limit.
+    // Scan the same cache through the range API.
     let docs_inode_id = InodeId(2);
     let lower_bound = format!("direntry-bind-{:020}-", docs_inode_id.0);
     let upper_bound = super::string_prefix_upper_bound(&lower_bound);
@@ -130,8 +126,7 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
         "a warm range scan should be served entirely from the cache"
     );
 
-    // A budget too small to hold anything still answers: admission and
-    // eviction both happen, and the lookup is served rather than refused.
+    // A one-byte budget must still serve lookups while evicting entries.
     let degenerate = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
         max_decoded_bytes: 1,
     });

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 
-/// Builds eight one-row segments and returns the reorganized manifest.
 async fn eight_files_one_row_per_segment<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -81,7 +80,6 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
     );
     assert!(after_repeat.hits > after_first.hits);
 
-    // Scan the same cache through the range API.
     let docs_inode_id = InodeId(2);
     let lower_bound = format!("direntry-bind-{:020}-", docs_inode_id.0);
     let upper_bound = super::string_prefix_upper_bound(&lower_bound);
@@ -126,7 +124,6 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
         "a warm range scan should be served entirely from the cache"
     );
 
-    // A one-byte budget must still serve lookups while evicting entries.
     let degenerate = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
         max_decoded_bytes: 1,
     });

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -2,19 +2,20 @@
 
 use super::*;
 
-#[tokio::test]
-async fn byte_budgeted_cache_admits_large_segment_scans() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store =
-        CountingStore::metadata_segments(LocalFsStore::new(temp_dir.path()).expect("store"));
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
+/// Eight files checkpointed and reorganized at one row per segment, so any
+/// scan over them has to visit more segments than the small-scan limit
+/// admits. Returns the manifest the reorganization published.
+async fn eight_files_one_row_per_segment<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> ManifestNo {
+    bootstrap_namespace(store, namespace_id, context, false)
         .await
         .expect("bootstrap");
     for index in 0..8 {
         let path = format!("/docs/file-{index}.txt");
-        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
+        write_file_bytes(store, namespace_id, &path, b"file\n", context, None)
             .await
             .expect("write file");
     }
@@ -22,7 +23,17 @@ async fn byte_budgeted_cache_admits_large_segment_scans() {
         max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
-    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
+    checkpoint_then_reorganize(store, namespace_id, context, policy).await
+}
+
+#[tokio::test]
+async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store =
+        CountingStore::metadata_segments(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    eight_files_one_row_per_segment(&store, &namespace_id, &context).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     // The default cache config carries a decoded-byte budget, so a scan wider
     // than the small-scan limit populates the cache instead of reading through.
@@ -71,6 +82,76 @@ async fn byte_budgeted_cache_admits_large_segment_scans() {
         "a warm wide scan should be served entirely from the cache"
     );
     assert!(after_repeat.hits > after_first.hits);
+
+    // The list preload path is the other entry point onto the same cache: a
+    // page-shaped range scan over a directory whose bind rows span more
+    // segments than the small-scan limit.
+    let docs_inode_id = InodeId(2);
+    let lower_bound = format!("direntry-bind-{:020}-", docs_inode_id.0);
+    let upper_bound = super::string_prefix_upper_bound(&lower_bound);
+    let before_range = cache.stats();
+    let page = segments
+        .scan_range_page(
+            ApiMetadataRowFamily::DirentryBinds,
+            &lower_bound,
+            upper_bound.as_deref(),
+            8,
+        )
+        .await
+        .expect("scan range page");
+    assert_eq!(page.len(), 8);
+    assert!(
+        cache.stats().inserts > before_range.inserts + 4,
+        "a wide range scan should admit its segments to the cache"
+    );
+
+    let fresh_segments = super::load_verified_manifest_segments_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load fresh segments");
+    store.reset();
+    let repeated_page = fresh_segments
+        .scan_range_page(
+            ApiMetadataRowFamily::DirentryBinds,
+            &lower_bound,
+            upper_bound.as_deref(),
+            8,
+        )
+        .await
+        .expect("repeated scan range page");
+    assert_eq!(repeated_page, page);
+    assert_eq!(
+        store.count(OperationClass::Read),
+        0,
+        "a warm range scan should be served entirely from the cache"
+    );
+
+    // A budget too small to hold anything still answers: admission and
+    // eviction both happen, and the lookup is served rather than refused.
+    let degenerate = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
+        max_decoded_bytes: 1,
+    });
+    let degenerate_segments = super::load_verified_manifest_segments_with_cache(
+        &store,
+        Some(&degenerate),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load segments against a degenerate budget");
+    let root_inode_key = "inode-00000000000000000001";
+    assert!(degenerate_segments
+        .get_for_lookup(ApiMetadataRowFamily::Inodes, root_inode_key, root_inode_key)
+        .await
+        .expect("get inode")
+        .is_some());
+    let degenerate_stats = degenerate.stats();
+    assert!(degenerate_stats.inserts > 0);
+    assert!(degenerate_stats.evictions > 0);
 }
 
 #[tokio::test]
@@ -80,20 +161,7 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
         CountingStore::metadata_segments(LocalFsStore::new(temp_dir.path()).expect("store"));
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    for index in 0..8 {
-        let path = format!("/docs/file-{index}.txt");
-        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
-            .await
-            .expect("write file");
-    }
-    let policy = MetadataLsmPolicy {
-        max_rows_per_segment: NonZeroUsize::MIN,
-        ..MetadataLsmPolicy::default()
-    };
-    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
+    eight_files_one_row_per_segment(&store, &namespace_id, &context).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     // Concurrent scans over one shared cache must not multiply fetches:
     // single-flight covers blocks racing before the first insert lands, and
@@ -277,105 +345,12 @@ async fn segment_range_page_merges_base_and_delta_in_row_key_order() {
 }
 
 #[tokio::test]
-async fn byte_budgeted_cache_admits_large_range_scans() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store =
-        CountingStore::metadata_segments(LocalFsStore::new(temp_dir.path()).expect("store"));
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    for index in 0..8 {
-        let path = format!("/docs/file-{index}.txt");
-        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
-            .await
-            .expect("write file");
-    }
-    let policy = MetadataLsmPolicy {
-        max_rows_per_segment: NonZeroUsize::MIN,
-        ..MetadataLsmPolicy::default()
-    };
-    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
-    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
-    let cache = super::MetadataSegmentCache::new(Default::default());
-    let segments = super::load_verified_manifest_segments_with_cache(
-        &store,
-        Some(&cache),
-        &namespace_id,
-        &manifest_object_id,
-    )
-    .await
-    .expect("load segments");
-
-    // The list preload path: one page-shaped range scan over a directory
-    // whose bind rows span more segments than the small-scan limit.
-    let docs_inode_id = InodeId(2);
-    let lower_bound = format!("direntry-bind-{:020}-", docs_inode_id.0);
-    let upper_bound = super::string_prefix_upper_bound(&lower_bound);
-    let page = segments
-        .scan_range_page(
-            ApiMetadataRowFamily::DirentryBinds,
-            &lower_bound,
-            upper_bound.as_deref(),
-            8,
-        )
-        .await
-        .expect("scan range page");
-    let after_first = cache.stats();
-    assert_eq!(page.len(), 8);
-    assert!(
-        after_first.inserts > 4,
-        "a wide range scan should admit its segments to the cache"
-    );
-
-    let fresh_segments = super::load_verified_manifest_segments_with_cache(
-        &store,
-        Some(&cache),
-        &namespace_id,
-        &manifest_object_id,
-    )
-    .await
-    .expect("load fresh segments");
-    store.reset();
-    let repeated = fresh_segments
-        .scan_range_page(
-            ApiMetadataRowFamily::DirentryBinds,
-            &lower_bound,
-            upper_bound.as_deref(),
-            8,
-        )
-        .await
-        .expect("repeated scan range page");
-
-    assert_eq!(repeated, page);
-    assert_eq!(
-        store.count(OperationClass::Read),
-        0,
-        "a warm range scan should be served entirely from the cache"
-    );
-}
-
-#[tokio::test]
 async fn maintenance_materialization_does_not_populate_metadata_segment_cache() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    for index in 0..8 {
-        let path = format!("/docs/file-{index}.txt");
-        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
-            .await
-            .expect("write file");
-    }
-    let policy = MetadataLsmPolicy {
-        max_rows_per_segment: NonZeroUsize::MIN,
-        ..MetadataLsmPolicy::default()
-    };
-    let manifest_no = checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
+    let manifest_no = eight_files_one_row_per_segment(&store, &namespace_id, &context).await;
     let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig::default());
     let before = cache.stats();
 
@@ -486,53 +461,6 @@ async fn lookup_skips_segments_whose_filter_rules_the_name_out() {
         stats.filter_skips >= 1,
         "the delta bind segment should be skipped by its filter, stats: {stats:?}"
     );
-}
-
-#[tokio::test]
-async fn metadata_cache_budget_counts_decoded_blocks() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/file.txt",
-        b"file\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write file");
-    create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("checkpoint");
-    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
-    let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
-        max_decoded_bytes: 1,
-    });
-    let segments = super::load_verified_manifest_segments_with_cache(
-        &store,
-        Some(&cache),
-        &namespace_id,
-        &manifest_object_id,
-    )
-    .await
-    .expect("load segments");
-
-    let key = "inode-00000000000000000001";
-    assert!(segments
-        .get_for_lookup(ApiMetadataRowFamily::Inodes, key, key)
-        .await
-        .expect("get inode")
-        .is_some());
-
-    let stats = cache.stats();
-    assert!(stats.inserts > 0);
-    assert!(stats.evictions > 0);
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -351,7 +351,6 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
     .await
     .expect("load manifest");
 
-    // Receipts below the floor are removed, but the floor's receipt remains.
     let receipts = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::CommitReceipts,
@@ -370,7 +369,6 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
         MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq == floor
     )));
 
-    // Revision history and its index remain complete.
     let revisions = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::Revisions,
@@ -391,7 +389,6 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
     );
     assert_eq!(index_rows.len(), revisions.len());
 
-    // The deleted file's bind and unbind rows are removed.
     let binds = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::DirentryBinds,
@@ -409,7 +406,6 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
         "spent unbind markers survived: {unbinds:?}"
     );
 
-    // Revisions below the floor can still be restored.
     let restored = restore_file_revision(
         &store,
         &namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -283,11 +283,6 @@ fn assert_revision_index_mismatch<T>(result: Result<T, ManifestLoadError>) {
     }
 }
 
-/// One seed, four properties of the same fold. The namespace is written so
-/// every commit that matters sits below the advanced floor: two plain files,
-/// two revisions of one file, and a file created and deleted again. Nine
-/// write-plus-checkpoint rounds then push the runs past the reorganization
-/// trigger, and one drain folds them.
 #[tokio::test]
 async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not() {
     let temp_dir = tempdir().expect("tempdir");
@@ -356,7 +351,7 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
     .await
     .expect("load manifest");
 
-    // Commit receipts below the floor go, and the floor's own receipt stays.
+    // Receipts below the floor are removed, but the floor's receipt remains.
     let receipts = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::CommitReceipts,
@@ -375,8 +370,7 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
         MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq == floor
     )));
 
-    // Revision rows are never dropped: file history is durable data, not
-    // replay state, and its index keeps one row per revision.
+    // Revision history and its index remain complete.
     let revisions = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::Revisions,
@@ -397,8 +391,7 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
     );
     assert_eq!(index_rows.len(), revisions.len());
 
-    // A binding unbound below the floor goes, and so does the spent unbind
-    // marker that covered it.
+    // The deleted file's bind and unbind rows are removed.
     let binds = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::DirentryBinds,
@@ -416,8 +409,7 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
         "spent unbind markers survived: {unbinds:?}"
     );
 
-    // And the user-visible consequence: a revision below the floor is still
-    // restorable after the fold.
+    // Revisions below the floor can still be restored.
     let restored = restore_file_revision(
         &store,
         &namespace_id,
@@ -1023,10 +1015,6 @@ async fn manifest_rejects_missing_revision_desc_index() {
     );
 }
 
-/// Every way one revision-index segment can disagree with the revision family
-/// it indexes is refused at manifest load. One materialization pays for all
-/// four: the index segment object is restored from its original bytes before
-/// each case, so every case starts from the same durable state.
 #[tokio::test]
 async fn manifest_rejects_a_revision_desc_index_that_disagrees_with_its_family() {
     enum Rejection {
@@ -1034,7 +1022,6 @@ async fn manifest_rejects_a_revision_desc_index_that_disagrees_with_its_family()
         DuplicateRow,
     }
 
-    /// One corruption of the revision index, and the rejection it must draw.
     type IndexCorruption = (&'static str, fn(&mut Vec<MetadataRow>), Rejection);
 
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -283,8 +283,13 @@ fn assert_revision_index_mismatch<T>(result: Result<T, ManifestLoadError>) {
     }
 }
 
+/// One seed, four properties of the same fold. The namespace is written so
+/// every commit that matters sits below the advanced floor: two plain files,
+/// two revisions of one file, and a file created and deleted again. Nine
+/// write-plus-checkpoint rounds then push the runs past the reorganization
+/// trigger, and one drain folds them.
 #[tokio::test]
-async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
+async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -292,35 +297,33 @@ async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
         .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/one.txt",
-        b"one\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write one");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/two.txt",
-        b"two\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write two");
+    for (path, body) in [
+        ("/docs/one.txt", &b"one\n"[..]),
+        ("/docs/two.txt", &b"two\n"[..]),
+        ("/docs/a.txt", &b"alpha one\n"[..]),
+        ("/docs/a.txt", &b"alpha two\n"[..]),
+        ("/docs/tmp.txt", &b"scratch\n"[..]),
+    ] {
+        write_file_bytes(&store, &namespace_id, path, body, &context, None)
+            .await
+            .expect("write");
+    }
+    delete_path(&store, &namespace_id, "/docs/tmp.txt", &context, None)
+        .await
+        .expect("delete tmp");
     create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("create checkpoint");
     let advanced = advance_retention_floor(&store, &namespace_id, &context)
         .await
         .expect("advance floor");
-    assert_eq!(advanced.retention_floor_seq, ChangeSeq(2));
+    let floor = advanced.retention_floor_seq;
+    assert_eq!(
+        floor,
+        ChangeSeq(6),
+        "every seeded commit sits at or below the floor"
+    );
 
-    let mut last_manifest_no = None;
     for round in 0..9u32 {
         write_file_bytes(
             &store,
@@ -332,14 +335,12 @@ async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
         )
         .await
         .expect("write");
-        let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+        create_checkpoint(&store, &namespace_id, &context)
             .await
             .expect("create checkpoint");
-        last_manifest_no = Some(checkpoint.manifest_no);
     }
     // Checkpoints only append; dropping happens when reorganization folds
     // the runs against the advanced floor.
-    let _ = last_manifest_no.expect("manifest number");
     let reorganized_manifest_no = drain_reorganization(
         &store,
         &namespace_id,
@@ -347,7 +348,6 @@ async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
         MetadataLsmPolicy::default(),
     )
     .await;
-
     let materialized = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,
@@ -355,6 +355,8 @@ async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
     )
     .await
     .expect("load manifest");
+
+    // Commit receipts below the floor go, and the floor's own receipt stays.
     let receipts = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::CommitReceipts,
@@ -363,17 +365,71 @@ async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
     for row in &receipts {
         if let MetadataRow::CommitReceipt { committed_seq, .. } = row {
             assert!(
-                *committed_seq >= ChangeSeq(2),
+                *committed_seq >= floor,
                 "receipt below floor survived: {committed_seq:?}"
             );
         }
     }
     assert!(receipts.iter().any(|row| matches!(
         row,
-        MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq == ChangeSeq(2)
+        MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq == floor
     )));
-}
 
+    // Revision rows are never dropped: file history is durable data, not
+    // replay state, and its index keeps one row per revision.
+    let revisions = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataRowFamily::Revisions,
+    );
+    let checksum_one = Checksum::sha256(b"alpha one\n");
+    let checksum_two = Checksum::sha256(b"alpha two\n");
+    assert!(revisions.iter().any(|row| matches!(
+        row,
+        MetadataRow::FileRevision { content_ref, .. } if content_ref.checksum == checksum_one
+    )));
+    assert!(revisions.iter().any(|row| matches!(
+        row,
+        MetadataRow::FileRevision { content_ref, .. } if content_ref.checksum == checksum_two
+    )));
+    let index_rows = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataRowFamily::RevisionsByInodeDesc,
+    );
+    assert_eq!(index_rows.len(), revisions.len());
+
+    // A binding unbound below the floor goes, and so does the spent unbind
+    // marker that covered it.
+    let binds = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataRowFamily::DirentryBinds,
+    );
+    assert!(!binds.iter().any(|row| matches!(
+        row,
+        MetadataRow::DirentryBind { display_name, .. } if display_name.as_str() == "tmp.txt"
+    )));
+    let unbinds = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataRowFamily::DirentryUnbinds,
+    );
+    assert!(
+        unbinds.is_empty(),
+        "spent unbind markers survived: {unbinds:?}"
+    );
+
+    // And the user-visible consequence: a revision below the floor is still
+    // restorable after the fold.
+    let restored = restore_file_revision(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        RevisionNo(1),
+        &context,
+        None,
+    )
+    .await
+    .expect("restoring a revision below the floor succeeds");
+    assert!(restored.committed_seq > ChangeSeq(0));
+}
 #[test]
 fn drop_pass_keeps_the_floor_visible_binding_across_a_later_rename() {
     use std::collections::BTreeMap;
@@ -482,255 +538,6 @@ fn drop_pass_refuses_superseded_bind_without_unbind() {
     let error = fold_rows_with_retention(MetadataFamilyGroup::Bindings, &mut rows, ChangeSeq(1))
         .expect_err("superseded live bind must refuse the drop");
     assert!(matches!(error, CoreError::NamespaceCorrupt(_)));
-}
-
-#[tokio::test]
-async fn restore_below_the_floor_succeeds_after_reorganization() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/a.txt",
-        b"one\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write one");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/a.txt",
-        b"two\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write two");
-    create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("create checkpoint");
-    advance_retention_floor(&store, &namespace_id, &context)
-        .await
-        .expect("advance floor");
-    for round in 0..9u32 {
-        write_file_bytes(
-            &store,
-            &namespace_id,
-            &format!("/docs/file-{round}.txt"),
-            b"body\n",
-            &context,
-            None,
-        )
-        .await
-        .expect("write");
-        create_checkpoint(&store, &namespace_id, &context)
-            .await
-            .expect("create checkpoint");
-    }
-    // Revision history is retained independently of the replay floor:
-    // folding the runs against the advanced floor must leave every
-    // revision readable.
-    drain_reorganization(
-        &store,
-        &namespace_id,
-        &context,
-        MetadataLsmPolicy::default(),
-    )
-    .await;
-
-    let restored = restore_file_revision(
-        &store,
-        &namespace_id,
-        "/docs/a.txt",
-        RevisionNo(1),
-        &context,
-        None,
-    )
-    .await
-    .expect("restoring a revision below the floor succeeds");
-    assert!(restored.committed_seq > ChangeSeq(0));
-}
-
-#[tokio::test]
-async fn base_rebuild_retains_revisions_superseded_below_floor() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/a.txt",
-        b"one\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write one");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/a.txt",
-        b"two\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write two");
-    create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("create checkpoint");
-    advance_retention_floor(&store, &namespace_id, &context)
-        .await
-        .expect("advance floor");
-
-    let mut last_manifest_no = None;
-    for round in 0..9u32 {
-        write_file_bytes(
-            &store,
-            &namespace_id,
-            &format!("/docs/file-{round}.txt"),
-            b"body\n",
-            &context,
-            None,
-        )
-        .await
-        .expect("write");
-        let checkpoint = create_checkpoint(&store, &namespace_id, &context)
-            .await
-            .expect("create checkpoint");
-        last_manifest_no = Some(checkpoint.manifest_no);
-    }
-    // Checkpoints only append, and the base rebuild folds the runs against
-    // the advanced floor — but revision rows are never dropped: file
-    // history is durable data, not replay state.
-    let _ = last_manifest_no.expect("manifest number");
-    let reorganized_manifest_no = drain_reorganization(
-        &store,
-        &namespace_id,
-        &context,
-        MetadataLsmPolicy::default(),
-    )
-    .await;
-
-    let materialized = load_manifest_materialization_for_inspection(
-        &store,
-        &namespace_id,
-        reorganized_manifest_no,
-    )
-    .await
-    .expect("load manifest");
-    let revisions = manifest_rows_for_family(
-        &materialized.metadata_state,
-        ApiMetadataRowFamily::Revisions,
-    );
-    let checksum_one = Checksum::sha256(b"one\n");
-    let checksum_two = Checksum::sha256(b"two\n");
-    assert!(revisions.iter().any(|row| matches!(
-        row,
-        MetadataRow::FileRevision { content_ref, .. } if content_ref.checksum == checksum_one
-    )));
-    assert!(revisions.iter().any(|row| matches!(
-        row,
-        MetadataRow::FileRevision { content_ref, .. } if content_ref.checksum == checksum_two
-    )));
-    let index_rows = manifest_rows_for_family(
-        &materialized.metadata_state,
-        ApiMetadataRowFamily::RevisionsByInodeDesc,
-    );
-    assert_eq!(index_rows.len(), revisions.len());
-}
-
-#[tokio::test]
-async fn base_rebuild_drops_bindings_unbound_below_floor() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/tmp.txt",
-        b"scratch\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write tmp");
-    delete_path(&store, &namespace_id, "/docs/tmp.txt", &context, None)
-        .await
-        .expect("delete tmp");
-    create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("create checkpoint");
-    advance_retention_floor(&store, &namespace_id, &context)
-        .await
-        .expect("advance floor");
-
-    let mut last_manifest_no = None;
-    for round in 0..9u32 {
-        write_file_bytes(
-            &store,
-            &namespace_id,
-            &format!("/docs/file-{round}.txt"),
-            b"body\n",
-            &context,
-            None,
-        )
-        .await
-        .expect("write");
-        let checkpoint = create_checkpoint(&store, &namespace_id, &context)
-            .await
-            .expect("create checkpoint");
-        last_manifest_no = Some(checkpoint.manifest_no);
-    }
-    // Checkpoints only append; dropping happens when reorganization folds
-    // the runs against the advanced floor.
-    let _ = last_manifest_no.expect("manifest number");
-    let reorganized_manifest_no = drain_reorganization(
-        &store,
-        &namespace_id,
-        &context,
-        MetadataLsmPolicy::default(),
-    )
-    .await;
-
-    let materialized = load_manifest_materialization_for_inspection(
-        &store,
-        &namespace_id,
-        reorganized_manifest_no,
-    )
-    .await
-    .expect("load manifest");
-    let binds = manifest_rows_for_family(
-        &materialized.metadata_state,
-        ApiMetadataRowFamily::DirentryBinds,
-    );
-    assert!(!binds.iter().any(|row| matches!(
-        row,
-        MetadataRow::DirentryBind { display_name, .. } if display_name.as_str() == "tmp.txt"
-    )));
-    let unbinds = manifest_rows_for_family(
-        &materialized.metadata_state,
-        ApiMetadataRowFamily::DirentryUnbinds,
-    );
-    assert!(
-        unbinds.is_empty(),
-        "spent unbind markers survived: {unbinds:?}"
-    );
 }
 
 #[tokio::test]
@@ -1216,8 +1023,20 @@ async fn manifest_rejects_missing_revision_desc_index() {
     );
 }
 
+/// Every way one revision-index segment can disagree with the revision family
+/// it indexes is refused at manifest load. One materialization pays for all
+/// four: the index segment object is restored from its original bytes before
+/// each case, so every case starts from the same durable state.
 #[tokio::test]
-async fn manifest_rejects_revision_desc_index_missing_row() {
+async fn manifest_rejects_a_revision_desc_index_that_disagrees_with_its_family() {
+    enum Rejection {
+        IndexMismatch,
+        DuplicateRow,
+    }
+
+    /// One corruption of the revision index, and the rejection it must draw.
+    type IndexCorruption = (&'static str, fn(&mut Vec<MetadataRow>), Rejection);
+
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1246,146 +1065,115 @@ async fn manifest_rejects_revision_desc_index_missing_row() {
     .await
     .expect("write other");
 
-    let (manifest_no, mut manifest, mut revision_index_rows) =
+    let (manifest_no, pristine_manifest, pristine_rows) =
         revision_index_test_materialization(&store, &namespace_id, &context).await;
-    revision_index_rows.pop().expect("revision index row");
-    rewrite_revision_index_segment(&store, &namespace_id, &mut manifest, revision_index_rows).await;
-    overwrite_manifest(&store, &namespace_id, manifest).await;
-
-    assert_revision_index_mismatch(
-        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no).await,
+    let index_key = metadata_segment_object_key(
+        pristine_manifest
+            .payload
+            .segments
+            .iter()
+            .find(|descriptor| {
+                descriptor.level == CHECKPOINT_BASE_RUN_LEVEL
+                    && descriptor.family == ApiMetadataRowFamily::RevisionsByInodeDesc
+            })
+            .expect("revision index metadata file"),
     );
-}
-
-#[tokio::test]
-async fn manifest_rejects_revision_desc_index_extra_row() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
+    let pristine_index_bytes = store
+        .get(&index_key, None)
         .await
-        .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/hello.txt",
-        b"hello\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write hello");
+        .expect("read revision index segment")
+        .expect("revision index segment exists");
 
-    let (manifest_no, mut manifest, mut revision_index_rows) =
-        revision_index_test_materialization(&store, &namespace_id, &context).await;
-    let extra_row = revision_index_rows
-        .first()
-        .expect("revision index row")
-        .clone();
-    revision_index_rows.push(match extra_row {
-        MetadataRow::FileRevision {
-            inode_id,
-            revision_no,
-            committed_seq,
-            commit_id,
-            committed_at_ms,
-            committed_by,
-            delta_index,
-            content_ref,
-        } => MetadataRow::FileRevision {
-            inode_id,
-            revision_no: loonfs_api::RevisionNo(revision_no.0 + 100),
-            committed_seq,
-            commit_id,
-            committed_at_ms,
-            committed_by,
-            delta_index,
-            content_ref,
-        },
-        other => other,
-    });
-    rewrite_revision_index_segment(&store, &namespace_id, &mut manifest, revision_index_rows).await;
-    overwrite_manifest(&store, &namespace_id, manifest).await;
+    let cases: [IndexCorruption; 4] = [
+        (
+            "missing row",
+            |rows| {
+                rows.pop().expect("revision index row");
+            },
+            Rejection::IndexMismatch,
+        ),
+        (
+            "extra row",
+            |rows| {
+                let extra = rows.first().expect("revision index row").clone();
+                rows.push(match extra {
+                    MetadataRow::FileRevision {
+                        inode_id,
+                        revision_no,
+                        committed_seq,
+                        commit_id,
+                        committed_at_ms,
+                        committed_by,
+                        delta_index,
+                        content_ref,
+                    } => MetadataRow::FileRevision {
+                        inode_id,
+                        revision_no: loonfs_api::RevisionNo(revision_no.0 + 100),
+                        committed_seq,
+                        commit_id,
+                        committed_at_ms,
+                        committed_by,
+                        delta_index,
+                        content_ref,
+                    },
+                    other => other,
+                });
+            },
+            Rejection::IndexMismatch,
+        ),
+        (
+            "changed content ref",
+            |rows| {
+                let first = rows.first_mut().expect("revision index row");
+                if let MetadataRow::FileRevision { content_ref, .. } = first {
+                    content_ref.content_id = ContentId::generate();
+                }
+            },
+            Rejection::IndexMismatch,
+        ),
+        (
+            "duplicate row",
+            |rows| {
+                rows.push(rows.first().expect("revision index row").clone());
+            },
+            Rejection::DuplicateRow,
+        ),
+    ];
 
-    assert_revision_index_mismatch(
-        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no).await,
-    );
-}
+    for (label, corrupt, expected) in cases {
+        store
+            .put_overwrite(&index_key, pristine_index_bytes.clone())
+            .await
+            .expect("restore the revision index segment");
+        let mut manifest = pristine_manifest.clone();
+        let mut rows = pristine_rows.clone();
+        corrupt(&mut rows);
+        rewrite_revision_index_segment(&store, &namespace_id, &mut manifest, rows).await;
+        overwrite_manifest(&store, &namespace_id, manifest).await;
 
-#[tokio::test]
-async fn manifest_rejects_revision_desc_index_changed_content_ref() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/hello.txt",
-        b"hello\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write hello");
-
-    let (manifest_no, mut manifest, mut revision_index_rows) =
-        revision_index_test_materialization(&store, &namespace_id, &context).await;
-    let first = revision_index_rows.first_mut().expect("revision index row");
-    if let MetadataRow::FileRevision { content_ref, .. } = first {
-        content_ref.content_id = ContentId::generate();
-    }
-    rewrite_revision_index_segment(&store, &namespace_id, &mut manifest, revision_index_rows).await;
-    overwrite_manifest(&store, &namespace_id, manifest).await;
-
-    assert_revision_index_mismatch(
-        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no).await,
-    );
-}
-
-#[tokio::test]
-async fn manifest_rejects_revision_desc_index_duplicate_rows() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/hello.txt",
-        b"hello\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write hello");
-
-    let (manifest_no, mut manifest, mut revision_index_rows) =
-        revision_index_test_materialization(&store, &namespace_id, &context).await;
-    revision_index_rows.push(
-        revision_index_rows
-            .first()
-            .expect("revision index row")
-            .clone(),
-    );
-    rewrite_revision_index_segment(&store, &namespace_id, &mut manifest, revision_index_rows).await;
-    overwrite_manifest(&store, &namespace_id, manifest).await;
-
-    match load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no).await {
-        Err(ManifestLoadError::DuplicateRevisionRow { family, .. }) => {
-            assert_eq!(family, ApiMetadataRowFamily::RevisionsByInodeDesc);
+        let result =
+            load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no).await;
+        match expected {
+            Rejection::IndexMismatch => match result {
+                Err(ManifestLoadError::RevisionIndexMismatch { .. }) => {}
+                Err(other) => {
+                    panic!("expected revision index mismatch for `{label}`, got {other:?}")
+                }
+                Ok(_) => panic!("expected revision index mismatch for `{label}`"),
+            },
+            Rejection::DuplicateRow => match result {
+                Err(ManifestLoadError::DuplicateRevisionRow { family, .. }) => {
+                    assert_eq!(
+                        family,
+                        ApiMetadataRowFamily::RevisionsByInodeDesc,
+                        "for `{label}`"
+                    );
+                }
+                other => panic!("expected duplicate revision row for `{label}`, got {other:?}"),
+            },
         }
-        other => panic!("expected duplicate revision row, got {other:?}"),
     }
 }
-
 #[tokio::test]
 async fn unreferenced_manifest_run_is_ignored_by_current_projection_load() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -525,7 +525,6 @@ async fn manifest_delta_run_materialization_matches_checkpoint_projection() {
         &second_materialized.metadata_state
     ));
 
-    // Additional checkpoints extend the delta chain without changing its base.
     let mut checkpoint_seqs = vec![first.checkpoint_seq, second.checkpoint_seq];
     let mut latest = second;
     for index in 3..=4u64 {

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -525,8 +525,7 @@ async fn manifest_delta_run_materialization_matches_checkpoint_projection() {
         &second_materialized.metadata_state
     ));
 
-    // Two more rounds: the base run still does not move, and the delta chain
-    // just grows, one run per checkpoint in sequence order.
+    // Additional checkpoints extend the delta chain without changing its base.
     let mut checkpoint_seqs = vec![first.checkpoint_seq, second.checkpoint_seq];
     let mut latest = second;
     for index in 3..=4u64 {

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -524,6 +524,42 @@ async fn manifest_delta_run_materialization_matches_checkpoint_projection() {
         &materialization_after.metadata_state,
         &second_materialized.metadata_state
     ));
+
+    // Two more rounds: the base run still does not move, and the delta chain
+    // just grows, one run per checkpoint in sequence order.
+    let mut checkpoint_seqs = vec![first.checkpoint_seq, second.checkpoint_seq];
+    let mut latest = second;
+    for index in 3..=4u64 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{index}.txt"),
+            format!("file {index}\n").as_bytes(),
+            &context,
+            None,
+        )
+        .await
+        .expect("write file");
+        latest = create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+        checkpoint_seqs.push(latest.checkpoint_seq);
+    }
+    let latest_materialized =
+        load_manifest_materialization_for_inspection(&store, &namespace_id, latest.manifest_no)
+            .await
+            .expect("load chained manifest");
+    assert_eq!(
+        latest_materialized.manifest.payload.base_seq,
+        ChangeSeq(0),
+        "always-append checkpoints keep the first published base"
+    );
+    let chained_delta_runs = super::delta_runs(&latest_materialized.manifest);
+    assert_eq!(chained_delta_runs.len(), checkpoint_seqs.len());
+    for (run, checkpoint_seq) in chained_delta_runs.iter().zip(&checkpoint_seqs) {
+        assert_eq!(run.run_seq, *checkpoint_seq);
+        assert_eq!(run.level, CHECKPOINT_DELTA_RUN_LEVEL);
+    }
 }
 
 #[tokio::test]
@@ -668,36 +704,6 @@ async fn manifest_run_rejects_rows_after_run_seq() {
             assert!(message.contains("after expected max"));
         }
         other => panic!("expected row range mismatch, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn manifest_delta_runs_chain_across_successive_manifests() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-
-    for index in 1..=4 {
-        write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
-    }
-
-    let materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestNo(5))
-            .await
-            .expect("load chained manifest");
-    // Always-append checkpoints keep the first published base (seq 0) and
-    // chain one delta run per checkpoint, the first included.
-    assert_eq!(materialized.manifest.payload.base_seq, ChangeSeq(0));
-    let delta_runs = delta_runs(&materialized.manifest);
-    assert_eq!(delta_runs.len(), 4);
-    for (offset, run) in delta_runs.iter().enumerate() {
-        let seq = ChangeSeq(offset as u64 + 1);
-        assert_eq!(run.run_seq, seq);
-        assert_eq!(run.level, CHECKPOINT_DELTA_RUN_LEVEL);
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1045,12 +1045,16 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
         .await
         .expect("bootstrap");
 
-    for index in 1..=4 {
+    // Ten rounds put the chain past this test's policy threshold and past
+    // the default cap as well.
+    let rounds = DEFAULT_MAX_CHECKPOINT_DELTA_RUNS + 2;
+    for index in 1..=u64::try_from(rounds).expect("round count fits") {
         write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
     }
 
-    // Checkpoints never compact: well past the policy threshold every
-    // delta run is still chained and the base is still the seed's.
+    // Checkpoints never compact: well past the policy threshold, and past
+    // the default cap that only triggers reorganization, every delta run is
+    // still chained and the base is still the seed's.
     let appended = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,
@@ -1058,7 +1062,8 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     )
     .await
     .expect("load appended manifest");
-    assert_eq!(delta_runs(&appended.manifest).len(), 4);
+    assert_eq!(delta_runs(&appended.manifest).len(), rounds);
+    assert!(delta_runs(&appended.manifest).len() > DEFAULT_MAX_CHECKPOINT_DELTA_RUNS);
     assert_eq!(appended.manifest.payload.base_seq, ChangeSeq(0));
 
     // Reorganization folds one family group per unit, each publishing its
@@ -1105,7 +1110,10 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
         .await
         .expect("materialization");
     assert!(delta_runs(&drained.manifest).is_empty());
-    assert_eq!(drained.manifest.payload.base_seq, ChangeSeq(4));
+    assert_eq!(
+        drained.manifest.payload.base_seq,
+        ChangeSeq(u64::try_from(rounds).expect("round count fits"))
+    );
     assert!(metadata_states_equivalent(
         &materialization_after.metadata_state,
         &drained.metadata_state
@@ -1619,32 +1627,6 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
         &materialization_after.metadata_state,
         &drained.metadata_state
     ));
-}
-
-#[tokio::test]
-async fn checkpoints_chain_delta_runs_past_the_default_cap() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    for index in 1..=10 {
-        write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
-    }
-
-    // The default cap is a reorganization trigger, never a checkpoint
-    // behavior: publication keeps appending regardless.
-    let appended = load_manifest_materialization_for_inspection(
-        &store,
-        &namespace_id,
-        current_manifest_no(&store, &namespace_id).await,
-    )
-    .await
-    .expect("load appended manifest");
-    assert!(delta_runs(&appended.manifest).len() > DEFAULT_MAX_CHECKPOINT_DELTA_RUNS);
-    assert_eq!(appended.manifest.payload.base_seq, ChangeSeq(0));
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1045,16 +1045,13 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
         .await
         .expect("bootstrap");
 
-    // Ten rounds put the chain past this test's policy threshold and past
-    // the default cap as well.
+    // Exceed both the configured threshold and the default delta-run cap.
     let rounds = DEFAULT_MAX_CHECKPOINT_DELTA_RUNS + 2;
     for index in 1..=u64::try_from(rounds).expect("round count fits") {
         write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
     }
 
-    // Checkpoints never compact: well past the policy threshold, and past
-    // the default cap that only triggers reorganization, every delta run is
-    // still chained and the base is still the seed's.
+    // Checkpointing adds delta runs; only reorganization compacts them.
     let appended = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1045,13 +1045,11 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
         .await
         .expect("bootstrap");
 
-    // Exceed both the configured threshold and the default delta-run cap.
     let rounds = DEFAULT_MAX_CHECKPOINT_DELTA_RUNS + 2;
     for index in 1..=u64::try_from(rounds).expect("round count fits") {
         write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
     }
 
-    // Checkpointing adds delta runs; only reorganization compacts them.
     let appended = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -2233,50 +2233,6 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
 }
 
 #[tokio::test]
-async fn a_cancelled_job_leaves_its_claim_standing() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    seed_bindings_workload(
-        &LocalFsStore::new(temp_dir.path()).expect("store"),
-        &namespace_id,
-    )
-    .await;
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let group = MetadataFamilyGroup::Bindings;
-    let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
-    let spec = step_until_a_compaction_is_planned(&store, &namespace_id, &context, policy).await;
-    let lease_key = metadata_compaction_lease(&namespace_id, spec.job_id());
-
-    let cancellation = MetadataCompactionCancellation::default();
-    let dying_store = CancelAfterReadsStore {
-        inner: LocalFsStore::new(temp_dir.path()).expect("store"),
-        cancellation: cancellation.clone(),
-        reads_before_cancel: 8,
-        reads: AtomicUsize::new(0),
-    };
-    let outcome = run_metadata_compaction_job(
-        &dying_store,
-        &namespace_id,
-        &context,
-        &spec,
-        policy,
-        &cancellation,
-    )
-    .await
-    .expect("run the job");
-    assert_eq!(outcome, MetadataCompactionJobOutcome::Cancelled);
-    assert!(
-        store
-            .head(&lease_key)
-            .await
-            .expect("head the lease")
-            .is_some(),
-        "a cancelled job's claim stands until it expires"
-    );
-}
-
-#[tokio::test]
 async fn a_worker_whose_expired_lease_was_claimed_is_fenced_and_publishes_nothing() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -3021,6 +2977,14 @@ async fn a_job_that_dies_mid_run_leaves_orphans_and_the_next_step_plans_it_again
             outcome,
             MetadataCompactionJobOutcome::Cancelled,
             "the cancellation must land before the job finishes"
+        );
+        assert!(
+            store
+                .head(&metadata_compaction_lease(&namespace_id, spec.job_id()))
+                .await
+                .expect("head the lease")
+                .is_some(),
+            "a cancelled job's claim stands until it expires"
         );
         assert_eq!(
             current_manifest_object_id(&store, &namespace_id).await,

--- a/crates/loonfs-core/src/commit/inode_allocator.rs
+++ b/crates/loonfs-core/src/commit/inode_allocator.rs
@@ -121,19 +121,6 @@ mod tests {
     }
 
     #[test]
-    fn multiple_accepted_candidates_advance_one_batch_allocator() {
-        let mut allocator = InodeAllocator::new(InodeId(2));
-        for expected in [InodeId(2), InodeId(3), InodeId(4)] {
-            let mut candidate = allocator.begin_candidate();
-            assert_eq!(candidate.allocate().expect("create"), expected);
-            allocator.commit_candidate(candidate).expect("commit");
-        }
-
-        let next = allocator.begin_candidate();
-        assert_eq!(next.resulting_next_inode_id(), InodeId(5));
-    }
-
-    #[test]
     fn retry_from_the_same_head_replays_the_same_allocations() {
         let allocator = InodeAllocator::new(InodeId(7));
         let mut first_attempt = allocator.begin_candidate();

--- a/crates/loonfs-core/src/commit/plan.rs
+++ b/crates/loonfs-core/src/commit/plan.rs
@@ -164,34 +164,3 @@ pub(crate) enum ValidatedOp {
         attributes_delta_index: u32,
     },
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn finishing_validated_plan_moves_identity_into_one_owner() {
-        let semantic_identity = CommitFingerprint::new_unchecked("v1:sha256:test".to_owned());
-        let validated = ValidatedCommitPlan {
-            namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
-            commit_id: CommitId::parse("commit-a").expect("valid commit id"),
-            actor: loonfs_test_support::test_actor(),
-            writer_epoch: WriterEpoch(7),
-            message: Some("create docs".to_owned()),
-            semantic_identity: semantic_identity.clone(),
-            apply_after_seq: ChangeSeq(3),
-            assigned_seq: ChangeSeq(4),
-            validated_ops: Vec::new(),
-        };
-        let plan = validated.finish(InodeId(3));
-
-        assert_eq!(plan.namespace_id.as_str(), "demo");
-        assert_eq!(plan.commit_id.as_str(), "commit-a");
-        assert_eq!(plan.writer_epoch, WriterEpoch(7));
-        assert_eq!(plan.message.as_deref(), Some("create docs"));
-        assert_eq!(plan.semantic_identity, semantic_identity);
-        assert_eq!(plan.apply_after_seq, ChangeSeq(3));
-        assert_eq!(plan.assigned_seq, ChangeSeq(4));
-        assert_eq!(plan.resulting_next_inode_id, InodeId(3));
-    }
-}

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -986,17 +986,6 @@ mod tests {
         assert_eq!(engine.writer_id(), "writer-a");
     }
 
-    #[test]
-    fn reader_engine_builds_without_any_writer_identity() {
-        let temp_dir = tempdir().expect("tempdir");
-        let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-
-        let engine = NamespaceEngine::reader(store, namespace_id.clone());
-
-        assert_eq!(engine.namespace_id(), &namespace_id);
-    }
-
     #[tokio::test]
     async fn reader_engine_still_serves_reads() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -986,7 +986,6 @@ mod tests {
         assert_eq!(details.active_writer.as_deref(), Some("writer-b"));
         assert_eq!(details.active_acquired_at_ms, Some(2_000));
 
-        // A head without writer metadata still reports both epochs.
         let anonymous = CoreError::WriterFenced(WriterFence {
             fenced_epoch: WriterEpoch(3),
             active_epoch: WriterEpoch(4),
@@ -1039,7 +1038,6 @@ mod tests {
         assert_eq!(details.inode_id, Some(InodeId(7)));
         assert_eq!(details.expected_revision_no, Some(RevisionNo(2)));
         assert_eq!(details.actual_revision_no, Some(RevisionNo(5)));
-        // Check both revisions without depending on the exact wording.
         let message = stale.to_string();
         assert!(message.contains("revision 2"), "{message}");
         assert!(message.contains("revision 5"), "{message}");

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -985,20 +985,20 @@ mod tests {
         assert_eq!(details.active_writer_epoch, Some(WriterEpoch(4)));
         assert_eq!(details.active_writer.as_deref(), Some("writer-b"));
         assert_eq!(details.active_acquired_at_ms, Some(2_000));
-        assert!(fenced
-            .to_string()
-            .contains("epoch 3 was fenced by epoch 4 (writer `writer-b`, acquired at 2000 ms)"));
 
-        // A head with no writer block still names both epochs.
+        // A head with no writer block still names both epochs and carries
+        // neither half of the writer block.
         let anonymous = CoreError::WriterFenced(WriterFence {
             fenced_epoch: WriterEpoch(3),
             active_epoch: WriterEpoch(4),
             active_writer: None,
             active_acquired_at_ms: None,
         });
-        assert!(anonymous
-            .to_string()
-            .ends_with("epoch 3 was fenced by epoch 4"));
+        let details = anonymous.details().expect("fence details");
+        assert_eq!(details.fenced_writer_epoch, Some(WriterEpoch(3)));
+        assert_eq!(details.active_writer_epoch, Some(WriterEpoch(4)));
+        assert_eq!(details.active_writer, None);
+        assert_eq!(details.active_acquired_at_ms, None);
 
         // A conflict decided against a durable receipt names where the
         // commit id landed and what landed there, which is what a retry
@@ -1041,13 +1041,12 @@ mod tests {
         assert_eq!(details.expected_revision_no, Some(RevisionNo(2)));
         assert_eq!(details.actual_revision_no, Some(RevisionNo(5)));
         // The prose says the same thing in words, so neither revision
-        // reaches a reader as Rust formatting.
-        assert!(
-            stale
-                .to_string()
-                .ends_with("expected revision 2, found revision 5"),
-            "{stale}"
-        );
+        // reaches a reader as Rust formatting. The sentence itself is free
+        // to change.
+        let message = stale.to_string();
+        assert!(message.contains("revision 2"), "{message}");
+        assert!(message.contains("revision 5"), "{message}");
+        assert!(!message.contains("Some("), "{message}");
 
         // A file with no revision at all reads as a sentence rather than
         // printing the absent value.
@@ -1057,12 +1056,9 @@ mod tests {
                 expected: RevisionNo(2),
                 actual: None,
             });
-        assert!(
-            unversioned
-                .to_string()
-                .ends_with("expected revision 2, found no revision"),
-            "{unversioned}"
-        );
+        let message = unversioned.to_string();
+        assert!(message.contains("revision 2"), "{message}");
+        assert!(!message.contains("None"), "{message}");
         assert_eq!(
             unversioned
                 .details()

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -986,8 +986,7 @@ mod tests {
         assert_eq!(details.active_writer.as_deref(), Some("writer-b"));
         assert_eq!(details.active_acquired_at_ms, Some(2_000));
 
-        // A head with no writer block still names both epochs and carries
-        // neither half of the writer block.
+        // A head without writer metadata still reports both epochs.
         let anonymous = CoreError::WriterFenced(WriterFence {
             fenced_epoch: WriterEpoch(3),
             active_epoch: WriterEpoch(4),
@@ -1040,9 +1039,7 @@ mod tests {
         assert_eq!(details.inode_id, Some(InodeId(7)));
         assert_eq!(details.expected_revision_no, Some(RevisionNo(2)));
         assert_eq!(details.actual_revision_no, Some(RevisionNo(5)));
-        // The prose says the same thing in words, so neither revision
-        // reaches a reader as Rust formatting. The sentence itself is free
-        // to change.
+        // Check both revisions without depending on the exact wording.
         let message = stale.to_string();
         assert!(message.contains("revision 2"), "{message}");
         assert!(message.contains("revision 5"), "{message}");

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1272,7 +1272,6 @@ async fn corrupt_metadata_rows_fail_the_pass_and_unreadable_ones_retain_the_cont
     );
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
 
-    // Unreadable rows are treated conservatively.
     store.fail_all();
     let report = gc_namespace(&store, &namespace_id, &config(), &past)
         .await
@@ -1289,7 +1288,6 @@ async fn corrupt_metadata_rows_fail_the_pass_and_unreadable_ones_retain_the_cont
         .await
         .is_some());
 
-    // Corrupt rows fail the pass.
     store.clear();
     for key in &segment_keys {
         let mut bytes = store
@@ -2829,7 +2827,6 @@ async fn gc_never_deletes_the_live_replay_chain() {
         .expect("tail commit stays readable");
 }
 
-/// Runs GC with the default or an overridden re-verification chunk size.
 async fn gc_pass(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
@@ -2845,7 +2842,6 @@ async fn gc_pass(
     }
 }
 
-/// Checks that a released record is deleted before its basis.
 async fn assert_record_reaped_and_basis_kept(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
@@ -2881,7 +2877,6 @@ async fn assert_record_reaped_and_basis_kept(
     }
 }
 
-/// Checks that a later pass deletes the unreferenced basis.
 async fn assert_basis_reaped(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
@@ -3504,7 +3499,6 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
         .expect("first gc pass");
     assert_eq!(first_pass.deleted.checkpoint_records, 1);
 
-    // The surviving record keeps the shared basis.
     let second_pass = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect("second gc pass");
@@ -3722,7 +3716,6 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         .expect("fork");
     let fork_record = read_fork_record(store.inner(), &source).await;
 
-    // An unreadable target head retains the fork record.
     store.fail_all();
     let report = gc_namespace(&store, &source, &config(), &setup)
         .await
@@ -3733,7 +3726,6 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         CheckpointStatus::Active {}
     );
 
-    // A corrupt target head fails the pass.
     store.clear();
     store
         .put_overwrite(&wal_head(&clone), Bytes::from_static(b"not json"))
@@ -3976,7 +3968,6 @@ async fn a_corrupt_checkpoint_record_and_an_unreadable_one_both_fail_the_pass() 
     let before = namespace_keys(store.inner(), &namespace_id).await;
     let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
 
-    // An unreadable record fails without deleting anything.
     store.fail_all();
     let error = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
@@ -3992,7 +3983,6 @@ async fn a_corrupt_checkpoint_record_and_an_unreadable_one_both_fail_the_pass() 
         "a failed pass deletes nothing"
     );
 
-    // A corrupt record reports namespace corruption.
     store.clear();
     store
         .put_overwrite(&record_key, Bytes::from_static(b"not json"))
@@ -4054,7 +4044,6 @@ async fn a_corrupt_reference_anchor_fails_and_an_unreadable_one_reads_as_missing
         .put_overwrite(&manifest_key, Bytes::from_static(b"not json"))
         .await
         .expect("corrupt reference manifest");
-    // The overwrite resets the object's age.
     let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
     let mut budget = PassBudget::new(None);
     let error = select_reference_anchor(&store, &namespace_id, GRACE_MS, &mut budget, &aged)
@@ -4098,7 +4087,6 @@ async fn a_corrupt_root_manifest_fails_the_pass_and_an_unreadable_one_degrades_i
     let before = namespace_keys(store.inner(), &namespace_id).await;
     let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
 
-    // Unreadable manifests degrade the pass.
     store.fail_all();
     let report = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
@@ -4116,7 +4104,6 @@ async fn a_corrupt_root_manifest_fails_the_pass_and_an_unreadable_one_degrades_i
         "a degraded pass reclaims nothing in the affected families"
     );
 
-    // Corrupt manifests fail the pass.
     store.clear();
     for key in &manifest_keys {
         store

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1209,10 +1209,6 @@ async fn namespace_with_a_scan_worth_bounding(
     }
 }
 
-/// A manifest the marking pass already counted can still go wrong before the
-/// reference scan reads it. Bytes that do not decode surface as corruption;
-/// a store that will not read leaves the reference set unavailable rather
-/// than partial, because a partial set would authorize a deletion.
 #[tokio::test]
 async fn a_corrupt_marked_manifest_fails_the_scan_and_an_unreadable_one_makes_it_unavailable() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1249,9 +1245,6 @@ async fn a_corrupt_marked_manifest_fails_the_scan_and_an_unreadable_one_makes_it
     assert!(error.message().contains(&manifest_key));
 }
 
-/// The metadata rows are where published content references live. Rows that
-/// do not decode fail the pass; rows the store will not read leave the pass
-/// conservative. Either way the unpublished content and its session stay.
 #[tokio::test]
 async fn corrupt_metadata_rows_fail_the_pass_and_unreadable_ones_retain_the_content() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1279,7 +1272,7 @@ async fn corrupt_metadata_rows_fail_the_pass_and_unreadable_ones_retain_the_cont
     );
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
 
-    // A store failure is not proof that nothing references the content.
+    // Unreadable rows are treated conservatively.
     store.fail_all();
     let report = gc_namespace(&store, &namespace_id, &config(), &past)
         .await
@@ -1296,7 +1289,7 @@ async fn corrupt_metadata_rows_fail_the_pass_and_unreadable_ones_retain_the_cont
         .await
         .is_some());
 
-    // Rows that do not decode are corruption, and the pass fails on them.
+    // Corrupt rows fail the pass.
     store.clear();
     for key in &segment_keys {
         let mut bytes = store
@@ -2836,8 +2829,7 @@ async fn gc_never_deletes_the_live_replay_chain() {
         .expect("tail commit stays readable");
 }
 
-/// Runs one pass, either through the production entry point or with the
-/// sweep's re-verification chunk forced to a size a small fixture reaches.
+/// Runs GC with the default or an overridden re-verification chunk size.
 async fn gc_pass(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
@@ -2853,9 +2845,7 @@ async fn gc_pass(
     }
 }
 
-/// Every release trigger ends the same way, so every trigger's test asserts
-/// this half here: the pass that deletes a released record leaves the basis
-/// that record rooted standing, manifest and segments alike.
+/// Checks that a released record is deleted before its basis.
 async fn assert_record_reaped_and_basis_kept(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
@@ -2891,8 +2881,7 @@ async fn assert_record_reaped_and_basis_kept(
     }
 }
 
-/// The cascade's second half: one more pass finds the basis unreferenced and
-/// aged, and reaps it.
+/// Checks that a later pass deletes the unreferenced basis.
 async fn assert_basis_reaped(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
@@ -2917,9 +2906,6 @@ async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
     assert_a_dead_records_cascade(None).await;
 }
 
-/// The same cascade with the sweep re-collecting the live set after every
-/// single decision, which is the path a pass with more candidates than one
-/// chunk takes.
 #[tokio::test]
 async fn a_chunked_sweep_reaches_the_same_dead_record_cascade() {
     assert_a_dead_records_cascade(Some(1)).await;
@@ -3518,8 +3504,7 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
         .expect("first gc pass");
     assert_eq!(first_pass.deleted.checkpoint_records, 1);
 
-    // The pass that reaps unreferenced bases runs and finds none, because
-    // the keeper still roots the shared one.
+    // The surviving record keeps the shared basis.
     let second_pass = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect("second gc pass");
@@ -3716,9 +3701,6 @@ async fn gc_releases_fork_checkpoints_of_terminally_deleted_targets_across_passe
     stat_root(&store, &source).await;
 }
 
-/// The fork target's head decides whether the source's fork record still has
-/// an owner. Bytes that do not decode fail the source's pass; a head the
-/// store will not read leaves the record where it was.
 #[tokio::test]
 async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains_the_record() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3740,7 +3722,7 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         .expect("fork");
     let fork_record = read_fork_record(store.inner(), &source).await;
 
-    // An unreadable target says nothing about whether the fork still lives.
+    // An unreadable target head retains the fork record.
     store.fail_all();
     let report = gc_namespace(&store, &source, &config(), &setup)
         .await
@@ -3751,7 +3733,7 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         CheckpointStatus::Active {}
     );
 
-    // A head that is not a head at all is corruption.
+    // A corrupt target head fails the pass.
     store.clear();
     store
         .put_overwrite(&wal_head(&clone), Bytes::from_static(b"not json"))
@@ -3964,9 +3946,6 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
         .expect("forked file readable");
 }
 
-/// One record, two ways it can be unusable. Corrupt bytes are a namespace
-/// the pass must not touch; an unreadable store is a transport answer the
-/// pass must not read as a verdict. Both fail the pass and delete nothing.
 #[tokio::test]
 async fn a_corrupt_checkpoint_record_and_an_unreadable_one_both_fail_the_pass() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3997,7 +3976,7 @@ async fn a_corrupt_checkpoint_record_and_an_unreadable_one_both_fail_the_pass() 
     let before = namespace_keys(store.inner(), &namespace_id).await;
     let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
 
-    // A record the store will not read is retryable, not a verdict.
+    // An unreadable record fails without deleting anything.
     store.fail_all();
     let error = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
@@ -4013,7 +3992,7 @@ async fn a_corrupt_checkpoint_record_and_an_unreadable_one_both_fail_the_pass() 
         "a failed pass deletes nothing"
     );
 
-    // Bytes that are not a record at all are terminal corruption.
+    // A corrupt record reports namespace corruption.
     store.clear();
     store
         .put_overwrite(&record_key, Bytes::from_static(b"not json"))
@@ -4035,10 +4014,6 @@ async fn a_corrupt_checkpoint_record_and_an_unreadable_one_both_fail_the_pass() 
     );
 }
 
-/// The reference anchor is what dates every object the pass considers. A
-/// manifest that does not decode has to surface as corruption rather than
-/// degrade to "no anchor"; a manifest the store will not read is exactly the
-/// case where "no anchor" is the safe answer.
 #[tokio::test]
 async fn a_corrupt_reference_anchor_fails_and_an_unreadable_one_reads_as_missing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4079,8 +4054,7 @@ async fn a_corrupt_reference_anchor_fails_and_an_unreadable_one_reads_as_missing
         .put_overwrite(&manifest_key, Bytes::from_static(b"not json"))
         .await
         .expect("corrupt reference manifest");
-    // Overwriting the object refreshed its age, so the clock the anchor is
-    // selected against has to move past it again.
+    // The overwrite resets the object's age.
     let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
     let mut budget = PassBudget::new(None);
     let error = select_reference_anchor(&store, &namespace_id, GRACE_MS, &mut budget, &aged)
@@ -4093,9 +4067,6 @@ async fn a_corrupt_reference_anchor_fails_and_an_unreadable_one_reads_as_missing
     assert!(error.message().contains(&manifest_key));
 }
 
-/// A rooted manifest that does not decode is corruption the pass fails on;
-/// one the store will not read is a degraded pass that reclaims nothing.
-/// The difference is the whole retention policy for unreadable roots.
 #[tokio::test]
 async fn a_corrupt_root_manifest_fails_the_pass_and_an_unreadable_one_degrades_it() {
     let temp_dir = tempdir().expect("tempdir");
@@ -4127,7 +4098,7 @@ async fn a_corrupt_root_manifest_fails_the_pass_and_an_unreadable_one_degrades_i
     let before = namespace_keys(store.inner(), &namespace_id).await;
     let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
 
-    // A read failure degrades the pass instead of failing it.
+    // Unreadable manifests degrade the pass.
     store.fail_all();
     let report = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
@@ -4145,7 +4116,7 @@ async fn a_corrupt_root_manifest_fails_the_pass_and_an_unreadable_one_degrades_i
         "a degraded pass reclaims nothing in the affected families"
     );
 
-    // Bytes that do not decode fail the pass instead.
+    // Corrupt manifests fail the pass.
     store.clear();
     for key in &manifest_keys {
         store

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -29,7 +29,9 @@ use loonfs_api::wire::control::{
     ControlObjectKind, ProxiedStaging, UploadSessionMode, UploadSessionRecordStatus,
     UploadSessionState,
 };
-use loonfs_api::{ContentRef, ContentStoreId, NamespaceId, UploadId};
+use loonfs_api::{
+    CheckpointId, ContentRef, ContentStoreId, ManifestObjectId, NamespaceId, UploadId,
+};
 use loonfs_objectstore::keys::{
     checkpoint_prefix, metadata_compaction_lease, metadata_compaction_segment,
     metadata_manifest_object, metadata_manifest_prefix, metadata_root, metadata_segment,
@@ -109,7 +111,7 @@ async fn marked<S: ObjectStore + ?Sized>(
 async fn checkpoint_lifecycle<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    checkpoint_id: &loonfs_api::CheckpointId,
+    checkpoint_id: &CheckpointId,
 ) -> CheckpointStatus {
     crate::checkpoint::load_checkpoint_record(store, namespace_id, checkpoint_id)
         .await
@@ -1207,22 +1209,39 @@ async fn namespace_with_a_scan_worth_bounding(
     }
 }
 
+/// A manifest the marking pass already counted can still go wrong before the
+/// reference scan reads it. Bytes that do not decode surface as corruption;
+/// a store that will not read leaves the reference set unavailable rather
+/// than partial, because a partial set would authorize a deletion.
 #[tokio::test]
-async fn content_reference_scan_surfaces_a_manifest_corrupted_after_marking() {
+async fn a_corrupt_marked_manifest_fails_the_scan_and_an_unreadable_one_makes_it_unavailable() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_id)),
+        OperationClass::Read,
+        InjectedError::Transport("marked manifest timed out".to_owned()),
+    );
     let setup = context(1_000);
-    namespace_with_a_scan_worth_bounding(&store, &namespace_id, &setup).await;
-    let live = live_set(&store, &namespace_id, &setup).await;
+    namespace_with_a_scan_worth_bounding(store.inner(), &namespace_id, &setup).await;
+    let live = live_set(store.inner(), &namespace_id, &setup).await;
     let manifest_object_id = live.manifests.iter().next().expect("live manifest").clone();
     let manifest_key = metadata_manifest_object(&namespace_id, &manifest_object_id);
+
+    store.fail_all();
+    let mut budget = PassBudget::new(None);
+    let references = collect_referenced_content(&store, &namespace_id, &live, &mut budget)
+        .await
+        .expect("a manifest store failure remains conservative");
+    assert!(matches!(references, CollectedReferences::Unavailable));
+
+    store.clear();
     store
         .put_overwrite(&manifest_key, Bytes::from_static(b"not json"))
         .await
         .expect("corrupt marked manifest");
     let mut budget = PassBudget::new(None);
-
     let error = collect_referenced_content(&store, &namespace_id, &live, &mut budget)
         .await
         .expect_err("corruption after marking must still surface");
@@ -1230,39 +1249,27 @@ async fn content_reference_scan_surfaces_a_manifest_corrupted_after_marking() {
     assert!(error.message().contains(&manifest_key));
 }
 
+/// The metadata rows are where published content references live. Rows that
+/// do not decode fail the pass; rows the store will not read leave the pass
+/// conservative. Either way the unpublished content and its session stay.
 #[tokio::test]
-async fn content_reference_scan_is_unavailable_when_a_marked_manifest_does_not_read() {
+async fn corrupt_metadata_rows_fail_the_pass_and_unreadable_ones_retain_the_content() {
     let temp_dir = tempdir().expect("tempdir");
-    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-    let setup = context(1_000);
-    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
-    let live = live_set(&inner, &namespace_id, &setup).await;
     let store = FailStore::new(
-        inner,
-        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_id)),
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(metadata_segment_prefix(&namespace_id)),
         OperationClass::Read,
-        InjectedError::Transport("marked manifest timed out".to_owned()),
+        InjectedError::Transport("metadata rows timed out".to_owned()),
     );
-    store.fail_all();
-    let mut budget = PassBudget::new(None);
-
-    let references = collect_referenced_content(&store, &namespace_id, &live, &mut budget)
-        .await
-        .expect("a manifest store failure remains conservative");
-    assert!(matches!(references, CollectedReferences::Unavailable));
-}
-
-#[tokio::test]
-async fn content_reference_scan_surfaces_corrupt_metadata_rows() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let setup = context(1_000);
-    namespace_with_a_scan_worth_bounding(&store, &namespace_id, &setup).await;
+    namespace_with_a_scan_worth_bounding(store.inner(), &namespace_id, &setup).await;
     let (upload_id, content_ref, content_store_id, _) =
-        complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
+        complete_upload_for_gc(store.inner(), &namespace_id, b"unpublished\n", &setup).await;
+    let content_key =
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let segment_keys = store
+        .inner()
         .list_prefix(&metadata_segment_prefix(&namespace_id))
         .await
         .expect("list metadata segments");
@@ -1270,6 +1277,27 @@ async fn content_reference_scan_surfaces_corrupt_metadata_rows() {
         !segment_keys.is_empty(),
         "the fixture must publish metadata segments"
     );
+    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+
+    // A store failure is not proof that nothing references the content.
+    store.fail_all();
+    let report = gc_namespace(&store, &namespace_id, &config(), &past)
+        .await
+        .expect("a metadata-row store failure retains conservatively");
+    assert_eq!(report.deleted.content_objects, 0);
+    assert_eq!(report.deleted.upload_sessions, 0);
+    assert!(store
+        .inner()
+        .head(&content_key)
+        .await
+        .expect("head content")
+        .is_some());
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_some());
+
+    // Rows that do not decode are corruption, and the pass fails on them.
+    store.clear();
     for key in &segment_keys {
         let mut bytes = store
             .get(key, None)
@@ -1283,50 +1311,11 @@ async fn content_reference_scan_surfaces_corrupt_metadata_rows() {
             .await
             .expect("corrupt metadata segment");
     }
-    let content_key =
-        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
-    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
-
     let error = gc_namespace(&store, &namespace_id, &config(), &past)
         .await
         .expect_err("corrupt content-reference rows must fail the pass");
     assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
     assert!(segment_keys.iter().any(|key| error.message().contains(key)));
-    assert!(store
-        .head(&content_key)
-        .await
-        .expect("head content")
-        .is_some());
-    assert!(read_upload_session(&store, &namespace_id, &upload_id)
-        .await
-        .is_some());
-}
-
-#[tokio::test]
-async fn content_reference_scan_retains_content_when_metadata_rows_do_not_read() {
-    let temp_dir = tempdir().expect("tempdir");
-    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-    let setup = context(1_000);
-    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
-    let (upload_id, content_ref, content_store_id, _) =
-        complete_upload_for_gc(&inner, &namespace_id, b"unpublished\n", &setup).await;
-    let content_key =
-        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
-    let store = FailStore::new(
-        inner,
-        KeyPredicate::prefix(metadata_segment_prefix(&namespace_id)),
-        OperationClass::Read,
-        InjectedError::Transport("metadata rows timed out".to_owned()),
-    );
-    store.fail_all();
-    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
-
-    let report = gc_namespace(&store, &namespace_id, &config(), &past)
-        .await
-        .expect("a metadata-row store failure retains conservatively");
-    assert_eq!(report.deleted.content_objects, 0);
-    assert_eq!(report.deleted.upload_sessions, 0);
     assert!(store
         .inner()
         .head(&content_key)
@@ -2847,8 +2836,96 @@ async fn gc_never_deletes_the_live_replay_chain() {
         .expect("tail commit stays readable");
 }
 
+/// Runs one pass, either through the production entry point or with the
+/// sweep's re-verification chunk forced to a size a small fixture reaches.
+async fn gc_pass(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    config: &GcConfig,
+    context: &MutationContext,
+    reverify_chunk: Option<usize>,
+) -> Result<GcResponse, CoreError> {
+    match reverify_chunk {
+        None => gc_namespace(store, namespace_id, config, context).await,
+        Some(chunk) => {
+            gc_namespace_with_reverify_chunk(store, namespace_id, config, context, chunk).await
+        }
+    }
+}
+
+/// Every release trigger ends the same way, so every trigger's test asserts
+/// this half here: the pass that deletes a released record leaves the basis
+/// that record rooted standing, manifest and segments alike.
+async fn assert_record_reaped_and_basis_kept(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    pass: &GcResponse,
+    checkpoint_id: &loonfs_api::CheckpointId,
+    manifest_object_id: &ManifestObjectId,
+) {
+    assert_eq!(pass.deleted.checkpoint_records, 1);
+    assert!(!pass.retention_degraded);
+    assert!(
+        crate::checkpoint::load_checkpoint_record(store, namespace_id, checkpoint_id)
+            .await
+            .expect("read record")
+            .is_none(),
+        "the released record goes on the pass that decides it"
+    );
+    let basis = crate::checkpoint::load_namespace_manifest_envelope(
+        store,
+        namespace_id,
+        manifest_object_id,
+    )
+    .await
+    .expect("the basis manifest survives its record");
+    for descriptor in &basis.payload.segments {
+        assert!(
+            store
+                .head(&metadata_segment_object_key(descriptor))
+                .await
+                .expect("head segment")
+                .is_some(),
+            "the basis segments survive the record too"
+        );
+    }
+}
+
+/// The cascade's second half: one more pass finds the basis unreferenced and
+/// aged, and reaps it.
+async fn assert_basis_reaped(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    pass: &GcResponse,
+    manifest_object_id: &ManifestObjectId,
+) {
+    assert!(
+        pass.deleted.manifests >= 1,
+        "the basis manifest is reaped once its record is gone"
+    );
+    assert!(crate::checkpoint::load_namespace_manifest_envelope(
+        store,
+        namespace_id,
+        manifest_object_id
+    )
+    .await
+    .is_err());
+}
+
 #[tokio::test]
 async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
+    assert_a_dead_records_cascade(None).await;
+}
+
+/// The same cascade with the sweep re-collecting the live set after every
+/// single decision, which is the path a pass with more candidates than one
+/// chunk takes.
+#[tokio::test]
+async fn a_chunked_sweep_reaches_the_same_dead_record_cascade() {
+    assert_a_dead_records_cascade(Some(1)).await;
+}
+
+async fn assert_a_dead_records_cascade(reverify_chunk: Option<usize>) {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -2875,56 +2952,30 @@ async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
         .expect("mark first dead");
 
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
-    let first_pass = gc_namespace(&store, &namespace_id, &config(), &aged)
+    let first_pass = gc_pass(&store, &namespace_id, &config(), &aged, reverify_chunk)
         .await
         .expect("first gc pass");
-
-    // Pass one deletes the dead record but the record still rooted its
-    // basis, so the referenced manifest and segments survive the pass.
-    assert_eq!(first_pass.deleted.checkpoint_records, 1);
-    assert!(!first_pass.retention_degraded);
-    assert!(
-        crate::checkpoint::load_checkpoint_record(&store, &namespace_id, &first.checkpoint_id)
-            .await
-            .expect("read record")
-            .is_none()
-    );
-    let basis = crate::checkpoint::load_namespace_manifest_envelope(
+    assert_record_reaped_and_basis_kept(
         &store,
         &namespace_id,
+        &first_pass,
+        &first.checkpoint_id,
         &first_record.manifest.manifest_object_id,
     )
-    .await
-    .expect("dead basis manifest survives its record");
-    for descriptor in &basis.payload.segments {
-        assert!(
-            store
-                .head(&metadata_segment_object_key(descriptor))
-                .await
-                .expect("head segment")
-                .is_some(),
-            "dead basis segment survives its record"
-        );
-    }
+    .await;
 
-    // Pass two finds the basis unreferenced and aged, and reaps it.
-    let second_pass = gc_namespace(&store, &namespace_id, &config(), &aged)
+    let second_pass = gc_pass(&store, &namespace_id, &config(), &aged, reverify_chunk)
         .await
         .expect("second gc pass");
-    assert!(
-        second_pass.deleted.manifests >= 1,
-        "dead basis manifest reaped once its record is gone"
-    );
-    assert!(crate::checkpoint::load_namespace_manifest_envelope(
+    assert_basis_reaped(
         &store,
         &namespace_id,
+        &second_pass,
         &first_record.manifest.manifest_object_id,
     )
-    .await
-    .is_err());
+    .await;
     stat_root(&store, &namespace_id).await;
 }
-
 #[tokio::test]
 async fn gc_retains_unrecognized_manifest_keys() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3091,16 +3142,35 @@ async fn gc_reaps_released_checkpoints_before_their_basis_across_passes() {
             .expect("repeat release");
     assert_eq!(repeat_release.checkpoint_id, pinned.checkpoint_id);
 
+    let pinned_record =
+        crate::checkpoint::load_checkpoint_record(&store, &namespace_id, &pinned.checkpoint_id)
+            .await
+            .expect("read pinned record")
+            .expect("pinned record exists")
+            .state;
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
     let first_pass = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect("first gc pass");
-    assert_eq!(first_pass.deleted.checkpoint_records, 1);
+    assert_record_reaped_and_basis_kept(
+        &store,
+        &namespace_id,
+        &first_pass,
+        &pinned.checkpoint_id,
+        &pinned_record.manifest.manifest_object_id,
+    )
+    .await;
 
     let second_pass = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect("second gc pass");
-    assert!(second_pass.deleted.manifests >= 1);
+    assert_basis_reaped(
+        &store,
+        &namespace_id,
+        &second_pass,
+        &pinned_record.manifest.manifest_object_id,
+    )
+    .await;
     // Releasing an already-reaped record stays idempotent success.
     let after_reap =
         crate::checkpoint::release_checkpoint(&store, &namespace_id, &pinned.checkpoint_id, &setup)
@@ -3365,19 +3435,24 @@ async fn gc_reaps_expired_checkpoints_before_their_basis_across_passes() {
             released_at_ms: expired.now_ms
         }
     );
+    let expiring_record =
+        crate::checkpoint::load_checkpoint_record(&store, &namespace_id, &expiring.checkpoint_id)
+            .await
+            .expect("read expiring record")
+            .expect("the released record is still there to read")
+            .state;
     let aged_out = context(expired.now_ms + GRACE_MS);
     let second_pass = gc_namespace(&store, &namespace_id, &config(), &aged_out)
         .await
         .expect("second post-expiry pass");
-    assert_eq!(second_pass.deleted.checkpoint_records, 1);
-    assert!(crate::checkpoint::load_checkpoint_record(
+    assert_record_reaped_and_basis_kept(
         &store,
         &namespace_id,
-        &expiring.checkpoint_id
+        &second_pass,
+        &expiring.checkpoint_id,
+        &expiring_record.manifest.manifest_object_id,
     )
-    .await
-    .expect("read record")
-    .is_none());
+    .await;
     // The unexpired pin — same basis, different owner — still roots it.
     let survivor =
         crate::checkpoint::load_checkpoint_record(&store, &namespace_id, &lasting.checkpoint_id)
@@ -3442,22 +3517,20 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
         .await
         .expect("first gc pass");
     assert_eq!(first_pass.deleted.checkpoint_records, 1);
+
+    // The pass that reaps unreferenced bases runs and finds none, because
+    // the keeper still roots the shared one.
     let second_pass = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect("second gc pass");
-    let _ = second_pass;
-    assert!(
-        crate::checkpoint::load_checkpoint_record(&store, &namespace_id, &first.checkpoint_id)
-            .await
-            .expect("read keeper record")
-            .is_some(),
-        "the surviving owner's record stays"
-    );
+    assert_eq!(second_pass.deleted.manifests, 0);
+    assert_eq!(second_pass.deleted.checkpoint_records, 0);
+
     let keeper =
         crate::checkpoint::load_checkpoint_record(&store, &namespace_id, &first.checkpoint_id)
             .await
             .expect("read keeper record")
-            .expect("keeper record exists")
+            .expect("the surviving owner's record stays")
             .state;
     assert!(
         crate::checkpoint::load_namespace_manifest_envelope(
@@ -3620,39 +3693,43 @@ async fn gc_releases_fork_checkpoints_of_terminally_deleted_targets_across_passe
     let second_pass = gc_namespace(&store, &source, &config(), &aged_out)
         .await
         .expect("second gc pass");
-    assert_eq!(second_pass.deleted.checkpoint_records, 1);
-    assert!(
-        crate::checkpoint::load_namespace_manifest_envelope(
-            &store,
-            &source,
-            &fork_record.manifest.manifest_object_id,
-        )
-        .await
-        .is_ok(),
-        "basis survives the pass that deletes its record"
-    );
+    assert_record_reaped_and_basis_kept(
+        &store,
+        &source,
+        &second_pass,
+        &fork_record.checkpoint_id,
+        &fork_record.manifest.manifest_object_id,
+    )
+    .await;
 
     // Pass three reaps the unreferenced basis.
     let third_pass = gc_namespace(&store, &source, &config(), &aged_out)
         .await
         .expect("third gc pass");
-    assert!(third_pass.deleted.manifests >= 1);
-    assert!(crate::checkpoint::load_namespace_manifest_envelope(
+    assert_basis_reaped(
         &store,
         &source,
+        &third_pass,
         &fork_record.manifest.manifest_object_id,
     )
-    .await
-    .is_err());
+    .await;
     stat_root(&store, &source).await;
 }
 
+/// The fork target's head decides whether the source's fork record still has
+/// an owner. Bytes that do not decode fail the source's pass; a head the
+/// store will not read leaves the record where it was.
 #[tokio::test]
-async fn gc_surfaces_a_corrupt_fork_target_head() {
+async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains_the_record() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let source = NamespaceId::parse("source").expect("namespace id");
     let clone = NamespaceId::parse("clone").expect("namespace id");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::exact(wal_head(&clone)),
+        OperationClass::Read,
+        InjectedError::Transport("target head timed out".to_owned()),
+    );
     let setup = context(1_000);
     bootstrap_namespace(&store, &source, &setup, false)
         .await
@@ -3661,43 +3738,10 @@ async fn gc_surfaces_a_corrupt_fork_target_head() {
     fork_namespace(&store, &source, &clone, &setup)
         .await
         .expect("fork");
-    store
-        .put_overwrite(&wal_head(&clone), Bytes::from_static(b"not json"))
-        .await
-        .expect("corrupt target head");
-    let before = namespace_keys(&store, &source).await;
+    let fork_record = read_fork_record(store.inner(), &source).await;
 
-    let error = gc_namespace(&store, &source, &config(), &setup)
-        .await
-        .expect_err("a corrupt target head must fail the source pass");
-    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
-    assert!(error.message().contains(&wal_head(&clone)));
-    assert_eq!(namespace_keys(&store, &source).await, before);
-}
-
-#[tokio::test]
-async fn gc_retains_a_fork_checkpoint_when_the_target_head_does_not_read() {
-    let temp_dir = tempdir().expect("tempdir");
-    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
-    let source = NamespaceId::parse("source").expect("namespace id");
-    let clone = NamespaceId::parse("clone").expect("namespace id");
-    let setup = context(1_000);
-    bootstrap_namespace(&inner, &source, &setup, false)
-        .await
-        .expect("bootstrap");
-    write_test_file(&inner, &source, "/docs/one.txt", "gc-one", &setup).await;
-    fork_namespace(&inner, &source, &clone, &setup)
-        .await
-        .expect("fork");
-    let fork_record = read_fork_record(&inner, &source).await;
-    let store = FailStore::new(
-        inner,
-        KeyPredicate::exact(wal_head(&clone)),
-        OperationClass::Read,
-        InjectedError::Transport("target head timed out".to_owned()),
-    );
+    // An unreadable target says nothing about whether the fork still lives.
     store.fail_all();
-
     let report = gc_namespace(&store, &source, &config(), &setup)
         .await
         .expect("an unreadable target is retained conservatively");
@@ -3706,6 +3750,20 @@ async fn gc_retains_a_fork_checkpoint_when_the_target_head_does_not_read() {
         checkpoint_lifecycle(store.inner(), &source, &fork_record.checkpoint_id).await,
         CheckpointStatus::Active {}
     );
+
+    // A head that is not a head at all is corruption.
+    store.clear();
+    store
+        .put_overwrite(&wal_head(&clone), Bytes::from_static(b"not json"))
+        .await
+        .expect("corrupt target head");
+    let before = namespace_keys(store.inner(), &source).await;
+    let error = gc_namespace(&store, &source, &config(), &setup)
+        .await
+        .expect_err("a corrupt target head must fail the source pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(error.message().contains(&wal_head(&clone)));
+    assert_eq!(namespace_keys(store.inner(), &source).await, before);
 }
 
 #[tokio::test]
@@ -3850,7 +3908,14 @@ async fn gc_releases_abandoned_fork_checkpoints_once_the_lease_expires() {
     let reaping = gc_namespace(&store, &source, &tight, &aged_out)
         .await
         .expect("gc past the release grace window");
-    assert_eq!(reaping.deleted.checkpoint_records, 1);
+    assert_record_reaped_and_basis_kept(
+        &store,
+        &source,
+        &reaping,
+        &abandoned.checkpoint_id,
+        &fork_record.manifest.manifest_object_id,
+    )
+    .await;
     stat_root(&store, &source).await;
 }
 
@@ -3899,52 +3964,11 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
         .expect("forked file readable");
 }
 
+/// One record, two ways it can be unusable. Corrupt bytes are a namespace
+/// the pass must not touch; an unreadable store is a transport answer the
+/// pass must not read as a verdict. Both fail the pass and delete nothing.
 #[tokio::test]
-async fn gc_fails_the_pass_on_a_corrupt_checkpoint_record() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-    let setup = context(1_000);
-    bootstrap_namespace(&store, &namespace_id, &setup, false)
-        .await
-        .expect("bootstrap");
-    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
-    create_checkpoint(&store, &namespace_id, &setup)
-        .await
-        .expect("checkpoint");
-
-    let record_keys = store
-        .list_prefix(&checkpoint_prefix(&namespace_id))
-        .await
-        .expect("list checkpoints");
-    let corrupt_key = record_keys
-        .first()
-        .expect("the checkpoint wrote a record")
-        .clone();
-    store
-        .put_overwrite(&corrupt_key, Bytes::from_static(b"not json"))
-        .await
-        .expect("corrupt record");
-
-    let before = namespace_keys(&store, &namespace_id).await;
-    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
-    let error = gc_namespace(&store, &namespace_id, &config(), &aged)
-        .await
-        .expect_err("a corrupt record fails the pass");
-    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
-    assert!(
-        error.message().contains(&corrupt_key),
-        "the error names the object: {error}"
-    );
-    assert_eq!(
-        namespace_keys(&store, &namespace_id).await,
-        before,
-        "a failed pass deletes nothing"
-    );
-}
-
-#[tokio::test]
-async fn gc_fails_the_pass_when_a_checkpoint_record_does_not_read() {
+async fn a_corrupt_checkpoint_record_and_an_unreadable_one_both_fail_the_pass() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let store = FailStore::new(
@@ -3962,19 +3986,19 @@ async fn gc_fails_the_pass_when_a_checkpoint_record_does_not_read() {
         .await
         .expect("checkpoint");
 
-    let record_keys = store
+    let record_key = store
         .inner()
         .list_prefix(&checkpoint_prefix(&namespace_id))
         .await
-        .expect("list checkpoints");
-    let record_key = record_keys
+        .expect("list checkpoints")
         .first()
         .expect("the checkpoint wrote a record")
         .clone();
     let before = namespace_keys(store.inner(), &namespace_id).await;
     let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
-    store.fail_all();
 
+    // A record the store will not read is retryable, not a verdict.
+    store.fail_all();
     let error = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect_err("a record the store will not read fails the pass");
@@ -3988,13 +4012,43 @@ async fn gc_fails_the_pass_when_a_checkpoint_record_does_not_read() {
         before,
         "a failed pass deletes nothing"
     );
+
+    // Bytes that are not a record at all are terminal corruption.
+    store.clear();
+    store
+        .put_overwrite(&record_key, Bytes::from_static(b"not json"))
+        .await
+        .expect("corrupt record");
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+    let error = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect_err("a corrupt record fails the pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(
+        error.message().contains(&record_key),
+        "the error names the object: {error}"
+    );
+    assert_eq!(
+        namespace_keys(store.inner(), &namespace_id).await,
+        before,
+        "a failed pass deletes nothing"
+    );
 }
 
+/// The reference anchor is what dates every object the pass considers. A
+/// manifest that does not decode has to surface as corruption rather than
+/// degrade to "no anchor"; a manifest the store will not read is exactly the
+/// case where "no anchor" is the safe answer.
 #[tokio::test]
-async fn corrupt_reference_anchor_manifest_fails_instead_of_becoming_missing() {
+async fn a_corrupt_reference_anchor_fails_and_an_unreadable_one_reads_as_missing() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_id)),
+        OperationClass::Read,
+        InjectedError::Transport("reference manifest timed out".to_owned()),
+    );
     let setup = context(1_000);
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
@@ -4003,7 +4057,18 @@ async fn corrupt_reference_anchor_manifest_fails_instead_of_becoming_missing() {
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("checkpoint");
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+
+    store.fail_all();
+    let mut budget = PassBudget::new(None);
+    let anchor = select_reference_anchor(&store, &namespace_id, GRACE_MS, &mut budget, &aged)
+        .await
+        .expect("a store failure keeps a missing anchor");
+    assert!(matches!(anchor, ReferenceAnchor::Missing));
+
+    store.clear();
     let manifest_key = store
+        .inner()
         .list_prefix(&metadata_manifest_prefix(&namespace_id))
         .await
         .expect("list manifests")
@@ -4014,9 +4079,10 @@ async fn corrupt_reference_anchor_manifest_fails_instead_of_becoming_missing() {
         .put_overwrite(&manifest_key, Bytes::from_static(b"not json"))
         .await
         .expect("corrupt reference manifest");
-    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    // Overwriting the object refreshed its age, so the clock the anchor is
+    // selected against has to move past it again.
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
     let mut budget = PassBudget::new(None);
-
     let error = select_reference_anchor(&store, &namespace_id, GRACE_MS, &mut budget, &aged)
         .await
         .expect_err("a corrupt reference anchor must surface");
@@ -4027,85 +4093,11 @@ async fn corrupt_reference_anchor_manifest_fails_instead_of_becoming_missing() {
     assert!(error.message().contains(&manifest_key));
 }
 
+/// A rooted manifest that does not decode is corruption the pass fails on;
+/// one the store will not read is a degraded pass that reclaims nothing.
+/// The difference is the whole retention policy for unreadable roots.
 #[tokio::test]
-async fn unreadable_reference_anchor_manifest_remains_conservative() {
-    let temp_dir = tempdir().expect("tempdir");
-    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-    let setup = context(1_000);
-    bootstrap_namespace(&inner, &namespace_id, &setup, false)
-        .await
-        .expect("bootstrap");
-    write_test_file(&inner, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
-    create_checkpoint(&inner, &namespace_id, &setup)
-        .await
-        .expect("checkpoint");
-    let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
-    let store = FailStore::new(
-        inner,
-        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_id)),
-        OperationClass::Read,
-        InjectedError::Transport("reference manifest timed out".to_owned()),
-    );
-    store.fail_all();
-    let mut budget = PassBudget::new(None);
-
-    let anchor = select_reference_anchor(&store, &namespace_id, GRACE_MS, &mut budget, &aged)
-        .await
-        .expect("a store failure keeps a missing anchor");
-    assert!(matches!(anchor, ReferenceAnchor::Missing));
-}
-
-#[tokio::test]
-async fn gc_fails_the_pass_on_a_corrupt_root_manifest() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-    let setup = context(1_000);
-    bootstrap_namespace(&store, &namespace_id, &setup, false)
-        .await
-        .expect("bootstrap");
-    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
-    create_checkpoint(&store, &namespace_id, &setup)
-        .await
-        .expect("checkpoint");
-
-    let manifest_keys = store
-        .list_prefix(&metadata_manifest_prefix(&namespace_id))
-        .await
-        .expect("list manifests");
-    assert!(
-        !manifest_keys.is_empty(),
-        "the checkpoint published a manifest"
-    );
-    for key in &manifest_keys {
-        store
-            .put_overwrite(key, Bytes::from_static(b"not json"))
-            .await
-            .expect("corrupt manifest");
-    }
-
-    let before = namespace_keys(&store, &namespace_id).await;
-    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
-    let error = gc_namespace(&store, &namespace_id, &config(), &aged)
-        .await
-        .expect_err("a corrupt root manifest fails the pass");
-    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
-    assert!(
-        manifest_keys
-            .iter()
-            .any(|key| error.message().contains(key)),
-        "the error names the object: {error}"
-    );
-    assert_eq!(
-        namespace_keys(&store, &namespace_id).await,
-        before,
-        "a failed pass deletes nothing"
-    );
-}
-
-#[tokio::test]
-async fn gc_degrades_when_a_root_manifest_does_not_read() {
+async fn a_corrupt_root_manifest_fails_the_pass_and_an_unreadable_one_degrades_it() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let store = FailStore::new(
@@ -4123,10 +4115,20 @@ async fn gc_degrades_when_a_root_manifest_does_not_read() {
         .await
         .expect("checkpoint");
 
+    let manifest_keys = store
+        .inner()
+        .list_prefix(&metadata_manifest_prefix(&namespace_id))
+        .await
+        .expect("list manifests");
+    assert!(
+        !manifest_keys.is_empty(),
+        "the checkpoint published a manifest"
+    );
     let before = namespace_keys(store.inner(), &namespace_id).await;
     let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
-    store.fail_all();
 
+    // A read failure degrades the pass instead of failing it.
+    store.fail_all();
     let report = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect("a read failure degrades the pass instead of failing it");
@@ -4141,6 +4143,31 @@ async fn gc_degrades_when_a_root_manifest_does_not_read() {
         namespace_keys(store.inner(), &namespace_id).await,
         before,
         "a degraded pass reclaims nothing in the affected families"
+    );
+
+    // Bytes that do not decode fail the pass instead.
+    store.clear();
+    for key in &manifest_keys {
+        store
+            .put_overwrite(key, Bytes::from_static(b"not json"))
+            .await
+            .expect("corrupt manifest");
+    }
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+    let error = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect_err("a corrupt root manifest fails the pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(
+        manifest_keys
+            .iter()
+            .any(|key| error.message().contains(key)),
+        "the error names the object: {error}"
+    );
+    assert_eq!(
+        namespace_keys(store.inner(), &namespace_id).await,
+        before,
+        "a failed pass deletes nothing"
     );
 }
 
@@ -4182,41 +4209,6 @@ async fn gc_retains_everything_without_provider_timestamps() {
 }
 
 #[tokio::test]
-async fn gc_sweep_reverification_chunks_preserve_outcomes() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-    let setup = context(1_000);
-    bootstrap_namespace(&store, &namespace_id, &setup, false)
-        .await
-        .expect("bootstrap");
-    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
-    let first = create_checkpoint(&store, &namespace_id, &setup)
-        .await
-        .expect("first checkpoint");
-    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
-    create_checkpoint(&store, &namespace_id, &setup)
-        .await
-        .expect("second checkpoint");
-    release_checkpoint_record(&store, &namespace_id, &first.checkpoint_id, setup.now_ms)
-        .await
-        .expect("mark first dead");
-
-    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
-    let first_pass = gc_namespace_with_reverify_chunk(&store, &namespace_id, &config(), &aged, 1)
-        .await
-        .expect("first gc pass");
-    assert_eq!(first_pass.deleted.checkpoint_records, 1);
-    assert!(!first_pass.retention_degraded);
-
-    let second_pass = gc_namespace_with_reverify_chunk(&store, &namespace_id, &config(), &aged, 1)
-        .await
-        .expect("second gc pass");
-    assert!(second_pass.deleted.manifests >= 1);
-    stat_root(&store, &namespace_id).await;
-}
-
-#[tokio::test]
 async fn gc_of_an_absent_namespace_lists_and_deletes_nothing() {
     let temp_dir = tempdir().expect("tempdir");
     let inner = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -4233,48 +4225,6 @@ async fn gc_of_an_absent_namespace_lists_and_deletes_nothing() {
     assert_eq!(report, GcResponse::empty(namespace_id.clone()));
     assert_eq!(store.lists.load(Ordering::SeqCst), 0);
     assert_eq!(store.deletes.load(Ordering::SeqCst), 0);
-}
-
-#[tokio::test]
-async fn gc_fails_the_pass_when_a_fork_pin_record_is_corrupt() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let source = NamespaceId::parse("source").expect("namespace id");
-    let clone = NamespaceId::parse("clone").expect("namespace id");
-    let setup = context(1_000);
-    bootstrap_namespace(&store, &source, &setup, false)
-        .await
-        .expect("bootstrap");
-    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
-    fork_namespace(&store, &source, &clone, &setup)
-        .await
-        .expect("fork");
-
-    let record_keys = store
-        .list_prefix(&checkpoint_prefix(&source))
-        .await
-        .expect("list checkpoints");
-    let corrupt_key = record_keys.first().expect("the fork pinned").clone();
-    store
-        .put_overwrite(&corrupt_key, Bytes::from_static(b"not json"))
-        .await
-        .expect("corrupt record");
-
-    let before = namespace_keys(&store, &source).await;
-    let aged = context(now_after_newest_object(&store, &source, GRACE_MS + 1).await);
-    let error = gc_namespace(&store, &source, &config(), &aged)
-        .await
-        .expect_err("a corrupt pin record fails the pass");
-    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
-    assert!(
-        error.message().contains(&corrupt_key),
-        "the error names the object: {error}"
-    );
-    assert_eq!(
-        namespace_keys(&store, &source).await,
-        before,
-        "a failed pass deletes nothing"
-    );
 }
 
 async fn add_bounded_gc_fixture(

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -442,8 +442,7 @@ fn find_commit_receipt_returns_latest_matching_receipt() {
 }
 
 #[test]
-fn revisions_advance_watermark_and_receipt_index() {
-    let receipt_commit_id = CommitId::parse("indexed-commit").expect("valid commit id");
+fn every_row_kind_advances_the_indexed_watermark() {
     let content_ref = ContentRef::blob_v1(ContentId::generate(), b"first revision bytes");
     let replacement_ref = ContentRef::blob_v1(ContentId::generate(), b"second revision bytes");
 
@@ -464,7 +463,7 @@ fn revisions_advance_watermark_and_receipt_index() {
         committed_at_ms: 4_200,
         committed_by: actor(),
         revision_delta_index: 0,
-        content_ref: content_ref.clone(),
+        content_ref,
     });
     builder.push_revision(RevisionRecord {
         inode_id: InodeId(7),
@@ -474,10 +473,10 @@ fn revisions_advance_watermark_and_receipt_index() {
         committed_at_ms: 4_200,
         committed_by: actor(),
         revision_delta_index: 0,
-        content_ref: replacement_ref.clone(),
+        content_ref: replacement_ref,
     });
     builder.push_commit_receipt(CommitReceiptRecord {
-        commit_id: receipt_commit_id.clone(),
+        commit_id: CommitId::parse("indexed-commit").expect("valid commit id"),
         committed_by: loonfs_test_support::test_actor(),
         semantic_commit_fingerprint: "fingerprint".to_owned(),
         committed_seq: ChangeSeq(3),
@@ -486,32 +485,10 @@ fn revisions_advance_watermark_and_receipt_index() {
     });
     let metadata_state = builder.finish();
 
+    // Every kind of row counts, and the watermark is the highest sequence
+    // any of them carries.
     assert_eq!(metadata_state.row_count(), 4);
-    assert!(metadata_state.decoded_bytes() >= metadata_state.row_count());
     assert_eq!(metadata_state.indexed_seq(), ChangeSeq(3));
-    assert_eq!(
-        metadata_state
-            .revisions()
-            .last()
-            .expect("revision rows")
-            .content_ref,
-        replacement_ref
-    );
-    assert_eq!(
-        metadata_state
-            .find_commit_receipt(&receipt_commit_id)
-            .expect("commit receipt")
-            .committed_seq,
-        ChangeSeq(3)
-    );
-
-    assert_eq!(
-        metadata_state
-            .find_commit_receipt(&receipt_commit_id)
-            .expect("indexed receipt")
-            .semantic_commit_fingerprint,
-        "fingerprint"
-    );
 }
 
 fn attribute_map(entries: &[(&str, &str)]) -> Attributes {
@@ -955,24 +932,39 @@ fn has_visible_children_sees_through_unbinds() {
 
 #[test]
 fn every_absent_visibility_leg_has_its_own_stable_name() {
-    use visibility::AbsentVisibilityLeg;
+    use visibility::AbsentVisibilityLeg::{
+        self, BindingSuperseded, BindingUnbound, ChildInode, ForwardBinding, ParentInode,
+        ParentNotDirectory, ReverseIndex,
+    };
 
-    let legs = [
-        (AbsentVisibilityLeg::ParentInode, "parent_inode"),
-        (
-            AbsentVisibilityLeg::ParentNotDirectory,
-            "parent_not_directory",
-        ),
-        (AbsentVisibilityLeg::ForwardBinding, "forward_binding"),
-        (AbsentVisibilityLeg::BindingUnbound, "binding_unbound"),
-        (AbsentVisibilityLeg::ReverseIndex, "reverse_index"),
-        (AbsentVisibilityLeg::BindingSuperseded, "binding_superseded"),
-        (AbsentVisibilityLeg::ChildInode, "child_inode"),
+    let legs: [AbsentVisibilityLeg; 7] = [
+        ParentInode,
+        ParentNotDirectory,
+        ForwardBinding,
+        BindingUnbound,
+        ReverseIndex,
+        BindingSuperseded,
+        ChildInode,
     ];
 
-    for (leg, name) in legs {
-        assert_eq!(leg.name(), name, "{leg:?} was renamed");
+    // The match below is exhaustive, so a leg added to the enum stops this
+    // test compiling, and the position it has to name is only right if the
+    // list above grew with it. The names themselves are log strings, not a
+    // contract: the test asks that they exist and differ, not what they say.
+    for (position, leg) in legs.into_iter().enumerate() {
+        let listed = match leg {
+            ParentInode => 0,
+            ParentNotDirectory => 1,
+            ForwardBinding => 2,
+            BindingUnbound => 3,
+            ReverseIndex => 4,
+            BindingSuperseded => 5,
+            ChildInode => 6,
+        };
+        assert_eq!(listed, position, "{leg:?} is listed out of order");
+        assert!(!leg.name().is_empty(), "{leg:?} has no name");
     }
-    let names: std::collections::BTreeSet<&str> = legs.iter().map(|(leg, _)| leg.name()).collect();
+
+    let names: std::collections::BTreeSet<&str> = legs.iter().map(|leg| leg.name()).collect();
     assert_eq!(names.len(), legs.len(), "two legs share one name");
 }

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -442,7 +442,7 @@ fn find_commit_receipt_returns_latest_matching_receipt() {
 }
 
 #[test]
-fn every_row_kind_advances_the_indexed_watermark() {
+fn metadata_builder_tracks_the_highest_row_sequence() {
     let content_ref = ContentRef::blob_v1(ContentId::generate(), b"first revision bytes");
     let replacement_ref = ContentRef::blob_v1(ContentId::generate(), b"second revision bytes");
 
@@ -485,8 +485,6 @@ fn every_row_kind_advances_the_indexed_watermark() {
     });
     let metadata_state = builder.finish();
 
-    // Every kind of row counts, and the watermark is the highest sequence
-    // any of them carries.
     assert_eq!(metadata_state.row_count(), 4);
     assert_eq!(metadata_state.indexed_seq(), ChangeSeq(3));
 }
@@ -928,43 +926,4 @@ fn has_visible_children_sees_through_unbinds() {
         !visibility::resolve_in_memory_read(view.has_visible_children(dir))
             .expect("probe emptied directory")
     );
-}
-
-#[test]
-fn every_absent_visibility_leg_has_its_own_stable_name() {
-    use visibility::AbsentVisibilityLeg::{
-        self, BindingSuperseded, BindingUnbound, ChildInode, ForwardBinding, ParentInode,
-        ParentNotDirectory, ReverseIndex,
-    };
-
-    let legs: [AbsentVisibilityLeg; 7] = [
-        ParentInode,
-        ParentNotDirectory,
-        ForwardBinding,
-        BindingUnbound,
-        ReverseIndex,
-        BindingSuperseded,
-        ChildInode,
-    ];
-
-    // The match below is exhaustive, so a leg added to the enum stops this
-    // test compiling, and the position it has to name is only right if the
-    // list above grew with it. The names themselves are log strings, not a
-    // contract: the test asks that they exist and differ, not what they say.
-    for (position, leg) in legs.into_iter().enumerate() {
-        let listed = match leg {
-            ParentInode => 0,
-            ParentNotDirectory => 1,
-            ForwardBinding => 2,
-            BindingUnbound => 3,
-            ReverseIndex => 4,
-            BindingSuperseded => 5,
-            ChildInode => 6,
-        };
-        assert_eq!(listed, position, "{leg:?} is listed out of order");
-        assert!(!leg.name().is_empty(), "{leg:?} has no name");
-    }
-
-    let names: std::collections::BTreeSet<&str> = legs.iter().map(|leg| leg.name()).collect();
-    assert_eq!(names.len(), legs.len(), "two legs share one name");
 }

--- a/crates/loonfs-core/src/recency.rs
+++ b/crates/loonfs-core/src/recency.rs
@@ -162,9 +162,7 @@ mod tests {
         touch(&mut recency, &mut entries, "a");
         assert_eq!(recency.positions(), 1);
 
-        // Under the floor nothing is dropped, so the ghosts stay visible, and
-        // the compaction that eventually runs leaves the one live entry
-        // behind. Where the floor sits is an internal number, not a contract.
+        // Repeated touches create ghosts until compaction leaves the live entry.
         let mut previous = recency.positions();
         let mut compacted = false;
         for _ in 0..1_024 {

--- a/crates/loonfs-core/src/recency.rs
+++ b/crates/loonfs-core/src/recency.rs
@@ -162,7 +162,6 @@ mod tests {
         touch(&mut recency, &mut entries, "a");
         assert_eq!(recency.positions(), 1);
 
-        // Repeated touches create ghosts until compaction leaves the live entry.
         let mut previous = recency.positions();
         let mut compacted = false;
         for _ in 0..1_024 {

--- a/crates/loonfs-core/src/recency.rs
+++ b/crates/loonfs-core/src/recency.rs
@@ -162,13 +162,22 @@ mod tests {
         touch(&mut recency, &mut entries, "a");
         assert_eq!(recency.positions(), 1);
 
-        // Under the floor nothing is dropped, so the ghosts stay visible.
-        for _ in 0..15 {
+        // Under the floor nothing is dropped, so the ghosts stay visible, and
+        // the compaction that eventually runs leaves the one live entry
+        // behind. Where the floor sits is an internal number, not a contract.
+        let mut previous = recency.positions();
+        let mut compacted = false;
+        for _ in 0..1_024 {
             touch(&mut recency, &mut entries, "a");
+            let positions = recency.positions();
+            if positions < previous {
+                assert_eq!(positions, 1, "crossing the floor drops every ghost");
+                compacted = true;
+                break;
+            }
+            assert_eq!(positions, previous + 1, "a ghost stays until compaction");
+            previous = positions;
         }
-        assert_eq!(recency.positions(), 16);
-
-        touch(&mut recency, &mut entries, "a");
-        assert_eq!(recency.positions(), 1, "crossing the floor drops ghosts");
+        assert!(compacted, "the queue must compact within the bound");
     }
 }

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -740,7 +740,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validate_content_ref_accepts_empty_files() {
+    async fn get_durable_content_bytes_accepts_empty_files() {
         let (_temp_dir, store, content_store_id) = test_store();
         let bytes = b"";
         let content_ref = content_ref(bytes);
@@ -1383,28 +1383,6 @@ mod tests {
             ),
             "unexpected verdict: {verdict}"
         );
-    }
-
-    #[tokio::test]
-    async fn a_streamed_read_verifies_a_reference_whose_only_evidence_is_a_crc64nvme() {
-        let (_temp_dir, store, content_store_id) = test_store();
-        let bytes = payload(2 * TEST_CHUNK_BYTES as usize);
-        let content_ref = ContentRef {
-            kind: ContentRefKind::BlobV1,
-            content_id: ContentId::generate(),
-            size_bytes: bytes.len() as u64,
-            checksum: Checksum::crc64nvme(&bytes),
-        };
-        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
-
-        let mut stream = open_stream(&store, &content_store_id, &content_ref)
-            .await
-            .expect("open stream");
-        let mut read = Vec::new();
-        while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
-            read.extend_from_slice(&chunk);
-        }
-        assert_eq!(read, bytes);
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/time.rs
+++ b/crates/loonfs-core/src/time.rs
@@ -36,11 +36,4 @@ mod tests {
             "unexpected error: {error}"
         );
     }
-
-    #[test]
-    fn epoch_and_later_instants_convert_to_milliseconds() {
-        assert_eq!(unix_ms(UNIX_EPOCH).expect("epoch converts"), 0);
-        let later = UNIX_EPOCH + Duration::from_millis(1500);
-        assert_eq!(unix_ms(later).expect("later converts"), 1500);
-    }
 }

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -112,8 +112,7 @@ fn wal_segment_namespace_mismatch_names_record_and_segment_values() {
     let error = prepare_wal_segment(segment_namespace.clone(), WriterEpoch(1), None, &[record])
         .expect_err("namespace mismatch should fail");
 
-    // Both namespaces have to reach the reader; the sentence around them is
-    // not the contract.
+    // Check both namespace IDs without depending on the exact wording.
     let message = error.to_string();
     assert!(
         message.contains(record_namespace.as_str()),
@@ -351,8 +350,7 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
     .await
     .expect_err("missing previous segment link should fail");
 
-    // The segment and the boundary it is missing a link before are the
-    // contract; the derived object key and the prose around them are not.
+    // Check the segment ID and missing boundary without pinning the full message.
     let message = error.to_string();
     assert!(
         message.contains(segment.envelope.payload.segment_id.as_str()),

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -109,12 +109,19 @@ fn wal_segment_namespace_mismatch_names_record_and_segment_values() {
         ChangeSeq(1),
     );
 
-    let error = prepare_wal_segment(segment_namespace, WriterEpoch(1), None, &[record])
+    let error = prepare_wal_segment(segment_namespace.clone(), WriterEpoch(1), None, &[record])
         .expect_err("namespace mismatch should fail");
 
-    assert_eq!(
-        error.to_string(),
-        "WAL segment namespace mismatch: record `record`, segment `segment`"
+    // Both namespaces have to reach the reader; the sentence around them is
+    // not the contract.
+    let message = error.to_string();
+    assert!(
+        message.contains(record_namespace.as_str()),
+        "the error names the record namespace: {message}"
+    );
+    assert!(
+        message.contains(segment_namespace.as_str()),
+        "the error names the segment namespace: {message}"
     );
 }
 
@@ -344,12 +351,16 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
     .await
     .expect_err("missing previous segment link should fail");
 
-    assert_eq!(
-        error.to_string(),
-        format!(
-            "WAL replay validation failed: WAL segment `{}` is missing its previous visible segment link before seq `0`",
-            prepared_segment_key(&segment)
-        )
+    // The segment and the boundary it is missing a link before are the
+    // contract; the derived object key and the prose around them are not.
+    let message = error.to_string();
+    assert!(
+        message.contains(segment.envelope.payload.segment_id.as_str()),
+        "the error names the segment: {message}"
+    );
+    assert!(
+        message.contains("`0`"),
+        "the error names the boundary seq: {message}"
     );
 }
 
@@ -963,28 +974,6 @@ fn tail_count_from_contiguous_hints_covers_the_longest_legal_tail() {
     ))
     .expect("count of empty tail");
     assert_eq!(count, 0);
-}
-
-#[test]
-fn wal_tail_segment_count_is_identical_across_head_hint_reshape() {
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let chain = prepared_unstored_chain(&namespace_id, 4);
-    // Before the reshape this whole tip-inclusive vector lived in
-    // `recent_segments`; afterward its first entry is `visible_wal_tip` and
-    // only the remaining predecessors are hints.
-    let former_tip_inclusive_hints = newest_first_pointers(&chain);
-    let former_public_count =
-        u64::try_from(former_tip_inclusive_hints.len()).expect("test tail count");
-
-    let reshaped_count = count_visible_wal_tail_segments(&tail_count_request(
-        &namespace_id,
-        ChangeSeq(0),
-        ChangeSeq(4),
-        &former_tip_inclusive_hints,
-    ))
-    .expect("count reshaped head");
-
-    assert_eq!(reshaped_count, former_public_count);
 }
 
 #[test]

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -112,7 +112,6 @@ fn wal_segment_namespace_mismatch_names_record_and_segment_values() {
     let error = prepare_wal_segment(segment_namespace.clone(), WriterEpoch(1), None, &[record])
         .expect_err("namespace mismatch should fail");
 
-    // Check both namespace IDs without depending on the exact wording.
     let message = error.to_string();
     assert!(
         message.contains(record_namespace.as_str()),
@@ -350,7 +349,6 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
     .await
     .expect_err("missing previous segment link should fail");
 
-    // Check the segment ID and missing boundary without pinning the full message.
     let message = error.to_string();
     assert!(
         message.contains(segment.envelope.payload.segment_id.as_str()),

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -38,9 +38,7 @@ fn path(value: &str) -> AbsolutePath {
     AbsolutePath::parse(value).expect("valid path")
 }
 
-/// Asserts a planner rejection by its typed variant and its wire code. The
-/// message prose is deliberately not pinned: an edit to the wording is not a
-/// contract change.
+/// Checks the typed error variant and public error code.
 fn assert_invalid_commit_request(error: &CoreError, label: &str) {
     assert!(
         matches!(error, CoreError::InvalidCommitRequest(_)),

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -38,6 +38,17 @@ fn path(value: &str) -> AbsolutePath {
     AbsolutePath::parse(value).expect("valid path")
 }
 
+/// Asserts a planner rejection by its typed variant and its wire code. The
+/// message prose is deliberately not pinned: an edit to the wording is not a
+/// contract change.
+fn assert_invalid_commit_request(error: &CoreError, label: &str) {
+    assert!(
+        matches!(error, CoreError::InvalidCommitRequest(_)),
+        "for `{label}`: {error:?}"
+    );
+    assert_eq!(error.code(), ErrorCode::InvalidRequest, "for `{label}`");
+}
+
 fn key(value: &str) -> AttributeKey {
     AttributeKey::parse(value).expect("valid attribute key")
 }
@@ -297,7 +308,7 @@ async fn an_update_rejects_a_request_that_does_not_describe_one_change() {
     .await
     .expect("seed file");
 
-    let cases: Vec<(&str, FilesystemOperation, &str)> = vec![
+    let cases: Vec<(&str, FilesystemOperation)> = vec![
         (
             "overlap",
             FilesystemOperation::UpdateAttributes {
@@ -307,7 +318,6 @@ async fn an_update_rejects_a_request_that_does_not_describe_one_change() {
                 expected_inode_id: None,
                 expected_attributes_revision_no: None,
             },
-            "both set and removed",
         ),
         (
             "duplicate-remove",
@@ -318,7 +328,6 @@ async fn an_update_rejects_a_request_that_does_not_describe_one_change() {
                 expected_inode_id: None,
                 expected_attributes_revision_no: None,
             },
-            "removed more than once",
         ),
         (
             "empty",
@@ -329,30 +338,23 @@ async fn an_update_rejects_a_request_that_does_not_describe_one_change() {
                 expected_inode_id: None,
                 expected_attributes_revision_no: None,
             },
-            "sets no attribute and removes none",
         ),
         (
             "reserved-set",
             set_attributes("/docs/a.txt", &[("loonfs.kind", "file")]),
-            "system-owned",
         ),
         (
             "reserved-remove",
             remove_attributes("/docs/a.txt", &["loonfs.kind"]),
-            "system-owned",
         ),
     ];
 
-    for (label, operation, expected_message) in cases {
+    for (label, operation) in cases {
         let error = match update(&store, &namespace_id, label, operation, &context).await {
             Ok(_) => panic!("`{label}` must be rejected"),
             Err(error) => error,
         };
-        assert_eq!(error.code(), ErrorCode::InvalidRequest, "for `{label}`");
-        assert!(
-            error.to_string().contains(expected_message),
-            "for `{label}`: {error}"
-        );
+        assert_invalid_commit_request(&error, label);
     }
 }
 
@@ -394,11 +396,7 @@ async fn an_update_that_changes_nothing_is_rejected() {
             Ok(_) => panic!("`{label}` must be rejected"),
             Err(error) => error,
         };
-        assert_eq!(error.code(), ErrorCode::InvalidRequest, "for `{label}`");
-        assert!(
-            error.to_string().contains("unchanged"),
-            "for `{label}`: {error}"
-        );
+        assert_invalid_commit_request(&error, label);
     }
 
     // A first write on an inode that has no attributes is not a no-op even
@@ -749,7 +747,7 @@ async fn attributes_survive_a_flush_and_the_counter_keeps_going() {
     )
     .await
     .expect_err("the flushed map is unchanged by this update");
-    assert!(no_op.to_string().contains("unchanged"), "{no_op}");
+    assert_invalid_commit_request(&no_op, "repeat-after-flush");
 
     update(
         &store,
@@ -816,7 +814,7 @@ async fn a_fork_reads_the_sources_attributes_before_and_after_its_first_flush() 
     )
     .await
     .expect_err("the fork already holds the source's map");
-    assert!(inherited.to_string().contains("unchanged"), "{inherited}");
+    assert_invalid_commit_request(&inherited, "repeat-in-fork");
 
     update(
         &store,
@@ -1016,7 +1014,7 @@ async fn a_delete_keeps_attributes_and_an_undelete_gives_them_back() {
     )
     .await
     .expect_err("undelete revealed the same map");
-    assert!(no_op.to_string().contains("unchanged"), "{no_op}");
+    assert_invalid_commit_request(&no_op, "repeat-after-undelete");
 }
 
 #[tokio::test]
@@ -1230,7 +1228,7 @@ async fn clearing_every_attribute_publishes_the_empty_map() {
     )
     .await
     .expect_err("the map is already empty");
-    assert!(no_op.to_string().contains("unchanged"), "{no_op}");
+    assert_invalid_commit_request(&no_op, "clear-again");
 
     // A cleared map is a real state that survives a flush.
     namespace_engine(&store, &namespace_id, &context)

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -38,7 +38,6 @@ fn path(value: &str) -> AbsolutePath {
     AbsolutePath::parse(value).expect("valid path")
 }
 
-/// Checks the typed error variant and public error code.
 fn assert_invalid_commit_request(error: &CoreError, label: &str) {
     assert!(
         matches!(error, CoreError::InvalidCommitRequest(_)),

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -12,8 +12,8 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_api::{
     v0::{FilesystemChange, UploadSessionStatus},
-    AbsolutePath, ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, DisplayName,
-    InodeId, NamespaceId, RevisionNo,
+    AbsolutePath, ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeId,
+    NamespaceId, RevisionNo,
 };
 use loonfs_core::content::{
     mint_content_token, store_bytes_as_content, verify_content_token, ContentTokenError,
@@ -140,8 +140,10 @@ fn commit_id(value: &str) -> CommitId {
     CommitId::parse(value).expect("valid commit id")
 }
 
+/// One unadmitted content reference fails on its own, and two candidates that
+/// share one unadmitted reference both fail. Neither shape reads the blob.
 #[tokio::test]
-async fn path_put_file_without_admission_fails_without_reading_content() {
+async fn unadmitted_content_fails_every_candidate_without_being_read() {
     let temp_dir = tempdir().expect("tempdir");
     let store = content_blob_counting_store(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -162,7 +164,7 @@ async fn path_put_file_without_admission_fails_without_reading_content() {
             commit_id("put-cold-content"),
             loonfs_test_support::test_actor(),
             None,
-            put_file("/docs/hello.txt", content.into_content_ref()),
+            put_file("/docs/hello.txt", content.content_ref().clone()),
         ))],
         &context,
     )
@@ -176,21 +178,6 @@ async fn path_put_file_without_admission_fails_without_reading_content() {
         ErrorCode::ContentNotPrepared
     );
     assert_eq!(store.count(OperationClass::Read), 0);
-}
-
-#[tokio::test]
-async fn path_batch_rejects_repeated_unadmitted_content_without_reading_it() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = content_blob_counting_store(temp_dir.path());
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = mutation_context();
-
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    let content = store_bytes_as_content(&store, &namespace_id, b"shared")
-        .await
-        .expect("stage content");
 
     store.reset();
     let responses = publish_namespace_commits_batch(
@@ -469,12 +456,6 @@ async fn a_rejected_batch_candidate_does_not_consume_inode_ids() {
     resolve_path(&store, &namespace_id, "/discarded")
         .await
         .expect_err("rejected candidate publishes nothing");
-}
-
-#[tokio::test]
-async fn mutation_paths_reject_invalid_display_names() {
-    assert!(DisplayName::parse("a/b").is_err());
-    assert!(DisplayName::parse(".").is_err());
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -140,8 +140,6 @@ fn commit_id(value: &str) -> CommitId {
     CommitId::parse(value).expect("valid commit id")
 }
 
-/// One unadmitted content reference fails on its own, and two candidates that
-/// share one unadmitted reference both fail. Neither shape reads the blob.
 #[tokio::test]
 async fn unadmitted_content_fails_every_candidate_without_being_read() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -333,39 +333,6 @@ async fn metadata_queries_do_not_get_content_blobs_but_file_reads_do_once() {
 }
 
 #[tokio::test]
-async fn query_driven_reads_use_initial_manifest_with_wal_overlay() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let context = mutation_context();
-    let namespace_id = namespace_id("demo");
-
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    put_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/file.txt",
-        b"file",
-        DestinationBehavior::NoReplace,
-        &context,
-        Some("put-file"),
-    )
-    .await
-    .expect("put file");
-
-    let stat = resolve_path_latest(&store, &namespace_id, "/docs/file.txt")
-        .await
-        .expect("stat with manifest");
-    let list = list_path_latest(&store, &namespace_id, "/docs")
-        .await
-        .expect("list with manifest");
-
-    assert_eq!(stat.size_bytes(), Some(4));
-    assert_eq!(list.len(), 1);
-}
-
-#[tokio::test]
 async fn query_driven_stat_and_list_use_metadata_view_with_delta_run_and_wal_overlay() {
     let temp_dir = tempdir().expect("tempdir");
     let store = content_blob_counting_store(temp_dir.path());
@@ -1088,88 +1055,11 @@ async fn name_key_stays_typed_through_planning_and_fingerprint() {
         )));
 }
 
+/// The batch resolves a move against the put before it, and the ladder keeps
+/// climbing across the single commits that follow: put, move, copy, delete at
+/// sequences one through four.
 #[tokio::test]
-async fn path_intents_cover_basic_mutations() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-
-    let content = store_bytes_as_content(&store, &namespace_id, b"hello")
-        .await
-        .expect("stage content");
-    let put = submit_operation(
-        &store,
-        &namespace_id,
-        CommitId::parse("put-path").expect("valid commit id"),
-        FilesystemOperation::PutFile {
-            path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-            content_ref: content.content_ref().clone(),
-            behavior: DestinationBehavior::NoReplace,
-            expected_revision_no: None,
-        },
-        &context,
-    )
-    .await
-    .expect("put path");
-    assert_eq!(put.committed_seq, ChangeSeq(1));
-
-    let moved = submit_operation(
-        &store,
-        &namespace_id,
-        CommitId::parse("move-path").expect("valid commit id"),
-        FilesystemOperation::MovePath {
-            from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-            to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
-            behavior: DestinationBehavior::NoReplace,
-        },
-        &context,
-    )
-    .await
-    .expect("move path");
-    assert_eq!(moved.committed_seq, ChangeSeq(2));
-
-    let copied = submit_operation(
-        &store,
-        &namespace_id,
-        CommitId::parse("copy-path").expect("valid commit id"),
-        FilesystemOperation::CopyPath {
-            from_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
-            to_path: AbsolutePath::parse("/docs/c.txt").expect("path"),
-            behavior: DestinationBehavior::NoReplace,
-        },
-        &context,
-    )
-    .await
-    .expect("copy path");
-    assert_eq!(copied.committed_seq, ChangeSeq(3));
-
-    let deleted = submit_operation(
-        &store,
-        &namespace_id,
-        CommitId::parse("delete-path").expect("valid commit id"),
-        FilesystemOperation::DeletePath {
-            path: AbsolutePath::parse("/docs/b.txt").expect("path"),
-            behavior: DeleteDirectoryBehavior::NonRecursive,
-            expected_inode_id: None,
-        },
-        &context,
-    )
-    .await
-    .expect("delete path");
-    assert_eq!(deleted.committed_seq, ChangeSeq(4));
-
-    let copied_bytes = read_file_bytes(&store, &namespace_id, "/docs/c.txt")
-        .await
-        .expect("read copied file");
-    assert_eq!(copied_bytes.bytes, b"hello");
-}
-
-#[tokio::test]
-async fn path_intents_in_one_batch_see_tentative_state() {
+async fn path_intents_in_one_batch_see_tentative_state_and_continue_the_seq_ladder() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1241,48 +1131,34 @@ async fn path_intents_in_one_batch_see_tentative_state() {
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
     assert_eq!(segment.payload.records.len(), 2);
-}
 
-#[tokio::test]
-async fn move_path_into_occupied_target_is_path_conflict() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
+    let copied = copy_file_path(
+        &store,
+        &namespace_id,
+        "/docs/b.txt",
+        "/docs/c.txt",
+        &context,
+        Some("copy-path"),
+    )
+    .await
+    .expect("copy path");
+    assert_eq!(copied.committed_seq, ChangeSeq(3));
+
+    let deleted = delete_path_non_recursive(
+        &store,
+        &namespace_id,
+        "/docs/b.txt",
+        &context,
+        Some("delete-path"),
+    )
+    .await
+    .expect("delete path");
+    assert_eq!(deleted.committed_seq, ChangeSeq(4));
+
+    let copied_bytes = read_file_bytes(&store, &namespace_id, "/docs/c.txt")
         .await
-        .expect("bootstrap namespace");
-    write_file_bytes(
-        &store,
-        &namespace_id("demo"),
-        "/docs/a.txt",
-        b"alpha",
-        &context,
-        Some("seed-docs"),
-    )
-    .await
-    .expect("seed docs");
-    write_file_bytes(
-        &store,
-        &namespace_id("demo"),
-        "/tmp/a.txt",
-        b"tmp-a",
-        &context,
-        Some("seed-tmp"),
-    )
-    .await
-    .expect("seed tmp");
-
-    let error = move_path(
-        &store,
-        &namespace_id("demo"),
-        "/tmp/a.txt",
-        "/docs/a.txt",
-        &context,
-        Some("move-conflict"),
-    )
-    .await
-    .expect_err("move conflict");
-    assert_eq!(error.code(), ErrorCode::PathConflict);
+        .expect("read copied file");
+    assert_eq!(copied_bytes.bytes, b"hello");
 }
 
 #[tokio::test]
@@ -1337,38 +1213,6 @@ async fn move_path_respells_the_same_slot_without_a_conflict() {
     .await
     .expect_err("unchanged spelling");
     assert_eq!(error.code(), ErrorCode::PathConflict);
-}
-
-#[tokio::test]
-async fn move_path_directory_cycle_is_would_cycle() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
-        .await
-        .expect("bootstrap namespace");
-    write_file_bytes(
-        &store,
-        &namespace_id("demo"),
-        "/docs/archive/leaf.txt",
-        b"leaf",
-        &context,
-        Some("seed-cycle"),
-    )
-    .await
-    .expect("seed cycle dirs");
-
-    let error = move_path(
-        &store,
-        &namespace_id("demo"),
-        "/docs",
-        "/docs/archive/docs",
-        &context,
-        Some("cycle"),
-    )
-    .await
-    .expect_err("cycle");
-    assert_eq!(error.code(), ErrorCode::WouldCycle);
 }
 
 #[tokio::test]
@@ -1555,8 +1399,10 @@ async fn path_move_writes_unbind_and_old_binding_stops_resolving() {
     .expect("the moved inode keeps its identity under the new binding");
 }
 
+/// Create-only refuses an occupied name, whether the request spells it exactly
+/// as stored or in a casefold- and NFC-equivalent way.
 #[tokio::test]
-async fn put_file_no_replace_rejects_existing_target_without_force() {
+async fn no_replace_put_rejects_an_existing_name_and_an_equivalent_spelling() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
@@ -1573,6 +1419,16 @@ async fn put_file_no_replace_rejects_existing_target_without_force() {
     )
     .await
     .expect("seed file");
+    write_file_bytes(
+        &store,
+        &namespace_id("demo"),
+        "/Cafe\u{0301}.txt",
+        b"hello",
+        &context,
+        Some("seed-unicode-name"),
+    )
+    .await
+    .expect("seed unicode name");
 
     let error = put_file_bytes(
         &store,
@@ -1585,6 +1441,19 @@ async fn put_file_no_replace_rejects_existing_target_without_force() {
     )
     .await
     .expect_err("put without force");
+    assert_eq!(error.code(), ErrorCode::PathConflict);
+
+    let error = put_file_bytes(
+        &store,
+        &namespace_id("demo"),
+        "/CAF\u{00c9}.TXT",
+        b"new-bytes",
+        DestinationBehavior::NoReplace,
+        &context,
+        Some("create-only-conflict"),
+    )
+    .await
+    .expect_err("create-only conflict");
     assert_eq!(error.code(), ErrorCode::PathConflict);
 }
 
@@ -1689,39 +1558,6 @@ async fn resolve_path_uses_nfc_casefold_folding() {
         .expect("resolve path");
     assert_eq!(resolved.path.as_str(), stored_path);
     assert_eq!(named_entry(&resolved), "Cafe\u{0301}.txt");
-}
-
-#[tokio::test]
-async fn no_replace_put_rejects_casefold_and_normalization_equivalent_name() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
-        .await
-        .expect("bootstrap namespace");
-    write_file_bytes(
-        &store,
-        &namespace_id("demo"),
-        "/Cafe\u{0301}.txt",
-        b"hello",
-        &context,
-        Some("seed-unicode-name"),
-    )
-    .await
-    .expect("seed unicode name");
-
-    let error = put_file_bytes(
-        &store,
-        &namespace_id("demo"),
-        "/CAF\u{00c9}.TXT",
-        b"new-bytes",
-        DestinationBehavior::NoReplace,
-        &context,
-        Some("create-only-conflict"),
-    )
-    .await
-    .expect_err("create-only conflict");
-    assert_eq!(error.code(), ErrorCode::PathConflict);
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -1055,9 +1055,6 @@ async fn name_key_stays_typed_through_planning_and_fingerprint() {
         )));
 }
 
-/// The batch resolves a move against the put before it, and the ladder keeps
-/// climbing across the single commits that follow: put, move, copy, delete at
-/// sequences one through four.
 #[tokio::test]
 async fn path_intents_in_one_batch_see_tentative_state_and_continue_the_seq_ladder() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1399,8 +1396,6 @@ async fn path_move_writes_unbind_and_old_binding_stops_resolving() {
     .expect("the moved inode keeps its identity under the new binding");
 }
 
-/// Create-only refuses an occupied name, whether the request spells it exactly
-/// as stored or in a casefold- and NFC-equivalent way.
 #[tokio::test]
 async fn no_replace_put_rejects_an_existing_name_and_an_equivalent_spelling() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -15,7 +15,7 @@ use loonfs_api::{Checksum, ChecksumAlgorithm};
 use loonfs_core::{
     BeginDirectPutUploadTargetResponse, Error as CoreError, ErrorCode, MutationContext,
 };
-use loonfs_objectstore::keys::{upload_session, upload_session_prefix};
+use loonfs_objectstore::keys::upload_session;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::stores::{
@@ -222,31 +222,6 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
         .expect("complete upload idempotently");
     assert_eq!(completed_again, completed);
     assert_eq!(store.count(OperationClass::Read), 0);
-}
-
-#[tokio::test]
-async fn upload_content_rejects_invalid_upload_id_before_key_construction() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-
-    let invalid_upload_id = ["upl", "123"].join("-");
-    let error = UploadId::parse(&invalid_upload_id)
-        .map_err(CoreError::InvalidUploadId)
-        .expect_err("invalid upload_id should be rejected");
-
-    assert_eq!(error.code(), ErrorCode::InvalidRequest);
-    assert_eq!(
-        store
-            .list_prefix(&upload_session_prefix(&namespace_id))
-            .await
-            .expect("list upload sessions"),
-        Vec::<String>::new()
-    );
 }
 
 /// The streamed proxied upload: same session, same reference, same
@@ -664,7 +639,10 @@ mod direct_multipart {
         .await
         .expect_err("a multipart completion needs at least one part");
         assert_eq!(error.code(), ErrorCode::InvalidRequest);
-        assert!(error.to_string().contains("at least one uploaded part"));
+        assert!(
+            matches!(error, CoreError::InvalidUploadContent(_)),
+            "{error:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Removes duplicate and low-value tests from `loonfs-core`, combines cases that exercise the same behavior, and shares expensive fixtures across related checkpoint and garbage-collection tests.

The remaining tests continue to cover checkpoint integrity, retention, garbage collection, recency, WAL behavior, path intents, upload sessions, and commit validation. Error tests now check typed errors and relevant fields instead of exact sentences. Production behavior is unchanged.