### PR TITLE
fix(cli): make grep waits, profile validation, and summaries consistent

### DIFF
--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -1,6 +1,6 @@
 //! Dispatches each resolved operation to its embedded or remote implementation.
 
-use super::progress::{rest_between_status_checks, wait_for_grep_index, GrepWaitAdvance};
+use super::progress::{rest_between_status_checks, wait_for_grep_index, GrepWaitStep};
 use super::{FileDownload, GrepWaitProgress, MaintenanceDrainProgress, StepBudget};
 use crate::backend_error::{map_namespace_scoped_runtime_error, BackendError};
 use crate::payload::LocalPayload;
@@ -412,11 +412,9 @@ impl ResolvedTarget {
                         let index = target.client.get_grep_index(namespace_id).await?;
                         Ok(index.lifecycle)
                     },
-                    // A status check is this arm's step: the server advances
-                    // the index, so the wait only asks again.
                     || async {
                         rest_between_status_checks().await;
-                        Ok(GrepWaitAdvance::Advanced)
+                        Ok(GrepWaitStep::Continue)
                     },
                 )
                 .await

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -1,6 +1,6 @@
 //! Dispatches each resolved operation to its embedded or remote implementation.
 
-use super::progress::rest_between_status_checks;
+use super::progress::{rest_between_status_checks, wait_for_grep_index, GrepWaitAdvance};
 use super::{FileDownload, GrepWaitProgress, MaintenanceDrainProgress, StepBudget};
 use crate::backend_error::{map_namespace_scoped_runtime_error, BackendError};
 use crate::payload::LocalPayload;
@@ -24,7 +24,6 @@ use loonfs_client::{
     MoveOptions, NamespacePath, PutFileOptions, RestoreRevisionOptions, StatPathOptions,
     UndeleteOptions, UpdateAttributesOptions,
 };
-use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::sync::Arc;
 
 /// Returns errors for commands that require a different profile type.
@@ -406,19 +405,21 @@ impl ResolvedTarget {
                     .await
             }
             Self::Remote(target) => {
-                let timer = StdMonotonicTimer::default();
-                let started_ms = timer.monotonic_now_ms();
-                let mut steps = 0;
-                loop {
-                    let lifecycle = target.client.get_grep_index(namespace_id).await?.lifecycle;
-                    let reached = lifecycle.is_built_through(target_seq);
-                    let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
-                    if reached || budget.spent(steps, elapsed_ms) {
-                        return Ok(GrepWaitProgress { steps, reached });
-                    }
-                    rest_between_status_checks().await;
-                    steps += 1;
-                }
+                wait_for_grep_index(
+                    target_seq,
+                    budget,
+                    || async {
+                        let index = target.client.get_grep_index(namespace_id).await?;
+                        Ok(index.lifecycle)
+                    },
+                    // A status check is this arm's step: the server advances
+                    // the index, so the wait only asks again.
+                    || async {
+                        rest_between_status_checks().await;
+                        Ok(GrepWaitAdvance::Advanced)
+                    },
+                )
+                .await
             }
         }
     }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -37,6 +37,7 @@ use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, Sto
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::sync::Arc;
 
+use super::progress::{wait_for_grep_index, GrepWaitAdvance};
 use super::{GrepWaitProgress, MaintenanceDrainProgress, MaintenanceKeyProgress, StepBudget};
 
 /// Purpose-specific handles over one shared store client: reads go through
@@ -374,37 +375,35 @@ impl EmbeddedBackend {
     ) -> Result<GrepWaitProgress, BackendError> {
         let worker = self.grep_worker();
         let job = GrepMaintenanceJob::new(worker.clone(), GramIndexBuildPolicy::default());
-        let timer = StdMonotonicTimer::default();
-        let started_ms = timer.monotonic_now_ms();
-        let mut steps = 0;
-        let mut settled = false;
-        loop {
-            let lifecycle = GrepIndexLifecycle::from(
-                &worker
+        wait_for_grep_index(
+            target_seq,
+            budget,
+            || async {
+                let status = worker
                     .lifecycle(namespace_id)
                     .await
-                    .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))?,
-            );
-            let reached = lifecycle.is_built_through(target_seq);
-            let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
-            if reached || settled || budget.spent(steps, elapsed_ms) {
-                return Ok(GrepWaitProgress { steps, reached });
-            }
-            let conclusion = job
-                .step(namespace_id, None)
-                .await
-                .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?
-                .conclusion;
-            steps += 1;
-            // A step that settled short of the target says the index has
-            // nothing more to do — disabled underneath us, or blocked on a
-            // budget of its own. Repeating it would only spin, so the next
-            // turn of this loop reports where it stopped.
-            settled = !matches!(
-                conclusion,
-                MaintenanceStepConclusion::Progressed | MaintenanceStepConclusion::Superseded
-            );
-        }
+                    .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))?;
+                Ok(GrepIndexLifecycle::from(&status))
+            },
+            || async {
+                let conclusion = job
+                    .step(namespace_id, None)
+                    .await
+                    .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?
+                    .conclusion;
+                // A step that settled short of the target says the index has
+                // nothing more to do — blocked on a budget of its own, or
+                // not enabled. Repeating it would only spin.
+                Ok(match conclusion {
+                    MaintenanceStepConclusion::Progressed
+                    | MaintenanceStepConclusion::Superseded => GrepWaitAdvance::Advanced,
+                    MaintenanceStepConclusion::Idle
+                    | MaintenanceStepConclusion::Blocked
+                    | MaintenanceStepConclusion::NotEnabled => GrepWaitAdvance::Settled,
+                })
+            },
+        )
+        .await
     }
 
     /// Registers the jobs this process composes itself, then resolves every

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -37,7 +37,7 @@ use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, Sto
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::sync::Arc;
 
-use super::progress::{wait_for_grep_index, GrepWaitAdvance};
+use super::progress::{wait_for_grep_index, GrepWaitStep};
 use super::{GrepWaitProgress, MaintenanceDrainProgress, MaintenanceKeyProgress, StepBudget};
 
 /// Purpose-specific handles over one shared store client: reads go through
@@ -391,15 +391,12 @@ impl EmbeddedBackend {
                     .await
                     .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?
                     .conclusion;
-                // A step that settled short of the target says the index has
-                // nothing more to do — blocked on a budget of its own, or
-                // not enabled. Repeating it would only spin.
                 Ok(match conclusion {
                     MaintenanceStepConclusion::Progressed
-                    | MaintenanceStepConclusion::Superseded => GrepWaitAdvance::Advanced,
+                    | MaintenanceStepConclusion::Superseded => GrepWaitStep::Continue,
                     MaintenanceStepConclusion::Idle
                     | MaintenanceStepConclusion::Blocked
-                    | MaintenanceStepConclusion::NotEnabled => GrepWaitAdvance::Settled,
+                    | MaintenanceStepConclusion::NotEnabled => GrepWaitStep::Settled,
                 })
             },
         )

--- a/crates/loonfs-cli/src/backend/progress.rs
+++ b/crates/loonfs-cli/src/backend/progress.rs
@@ -1,7 +1,11 @@
 //! Progress and budget state for iterative maintenance and grep operations.
 
+use crate::backend_error::BackendError;
 use loonfs::{MaintenanceJobId, MaintenanceStepConclusion};
-use loonfs_api::NamespaceId;
+use loonfs_api::v0::GrepIndexLifecycle;
+use loonfs_api::{ChangeSeq, NamespaceId};
+use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
+use std::future::Future;
 
 /// Delay between remote status checks.
 const REMOTE_STATUS_POLL_INTERVAL_MS: u64 = 250;
@@ -79,6 +83,61 @@ pub(crate) struct GrepWaitProgress {
     pub reached: bool,
 }
 
+/// What one turn of a grep-index wait did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GrepWaitAdvance {
+    /// The arm did something the next reading may reflect.
+    Advanced,
+    /// The arm has nothing more to do; repeating the turn would only spin.
+    Settled,
+}
+
+/// Waits for one namespace's grep index to reach `target_seq`.
+///
+/// `read` reports where the index is; `advance` moves it one step, in
+/// whatever a step means for the arm — a bounded index step where the
+/// profile is embedded, a status check where it is remote. The wait returns
+/// when the target is reached, when the lifecycle has stopped where it is,
+/// when the arm settles, or when the budget is spent, and reports how far it
+/// got either way.
+pub(super) async fn wait_for_grep_index<Read, ReadTurn, Advance, AdvanceTurn>(
+    target_seq: ChangeSeq,
+    budget: StepBudget,
+    read: Read,
+    advance: Advance,
+) -> Result<GrepWaitProgress, BackendError>
+where
+    Read: Fn() -> ReadTurn,
+    ReadTurn: Future<Output = Result<GrepIndexLifecycle, BackendError>>,
+    Advance: Fn() -> AdvanceTurn,
+    AdvanceTurn: Future<Output = Result<GrepWaitAdvance, BackendError>>,
+{
+    let timer = StdMonotonicTimer::default();
+    let started_ms = timer.monotonic_now_ms();
+    let mut steps = 0;
+    let mut settled = false;
+    loop {
+        let lifecycle = read().await?;
+        let reached = lifecycle.is_built_through(target_seq);
+        let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
+        if reached || settled || lifecycle_stopped(&lifecycle) || budget.spent(steps, elapsed_ms) {
+            return Ok(GrepWaitProgress { steps, reached });
+        }
+        settled = advance().await? == GrepWaitAdvance::Settled;
+        steps += 1;
+    }
+}
+
+/// Whether a lifecycle has stopped where it is. Nobody builds a disabled
+/// index, so a wait on one reports where it stopped rather than asking
+/// again forever.
+fn lifecycle_stopped(lifecycle: &GrepIndexLifecycle) -> bool {
+    match lifecycle {
+        GrepIndexLifecycle::Disabled => true,
+        GrepIndexLifecycle::Backfilling { .. } | GrepIndexLifecycle::Active { .. } => false,
+    }
+}
+
 /// Waits before the next remote status check.
 #[allow(clippy::disallowed_methods)]
 pub(super) async fn rest_between_status_checks() {
@@ -86,4 +145,62 @@ pub(super) async fn rest_between_status_checks() {
         REMOTE_STATUS_POLL_INTERVAL_MS,
     ))
     .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{wait_for_grep_index, GrepWaitAdvance, GrepWaitProgress, StepBudget};
+    use loonfs_api::v0::GrepIndexLifecycle;
+    use loonfs_api::ChangeSeq;
+    use std::cell::Cell;
+
+    /// A wait with no budget: only settling can end it.
+    #[tokio::test]
+    async fn an_unbudgeted_wait_stops_where_the_index_stops() {
+        let turns = Cell::new(0u64);
+        let disabled = wait_for_grep_index(
+            ChangeSeq(3),
+            StepBudget::default(),
+            || async { Ok(GrepIndexLifecycle::Disabled) },
+            || async {
+                turns.set(turns.get() + 1);
+                assert!(turns.get() < 4, "a disabled index must end the wait");
+                Ok(GrepWaitAdvance::Advanced)
+            },
+        )
+        .await
+        .expect("wait over a disabled index");
+        assert_eq!(
+            disabled,
+            GrepWaitProgress {
+                steps: 0,
+                reached: false
+            }
+        );
+
+        let backfilling = wait_for_grep_index(
+            ChangeSeq(3),
+            StepBudget::default(),
+            || async {
+                Ok(GrepIndexLifecycle::Backfilling {
+                    target_seq: ChangeSeq(3),
+                    cursor_inode_id: None,
+                    checkpoint_id: loonfs_api::CheckpointId::parse(
+                        "chk_0123456789abcdef0123456789abcdef",
+                    )
+                    .expect("checkpoint id"),
+                })
+            },
+            || async { Ok(GrepWaitAdvance::Settled) },
+        )
+        .await
+        .expect("wait over an index that settles short");
+        assert_eq!(
+            backfilling,
+            GrepWaitProgress {
+                steps: 1,
+                reached: false
+            }
+        );
+    }
 }

--- a/crates/loonfs-cli/src/backend/progress.rs
+++ b/crates/loonfs-cli/src/backend/progress.rs
@@ -77,40 +77,30 @@ impl MaintenanceDrainProgress {
 /// Result of waiting for a grep index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GrepWaitProgress {
-    /// Number of status checks or maintenance steps performed.
+    /// Number of polling intervals or maintenance steps completed.
     pub steps: u64,
     /// True when the index reached the target sequence.
     pub reached: bool,
 }
 
-/// What one turn of a grep-index wait did.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum GrepWaitAdvance {
-    /// The arm did something the next reading may reflect.
-    Advanced,
-    /// The arm has nothing more to do; repeating the turn would only spin.
+pub(super) enum GrepWaitStep {
+    Continue,
     Settled,
 }
 
-/// Waits for one namespace's grep index to reach `target_seq`.
-///
-/// `read` reports where the index is; `advance` moves it one step, in
-/// whatever a step means for the arm — a bounded index step where the
-/// profile is embedded, a status check where it is remote. The wait returns
-/// when the target is reached, when the lifecycle has stopped where it is,
-/// when the arm settles, or when the budget is spent, and reports how far it
-/// got either way.
-pub(super) async fn wait_for_grep_index<Read, ReadTurn, Advance, AdvanceTurn>(
+/// Waits until the grep index reaches the target, stops, or exhausts the budget.
+pub(super) async fn wait_for_grep_index<Read, ReadTurn, Step, StepTurn>(
     target_seq: ChangeSeq,
     budget: StepBudget,
     read: Read,
-    advance: Advance,
+    step: Step,
 ) -> Result<GrepWaitProgress, BackendError>
 where
     Read: Fn() -> ReadTurn,
     ReadTurn: Future<Output = Result<GrepIndexLifecycle, BackendError>>,
-    Advance: Fn() -> AdvanceTurn,
-    AdvanceTurn: Future<Output = Result<GrepWaitAdvance, BackendError>>,
+    Step: Fn() -> StepTurn,
+    StepTurn: Future<Output = Result<GrepWaitStep, BackendError>>,
 {
     let timer = StdMonotonicTimer::default();
     let started_ms = timer.monotonic_now_ms();
@@ -123,14 +113,11 @@ where
         if reached || settled || lifecycle_stopped(&lifecycle) || budget.spent(steps, elapsed_ms) {
             return Ok(GrepWaitProgress { steps, reached });
         }
-        settled = advance().await? == GrepWaitAdvance::Settled;
+        settled = step().await? == GrepWaitStep::Settled;
         steps += 1;
     }
 }
 
-/// Whether a lifecycle has stopped where it is. Nobody builds a disabled
-/// index, so a wait on one reports where it stopped rather than asking
-/// again forever.
 fn lifecycle_stopped(lifecycle: &GrepIndexLifecycle) -> bool {
     match lifecycle {
         GrepIndexLifecycle::Disabled => true,
@@ -149,12 +136,11 @@ pub(super) async fn rest_between_status_checks() {
 
 #[cfg(test)]
 mod tests {
-    use super::{wait_for_grep_index, GrepWaitAdvance, GrepWaitProgress, StepBudget};
+    use super::{wait_for_grep_index, GrepWaitProgress, GrepWaitStep, StepBudget};
     use loonfs_api::v0::GrepIndexLifecycle;
     use loonfs_api::ChangeSeq;
     use std::cell::Cell;
 
-    /// A wait with no budget: only settling can end it.
     #[tokio::test]
     async fn an_unbudgeted_wait_stops_where_the_index_stops() {
         let turns = Cell::new(0u64);
@@ -165,7 +151,7 @@ mod tests {
             || async {
                 turns.set(turns.get() + 1);
                 assert!(turns.get() < 4, "a disabled index must end the wait");
-                Ok(GrepWaitAdvance::Advanced)
+                Ok(GrepWaitStep::Continue)
             },
         )
         .await
@@ -191,7 +177,7 @@ mod tests {
                     .expect("checkpoint id"),
                 })
             },
-            || async { Ok(GrepWaitAdvance::Settled) },
+            || async { Ok(GrepWaitStep::Settled) },
         )
         .await
         .expect("wait over an index that settles short");

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -12,7 +12,7 @@ use crate::args::{
     MaintenanceJobArg, RuntimeBehavior,
 };
 use crate::backend::{MaintenanceKeyProgress, StepBudget};
-use crate::render::{format_utc_ms, write_stderr_progress};
+use crate::render::{gc_pass_line, write_stderr_progress};
 use crate::resolve::{parse_namespace_id, resolve_target_profile};
 use clap::ValueEnum;
 use loonfs::{MaintenanceJobId, NamespaceId};
@@ -208,26 +208,6 @@ impl PassProgress {
         lines.push(format!("pass {}: {line}", self.passes));
         lines
     }
-}
-
-/// What one collection pass did, in the terms an operator watching a long
-/// run needs: what went, what stayed and mostly why, and when the next thing
-/// this pass kept becomes reclaimable.
-fn gc_pass_line(pass: &loonfs_api::GcResponse) -> String {
-    let deleted = pass.deleted.wal_segments
-        + pass.deleted.metadata_segments
-        + pass.deleted.manifests
-        + pass.deleted.checkpoint_records
-        + pass.deleted.upload_sessions
-        + pass.deleted.content_objects;
-    let mut line = format!("{deleted} deleted, {} retained", pass.retained_candidates);
-    if let Some((reason, count)) = pass.retained.top_reason() {
-        line.push_str(&format!(" (mostly {reason}: {count})"));
-    }
-    if let Some(at_ms) = pass.next_reclamation_at_ms {
-        line.push_str(&format!("; next reclaimable at {}", format_utc_ms(at_ms)));
-    }
-    line
 }
 
 fn accumulate_gc_response(total: &mut loonfs_api::GcResponse, pass: loonfs_api::GcResponse) {
@@ -864,6 +844,7 @@ mod tests {
     fn a_pass_line_names_what_stayed_and_mostly_why() {
         let mut pass = GcResponse::empty(NamespaceId::parse("demo").expect("namespace id"));
         pass.deleted.wal_segments = 2;
+        pass.deleted.upload_sessions = 3;
         pass.deleted.content_objects = 1;
         for _ in 0..4 {
             pass.retain(RetainedReason::WithinGraceWindow);
@@ -873,8 +854,8 @@ mod tests {
 
         let line = gc_pass_line(&pass);
         assert!(
-            line.contains("3 deleted, 5 retained (mostly within_grace_window: 4)"),
-            "{line}"
+            line.contains("6 deleted, 5 retained; mostly within_grace_window: 4"),
+            "every deleted family counts, upload sessions included: {line}"
         );
         assert!(
             line.contains("next reclaimable at 2023-11-14 22:13:20Z"),

--- a/crates/loonfs-cli/src/commands/inspection.rs
+++ b/crates/loonfs-cli/src/commands/inspection.rs
@@ -10,8 +10,9 @@ use crate::config::{
 };
 use crate::error::CliError;
 use crate::profiles::resolve_profile;
+use crate::render::{store_probe_summary_line, store_probe_verdict, StoreProbeVerdict};
 use crate::resolve::{resolve_namespace, resolve_target_profile, ResolvedTarget};
-use loonfs_api::v0::{StoreProbeCheckOutcome, StoreProbeResponse};
+use loonfs_api::v0::StoreProbeResponse;
 use loonfs_api::{CapabilityDocument, PROTOCOL_VERSION};
 use std::path::Path;
 
@@ -349,46 +350,15 @@ fn capability_document_check(result: Result<CapabilityDocument, BackendError>) -
 }
 
 fn store_probe_check(response: StoreProbeResponse) -> DoctorCheck {
-    let failed_count = response
-        .checks
-        .iter()
-        .filter(|check| check.outcome == StoreProbeCheckOutcome::Failed)
-        .count();
-    let unsupported_count = response
-        .checks
-        .iter()
-        .filter(|check| check.outcome == StoreProbeCheckOutcome::Unsupported)
-        .count();
-    let status = if failed_count > 0 {
-        DoctorStatus::Failed
-    } else if unsupported_count > 0 {
-        DoctorStatus::Warning
-    } else {
-        DoctorStatus::Ok
-    };
-    let message = if failed_count > 0 {
-        format!(
-            "store probe {}: {failed_count} of {} checks failed",
-            response.run_id,
-            response.checks.len()
-        )
-    } else if unsupported_count > 0 {
-        format!(
-            "store probe {}: {unsupported_count} of {} checks are unsupported",
-            response.run_id,
-            response.checks.len()
-        )
-    } else {
-        format!(
-            "store probe {}: {} checks passed",
-            response.run_id,
-            response.checks.len()
-        )
+    let status = match store_probe_verdict(&response) {
+        StoreProbeVerdict::Failed { .. } => DoctorStatus::Failed,
+        StoreProbeVerdict::Unsupported { .. } => DoctorStatus::Warning,
+        StoreProbeVerdict::Passed => DoctorStatus::Ok,
     };
     DoctorCheck {
         name: WRITE_CHECK_NAME.to_owned(),
         status,
-        message,
+        message: store_probe_summary_line(&response),
         request_id: None,
         store_probe: Some(response),
     }
@@ -503,7 +473,7 @@ fn doctor_output(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_api::v0::StoreProbeCheckResult;
+    use loonfs_api::v0::{StoreProbeCheckOutcome, StoreProbeCheckResult};
     use std::collections::BTreeMap;
 
     fn capability_document(protocol_version: &str) -> CapabilityDocument {
@@ -526,18 +496,56 @@ mod tests {
         assert!(failed.message.contains("but this CLI expects"));
     }
 
+    fn probe_response(outcomes: &[StoreProbeCheckOutcome]) -> StoreProbeResponse {
+        StoreProbeResponse {
+            run_id: "probe_test".to_owned(),
+            checks: outcomes
+                .iter()
+                .enumerate()
+                .map(|(index, outcome)| StoreProbeCheckResult {
+                    name: format!("check_{index}"),
+                    outcome: *outcome,
+                    message: Some("replacement was not atomic".to_owned()),
+                })
+                .collect(),
+        }
+    }
+
     #[test]
     fn store_probe_failure_is_included_and_fails_doctor() {
-        let response = StoreProbeResponse {
-            run_id: "probe_test".to_owned(),
-            checks: vec![StoreProbeCheckResult {
-                name: "compare_and_swap".to_owned(),
-                outcome: StoreProbeCheckOutcome::Failed,
-                message: Some("replacement was not atomic".to_owned()),
-            }],
-        };
+        let response = probe_response(&[StoreProbeCheckOutcome::Failed]);
         let check = store_probe_check(response.clone());
         assert_eq!(check.status, DoctorStatus::Failed);
+        assert_eq!(
+            check.message,
+            "store probe probe_test: 1 of 1 checks failed"
+        );
         assert_eq!(check.store_probe, Some(response));
+    }
+
+    #[test]
+    fn an_unsupported_check_warns_and_never_reads_as_passed() {
+        let response = probe_response(&[
+            StoreProbeCheckOutcome::Passed,
+            StoreProbeCheckOutcome::Unsupported,
+        ]);
+        let check = store_probe_check(response.clone());
+        assert_eq!(check.status, DoctorStatus::Warning);
+        assert_eq!(
+            check.message,
+            "store probe probe_test: 1 of 2 checks are unsupported"
+        );
+        assert_eq!(
+            check.message,
+            store_probe_summary_line(&response),
+            "the doctor line and the probe report say the same thing"
+        );
+
+        let passed = probe_response(&[StoreProbeCheckOutcome::Passed]);
+        assert_eq!(store_probe_check(passed.clone()).status, DoctorStatus::Ok);
+        assert_eq!(
+            store_probe_summary_line(&passed),
+            "store probe probe_test: 1 checks passed"
+        );
     }
 }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -4,9 +4,8 @@ use crate::args::CommandKind;
 use crate::config::{CliConfig, ConfigSource, ProfileConfig};
 use crate::error::CliError;
 use crate::profiles::ProfileSummary;
-use loonfs_api::v0::{
-    GrepGcResponse, GrepIndex, ListChangesResponse, StoreProbeCheckOutcome, StoreProbeResponse,
-};
+use crate::render::{store_probe_verdict, StoreProbeVerdict};
+use loonfs_api::v0::{GrepGcResponse, GrepIndex, ListChangesResponse, StoreProbeResponse};
 use loonfs_api::{
     AbsolutePath, CapabilityDocument, ChangeSeq, Checkpoint, CommitId, DeleteNamespaceResponse,
     FileRevision, GcResponse, GrepMatch, InodeId, ListCheckpointsResponse, MaintenanceStepResponse,
@@ -351,10 +350,9 @@ impl CommandData {
             // A probe that found a broken store prints every check's verdict
             // and still exits nonzero, because the store it was asked about
             // cannot be trusted.
-            CommandData::StoreProbed(response) => response
-                .checks
-                .iter()
-                .any(|check| check.outcome == StoreProbeCheckOutcome::Failed),
+            CommandData::StoreProbed(response) => {
+                matches!(store_probe_verdict(response), StoreProbeVerdict::Failed { .. })
+            }
             _ => false,
         }
     }

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -33,7 +33,6 @@ struct FileJob {
     content_ref: Option<loonfs_api::ContentRef>,
 }
 
-/// Whether a destination directory came into being in this transfer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DirectoryOutcome {
     Created,
@@ -64,9 +63,6 @@ impl TreeTally {
         }
     }
 
-    /// Counts a destination directory this transfer created. `put -r`,
-    /// `get -r`, and `cp -r` all report the same number: directories this
-    /// run added, never ones that were already there.
     fn record_directory(&mut self, outcome: DirectoryOutcome) {
         if outcome == DirectoryOutcome::Created {
             self.directories += 1;
@@ -81,8 +77,6 @@ impl TreeTally {
     }
 }
 
-/// Creates one local destination directory, saying whether this transfer is
-/// what created it.
 fn create_local_directory(path: &Path) -> std::io::Result<DirectoryOutcome> {
     if path.is_dir() {
         return Ok(DirectoryOutcome::AlreadyExists);

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -33,6 +33,22 @@ struct FileJob {
     content_ref: Option<loonfs_api::ContentRef>,
 }
 
+/// Whether a destination directory came into being in this transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirectoryOutcome {
+    Created,
+    AlreadyExists,
+}
+
+impl DirectoryOutcome {
+    fn progress_label(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::AlreadyExists => "already exists",
+        }
+    }
+}
+
 struct TreeTally {
     files: u64,
     directories: u64,
@@ -48,12 +64,31 @@ impl TreeTally {
         }
     }
 
+    /// Counts a destination directory this transfer created. `put -r`,
+    /// `get -r`, and `cp -r` all report the same number: directories this
+    /// run added, never ones that were already there.
+    fn record_directory(&mut self, outcome: DirectoryOutcome) {
+        if outcome == DirectoryOutcome::Created {
+            self.directories += 1;
+        }
+    }
+
     fn fail(&mut self, path: impl Into<String>, error: CliError) {
         self.failures.push(TreeTransferFailure {
             path: path.into(),
             error,
         });
     }
+}
+
+/// Creates one local destination directory, saying whether this transfer is
+/// what created it.
+fn create_local_directory(path: &Path) -> std::io::Result<DirectoryOutcome> {
+    if path.is_dir() {
+        return Ok(DirectoryOutcome::AlreadyExists);
+    }
+    std::fs::create_dir_all(path)?;
+    Ok(DirectoryOutcome::Created)
 }
 
 /// Returns the total size when every file length is known.
@@ -135,7 +170,7 @@ pub(crate) async fn run_put_tree(
                 continue;
             }
         };
-        let progress_label = match context
+        let outcome = match context
             .target
             .create_directory(
                 &spec,
@@ -150,14 +185,16 @@ pub(crate) async fn run_put_tree(
             )
             .await
         {
-            Ok(_) => "created",
+            Ok(_) => DirectoryOutcome::Created,
             Err(error) if error.code == ErrorCode::PathConflict.as_str() => {
                 match context
                     .target
                     .get_path_entry_without_attributes(&spec)
                     .await
                 {
-                    Ok(entry) if entry.inode_kind() == InodeKind::Directory => "already exists",
+                    Ok(entry) if entry.inode_kind() == InodeKind::Directory => {
+                        DirectoryOutcome::AlreadyExists
+                    }
                     Ok(_) => {
                         tally.fail(remote, error.into());
                         continue;
@@ -173,9 +210,13 @@ pub(crate) async fn run_put_tree(
                 continue;
             }
         };
-        tally.directories += 1;
+        tally.record_directory(outcome);
         if runtime.progress.human_lines_enabled() {
-            write_stderr_progress(format_args!("{progress_label} {}", spec_target(&spec)));
+            write_stderr_progress(format_args!(
+                "{} {}",
+                outcome.progress_label(),
+                spec_target(&spec)
+            ));
         }
     }
 
@@ -273,9 +314,9 @@ pub(crate) async fn run_get_tree(
 ) -> Result<CommandOutput, CommandFailure> {
     let mut tally = TreeTally::new();
     // Fail early if the destination cannot be created.
-    std::fs::create_dir_all(local_root)
+    let root_outcome = create_local_directory(local_root)
         .map_err(|error| context.fail(kind, CliError::io_for_path(local_root, error)))?;
-    tally.directories += 1;
+    tally.record_directory(root_outcome);
     let listing = walk_remote_tree(context, kind, "remote_path", remote_root).await?;
     if !runtime.json {
         if let Some(drift) = listing.head_drift.as_ref() {
@@ -286,8 +327,8 @@ pub(crate) async fn run_get_tree(
 
     for components in &listing.directories {
         let local_dir = local_root.join(components.join("/"));
-        match std::fs::create_dir_all(&local_dir) {
-            Ok(()) => tally.directories += 1,
+        match create_local_directory(&local_dir) {
+            Ok(outcome) => tally.record_directory(outcome),
             Err(error) => tally.fail(
                 local_dir.display().to_string(),
                 CliError::io_for_path(&local_dir, error),
@@ -425,7 +466,7 @@ pub(crate) async fn run_copy_tree(
             .await
         {
             Ok(_) => {
-                tally.directories += 1;
+                tally.record_directory(DirectoryOutcome::Created);
                 if runtime.progress.human_lines_enabled() {
                     write_stderr_progress(format_args!("created {}", spec_target(&spec)));
                 }

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -203,7 +203,7 @@ impl ProfileConfig {
                 ca_cert_path,
             } => {
                 validate_actor_and_default_namespace(name, actor, default_namespace.as_deref())?;
-                validate_remote_client_config(
+                validate_stored_remote_client_config(
                     name,
                     server_url,
                     auth_token.as_ref(),
@@ -649,12 +649,7 @@ fn validate_default_namespace(field: &str, value: &str) -> Result<(), CliError> 
         .map_err(|err| CliError::invalid_config(format!("invalid `{field}`: {err}")))
 }
 
-/// The client configuration a remote profile resolves to under the current
-/// environment.
-///
-/// Validation and request setup both build it here, so a profile that
-/// `profile create` accepts is one a request can open a client from: the
-/// environment token counts at both ends.
+/// Builds the client configuration used by a remote profile.
 pub(crate) fn remote_client_config(
     server_url: &str,
     auth_token: Option<&SecretString>,
@@ -679,7 +674,6 @@ fn remote_client_config_from(
 ) -> ClientConfig {
     ClientConfig {
         server_url: server_url.to_owned(),
-        // A stored token wins over the environment, matching the server.
         auth_token: auth_token.cloned().or_else(|| {
             lookup(AUTH_TOKEN_ENV)
                 .filter(|token| !token.trim().is_empty())
@@ -697,21 +691,35 @@ pub(crate) fn validate_remote_client_config(
     auth_token: Option<&SecretString>,
     ca_cert_path: Option<&str>,
 ) -> Result<(), CliError> {
-    // Retry is a per-invocation behavior and never decides validity, so this
-    // asks whether a plain request could use the profile at all.
-    remote_client_config(server_url, auth_token, ca_cert_path, false)
-        .validate()
-        .map_err(|error| match error {
-            ClientError::MissingConfigField { field } => CliError::invalid_config(format!(
-                "missing `{}`",
-                profile_field(profile_name, field)
-            )),
-            ClientError::ConfigValidation { field, reason } => CliError::invalid_config(format!(
-                "invalid `{}`: {reason}",
-                profile_field(profile_name, field)
-            )),
-            error => CliError::invalid_config(error.to_string()),
-        })
+    validate_client_config(
+        profile_name,
+        remote_client_config(server_url, auth_token, ca_cert_path, false),
+    )
+}
+
+fn validate_stored_remote_client_config(
+    profile_name: &str,
+    server_url: &str,
+    auth_token: Option<&SecretString>,
+    ca_cert_path: Option<&str>,
+) -> Result<(), CliError> {
+    validate_client_config(
+        profile_name,
+        remote_client_config_from(server_url, auth_token, ca_cert_path, false, |_| None),
+    )
+}
+
+fn validate_client_config(profile_name: &str, config: ClientConfig) -> Result<(), CliError> {
+    config.validate().map_err(|error| match error {
+        ClientError::MissingConfigField { field } => {
+            CliError::invalid_config(format!("missing `{}`", profile_field(profile_name, field)))
+        }
+        ClientError::ConfigValidation { field, reason } => CliError::invalid_config(format!(
+            "invalid `{}`: {reason}",
+            profile_field(profile_name, field)
+        )),
+        error => CliError::invalid_config(error.to_string()),
+    })
 }
 
 #[cfg(test)]
@@ -761,27 +769,6 @@ mod tests {
                 Some("  ".to_owned())
             });
         assert!(blank.auth_token.is_none());
-    }
-
-    #[test]
-    fn the_environment_token_is_what_validation_judges() {
-        // The same profile a request would build: validation must see the
-        // environment token, or it accepts what every request then rejects.
-        let config =
-            remote_client_config_from("http://example.internal", None, None, false, |_| {
-                Some("env-token".to_owned())
-            });
-        let reason = match config.validate() {
-            Err(loonfs_client::ClientError::ConfigValidation { field, reason }) => {
-                assert_eq!(field, "server_url");
-                reason
-            }
-            other => panic!("expected a config validation failure, got {other:?}"),
-        };
-        assert!(
-            reason.contains("bearer tokens require https except for loopback http URLs"),
-            "{reason}"
-        );
     }
 
     fn parse(contents: &str) -> Result<CliConfig, toml::de::Error> {

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -1,6 +1,7 @@
 //! The CLI config file: profiles, defaults, and strict TOML loading.
 
 use crate::error::CliError;
+use loonfs_api::env::AUTH_TOKEN_ENV;
 use loonfs_api::{ActorId, ActorKind, ActorRef, NamespaceId, SecretString};
 use loonfs_client::{ClientConfig, ClientError};
 use loonfs_objectstore::StoreConfigError;
@@ -648,30 +649,69 @@ fn validate_default_namespace(field: &str, value: &str) -> Result<(), CliError> 
         .map_err(|err| CliError::invalid_config(format!("invalid `{field}`: {err}")))
 }
 
+/// The client configuration a remote profile resolves to under the current
+/// environment.
+///
+/// Validation and request setup both build it here, so a profile that
+/// `profile create` accepts is one a request can open a client from: the
+/// environment token counts at both ends.
+pub(crate) fn remote_client_config(
+    server_url: &str,
+    auth_token: Option<&SecretString>,
+    ca_cert_path: Option<&str>,
+    no_retry: bool,
+) -> ClientConfig {
+    remote_client_config_from(
+        server_url,
+        auth_token,
+        ca_cert_path,
+        no_retry,
+        non_empty_env,
+    )
+}
+
+fn remote_client_config_from(
+    server_url: &str,
+    auth_token: Option<&SecretString>,
+    ca_cert_path: Option<&str>,
+    no_retry: bool,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> ClientConfig {
+    ClientConfig {
+        server_url: server_url.to_owned(),
+        // A stored token wins over the environment, matching the server.
+        auth_token: auth_token.cloned().or_else(|| {
+            lookup(AUTH_TOKEN_ENV)
+                .filter(|token| !token.trim().is_empty())
+                .map(SecretString::from)
+        }),
+        request_timeout_ms: None,
+        disable_transient_retry: no_retry,
+        ca_cert_path: ca_cert_path.map(ToOwned::to_owned),
+    }
+}
+
 pub(crate) fn validate_remote_client_config(
     profile_name: &str,
     server_url: &str,
     auth_token: Option<&SecretString>,
     ca_cert_path: Option<&str>,
 ) -> Result<(), CliError> {
-    ClientConfig {
-        server_url: server_url.to_owned(),
-        auth_token: auth_token.cloned(),
-        request_timeout_ms: None,
-        disable_transient_retry: false,
-        ca_cert_path: ca_cert_path.map(ToOwned::to_owned),
-    }
-    .validate()
-    .map_err(|error| match error {
-        ClientError::MissingConfigField { field } => {
-            CliError::invalid_config(format!("missing `{}`", profile_field(profile_name, field)))
-        }
-        ClientError::ConfigValidation { field, reason } => CliError::invalid_config(format!(
-            "invalid `{}`: {reason}",
-            profile_field(profile_name, field)
-        )),
-        error => CliError::invalid_config(error.to_string()),
-    })
+    // Retry is a per-invocation behavior and never decides validity, so this
+    // asks whether a plain request could use the profile at all.
+    remote_client_config(server_url, auth_token, ca_cert_path, false)
+        .validate()
+        .map_err(|error| match error {
+            ClientError::MissingConfigField { field } => CliError::invalid_config(format!(
+                "missing `{}`",
+                profile_field(profile_name, field)
+            )),
+            ClientError::ConfigValidation { field, reason } => CliError::invalid_config(format!(
+                "invalid `{}`: {reason}",
+                profile_field(profile_name, field)
+            )),
+            error => CliError::invalid_config(error.to_string()),
+        })
 }
 
 #[cfg(test)]
@@ -679,7 +719,70 @@ mod tests {
     #![allow(clippy::panic)]
     // Config tests use panic in unexpected match arms for precise diagnostics.
 
-    use super::{CliConfig, ProfileConfig};
+    use super::{remote_client_config_from, CliConfig, ProfileConfig};
+    use loonfs_api::env::AUTH_TOKEN_ENV;
+    use loonfs_api::SecretString;
+
+    #[test]
+    fn a_remote_profile_takes_its_token_from_the_config_then_the_environment() {
+        let stored = SecretString::from("stored-token");
+        let from_config = remote_client_config_from(
+            "https://loonfs.example.com",
+            Some(&stored),
+            None,
+            false,
+            |_| Some("env-token".to_owned()),
+        );
+        assert_eq!(
+            from_config.auth_token.as_ref().map(SecretString::expose),
+            Some("stored-token")
+        );
+        assert!(!from_config.disable_transient_retry);
+
+        let from_environment =
+            remote_client_config_from("https://loonfs.example.com", None, None, true, |name| {
+                assert_eq!(name, AUTH_TOKEN_ENV);
+                Some("env-token".to_owned())
+            });
+        assert_eq!(
+            from_environment
+                .auth_token
+                .as_ref()
+                .map(SecretString::expose),
+            Some("env-token")
+        );
+        assert!(
+            from_environment.disable_transient_retry,
+            "--no-retry reaches the client"
+        );
+
+        let blank =
+            remote_client_config_from("https://loonfs.example.com", None, None, false, |_| {
+                Some("  ".to_owned())
+            });
+        assert!(blank.auth_token.is_none());
+    }
+
+    #[test]
+    fn the_environment_token_is_what_validation_judges() {
+        // The same profile a request would build: validation must see the
+        // environment token, or it accepts what every request then rejects.
+        let config =
+            remote_client_config_from("http://example.internal", None, None, false, |_| {
+                Some("env-token".to_owned())
+            });
+        let reason = match config.validate() {
+            Err(loonfs_client::ClientError::ConfigValidation { field, reason }) => {
+                assert_eq!(field, "server_url");
+                reason
+            }
+            other => panic!("expected a config validation failure, got {other:?}"),
+        };
+        assert!(
+            reason.contains("bearer tokens require https except for loopback http URLs"),
+            "{reason}"
+        );
+    }
 
     fn parse(contents: &str) -> Result<CliConfig, toml::de::Error> {
         toml::from_str(contents)

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -618,8 +618,6 @@ fn human_doctor(checks: &[DoctorCheck]) -> String {
             ));
         }
         if let Some(response) = &check.store_probe {
-            // The check line above already carries the verdict this probe
-            // reached, so the indented report stays per-check.
             lines.extend(
                 response
                     .checks

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -65,7 +65,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         ),
         CommandData::CheckpointCreated(checkpoint) => {
             let expiry = match checkpoint.expires_at_ms {
-                Some(expires_at_ms) => format!(", expires at {expires_at_ms}"),
+                Some(expires_at_ms) => format!(", expires at {}", format_utc_ms(expires_at_ms)),
                 None => String::new(),
             };
             format!(
@@ -618,10 +618,13 @@ fn human_doctor(checks: &[DoctorCheck]) -> String {
             ));
         }
         if let Some(response) = &check.store_probe {
+            // The check line above already carries the verdict this probe
+            // reached, so the indented report stays per-check.
             lines.extend(
-                store_probe_report_lines(response)
-                    .into_iter()
-                    .map(|line| format!("  {line}")),
+                response
+                    .checks
+                    .iter()
+                    .map(|check| format!("  {}", store_probe_check_line(check))),
             );
         }
     }

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -21,7 +21,9 @@ use std::io::{self, Write};
 
 pub(crate) use human::{human_path_entry, human_success};
 pub(crate) use json::{json_error, json_success, render_parse_error};
-pub(crate) use summaries::format_utc_ms;
+pub(crate) use summaries::{
+    gc_pass_line, store_probe_summary_line, store_probe_verdict, StoreProbeVerdict,
+};
 
 pub(crate) fn render_success(output: &CommandOutput, json_mode: bool) -> io::Result<()> {
     if json_mode {

--- a/crates/loonfs-cli/src/render/summaries.rs
+++ b/crates/loonfs-cli/src/render/summaries.rs
@@ -18,8 +18,7 @@ pub(super) fn store_probe_check_line(check: &StoreProbeCheckResult) -> String {
     }
 }
 
-/// How a store probe came out. An unsupported check did not pass, so it is
-/// its own outcome rather than a quiet success.
+/// Overall result of an object-store probe.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StoreProbeVerdict {
     Failed { checks: usize },
@@ -27,8 +26,6 @@ pub(crate) enum StoreProbeVerdict {
     Passed,
 }
 
-/// Decides how one probe came out. The doctor status, the summary sentence,
-/// and the exit code all read this answer rather than counting again.
 pub(crate) fn store_probe_verdict(
     response: &loonfs_api::v0::StoreProbeResponse,
 ) -> StoreProbeVerdict {
@@ -49,8 +46,6 @@ pub(crate) fn store_probe_verdict(
     }
 }
 
-/// The one sentence that says how a probe came out, for `admin store probe`
-/// and for the `doctor --write-check` line.
 pub(crate) fn store_probe_summary_line(response: &loonfs_api::v0::StoreProbeResponse) -> String {
     let run_id = &response.run_id;
     let total = response.checks.len();
@@ -65,8 +60,6 @@ pub(crate) fn store_probe_summary_line(response: &loonfs_api::v0::StoreProbeResp
     }
 }
 
-/// Formats the object-store probe for `admin store probe`: every check, then
-/// the verdict.
 pub(super) fn store_probe_report_lines(
     response: &loonfs_api::v0::StoreProbeResponse,
 ) -> Vec<String> {
@@ -227,8 +220,6 @@ pub(super) fn checkpoint_owner_label(owner: &CheckpointOwnerSummary) -> String {
     }
 }
 
-/// Every family a collection pass deletes, in the order the summary names
-/// them. One list, so a total and an enumeration cannot disagree.
 fn gc_deleted_counts(deleted: &loonfs_api::DeletedObjectCounts) -> [(&'static str, u64); 6] {
     [
         ("wal segments", deleted.wal_segments),
@@ -240,18 +231,12 @@ fn gc_deleted_counts(deleted: &loonfs_api::DeletedObjectCounts) -> [(&'static st
     ]
 }
 
-/// Names the retention reason that dominates, where one does. The per-pass
-/// line and the run summary say it the same way; `--json` carries the
-/// complete breakdown.
 fn push_top_retention_reason(summary: &mut String, response: &GcResponse) {
     if let Some((reason, count)) = response.retained.top_reason() {
         summary.push_str(&format!("; mostly {reason}: {count}"));
     }
 }
 
-/// What one collection pass did, in the terms an operator watching a long
-/// run needs: what went, what stayed and mostly why, and when the next thing
-/// this pass kept becomes reclaimable.
 pub(crate) fn gc_pass_line(pass: &GcResponse) -> String {
     let deleted: u64 = gc_deleted_counts(&pass.deleted)
         .iter()

--- a/crates/loonfs-cli/src/render/summaries.rs
+++ b/crates/loonfs-cli/src/render/summaries.rs
@@ -18,30 +18,60 @@ pub(super) fn store_probe_check_line(check: &StoreProbeCheckResult) -> String {
     }
 }
 
-/// Formats the object-store probe for both `admin store probe` and
-/// `doctor --write-check`.
+/// How a store probe came out. An unsupported check did not pass, so it is
+/// its own outcome rather than a quiet success.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StoreProbeVerdict {
+    Failed { checks: usize },
+    Unsupported { checks: usize },
+    Passed,
+}
+
+/// Decides how one probe came out. The doctor status, the summary sentence,
+/// and the exit code all read this answer rather than counting again.
+pub(crate) fn store_probe_verdict(
+    response: &loonfs_api::v0::StoreProbeResponse,
+) -> StoreProbeVerdict {
+    let counted = |outcome: StoreProbeCheckOutcome| {
+        response
+            .checks
+            .iter()
+            .filter(|check| check.outcome == outcome)
+            .count()
+    };
+    match (
+        counted(StoreProbeCheckOutcome::Failed),
+        counted(StoreProbeCheckOutcome::Unsupported),
+    ) {
+        (0, 0) => StoreProbeVerdict::Passed,
+        (0, checks) => StoreProbeVerdict::Unsupported { checks },
+        (checks, _) => StoreProbeVerdict::Failed { checks },
+    }
+}
+
+/// The one sentence that says how a probe came out, for `admin store probe`
+/// and for the `doctor --write-check` line.
+pub(crate) fn store_probe_summary_line(response: &loonfs_api::v0::StoreProbeResponse) -> String {
+    let run_id = &response.run_id;
+    let total = response.checks.len();
+    match store_probe_verdict(response) {
+        StoreProbeVerdict::Failed { checks } => {
+            format!("store probe {run_id}: {checks} of {total} checks failed")
+        }
+        StoreProbeVerdict::Unsupported { checks } => {
+            format!("store probe {run_id}: {checks} of {total} checks are unsupported")
+        }
+        StoreProbeVerdict::Passed => format!("store probe {run_id}: {total} checks passed"),
+    }
+}
+
+/// Formats the object-store probe for `admin store probe`: every check, then
+/// the verdict.
 pub(super) fn store_probe_report_lines(
     response: &loonfs_api::v0::StoreProbeResponse,
 ) -> Vec<String> {
-    let failed = response
-        .checks
-        .iter()
-        .filter(|check| check.outcome == StoreProbeCheckOutcome::Failed)
-        .count();
     let mut lines: Vec<String> = response.checks.iter().map(store_probe_check_line).collect();
-    lines.push(if failed == 0 {
-        format!(
-            "store probe {}: {} checks passed",
-            response.run_id,
-            response.checks.len()
-        )
-    } else {
-        format!(
-            "store probe {}: {failed} of {} checks failed",
-            response.run_id,
-            response.checks.len()
-        )
-    });
+    lines.push(store_probe_summary_line(response));
     lines
 }
 
@@ -197,21 +227,55 @@ pub(super) fn checkpoint_owner_label(owner: &CheckpointOwnerSummary) -> String {
     }
 }
 
-pub(super) fn gc_summary(report: &GcResponse) -> String {
-    let mut summary = format!(
-        "gc deleted {} wal segments, {} metadata segments, {} manifests, {} checkpoint records, {} content objects ({} retained)",
-        report.deleted.wal_segments,
-        report.deleted.metadata_segments,
-        report.deleted.manifests,
-        report.deleted.checkpoint_records,
-        report.deleted.content_objects,
-        report.retained_candidates
-    );
-    // Keep the text summary short by showing only the most common retention
-    // reason. JSON output includes the complete breakdown.
-    if let Some((reason, count)) = report.retained.top_reason() {
+/// Every family a collection pass deletes, in the order the summary names
+/// them. One list, so a total and an enumeration cannot disagree.
+fn gc_deleted_counts(deleted: &loonfs_api::DeletedObjectCounts) -> [(&'static str, u64); 6] {
+    [
+        ("wal segments", deleted.wal_segments),
+        ("metadata segments", deleted.metadata_segments),
+        ("manifests", deleted.manifests),
+        ("checkpoint records", deleted.checkpoint_records),
+        ("upload sessions", deleted.upload_sessions),
+        ("content objects", deleted.content_objects),
+    ]
+}
+
+/// Names the retention reason that dominates, where one does. The per-pass
+/// line and the run summary say it the same way; `--json` carries the
+/// complete breakdown.
+fn push_top_retention_reason(summary: &mut String, response: &GcResponse) {
+    if let Some((reason, count)) = response.retained.top_reason() {
         summary.push_str(&format!("; mostly {reason}: {count}"));
     }
+}
+
+/// What one collection pass did, in the terms an operator watching a long
+/// run needs: what went, what stayed and mostly why, and when the next thing
+/// this pass kept becomes reclaimable.
+pub(crate) fn gc_pass_line(pass: &GcResponse) -> String {
+    let deleted: u64 = gc_deleted_counts(&pass.deleted)
+        .iter()
+        .map(|(_, count)| count)
+        .sum();
+    let mut line = format!("{deleted} deleted, {} retained", pass.retained_candidates);
+    push_top_retention_reason(&mut line, pass);
+    if let Some(at_ms) = pass.next_reclamation_at_ms {
+        line.push_str(&format!("; next reclaimable at {}", format_utc_ms(at_ms)));
+    }
+    line
+}
+
+pub(super) fn gc_summary(report: &GcResponse) -> String {
+    let deleted = gc_deleted_counts(&report.deleted)
+        .into_iter()
+        .map(|(family, count)| format!("{count} {family}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut summary = format!(
+        "gc deleted {deleted} ({} retained)",
+        report.retained_candidates
+    );
+    push_top_retention_reason(&mut summary, report);
     if report.released_checkpoints.fork > 0 {
         summary.push_str(&format!(
             "; released {} fork checkpoints",
@@ -238,7 +302,7 @@ pub(super) fn gc_summary(report: &GcResponse) -> String {
 /// Renders Unix milliseconds as `YYYY-MM-DD HH:MM:SSZ` without adding a date
 /// library dependency. The conversion uses Howard Hinnant's civil-date
 /// algorithm.
-pub(crate) fn format_utc_ms(unix_ms: u64) -> String {
+pub(super) fn format_utc_ms(unix_ms: u64) -> String {
     let seconds = unix_ms / 1_000;
     let days = i64::try_from(seconds / 86_400).unwrap_or(0);
     let second_of_day = seconds % 86_400;

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -4,15 +4,14 @@
 use crate::backend::EmbeddedBackend;
 use crate::backend_error::map_runtime_error;
 use crate::config::{
-    load_config, non_empty_env, CliConfig, ProfileConfig, StoreConfig, ACTOR_ID_ENV,
-    ACTOR_KIND_ENV, NAMESPACE_ENV,
+    load_config, non_empty_env, remote_client_config, CliConfig, ProfileConfig, StoreConfig,
+    ACTOR_ID_ENV, ACTOR_KIND_ENV, NAMESPACE_ENV,
 };
 use crate::error::CliError;
 use crate::profiles::{default_namespace, resolve_profile};
 use loonfs::{FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreKind};
-use loonfs_api::env::AUTH_TOKEN_ENV;
 use loonfs_api::{ActorId, ActorKind, ActorRef, NamespaceId, SecretString};
-use loonfs_client::{Client, ClientConfig};
+use loonfs_client::Client;
 use loonfs_grep::{GrepBlockCache, GrepService, DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES};
 use std::sync::Arc;
 
@@ -198,7 +197,7 @@ impl ResolvedTarget {
                 ..
             } => Ok(Self::Remote(RemoteTarget::new(
                 server_url,
-                resolve_remote_auth_token(auth_token),
+                auth_token.as_ref(),
                 ca_cert_path.as_deref(),
                 no_retry,
             )?)),
@@ -211,21 +210,6 @@ impl ResolvedTarget {
             ResolvedTarget::Remote(_) => "remote",
         }
     }
-}
-
-fn resolve_remote_auth_token(stored: &Option<SecretString>) -> Option<SecretString> {
-    resolve_remote_auth_token_from(stored, non_empty_env)
-}
-
-fn resolve_remote_auth_token_from(
-    stored: &Option<SecretString>,
-    lookup: impl Fn(&str) -> Option<String>,
-) -> Option<SecretString> {
-    stored.clone().or_else(|| {
-        lookup(AUTH_TOKEN_ENV)
-            .filter(|token| !token.trim().is_empty())
-            .map(SecretString::from)
-    })
 }
 
 impl EmbeddedTarget {
@@ -294,17 +278,16 @@ impl EmbeddedTarget {
 impl RemoteTarget {
     fn new(
         server_url: &str,
-        auth_token: Option<SecretString>,
+        auth_token: Option<&SecretString>,
         ca_cert_path: Option<&str>,
         no_retry: bool,
     ) -> Result<Self, CliError> {
-        let client = Client::new(ClientConfig {
-            server_url: server_url.to_owned(),
+        let client = Client::new(remote_client_config(
+            server_url,
             auth_token,
-            request_timeout_ms: None,
-            disable_transient_retry: no_retry,
-            ca_cert_path: ca_cert_path.map(ToOwned::to_owned),
-        })
+            ca_cert_path,
+            no_retry,
+        ))
         .map_err(|error| CliError::invalid_config(error.to_string()))?;
         Ok(Self { client })
     }
@@ -312,37 +295,15 @@ impl RemoteTarget {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_remote_auth_token_from, RemoteTarget};
-    use loonfs_api::env::AUTH_TOKEN_ENV;
+    use super::RemoteTarget;
     use loonfs_api::SecretString;
 
     #[test]
-    fn remote_auth_prefers_the_stored_token_then_falls_back_to_the_environment() {
-        let stored = Some(SecretString::from("stored-token"));
-        let resolved = resolve_remote_auth_token_from(&stored, |_| Some("env-token".to_owned()));
-        assert_eq!(
-            resolved.as_ref().map(SecretString::expose),
-            Some("stored-token")
-        );
-
-        let resolved = resolve_remote_auth_token_from(&None, |_| Some("env-token".to_owned()));
-        assert_eq!(
-            resolved.as_ref().map(SecretString::expose),
-            Some("env-token")
-        );
-
-        assert!(resolve_remote_auth_token_from(&None, |_| Some("  ".to_owned())).is_none());
-    }
-
-    #[test]
-    fn environment_token_is_rejected_for_non_loopback_http() {
-        let auth_token = resolve_remote_auth_token_from(&None, |name| {
-            assert_eq!(name, AUTH_TOKEN_ENV);
-            Some("environment-token".to_owned())
-        });
-        let error = RemoteTarget::new("http://example.internal", auth_token, None, false)
+    fn a_stored_token_is_rejected_for_non_loopback_http() {
+        let stored = SecretString::from("stored-token");
+        let error = RemoteTarget::new("http://example.internal", Some(&stored), None, false)
             .err()
-            .expect("environment token over non-loopback plaintext HTTP should be rejected");
+            .expect("a token over non-loopback plaintext HTTP should be rejected");
 
         assert_eq!(error.code, "invalid_config");
         assert!(

--- a/crates/loonfs-cli/tests/it/admin.rs
+++ b/crates/loonfs-cli/tests/it/admin.rs
@@ -187,9 +187,32 @@ fn changes_checkpoints_and_grep_jsonl_follow_across_pages() {
     assert_success(&changes);
     assert_eq!(stdout_string(&changes).lines().count(), 2);
 
-    for name in ["first", "second"] {
-        assert_success(&harness.run(&["admin", "checkpoint", "create", "--name", name]));
-    }
+    assert_success(&harness.run(&["admin", "checkpoint", "create", "--name", "first"]));
+    let dated = harness.run(&[
+        "admin",
+        "checkpoint",
+        "create",
+        "--name",
+        "second",
+        "--ttl-ms",
+        "600000",
+    ]);
+    assert_success(&dated);
+    let created_line = stdout_string(&dated);
+    let expiry = created_line
+        .split("expires at ")
+        .nth(1)
+        .expect("a checkpoint with a ttl prints when it expires")
+        .trim_end()
+        .trim_end_matches(')')
+        .to_owned();
+    let listed_expiries = harness.run(&["admin", "checkpoint", "list"]);
+    assert_success(&listed_expiries);
+    assert!(
+        stdout_string(&listed_expiries).contains(&expiry),
+        "create and list must spell one expiry the same way: {created_line}{}",
+        stdout_string(&listed_expiries)
+    );
     let one_checkpoint =
         harness.run(&["--json", "admin", "checkpoint", "list", "--page-size", "1"]);
     assert_success(&one_checkpoint);
@@ -388,6 +411,17 @@ fn index_status_and_enable_answer_the_same_over_the_remote_transport() {
     let active = harness.run(&["--json", "admin", "index", "status"]);
     assert_success(&active);
     assert_eq!(json_data(&active)["built_through_seq"], 1);
+
+    // The same wait the embedded arm runs: an index already at the target
+    // returns without a single status check.
+    let caught_up = harness.run(&["--json", "admin", "index", "enable"]);
+    assert_success(&caught_up);
+    assert_eq!(json_data(&caught_up)["waited_for_seq"], 1);
+    assert_eq!(
+        json_data(&caught_up)["steps"],
+        0,
+        "an index already at the captured target takes no steps"
+    );
 
     let found = harness.run(&["--json", "grep", "remote needle"]);
     assert_success(&found);

--- a/crates/loonfs-cli/tests/it/admin.rs
+++ b/crates/loonfs-cli/tests/it/admin.rs
@@ -412,8 +412,6 @@ fn index_status_and_enable_answer_the_same_over_the_remote_transport() {
     assert_success(&active);
     assert_eq!(json_data(&active)["built_through_seq"], 1);
 
-    // The same wait the embedded arm runs: an index already at the target
-    // returns without a single status check.
     let caught_up = harness.run(&["--json", "admin", "index", "enable"]);
     assert_success(&caught_up);
     assert_eq!(json_data(&caught_up)["waited_for_seq"], 1);

--- a/crates/loonfs-cli/tests/it/common/mod.rs
+++ b/crates/loonfs-cli/tests/it/common/mod.rs
@@ -171,7 +171,8 @@ impl Harness {
             .env_remove("LOONFS_PROFILE")
             .env_remove("LOONFS_NAMESPACE")
             .env_remove("LOONFS_ACTOR_KIND")
-            .env_remove("LOONFS_ACTOR_ID");
+            .env_remove("LOONFS_ACTOR_ID")
+            .env_remove("LOONFS_AUTH_TOKEN");
         command
     }
 
@@ -195,6 +196,7 @@ impl Harness {
             .env_remove("LOONFS_NAMESPACE")
             .env_remove("LOONFS_ACTOR_KIND")
             .env_remove("LOONFS_ACTOR_ID")
+            .env_remove("LOONFS_AUTH_TOKEN")
             .output()
             .expect("replay the printed command")
     }

--- a/crates/loonfs-cli/tests/it/profile.rs
+++ b/crates/loonfs-cli/tests/it/profile.rs
@@ -1016,8 +1016,6 @@ fn profile_create_rejects_token_over_non_loopback_http_before_writing() {
         "unsafe profile must be rejected before creating the config file"
     );
 
-    // A token from the environment is the token every request would carry,
-    // so creation judges the profile the same way.
     let ambient = harness.run_with_env(
         &[("LOONFS_AUTH_TOKEN", "ambient-auth-token")],
         &[
@@ -1044,6 +1042,26 @@ fn profile_create_rejects_token_over_non_loopback_http_before_writing() {
         !harness.config_path.exists(),
         "a profile no request could use must not be written"
     );
+}
+
+#[test]
+fn an_ambient_token_does_not_invalidate_an_unselected_profile() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&[
+        "profile",
+        "create",
+        "remote",
+        "unused",
+        "--server-url",
+        "http://example.internal",
+    ]));
+
+    let listed = harness.run_with_env(
+        &[("LOONFS_AUTH_TOKEN", "ambient-auth-token")],
+        &["profile", "list"],
+    );
+    assert_success(&listed);
 }
 
 #[test]

--- a/crates/loonfs-cli/tests/it/profile.rs
+++ b/crates/loonfs-cli/tests/it/profile.rs
@@ -1015,6 +1015,35 @@ fn profile_create_rejects_token_over_non_loopback_http_before_writing() {
         !harness.config_path.exists(),
         "unsafe profile must be rejected before creating the config file"
     );
+
+    // A token from the environment is the token every request would carry,
+    // so creation judges the profile the same way.
+    let ambient = harness.run_with_env(
+        &[("LOONFS_AUTH_TOKEN", "ambient-auth-token")],
+        &[
+            "--json",
+            "profile",
+            "create",
+            "remote",
+            "default",
+            "--server-url",
+            "http://example.internal",
+        ],
+    );
+    assert_failure(&ambient);
+    let error = json_error(&ambient);
+    assert_eq!(error["code"], "invalid_config");
+    assert!(
+        error["message"]
+            .as_str()
+            .expect("json string")
+            .contains("bearer tokens require https except for loopback http URLs"),
+        "{error}"
+    );
+    assert!(
+        !harness.config_path.exists(),
+        "a profile no request could use must not be written"
+    );
 }
 
 #[test]

--- a/crates/loonfs-cli/tests/it/recursive.rs
+++ b/crates/loonfs-cli/tests/it/recursive.rs
@@ -304,7 +304,10 @@ fn recursive_transfers_roundtrip_a_tree() {
     assert_failure(&rerun);
     let rerun_data = json_data(&rerun);
     assert_eq!(rerun_data["files"], 0);
-    assert_eq!(rerun_data["directories"], 1);
+    assert_eq!(
+        rerun_data["directories"], 0,
+        "the empty directory was already there: {rerun_data}"
+    );
     assert_eq!(
         rerun_data["failures"].as_array().expect("failures").len(),
         3
@@ -324,7 +327,10 @@ fn recursive_transfers_roundtrip_a_tree() {
     assert_success(&forced);
     let forced_data = json_data(&forced);
     assert_eq!(forced_data["files"], 3);
-    assert_eq!(forced_data["directories"], 1);
+    assert_eq!(
+        forced_data["directories"], 0,
+        "--force replaces files, and creates no directory that already exists: {forced_data}"
+    );
     assert_eq!(
         forced_data["failures"].as_array().expect("failures").len(),
         0,
@@ -389,7 +395,7 @@ fn recursive_put_reuses_existing_directories_but_rejects_files() {
     let rerun = harness.run(&["--no-progress", "put", "-r", "--force", local_tree, "/tree"]);
     assert_success(&rerun);
     assert!(
-        stdout_string(&rerun).contains("stored 0 files and 1 directory"),
+        stdout_string(&rerun).contains("stored 0 files and 0 directories"),
         "{}",
         stdout_string(&rerun)
     );
@@ -564,8 +570,9 @@ fn recursive_get_names_only_the_paths_it_could_not_write_in_both_modes() {
         assert_failure(&get);
         let data = json_data(&get);
         assert_eq!(data["files"], 2, "{data}");
-        // The destination root and `other`; `docs` is the one that failed.
-        assert_eq!(data["directories"], 2, "{data}");
+        // `other` alone: the destination root was already there, and `docs`
+        // is the one that failed.
+        assert_eq!(data["directories"], 1, "{data}");
 
         // The blocked directory is named by the local path that failed, the
         // files under it by the remote paths that could not be written.

--- a/crates/loonfs-cli/tests/it/recursive.rs
+++ b/crates/loonfs-cli/tests/it/recursive.rs
@@ -570,8 +570,6 @@ fn recursive_get_names_only_the_paths_it_could_not_write_in_both_modes() {
         assert_failure(&get);
         let data = json_data(&get);
         assert_eq!(data["files"], 2, "{data}");
-        // `other` alone: the destination root was already there, and `docs`
-        // is the one that failed.
         assert_eq!(data["directories"], 1, "{data}");
 
         // The blocked directory is named by the local path that failed, the


### PR DESCRIPTION
Uses one wait loop for embedded and remote grep indexes, and stops when an index is disabled instead of polling forever. Remote profile creation and requests now build the same effective client configuration, including `LOONFS_AUTH_TOKEN` and `--no-retry`; loading the config file itself remains independent of ambient credentials.

Recursive transfers now count only directories created by the current command. GC summaries include upload sessions, checkpoint creation formats expiry times consistently with listing, and store-probe output uses one verdict across normal output, `doctor`, and exit status.