### PR TITLE
refactor(objectstore): share signed request handling

### DIFF
--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -2,9 +2,8 @@
 
 use super::{ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::object_store::Result;
-use crate::presign::{
-    stored_crc32c, GcsPresignerConfig, GcsV4Presigner, PresignedUrl, CHECKSUM_HEAD_TTL,
-};
+use crate::presign::{stored_crc32c, GcsPresignerConfig, GcsV4Presigner, CHECKSUM_HEAD_TTL};
+use crate::signed_request::{execute_signed, stored_checksum_from_signed_head};
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig, StoredObjectChecksum,
@@ -115,33 +114,6 @@ impl GcpGcsStore {
         SystemTime::now()
     }
 
-    /// Issues one internally signed request and returns its status and headers.
-    ///
-    /// The metadata read this serves carries no body in either direction, so
-    /// it lands on the store's own HTTP client, runtime, and timeouts without
-    /// reading one.
-    async fn execute_signed(&self, key: &str, signed: PresignedUrl) -> Result<http::Response<()>> {
-        let mut builder = http::Request::builder()
-            .method(signed.method.as_str())
-            .uri(&signed.url);
-        for (name, value) in &signed.headers {
-            builder = builder.header(name, value);
-        }
-        let request = builder
-            .body(HttpRequestBody::empty())
-            .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
-        let response = self
-            .http
-            .execute(request)
-            .await
-            .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
-
-        let mut parts = http::Response::new(());
-        *parts.status_mut() = response.status();
-        *parts.headers_mut() = response.headers().clone();
-        Ok(parts)
-    }
-
     fn generation_as_compare_token(metadata: ObjectMetadata) -> ObjectMetadata {
         ObjectMetadata {
             etag: metadata.version.clone(),
@@ -176,60 +148,14 @@ impl ObjectStore for GcpGcsStore {
     /// request, so this is a `HEAD` and nothing more. The provider client
     /// surfaces neither that header nor any other checksum, which is why the
     /// request is signed here rather than asked of the client.
-    ///
-    /// An object GCS acknowledges but reports no usable CRC-32C for is an
-    /// error, never a size-only answer: completion compares a stored checksum
-    /// against a promised one, and there is nothing to compare.
     async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
         let signed = self.request_signer.presign_head_stored_checksum(
             key,
             CHECKSUM_HEAD_TTL,
             Self::signing_time(),
         )?;
-        let response = self.execute_signed(key, signed).await?;
-
-        let status = response.status();
-        if status == http::StatusCode::NOT_FOUND {
-            return Ok(None);
-        }
-        if status == http::StatusCode::FORBIDDEN || status == http::StatusCode::UNAUTHORIZED {
-            return Err(ObjectStoreError::PermissionDenied {
-                object_key: key.to_owned(),
-                message: format!("provider refused the checksum head with {status}"),
-            });
-        }
-        if !status.is_success() {
-            let message = format!("checksum head failed with {status}");
-            return Err(
-                if status == http::StatusCode::REQUEST_TIMEOUT
-                    || status == http::StatusCode::TOO_MANY_REQUESTS
-                    || status.is_server_error()
-                {
-                    ObjectStoreError::retryable_transport(key, message)
-                } else {
-                    ObjectStoreError::transport(key, message)
-                },
-            );
-        }
-
-        let headers = response.headers();
-        let checksum = stored_crc32c_from_headers(headers).ok_or_else(|| {
-            ObjectStoreError::StoredChecksumMissing {
-                object_key: key.to_owned(),
-            }
-        })?;
-        let size_bytes = headers
-            .get(http::header::CONTENT_LENGTH)
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.parse::<u64>().ok())
-            .ok_or_else(|| {
-                ObjectStoreError::transport(key, "checksum head reported no content length")
-            })?;
-
-        Ok(Some(StoredObjectChecksum {
-            size_bytes,
-            checksum,
-        }))
+        let response = execute_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
+        stored_checksum_from_signed_head(key, &response, stored_crc32c_from_headers)
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -1,4 +1,5 @@
-//! Key validation and prefix scoping shared by the provider stores.
+//! Key validation, prefix scoping, and endpoint addressing shared by the
+//! provider stores.
 
 use crate::object_store::Result;
 use crate::ObjectStoreError;
@@ -108,6 +109,16 @@ pub(crate) fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>> {
         authority,
         path: path.trim_end_matches('/'),
     })
+}
+
+/// Prefixes the bucket onto a virtual-hosted authority unless the endpoint
+/// already carries it.
+pub(crate) fn virtual_hosted_authority(bucket: &str, authority: &str) -> String {
+    let bucket = bucket.trim();
+    if authority.starts_with(&format!("{bucket}.")) {
+        return authority.to_owned();
+    }
+    format!("{bucket}.{authority}")
 }
 
 #[cfg(test)]

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -1,5 +1,4 @@
-//! Key validation, prefix scoping, and endpoint addressing shared by the
-//! provider stores.
+//! Shared key and endpoint helpers for provider stores.
 
 use crate::object_store::Result;
 use crate::ObjectStoreError;
@@ -111,8 +110,6 @@ pub(crate) fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>> {
     })
 }
 
-/// Prefixes the bucket onto a virtual-hosted authority unless the endpoint
-/// already carries it.
 pub(crate) fn virtual_hosted_authority(bucket: &str, authority: &str) -> String {
     let bucket = bucket.trim();
     if authority.starts_with(&format!("{bucket}.")) {

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -29,6 +29,7 @@ pub mod probe;
 mod provider_object_store;
 mod retry;
 pub mod s3_compatible;
+mod signed_request;
 mod store_config;
 mod store_io_runtime;
 #[cfg(test)]

--- a/crates/loonfs-objectstore/src/presign/mod.rs
+++ b/crates/loonfs-objectstore/src/presign/mod.rs
@@ -23,3 +23,4 @@ pub use s3_compatible::{
 };
 
 pub(crate) use gcs::stored_crc32c;
+pub(crate) use s3_compatible::base64_crc64nvme;

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -8,7 +8,9 @@ use crate::aws_credentials::{
     aws_credentials_source, AwsSigningCredentials, SharedAwsCredentialsSource,
 };
 use crate::crypto::hmac_sha256;
-use crate::keyspace::{normalize_key_prefix, parse_endpoint_url, scope_object_key};
+use crate::keyspace::{
+    normalize_key_prefix, parse_endpoint_url, scope_object_key, virtual_hosted_authority,
+};
 use crate::object_store::Result;
 use crate::presign::v4::{
     canonical_query_string, hex_lower, normalize_header_value, percent_encode_path,
@@ -377,15 +379,9 @@ impl S3CompatiblePresigner {
                         ),
                     })
                 } else {
-                    let bucket_prefix = format!("{}.", self.config.bucket);
-                    let host = if parsed.authority.starts_with(&bucket_prefix) {
-                        parsed.authority.to_owned()
-                    } else {
-                        format!("{}.{}", self.config.bucket, parsed.authority)
-                    };
                     Ok(S3Endpoint {
                         scheme: parsed.scheme.to_owned(),
-                        host,
+                        host: virtual_hosted_authority(&self.config.bucket, parsed.authority),
                         canonical_uri: format!("{}/{}", base_path, encoded_key),
                     })
                 }
@@ -504,7 +500,7 @@ impl DirectGetIssuer for S3CompatiblePresigner {
 }
 
 /// Converts a CRC-64/NVME into the base64 spelling the S3 family signs.
-fn base64_crc64nvme(checksum: &Checksum) -> Result<String> {
+pub(crate) fn base64_crc64nvme(checksum: &Checksum) -> Result<String> {
     if checksum.algorithm != ChecksumAlgorithm::Crc64nvme {
         return Err(invalid_direct_put_content(
             "multipart uploads are checksummed with crc64nvme",

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -14,7 +14,9 @@ use crate::presign::{
     base64_crc64nvme, S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES,
     CHECKSUM_HEAD_TTL, CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
 };
-use crate::signed_request::{execute_signed, stored_checksum_from_signed_head, SignedResponse};
+use crate::signed_request::{
+    execute_signed, execute_signed_with_body, stored_checksum_from_signed_head, SignedResponse,
+};
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
@@ -288,8 +290,6 @@ impl S3CompatibleStore {
     }
 }
 
-/// The S3 family's own reading of a signed response: a flat XML control
-/// document, and a failure that can arrive inside a 200.
 impl SignedResponse {
     fn text(&self) -> std::borrow::Cow<'_, str> {
         String::from_utf8_lossy(&self.body)
@@ -341,7 +341,8 @@ impl ObjectStore for S3CompatibleStore {
             .request_signer
             .presign_create_multipart(key, MULTIPART_CONTROL_TTL, Self::signing_time())
             .await?;
-        let response = execute_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
+        let response =
+            execute_signed_with_body(&self.http, key, signed, HttpRequestBody::empty()).await?;
         if let Some(code) = response.provider_error_code() {
             return Err(multipart_error(key, "create", &code));
         }
@@ -367,7 +368,7 @@ impl ObjectStore for S3CompatibleStore {
                 Self::signing_time(),
             )
             .await?;
-        let response = execute_signed(
+        let response = execute_signed_with_body(
             &self.http,
             key,
             signed,
@@ -394,7 +395,8 @@ impl ObjectStore for S3CompatibleStore {
                 Self::signing_time(),
             )
             .await?;
-        let response = execute_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
+        let response =
+            execute_signed_with_body(&self.http, key, signed, HttpRequestBody::empty()).await?;
         match response.provider_error_code().as_deref() {
             // Nothing to abandon is the state an abort is trying to reach.
             None | Some("NoSuchUpload") => Ok(()),

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -8,13 +8,13 @@ use crate::aws_credentials::{
     aws_credentials_source, static_aws_credentials_source, ObjectStoreAwsCredentialProvider,
     SharedAwsCredentialsSource,
 };
-use crate::keyspace::parse_endpoint_url;
+use crate::keyspace::{parse_endpoint_url, virtual_hosted_authority};
 use crate::object_store::Result;
-use crate::presign::PresignedUrl;
 use crate::presign::{
-    S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES, CHECKSUM_HEAD_TTL,
-    CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
+    base64_crc64nvme, S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES,
+    CHECKSUM_HEAD_TTL, CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
 };
+use crate::signed_request::{execute_signed, stored_checksum_from_signed_head, SignedResponse};
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
@@ -286,60 +286,10 @@ impl S3CompatibleStore {
         // enter wall time here. Nothing durable is derived from it.
         SystemTime::now()
     }
-
-    /// Issues one internally signed request and returns its status, headers,
-    /// and body.
-    ///
-    /// Every caller here signs a request the provider client cannot build,
-    /// so they all land on the same transport: the store's own HTTP client,
-    /// runtime, and timeouts.
-    async fn execute_signed(
-        &self,
-        key: &str,
-        signed: PresignedUrl,
-        body: HttpRequestBody,
-    ) -> Result<SignedResponse> {
-        let mut builder = http::Request::builder()
-            .method(signed.method.as_str())
-            .uri(&signed.url);
-        for (name, value) in &signed.headers {
-            builder = builder.header(name, value);
-        }
-        let request = builder
-            .body(body)
-            .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
-        let response = self
-            .http
-            .execute(request)
-            .await
-            .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
-
-        let status = response.status();
-        let headers = response.headers().clone();
-        let body = response
-            .into_body()
-            .bytes()
-            .await
-            .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
-        Ok(SignedResponse {
-            status,
-            headers,
-            body,
-        })
-    }
 }
 
-/// One internally signed response, read whole.
-///
-/// The bodies here are small provider control documents — an upload id, or
-/// an error — so reading them fully is what makes the S3 family's habit of
-/// reporting failures inside a 200 response detectable at all.
-struct SignedResponse {
-    status: http::StatusCode,
-    headers: http::HeaderMap,
-    body: bytes::Bytes,
-}
-
+/// The S3 family's own reading of a signed response: a flat XML control
+/// document, and a failure that can arrive inside a 200.
 impl SignedResponse {
     fn text(&self) -> std::borrow::Cow<'_, str> {
         String::from_utf8_lossy(&self.body)
@@ -382,46 +332,8 @@ impl ObjectStore for S3CompatibleStore {
             .request_signer
             .presign_head_stored_checksum(key, CHECKSUM_HEAD_TTL, Self::signing_time())
             .await?;
-        let response = self
-            .execute_signed(key, signed, HttpRequestBody::empty())
-            .await?;
-
-        let status = response.status;
-        if status == http::StatusCode::NOT_FOUND {
-            return Ok(None);
-        }
-        if status == http::StatusCode::FORBIDDEN || status == http::StatusCode::UNAUTHORIZED {
-            return Err(ObjectStoreError::PermissionDenied {
-                object_key: key.to_owned(),
-                message: format!("provider refused the checksum head with {status}"),
-            });
-        }
-        if !status.is_success() {
-            return Err(transport_for_status(
-                key,
-                status,
-                format!("checksum head failed with {status}"),
-            ));
-        }
-
-        let headers = &response.headers;
-        let Some(checksum) = s3_stored_checksum(headers) else {
-            return Err(ObjectStoreError::StoredChecksumMissing {
-                object_key: key.to_owned(),
-            });
-        };
-        let size_bytes = headers
-            .get(http::header::CONTENT_LENGTH)
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.parse::<u64>().ok())
-            .ok_or_else(|| {
-                ObjectStoreError::transport(key, "checksum head reported no content length")
-            })?;
-
-        Ok(Some(StoredObjectChecksum {
-            size_bytes,
-            checksum,
-        }))
+        let response = execute_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
+        stored_checksum_from_signed_head(key, &response, s3_stored_checksum)
     }
 
     async fn create_multipart_upload(&self, key: &str) -> Result<String> {
@@ -429,9 +341,7 @@ impl ObjectStore for S3CompatibleStore {
             .request_signer
             .presign_create_multipart(key, MULTIPART_CONTROL_TTL, Self::signing_time())
             .await?;
-        let response = self
-            .execute_signed(key, signed, HttpRequestBody::empty())
-            .await?;
+        let response = execute_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
         if let Some(code) = response.provider_error_code() {
             return Err(multipart_error(key, "create", &code));
         }
@@ -457,9 +367,13 @@ impl ObjectStore for S3CompatibleStore {
                 Self::signing_time(),
             )
             .await?;
-        let response = self
-            .execute_signed(key, signed, complete_multipart_body(parts)?.into())
-            .await?;
+        let response = execute_signed(
+            &self.http,
+            key,
+            signed,
+            complete_multipart_body(parts)?.into(),
+        )
+        .await?;
         match response.provider_error_code().as_deref() {
             None => Ok(MultipartCompletion::Assembled),
             // The upload is gone, which says nothing about the object: an
@@ -480,9 +394,7 @@ impl ObjectStore for S3CompatibleStore {
                 Self::signing_time(),
             )
             .await?;
-        let response = self
-            .execute_signed(key, signed, HttpRequestBody::empty())
-            .await?;
+        let response = execute_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
         match response.provider_error_code().as_deref() {
             // Nothing to abandon is the state an abort is trying to reach.
             None | Some("NoSuchUpload") => Ok(()),
@@ -589,20 +501,11 @@ fn complete_multipart_body(parts: &[MultipartPart]) -> Result<String> {
         body.push_str("</PartNumber><ETag>");
         body.push_str(&xml_escape(&part.etag));
         body.push_str("</ETag><ChecksumCRC64NVME>");
-        body.push_str(&xml_escape(&base64_checksum(&part.checksum)?));
+        body.push_str(&xml_escape(&base64_crc64nvme(&part.checksum)?));
         body.push_str("</ChecksumCRC64NVME></Part>");
     }
     body.push_str("</CompleteMultipartUpload>");
     Ok(body)
-}
-
-fn base64_checksum(checksum: &Checksum) -> Result<String> {
-    checksum
-        .validate()
-        .map_err(|error| ObjectStoreError::InvalidContentRef(error.to_string()))?;
-    let raw = loonfs_api::wire::hex::hex_decode_bytes(&checksum.value)
-        .map_err(|error| ObjectStoreError::InvalidContentRef(error.to_string()))?;
-    Ok(base64::engine::general_purpose::STANDARD.encode(raw))
 }
 
 fn multipart_error(key: &str, operation: &str, code: &str) -> ObjectStoreError {
@@ -631,21 +534,6 @@ fn multipart_error(key: &str, operation: &str, code: &str) -> ObjectStoreError {
     }
 }
 
-fn transport_for_status(
-    key: &str,
-    status: http::StatusCode,
-    message: impl Into<String>,
-) -> ObjectStoreError {
-    if status == http::StatusCode::REQUEST_TIMEOUT
-        || status == http::StatusCode::TOO_MANY_REQUESTS
-        || status.is_server_error()
-    {
-        ObjectStoreError::retryable_transport(key, message)
-    } else {
-        ObjectStoreError::transport(key, message)
-    }
-}
-
 fn validate_config(config: &S3CompatibleConfig) -> Result<()> {
     if config.bucket.trim().is_empty() {
         return Err(ObjectStoreError::Configuration(
@@ -670,14 +558,11 @@ fn object_store_endpoint_url(
     }
 
     let parsed = parse_endpoint_url(endpoint_url)?;
-    let bucket_prefix = format!("{}.", bucket.trim());
-    if parsed.authority.starts_with(&bucket_prefix) {
-        return Ok(endpoint_url.to_owned());
-    }
-
     Ok(format!(
-        "{}://{}.{}/{}",
-        parsed.scheme, bucket, parsed.authority, parsed.path
+        "{}://{}/{}",
+        parsed.scheme,
+        virtual_hosted_authority(bucket, parsed.authority),
+        parsed.path
     )
     .trim_end_matches('/')
     .to_owned())

--- a/crates/loonfs-objectstore/src/signed_request.rs
+++ b/crates/loonfs-objectstore/src/signed_request.rs
@@ -1,0 +1,111 @@
+//! Requests this crate signs for itself when a provider client cannot
+//! express them, and the provider-independent reading of their responses.
+
+use crate::object_store::Result;
+use crate::presign::PresignedUrl;
+use crate::{ObjectStoreError, StoredObjectChecksum};
+use loonfs_api::Checksum;
+use object_store::client::{HttpClient, HttpRequestBody};
+
+/// One internally signed response, read whole: the bodies are small control
+/// documents, and the S3 family can report failure inside a 200 body.
+pub(crate) struct SignedResponse {
+    pub(crate) status: http::StatusCode,
+    pub(crate) headers: http::HeaderMap,
+    pub(crate) body: bytes::Bytes,
+}
+
+pub(crate) async fn execute_signed(
+    client: &HttpClient,
+    key: &str,
+    signed: PresignedUrl,
+    body: HttpRequestBody,
+) -> Result<SignedResponse> {
+    let mut builder = http::Request::builder()
+        .method(signed.method.as_str())
+        .uri(&signed.url);
+    for (name, value) in &signed.headers {
+        builder = builder.header(name, value);
+    }
+    let request = builder
+        .body(body)
+        .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
+    let response = client
+        .execute(request)
+        .await
+        .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = response
+        .into_body()
+        .bytes()
+        .await
+        .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
+    Ok(SignedResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+/// Reads a signed checksum head, taking the provider's header reader. An
+/// object with no usable checksum is an error, never a size-only answer:
+/// completion has nothing to compare.
+pub(crate) fn stored_checksum_from_signed_head(
+    key: &str,
+    response: &SignedResponse,
+    stored_checksum: impl FnOnce(&http::HeaderMap) -> Option<Checksum>,
+) -> Result<Option<StoredObjectChecksum>> {
+    let status = response.status;
+    if status == http::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if status == http::StatusCode::FORBIDDEN || status == http::StatusCode::UNAUTHORIZED {
+        return Err(ObjectStoreError::PermissionDenied {
+            object_key: key.to_owned(),
+            message: format!("provider refused the checksum head with {status}"),
+        });
+    }
+    if !status.is_success() {
+        return Err(transport_for_status(
+            key,
+            status,
+            format!("checksum head failed with {status}"),
+        ));
+    }
+
+    let Some(checksum) = stored_checksum(&response.headers) else {
+        return Err(ObjectStoreError::StoredChecksumMissing {
+            object_key: key.to_owned(),
+        });
+    };
+    let size_bytes = response
+        .headers
+        .get(http::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .ok_or_else(|| {
+            ObjectStoreError::transport(key, "checksum head reported no content length")
+        })?;
+
+    Ok(Some(StoredObjectChecksum {
+        size_bytes,
+        checksum,
+    }))
+}
+
+fn transport_for_status(
+    key: &str,
+    status: http::StatusCode,
+    message: impl Into<String>,
+) -> ObjectStoreError {
+    if status == http::StatusCode::REQUEST_TIMEOUT
+        || status == http::StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+    {
+        ObjectStoreError::retryable_transport(key, message)
+    } else {
+        ObjectStoreError::transport(key, message)
+    }
+}

--- a/crates/loonfs-objectstore/src/signed_request.rs
+++ b/crates/loonfs-objectstore/src/signed_request.rs
@@ -1,14 +1,11 @@
-//! Requests this crate signs for itself when a provider client cannot
-//! express them, and the provider-independent reading of their responses.
+//! Helpers for HTTP requests signed by LoonFS.
 
 use crate::object_store::Result;
 use crate::presign::PresignedUrl;
 use crate::{ObjectStoreError, StoredObjectChecksum};
 use loonfs_api::Checksum;
-use object_store::client::{HttpClient, HttpRequestBody};
+use object_store::client::{HttpClient, HttpRequestBody, HttpResponse};
 
-/// One internally signed response, read whole: the bodies are small control
-/// documents, and the S3 family can report failure inside a 200 body.
 pub(crate) struct SignedResponse {
     pub(crate) status: http::StatusCode,
     pub(crate) headers: http::HeaderMap,
@@ -20,7 +17,7 @@ pub(crate) async fn execute_signed(
     key: &str,
     signed: PresignedUrl,
     body: HttpRequestBody,
-) -> Result<SignedResponse> {
+) -> Result<HttpResponse> {
     let mut builder = http::Request::builder()
         .method(signed.method.as_str())
         .uri(&signed.url);
@@ -30,11 +27,19 @@ pub(crate) async fn execute_signed(
     let request = builder
         .body(body)
         .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
-    let response = client
+    client
         .execute(request)
         .await
-        .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
+        .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))
+}
 
+pub(crate) async fn execute_signed_with_body(
+    client: &HttpClient,
+    key: &str,
+    signed: PresignedUrl,
+    body: HttpRequestBody,
+) -> Result<SignedResponse> {
+    let response = execute_signed(client, key, signed, body).await?;
     let status = response.status();
     let headers = response.headers().clone();
     let body = response
@@ -49,15 +54,13 @@ pub(crate) async fn execute_signed(
     })
 }
 
-/// Reads a signed checksum head, taking the provider's header reader. An
-/// object with no usable checksum is an error, never a size-only answer:
-/// completion has nothing to compare.
-pub(crate) fn stored_checksum_from_signed_head(
+/// Reads an object's size and checksum from a signed `HEAD` response.
+pub(crate) fn stored_checksum_from_signed_head<B>(
     key: &str,
-    response: &SignedResponse,
+    response: &http::Response<B>,
     stored_checksum: impl FnOnce(&http::HeaderMap) -> Option<Checksum>,
 ) -> Result<Option<StoredObjectChecksum>> {
-    let status = response.status;
+    let status = response.status();
     if status == http::StatusCode::NOT_FOUND {
         return Ok(None);
     }
@@ -75,13 +78,13 @@ pub(crate) fn stored_checksum_from_signed_head(
         ));
     }
 
-    let Some(checksum) = stored_checksum(&response.headers) else {
+    let Some(checksum) = stored_checksum(response.headers()) else {
         return Err(ObjectStoreError::StoredChecksumMissing {
             object_key: key.to_owned(),
         });
     };
     let size_bytes = response
-        .headers
+        .headers()
         .get(http::header::CONTENT_LENGTH)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<u64>().ok())


### PR DESCRIPTION
Uses one helper for HTTP requests that the GCS and S3-compatible clients cannot express directly. Checksum HEAD requests read only the status and headers, while S3 multipart requests also read the response body so provider errors returned with HTTP 200 are still detected.

Uses the same virtual-hosted bucket rule in the store and presigner. Multipart completion also uses the same CRC-64/NVME encoder as part signing, which rejects checksums with the wrong algorithm before sending the request.