### PR TITLE
fix(server): make download routes and token fallbacks consistent

### DIFF
--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -967,8 +967,7 @@ access_key = "{AZURITE_ACCOUNT_KEY}"
 
     #[test]
     fn load_rejects_blank_auth_token_when_present() {
-        // A blank file value falls back to the environment, so an ambient
-        // token would satisfy this config instead of failing it.
+        // Prevent an ambient token from filling the blank value.
         let _auth_token = EnvGuard::unset(AUTH_TOKEN_ENV);
         let path = write_config(
             r#"
@@ -1364,7 +1363,6 @@ root = "/tmp/loonfs-server"
         );
         assert_eq!(config.content_token_secret(), "env-content-token-secret");
 
-        // A blank file value falls back to the environment for both secrets.
         config.auth_token = Some(loonfs_api::SecretString::new("   ".to_owned()));
         config.content_token_secret = loonfs_api::SecretString::new("   ".to_owned());
         config.apply_env_fallbacks(

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -342,15 +342,18 @@ impl ServerConfig {
     }
 
     /// Fills `auth_token` and `content_token_secret` from the environment
-    /// when the file left them unset. Non-blank file values win; blank
-    /// environment values are ignored.
-    ///
+    /// when the file left them unset or blank. Non-blank file values win;
+    /// blank environment values are ignored.
     fn apply_env_fallbacks(
         &mut self,
         auth_token_env: Option<String>,
         content_token_secret_env: Option<String>,
     ) {
-        if self.auth_token.is_none() {
+        if self
+            .auth_token
+            .as_ref()
+            .is_none_or(|token| token.expose().trim().is_empty())
+        {
             if let Some(token) = non_blank(auth_token_env) {
                 self.auth_token = Some(SecretString::new(token));
             }
@@ -964,6 +967,9 @@ access_key = "{AZURITE_ACCOUNT_KEY}"
 
     #[test]
     fn load_rejects_blank_auth_token_when_present() {
+        // A blank file value falls back to the environment, so an ambient
+        // token would satisfy this config instead of failing it.
+        let _auth_token = EnvGuard::unset(AUTH_TOKEN_ENV);
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"
@@ -1320,7 +1326,7 @@ session_token = "debug-session-token"
     }
 
     #[test]
-    fn env_fallbacks_fill_only_unset_secrets() {
+    fn env_fallbacks_fill_blank_or_unset_secrets() {
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"
@@ -1348,6 +1354,19 @@ root = "/tmp/loonfs-server"
         // The environment fills fields the file left unset.
         config.auth_token = None;
         config.content_token_secret = loonfs_api::SecretString::default();
+        config.apply_env_fallbacks(
+            Some("env-auth-token".to_owned()),
+            Some("env-content-token-secret".to_owned()),
+        );
+        assert_eq!(
+            config.auth_token.as_ref().map(|token| token.expose()),
+            Some("env-auth-token")
+        );
+        assert_eq!(config.content_token_secret(), "env-content-token-secret");
+
+        // A blank file value falls back to the environment for both secrets.
+        config.auth_token = Some(loonfs_api::SecretString::new("   ".to_owned()));
+        config.content_token_secret = loonfs_api::SecretString::new("   ".to_owned());
         config.apply_env_fallbacks(
             Some("env-auth-token".to_owned()),
             Some("env-content-token-secret".to_owned()),

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -26,6 +26,22 @@ pub(super) fn server_busy_error(what: &str) -> ApiResponseError {
     )
 }
 
+/// The admission slot a proxied content read holds until its response body
+/// is consumed. Handlers acquire it after validating the request, so a
+/// malformed read never takes a slot.
+pub(super) fn acquire_download_permit(
+    state: &AppState,
+) -> Result<OwnedSemaphorePermit, ApiResponseError> {
+    state
+        .download_permits
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| {
+            state.metrics.download_rejected_as_busy();
+            server_busy_error("proxied content reads")
+        })
+}
+
 pub(super) fn authorize(
     policy: AuthPolicy<'_>,
     headers: &HeaderMap,

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -26,9 +26,6 @@ pub(super) fn server_busy_error(what: &str) -> ApiResponseError {
     )
 }
 
-/// The admission slot a proxied content read holds until its response body
-/// is consumed. Handlers acquire it after validating the request, so a
-/// malformed read never takes a slot.
 pub(super) fn acquire_download_permit(
     state: &AppState,
 ) -> Result<OwnedSemaphorePermit, ApiResponseError> {

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -6,7 +6,9 @@ use super::error::ApiResponseError;
 use super::handlers_uploads::{
     content_preparation_for_puts, current_unix_ms, ContentTokenVerifier, PutContentPreparation,
 };
-use super::{authorize, AppJson, AppQuery, AppState, NamespaceIdPath, NoQuery};
+use super::{
+    acquire_download_permit, authorize, AppJson, AppQuery, AppState, NamespaceIdPath, NoQuery,
+};
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
@@ -315,22 +317,13 @@ pub(super) async fn get_file_bytes(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
-    // Content reads buffer the whole file, so the permit must follow those
-    // bytes through the response body rather than ending with this handler.
-    let permit = state
-        .download_permits
-        .clone()
-        .try_acquire_owned()
-        .map_err(|_| {
-            state.metrics.download_rejected_as_busy();
-            super::server_busy_error("proxied content reads")
-        })?;
     let path = required_query_param(query.path, "path")?;
     let revision_no = query
         .revision_no
         .as_deref()
         .map(parse_revision_no)
         .transpose()?;
+    let permit = acquire_download_permit(&state)?;
     let file = match revision_no {
         Some(revision_no) => {
             state

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -5,7 +5,9 @@ use super::handlers_filesystem::{
     buffered_download_response, decode_optional_cursor, parse_include_attributes,
     parse_revision_no, resolve_page_limit, PageQuery,
 };
-use super::{authorize, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery};
+use super::{
+    acquire_download_permit, authorize, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery,
+};
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::Response;
@@ -183,14 +185,7 @@ pub(super) async fn get_file_revision_bytes_by_inode(
     query.into_params()?;
     let inode_id = parse_inode_id(&path.inode_id)?;
     let revision_no = parse_revision_no(&path.revision_no)?;
-    let permit = state
-        .download_permits
-        .clone()
-        .try_acquire_owned()
-        .map_err(|_| {
-            state.metrics.download_rejected_as_busy();
-            super::server_busy_error("proxied content reads")
-        })?;
+    let permit = acquire_download_permit(&state)?;
     let bytes = state
         .reader
         .get_file_revision_bytes_by_inode(&namespace_id, inode_id, revision_no)

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -32,7 +32,7 @@ pub use self::tls::TlsConfigError;
 
 use self::error::{status_for_core_error_code, ApiResponseError, ServedErrorCode};
 use self::extractors::{
-    authorize, server_busy_error, AppJson, AppPath, AppQuery, NamespaceIdPath, NoQuery,
+    acquire_download_permit, authorize, AppJson, AppPath, AppQuery, NamespaceIdPath, NoQuery,
     OptionalAppJson, UploadBodyBytes, UploadBodyStream, UploadControlJson,
     MAX_COMPLETION_BODY_BYTES, MAX_UPLOAD_CONTROL_BODY_BYTES,
 };
@@ -108,6 +108,7 @@ enum RequestLogSeverity {
 // Membership is limited to streamed content and operator work that is long by design.
 const DEADLINE_EXEMPT_ROUTES: &[&str] = &[
     "/v0/namespaces/{namespace_id}/filesystem/content",
+    "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content",
     "/v0/admin/namespaces/{namespace_id}/maintenance/run",
     "/v0/admin/store/probe",

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -152,10 +152,10 @@ pub(super) struct AppState {
     /// do. Absent under `maintenance = "manual"`, where the mutating index
     /// routes still work and nothing schedules itself behind them.
     pub(super) grep_maintenance: Option<GrepMaintenance>,
-    /// Bounds concurrently buffered proxied-upload bodies; with the
-    /// per-request body limit this makes worst-case upload memory
-    /// `max_concurrent_uploads * max_upload_bytes`. Requests past the cap
-    /// answer 503 `server_busy` before any buffering.
+    /// Bounds concurrently streamed proxied-upload bodies; bodies forward to
+    /// the store incrementally, so worst-case upload memory is this times one
+    /// streamed part. Requests past the cap answer 503 `server_busy` before
+    /// any transfer.
     pub(super) upload_permits: Arc<Semaphore>,
     /// Bounds concurrently materialized proxied content reads the same way:
     /// worst-case download memory is

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -794,7 +794,7 @@ async fn request_deadline_answers_503_and_leaves_fast_handlers_untouched() {
 }
 
 #[tokio::test]
-async fn every_deadline_exemption_names_a_served_route() {
+async fn deadline_exemptions_name_served_routes_and_cover_both_content_spellings() {
     use tower::ServiceExt;
 
     let temp_dir = tempdir().expect("tempdir");
@@ -806,10 +806,24 @@ async fn every_deadline_exemption_names_a_served_route() {
     .await
     .expect("build app");
 
+    // The same bytes by path and by inode are one operation, so neither
+    // spelling is cancelled at the deadline while the other runs on.
+    for content_route in [
+        "/v0/namespaces/{namespace_id}/filesystem/content",
+        "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
+    ] {
+        assert!(
+            super::DEADLINE_EXEMPT_ROUTES.contains(&content_route),
+            "content route `{content_route}` is not deadline exempt"
+        );
+    }
+
     for route in super::DEADLINE_EXEMPT_ROUTES {
         let uri = route
             .replace("{namespace_id}", "deadline-exempt")
-            .replace("{upload_id}", "upl_deadline_exempt");
+            .replace("{upload_id}", "upl_deadline_exempt")
+            .replace("{inode_id}", "ino_1")
+            .replace("{revision_no}", "1");
         let response = router
             .clone()
             .oneshot(
@@ -2636,6 +2650,8 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
     server.abort();
 }
 
+// The request closures return ureq's large error type.
+#[allow(clippy::result_large_err)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2703,6 +2719,35 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
         503,
         "server_busy",
         Some("the server is at its concurrency limit for proxied content reads; retry shortly"),
+    );
+    // Both routes validate before they take a slot, so a malformed read
+    // answers 400 rather than 503 while the cap is full, and the two
+    // rejections above stay the only ones counted.
+    expect_enveloped(
+        || {
+            raw_agent()
+                .get(&format!(
+                    "http://{addr}/v0/namespaces/demo/filesystem/content"
+                ))
+                .set("authorization", "Bearer test-token")
+                .call()
+        },
+        "a missing path should answer 400 at the concurrency cap",
+        400,
+        "invalid_request",
+    );
+    expect_enveloped(
+        || {
+            raw_agent()
+                .get(&format!(
+                    "http://{addr}/v0/namespaces/demo/inodes/not-an-inode/revisions/1/content"
+                ))
+                .set("authorization", "Bearer test-token")
+                .call()
+        },
+        "a malformed inode id should answer 400 at the concurrency cap",
+        400,
+        "invalid_request",
     );
     assert!(state
         .metrics

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -806,8 +806,6 @@ async fn deadline_exemptions_name_served_routes_and_cover_both_content_spellings
     .await
     .expect("build app");
 
-    // The same bytes by path and by inode are one operation, so neither
-    // spelling is cancelled at the deadline while the other runs on.
     for content_route in [
         "/v0/namespaces/{namespace_id}/filesystem/content",
         "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
@@ -2720,9 +2718,6 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
         "server_busy",
         Some("the server is at its concurrency limit for proxied content reads; retry shortly"),
     );
-    // Both routes validate before they take a slot, so a malformed read
-    // answers 400 rather than 503 while the cap is full, and the two
-    // rejections above stay the only ones counted.
     expect_enveloped(
         || {
             raw_agent()


### PR DESCRIPTION
Validates both download routes before taking a concurrency permit, so malformed requests return 400 even when the server is busy. It also exempts both path- and inode-based content downloads from request deadlines.

A blank auth token in the config now falls back to `LOONFS_AUTH_TOKEN`, matching the content-token secret. The upload memory comment now describes the streamed request path accurately. The OpenAPI contract is unchanged.