### PR TITLE
fix(runtime): use one publication hook for maintenance

### DIFF
--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -50,11 +50,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
         GREP_INDEX_JOB
     }
 
-    /// The index is a projection of the namespace's own history, so a
-    /// publication that committed is its one real trigger and the cheapest
-    /// possible hint. Declaring it here is all it takes: no host wires
-    /// anything to the write path on grep's behalf.
-    fn nudged_by_publication(&self, publication: &NamespacePublication) -> bool {
+    fn should_nudge_after_publication(&self, publication: &NamespacePublication) -> bool {
         publication.committed_through_seq.is_some()
     }
 

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use loonfs::{
     current_time_ms, MaintenanceJob, MaintenanceJobId, MaintenanceProbe, MaintenanceStepConclusion,
-    MaintenanceStepReport, NamespaceId, Result, RuntimeError,
+    MaintenanceStepReport, NamespaceId, NamespacePublication, Result, RuntimeError,
 };
 use loonfs_api::ErrorCode;
 use loonfs_objectstore::ObjectStore;
@@ -51,11 +51,11 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
     }
 
     /// The index is a projection of the namespace's own history, so a
-    /// publication is its one real trigger and the cheapest possible hint.
-    /// Subscribing here is all it takes: no host wires anything to the
-    /// write path on grep's behalf.
-    fn nudged_by_publications(&self) -> bool {
-        true
+    /// publication that committed is its one real trigger and the cheapest
+    /// possible hint. Declaring it here is all it takes: no host wires
+    /// anything to the write path on grep's behalf.
+    fn nudged_by_publication(&self, publication: &NamespacePublication) -> bool {
+        publication.committed_through_seq.is_some()
     }
 
     /// Runs one bounded build step, then one reorganization step only when the

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -2,7 +2,7 @@
 
 use crate::cache::{RuntimeCacheStatsInner, RuntimeControlCache};
 use crate::config::{validate_writer_id, ReadConfig};
-use crate::maintenance_runner::MaintenanceRunner;
+use crate::maintenance_runner::{MaintenanceRunner, NamespacePublication};
 use crate::metrics::RuntimeInstruments;
 use crate::publisher::{NamespaceAdvanceHint, NamespaceAdvanceObserver};
 use crate::{
@@ -62,19 +62,26 @@ pub(crate) struct WriterBits {
 }
 
 impl WriterBits {
-    /// Reports that `namespace_id` is durably visible through `through_seq`.
+    /// Reports what one publication attempt against `namespace_id` left
+    /// behind.
     ///
-    /// The one post-publication emission point. A host observer panic is
-    /// contained here: the commit it followed is already durable.
-    pub(crate) fn notify_namespace_advanced(
+    /// The one post-publication emission point. Maintenance jobs decide for
+    /// themselves which attempts concern them; the host observer hears only
+    /// the ones that committed. A host observer panic is contained here: the
+    /// commit it followed is already durable.
+    pub(crate) fn notify_published(
         &self,
         namespace_id: &NamespaceId,
-        through_seq: ChangeSeq,
+        publication: &NamespacePublication,
     ) {
         // Nudge runtime-owned work first: a slow or panicking observer must
         // not delay it.
-        self.maintenance.nudge_publication_subscribers(namespace_id);
+        self.maintenance
+            .nudge_publication_subscribers(namespace_id, publication);
 
+        let Some(through_seq) = publication.committed_through_seq else {
+            return;
+        };
         let Some(observer) = &self.namespace_advance_observer else {
             return;
         };

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -62,22 +62,16 @@ pub(crate) struct WriterBits {
 }
 
 impl WriterBits {
-    /// Reports what one publication attempt against `namespace_id` left
-    /// behind.
-    ///
-    /// The one post-publication emission point. Maintenance jobs decide for
-    /// themselves which attempts concern them; the host observer hears only
-    /// the ones that committed. A host observer panic is contained here: the
-    /// commit it followed is already durable.
-    pub(crate) fn notify_published(
+    /// Notifies maintenance after every publish attempt and the observer
+    /// after a successful commit.
+    pub(crate) fn notify_after_publish(
         &self,
         namespace_id: &NamespaceId,
         publication: &NamespacePublication,
     ) {
-        // Nudge runtime-owned work first: a slow or panicking observer must
-        // not delay it.
+        // Notify maintenance before running host code.
         self.maintenance
-            .nudge_publication_subscribers(namespace_id, publication);
+            .nudge_jobs_after_publication(namespace_id, publication);
 
         let Some(through_seq) = publication.committed_through_seq else {
             return;

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -264,7 +264,7 @@ impl FsAdmin {
         options: MetadataMaintenanceOptions,
         status_before: &NamespaceDiagnostics,
     ) -> Result<MetadataMaintenanceResponse> {
-        let flush = status_before.wal_tail_segments >= options.max_wal_tail_segments.get();
+        let flush = options.flush_is_due(status_before.wal_tail_segments);
         self.flush_then_reorganize(namespace_id, flush, status_before.head_seq)
             .await
     }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -973,9 +973,7 @@ pub(crate) async fn publish_batch_with_engine(
         .into_iter()
         .map(|result| result.map_err(RuntimeError::Core))
         .collect::<Vec<_>>();
-    // The attempt reports what it left behind. Each job decides for
-    // itself whether that is one of its own triggers.
-    writer.notify_published(
+    writer.notify_after_publish(
         namespace_id,
         &NamespacePublication {
             committed_through_seq: highest_committed_seq(&results),

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -1,14 +1,14 @@
 //! [`FsWriter`]'s path mutations, commits, and the publication pipeline.
 
 use super::core::{ReadCore, WriterBits};
+use crate::maintenance_runner::NamespacePublication;
 use crate::publish::{CommitCandidate, CommitRequest, FilesystemOperation, PreparedContent};
 use crate::ByteStream;
 use crate::FsWriter;
 use crate::{
     ChangeSeq, CommitId, CommitOptions, CommitResponse, ContentRef, CopyOptions, CoreError,
-    CreateDirectoryOptions, DeleteOptions, InodeId, MaintenanceJobId, MetadataMaintenanceOptions,
-    MoveOptions, NamespaceId, PutFileOptions, RestoreRevisionOptions, RevisionNo, UndeleteOptions,
-    UpdateAttributesOptions,
+    CreateDirectoryOptions, DeleteOptions, InodeId, MoveOptions, NamespaceId, PutFileOptions,
+    RestoreRevisionOptions, RevisionNo, UndeleteOptions, UpdateAttributesOptions,
 };
 use crate::{Result, RuntimeError};
 use loonfs_api::{
@@ -973,11 +973,15 @@ pub(crate) async fn publish_batch_with_engine(
         .into_iter()
         .map(|result| result.map_err(RuntimeError::Core))
         .collect::<Vec<_>>();
-    // Notify observers only when at least one commit succeeded.
-    if let Some(through_seq) = highest_committed_seq(&results) {
-        writer.notify_namespace_advanced(namespace_id, through_seq);
-    }
-    maybe_auto_step_after_publish(writer, namespace_id, wal_tail_segments);
+    // The attempt reports what it left behind. Each job decides for
+    // itself whether that is one of its own triggers.
+    writer.notify_published(
+        namespace_id,
+        &NamespacePublication {
+            committed_through_seq: highest_committed_seq(&results),
+            wal_tail_segments,
+        },
+    );
     results
 }
 
@@ -988,28 +992,4 @@ fn highest_committed_seq(results: &[Result<CommitResponse>]) -> Option<ChangeSeq
         .filter_map(|result| result.as_ref().ok())
         .map(|response| response.committed_seq)
         .max()
-}
-
-/// Tells the maintenance runner a namespace crossed its WAL-tail threshold.
-///
-/// The nudge is a hint and nothing more: it never blocks the publish, never
-/// waits for a permit, and carries no claim on the step it suggests. The
-/// runner decides when — and whether — to run, and the step it eventually
-/// runs re-reads the tail rather than trusting what this publish saw.
-fn maybe_auto_step_after_publish(
-    writer: &Arc<WriterBits>,
-    namespace_id: &NamespaceId,
-    wal_tail_segments: u64,
-) {
-    if wal_tail_segments
-        < MetadataMaintenanceOptions::default()
-            .max_wal_tail_segments
-            .get()
-    {
-        return;
-    }
-    writer
-        .maintenance
-        .handle()
-        .nudge(MaintenanceJobId::METADATA, namespace_id);
 }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -185,7 +185,7 @@ pub use fs::{
 pub use handle::{FsAdmin, FsAdminBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder};
 pub use maintenance_runner::{
     FsBackgroundWork, MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,
-    MaintenanceStepConclusion, MaintenanceStepReport,
+    MaintenanceStepConclusion, MaintenanceStepReport, NamespacePublication,
 };
 pub use options::{
     CommitOptions, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -150,18 +150,12 @@ impl MaintenanceStepReport {
     }
 }
 
-/// What one publication attempt left behind, as the jobs it may concern see
-/// it.
-///
-/// The write path reports every attempt. Each job decides which attempts are
-/// its own trigger, through [`MaintenanceJob::nudged_by_publication`].
+/// State available to maintenance jobs after a publish attempt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NamespacePublication {
-    /// The highest sequence the attempt committed, or `None` when it
-    /// committed nothing.
+    /// Highest sequence committed by the attempt, if any.
     pub committed_through_seq: Option<ChangeSeq>,
-    /// Visible WAL-tail length the attempt left behind. Zero when the
-    /// attempt failed before reading the tail.
+    /// Visible WAL-tail length, or zero if the attempt did not read it.
     pub wal_tail_segments: u64,
 }
 
@@ -201,14 +195,10 @@ pub trait MaintenanceJob: Send + Sync + 'static {
     /// reconciliation.
     async fn probe(&self, namespace_id: &NamespaceId) -> Result<MaintenanceProbe>;
 
-    /// Returns whether `publication` should nudge this job.
+    /// Returns whether this publish attempt should nudge the job.
     ///
-    /// Work derived from namespace history, such as an index or projection,
-    /// answers on `committed_through_seq`: every commit concerns it. Work
-    /// that starts at a WAL-tail threshold answers on `wal_tail_segments`.
-    /// The nudge is only a scheduling hint; the step must reload durable
-    /// state. Deadline-driven jobs keep the default `false`.
-    fn nudged_by_publication(&self, _publication: &NamespacePublication) -> bool {
+    /// A nudge is only a scheduling hint; the job must reload durable state.
+    fn should_nudge_after_publication(&self, _publication: &NamespacePublication) -> bool {
         false
     }
 }
@@ -535,12 +525,11 @@ impl MaintenanceRunner {
         Ok(())
     }
 
-    /// Nudges each registered job that `publication` concerns.
+    /// Nudges interested jobs after a publish attempt.
     ///
-    /// Subscription is declared by [`MaintenanceJob::nudged_by_publication`], so
-    /// the write path does not need job-specific wiring. Nudges are non-blocking,
-    /// coalesced, and ignored when automatic maintenance is disabled or closed.
-    pub(crate) fn nudge_publication_subscribers(
+    /// Nudges are non-blocking, coalesced, and ignored when automatic
+    /// maintenance is disabled or closed.
+    pub(crate) fn nudge_jobs_after_publication(
         &self,
         namespace_id: &NamespaceId,
         publication: &NamespacePublication,
@@ -550,7 +539,7 @@ impl MaintenanceRunner {
             .inner
             .lock_jobs()
             .iter()
-            .filter(|(_, job)| job.nudged_by_publication(publication))
+            .filter(|(_, job)| job.should_nudge_after_publication(publication))
             .map(|(id, _)| *id)
             .collect();
         for job in subscribers {

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -11,7 +11,7 @@ mod jobs;
 mod tests;
 
 use crate::metrics::RuntimeInstruments;
-use crate::{NamespaceId, Result, RuntimeError};
+use crate::{ChangeSeq, NamespaceId, Result, RuntimeError};
 use admission::{Admission, MaintenanceDispatch, MaintenanceKey, StepOutcome};
 pub(crate) use compaction::{BackgroundCompactions, CompactionStart};
 use futures::FutureExt as _;
@@ -150,6 +150,21 @@ impl MaintenanceStepReport {
     }
 }
 
+/// What one publication attempt left behind, as the jobs it may concern see
+/// it.
+///
+/// The write path reports every attempt. Each job decides which attempts are
+/// its own trigger, through [`MaintenanceJob::nudged_by_publication`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NamespacePublication {
+    /// The highest sequence the attempt committed, or `None` when it
+    /// committed nothing.
+    pub committed_through_seq: Option<ChangeSeq>,
+    /// Visible WAL-tail length the attempt left behind. Zero when the
+    /// attempt failed before reading the tail.
+    pub wal_tail_segments: u64,
+}
+
 /// Result of checking whether a maintenance job has work to do.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MaintenanceProbe {
@@ -186,12 +201,14 @@ pub trait MaintenanceJob: Send + Sync + 'static {
     /// reconciliation.
     async fn probe(&self, namespace_id: &NamespaceId) -> Result<MaintenanceProbe>;
 
-    /// Returns whether successful publications should nudge this job.
+    /// Returns whether `publication` should nudge this job.
     ///
-    /// Use `true` for work derived from namespace history, such as an index or
-    /// projection. The nudge is only a scheduling hint; the step must reload
-    /// durable state. Deadline-driven jobs keep the default `false`.
-    fn nudged_by_publications(&self) -> bool {
+    /// Work derived from namespace history, such as an index or projection,
+    /// answers on `committed_through_seq`: every commit concerns it. Work
+    /// that starts at a WAL-tail threshold answers on `wal_tail_segments`.
+    /// The nudge is only a scheduling hint; the step must reload durable
+    /// state. Deadline-driven jobs keep the default `false`.
+    fn nudged_by_publication(&self, _publication: &NamespacePublication) -> bool {
         false
     }
 }
@@ -518,18 +535,22 @@ impl MaintenanceRunner {
         Ok(())
     }
 
-    /// Nudges each registered job that subscribes to successful publications.
+    /// Nudges each registered job that `publication` concerns.
     ///
-    /// Subscription is declared by [`MaintenanceJob::nudged_by_publications`], so
+    /// Subscription is declared by [`MaintenanceJob::nudged_by_publication`], so
     /// the write path does not need job-specific wiring. Nudges are non-blocking,
     /// coalesced, and ignored when automatic maintenance is disabled or closed.
-    pub(crate) fn nudge_publication_subscribers(&self, namespace_id: &NamespaceId) {
+    pub(crate) fn nudge_publication_subscribers(
+        &self,
+        namespace_id: &NamespaceId,
+        publication: &NamespacePublication,
+    ) {
         // Release the job lock before acquiring scheduling state.
         let subscribers: Vec<MaintenanceJobId> = self
             .inner
             .lock_jobs()
             .iter()
-            .filter(|(_, job)| job.nudged_by_publications())
+            .filter(|(_, job)| job.nudged_by_publication(publication))
             .map(|(id, _)| *id)
             .collect();
         for job in subscribers {

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -7,7 +7,7 @@
 
 use super::{
     BackgroundCompactions, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,
-    MaintenanceStepConclusion, MaintenanceStepReport,
+    MaintenanceStepConclusion, MaintenanceStepReport, NamespacePublication,
 };
 use crate::fs::{ReadCore, WriterBits};
 use crate::publisher::PublisherRegistry;
@@ -35,7 +35,10 @@ pub(crate) fn register_core_jobs(
         publisher: publisher.clone(),
         compactions: runner.compactions(),
     };
-    runner.register(Arc::new(MetadataJob { context: context() }))?;
+    runner.register(Arc::new(MetadataJob {
+        context: context(),
+        options: MetadataMaintenanceOptions::default(),
+    }))?;
     runner.register(Arc::new(GcJob { context: context() }))?;
     Ok(())
 }
@@ -91,12 +94,22 @@ impl StepContext {
 /// reorganization unit.
 struct MetadataJob {
     context: StepContext,
+    /// The upkeep every step runs with. The trigger and the probe ask about
+    /// the same threshold, so the three cannot disagree.
+    options: MetadataMaintenanceOptions,
 }
 
 #[async_trait::async_trait]
 impl MaintenanceJob for MetadataJob {
     fn id(&self) -> MaintenanceJobId {
         MaintenanceJobId::METADATA
+    }
+
+    /// A publication is this job's trigger only once the tail it left has
+    /// reached the flush threshold. An earlier one would start a step that
+    /// declines to flush.
+    fn nudged_by_publication(&self, publication: &NamespacePublication) -> bool {
+        self.options.flush_is_due(publication.wal_tail_segments)
     }
 
     /// Carries no continuation: what is left to flush or fold is what the
@@ -114,10 +127,11 @@ impl MaintenanceJob for MetadataJob {
         };
         // Upkeep alone: no retention, no garbage collection. Both are other
         // decisions, and one of them is another job.
-        match admin
-            .run_maintenance(namespace_id, MaintenancePlan::metadata())
-            .await
-        {
+        let plan = MaintenancePlan {
+            metadata: Some(self.options),
+            ..MaintenancePlan::default()
+        };
+        match admin.run_maintenance(namespace_id, plan).await {
             Ok(step) => {
                 let metadata = step
                     .metadata_maintenance
@@ -153,14 +167,11 @@ impl MaintenanceJob for MetadataJob {
         // publishing unit concludes `Progressed`, so a backlog is folded by
         // the run that found it rather than left for a sweep.
         match admin.get_namespace_diagnostics(namespace_id).await {
-            Ok(status) => {
-                let threshold = MetadataMaintenanceOptions::default().max_wal_tail_segments;
-                Ok(if status.wal_tail_segments >= threshold.get() {
-                    MaintenanceProbe::Due
-                } else {
-                    MaintenanceProbe::Idle
-                })
-            }
+            Ok(status) => Ok(if self.options.flush_is_due(status.wal_tail_segments) {
+                MaintenanceProbe::Due
+            } else {
+                MaintenanceProbe::Idle
+            }),
             Err(error) if metadata_has_nothing_to_maintain(&error) => Ok(MaintenanceProbe::Idle),
             Err(error) => Err(error),
         }

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -94,8 +94,6 @@ impl StepContext {
 /// reorganization unit.
 struct MetadataJob {
     context: StepContext,
-    /// The upkeep every step runs with. The trigger and the probe ask about
-    /// the same threshold, so the three cannot disagree.
     options: MetadataMaintenanceOptions,
 }
 
@@ -105,10 +103,7 @@ impl MaintenanceJob for MetadataJob {
         MaintenanceJobId::METADATA
     }
 
-    /// A publication is this job's trigger only once the tail it left has
-    /// reached the flush threshold. An earlier one would start a step that
-    /// declines to flush.
-    fn nudged_by_publication(&self, publication: &NamespacePublication) -> bool {
+    fn should_nudge_after_publication(&self, publication: &NamespacePublication) -> bool {
         self.options.flush_is_due(publication.wal_tail_segments)
     }
 

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -237,8 +237,6 @@ impl MaintenanceJob for TestJob {
 
 const SUBSCRIBING_JOB: MaintenanceJobId = MaintenanceJobId::new("subscribing");
 
-/// A job triggered by publications that committed, like the projections the
-/// hook is written for, recording which namespaces it was told about.
 #[derive(Default)]
 struct SubscribingJob {
     steps: StdMutex<Vec<NamespaceId>>,
@@ -256,7 +254,7 @@ impl MaintenanceJob for SubscribingJob {
         SUBSCRIBING_JOB
     }
 
-    fn nudged_by_publication(&self, publication: &NamespacePublication) -> bool {
+    fn should_nudge_after_publication(&self, publication: &NamespacePublication) -> bool {
         publication.committed_through_seq.is_some()
     }
 
@@ -606,9 +604,7 @@ async fn a_publication_nudges_only_the_jobs_it_concerns() {
         .expect("register the subscribing job");
     let namespace_id = namespace_id("published");
 
-    // An attempt that committed nothing still reaches every job. The job
-    // that answers on commits declines it; nothing is scheduled.
-    runner.nudge_publication_subscribers(
+    runner.nudge_jobs_after_publication(
         &namespace_id,
         &NamespacePublication {
             committed_through_seq: None,
@@ -621,7 +617,7 @@ async fn a_publication_nudges_only_the_jobs_it_concerns() {
         "a publication that committed nothing is not this job's trigger"
     );
 
-    runner.nudge_publication_subscribers(
+    runner.nudge_jobs_after_publication(
         &namespace_id,
         &NamespacePublication {
             committed_through_seq: Some(ChangeSeq(7)),

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -237,8 +237,8 @@ impl MaintenanceJob for TestJob {
 
 const SUBSCRIBING_JOB: MaintenanceJobId = MaintenanceJobId::new("subscribing");
 
-/// A job that says publications concern it, and records which namespaces
-/// it was told about.
+/// A job triggered by publications that committed, like the projections the
+/// hook is written for, recording which namespaces it was told about.
 #[derive(Default)]
 struct SubscribingJob {
     steps: StdMutex<Vec<NamespaceId>>,
@@ -256,8 +256,8 @@ impl MaintenanceJob for SubscribingJob {
         SUBSCRIBING_JOB
     }
 
-    fn nudged_by_publications(&self) -> bool {
-        true
+    fn nudged_by_publication(&self, publication: &NamespacePublication) -> bool {
+        publication.committed_through_seq.is_some()
     }
 
     async fn step(
@@ -597,7 +597,7 @@ async fn a_step_that_reports_a_deadline_re_arms_its_own_key() {
 }
 
 #[tokio::test]
-async fn a_publication_nudges_only_the_jobs_that_subscribe_to_it() {
+async fn a_publication_nudges_only_the_jobs_it_concerns() {
     let quiet = TestJob::idle();
     let subscriber = Arc::new(SubscribingJob::default());
     let runner = enabled_runner(quiet.clone());
@@ -606,13 +606,34 @@ async fn a_publication_nudges_only_the_jobs_that_subscribe_to_it() {
         .expect("register the subscribing job");
     let namespace_id = namespace_id("published");
 
-    runner.nudge_publication_subscribers(&namespace_id);
+    // An attempt that committed nothing still reaches every job. The job
+    // that answers on commits declines it; nothing is scheduled.
+    runner.nudge_publication_subscribers(
+        &namespace_id,
+        &NamespacePublication {
+            committed_through_seq: None,
+            wal_tail_segments: 4,
+        },
+    );
+    runner.drain().await.expect("nothing was scheduled");
+    assert!(
+        subscriber.stepped().is_empty(),
+        "a publication that committed nothing is not this job's trigger"
+    );
+
+    runner.nudge_publication_subscribers(
+        &namespace_id,
+        &NamespacePublication {
+            committed_through_seq: Some(ChangeSeq(7)),
+            wal_tail_segments: 5,
+        },
+    );
     runner.drain().await.expect("the subscriber's step settles");
 
     assert_eq!(subscriber.stepped(), vec!["published".to_owned()]);
     assert!(
         quiet.stepped().is_empty(),
-        "a job that did not subscribe hears nothing from a publication"
+        "a job that declares no publication trigger hears nothing"
     );
 }
 

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -55,6 +55,17 @@ impl Default for MetadataMaintenanceOptions {
     }
 }
 
+impl MetadataMaintenanceOptions {
+    /// True when a visible WAL tail of `wal_tail_segments` has reached the
+    /// flush threshold these options carry.
+    ///
+    /// The one owner of that comparison: the step flushes on it, and the
+    /// runtime's metadata job triggers and probes on it.
+    pub fn flush_is_due(&self, wal_tail_segments: u64) -> bool {
+        wal_tail_segments >= self.max_wal_tail_segments.get()
+    }
+}
+
 impl MaintenancePlan {
     /// The plan for one metadata-upkeep pass at the default threshold.
     pub fn metadata() -> Self {

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -56,11 +56,7 @@ impl Default for MetadataMaintenanceOptions {
 }
 
 impl MetadataMaintenanceOptions {
-    /// True when a visible WAL tail of `wal_tail_segments` has reached the
-    /// flush threshold these options carry.
-    ///
-    /// The one owner of that comparison: the step flushes on it, and the
-    /// runtime's metadata job triggers and probes on it.
+    /// Returns whether the WAL tail has reached the flush threshold.
     pub fn flush_is_due(&self, wal_tail_segments: u64) -> bool {
         wal_tail_segments >= self.max_wal_tail_segments.get()
     }

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -753,9 +753,6 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
                 .build()
                 .await
                 .expect("build admin");
-            // The tail, not the publication, is what schedules the step. A
-            // writer that publishes below the threshold does no upkeep at
-            // all, so the common write costs nothing in the background.
             writer
                 .put_file_bytes(
                     &namespace_id,
@@ -807,10 +804,6 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
 
 #[test]
 fn a_refused_publish_schedules_the_step_that_relieves_the_debt() {
-    // The debt is inherited: another process left the tail at the write-stop
-    // bound, so this writer's runner has never heard of the namespace. Its
-    // first publish is refused, and that refusal is the only report the
-    // namespace can make — nothing committed, so no advance follows it.
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     block_on(async {

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -747,17 +747,44 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
                 .create_namespace(&namespace_id, CreateNamespaceOptions::default())
                 .await
                 .expect("create namespace");
-            fill_wal_tail_past_threshold(&writer, &namespace_id).await;
-            writer
-                .flush_background()
-                .await
-                .expect("background maintenance quiesces");
 
             let admin = FsAdmin::builder(store_config(temp_dir.path()))
                 .actor_id("handle-test-admin")
                 .build()
                 .await
                 .expect("build admin");
+            // The tail, not the publication, is what schedules the step. A
+            // writer that publishes below the threshold does no upkeep at
+            // all, so the common write costs nothing in the background.
+            writer
+                .put_file_bytes(
+                    &namespace_id,
+                    "/docs/under-threshold.txt",
+                    b"body",
+                    PutFileOptions::new(loonfs_test_support::test_actor()),
+                )
+                .await
+                .expect("put file below the threshold");
+            writer
+                .flush_background()
+                .await
+                .expect("nothing was scheduled below the threshold");
+            let status = admin
+                .get_namespace_diagnostics(&namespace_id)
+                .await
+                .expect("status below the threshold");
+            assert_eq!(
+                status.current_manifest_no, None,
+                "a publish below the threshold must not step: {status:?}"
+            );
+            assert_eq!(status.wal_tail_segments, 1, "{status:?}");
+
+            fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+            writer
+                .flush_background()
+                .await
+                .expect("background maintenance quiesces");
+
             let status = admin
                 .get_namespace_diagnostics(&namespace_id)
                 .await
@@ -776,6 +803,76 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
                 .expect("shut down writer background work");
         });
     }
+}
+
+#[test]
+fn a_refused_publish_schedules_the_step_that_relieves_the_debt() {
+    // The debt is inherited: another process left the tail at the write-stop
+    // bound, so this writer's runner has never heard of the namespace. Its
+    // first publish is refused, and that refusal is the only report the
+    // namespace can make — nothing committed, so no advance follows it.
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    block_on(async {
+        let stalled = FsWriter::builder(store_config(temp_dir.path()))
+            .writer_id("handle-test-stalled-writer")
+            .background_work(FsBackgroundWork::ManualOnly)
+            .build()
+            .await
+            .expect("build the writer that leaves the debt");
+        stalled
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        fill_wal_tail_to_write_stop(&stalled, &namespace_id).await;
+        stalled
+            .shutdown()
+            .await
+            .expect("shut down the first writer");
+
+        let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
+        let refused = writer
+            .put_file_bytes(
+                &namespace_id,
+                "/write-stop/refused.txt",
+                b"body",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect_err("a tail at the write-stop bound refuses the publish");
+        assert_eq!(refused.code(), ErrorCode::MaintenanceRequired);
+
+        writer
+            .flush_background()
+            .await
+            .expect("the step the refusal asked for settles");
+        let admin = FsAdmin::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .get_namespace_diagnostics(&namespace_id)
+            .await
+            .expect("status after the refused publish");
+        assert!(
+            status.wal_tail_segments < wal_tail_segment_threshold(),
+            "the refused publish must schedule the flush that unblocks it: {status:?}"
+        );
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                "/write-stop/recovered.txt",
+                b"body",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("the retry lands once the debt is cleared");
+        writer
+            .shutdown()
+            .await
+            .expect("shut down writer background work");
+    });
 }
 
 #[test]

--- a/crates/loonfs/tests/it/namespace_advance_observer.rs
+++ b/crates/loonfs/tests/it/namespace_advance_observer.rs
@@ -66,8 +66,6 @@ async fn registered_observer_sees_one_hint_per_publication() {
 
 const SUBSCRIBING_JOB: MaintenanceJobId = MaintenanceJobId::new("namespace-advance-subscriber");
 
-/// A job triggered by publications that committed, recording which
-/// namespaces it was stepped for.
 #[derive(Default)]
 struct SubscribingJob {
     steps: Mutex<Vec<NamespaceId>>,
@@ -85,7 +83,7 @@ impl MaintenanceJob for SubscribingJob {
         SUBSCRIBING_JOB
     }
 
-    fn nudged_by_publication(&self, publication: &NamespacePublication) -> bool {
+    fn should_nudge_after_publication(&self, publication: &NamespacePublication) -> bool {
         publication.committed_through_seq.is_some()
     }
 

--- a/crates/loonfs/tests/it/namespace_advance_observer.rs
+++ b/crates/loonfs/tests/it/namespace_advance_observer.rs
@@ -6,7 +6,7 @@
 use loonfs::{
     CreateNamespaceOptions, FsBackgroundWork, FsWriter, MaintenanceJob, MaintenanceJobId,
     MaintenanceProbe, MaintenanceStepConclusion, MaintenanceStepReport, NamespaceAdvanceHint,
-    PutFileOptions, Result, SharedObjectStore,
+    NamespacePublication, PutFileOptions, Result, SharedObjectStore,
 };
 use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -66,8 +66,8 @@ async fn registered_observer_sees_one_hint_per_publication() {
 
 const SUBSCRIBING_JOB: MaintenanceJobId = MaintenanceJobId::new("namespace-advance-subscriber");
 
-/// A job that says publications concern it, and records which namespaces it
-/// was stepped for.
+/// A job triggered by publications that committed, recording which
+/// namespaces it was stepped for.
 #[derive(Default)]
 struct SubscribingJob {
     steps: Mutex<Vec<NamespaceId>>,
@@ -85,8 +85,8 @@ impl MaintenanceJob for SubscribingJob {
         SUBSCRIBING_JOB
     }
 
-    fn nudged_by_publications(&self) -> bool {
-        true
+    fn nudged_by_publication(&self, publication: &NamespacePublication) -> bool {
+        publication.committed_through_seq.is_some()
     }
 
     async fn step(


### PR DESCRIPTION
Routes metadata and grep maintenance scheduling through one post-publish hook. Each job decides whether to run from the committed sequence and WAL-tail length, so small writes do not start unnecessary metadata work.

`MaintenanceJob::should_nudge_after_publication` now receives a `NamespacePublication` with those values. Failed writes at the WAL limit still schedule the metadata flush needed to unblock future writes, while the separate metadata-only hook and repeated threshold checks are removed. This changes the public maintenance trait but not any wire or durable format.