### PR TITLE
fix(objectstore): reject descending ranges consistently

### DIFF
--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -373,8 +373,7 @@ impl LocalFsStore {
         let invalid_range = || ObjectStoreError::InvalidRange {
             object_key: key.to_owned(),
         };
-        // A descending range is a caller error, answered before the open so a
-        // missing object cannot report absence in its place.
+        // Reject descending ranges before checking whether the object exists.
         if range
             .as_ref()
             .is_some_and(|range| range.end_exclusive < range.start_inclusive)

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -370,6 +370,17 @@ impl LocalFsStore {
     /// promise on this provider alone.
     async fn get_object(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Vec<u8>>> {
         let path = self.resolve_key(key)?;
+        let invalid_range = || ObjectStoreError::InvalidRange {
+            object_key: key.to_owned(),
+        };
+        // A descending range is a caller error, answered before the open so a
+        // missing object cannot report absence in its place.
+        if range
+            .as_ref()
+            .is_some_and(|range| range.end_exclusive < range.start_inclusive)
+        {
+            return Err(invalid_range());
+        }
         let mut file = match File::open(&path).await {
             Ok(file) => file,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -384,15 +395,12 @@ impl LocalFsStore {
             return Ok(Some(bytes));
         };
 
-        let invalid_range = || ObjectStoreError::InvalidRange {
-            object_key: key.to_owned(),
-        };
         let size_bytes = file
             .metadata()
             .await
             .map_err(|err| io_error(key, err))?
             .len();
-        if range.end_exclusive < range.start_inclusive || range.start_inclusive > size_bytes {
+        if range.start_inclusive > size_bytes {
             return Err(invalid_range());
         }
         // A range ending past the object is truncated, never refused.

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -434,7 +434,9 @@ pub trait ObjectStore: Send + Sync + Debug {
     /// Reads a full object or one half-open byte range, returning `None` when absent.
     ///
     /// A range ending beyond the object is truncated; a descending range or
-    /// start beyond the object returns [`ObjectStoreError::InvalidRange`].
+    /// start beyond the object returns [`ObjectStoreError::InvalidRange`]. A
+    /// descending range is refused before existence is consulted, so absence
+    /// never answers in its place.
     async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>>;
 
     /// Writes bytes under the requested overwrite or provider-enforced precondition.

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -615,8 +615,6 @@ async fn range_reads(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
             "a bounded read of a deleted object answered bytes instead of absence",
         ));
     }
-    // A descending range is a caller error, refused whether or not the object
-    // exists; a store that consulted existence first would answer absence.
     match store.get(&key, bounded(4, 1)).await {
         Err(ObjectStoreError::InvalidRange { .. }) => {}
         Err(error) => {

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -615,6 +615,22 @@ async fn range_reads(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
             "a bounded read of a deleted object answered bytes instead of absence",
         ));
     }
+    // A descending range is a caller error, refused whether or not the object
+    // exists; a store that consulted existence first would answer absence.
+    match store.get(&key, bounded(4, 1)).await {
+        Err(ObjectStoreError::InvalidRange { .. }) => {}
+        Err(error) => {
+            return Err(wrong(format!(
+                "a descending range of a missing object should be an invalid range, but failed differently: {}",
+                error.public_message()
+            )))
+        }
+        Ok(_) => {
+            return Err(wrong(
+                "a descending range of a missing object should be an invalid range, but returned a response",
+            ))
+        }
+    }
     Ok(())
 }
 

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -747,8 +747,9 @@ impl ObjectStore for ProviderObjectStore {
     /// Bounded reads issue the ranged GET directly — one round trip, not a
     /// sizing HEAD plus a GET — and pay a single HEAD only on the failure
     /// path, to decide whether the range or the transport was the problem.
-    /// The contract matches the local reference provider exactly: a missing
-    /// object is `Ok(None)` however the request was shaped, an end past the
+    /// The contract matches the local reference provider exactly: a descending
+    /// range is `InvalidRange` before existence is consulted, a missing object
+    /// is otherwise `Ok(None)` however the request was shaped, an end past the
     /// object clamps, `start == size` reads empty, and `start > size` is
     /// `InvalidRange`.
     async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {


### PR DESCRIPTION
Rejects a descending byte range before checking whether an object exists. Local storage now returns `InvalidRange` for a request such as `10..5`, matching cloud providers even when the key is missing.

The object-store probe now checks this contract, and the provider documentation describes the behavior explicitly.