### PR TITLE
fix(grep): handle storage failures consistently

### DIFF
--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -141,12 +141,19 @@ pub(super) async fn load_section_bytes<S: ObjectStore + ?Sized>(
     offset: u64,
     len: u64,
 ) -> Result<Vec<u8>, ManifestLoadError> {
+    let end_exclusive =
+        offset
+            .checked_add(len)
+            .ok_or_else(|| ManifestLoadError::SegmentDescriptorMismatch {
+                object_key: object_key.to_owned(),
+                message: "the named section runs past the address space".to_owned(),
+            })?;
     let Some(bytes) = store
         .get(
             object_key,
             Some(ByteRange {
                 start_inclusive: offset,
-                end_exclusive: offset + len,
+                end_exclusive,
             }),
         )
         .await

--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -63,6 +63,17 @@ async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
         .ok_or_else(|| GrepError::CorruptIndex {
             message: format!("manifest references missing index segment `{object_key}`"),
         })?;
+    if bytes.len() != handle.stored_len as usize {
+        return Err(GrepError::StoreUnavailable {
+            object_key: object_key.to_owned(),
+            message: format!(
+                "ranged read returned {} bytes, expected {}",
+                bytes.len(),
+                handle.stored_len
+            ),
+            class: StoreFailureClass::Other,
+        });
+    }
     Ok(bytes.to_vec())
 }
 
@@ -152,5 +163,74 @@ fn cache_kind_corrupt(object_key: &str, expected: &str) -> GrepError {
         message: format!(
             "index segment `{object_key}` resolved its {expected} block to a different cache kind"
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unreachable)]
+    // The stub store below serves one ranged read and reaches nothing else.
+
+    use super::{load_index_section_bytes, BlockHandle, GrepError};
+    use bytes::Bytes;
+    use futures::stream::BoxStream;
+    use loonfs_objectstore::{
+        ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode, Result as StoreResult,
+    };
+
+    #[derive(Debug)]
+    struct ShortReadStore;
+
+    #[async_trait::async_trait]
+    impl ObjectStore for ShortReadStore {
+        async fn head(&self, _key: &str) -> StoreResult<Option<ObjectMetadata>> {
+            unreachable!()
+        }
+
+        async fn get_with_metadata(&self, _key: &str) -> StoreResult<Option<ObjectBody>> {
+            unreachable!()
+        }
+
+        async fn get(&self, _key: &str, _range: Option<ByteRange>) -> StoreResult<Option<Bytes>> {
+            Ok(Some(Bytes::from_static(b"truncated")))
+        }
+
+        async fn put(
+            &self,
+            _key: &str,
+            _bytes: Bytes,
+            _mode: PutMode,
+        ) -> StoreResult<ObjectMetadata> {
+            unreachable!()
+        }
+
+        async fn delete(&self, _key: &str) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        fn list_prefix_from_stream(
+            &self,
+            _prefix: &str,
+            _start_after: Option<&str>,
+        ) -> BoxStream<'static, StoreResult<String>> {
+            unreachable!()
+        }
+    }
+
+    #[tokio::test]
+    async fn a_short_ranged_read_is_a_store_failure_not_index_corruption() {
+        let handle = BlockHandle {
+            offset: 0,
+            stored_len: 64,
+            decoded_len: 64,
+            crc32c: 0,
+        };
+        let error = load_index_section_bytes(&ShortReadStore, "segments/one", &handle)
+            .await
+            .expect_err("a short ranged read should not decode");
+        assert!(
+            matches!(error, GrepError::StoreUnavailable { .. }),
+            "expected a store failure, got {error:?}"
+        );
     }
 }

--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -169,7 +169,7 @@ fn cache_kind_corrupt(object_key: &str, expected: &str) -> GrepError {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unreachable)]
-    // The stub store below serves one ranged read and reaches nothing else.
+    // Only `get` is used by this test store.
 
     use super::{load_index_section_bytes, BlockHandle, GrepError};
     use bytes::Bytes;

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -32,7 +32,7 @@ use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::sst_blocks::{
     index_blocks_for_key_range, DecodedDataBlock, SegmentBlocksBuilder, SegmentIndexEntry,
     DEFAULT_INLINE_FILTER_MAX_BYTES, DEFAULT_MAX_DELTA_RUNS, DEFAULT_MAX_REORGANIZATION_INPUT_ROWS,
-    DEFAULT_MAX_REORGANIZATION_INPUT_RUNS, DEFAULT_MAX_ROWS_PER_SEGMENT,
+    DEFAULT_MAX_ROWS_PER_SEGMENT,
 };
 use loonfs_api::{
     decode_namespace_cursor, encode_cursor, next_public_ordinal, sha256_digest, ChangeSeq,
@@ -81,6 +81,9 @@ const MAX_GREP_WORKER_IO: usize = 8;
 const INDEX_GRAMS_DELTA_LEVEL: u32 = 0;
 const INDEX_GRAMS_MID_LEVEL: u32 = 1;
 const INDEX_GRAMS_BASE_LEVEL: u32 = 2;
+/// Mid-level runs that trigger a fold into a fresh base run. Grep owns this
+/// trigger so a change to the metadata reorganization input cap cannot move it.
+const GREP_MAX_MID_RUNS: usize = 8;
 
 /// Writer-side budgets for one grep build or reorganize step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -108,7 +111,7 @@ impl Default for GramIndexBuildPolicy {
             },
             max_rows_per_segment: const { NonZeroUsize::new(DEFAULT_MAX_ROWS_PER_SEGMENT).unwrap() },
             max_delta_runs: const { NonZeroUsize::new(DEFAULT_MAX_DELTA_RUNS).unwrap() },
-            max_mid_runs: const { NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_RUNS).unwrap() },
+            max_mid_runs: const { NonZeroUsize::new(GREP_MAX_MID_RUNS).unwrap() },
             max_decoded_input_rows_per_step: const {
                 NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_ROWS).unwrap()
             },
@@ -671,7 +674,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             segments,
         )
         .map_err(|error| core_state_error(namespace_id, error))?;
-        ensure_publication_budget(&timer, publication_started_ms)?;
+        ensure_publication_budget(&timer, publication_started_ms, namespace_id)?;
         match self.advance_root(&current, &next).await {
             Ok(_) => {
                 if let Some(checkpoint_id) = completed_checkpoint_id {
@@ -1264,7 +1267,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             segments,
         )
         .map_err(|error| core_state_error(namespace_id, error))?;
-        ensure_publication_budget(&timer, publication_started_ms)?;
+        ensure_publication_budget(&timer, publication_started_ms, namespace_id)?;
         match self.advance_root(&current, &next).await {
             Ok(_) => Ok(reorganize_report(
                 namespace_id,
@@ -1804,11 +1807,21 @@ fn count_deleted_key(key: &str, report: &mut GrepGcReport) {
     }
 }
 
-fn ensure_publication_budget(timer: &impl MonotonicTimer, started_ms: u64) -> Result<()> {
+fn ensure_publication_budget(
+    timer: &impl MonotonicTimer,
+    started_ms: u64,
+    namespace_id: &NamespaceId,
+) -> Result<()> {
     let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
     if elapsed_ms <= METADATA_PUBLICATION_BUDGET_MS {
         return Ok(());
     }
+    tracing::error!(
+        namespace_id = namespace_id.as_str(),
+        elapsed_ms,
+        budget_ms = METADATA_PUBLICATION_BUDGET_MS,
+        "grep publication overran its budget; aborting before the root compare-and-swap",
+    );
     Err(CoreError::MetadataPublicationBudgetExceeded {
         elapsed_ms,
         budget_ms: METADATA_PUBLICATION_BUDGET_MS,
@@ -1845,16 +1858,18 @@ fn core_store_error(object_key: &str, error: &ObjectStoreError) -> GrepError {
 }
 
 fn grep_immutable_write_error(error: ImmutableWriteError) -> GrepError {
-    let object_key = error.object_key().to_owned();
+    let fallback_object_key = error.object_key().to_owned();
     match error {
         ImmutableWriteError::DifferentObject { object_key } => GrepError::CorruptIndex {
-            message: format!("immutable object `{object_key}` contains different bytes"),
+            message: format!("immutable object `{object_key}` already exists with different bytes"),
         },
         ImmutableWriteError::Transport { object_key, source } => {
             core_store_error(&object_key, &source)
         }
-        error => GrepError::CorruptIndex {
-            message: format!("index segment `{object_key}`: {error}"),
+        error => GrepError::StoreUnavailable {
+            object_key: fallback_object_key,
+            message: error.to_string(),
+            class: StoreFailureClass::Other,
         },
     }
 }

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -81,8 +81,7 @@ const MAX_GREP_WORKER_IO: usize = 8;
 const INDEX_GRAMS_DELTA_LEVEL: u32 = 0;
 const INDEX_GRAMS_MID_LEVEL: u32 = 1;
 const INDEX_GRAMS_BASE_LEVEL: u32 = 2;
-/// Mid-level runs that trigger a fold into a fresh base run. Grep owns this
-/// trigger so a change to the metadata reorganization input cap cannot move it.
+// Keep grep's fold threshold independent of metadata reorganization limits.
 const GREP_MAX_MID_RUNS: usize = 8;
 
 /// Writer-side budgets for one grep build or reorganize step.


### PR DESCRIPTION
Treats immutable-write and short-range failures the same way as core: storage problems remain store failures, while conflicting immutable bytes remain index corruption. Grep also logs publication budget overruns with namespace context.

This gives grep its own fold threshold and adds overflow and short-read checks to ranged index reads. No format or fixture changes are required.