### PR TITLE
fix(core): preserve fork pins and validate replayed heads

### DIFF
--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -9,8 +9,7 @@
 //! stop collection because ownership cannot be verified.
 
 use crate::control_object::{
-    core_control_load_error, expect_identity_field, expect_namespace, load_control_object,
-    ControlObjectLoadError,
+    expect_identity_field, expect_namespace, load_control_object, ControlObjectLoadError,
 };
 use crate::error::{CoreError, Result};
 use crate::limits::{
@@ -77,7 +76,7 @@ pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => {
             return Ok(CompactionPrefixOwner::NoOne)
         }
-        Err(error) => return Err(core_control_load_error(error)),
+        Err(error) => return Err(CoreError::load_head(error)),
     };
     let object_key = loaded.object_key;
     let expected_etag = loaded.etag;
@@ -299,7 +298,7 @@ impl<'a> CompactionLease<'a> {
         let loaded = match loaded {
             Ok(loaded) => loaded,
             Err(ControlObjectLoadError::MissingObject { .. }) => return self.create(store).await,
-            Err(error) => return Err(core_control_load_error(error)),
+            Err(error) => return Err(CoreError::load_head(error)),
         };
         self.etag = Some(loaded.etag);
         Ok(())

--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -76,7 +76,7 @@ pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => {
             return Ok(CompactionPrefixOwner::NoOne)
         }
-        Err(error) => return Err(CoreError::load_head(error)),
+        Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
     let object_key = loaded.object_key;
     let expected_etag = loaded.etag;
@@ -298,7 +298,7 @@ impl<'a> CompactionLease<'a> {
         let loaded = match loaded {
             Ok(loaded) => loaded,
             Err(ControlObjectLoadError::MissingObject { .. }) => return self.create(store).await,
-            Err(error) => return Err(CoreError::load_head(error)),
+            Err(error) => return Err(CoreError::ControlObjectLoad(error)),
         };
         self.etag = Some(loaded.etag);
         Ok(())

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -27,7 +27,10 @@ use crate::namespace::basis::{
     resolve_retention_floor_seq, MetadataBasis,
 };
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
-use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
+use crate::wal::{
+    ensure_replayed_head_matches, load_validated_wal_chain, project_validated_wal_tail,
+    WalChainLoadRequest,
+};
 use loonfs_api::wire::control::{HeadState, ManifestRef, NamespaceStatus};
 use loonfs_api::wire::manifest::{NamespaceManifestEnvelope, NamespaceManifestPayload};
 use loonfs_api::{
@@ -269,7 +272,7 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
         .map_err(MetadataProjectionLoadError::WalReplay)
         .map_err(CoreError::MetadataProjection)?
     };
-    ensure_reconstructed_head_matches(&head, &replayed.resulting_head)?;
+    ensure_replayed_head_matches(&head, &replayed.resulting_head)?;
     Ok(RootProjection {
         head,
         basis: loaded.basis,
@@ -277,27 +280,6 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
         manifest_segments,
         tail_state: replayed.resulting_metadata_state,
     })
-}
-
-fn ensure_reconstructed_head_matches(
-    current_head: &HeadState,
-    reconstructed: &HeadState,
-) -> Result<()> {
-    if current_head.namespace_id != reconstructed.namespace_id
-        || current_head.seq != reconstructed.seq
-        || current_head.head_commit_id != reconstructed.head_commit_id
-        || current_head.next_inode_id != reconstructed.next_inode_id
-        || (reconstructed.visible_wal_tip.is_some()
-            && current_head.visible_wal_tip != reconstructed.visible_wal_tip)
-    {
-        return Err(CoreError::MetadataProjection(
-            MetadataProjectionLoadError::ReplayedHeadMismatch {
-                expected: Box::new(current_head.clone()),
-                actual: Box::new(reconstructed.clone()),
-            },
-        ));
-    }
-    Ok(())
 }
 
 pub(super) fn next_manifest_no_after(current: ManifestNo) -> Result<ManifestNo> {

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -222,7 +222,7 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
 ) -> Result<RootProjection<'a, S>> {
     let loaded = load_head_and_metadata_basis(store, namespace_id)
         .await
-        .map_err(CoreError::load_head)?;
+        .map_err(CoreError::ControlObjectLoad)?;
     let head = loaded.head.state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::MetadataProjection(
@@ -233,7 +233,7 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
     }
     let floor_seq = resolve_retention_floor_seq(store, &head)
         .await
-        .map_err(CoreError::load_head)?;
+        .map_err(CoreError::ControlObjectLoad)?;
     // The floor never advances past the materialized root, so a floor above
     // the namespace's birth sequence with no root of its own means the root
     // was lost.

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -3,7 +3,7 @@
 //! The listing reads the `checkpoints/` prefix and excludes released records.
 
 use super::record::load_checkpoint_record_at_key;
-use crate::control_object::{core_control_load_error, ControlObjectLoadError};
+use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::control::load_head_object;
 use futures::StreamExt;
@@ -101,7 +101,7 @@ pub(crate) async fn list_checkpoints_page<S: ObjectStore + ?Sized>(
         let loaded = match load_checkpoint_record_at_key(store, &key).await {
             Ok(loaded) => loaded,
             Err(ControlObjectLoadError::MissingObject { .. }) => continue,
-            Err(error) => return Err(core_control_load_error(error)),
+            Err(error) => return Err(CoreError::load_head(error)),
         };
         if loaded.state.status != (CheckpointStatus::Active {}) {
             continue;

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -74,7 +74,7 @@ pub(crate) async fn list_checkpoints_page<S: ObjectStore + ?Sized>(
 ) -> Result<Page<Checkpoint, CheckpointPageCursor>> {
     load_head_object(store, namespace_id)
         .await
-        .map_err(CoreError::load_head)?;
+        .map_err(CoreError::ControlObjectLoad)?;
 
     if let Some(cursor) = &request.cursor {
         cursor.validate_for(namespace_id)?;
@@ -101,7 +101,7 @@ pub(crate) async fn list_checkpoints_page<S: ObjectStore + ?Sized>(
         let loaded = match load_checkpoint_record_at_key(store, &key).await {
             Ok(loaded) => loaded,
             Err(ControlObjectLoadError::MissingObject { .. }) => continue,
-            Err(error) => return Err(CoreError::load_head(error)),
+            Err(error) => return Err(CoreError::ControlObjectLoad(error)),
         };
         if loaded.state.status != (CheckpointStatus::Active {}) {
             continue;

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -129,7 +129,7 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
     for _attempt in 0..CONTENTION_RETRY_LIMIT {
         let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
             .await
-            .map_err(CoreError::load_head)?
+            .map_err(CoreError::ControlObjectLoad)?
         else {
             match create_first_metadata_root(store, namespace_id, &candidate, updated_at_ms).await?
             {
@@ -179,7 +179,7 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
             Err(error) => {
                 let recovered = load_metadata_root_object(store, namespace_id)
                     .await
-                    .map_err(CoreError::load_head)?
+                    .map_err(CoreError::ControlObjectLoad)?
                     .state;
                 if recovered.manifest == candidate {
                     return Ok(ManifestPublicationOutcome::Published(recovered));

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -8,8 +8,8 @@
 use super::load::load_namespace_manifest_envelope;
 use super::ManifestLoadError;
 use crate::control_object::{
-    core_control_load_error, expect_identity_field, expect_namespace, expect_own_manifest,
-    load_control_object, ControlObjectLoadError, LoadedControl,
+    expect_identity_field, expect_namespace, expect_own_manifest, load_control_object,
+    ControlObjectLoadError, LoadedControl,
 };
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::basis::resolve_retention_floor_seq;
@@ -143,7 +143,7 @@ pub(crate) async fn load_checkpoint_record<S: ObjectStore + ?Sized>(
     match loaded {
         Ok(loaded) => Ok(Some(loaded)),
         Err(ControlObjectLoadError::MissingObject { .. }) => Ok(None),
-        Err(error) => Err(core_control_load_error(error)),
+        Err(error) => Err(CoreError::load_head(error)),
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -143,7 +143,7 @@ pub(crate) async fn load_checkpoint_record<S: ObjectStore + ?Sized>(
     match loaded {
         Ok(loaded) => Ok(Some(loaded)),
         Err(ControlObjectLoadError::MissingObject { .. }) => Ok(None),
-        Err(error) => Err(CoreError::load_head(error)),
+        Err(error) => Err(CoreError::ControlObjectLoad(error)),
     }
 }
 
@@ -207,11 +207,11 @@ pub(crate) async fn verify_checkpoint_basis<S: ObjectStore + ?Sized>(
 ) -> Result<CheckpointBasisVerification> {
     let head = load_head_object(store, &record.namespace_id)
         .await
-        .map_err(CoreError::load_head)?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     let floor_seq = resolve_retention_floor_seq(store, &head)
         .await
-        .map_err(CoreError::load_head)?;
+        .map_err(CoreError::ControlObjectLoad)?;
     if floor_seq > record.manifest.manifest_head_seq {
         return Ok(CheckpointBasisVerification::Invalid);
     }

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -196,7 +196,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     // fold: reorganization has nothing to do until its first flush.
     let Some(root) = load_metadata_root_object_if_present(store, namespace_id)
         .await
-        .map_err(CoreError::load_head)?
+        .map_err(CoreError::ControlObjectLoad)?
         .map(|loaded| loaded.state)
     else {
         return Ok(report(
@@ -238,11 +238,11 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     // for the job's life.
     let head = load_head_object(store, namespace_id)
         .await
-        .map_err(CoreError::load_head)?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     let floor_seq = resolve_retention_floor_seq(store, &head)
         .await
-        .map_err(CoreError::load_head)?;
+        .map_err(CoreError::ControlObjectLoad)?;
     let selection = select_reorganization_input(
         &segments,
         group,

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -35,18 +35,18 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     // not have caught anyway.
     let head = load_head_object(store, namespace_id)
         .await
-        .map_err(CoreError::load_head)?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     // A namespace that has published no manifest has nothing to derive a
     // target floor from: its history is retained from birth either way.
     let Some(loaded_root) = load_metadata_root_object_if_present(store, namespace_id)
         .await
-        .map_err(CoreError::load_head)?
+        .map_err(CoreError::ControlObjectLoad)?
     else {
         return Ok(AdvanceRetentionResponse {
             retention_floor_seq: resolve_retention_floor_seq(store, &head)
                 .await
-                .map_err(CoreError::load_head)?,
+                .map_err(CoreError::ControlObjectLoad)?,
         });
     };
     let root = loaded_root.state;
@@ -62,7 +62,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     let target_floor = manifest_segments.manifest().payload.head_seq;
     let current_floor = resolve_retention_floor_seq(store, &head)
         .await
-        .map_err(CoreError::load_head)?;
+        .map_err(CoreError::ControlObjectLoad)?;
     if current_floor >= target_floor {
         // Already advanced, so the idempotent re-invocation writes nothing.
         return Ok(AdvanceRetentionResponse {
@@ -76,7 +76,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         let loaded = match load_wal_floor_object(store, namespace_id).await {
             Ok(loaded) => Some(loaded),
             Err(ControlObjectLoadError::MissingObject { .. }) => None,
-            Err(error) => return Err(CoreError::load_head(error)),
+            Err(error) => return Err(CoreError::ControlObjectLoad(error)),
         };
         let published_floor = loaded.as_ref().map(|loaded| loaded.state.floor_seq);
         if let Some(floor_seq) = published_floor.filter(|floor_seq| *floor_seq >= target_floor) {

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -603,7 +603,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         let publication_started_ms = timer.monotonic_now_ms();
         let Some(root) = load_metadata_root_object_if_present(store, namespace_id)
             .await
-            .map_err(CoreError::load_head)?
+            .map_err(CoreError::ControlObjectLoad)?
             .map(|loaded| loaded.state)
         else {
             return Ok(Finalization::Abandoned);
@@ -715,7 +715,7 @@ async fn load_current_manifest_segments<'a, S: ObjectStore + ?Sized>(
 ) -> Result<Option<VerifiedMetadataSegments<'a, S>>> {
     let Some(root) = load_metadata_root_object_if_present(store, namespace_id)
         .await
-        .map_err(CoreError::load_head)?
+        .map_err(CoreError::ControlObjectLoad)?
         .map(|loaded| loaded.state)
     else {
         return Ok(None);

--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -1,7 +1,7 @@
 //! Loading and classification shared by mutable control-object families.
 
 use super::ControlObjectLoadError;
-use crate::error::{CoreError, StoreFailureClass};
+use crate::error::StoreFailureClass;
 use loonfs_api::wire::control::{decode_control_object, ControlObjectKind, ForkBasis, ManifestRef};
 use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::NamespaceId;
@@ -119,21 +119,6 @@ pub(crate) fn expect_foreign_fork_basis(
     Err(EmbeddedIdentityMismatch::ForkBasisOwner {
         namespace_id: namespace_id.clone(),
     })
-}
-
-pub(crate) fn core_control_load_error(error: ControlObjectLoadError) -> CoreError {
-    match error {
-        ControlObjectLoadError::Store {
-            object_key,
-            message,
-            class,
-        } => CoreError::Store {
-            object_key,
-            message,
-            class,
-        },
-        error => CoreError::NamespaceCorrupt(error.to_string()),
-    }
 }
 
 fn classify(object_key: &str, failure: ControlLoadFailure) -> ControlObjectLoadError {

--- a/crates/loonfs-core/src/control_object/mod.rs
+++ b/crates/loonfs-core/src/control_object/mod.rs
@@ -5,6 +5,6 @@ mod load;
 
 pub use error::ControlObjectLoadError;
 pub(crate) use load::{
-    core_control_load_error, expect_foreign_fork_basis, expect_identity_field, expect_namespace,
-    expect_own_manifest, load_control_object, LoadedControl,
+    expect_foreign_fork_basis, expect_identity_field, expect_namespace, expect_own_manifest,
+    load_control_object, LoadedControl,
 };

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -204,7 +204,7 @@ async fn load_upload_session_object<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => Err(CoreError::UploadNotFound {
             upload_id: upload_id.clone(),
         }),
-        Err(error) => Err(CoreError::load_head(error)),
+        Err(error) => Err(CoreError::ControlObjectLoad(error)),
     }
 }
 

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -2,8 +2,8 @@
 //! compare-and-swap the head or an upload session on its etag.
 
 use crate::control_object::{
-    core_control_load_error, expect_identity_field, expect_namespace, load_control_object,
-    ControlObjectLoadError, LoadedControl,
+    expect_identity_field, expect_namespace, load_control_object, ControlObjectLoadError,
+    LoadedControl,
 };
 use crate::error::{CoreError, StoreFailureClass};
 use crate::namespace::control::{load_head_object, LoadedHeadObject};
@@ -204,7 +204,7 @@ async fn load_upload_session_object<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => Err(CoreError::UploadNotFound {
             upload_id: upload_id.clone(),
         }),
-        Err(error) => Err(core_control_load_error(error)),
+        Err(error) => Err(CoreError::load_head(error)),
     }
 }
 

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -316,20 +316,6 @@ impl From<ImmutableWriteError> for CoreError {
     }
 }
 
-fn classify_store_failure(class: StoreFailureClass) -> ErrorCode {
-    match class {
-        StoreFailureClass::PermissionDenied => ErrorCode::StoragePermissionDenied,
-        StoreFailureClass::NotFound
-        | StoreFailureClass::InvalidRequest
-        | StoreFailureClass::PreconditionFailed
-        | StoreFailureClass::StoredChecksumMissing
-        | StoreFailureClass::Unsupported
-        | StoreFailureClass::Configuration
-        | StoreFailureClass::RetryableTransport
-        | StoreFailureClass::Other => ErrorCode::ServerError,
-    }
-}
-
 impl CoreError {
     pub(crate) fn load_head(error: ControlObjectLoadError) -> Self {
         Self::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
@@ -361,7 +347,7 @@ impl CoreError {
                 ErrorCode::ServerError
             }
             CoreError::WalWrite { class, .. } | CoreError::Store { class, .. } => {
-                classify_store_failure(*class)
+                class.error_code()
             }
             CoreError::HeadPublish(error) => classify_head_publish_error(error),
             CoreError::InvalidPath(_)
@@ -683,7 +669,7 @@ pub(crate) fn classify_control_object_load_error(error: &ControlObjectLoadError)
         | ControlObjectLoadError::KeyLayout { .. }
         | ControlObjectLoadError::ChecksumMismatch { .. }
         | ControlObjectLoadError::Codec { .. } => ErrorCode::NamespaceCorrupt,
-        ControlObjectLoadError::Store { class, .. } => classify_store_failure(*class),
+        ControlObjectLoadError::Store { class, .. } => class.error_code(),
     }
 }
 
@@ -751,7 +737,7 @@ fn classify_writer_epoch_acquire_error(error: &WriterEpochAcquireError) -> Error
         WriterEpochAcquireError::EmptyWriterId
         | WriterEpochAcquireError::WriterEpochOverflow { .. }
         | WriterEpochAcquireError::RetryExhausted { .. } => ErrorCode::ServerError,
-        WriterEpochAcquireError::HeadWrite { class, .. } => classify_store_failure(*class),
+        WriterEpochAcquireError::HeadWrite { class, .. } => class.error_code(),
     }
 }
 

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -45,6 +45,8 @@ pub enum CoreError {
     #[error(transparent)]
     MetadataProjection(#[from] MetadataProjectionLoadError),
     #[error(transparent)]
+    ControlObjectLoad(#[from] ControlObjectLoadError),
+    #[error(transparent)]
     MetadataView(#[from] MetadataViewError),
     #[error(transparent)]
     VisiblePath(#[from] VisiblePathError),
@@ -316,11 +318,22 @@ impl From<ImmutableWriteError> for CoreError {
     }
 }
 
-impl CoreError {
-    pub(crate) fn load_head(error: ControlObjectLoadError) -> Self {
-        Self::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+fn classify_store_failure(class: StoreFailureClass) -> ErrorCode {
+    match class {
+        StoreFailureClass::PermissionDenied => ErrorCode::StoragePermissionDenied,
+        StoreFailureClass::NotFound
+        | StoreFailureClass::InvalidRequest
+        | StoreFailureClass::InvalidKey
+        | StoreFailureClass::PreconditionFailed
+        | StoreFailureClass::StoredChecksumMissing
+        | StoreFailureClass::Unsupported
+        | StoreFailureClass::Configuration
+        | StoreFailureClass::RetryableTransport
+        | StoreFailureClass::Other => ErrorCode::ServerError,
     }
+}
 
+impl CoreError {
     /// Builds [`CoreError::Store`] for a failed object-store operation on
     /// `object_key`.
     pub(crate) fn store(object_key: impl Into<String>, error: &ObjectStoreError) -> Self {
@@ -338,6 +351,7 @@ impl CoreError {
     pub fn code(&self) -> ErrorCode {
         match self {
             CoreError::MetadataProjection(error) => classify_metadata_projection_load_error(error),
+            CoreError::ControlObjectLoad(error) => classify_control_object_load_error(error),
             CoreError::MetadataView(error) => classify_metadata_view_error(error),
             CoreError::VisiblePath(error) => classify_visible_path_error(error),
             CoreError::DurableContent(error) => classify_durable_content_error(error),
@@ -347,7 +361,7 @@ impl CoreError {
                 ErrorCode::ServerError
             }
             CoreError::WalWrite { class, .. } | CoreError::Store { class, .. } => {
-                class.error_code()
+                classify_store_failure(*class)
             }
             CoreError::HeadPublish(error) => classify_head_publish_error(error),
             CoreError::InvalidPath(_)
@@ -420,6 +434,7 @@ impl CoreError {
     pub fn object_store_public_message(&self) -> Option<std::borrow::Cow<'static, str>> {
         match self {
             CoreError::MetadataProjection(error) => metadata_projection_store_message(error),
+            CoreError::ControlObjectLoad(error) => control_object_store_message(error),
             CoreError::DurableContent(DurableContentValidationError::Store { message, .. }) => {
                 Some(std::borrow::Cow::Owned(message.clone()))
             }
@@ -669,7 +684,7 @@ pub(crate) fn classify_control_object_load_error(error: &ControlObjectLoadError)
         | ControlObjectLoadError::KeyLayout { .. }
         | ControlObjectLoadError::ChecksumMismatch { .. }
         | ControlObjectLoadError::Codec { .. } => ErrorCode::NamespaceCorrupt,
-        ControlObjectLoadError::Store { class, .. } => class.error_code(),
+        ControlObjectLoadError::Store { class, .. } => classify_store_failure(*class),
     }
 }
 
@@ -737,7 +752,7 @@ fn classify_writer_epoch_acquire_error(error: &WriterEpochAcquireError) -> Error
         WriterEpochAcquireError::EmptyWriterId
         | WriterEpochAcquireError::WriterEpochOverflow { .. }
         | WriterEpochAcquireError::RetryExhausted { .. } => ErrorCode::ServerError,
-        WriterEpochAcquireError::HeadWrite { class, .. } => class.error_code(),
+        WriterEpochAcquireError::HeadWrite { class, .. } => classify_store_failure(*class),
     }
 }
 
@@ -1068,7 +1083,7 @@ mod tests {
     }
 
     #[test]
-    fn store_permission_denied_classifies_to_its_wire_code() {
+    fn store_failures_classify_to_their_wire_codes() {
         let denied = ObjectStoreError::PermissionDenied {
             object_key: "namespaces/demo/wal/head.json".to_owned(),
             message: "AccessDenied: bucket policy".to_owned(),
@@ -1079,6 +1094,12 @@ mod tests {
 
         let transport = ObjectStoreError::transport("namespaces/demo/wal/head.json", "timed out");
         let error = CoreError::store("namespaces/demo/wal/head.json", &transport);
+        assert_eq!(error.code(), ErrorCode::ServerError);
+
+        let invalid_range = ObjectStoreError::InvalidRange {
+            object_key: "namespaces/demo/metadata/segment".to_owned(),
+        };
+        let error = CoreError::store("namespaces/demo/metadata/segment", &invalid_range);
         assert_eq!(error.code(), ErrorCode::ServerError);
     }
 
@@ -1091,7 +1112,7 @@ mod tests {
         };
 
         let core_wrappers = [
-            CoreError::load_head(denied.clone()),
+            CoreError::ControlObjectLoad(denied.clone()),
             CoreError::WriterEpoch(WriterEpochAcquireError::LoadHead(denied.clone())),
             CoreError::from(NamespaceCatalogLoadError::LoadHead(denied.clone())),
             CoreError::from(ControlUpdateError::LoadHead(denied.clone())),

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -4,7 +4,7 @@ use crate::checkpoint::record::{
     encode_checkpoint_record, load_checkpoint_record_at_key, release_checkpoint_record,
 };
 use crate::context::MutationContext;
-use crate::control_object::{core_control_load_error, ControlObjectLoadError};
+use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::control::load_head_object;
 use loonfs_api::wire::control::{CheckpointOwner, CheckpointStatus, NamespaceStatus};
@@ -24,11 +24,11 @@ pub(super) enum ForkCheckpointSweep {
 
 /// Releases a still-active record whose basis manifest is verifiably gone.
 /// Every check runs against fresh reads at decision time: the record must
-/// still be active, older than the grace window by its own `created_at_ms`
-/// (an in-flight create is never raced), and the basis manifest must still
-/// be absent. The release is the compare-and-swap the creator's own
-/// verification failure would have performed; the released record then ages
-/// out through the normal delete path on a later pass.
+/// still be active, not fork-owned, older than the grace window by its own
+/// `created_at_ms` (an in-flight create is never raced), and the basis
+/// manifest must still be absent. The release is the compare-and-swap the
+/// creator's own verification failure would have performed; the released
+/// record then ages out through the normal delete path on a later pass.
 pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -40,10 +40,16 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
     let loaded = match loaded {
         Ok(loaded) => loaded,
         Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(false),
-        Err(error) => return Err(core_control_load_error(error)),
+        Err(error) => return Err(CoreError::load_head(error)),
     };
     let record = loaded.state;
     if record.status != (CheckpointStatus::Active {}) {
+        return Ok(false);
+    }
+    // A fork pin ends with its target namespace, and only the fork arm below
+    // reads that. An absent basis says the source is already broken; it says
+    // nothing about whether the target stopped reading through this record.
+    if matches!(record.owner, CheckpointOwner::Fork { .. }) {
         return Ok(false);
     }
     if context.now_ms.saturating_sub(record.created_at_ms) < grace_window_ms {
@@ -78,7 +84,7 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => {
             return Ok(ForkCheckpointSweep::NotAnActiveFork)
         }
-        Err(error) => return Err(core_control_load_error(error)),
+        Err(error) => return Err(CoreError::load_head(error)),
     };
     let record = loaded.state;
     if record.status != (CheckpointStatus::Active {}) {

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -22,13 +22,8 @@ pub(super) enum ForkCheckpointSweep {
     NotAnActiveFork,
 }
 
-/// Releases a still-active record whose basis manifest is verifiably gone.
-/// Every check runs against fresh reads at decision time: the record must
-/// still be active, not fork-owned, older than the grace window by its own
-/// `created_at_ms` (an in-flight create is never raced), and the basis
-/// manifest must still be absent. The release is the compare-and-swap the
-/// creator's own verification failure would have performed; the released
-/// record then ages out through the normal delete path on a later pass.
+/// Releases an active, non-fork checkpoint whose basis manifest is still
+/// missing after the grace period.
 pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -40,15 +35,13 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
     let loaded = match loaded {
         Ok(loaded) => loaded,
         Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(false),
-        Err(error) => return Err(CoreError::load_head(error)),
+        Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
     let record = loaded.state;
     if record.status != (CheckpointStatus::Active {}) {
         return Ok(false);
     }
-    // A fork pin ends with its target namespace, and only the fork arm below
-    // reads that. An absent basis says the source is already broken; it says
-    // nothing about whether the target stopped reading through this record.
+    // Fork checkpoints remain until their target namespace is deleted.
     if matches!(record.owner, CheckpointOwner::Fork { .. }) {
         return Ok(false);
     }
@@ -84,7 +77,7 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => {
             return Ok(ForkCheckpointSweep::NotAnActiveFork)
         }
-        Err(error) => return Err(CoreError::load_head(error)),
+        Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
     let record = loaded.state;
     if record.status != (CheckpointStatus::Active {}) {

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -8,7 +8,7 @@ use super::reap::{lease_expired, manifest_object_id_of};
 use crate::checkpoint::record::load_checkpoint_record_at_key;
 use crate::checkpoint::{load_namespace_manifest_envelope_if_present, ManifestLoadFailureClass};
 use crate::context::MutationContext;
-use crate::control_object::{core_control_load_error, ControlObjectLoadError};
+use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::basis::{
     load_head_and_metadata_basis, resolve_retention_floor_seq, LoadedNamespaceBasis,
@@ -361,7 +361,7 @@ async fn collect_checkpoint_records<S: ObjectStore + ?Sized>(
         let record = match loaded {
             Ok(loaded) => loaded.state,
             Err(ControlObjectLoadError::MissingObject { .. }) => continue,
-            Err(error) => return Err(core_control_load_error(error).into()),
+            Err(error) => return Err(CoreError::load_head(error).into()),
         };
         let candidate = checkpoint_is_candidate(store, &record, budget, context).await?;
         // A deleted namespace has no readers. Only an active fork checkpoint

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -246,7 +246,7 @@ pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
     }
     let loaded = load_head_and_metadata_basis(store, namespace_id)
         .await
-        .map_err(CoreError::load_head)?;
+        .map_err(CoreError::ControlObjectLoad)?;
     collect_live_set(
         store,
         namespace_id,
@@ -289,7 +289,7 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
         charge(budget)?;
         let floor_seq = resolve_retention_floor_seq(store, head)
             .await
-            .map_err(CoreError::load_head)?;
+            .map_err(CoreError::ControlObjectLoad)?;
         let mut live = LiveSet::collecting(namespace_deleted);
         let mut manifest_object_ids = BTreeSet::new();
         if !namespace_deleted {
@@ -361,7 +361,7 @@ async fn collect_checkpoint_records<S: ObjectStore + ?Sized>(
         let record = match loaded {
             Ok(loaded) => loaded.state,
             Err(ControlObjectLoadError::MissingObject { .. }) => continue,
-            Err(error) => return Err(CoreError::load_head(error).into()),
+            Err(error) => return Err(CoreError::ControlObjectLoad(error).into()),
         };
         let candidate = checkpoint_is_candidate(store, &record, budget, context).await?;
         // A deleted namespace has no readers. Only an active fork checkpoint

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -6,7 +6,7 @@
 
 use crate::checkpoint::record::{encode_checkpoint_record, load_checkpoint_record_at_key};
 use crate::context::MutationContext;
-use crate::control_object::{core_control_load_error, ControlObjectLoadError};
+use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
 use loonfs_api::wire::control::{CheckpointOwner, CheckpointRecordState, CheckpointStatus};
 use loonfs_api::{GeneratedIdValidationError, ManifestObjectId, NamespaceId, RetainedReason};
@@ -55,7 +55,7 @@ pub(super) async fn sweep_checkpoint_record<S: ObjectStore + ?Sized>(
     let loaded = match loaded {
         Ok(loaded) => loaded,
         Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(CheckpointSweep::Retain),
-        Err(error) => return Err(core_control_load_error(error)),
+        Err(error) => return Err(CoreError::load_head(error)),
     };
     let record = loaded.state;
     if let CheckpointStatus::Released { released_at_ms } = record.status {

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -55,7 +55,7 @@ pub(super) async fn sweep_checkpoint_record<S: ObjectStore + ?Sized>(
     let loaded = match loaded {
         Ok(loaded) => loaded,
         Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(CheckpointSweep::Retain),
-        Err(error) => return Err(CoreError::load_head(error)),
+        Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
     let record = loaded.state;
     if let CheckpointStatus::Released { released_at_ms } = record.status {

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -71,7 +71,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     let loaded = match load_head_and_metadata_basis(store, namespace_id).await {
         Ok(loaded) => loaded,
         Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(report),
-        Err(error) => return Err(CoreError::load_head(error)),
+        Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
     let content_store_id = loaded.head.state.content_store_id.clone();
 

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -3801,9 +3801,6 @@ async fn gc_never_releases_a_fork_record_while_its_target_lives() {
 
 #[tokio::test]
 async fn a_fork_pin_with_a_missing_basis_survives_the_missing_basis_pass() {
-    // The missing-basis pass releases a record the creator could never have
-    // verified. A fork pin is not its to release: the target namespace's
-    // fate decides that, and only the fork arm reads it.
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let source = NamespaceId::parse("source").expect("namespace id");
@@ -3817,8 +3814,7 @@ async fn a_fork_pin_with_a_missing_basis_survives_the_missing_basis_pass() {
         .await
         .expect("fork");
     let fork_record = read_fork_record(&store, &source).await;
-    // Advance the source root past the fork basis so the absent basis below
-    // is not the root's own, which would degrade the pass instead.
+    // Keep the source root valid after deleting the fork basis.
     write_test_file(&store, &source, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &source, &setup)
         .await
@@ -3835,7 +3831,7 @@ async fn a_fork_pin_with_a_missing_basis_survives_the_missing_basis_pass() {
     assert_eq!(
         checkpoint_lifecycle(&store, &source, &fork_record.checkpoint_id).await,
         CheckpointStatus::Active {},
-        "a live target keeps its pin whatever became of the basis"
+        "a live target keeps its fork checkpoint"
     );
 }
 

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -3800,6 +3800,46 @@ async fn gc_never_releases_a_fork_record_while_its_target_lives() {
 }
 
 #[tokio::test]
+async fn a_fork_pin_with_a_missing_basis_survives_the_missing_basis_pass() {
+    // The missing-basis pass releases a record the creator could never have
+    // verified. A fork pin is not its to release: the target namespace's
+    // fate decides that, and only the fork arm reads it.
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let source = NamespaceId::parse("source").expect("namespace id");
+    let clone = NamespaceId::parse("clone").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &source, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    fork_namespace(&store, &source, &clone, &setup)
+        .await
+        .expect("fork");
+    let fork_record = read_fork_record(&store, &source).await;
+    // Advance the source root past the fork basis so the absent basis below
+    // is not the root's own, which would degrade the pass instead.
+    write_test_file(&store, &source, "/docs/two.txt", "gc-two", &setup).await;
+    create_checkpoint(&store, &source, &setup)
+        .await
+        .expect("advance root past the fork basis");
+    let basis_key = metadata_manifest_object(&source, &fork_record.manifest.manifest_object_id);
+    store.delete(&basis_key).await.expect("drop basis manifest");
+
+    let aged = context(now_after_newest_object(&store, &source, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &source, &config(), &aged)
+        .await
+        .expect("gc pass");
+    assert_eq!(report.released_checkpoints.missing_basis, 0);
+    assert_eq!(report.released_checkpoints.fork, 0);
+    assert_eq!(
+        checkpoint_lifecycle(&store, &source, &fork_record.checkpoint_id).await,
+        CheckpointStatus::Active {},
+        "a live target keeps its pin whatever became of the basis"
+    );
+}
+
+#[tokio::test]
 async fn gc_releases_abandoned_fork_checkpoints_once_the_lease_expires() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -180,7 +180,7 @@ pub(super) async fn install_namespace_head<S: ObjectStore + ?Sized>(
                 // An unreadable head still occupies the id: report the
                 // corruption rather than a lifecycle answer this attempt
                 // cannot support.
-                Err(error) => return Err(CoreError::load_head(error)),
+                Err(error) => return Err(CoreError::ControlObjectLoad(error)),
             };
             if existing.status == (NamespaceStatus::Deleted {}) {
                 return Ok(NamespaceHeadInstall::Deleted);

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -65,7 +65,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     .map_err(|err| CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(err)))?;
     let source_head = crate::namespace::control::load_head_object(store, source_namespace_id)
         .await
-        .map_err(CoreError::load_head)?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     // Start the target from the manifest pinned by the source checkpoint.
     let fork_basis = ForkBasis {

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -87,7 +87,7 @@ pub async fn load_namespace<S: ObjectStore + ?Sized>(
 ) -> Result<Namespace> {
     let head = crate::namespace::control::load_head_object(store, expected_namespace_id)
         .await
-        .map_err(CoreError::load_head)?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::NamespaceDeleted {
@@ -96,7 +96,7 @@ pub async fn load_namespace<S: ObjectStore + ?Sized>(
     }
     let retention_floor_seq = resolve_retention_floor_seq(store, &head)
         .await
-        .map_err(CoreError::load_head)?;
+        .map_err(CoreError::ControlObjectLoad)?;
     Ok(Namespace {
         namespace_id: head.namespace_id,
         head_seq: head.seq,

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -19,7 +19,10 @@ use crate::namespace::basis::MetadataBasis;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::path::mutation_path::{map_path_error_to_core, parse_absolute_path_for_core};
 use crate::storage::content::{content_object_key_for_ref, get_durable_content_bytes};
-use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
+use crate::wal::{
+    ensure_replayed_head_matches, load_validated_wal_chain, project_validated_wal_tail,
+    WalChainLoadRequest,
+};
 use loonfs_api::v0::DirectoryBinding;
 use loonfs_api::wire::control::{HeadState, NamespaceStatus};
 use loonfs_api::{
@@ -271,6 +274,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 CoreError::MetadataProjection(MetadataProjectionLoadError::WalReplay(error))
             })
         }?;
+        ensure_replayed_head_matches(&head, &replayed.resulting_head)?;
         let wal_tail_rows = Arc::new(replayed.resulting_metadata_state);
         if let Some(cache) = load_context.tail_cache {
             cache.insert(cache_key, Arc::clone(&wal_tail_rows));
@@ -905,8 +909,12 @@ mod tests {
     use crate::commit_engine::{publish_namespace_commits_batch, CommitCandidate};
     use crate::context::MutationContext;
     use crate::namespace::bootstrap::bootstrap_namespace;
+    use crate::namespace::control::load_head_object;
     use crate::path::write::{CommitRequest, FilesystemOperation};
-    use loonfs_api::{AttributeRevisionNo, AttributeValue, CommitId};
+    use bytes::Bytes;
+    use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
+    use loonfs_api::{AttributeRevisionNo, AttributeValue, CommitId, ErrorCode};
+    use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_test_support::ids::attribute_key;
     use std::collections::BTreeMap;
@@ -985,6 +993,52 @@ mod tests {
             .expect("commit lands");
         }
         (temp_dir, store, namespace_id)
+    }
+
+    #[tokio::test]
+    async fn a_tail_that_replays_to_another_head_is_refused_by_reads_and_publishes_alike() {
+        let (_temp_dir, store, namespace_id) = namespace_with_annotated_children().await;
+        let mut head = load_head_object(&store, &namespace_id)
+            .await
+            .expect("load head")
+            .state;
+        head.next_inode_id = InodeId(head.next_inode_id.0 + 1);
+        let envelope =
+            HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
+        store
+            .put_overwrite(
+                &wal_head(&namespace_id),
+                Bytes::from(encode_control_object(&envelope).expect("encode head")),
+            )
+            .await
+            .expect("rewrite head");
+
+        let read = load_current_metadata_view(&store, &namespace_id)
+            .await
+            .err()
+            .expect("a head the tail does not reconstruct is corruption");
+        assert_eq!(read.code(), ErrorCode::NamespaceCorrupt);
+
+        let published = publish_namespace_commits_batch(
+            &store,
+            &namespace_id,
+            vec![CommitCandidate::new(CommitRequest::single(
+                CommitId::parse("create-after-tamper").expect("commit id"),
+                loonfs_test_support::test_actor(),
+                None,
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/docs/after").expect("path"),
+                    parents: false,
+                },
+            ))],
+            &context(),
+        )
+        .await
+        .into_iter()
+        .next()
+        .expect("one result")
+        .expect_err("the publish path refuses the same state");
+        assert_eq!(published.code(), read.code());
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -13,7 +13,10 @@ use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
 use crate::namespace::basis::{load_head_and_metadata_basis, MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::control::load_head_object;
-use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
+use crate::wal::{
+    ensure_replayed_head_matches, load_validated_wal_chain, project_validated_wal_tail,
+    WalChainLoadRequest,
+};
 use loonfs_api::v0::CommittedChange;
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceStatus};
 use loonfs_api::{ChangeSeq, CommitId, ContentStoreId, NamespaceId};
@@ -257,7 +260,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     .map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalReplay(error))
     })?;
-    ensure_publish_reconstructed_head_matches(head, &replayed.resulting_head)?;
+    ensure_replayed_head_matches(head, &replayed.resulting_head)?;
     let wal_tail_segments = u64::try_from(wal_chain.segments().len()).unwrap_or(u64::MAX);
     let projection = PublishTailProjection {
         key,
@@ -265,27 +268,6 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         tail_state: replayed.resulting_metadata_state,
     };
     Ok(projection)
-}
-
-fn ensure_publish_reconstructed_head_matches(
-    current_head: &HeadState,
-    reconstructed: &HeadState,
-) -> Result<()> {
-    if current_head.namespace_id != reconstructed.namespace_id
-        || current_head.seq != reconstructed.seq
-        || current_head.head_commit_id != reconstructed.head_commit_id
-        || current_head.next_inode_id != reconstructed.next_inode_id
-        || (reconstructed.visible_wal_tip.is_some()
-            && current_head.visible_wal_tip != reconstructed.visible_wal_tip)
-    {
-        return Err(CoreError::MetadataProjection(
-            MetadataProjectionLoadError::ReplayedHeadMismatch {
-                expected: Box::new(current_head.clone()),
-                actual: Box::new(reconstructed.clone()),
-            },
-        ));
-    }
-    Ok(())
 }
 
 /// Confirms that the namespace head did not change while the publish view

--- a/crates/loonfs-core/src/wal/mod.rs
+++ b/crates/loonfs-core/src/wal/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use self::frame::{
 pub(crate) use self::reader::{
     count_visible_wal_tail_segments, load_validated_wal_chain, load_wal_chain_within, WalChainLoad,
 };
-pub(crate) use self::replay::project_validated_wal_tail;
+pub(crate) use self::replay::{ensure_replayed_head_matches, project_validated_wal_tail};
 pub(crate) use self::writer::prepare_wal_segment;
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -2,6 +2,7 @@
 
 pub(crate) use super::frame::WalReplayError;
 use super::{DecodedWalRecord, ReplayedWalTail, ValidatedWalChain};
+use crate::error::MetadataProjectionLoadError;
 use crate::metadata::{CommitReceiptRecord, MetadataState};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::{WalCommitDelta, WalDelta, WalSegmentEnvelope};
@@ -23,6 +24,33 @@ pub(crate) fn project_validated_wal_tail(
         replayed.resulting_head.visible_wal_tip = Some(last_segment.pointer());
     }
     Ok(replayed)
+}
+
+/// Proves the durable head is exactly what replaying the WAL tail onto the
+/// basis lands on.
+///
+/// A tail that lands somewhere else is corruption, and it is the same
+/// corruption wherever it is met: publication, flush, and the read path all
+/// fail closed here rather than storing or serving the disagreement. The tip
+/// clause applies only once the tail has a tip of its own, because an empty
+/// tail leaves the basis tip in place.
+pub(crate) fn ensure_replayed_head_matches(
+    current_head: &HeadState,
+    reconstructed: &HeadState,
+) -> Result<(), MetadataProjectionLoadError> {
+    if current_head.namespace_id != reconstructed.namespace_id
+        || current_head.seq != reconstructed.seq
+        || current_head.head_commit_id != reconstructed.head_commit_id
+        || current_head.next_inode_id != reconstructed.next_inode_id
+        || (reconstructed.visible_wal_tip.is_some()
+            && current_head.visible_wal_tip != reconstructed.visible_wal_tip)
+    {
+        return Err(MetadataProjectionLoadError::ReplayedHeadMismatch {
+            expected: Box::new(current_head.clone()),
+            actual: Box::new(reconstructed.clone()),
+        });
+    }
+    Ok(())
 }
 
 pub(crate) fn replay_wal_records<'a, I>(

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -26,14 +26,10 @@ pub(crate) fn project_validated_wal_tail(
     Ok(replayed)
 }
 
-/// Proves the durable head is exactly what replaying the WAL tail onto the
-/// basis lands on.
+/// Verifies that replaying the WAL tail produces the current head.
 ///
-/// A tail that lands somewhere else is corruption, and it is the same
-/// corruption wherever it is met: publication, flush, and the read path all
-/// fail closed here rather than storing or serving the disagreement. The tip
-/// clause applies only once the tail has a tip of its own, because an empty
-/// tail leaves the basis tip in place.
+/// An empty tail retains the basis tip, so the tip is compared only when the
+/// replay produced one.
 pub(crate) fn ensure_replayed_head_matches(
     current_head: &HeadState,
     reconstructed: &HeadState,

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -71,7 +71,10 @@ impl GrepError {
     pub fn code(&self) -> ErrorCode {
         match self {
             Self::NotEnabled | Self::Backfilling => ErrorCode::NotSupported,
-            Self::StoreUnavailable { class, .. } => class.error_code(),
+            Self::StoreUnavailable { class, .. } => match class {
+                StoreFailureClass::PermissionDenied => ErrorCode::StoragePermissionDenied,
+                _ => ErrorCode::ServerError,
+            },
             Self::CorruptIndex { .. } => ErrorCode::IndexCorrupt,
             Self::PublicationConflict { .. } => ErrorCode::StaleHead,
             Self::Runtime(error) => error.code(),
@@ -128,6 +131,7 @@ mod tests {
                 StoreFailureClass::PermissionDenied,
                 ErrorCode::StoragePermissionDenied,
             ),
+            (StoreFailureClass::InvalidRequest, ErrorCode::ServerError),
             (StoreFailureClass::Other, ErrorCode::ServerError),
         ] {
             let error = GrepError::StoreUnavailable {

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -71,10 +71,7 @@ impl GrepError {
     pub fn code(&self) -> ErrorCode {
         match self {
             Self::NotEnabled | Self::Backfilling => ErrorCode::NotSupported,
-            Self::StoreUnavailable { class, .. } => match class {
-                StoreFailureClass::PermissionDenied => ErrorCode::StoragePermissionDenied,
-                _ => ErrorCode::ServerError,
-            },
+            Self::StoreUnavailable { class, .. } => class.error_code(),
             Self::CorruptIndex { .. } => ErrorCode::IndexCorrupt,
             Self::PublicationConflict { .. } => ErrorCode::StaleHead,
             Self::Runtime(error) => error.code(),

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{BoxStream, TryStreamExt};
-use loonfs_api::{Checksum, ErrorCode};
+use loonfs_api::Checksum;
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -196,12 +196,9 @@ pub enum ObjectStoreError {
 pub enum ObjectStoreErrorClass {
     /// A required object was absent.
     NotFound,
-    /// A content reference or byte range the caller described was invalid.
+    /// A content reference or byte range was invalid.
     InvalidRequest,
-    /// An object key or listing prefix was outside the store's key grammar.
-    /// LoonFS builds every key it asks for from validated ids, so this is a
-    /// fault in the asking code or in the configured key prefix, never in
-    /// the end user's request.
+    /// An object key or listing prefix was invalid.
     InvalidKey,
     /// A conditional operation observed a conflicting state.
     PreconditionFailed,
@@ -225,33 +222,12 @@ impl ObjectStoreErrorClass {
         error.class()
     }
 
-    /// Returns the wire code every surface answers this category with.
-    ///
-    /// `InvalidRequest` is the one caller-derived category: the content ref
-    /// and the byte range come from the request, so a store that refuses
-    /// them is refusing what the caller asked for. Every other category is
-    /// the deployment's own problem and reads as a server fault.
-    pub fn error_code(self) -> ErrorCode {
-        match self {
-            Self::PermissionDenied => ErrorCode::StoragePermissionDenied,
-            Self::InvalidRequest => ErrorCode::InvalidRequest,
-            Self::NotFound
-            | Self::InvalidKey
-            | Self::PreconditionFailed
-            | Self::StoredChecksumMissing
-            | Self::Unsupported
-            | Self::Configuration
-            | Self::RetryableTransport
-            | Self::Other => ErrorCode::ServerError,
-        }
-    }
-
     /// Returns a safe message for users.
     pub fn public_message(self) -> Cow<'static, str> {
         Cow::Borrowed(match self {
             Self::NotFound => "object-store object not found",
             Self::InvalidRequest => {
-                "object-store rejected the content reference or byte range in this request"
+                "object-store rejected a content reference or byte range"
             }
             Self::InvalidKey => {
                 "object-store rejected an object key this deployment constructed"

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{BoxStream, TryStreamExt};
-use loonfs_api::Checksum;
+use loonfs_api::{Checksum, ErrorCode};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -196,8 +196,13 @@ pub enum ObjectStoreError {
 pub enum ObjectStoreErrorClass {
     /// A required object was absent.
     NotFound,
-    /// A key, content reference, or range was invalid.
+    /// A content reference or byte range the caller described was invalid.
     InvalidRequest,
+    /// An object key or listing prefix was outside the store's key grammar.
+    /// LoonFS builds every key it asks for from validated ids, so this is a
+    /// fault in the asking code or in the configured key prefix, never in
+    /// the end user's request.
+    InvalidKey,
     /// A conditional operation observed a conflicting state.
     PreconditionFailed,
     /// The selected identity or credentials were rejected.
@@ -220,11 +225,37 @@ impl ObjectStoreErrorClass {
         error.class()
     }
 
+    /// Returns the wire code every surface answers this category with.
+    ///
+    /// `InvalidRequest` is the one caller-derived category: the content ref
+    /// and the byte range come from the request, so a store that refuses
+    /// them is refusing what the caller asked for. Every other category is
+    /// the deployment's own problem and reads as a server fault.
+    pub fn error_code(self) -> ErrorCode {
+        match self {
+            Self::PermissionDenied => ErrorCode::StoragePermissionDenied,
+            Self::InvalidRequest => ErrorCode::InvalidRequest,
+            Self::NotFound
+            | Self::InvalidKey
+            | Self::PreconditionFailed
+            | Self::StoredChecksumMissing
+            | Self::Unsupported
+            | Self::Configuration
+            | Self::RetryableTransport
+            | Self::Other => ErrorCode::ServerError,
+        }
+    }
+
     /// Returns a safe message for users.
     pub fn public_message(self) -> Cow<'static, str> {
         Cow::Borrowed(match self {
             Self::NotFound => "object-store object not found",
-            Self::InvalidRequest => "object-store request is invalid",
+            Self::InvalidRequest => {
+                "object-store rejected the content reference or byte range in this request"
+            }
+            Self::InvalidKey => {
+                "object-store rejected an object key this deployment constructed"
+            }
             Self::PreconditionFailed => {
                 "object-store precondition failed; retry against the latest state"
             }
@@ -273,7 +304,8 @@ impl ObjectStoreError {
     pub fn class(&self) -> ObjectStoreErrorClass {
         match self {
             Self::NotFound { .. } => ObjectStoreErrorClass::NotFound,
-            Self::InvalidKey { .. } | Self::InvalidContentRef(_) | Self::InvalidRange { .. } => {
+            Self::InvalidKey { .. } => ObjectStoreErrorClass::InvalidKey,
+            Self::InvalidContentRef(_) | Self::InvalidRange { .. } => {
                 ObjectStoreErrorClass::InvalidRequest
             }
             Self::PreconditionFailed { .. } => ObjectStoreErrorClass::PreconditionFailed,

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -351,24 +351,20 @@ async fn sign_parts(
 }
 
 pub(super) fn presign_issuer_error(error: ObjectStoreError) -> ApiResponseError {
-    let message = error.public_message();
-    match error {
-        ObjectStoreError::InvalidContentRef(_) => {
-            ApiResponseError::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, &message)
-                .with_param("/content")
-        }
-        // The status comes from the registry so this handler cannot drift
-        // from the status the rest of the server serves for the code.
-        ObjectStoreError::PermissionDenied { .. } => ApiResponseError::new(
-            status_for_core_error_code(ErrorCode::StoragePermissionDenied),
-            ErrorCode::StoragePermissionDenied,
-            &message,
-        ),
-        _ => ApiResponseError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            ErrorCode::ServerError,
-            &message,
-        ),
+    // The code and the status both come from the registry, so an issuer
+    // failure answers exactly what the same store failure answers anywhere
+    // else in the server.
+    let code = error.class().error_code();
+    let response = ApiResponseError::new(
+        status_for_core_error_code(code),
+        code,
+        &error.public_message(),
+    );
+    match code {
+        // Everything an issuer calls a bad request is a content descriptor
+        // the caller wrote.
+        ErrorCode::InvalidRequest => response.with_param("/content"),
+        _ => response,
     }
 }
 

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -351,20 +351,20 @@ async fn sign_parts(
 }
 
 pub(super) fn presign_issuer_error(error: ObjectStoreError) -> ApiResponseError {
-    // The code and the status both come from the registry, so an issuer
-    // failure answers exactly what the same store failure answers anywhere
-    // else in the server.
-    let code = error.class().error_code();
+    let (code, param) = match &error {
+        ObjectStoreError::InvalidContentRef(_) => (ErrorCode::InvalidRequest, Some("/content")),
+        ObjectStoreError::PermissionDenied { .. } => (ErrorCode::StoragePermissionDenied, None),
+        _ => (ErrorCode::ServerError, None),
+    };
     let response = ApiResponseError::new(
         status_for_core_error_code(code),
         code,
         &error.public_message(),
     );
-    match code {
-        // Everything an issuer calls a bad request is a content descriptor
-        // the caller wrote.
-        ErrorCode::InvalidRequest => response.with_param("/content"),
-        _ => response,
+    if let Some(param) = param {
+        response.with_param(param)
+    } else {
+        response
     }
 }
 

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -561,6 +561,23 @@ async fn provider_failure_is_projected_in_the_presign_api_envelope() {
     assert!(rendered.contains("req_presign_hygiene"), "{rendered}");
 }
 
+#[tokio::test]
+async fn invalid_presign_content_is_a_bad_request() {
+    use axum::response::IntoResponse;
+
+    let response = super::handlers_uploads::presign_issuer_error(
+        ObjectStoreError::InvalidContentRef("invalid checksum".to_owned()),
+    )
+    .into_response();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read presign error body");
+    let rendered = String::from_utf8(body.to_vec()).expect("API body is UTF-8");
+    assert!(rendered.contains("invalid_request"), "{rendered}");
+    assert!(rendered.contains("/content"), "{rendered}");
+}
+
 #[derive(Debug)]
 struct StaleHeadOnceStore {
     inner: LocalFsStore,


### PR DESCRIPTION
Prevents the missing-basis garbage collection pass from releasing checkpoints owned by active forks. Fork checkpoints now remain pinned until their target namespace is deleted.

Uses one WAL replay consistency check for reads, publishes, and flushes, so all three reject a head that does not match its WAL history.

Preserves typed control-object and storage errors without treating internal invalid byte ranges as client mistakes. Invalid presign content still returns a bad-request response at the HTTP boundary, while invalid keys and internal range failures remain server errors.