### PR TITLE
refactor(cache): share decoded block caching between metadata and grep

### DIFF
--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -848,6 +848,16 @@ numeric_id! {
     schema_description = "Monotonic run counter allocated by the manifest that names the run. A run is the set of segments one producer wrote together."
 }
 
+impl RunNo {
+    /// Returns the number the allocator hands out after this one, or the
+    /// range error when this run number is already the public maximum.
+    pub fn successor(self) -> Result<Self, PublicOrdinalRangeError> {
+        next_public_ordinal(self.0)
+            .map(Self)
+            .ok_or(PublicOrdinalRangeError)
+    }
+}
+
 numeric_id! {
     /// Counter used to reject writes from an older writer.
     WriterEpoch,

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -849,8 +849,7 @@ numeric_id! {
 }
 
 impl RunNo {
-    /// Returns the number the allocator hands out after this one, or the
-    /// range error when this run number is already the public maximum.
+    /// Returns the next run number, or an error at the public maximum.
     pub fn successor(self) -> Result<Self, PublicOrdinalRangeError> {
         next_public_ordinal(self.0)
             .map(Self)

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -604,7 +604,9 @@ fn shared_prefix_len(previous: &str, current: &str) -> usize {
     len
 }
 
-pub(crate) fn write_varint(bytes: &mut Vec<u8>, mut value: u64) {
+/// Appends `value` to `bytes` in the LEB128 varint encoding the durable
+/// block grammar uses for its lengths and deltas.
+pub fn write_varint(bytes: &mut Vec<u8>, mut value: u64) {
     loop {
         let byte = (value & 0x7f) as u8;
         value >>= 7;
@@ -616,7 +618,8 @@ pub(crate) fn write_varint(bytes: &mut Vec<u8>, mut value: u64) {
     }
 }
 
-pub(crate) fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64, SstBlockCodecError> {
+/// Reads the LEB128 varint at `cursor` and advances `cursor` past it.
+pub fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64, SstBlockCodecError> {
     let mut value = 0u64;
     let mut shift = 0u32;
     loop {

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -604,8 +604,7 @@ fn shared_prefix_len(previous: &str, current: &str) -> usize {
     len
 }
 
-/// Appends `value` to `bytes` in the LEB128 varint encoding the durable
-/// block grammar uses for its lengths and deltas.
+/// Appends `value` as an unsigned LEB128 integer.
 pub fn write_varint(bytes: &mut Vec<u8>, mut value: u64) {
     loop {
         let byte = (value & 0x7f) as u8;

--- a/crates/loonfs-core/src/block_cache.rs
+++ b/crates/loonfs-core/src/block_cache.rs
@@ -1,5 +1,4 @@
-//! [`DecodedBlockCache`]: the byte-budgeted, single-flight cache of decoded
-//! immutable objects that metadata reads and derived projections share.
+//! Shared cache for decoded immutable objects.
 
 use crate::recency::Recency;
 use std::collections::HashMap;
@@ -8,7 +7,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::OnceCell;
 
-/// A decoded value the cache charges against its byte budget.
+/// A value whose decoded size counts against the cache budget.
 pub trait DecodedBlock: Clone {
     /// Bytes this value occupies in its decoded form.
     fn decoded_bytes(&self) -> usize;
@@ -22,7 +21,7 @@ pub trait DecodedBlockCacheObserver: Send + Sync + 'static {
     fn evict(&self);
 }
 
-/// Cumulative activity counters for one decoded-block cache.
+/// Cumulative cache activity.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DecodedBlockCacheStats {
     pub hits: usize,
@@ -31,16 +30,13 @@ pub struct DecodedBlockCacheStats {
     pub evictions: usize,
 }
 
-/// A process-shareable cache of decoded immutable objects, keyed by an
-/// identity that can never go stale, evicted in recency order once the
-/// decoded bytes it holds exceed its budget. A budget of zero disables it.
+/// A byte-bounded cache with recency eviction and one in-flight load per key.
+/// A budget of zero disables the cache.
 pub struct DecodedBlockCache<K, V> {
     max_decoded_bytes: usize,
     inner: Mutex<Inner<K, V>>,
     stats: StatsInner,
     observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
-    /// One cell per in-flight fetch, keyed by the entry's cache key, so
-    /// concurrent readers share a single object-store read per entry.
     in_flight: Mutex<HashMap<K, Arc<OnceCell<V>>>>,
 }
 
@@ -66,8 +62,7 @@ struct Inner<K, V> {
 #[derive(Debug)]
 struct CacheSlot<V> {
     block: V,
-    /// Recency stamp assigned on the most recent access. Recency records with
-    /// an older stamp for this key are ignored.
+    /// The entry's current recency stamp.
     last_touch: u64,
 }
 
@@ -103,7 +98,7 @@ impl<K: Clone + Eq + Hash, V: DecodedBlock> DecodedBlockCache<K, V> {
         }
     }
 
-    /// Resolves one access through a per-key single-flight cell.
+    /// Loads a missing value once when callers request the same key concurrently.
     pub async fn get_or_load<E, F, Fut>(&self, cache_key: &K, fetch: F) -> Result<V, E>
     where
         F: FnOnce() -> Fut,
@@ -237,8 +232,6 @@ impl<K: Clone + Eq + Hash, V> Inner<K, V> {
     }
 }
 
-/// Returns `true` when `stamp` matches the key's most recent access.
-/// Replacing, evicting, or accessing an entry can leave older recency records.
 fn slot_is_live<K: Eq + Hash, V>(entries: &HashMap<K, CacheSlot<V>>, key: &K, stamp: u64) -> bool {
     entries
         .get(key)

--- a/crates/loonfs-core/src/block_cache.rs
+++ b/crates/loonfs-core/src/block_cache.rs
@@ -1,0 +1,280 @@
+//! [`DecodedBlockCache`]: the byte-budgeted, single-flight cache of decoded
+//! immutable objects that metadata reads and derived projections share.
+
+use crate::recency::Recency;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::OnceCell;
+
+/// A decoded value the cache charges against its byte budget.
+pub trait DecodedBlock: Clone {
+    /// Bytes this value occupies in its decoded form.
+    fn decoded_bytes(&self) -> usize;
+}
+
+/// Receives decoded-block cache events for metrics.
+pub trait DecodedBlockCacheObserver: Send + Sync + 'static {
+    fn hit(&self);
+    fn miss(&self);
+    fn insert(&self);
+    fn evict(&self);
+}
+
+/// Cumulative activity counters for one decoded-block cache.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DecodedBlockCacheStats {
+    pub hits: usize,
+    pub misses: usize,
+    pub inserts: usize,
+    pub evictions: usize,
+}
+
+/// A process-shareable cache of decoded immutable objects, keyed by an
+/// identity that can never go stale, evicted in recency order once the
+/// decoded bytes it holds exceed its budget. A budget of zero disables it.
+pub struct DecodedBlockCache<K, V> {
+    max_decoded_bytes: usize,
+    inner: Mutex<Inner<K, V>>,
+    stats: StatsInner,
+    observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
+    /// One cell per in-flight fetch, keyed by the entry's cache key, so
+    /// concurrent readers share a single object-store read per entry.
+    in_flight: Mutex<HashMap<K, Arc<OnceCell<V>>>>,
+}
+
+impl<K: std::fmt::Debug, V: std::fmt::Debug> std::fmt::Debug for DecodedBlockCache<K, V> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DecodedBlockCache")
+            .field("max_decoded_bytes", &self.max_decoded_bytes)
+            .field("inner", &self.inner)
+            .field("stats", &self.stats)
+            .field("in_flight", &self.in_flight)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+struct Inner<K, V> {
+    entries: HashMap<K, CacheSlot<V>>,
+    order: Recency<K>,
+    decoded_bytes: usize,
+}
+
+#[derive(Debug)]
+struct CacheSlot<V> {
+    block: V,
+    /// Recency stamp assigned on the most recent access. Recency records with
+    /// an older stamp for this key are ignored.
+    last_touch: u64,
+}
+
+#[derive(Debug, Default)]
+struct StatsInner {
+    hits: AtomicUsize,
+    misses: AtomicUsize,
+    inserts: AtomicUsize,
+    evictions: AtomicUsize,
+}
+
+impl<K: Clone + Eq + Hash, V: DecodedBlock> DecodedBlockCache<K, V> {
+    /// Creates a cache with the supplied decoded-byte budget.
+    pub fn new(max_decoded_bytes: usize) -> Self {
+        Self::with_observer(max_decoded_bytes, None)
+    }
+
+    /// Creates a cache that reports activity to the optional `observer`.
+    pub fn with_observer(
+        max_decoded_bytes: usize,
+        observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
+    ) -> Self {
+        Self {
+            max_decoded_bytes,
+            inner: Mutex::new(Inner {
+                entries: HashMap::new(),
+                order: Recency::default(),
+                decoded_bytes: 0,
+            }),
+            stats: StatsInner::default(),
+            observer,
+            in_flight: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Resolves one access through a per-key single-flight cell.
+    pub async fn get_or_load<E, F, Fut>(&self, cache_key: &K, fetch: F) -> Result<V, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<V, E>>,
+    {
+        let cell = {
+            let mut in_flight = self
+                .in_flight
+                .lock()
+                .expect("decoded block cache in-flight lock should not be poisoned");
+            Arc::clone(
+                in_flight
+                    .entry(cache_key.clone())
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        let result = cell
+            .get_or_try_init(|| async {
+                if let Some(block) = self.get(cache_key) {
+                    return Ok(block);
+                }
+                let block = fetch().await?;
+                self.insert(cache_key.clone(), block.clone());
+                Ok(block)
+            })
+            .await
+            .cloned();
+        let mut in_flight = self
+            .in_flight
+            .lock()
+            .expect("decoded block cache in-flight lock should not be poisoned");
+        if in_flight
+            .get(cache_key)
+            .is_some_and(|current| Arc::ptr_eq(current, &cell))
+        {
+            in_flight.remove(cache_key);
+        }
+        result
+    }
+
+    /// Returns cumulative hit, miss, insert, and eviction counters.
+    pub fn stats(&self) -> DecodedBlockCacheStats {
+        DecodedBlockCacheStats {
+            hits: self.stats.hits.load(Ordering::SeqCst),
+            misses: self.stats.misses.load(Ordering::SeqCst),
+            inserts: self.stats.inserts.load(Ordering::SeqCst),
+            evictions: self.stats.evictions.load(Ordering::SeqCst),
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<V> {
+        if self.max_decoded_bytes == 0 {
+            return None;
+        }
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("decoded block cache lock should not be poisoned");
+        let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
+            self.stats.misses.fetch_add(1, Ordering::SeqCst);
+            if let Some(observer) = &self.observer {
+                observer.miss();
+            }
+            return None;
+        };
+        inner.touch(key);
+        self.stats.hits.fetch_add(1, Ordering::SeqCst);
+        if let Some(observer) = &self.observer {
+            observer.hit();
+        }
+        Some(block)
+    }
+
+    pub fn insert(&self, key: K, block: V) {
+        if self.max_decoded_bytes == 0 {
+            return;
+        }
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("decoded block cache lock should not be poisoned");
+        let decoded_bytes = block.decoded_bytes();
+        if let Some(previous) = inner.entries.insert(
+            key.clone(),
+            CacheSlot {
+                block,
+                last_touch: 0,
+            },
+        ) {
+            inner.decoded_bytes = inner
+                .decoded_bytes
+                .saturating_sub(previous.block.decoded_bytes());
+        }
+        inner.decoded_bytes = inner.decoded_bytes.saturating_add(decoded_bytes);
+        inner.touch(&key);
+        self.stats.inserts.fetch_add(1, Ordering::SeqCst);
+        if let Some(observer) = &self.observer {
+            observer.insert();
+        }
+        let Inner {
+            entries,
+            order,
+            decoded_bytes,
+        } = &mut *inner;
+        while *decoded_bytes > self.max_decoded_bytes {
+            let Some(candidate) = order.pop_oldest(|key, stamp| slot_is_live(entries, key, stamp))
+            else {
+                break;
+            };
+            if let Some(slot) = entries.remove(&candidate) {
+                *decoded_bytes = decoded_bytes.saturating_sub(slot.block.decoded_bytes());
+                self.stats.evictions.fetch_add(1, Ordering::SeqCst);
+                if let Some(observer) = &self.observer {
+                    observer.evict();
+                }
+            }
+        }
+    }
+}
+
+impl<K: Clone + Eq + Hash, V> Inner<K, V> {
+    fn touch(&mut self, key: &K) {
+        let stamp = self.order.touch(key);
+        if let Some(slot) = self.entries.get_mut(key) {
+            slot.last_touch = stamp;
+        }
+        let entries = &self.entries;
+        self.order.compact(entries.len(), |key, stamp| {
+            slot_is_live(entries, key, stamp)
+        });
+    }
+}
+
+/// Returns `true` when `stamp` matches the key's most recent access.
+/// Replacing, evicting, or accessing an entry can leave older recency records.
+fn slot_is_live<K: Eq + Hash, V>(entries: &HashMap<K, CacheSlot<V>>, key: &K, stamp: u64) -> bool {
+    entries
+        .get(key)
+        .is_some_and(|slot| slot.last_touch == stamp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DecodedBlock, DecodedBlockCache};
+
+    #[derive(Clone)]
+    struct Block(usize);
+
+    impl DecodedBlock for Block {
+        fn decoded_bytes(&self) -> usize {
+            self.0
+        }
+    }
+
+    #[test]
+    fn recency_queue_stays_bounded_under_repeated_hits() {
+        let cache = DecodedBlockCache::new(10_000);
+        for index in 0..8 {
+            cache.insert(format!("k{index}"), Block(10));
+        }
+        let (first, second) = ("k0".to_owned(), "k3".to_owned());
+        for _ in 0..10_000 {
+            cache.get(&first);
+            cache.get(&second);
+        }
+        let inner = cache.inner.lock().expect("cache lock");
+        assert_eq!(inner.entries.len(), 8);
+        assert!(
+            inner.order.positions() <= (inner.entries.len() * 2).max(16),
+            "hits must not grow the recency queue unboundedly, queue = {}",
+            inner.order.positions()
+        );
+    }
+}

--- a/crates/loonfs-core/src/checkpoint/block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/block_load.rs
@@ -6,6 +6,7 @@ use super::data_block_load::load_segment_data_block_span;
 use super::error::ManifestLoadError;
 use super::scan::Readahead;
 use super::validate::validate_manifest_row_seq_range;
+use crate::block_cache::DecodedBlock as _;
 use loonfs_api::wire::manifest::{MetadataRow, MetadataSegmentRef};
 use loonfs_api::wire::sst_blocks::{index_blocks_for_key_range, DecodedDataBlock};
 use loonfs_objectstore::keys::metadata_segment_object_key;

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -7,6 +7,7 @@
 
 use super::runs::MetadataRunManifest;
 use super::stored_block_cache::StoredMetadataBlockCache;
+use crate::block_cache::{DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver};
 use crate::metadata::MetadataState;
 use crate::recency::Recency;
 use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
@@ -16,7 +17,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::sync::OnceCell;
 
 /// Default decoded-byte budget for metadata segment blocks. A value of zero
 /// disables the cache.
@@ -106,8 +106,8 @@ pub(super) enum DecodedMetadataSegmentBlock {
     },
 }
 
-impl DecodedMetadataSegmentBlock {
-    pub(super) fn decoded_bytes(&self) -> usize {
+impl DecodedBlock for DecodedMetadataSegmentBlock {
+    fn decoded_bytes(&self) -> usize {
         match self {
             Self::Index { decoded_bytes, .. }
             | Self::Filter { decoded_bytes, .. }
@@ -118,13 +118,9 @@ impl DecodedMetadataSegmentBlock {
 }
 
 pub struct MetadataSegmentCache {
-    config: MetadataSegmentCacheConfig,
-    inner: Mutex<MetadataSegmentCacheInner>,
-    stats: MetadataSegmentCacheStatsInner,
+    blocks: DecodedBlockCache<MetadataSegmentCacheKey, DecodedMetadataSegmentBlock>,
+    stats: MetadataSegmentFilterStatsInner,
     observer: Option<Arc<dyn MetadataSegmentCacheObserver>>,
-    /// One cell per in-flight block fetch, keyed by the block's cache key,
-    /// so concurrent readers share a single ranged GET per block.
-    in_flight: Mutex<HashMap<MetadataSegmentCacheKey, Arc<OnceCell<DecodedMetadataSegmentBlock>>>>,
     /// Optional node-local cache for encoded blocks. Keeping it with the
     /// decoded cache ensures callers use both cache tiers or neither tier.
     stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
@@ -134,38 +130,41 @@ impl std::fmt::Debug for MetadataSegmentCache {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("MetadataSegmentCache")
-            .field("config", &self.config)
-            .field("inner", &self.inner)
+            .field("blocks", &self.blocks)
             .field("stats", &self.stats)
-            .field("in_flight", &self.in_flight)
             .field("stored_block_cache", &self.stored_block_cache)
             .finish_non_exhaustive()
     }
 }
 
+/// The two counters the shared cache knows nothing about: a metadata scan
+/// records them from what the filter told it, not from a cache access.
 #[derive(Debug, Default)]
-struct MetadataSegmentCacheInner {
-    entries: HashMap<MetadataSegmentCacheKey, CacheSlot>,
-    order: Recency<MetadataSegmentCacheKey>,
-    decoded_bytes: usize,
-}
-
-#[derive(Debug)]
-struct CacheSlot {
-    block: DecodedMetadataSegmentBlock,
-    /// Recency stamp assigned on the most recent access. Recency records with
-    /// an older stamp for this key are ignored.
-    last_touch: u64,
-}
-
-#[derive(Debug, Default)]
-struct MetadataSegmentCacheStatsInner {
-    hits: AtomicUsize,
-    misses: AtomicUsize,
-    inserts: AtomicUsize,
-    evictions: AtomicUsize,
+struct MetadataSegmentFilterStatsInner {
     filter_skips: AtomicUsize,
     filter_false_positives: AtomicUsize,
+}
+
+/// Reports the shared cache's four events to a metadata observer that also
+/// takes the two filter events.
+struct MetadataSegmentCacheEvents(Arc<dyn MetadataSegmentCacheObserver>);
+
+impl DecodedBlockCacheObserver for MetadataSegmentCacheEvents {
+    fn hit(&self) {
+        self.0.hit();
+    }
+
+    fn miss(&self) {
+        self.0.miss();
+    }
+
+    fn insert(&self) {
+        self.0.insert();
+    }
+
+    fn evict(&self) {
+        self.0.evict();
+    }
 }
 
 impl MetadataSegmentCache {
@@ -179,12 +178,13 @@ impl MetadataSegmentCache {
         stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
         observer: Option<Arc<dyn MetadataSegmentCacheObserver>>,
     ) -> Self {
+        let block_observer = observer.clone().map(|observer| {
+            Arc::new(MetadataSegmentCacheEvents(observer)) as Arc<dyn DecodedBlockCacheObserver>
+        });
         Self {
-            config,
-            inner: Mutex::new(MetadataSegmentCacheInner::default()),
-            stats: MetadataSegmentCacheStatsInner::default(),
+            blocks: DecodedBlockCache::with_observer(config.max_decoded_bytes, block_observer),
+            stats: MetadataSegmentFilterStatsInner::default(),
             observer,
-            in_flight: Mutex::new(HashMap::new()),
             stored_block_cache,
         }
     }
@@ -204,47 +204,16 @@ impl MetadataSegmentCache {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<DecodedMetadataSegmentBlock, E>>,
     {
-        let cell = {
-            let mut in_flight = self
-                .in_flight
-                .lock()
-                .expect("metadata segment cache in-flight lock should not be poisoned");
-            Arc::clone(
-                in_flight
-                    .entry(cache_key.clone())
-                    .or_insert_with(|| Arc::new(OnceCell::new())),
-            )
-        };
-        let result = cell
-            .get_or_try_init(|| async {
-                if let Some(block) = self.get(cache_key) {
-                    return Ok(block);
-                }
-                let block = fetch().await?;
-                self.insert(cache_key.clone(), block.clone());
-                Ok(block)
-            })
-            .await
-            .cloned();
-        let mut in_flight = self
-            .in_flight
-            .lock()
-            .expect("metadata segment cache in-flight lock should not be poisoned");
-        if in_flight
-            .get(cache_key)
-            .is_some_and(|current| Arc::ptr_eq(current, &cell))
-        {
-            in_flight.remove(cache_key);
-        }
-        result
+        self.blocks.get_or_load(cache_key, fetch).await
     }
 
     pub fn stats(&self) -> MetadataSegmentCacheStats {
+        let blocks = self.blocks.stats();
         MetadataSegmentCacheStats {
-            hits: self.stats.hits.load(Ordering::SeqCst),
-            misses: self.stats.misses.load(Ordering::SeqCst),
-            inserts: self.stats.inserts.load(Ordering::SeqCst),
-            evictions: self.stats.evictions.load(Ordering::SeqCst),
+            hits: blocks.hits,
+            misses: blocks.misses,
+            inserts: blocks.inserts,
+            evictions: blocks.evictions,
             filter_skips: self.stats.filter_skips.load(Ordering::SeqCst),
             filter_false_positives: self.stats.filter_false_positives.load(Ordering::SeqCst),
         }
@@ -267,98 +236,12 @@ impl MetadataSegmentCache {
     }
 
     pub(super) fn get(&self, key: &MetadataSegmentCacheKey) -> Option<DecodedMetadataSegmentBlock> {
-        if self.config.max_decoded_bytes == 0 {
-            return None;
-        }
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("metadata segment cache lock should not be poisoned");
-        let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
-            self.stats.misses.fetch_add(1, Ordering::SeqCst);
-            if let Some(observer) = &self.observer {
-                observer.miss();
-            }
-            return None;
-        };
-        inner.touch(key);
-        self.stats.hits.fetch_add(1, Ordering::SeqCst);
-        if let Some(observer) = &self.observer {
-            observer.hit();
-        }
-        Some(block)
+        self.blocks.get(key)
     }
 
     pub(super) fn insert(&self, key: MetadataSegmentCacheKey, block: DecodedMetadataSegmentBlock) {
-        if self.config.max_decoded_bytes == 0 {
-            return;
-        }
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("metadata segment cache lock should not be poisoned");
-        let decoded_bytes = block.decoded_bytes();
-        if let Some(previous) = inner.entries.insert(
-            key.clone(),
-            CacheSlot {
-                block,
-                last_touch: 0,
-            },
-        ) {
-            inner.decoded_bytes = inner
-                .decoded_bytes
-                .saturating_sub(previous.block.decoded_bytes());
-        }
-        inner.decoded_bytes = inner.decoded_bytes.saturating_add(decoded_bytes);
-        inner.touch(&key);
-        self.stats.inserts.fetch_add(1, Ordering::SeqCst);
-        if let Some(observer) = &self.observer {
-            observer.insert();
-        }
-        let MetadataSegmentCacheInner {
-            entries,
-            order,
-            decoded_bytes,
-        } = &mut *inner;
-        while *decoded_bytes > self.config.max_decoded_bytes {
-            let Some(candidate) = order.pop_oldest(|key, stamp| slot_is_live(entries, key, stamp))
-            else {
-                break;
-            };
-            if let Some(slot) = entries.remove(&candidate) {
-                *decoded_bytes = decoded_bytes.saturating_sub(slot.block.decoded_bytes());
-                self.stats.evictions.fetch_add(1, Ordering::SeqCst);
-                if let Some(observer) = &self.observer {
-                    observer.evict();
-                }
-            }
-        }
+        self.blocks.insert(key, block);
     }
-}
-
-impl MetadataSegmentCacheInner {
-    fn touch(&mut self, key: &MetadataSegmentCacheKey) {
-        let stamp = self.order.touch(key);
-        if let Some(slot) = self.entries.get_mut(key) {
-            slot.last_touch = stamp;
-        }
-        let entries = &self.entries;
-        self.order.compact(entries.len(), |key, stamp| {
-            slot_is_live(entries, key, stamp)
-        });
-    }
-}
-
-/// Returns `true` when `stamp` matches the key's most recent access.
-/// Replacing, evicting, or accessing an entry can leave older recency records.
-fn slot_is_live(
-    entries: &HashMap<MetadataSegmentCacheKey, CacheSlot>,
-    key: &MetadataSegmentCacheKey,
-    stamp: u64,
-) -> bool {
-    entries
-        .get(key)
-        .is_some_and(|slot| slot.last_touch == stamp)
 }
 
 /// Default bounds for WAL-tail projections, shared by the read-side
@@ -756,27 +639,6 @@ mod tests {
         assert!(cache.get(&key("a")).is_some());
         assert!(cache.get(&key("b")).is_some());
         assert_eq!(cache.stats().evictions, 0);
-    }
-
-    #[test]
-    fn recency_queue_stays_bounded_under_repeated_hits() {
-        let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
-            max_decoded_bytes: 10_000,
-        });
-        for index in 0..8 {
-            cache.insert(key(&format!("k{index}")), block(10));
-        }
-        for _ in 0..10_000 {
-            cache.get(&key("k0"));
-            cache.get(&key("k3"));
-        }
-        let inner = cache.inner.lock().expect("cache lock");
-        assert_eq!(inner.entries.len(), 8);
-        assert!(
-            inner.order.positions() <= (inner.entries.len() * 2).max(16),
-            "hits must not grow the recency queue unboundedly, queue = {}",
-            inner.order.positions()
-        );
     }
 
     #[test]

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -137,16 +137,12 @@ impl std::fmt::Debug for MetadataSegmentCache {
     }
 }
 
-/// The two counters the shared cache knows nothing about: a metadata scan
-/// records them from what the filter told it, not from a cache access.
 #[derive(Debug, Default)]
 struct MetadataSegmentFilterStatsInner {
     filter_skips: AtomicUsize,
     filter_false_positives: AtomicUsize,
 }
 
-/// Reports the shared cache's four events to a metadata observer that also
-/// takes the two filter events.
 struct MetadataSegmentCacheEvents(Arc<dyn MetadataSegmentCacheObserver>);
 
 impl DecodedBlockCacheObserver for MetadataSegmentCacheEvents {

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -295,9 +295,9 @@ pub(super) fn next_manifest_no_after(current: ManifestNo) -> Result<ManifestNo> 
 /// Advances the manifest's run allocator after a producer has taken
 /// `current`.
 pub(super) fn next_run_no_after(current: RunNo) -> Result<RunNo> {
-    next_public_ordinal(current.0).map(RunNo).ok_or_else(|| {
-        CoreError::Internal(format!("run number cannot exceed {MAX_PUBLIC_INTEGER}"))
-    })
+    current
+        .successor()
+        .map_err(|error| CoreError::Internal(format!("run number {error}")))
 }
 
 /// Refuses to initiate a root compare-and-swap once the publication budget

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -52,6 +52,7 @@
 //! );
 //! ```
 
+mod block_cache;
 mod checkpoint;
 mod commit_engine;
 mod context;
@@ -95,6 +96,9 @@ pub mod time;
 /// Cache types and configuration used by runtime read paths. The `loonfs`
 /// runtime owns these caches and their statistics.
 pub mod cache {
+    pub use crate::block_cache::{
+        DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver, DecodedBlockCacheStats,
+    };
     pub use crate::recency::Recency;
 
     pub use crate::checkpoint::{

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -3,14 +3,11 @@
 use crate::codec::IndexRow;
 use crate::root::GrepManifestState;
 use loonfs::metrics::{CounterHandle, MetricsRecorder};
-use loonfs::Recency;
+use loonfs::{DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver};
 use loonfs_api::wire::sst_blocks::{
     DecodedDataBlock, SegmentFilter, SegmentIndexEntry, DEFAULT_TARGET_BLOCK_BYTES,
 };
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
-use tokio::sync::OnceCell;
+use std::sync::Arc;
 
 /// Default decoded-byte budget for cached grep manifests and segment blocks.
 ///
@@ -20,18 +17,9 @@ use tokio::sync::OnceCell;
 /// the cache.
 pub const DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES: usize = 4_096 * DEFAULT_TARGET_BLOCK_BYTES;
 
-/// Cumulative activity counters for one grep block cache.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct GrepBlockCacheStats {
-    /// Successful cache lookups.
-    pub hits: usize,
-    /// Cache lookups that required a load.
-    pub misses: usize,
-    /// Blocks inserted after successful loads.
-    pub inserts: usize,
-    /// Blocks removed to enforce the decoded-byte budget.
-    pub evictions: usize,
-}
+/// The runtime's decoded-block cache, holding grep's manifests and segment
+/// blocks.
+pub type GrepBlockCache = DecodedBlockCache<GrepBlockCacheKey, DecodedGrepBlock>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum GrepBlockKind {
@@ -41,8 +29,10 @@ pub(crate) enum GrepBlockKind {
     Data,
 }
 
+/// One cache entry's identity. Only grep mints these: the fields stay
+/// crate-private so no caller outside can name a block the cache holds.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct GrepBlockCacheKey {
+pub struct GrepBlockCacheKey {
     /// Immutable cache identity. Manifest entries use `payload_checksum`;
     /// segment blocks use `object_checksum`.
     pub(crate) identity: String,
@@ -50,273 +40,49 @@ pub(crate) struct GrepBlockCacheKey {
     pub(crate) block_offset: u64,
 }
 
+/// One decoded, verified object the cache holds.
 #[derive(Debug, Clone)]
-pub(crate) enum DecodedGrepBlock {
+pub enum DecodedGrepBlock {
     Manifest {
         state: Arc<GrepManifestState>,
-        decoded_byte_len: usize,
+        decoded_bytes: usize,
     },
     Filter {
         filter: Arc<SegmentFilter>,
-        decoded_byte_len: usize,
+        decoded_bytes: usize,
     },
     Index {
         entries: Arc<Vec<SegmentIndexEntry>>,
-        decoded_byte_len: usize,
+        decoded_bytes: usize,
     },
     Data {
         block: Arc<DecodedDataBlock<IndexRow>>,
-        decoded_byte_len: usize,
+        decoded_bytes: usize,
     },
 }
 
-impl DecodedGrepBlock {
-    fn decoded_byte_len(&self) -> usize {
+impl DecodedBlock for DecodedGrepBlock {
+    fn decoded_bytes(&self) -> usize {
         match self {
-            Self::Manifest {
-                decoded_byte_len, ..
-            }
-            | Self::Filter {
-                decoded_byte_len, ..
-            }
-            | Self::Index {
-                decoded_byte_len, ..
-            }
-            | Self::Data {
-                decoded_byte_len, ..
-            } => *decoded_byte_len,
+            Self::Manifest { decoded_bytes, .. }
+            | Self::Filter { decoded_bytes, .. }
+            | Self::Index { decoded_bytes, .. }
+            | Self::Data { decoded_bytes, .. } => *decoded_bytes,
         }
     }
 }
 
-/// A process-shareable cache of immutable decoded grep blocks.
-pub struct GrepBlockCache {
-    max_decoded_bytes: usize,
-    inner: Mutex<GrepBlockCacheInner>,
-    stats: GrepBlockCacheStatsInner,
-    metrics: Option<GrepBlockCacheMetrics>,
-    /// One cell per in-flight block fetch, keyed by immutable block identity,
-    /// so concurrent readers share a single object-store read per block.
-    in_flight: Mutex<HashMap<GrepBlockCacheKey, Arc<OnceCell<DecodedGrepBlock>>>>,
-}
-
-impl std::fmt::Debug for GrepBlockCache {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("GrepBlockCache")
-            .field("max_decoded_bytes", &self.max_decoded_bytes)
-            .field("inner", &self.inner)
-            .field("stats", &self.stats)
-            .field("in_flight", &self.in_flight)
-            .finish_non_exhaustive()
-    }
-}
-
-#[derive(Debug, Default)]
-struct GrepBlockCacheInner {
-    entries: HashMap<GrepBlockCacheKey, CacheSlot>,
-    order: Recency<GrepBlockCacheKey>,
-    decoded_byte_len: usize,
-}
-
-#[derive(Debug)]
-struct CacheSlot {
-    block: DecodedGrepBlock,
-    /// Recency stamp assigned on the most recent access. Recency records with
-    /// an older stamp for this key are ignored.
-    last_touch: u64,
-}
-
-#[derive(Debug, Default)]
-struct GrepBlockCacheStatsInner {
-    hits: AtomicUsize,
-    misses: AtomicUsize,
-    inserts: AtomicUsize,
-    evictions: AtomicUsize,
-}
-
-struct GrepBlockCacheMetrics {
+/// Records grep block cache activity through a metrics recorder.
+pub struct GrepBlockCacheMetrics {
     hits: Arc<dyn CounterHandle>,
     misses: Arc<dyn CounterHandle>,
     inserts: Arc<dyn CounterHandle>,
     evictions: Arc<dyn CounterHandle>,
 }
 
-impl GrepBlockCache {
-    /// Creates a cache with the supplied decoded-byte budget.
-    pub fn new(max_decoded_bytes: usize) -> Self {
-        Self {
-            max_decoded_bytes,
-            inner: Mutex::new(GrepBlockCacheInner::default()),
-            stats: GrepBlockCacheStatsInner::default(),
-            metrics: None,
-            in_flight: Mutex::new(HashMap::new()),
-        }
-    }
-
-    /// Creates a cache and records its activity with `recorder`.
-    pub fn with_metrics(max_decoded_bytes: usize, recorder: &dyn MetricsRecorder) -> Self {
-        Self {
-            max_decoded_bytes,
-            inner: Mutex::new(GrepBlockCacheInner::default()),
-            stats: GrepBlockCacheStatsInner::default(),
-            metrics: Some(GrepBlockCacheMetrics::register(recorder)),
-            in_flight: Mutex::new(HashMap::new()),
-        }
-    }
-
-    /// Resolves one block access through a per-key single-flight cell.
-    pub(crate) async fn get_or_load<E, F, Fut>(
-        &self,
-        cache_key: &GrepBlockCacheKey,
-        fetch: F,
-    ) -> Result<DecodedGrepBlock, E>
-    where
-        F: FnOnce() -> Fut,
-        Fut: std::future::Future<Output = Result<DecodedGrepBlock, E>>,
-    {
-        let cell = {
-            let mut in_flight = self
-                .in_flight
-                .lock()
-                .expect("grep block cache in-flight lock should not be poisoned");
-            Arc::clone(
-                in_flight
-                    .entry(cache_key.clone())
-                    .or_insert_with(|| Arc::new(OnceCell::new())),
-            )
-        };
-        let result = cell
-            .get_or_try_init(|| async {
-                if let Some(block) = self.get(cache_key) {
-                    return Ok(block);
-                }
-                let block = fetch().await?;
-                self.insert(cache_key.clone(), block.clone());
-                Ok(block)
-            })
-            .await
-            .cloned();
-        let mut in_flight = self
-            .in_flight
-            .lock()
-            .expect("grep block cache in-flight lock should not be poisoned");
-        if in_flight
-            .get(cache_key)
-            .is_some_and(|current| Arc::ptr_eq(current, &cell))
-        {
-            in_flight.remove(cache_key);
-        }
-        result
-    }
-
-    /// Returns cumulative hit, miss, insert, and eviction counters.
-    pub fn stats(&self) -> GrepBlockCacheStats {
-        GrepBlockCacheStats {
-            hits: self.stats.hits.load(Ordering::SeqCst),
-            misses: self.stats.misses.load(Ordering::SeqCst),
-            inserts: self.stats.inserts.load(Ordering::SeqCst),
-            evictions: self.stats.evictions.load(Ordering::SeqCst),
-        }
-    }
-
-    fn get(&self, key: &GrepBlockCacheKey) -> Option<DecodedGrepBlock> {
-        if self.max_decoded_bytes == 0 {
-            return None;
-        }
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("grep block cache lock should not be poisoned");
-        let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
-            self.stats.misses.fetch_add(1, Ordering::SeqCst);
-            if let Some(metrics) = &self.metrics {
-                metrics.misses.increment(1);
-            }
-            return None;
-        };
-        inner.touch(key);
-        self.stats.hits.fetch_add(1, Ordering::SeqCst);
-        if let Some(metrics) = &self.metrics {
-            metrics.hits.increment(1);
-        }
-        Some(block)
-    }
-
-    fn insert(&self, key: GrepBlockCacheKey, block: DecodedGrepBlock) {
-        if self.max_decoded_bytes == 0 {
-            return;
-        }
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("grep block cache lock should not be poisoned");
-        let decoded_byte_len = block.decoded_byte_len();
-        if let Some(previous) = inner.entries.insert(
-            key.clone(),
-            CacheSlot {
-                block,
-                last_touch: 0,
-            },
-        ) {
-            inner.decoded_byte_len = inner
-                .decoded_byte_len
-                .saturating_sub(previous.block.decoded_byte_len());
-        }
-        inner.decoded_byte_len = inner.decoded_byte_len.saturating_add(decoded_byte_len);
-        inner.touch(&key);
-        self.stats.inserts.fetch_add(1, Ordering::SeqCst);
-        if let Some(metrics) = &self.metrics {
-            metrics.inserts.increment(1);
-        }
-        let GrepBlockCacheInner {
-            entries,
-            order,
-            decoded_byte_len,
-        } = &mut *inner;
-        while *decoded_byte_len > self.max_decoded_bytes {
-            let Some(candidate) = order.pop_oldest(|key, stamp| slot_is_live(entries, key, stamp))
-            else {
-                break;
-            };
-            if let Some(slot) = entries.remove(&candidate) {
-                *decoded_byte_len = decoded_byte_len.saturating_sub(slot.block.decoded_byte_len());
-                self.stats.evictions.fetch_add(1, Ordering::SeqCst);
-                if let Some(metrics) = &self.metrics {
-                    metrics.evictions.increment(1);
-                }
-            }
-        }
-    }
-}
-
-impl GrepBlockCacheInner {
-    fn touch(&mut self, key: &GrepBlockCacheKey) {
-        let stamp = self.order.touch(key);
-        if let Some(slot) = self.entries.get_mut(key) {
-            slot.last_touch = stamp;
-        }
-        let entries = &self.entries;
-        self.order.compact(entries.len(), |key, stamp| {
-            slot_is_live(entries, key, stamp)
-        });
-    }
-}
-
-/// Returns `true` when `stamp` matches the key's most recent access.
-/// Replacing, evicting, or accessing an entry can leave older recency records.
-fn slot_is_live(
-    entries: &HashMap<GrepBlockCacheKey, CacheSlot>,
-    key: &GrepBlockCacheKey,
-    stamp: u64,
-) -> bool {
-    entries
-        .get(key)
-        .is_some_and(|slot| slot.last_touch == stamp)
-}
-
 impl GrepBlockCacheMetrics {
-    fn register(recorder: &dyn MetricsRecorder) -> Self {
+    /// Registers grep's block cache counters with `recorder`.
+    pub fn register(recorder: &dyn MetricsRecorder) -> Self {
         let get = |result| {
             recorder.register_counter(
                 "loonfs.grep_block_cache.gets",
@@ -341,25 +107,45 @@ impl GrepBlockCacheMetrics {
     }
 }
 
+impl DecodedBlockCacheObserver for GrepBlockCacheMetrics {
+    fn hit(&self) {
+        self.hits.increment(1);
+    }
+
+    fn miss(&self) {
+        self.misses.increment(1);
+    }
+
+    fn insert(&self) {
+        self.inserts.increment(1);
+    }
+
+    fn evict(&self) {
+        self.evictions.increment(1);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic)]
     // The metric helper below expects counters and panics if a test requests
     // a metric of another type.
 
-    use super::{DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind};
+    use super::{
+        DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockCacheMetrics, GrepBlockKind,
+    };
     use loonfs::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};
     use loonfs_api::wire::sst_blocks::DecodedDataBlock;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    fn block(decoded_byte_len: usize) -> DecodedGrepBlock {
+    fn block(decoded_bytes: usize) -> DecodedGrepBlock {
         DecodedGrepBlock::Data {
             block: Arc::new(DecodedDataBlock {
                 row_keys: Vec::new(),
                 rows: Vec::new(),
             }),
-            decoded_byte_len,
+            decoded_bytes,
         }
     }
 
@@ -385,7 +171,10 @@ mod tests {
     #[test]
     fn cache_activity_reaches_the_metrics_recorder() {
         let recorder = DefaultMetricsRecorder::new();
-        let cache = GrepBlockCache::with_metrics(1_000, &recorder);
+        let cache = GrepBlockCache::with_observer(
+            1_000,
+            Some(Arc::new(GrepBlockCacheMetrics::register(&recorder))),
+        );
         cache.insert(key("a"), block(600));
         cache.insert(key("b"), block(600));
         assert!(cache.get(&key("a")).is_none());

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -10,15 +10,9 @@ use loonfs_api::wire::sst_blocks::{
 use std::sync::Arc;
 
 /// Default decoded-byte budget for cached grep manifests and segment blocks.
-///
-/// This preserves the former 4,096-entry cache's intended capacity at the
-/// usual 64 KiB decoded data-block target while preventing unusually large
-/// decoded blocks from making the cache effectively unbounded. Zero disables
-/// the cache.
 pub const DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES: usize = 4_096 * DEFAULT_TARGET_BLOCK_BYTES;
 
-/// The runtime's decoded-block cache, holding grep's manifests and segment
-/// blocks.
+/// Grep's cache for decoded manifests and segment blocks.
 pub type GrepBlockCache = DecodedBlockCache<GrepBlockCacheKey, DecodedGrepBlock>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -29,8 +23,7 @@ pub(crate) enum GrepBlockKind {
     Data,
 }
 
-/// One cache entry's identity. Only grep mints these: the fields stay
-/// crate-private so no caller outside can name a block the cache holds.
+/// Identifies a cached grep block.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GrepBlockCacheKey {
     /// Immutable cache identity. Manifest entries use `payload_checksum`;
@@ -40,7 +33,7 @@ pub struct GrepBlockCacheKey {
     pub(crate) block_offset: u64,
 }
 
-/// One decoded, verified object the cache holds.
+/// A decoded grep block.
 #[derive(Debug, Clone)]
 pub enum DecodedGrepBlock {
     Manifest {
@@ -72,8 +65,7 @@ impl DecodedBlock for DecodedGrepBlock {
     }
 }
 
-/// Records grep block cache activity through a metrics recorder.
-pub struct GrepBlockCacheMetrics {
+struct GrepBlockCacheMetrics {
     hits: Arc<dyn CounterHandle>,
     misses: Arc<dyn CounterHandle>,
     inserts: Arc<dyn CounterHandle>,
@@ -81,8 +73,7 @@ pub struct GrepBlockCacheMetrics {
 }
 
 impl GrepBlockCacheMetrics {
-    /// Registers grep's block cache counters with `recorder`.
-    pub fn register(recorder: &dyn MetricsRecorder) -> Self {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
         let get = |result| {
             recorder.register_counter(
                 "loonfs.grep_block_cache.gets",
@@ -105,6 +96,17 @@ impl GrepBlockCacheMetrics {
             ),
         }
     }
+}
+
+/// Creates a grep block cache that reports metrics to `recorder`.
+pub fn new_grep_block_cache(
+    max_decoded_bytes: usize,
+    recorder: &dyn MetricsRecorder,
+) -> GrepBlockCache {
+    GrepBlockCache::with_observer(
+        max_decoded_bytes,
+        Some(Arc::new(GrepBlockCacheMetrics::register(recorder))),
+    )
 }
 
 impl DecodedBlockCacheObserver for GrepBlockCacheMetrics {

--- a/crates/loonfs-grep/src/codec.rs
+++ b/crates/loonfs-grep/src/codec.rs
@@ -3,6 +3,7 @@
 //! The frozen tokenizer, posting-batch, and row-key grammar is specified in
 //! [`docs/specs/format.md` §4.2.2](../../../docs/specs/format.md#422-grep-roots-manifests-and-gram-index-segments).
 
+use loonfs_api::wire::sst_blocks::{read_varint, write_varint, SstBlockCodecError};
 use loonfs_api::{InodeId, RevisionNo};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -133,7 +134,7 @@ pub fn encode_gram_postings(postings: &[GramPosting]) -> Result<Vec<u8>, IndexGr
 /// and that the batch ends exactly where its bytes do.
 pub fn decode_gram_postings(bytes: &[u8]) -> Result<Vec<GramPosting>, IndexGramsCodecError> {
     let mut cursor = 0usize;
-    let count = read_varint(bytes, &mut cursor)?;
+    let count = read_varint(bytes, &mut cursor).map_err(malformed_varint)?;
     if count == 0 {
         return Err(IndexGramsCodecError::EmptyPostings);
     }
@@ -149,12 +150,12 @@ pub fn decode_gram_postings(bytes: &[u8]) -> Result<Vec<GramPosting>, IndexGrams
     }
     let mut postings = Vec::with_capacity(count);
     let mut previous = GramPosting {
-        inode_id: InodeId(read_varint(bytes, &mut cursor)?),
+        inode_id: InodeId(read_varint(bytes, &mut cursor).map_err(malformed_varint)?),
         revision_no: read_revision_no(bytes, &mut cursor)?,
     };
     postings.push(previous);
     for _ in 1..count {
-        let inode_delta = read_varint(bytes, &mut cursor)?;
+        let inode_delta = read_varint(bytes, &mut cursor).map_err(malformed_varint)?;
         let inode_id = previous
             .inode_id
             .0
@@ -187,43 +188,14 @@ pub fn decode_gram_postings(bytes: &[u8]) -> Result<Vec<GramPosting>, IndexGrams
 }
 
 fn read_revision_no(bytes: &[u8], cursor: &mut usize) -> Result<RevisionNo, IndexGramsCodecError> {
-    let value = read_varint(bytes, cursor)?;
+    let value = read_varint(bytes, cursor).map_err(malformed_varint)?;
     RevisionNo::parse(value).map_err(|error| {
         IndexGramsCodecError::Malformed(format!("invalid posting revision `{value}`: {error}"))
     })
 }
 
-fn write_varint(bytes: &mut Vec<u8>, mut value: u64) {
-    loop {
-        let byte = (value & 0x7f) as u8;
-        value >>= 7;
-        if value == 0 {
-            bytes.push(byte);
-            return;
-        }
-        bytes.push(byte | 0x80);
-    }
-}
-
-fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64, IndexGramsCodecError> {
-    let mut value = 0u64;
-    let mut shift = 0u32;
-    loop {
-        let byte = *bytes.get(*cursor).ok_or_else(|| {
-            IndexGramsCodecError::Malformed("varint runs past the block".to_owned())
-        })?;
-        *cursor += 1;
-        if shift >= 64 {
-            return Err(IndexGramsCodecError::Malformed(
-                "varint exceeds 64 bits".to_owned(),
-            ));
-        }
-        value |= u64::from(byte & 0x7f) << shift;
-        if byte & 0x80 == 0 {
-            return Ok(value);
-        }
-        shift += 7;
-    }
+fn malformed_varint(error: SstBlockCodecError) -> IndexGramsCodecError {
+    IndexGramsCodecError::Malformed(error.to_string())
 }
 
 /// One row of a gram index segment. Kind-tagged so a later released format

--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -94,7 +94,7 @@ pub(crate) async fn load_filter_block<S: ObjectStore + ?Sized>(
             );
             Ok::<_, GrepError>(DecodedGrepBlock::Filter {
                 filter,
-                decoded_byte_len: handle.decoded_len as usize,
+                decoded_bytes: handle.decoded_len as usize,
             })
         })
         .await?;
@@ -121,7 +121,7 @@ pub(crate) async fn load_index_block<S: ObjectStore + ?Sized>(
             );
             Ok::<_, GrepError>(DecodedGrepBlock::Index {
                 entries,
-                decoded_byte_len: handle.decoded_len as usize,
+                decoded_bytes: handle.decoded_len as usize,
             })
         })
         .await?;
@@ -148,7 +148,7 @@ pub(crate) async fn load_data_block<S: ObjectStore + ?Sized>(
             );
             Ok::<_, GrepError>(DecodedGrepBlock::Data {
                 block,
-                decoded_byte_len: handle.decoded_len as usize,
+                decoded_bytes: handle.decoded_len as usize,
             })
         })
         .await?;

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -27,7 +27,7 @@ mod service;
 mod worker;
 
 pub use cache::{
-    DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockCacheMetrics,
+    new_grep_block_cache, DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey,
     DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
 };
 pub use config::{GrepWorkerConfig, GrepWorkerConfigError};

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -26,7 +26,10 @@ pub mod root;
 mod service;
 mod worker;
 
-pub use cache::{GrepBlockCache, GrepBlockCacheStats, DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES};
+pub use cache::{
+    DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockCacheMetrics,
+    DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
+};
 pub use config::{GrepWorkerConfig, GrepWorkerConfigError};
 pub use error::GrepError as Error;
 pub use error::{GrepError, Result};

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -119,7 +119,7 @@ impl GrepService {
                 // As with the metadata manifest cache, JSON-backed decoded
                 // state is weighted at twice its canonical payload bytes to
                 // cover both owned strings and decoded structure overhead.
-                let decoded_byte_len = serde_json::to_vec(manifest.manifest_state())
+                let decoded_bytes = serde_json::to_vec(manifest.manifest_state())
                     .map_err(|error| {
                         CoreError::Internal(format!(
                             "failed to size decoded grep manifest `{}`: {error}",
@@ -130,7 +130,7 @@ impl GrepService {
                     .saturating_mul(2);
                 Ok(DecodedGrepBlock::Manifest {
                     state,
-                    decoded_byte_len,
+                    decoded_bytes,
                 })
             })
             .await

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -35,9 +35,9 @@ use loonfs_api::wire::sst_blocks::{
     DEFAULT_MAX_ROWS_PER_SEGMENT,
 };
 use loonfs_api::{
-    decode_namespace_cursor, encode_cursor, next_public_ordinal, sha256_digest, ChangeSeq,
-    CheckpointId, ContentRef, ErrorCode, IndexSegmentId, InodeId, NamespaceCursor,
-    NamespaceCursorError, NamespaceId, PageCursor, RevisionNo, RunNo, MAX_PUBLIC_INTEGER,
+    decode_namespace_cursor, encode_cursor, sha256_digest, ChangeSeq, CheckpointId, ContentRef,
+    ErrorCode, IndexSegmentId, InodeId, NamespaceCursor, NamespaceCursorError, NamespaceId,
+    PageCursor, RevisionNo, RunNo,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
@@ -1840,12 +1840,9 @@ fn core_state_error(
 }
 
 fn next_grep_run_no(current: RunNo) -> Result<RunNo> {
-    next_public_ordinal(current.0).map(RunNo).ok_or_else(|| {
-        CoreError::Internal(format!(
-            "grep run number cannot exceed {MAX_PUBLIC_INTEGER}"
-        ))
-        .into()
-    })
+    current
+        .successor()
+        .map_err(|error| CoreError::Internal(format!("grep run number {error}")).into())
 }
 
 fn core_store_error(object_key: &str, error: &ObjectStoreError) -> GrepError {

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -344,7 +344,7 @@ async fn exhausted_run_numbers_fail_as_server_errors_without_writing_the_root() 
         assert!(matches!(
             error,
             GrepError::Runtime(RuntimeError::Core(CoreError::Internal(message)))
-                if message.contains("grep run number cannot exceed")
+                if message.contains("grep run number must be an integer")
         ));
     }
 

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -19,7 +19,7 @@ use loonfs::{
 };
 use loonfs_api::NamespaceId;
 use loonfs_grep::{
-    GrepBlockCache, GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker,
+    GrepBlockCache, GrepBlockCacheMetrics, GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker,
     DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES, GREP_INDEX_JOB,
 };
 use loonfs_objectstore::presign::DirectTransferIssuers;
@@ -304,9 +304,11 @@ pub(super) async fn app_with_store_and_direct_transfers(
     )
     .await?;
     let probe_store = writer.object_store();
-    let grep_block_cache = Arc::new(GrepBlockCache::with_metrics(
+    let grep_block_cache = Arc::new(GrepBlockCache::with_observer(
         DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
-        metrics.recorder().as_ref(),
+        Some(Arc::new(GrepBlockCacheMetrics::register(
+            metrics.recorder().as_ref(),
+        ))),
     ));
     // A deployment that maintains the index needs a worker whether or not it
     // answers queries with one. It runs on the writer's own instrumented

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -19,7 +19,7 @@ use loonfs::{
 };
 use loonfs_api::NamespaceId;
 use loonfs_grep::{
-    GrepBlockCache, GrepBlockCacheMetrics, GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker,
+    new_grep_block_cache, GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker,
     DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES, GREP_INDEX_JOB,
 };
 use loonfs_objectstore::presign::DirectTransferIssuers;
@@ -304,11 +304,9 @@ pub(super) async fn app_with_store_and_direct_transfers(
     )
     .await?;
     let probe_store = writer.object_store();
-    let grep_block_cache = Arc::new(GrepBlockCache::with_observer(
+    let grep_block_cache = Arc::new(new_grep_block_cache(
         DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
-        Some(Arc::new(GrepBlockCacheMetrics::register(
-            metrics.recorder().as_ref(),
-        ))),
+        metrics.recorder().as_ref(),
     ));
     // A deployment that maintains the index needs a worker whether or not it
     // answers queries with one. It runs on the writer's own instrumented

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -93,6 +93,7 @@ pub use loonfs_api::{
     PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::{
+    DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver, DecodedBlockCacheStats,
     MetadataSegmentCacheConfig, Recency, StoredMetadataBlockCache,
     StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey, StoredMetadataBlockKind,
 };


### PR DESCRIPTION
Adds a shared decoded-block cache in loonfs-core for metadata and grep. The cache provides byte-budgeted eviction, per-key request coalescing, and common counters while allowing each caller to keep its own metrics. Existing cache behavior and metric names are unchanged.

Metadata and grep now use the same LEB128 encoding helpers and run-number increment logic. Durable bytes are unchanged.