### PR TITLE
refactor(cli): share recursive transfer helpers

### DIFF
--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -604,10 +604,7 @@ pub(crate) async fn run_filesystem_get(
     })
 }
 
-/// Opens a download of `spec` at the point an interrupted run left off: the
-/// bytes named after `destination` count toward the start offset only while
-/// they still describe the content resolved just now. A file with no content
-/// reference to compare against starts over.
+/// Opens a download at the offset recorded in a matching partial file.
 pub(super) async fn open_resumable_download(
     context: &CommandContext,
     spec: &NamespacePath,

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -28,7 +28,7 @@ use crate::uploads::{SourceIdentity, UploadJournal};
 use loonfs_api::v0::UploadSessionStatus;
 use loonfs_api::{
     AbsolutePath, ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue, ChangeSeq, CommitId,
-    CommitResponse, DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeKind,
+    CommitResponse, ContentRef, DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeKind,
     ListPathEntriesResponse, NamespaceId, RevisionNo,
 };
 use loonfs_client::{
@@ -554,22 +554,16 @@ pub(crate) async fn run_filesystem_get(
         args.local_destination.as_deref(),
     )
     .map_err(|error| context.fail(kind, error))?;
-    // Where a download starts is decided before it is opened: the bytes an
-    // interrupted run left are named after this destination, and how many of
-    // them still describe the content resolved just now is how far in this
-    // one begins. A file with no content reference to compare against — one
-    // this build cannot identify — starts over.
-    let meta = entry
-        .content_ref()
-        .map(|content_ref| PartialMeta::describe(content_ref, revision_no));
-    let start_offset = meta
-        .as_ref()
-        .map_or(0, |meta| partial::resumable_bytes(&destination, meta));
-    let mut download = context
-        .target
-        .open_file_download(&spec, revision_no, entry.size_bytes(), start_offset)
-        .await
-        .map_err(|error| context.fail(kind, error))?;
+    let (mut download, meta) = open_resumable_download(
+        &context,
+        &spec,
+        revision_no,
+        entry.size_bytes(),
+        &destination,
+        entry.content_ref(),
+    )
+    .await
+    .map_err(|error| context.fail(kind, error))?;
 
     let progress = Arc::new(ProgressReporter::new(
         runtime,
@@ -608,6 +602,29 @@ pub(crate) async fn run_filesystem_get(
         mode: Some(context.mode),
         data,
     })
+}
+
+/// Opens a download of `spec` at the point an interrupted run left off: the
+/// bytes named after `destination` count toward the start offset only while
+/// they still describe the content resolved just now. A file with no content
+/// reference to compare against starts over.
+pub(super) async fn open_resumable_download(
+    context: &CommandContext,
+    spec: &NamespacePath,
+    revision_no: Option<RevisionNo>,
+    size_bytes: Option<u64>,
+    destination: &Path,
+    content_ref: Option<&ContentRef>,
+) -> Result<(FileDownload, Option<PartialMeta>), CliError> {
+    let meta = content_ref.map(|content_ref| PartialMeta::describe(content_ref, revision_no));
+    let start_offset = meta
+        .as_ref()
+        .map_or(0, |meta| partial::resumable_bytes(destination, meta));
+    let download = context
+        .target
+        .open_file_download(spec, revision_no, size_bytes, start_offset)
+        .await?;
+    Ok((download, meta))
 }
 
 /// Writes a download into its destination through the partial file, and
@@ -664,13 +681,11 @@ fn write_path_entries_page(
     entries: &[loonfs_api::PathEntry],
     jsonl: bool,
 ) -> io::Result<()> {
+    if jsonl {
+        return write_jsonl_page(stdout, entries);
+    }
     for entry in entries {
-        if jsonl {
-            serde_json::to_writer(&mut *stdout, entry).map_err(io::Error::other)?;
-            stdout.write_all(b"\n")?;
-        } else {
-            writeln!(stdout, "{}", crate::render::human_path_entry(entry))?;
-        }
+        writeln!(stdout, "{}", crate::render::human_path_entry(entry))?;
     }
     stdout.flush()
 }

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -154,13 +154,10 @@ pub(crate) async fn run_put_tree(
     // Create empty subtrees before uploading files.
     for components in empty_dirs {
         let remote = joined_remote(remote_root, &components);
-        let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
+        let spec = match parse_remote(context, &remote, "local_path") {
             Ok(spec) => spec,
             Err(error) => {
-                tally.fail(
-                    remote,
-                    CliError::invalid_request(error.to_string()).with_param("local_path"),
-                );
+                tally.fail(remote, error);
                 continue;
             }
         };
@@ -225,14 +222,9 @@ pub(crate) async fn run_put_tree(
         let progress = Arc::clone(&progress);
         let remote = format!("{}/{}", remote_root.trim_end_matches('/'), job.remote);
         async move {
-            let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
+            let spec = match parse_remote(context, &remote, "local_path") {
                 Ok(spec) => spec,
-                Err(error) => {
-                    return (
-                        remote,
-                        Err(CliError::invalid_request(error.to_string()).with_param("local_path")),
-                    )
-                }
+                Err(error) => return (remote, Err(error)),
             };
             // Use the size found during the directory walk when available.
             // If it was unavailable, try again before uploading this file.
@@ -337,35 +329,25 @@ pub(crate) async fn run_get_tree(
     ));
     progress.expect(tree_bytes(&listing.files), Some(listing.files.len() as u64));
     let outcomes = futures::stream::iter(listing.files.into_iter().map(|job| {
-        let backend = &context.target;
-        let namespace = context.namespace.clone();
         let progress = Arc::clone(&progress);
         let local = local_root.join(job.local);
         async move {
-            let spec = match NamespacePath::parse(namespace.as_str(), &job.remote) {
+            let spec = match parse_remote(context, &job.remote, "remote_path") {
                 Ok(spec) => spec,
-                Err(error) => {
-                    return (
-                        job.remote,
-                        Err(CliError::invalid_request(error.to_string()).with_param("remote_path")),
-                    )
-                }
+                Err(error) => return (job.remote, Err(error)),
             };
-            // Recursive downloads use the same streaming and resume behavior
-            // as single-file downloads.
-            let meta = job
-                .content_ref
-                .as_ref()
-                .map(|content_ref| super::partial::PartialMeta::describe(content_ref, None));
-            let start_offset = meta
-                .as_ref()
-                .map_or(0, |meta| super::partial::resumable_bytes(&local, meta));
-            let mut download = match backend
-                .open_file_download(&spec, None, job.size_bytes, start_offset)
-                .await
+            let (mut download, meta) = match super::fs::open_resumable_download(
+                context,
+                &spec,
+                None,
+                job.size_bytes,
+                &local,
+                job.content_ref.as_ref(),
+            )
+            .await
             {
-                Ok(download) => download,
-                Err(error) => return (job.remote, Err(error.into())),
+                Ok(opened) => opened,
+                Err(error) => return (job.remote, Err(error)),
             };
             progress.file_started(&job.remote, job.size_bytes);
             let derived_name = false;
@@ -434,13 +416,10 @@ pub(crate) async fn run_copy_tree(
     directories.extend(listing.directories);
     for components in &directories {
         let remote = joined_remote(destination_root, components);
-        let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
+        let spec = match parse_remote(context, &remote, "destination_path") {
             Ok(spec) => spec,
             Err(error) => {
-                tally.fail(
-                    remote,
-                    CliError::invalid_request(error.to_string()).with_param("destination_path"),
-                );
+                tally.fail(remote, error);
                 continue;
             }
         };
@@ -475,8 +454,6 @@ pub(crate) async fn run_copy_tree(
         DestinationBehavior::NoReplace
     };
     let outcomes = futures::stream::iter(listing.files.into_iter().map(|job| {
-        let backend = &context.target;
-        let namespace = context.namespace.clone();
         let message = message.clone();
         let destination = joined_remote(
             destination_root,
@@ -486,25 +463,14 @@ pub(crate) async fn run_copy_tree(
                 .collect::<Vec<_>>(),
         );
         async move {
-            let from = NamespacePath::parse(namespace.as_str(), &job.remote);
-            let to = NamespacePath::parse(namespace.as_str(), &destination);
+            let from = parse_remote(context, &job.remote, "source_path");
+            let to = parse_remote(context, &destination, "destination_path");
             let (from, to) = match (from, to) {
                 (Ok(from), Ok(to)) => (from, to),
-                (Err(error), _) => {
-                    return (
-                        job.remote,
-                        Err(CliError::invalid_request(error.to_string()).with_param("source_path")),
-                    )
-                }
-                (_, Err(error)) => {
-                    return (
-                        job.remote,
-                        Err(CliError::invalid_request(error.to_string())
-                            .with_param("destination_path")),
-                    )
-                }
+                (Err(error), _) | (_, Err(error)) => return (job.remote, Err(error)),
             };
-            let result = backend
+            let result = context
+                .target
                 .copy_path(
                     &from,
                     &to,
@@ -546,6 +512,20 @@ pub(crate) async fn run_copy_tree(
         tally,
         head_drift,
     ))
+}
+
+/// Parses a path assembled during a tree walk, blaming the argument that
+/// carried it through the same conversion single-file commands use.
+fn parse_remote(
+    context: &CommandContext,
+    path: &str,
+    param: &str,
+) -> Result<NamespacePath, CliError> {
+    NamespacePath::parse(context.namespace.as_str(), path).map_err(|error| {
+        crate::backend_error::BackendError::from(error)
+            .with_invalid_request_param(param)
+            .into()
+    })
 }
 
 fn spec_target(spec: &NamespacePath) -> String {
@@ -663,12 +643,8 @@ async fn walk_remote_tree(
         } else {
             &remote_dir
         };
-        let spec = NamespacePath::parse(context.namespace.as_str(), listed).map_err(|error| {
-            context.fail(
-                kind,
-                CliError::invalid_request(error.to_string()).with_param(remote_param),
-            )
-        })?;
+        let spec = parse_remote(context, listed, remote_param)
+            .map_err(|error| context.fail(kind, error))?;
         let mut pager = context
             .target
             .list_path_entries_pager(&spec, None, None)

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -514,8 +514,6 @@ pub(crate) async fn run_copy_tree(
     ))
 }
 
-/// Parses a path assembled during a tree walk, blaming the argument that
-/// carried it through the same conversion single-file commands use.
 fn parse_remote(
     context: &CommandContext,
     path: &str,

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -445,10 +445,8 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             };
             let mut lines = Vec::new();
             for failure in failures {
-                lines.push(format!(
-                    "failed {}: {}: {}",
-                    failure.path, failure.error.code, failure.error.message
-                ));
+                let rendered = human_error(&failure.error);
+                lines.push(format!("failed {}: {rendered}", failure.path));
             }
             let directory_noun = if *directories == 1 {
                 "directory"
@@ -604,11 +602,9 @@ fn human_doctor(checks: &[DoctorCheck]) -> String {
         }
         if check.status == DoctorStatus::Failed {
             lines.push(format!("{}: failed", check.name));
-            let mut detail = format!("  detail: {}", single_line(&check.message));
-            if let Some(request_id) = &check.request_id {
-                detail.push_str(&format!(" (request id: {request_id})"));
-            }
-            lines.push(detail);
+            let detail = single_line(&check.message);
+            let request_id = request_id_suffix(check.request_id.as_deref());
+            lines.push(format!("  detail: {detail}{request_id}"));
         } else {
             lines.push(format!(
                 "{}: {}: {}",

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -78,7 +78,6 @@ fn human_error(error: &CliError) -> String {
     rendered
 }
 
-/// The one spelling of a server correlation id in human output.
 fn request_id_suffix(request_id: Option<&str>) -> String {
     request_id.map_or_else(String::new, |request_id| {
         format!(" (request id: {request_id})")

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -68,9 +68,7 @@ pub(crate) fn render_error(failure: &CommandFailure, json_mode: bool) -> io::Res
 
 fn human_error(error: &CliError) -> String {
     let mut rendered = error.message.clone();
-    if let Some(request_id) = &error.request_id {
-        rendered.push_str(&format!(" (request id: {request_id})"));
-    }
+    rendered.push_str(&request_id_suffix(error.request_id.as_deref()));
     if let Some(feature) = &error.feature {
         rendered.push_str(&format!("\nfeature: {feature}"));
     }
@@ -78,6 +76,13 @@ fn human_error(error: &CliError) -> String {
         rendered.push_str(&format!("\nparam: {param}"));
     }
     rendered
+}
+
+/// The one spelling of a server correlation id in human output.
+fn request_id_suffix(request_id: Option<&str>) -> String {
+    request_id.map_or_else(String::new, |request_id| {
+        format!(" (request id: {request_id})")
+    })
 }
 
 pub(crate) fn write_stderr_warning(message: impl std::fmt::Display) {


### PR DESCRIPTION
Uses the same remote-path parsing, resumable-download setup, JSONL writer, and request ID formatting for single-file and recursive commands.

Recursive transfer failures now include the same request ID, feature, and parameter details as other CLI errors. JSON output is unchanged.