### PR TITLE
refactor(api): centralize metadata keys and ID helpers

### DIFF
--- a/crates/loonfs-api/src/actor.rs
+++ b/crates/loonfs-api/src/actor.rs
@@ -3,8 +3,8 @@
 //! Use a stable ID such as `usr_8f3c`, rather than an email address or display
 //! name. Profile changes should not change the actor recorded in file history.
 
+use crate::ids::{string_id, validation_error};
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use thiserror::Error;
 
 const MAX_ACTOR_ID_BYTES: usize = 256;
@@ -85,127 +85,24 @@ impl ActorKind {
     }
 }
 
-/// A validated actor identifier supplied by the application.
-///
-/// Actor IDs may use the syntax of the application's identity system. They
-/// must contain between 1 and 256 UTF-8 bytes, must not begin or end with
-/// whitespace, and must not contain control characters.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ActorId(String);
+validation_error!(
+    ActorIdValidationError,
+    "invalid actor_id {value:?}: {reason}"
+);
 
-impl ActorId {
-    /// Parses and validates an actor ID.
-    pub fn parse(value: impl AsRef<str>) -> Result<Self, ActorIdValidationError> {
-        let value = value.as_ref();
-        validate_actor_id(value)?;
-        Ok(Self(value.to_owned()))
-    }
-
-    /// Returns the actor ID as a string.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl TryFrom<&str> for ActorId {
-    type Error = ActorIdValidationError;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::parse(value)
-    }
-}
-
-impl TryFrom<String> for ActorId {
-    type Error = ActorIdValidationError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::parse(value)
-    }
-}
-
-impl std::str::FromStr for ActorId {
-    type Err = ActorIdValidationError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Self::parse(value)
-    }
-}
-
-impl AsRef<str> for ActorId {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl std::borrow::Borrow<str> for ActorId {
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl fmt::Display for ActorId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-#[cfg(feature = "openapi")]
-impl utoipa::PartialSchema for ActorId {
-    #[allow(
-        deprecated,
-        reason = "the published schema uses the requested singular example field"
-    )]
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        utoipa::openapi::schema::Object::builder()
-            .schema_type(utoipa::openapi::schema::Type::String)
-            .description(Some(
-                "Opaque hosting-platform actor id: non-empty, at most 256 UTF-8 bytes, without leading or trailing whitespace or control characters.",
-            ))
-            .example(Some(serde_json::json!("usr_8f3c")))
-            .into()
-    }
-}
-
-#[cfg(feature = "openapi")]
-impl utoipa::ToSchema for ActorId {}
-
-impl Serialize for ActorId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.0)
-    }
-}
-
-impl<'de> Deserialize<'de> for ActorId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        Self::parse(value).map_err(serde::de::Error::custom)
-    }
-}
-
-/// An error returned when an actor ID is invalid.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error("invalid actor_id {value:?}: {reason}")]
-pub struct ActorIdValidationError {
-    value: String,
-    reason: String,
-}
-
-impl ActorIdValidationError {
-    /// Returns the rejected input.
-    pub fn value(&self) -> &str {
-        &self.value
-    }
-
-    /// Returns the reason the input was rejected.
-    pub fn reason(&self) -> &str {
-        &self.reason
-    }
+string_id! {
+    /// A validated actor identifier supplied by the application.
+    ///
+    /// Actor IDs may use the syntax of the application's identity system. They
+    /// must contain between 1 and 256 UTF-8 bytes, must not begin or end with
+    /// whitespace, and must not contain control characters.
+    ActorId,
+    error = ActorIdValidationError,
+    validate = validate_actor_id,
+    schema(
+        description = "Opaque hosting-platform actor id: non-empty, at most 256 UTF-8 bytes, without leading or trailing whitespace or control characters.",
+        example = "usr_8f3c"
+    )
 }
 
 fn validate_actor_id(value: &str) -> Result<(), ActorIdValidationError> {

--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -1,7 +1,7 @@
 //! [`ContentRef`]: the durable reference a file revision points at, naming
 //! one immutable content object and carrying the integrity evidence for it.
 
-use crate::hex::hex_encode_bytes;
+use crate::hex::{hex_encode_bytes, is_lower_hex_byte};
 use crate::ids::ContentId;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256 as Sha2Sha256};
@@ -169,11 +169,7 @@ impl Checksum {
                 actual_len: self.value.len(),
             });
         }
-        if !self
-            .value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-        {
+        if !self.value.bytes().all(is_lower_hex_byte) {
             return Err(ChecksumValidationError::InvalidAlphabet {
                 algorithm: self.algorithm,
             });

--- a/crates/loonfs-api/src/hex.rs
+++ b/crates/loonfs-api/src/hex.rs
@@ -38,8 +38,6 @@ fn nibble(byte: u8) -> Result<u8, HexDecodeError> {
     }
 }
 
-/// Reports whether `byte` is in the lowercase hexadecimal alphabet: it is
-/// exactly the set of bytes this module can decode.
 pub(crate) fn is_lower_hex_byte(byte: u8) -> bool {
     nibble(byte).is_ok()
 }

--- a/crates/loonfs-api/src/hex.rs
+++ b/crates/loonfs-api/src/hex.rs
@@ -30,17 +30,23 @@ pub fn hex_encode_bytes(bytes: &[u8]) -> String {
     encoded
 }
 
+fn nibble(byte: u8) -> Result<u8, HexDecodeError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        _ => Err(HexDecodeError::InvalidByte { byte }),
+    }
+}
+
+/// Reports whether `byte` is in the lowercase hexadecimal alphabet: it is
+/// exactly the set of bytes this module can decode.
+pub(crate) fn is_lower_hex_byte(byte: u8) -> bool {
+    nibble(byte).is_ok()
+}
+
 /// Decodes lowercase hex. Errors carry no input bytes; callers name the
 /// field they were decoding.
 pub fn hex_decode_bytes(encoded: &str) -> Result<Vec<u8>, HexDecodeError> {
-    fn nibble(byte: u8) -> Result<u8, HexDecodeError> {
-        match byte {
-            b'0'..=b'9' => Ok(byte - b'0'),
-            b'a'..=b'f' => Ok(byte - b'a' + 10),
-            _ => Err(HexDecodeError::InvalidByte { byte }),
-        }
-    }
-
     let bytes = encoded.as_bytes();
     if bytes.len() % 2 != 0 {
         return Err(HexDecodeError::OddLength {

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -2,7 +2,7 @@
 //! `string_id!` and `numeric_id!` macros so all ids share one validated
 //! surface.
 
-use crate::hex::hex_encode_bytes;
+use crate::hex::{hex_encode_bytes, is_lower_hex_byte};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
@@ -437,10 +437,6 @@ fn parse_position_suffix_id<'a>(
     Ok((position, suffix))
 }
 
-fn is_lower_hex_byte(byte: u8) -> bool {
-    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
-}
-
 fn validate_id_grammar(value: &str) -> Result<(), String> {
     if value.is_empty() {
         return Err("must not be empty".to_owned());
@@ -588,8 +584,7 @@ string_id! {
     /// names *which object*, never what it contains — integrity evidence
     /// rides [`crate::ContentRef`] beside it.
     ContentId,
-    error = GeneratedIdValidationError,
-    validate = |value: &str| validate_generated_id("con", value),
+    prefix = "con",
     schema(
         pattern = r"^con_[0-9a-f]{32}$",
         example = "con_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41"
@@ -597,14 +592,6 @@ string_id! {
 }
 
 impl ContentId {
-    /// Generates an id from 128 fresh random bits.
-    pub fn generate() -> Self {
-        Self(format!(
-            "con_{}",
-            crate::hex::hex_encode_bytes(&random_128())
-        ))
-    }
-
     /// Returns the two-character components for both content-key shard levels.
     ///
     /// Every valid id has a 32-character lowercase hex body, so this never
@@ -874,12 +861,19 @@ pub enum InodeKind {
     Directory,
 }
 
+impl InodeKind {
+    /// Returns the frozen wire value for this kind.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Directory => "dir",
+        }
+    }
+}
+
 impl fmt::Display for InodeKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::File => f.write_str("file"),
-            Self::Directory => f.write_str("dir"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -862,7 +862,7 @@ pub enum InodeKind {
 }
 
 impl InodeKind {
-    /// Returns the frozen wire value for this kind.
+    /// Returns the serialized value.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::File => "file",

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -517,12 +517,7 @@ impl MetadataRow {
         }
     }
 
-    /// The exact lookup prefix a point read probes for this row in `family`,
-    /// and therefore the key inserted into the segment's bloom filter. A
-    /// filter is an exact-match structure, so the probe a reader builds and
-    /// the key a writer stores both come from [`lookup_keys`]. Range scans
-    /// at coarser granularity (a whole directory, a wave of names) do not
-    /// consult filters.
+    /// Returns the Bloom filter key for this row in `family`.
     pub fn filter_key_for_family(&self, family: MetadataRowFamily) -> String {
         match self {
             Self::Inode { .. } => self.row_key_for_family(family),
@@ -567,33 +562,19 @@ pub fn hex_encode_row_key_component(value: &str) -> String {
     crate::hex::hex_encode_bytes(value.as_bytes())
 }
 
-/// The metadata row-key grammar: every row key, bloom-filter probe, range
-/// prefix, and resume bound the families use. [`MetadataRow::row_key_for_family`]
-/// and [`MetadataRow::filter_key_for_family`] build their answers from here,
-/// so a probe cannot drift from the filter key the writer stored and a
-/// prefix cannot drift from the row keys it selects.
+/// Builders for metadata row keys, lookup prefixes, and Bloom filter probes.
+///
+/// See [metadata segments](../../../docs/specs/format.md#421-metadata-segments).
 pub mod lookup_keys {
     use super::{hex_encode_row_key_component, TombstoneGeneration};
     use crate::{AttributeRevisionNo, ChangeSeq, InodeId, RevisionNo};
 
-    /// The prefix every inode row key starts with. Inode ids are
-    /// zero-padded to a fixed width after it, so a range scan over this
-    /// prefix walks the inode family in ascending inode-id order.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Prefix for inode row keys.
     pub const INODE_ROW_PREFIX: &str = "inode-";
 
-    /// The prefix every canonical revision row key starts with. A range scan
-    /// over it walks every revision the manifest records, superseded ones
-    /// included, which is what a reachability question about content needs.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Prefix for canonical revision row keys.
     pub const REVISION_ROW_PREFIX: &str = "revision-";
 
-    // The remaining family prefixes. No consumer outside this crate scans
-    // these families by prefix, so they stay internal;
-    // `MetadataRowFamily::row_key_prefix` is how the rest of the workspace
-    // asks for one.
     pub(super) const DIRENTRY_BIND_ROW_PREFIX: &str = "direntry-bind-";
     pub(super) const DIRENTRY_CHILD_BIND_ROW_PREFIX: &str = "direntry-child-bind-";
     pub(super) const DIRENTRY_UNBIND_ROW_PREFIX: &str = "direntry-unbind-";
@@ -602,31 +583,22 @@ pub mod lookup_keys {
     pub(super) const COMMIT_RECEIPT_ROW_PREFIX: &str = "commit-receipt-";
     pub(super) const ATTRIBUTE_ROW_PREFIX: &str = "attribute-";
 
-    /// Builds the exact point-lookup key for an inode row.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds an inode row key.
     pub fn inode_key(inode_id: InodeId) -> String {
         format!("{INODE_ROW_PREFIX}{:020}", inode_id.0)
     }
 
-    /// Builds the resume bound for a scan that must continue strictly after
-    /// `inode_id`'s row.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a scan bound immediately after an inode row.
     pub fn inode_key_after(inode_id: InodeId) -> String {
         format!("{}\0", inode_key(inode_id))
     }
 
-    /// Builds the range prefix selecting directory bindings under one parent.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for directory bindings under one parent.
     pub fn direntry_parent_prefix(parent_inode_id: InodeId) -> String {
         format!("{DIRENTRY_BIND_ROW_PREFIX}{:020}-", parent_inode_id.0)
     }
 
-    /// Builds the bloom-filter probe shared by all generations of one parent/name binding.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the Bloom filter probe for a parent/name binding.
     pub fn direntry_bind_probe(parent_inode_id: InodeId, name_key: &str) -> String {
         format!(
             "{}{}",
@@ -635,16 +607,12 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the range prefix selecting every generation of one parent/name binding.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for every generation of a parent/name binding.
     pub fn direntry_bind_prefix(parent_inode_id: InodeId, name_key: &str) -> String {
         format!("{}-", direntry_bind_probe(parent_inode_id, name_key))
     }
 
-    /// Builds the full row key for one generation of a parent/name binding.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a row key for one generation of a parent/name binding.
     pub fn direntry_bind_row_key(
         parent_inode_id: InodeId,
         name_key: &str,
@@ -658,24 +626,17 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the bloom-filter probe shared by bindings that target one child inode.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the Bloom filter probe for bindings to one child inode.
     pub fn direntry_child_probe(child_inode_id: InodeId) -> String {
         format!("{DIRENTRY_CHILD_BIND_ROW_PREFIX}{:020}", child_inode_id.0)
     }
 
-    /// Builds the reverse-index range prefix selecting bindings to one child inode.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the reverse-index prefix for bindings to one child inode.
     pub fn direntry_child_prefix(child_inode_id: InodeId) -> String {
         format!("{}-", direntry_child_probe(child_inode_id))
     }
 
-    /// Builds the full row key one binding generation takes in the by-child
-    /// re-index.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a reverse-index row key for one binding generation.
     pub fn direntry_child_bind_row_key(
         child_inode_id: InodeId,
         bind_seq: ChangeSeq,
@@ -692,9 +653,7 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the bloom-filter probe shared by unbinds for one parent/name pair.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the Bloom filter probe for unbinds of one parent/name pair.
     pub fn direntry_unbind_probe(parent_inode_id: InodeId, name_key: &str) -> String {
         format!(
             "{}{}",
@@ -703,9 +662,7 @@ pub mod lookup_keys {
         )
     }
 
-    /// Rows for one specific binding generation under the unbind probe.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for unbinds of one binding generation.
     pub fn direntry_unbind_binding_prefix(
         parent_inode_id: InodeId,
         name_key: &str,
@@ -719,9 +676,7 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the full row key for one unbind event.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a row key for one unbind event.
     pub fn direntry_unbind_row_key(
         parent_inode_id: InodeId,
         name_key: &str,
@@ -737,39 +692,30 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the range prefix selecting every unbind below one parent directory.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for unbinds below one parent directory.
     pub fn direntry_unbind_parent_prefix(parent_inode_id: InodeId) -> String {
         format!("{DIRENTRY_UNBIND_ROW_PREFIX}{:020}-", parent_inode_id.0)
     }
 
-    /// Builds the range prefix selecting unbinds for one parent/name pair.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for unbinds of one parent/name pair.
     pub fn direntry_unbind_name_prefix(parent_inode_id: InodeId, name_key: &str) -> String {
         format!("{}-", direntry_unbind_probe(parent_inode_id, name_key))
     }
 
-    /// Builds the bloom-filter probe shared by tombstone events for one root inode.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the Bloom filter probe for one tombstone root.
     pub fn tombstone_probe(root_inode_id: InodeId) -> String {
         format!("{TOMBSTONE_ROW_PREFIX}{:020}", root_inode_id.0)
     }
 
-    /// Builds the range prefix selecting the tombstone history of one root inode.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for a root inode's tombstone history.
     pub fn tombstone_prefix(root_inode_id: InodeId) -> String {
         format!("{}-", tombstone_probe(root_inode_id))
     }
 
-    /// Builds the full row key for one tombstone event. The event's action
-    /// stays in the value, so a revoke sorts exactly like the deletion it
-    /// cancels and a newest-per-root scan reads both in one prefix pass.
+    /// Builds a row key for one tombstone event.
     ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// The action is stored in the value, so delete and revoke rows for one
+    /// generation share a key.
     pub fn tombstone_row_key(root_inode_id: InodeId, generation: TombstoneGeneration) -> String {
         format!(
             "{}{:020}-{:010}",
@@ -779,12 +725,7 @@ pub mod lookup_keys {
         )
     }
 
-    /// The prefix every active-deletion row key starts with. Deletion
-    /// sequence and root inode are zero-padded to fixed widths after it, so a
-    /// range scan over this prefix walks the namespace's recoverable
-    /// deletions oldest deletion first — the trash listing's whole read.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Prefix for active-deletion row keys.
     pub const ACTIVE_DELETION_ROW_PREFIX: &str = "active-deletion-";
 
     /// Rank of an undelete's removal marker within one deletion generation.
@@ -797,9 +738,7 @@ pub mod lookup_keys {
     /// rank the family defines.
     pub const ACTIVE_DELETION_RANK_LISTED: u32 = 1;
 
-    /// Builds an active-deletion row key from its generation and rank.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds an active-deletion row key.
     pub fn active_deletion_row_key(
         deletion_seq: ChangeSeq,
         root_inode_id: InodeId,
@@ -811,12 +750,7 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the resume bound for a trash page that must continue strictly
-    /// after the deletion generation it last returned. The listed row is the
-    /// generation's highest-ranked row, so resuming past it skips the whole
-    /// generation and nothing else.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a trash scan bound after one deletion generation.
     pub fn active_deletion_key_after(deletion_seq: ChangeSeq, root_inode_id: InodeId) -> String {
         format!(
             "{}\0",
@@ -824,9 +758,7 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the bloom-filter probe shared by receipts for one commit id.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the Bloom filter probe for one commit ID.
     pub fn commit_receipt_probe(commit_id: &str) -> String {
         format!(
             "{COMMIT_RECEIPT_ROW_PREFIX}{}",
@@ -834,16 +766,12 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the range prefix selecting durable receipts for one commit id.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for receipts with one commit ID.
     pub fn commit_receipt_prefix(commit_id: &str) -> String {
         format!("{}-", commit_receipt_probe(commit_id))
     }
 
-    /// Builds the full row key for one commit receipt.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a commit receipt row key.
     pub fn commit_receipt_row_key(commit_id: &str, committed_seq: ChangeSeq) -> String {
         format!(
             "{}{:020}",
@@ -852,16 +780,12 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the bloom-filter probe shared by every canonical revision of one inode.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the Bloom filter probe for an inode's canonical revisions.
     pub fn revision_probe(inode_id: InodeId) -> String {
         format!("{REVISION_ROW_PREFIX}{:020}", inode_id.0)
     }
 
-    /// Builds the full canonical revision row key.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a canonical revision row key.
     pub fn revision_row_key(
         inode_id: InodeId,
         revision_no: RevisionNo,
@@ -874,23 +798,17 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the bloom-filter probe shared by newest-first revisions of one inode.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the Bloom filter probe for an inode's newest-first revisions.
     pub fn revision_by_inode_desc_probe(inode_id: InodeId) -> String {
         format!("{REVISION_BY_INODE_DESC_ROW_PREFIX}{:020}", inode_id.0)
     }
 
-    /// Builds the range prefix selecting newest-first revisions of one inode.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for an inode's newest-first revisions.
     pub fn revision_by_inode_desc_prefix(inode_id: InodeId) -> String {
         format!("{}-", revision_by_inode_desc_probe(inode_id))
     }
 
-    /// Revision numbers are stored inverted so newest sorts first.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a prefix for one revision in the newest-first index.
     pub fn revision_by_inode_desc_revision_prefix(
         inode_id: InodeId,
         revision_no: RevisionNo,
@@ -902,10 +820,7 @@ pub mod lookup_keys {
         )
     }
 
-    /// The full descending-index row key: revision number, commit seq, and
-    /// delta index all inverted so newest sorts first.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a row key for the newest-first revision index.
     pub fn revision_by_inode_desc_row_key(
         inode_id: InodeId,
         revision_no: RevisionNo,
@@ -920,27 +835,17 @@ pub mod lookup_keys {
         )
     }
 
-    /// Builds the bloom-filter probe shared by every attribute revision of one
-    /// inode.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the Bloom filter probe for an inode's attribute revisions.
     pub fn attributes_probe(inode_id: InodeId) -> String {
         format!("{ATTRIBUTE_ROW_PREFIX}{:020}", inode_id.0)
     }
 
-    /// Builds the range prefix selecting one inode's attribute revisions,
-    /// newest first.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds the prefix for an inode's newest-first attribute revisions.
     pub fn attributes_prefix(inode_id: InodeId) -> String {
         format!("{}-", attributes_probe(inode_id))
     }
 
-    /// The full attribute row key: revision number, commit seq, and delta
-    /// index all inverted so an ascending scan of one inode's prefix reads
-    /// its newest attribute state first.
-    ///
-    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    /// Builds a row key for an attribute revision.
     pub fn attributes_row_key(
         inode_id: InodeId,
         attributes_revision_no: AttributeRevisionNo,

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -388,19 +388,19 @@ impl ActiveDeletionRowAction {
 impl MetadataRowFamily {
     /// Fixed prefix before the first variable component in this family's row
     /// keys. Compaction uses the remaining components to group rows for
-    /// retention, so this must match [`MetadataRow::row_key_for_family`].
+    /// retention.
     pub const fn row_key_prefix(self) -> &'static str {
         match self {
-            Self::Inodes => "inode-",
-            Self::DirentryBinds => "direntry-bind-",
-            Self::DirentryChildBinds => "direntry-child-bind-",
-            Self::DirentryUnbinds => "direntry-unbind-",
-            Self::Revisions => "revision-",
-            Self::RevisionsByInodeDesc => "revision-by-inode-desc-",
-            Self::Tombstones => "tombstone-",
-            Self::ActiveDeletions => "active-deletion-",
-            Self::CommitReceipts => "commit-receipt-",
-            Self::Attributes => "attribute-",
+            Self::Inodes => lookup_keys::INODE_ROW_PREFIX,
+            Self::DirentryBinds => lookup_keys::DIRENTRY_BIND_ROW_PREFIX,
+            Self::DirentryChildBinds => lookup_keys::DIRENTRY_CHILD_BIND_ROW_PREFIX,
+            Self::DirentryUnbinds => lookup_keys::DIRENTRY_UNBIND_ROW_PREFIX,
+            Self::Revisions => lookup_keys::REVISION_ROW_PREFIX,
+            Self::RevisionsByInodeDesc => lookup_keys::REVISION_BY_INODE_DESC_ROW_PREFIX,
+            Self::Tombstones => lookup_keys::TOMBSTONE_ROW_PREFIX,
+            Self::ActiveDeletions => lookup_keys::ACTIVE_DELETION_ROW_PREFIX,
+            Self::CommitReceipts => lookup_keys::COMMIT_RECEIPT_ROW_PREFIX,
+            Self::Attributes => lookup_keys::ATTRIBUTE_ROW_PREFIX,
         }
     }
 }
@@ -427,7 +427,7 @@ impl MetadataRow {
     /// See [metadata segments](../../../docs/specs/format.md#421-metadata-segments).
     pub fn row_key_for_family(&self, family: MetadataRowFamily) -> String {
         match self {
-            Self::Inode { inode_id, .. } => format!("inode-{:020}", inode_id.0),
+            Self::Inode { inode_id, .. } => lookup_keys::inode_key(*inode_id),
             Self::DirentryBind {
                 parent_inode_id,
                 name_key,
@@ -435,23 +435,21 @@ impl MetadataRow {
                 bind_seq,
                 bind_delta_index,
                 ..
-            } => {
-                let name_key = hex_encode_row_key_component(name_key.as_str());
-                match family {
-                    MetadataRowFamily::DirentryChildBinds => {
-                        format!(
-                            "direntry-child-bind-{:020}-{:020}-{:010}-{:020}-{name_key}",
-                            child_inode_id.0, bind_seq.0, bind_delta_index, parent_inode_id.0
-                        )
-                    }
-                    _ => {
-                        format!(
-                            "direntry-bind-{:020}-{name_key}-{:020}-{:010}",
-                            parent_inode_id.0, bind_seq.0, bind_delta_index
-                        )
-                    }
-                }
-            }
+            } => match family {
+                MetadataRowFamily::DirentryChildBinds => lookup_keys::direntry_child_bind_row_key(
+                    *child_inode_id,
+                    *bind_seq,
+                    *bind_delta_index,
+                    *parent_inode_id,
+                    name_key.as_str(),
+                ),
+                _ => lookup_keys::direntry_bind_row_key(
+                    *parent_inode_id,
+                    name_key.as_str(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ),
+            },
             Self::DirentryUnbind {
                 parent_inode_id,
                 name_key,
@@ -460,17 +458,14 @@ impl MetadataRow {
                 unbind_seq,
                 unbind_delta_index,
                 ..
-            } => {
-                let name_key = hex_encode_row_key_component(name_key.as_str());
-                format!(
-                    "direntry-unbind-{:020}-{name_key}-{:020}-{:010}-{:020}-{:010}",
-                    parent_inode_id.0,
-                    bind_seq.0,
-                    bind_delta_index,
-                    unbind_seq.0,
-                    unbind_delta_index
-                )
-            }
+            } => lookup_keys::direntry_unbind_row_key(
+                *parent_inode_id,
+                name_key.as_str(),
+                *bind_seq,
+                *bind_delta_index,
+                *unbind_seq,
+                *unbind_delta_index,
+            ),
             Self::FileRevision {
                 inode_id,
                 revision_no,
@@ -479,34 +474,20 @@ impl MetadataRow {
                 ..
             } => match family {
                 MetadataRowFamily::RevisionsByInodeDesc => {
-                    let reverse_revision_no = u64::MAX - revision_no.0;
-                    let reverse_committed_seq = u64::MAX - committed_seq.0;
-                    let reverse_delta_index = u32::MAX - delta_index;
-                    format!(
-                        "revision-by-inode-desc-{:020}-{:020}-{:020}-{:010}",
-                        inode_id.0, reverse_revision_no, reverse_committed_seq, reverse_delta_index
+                    lookup_keys::revision_by_inode_desc_row_key(
+                        *inode_id,
+                        *revision_no,
+                        *committed_seq,
+                        *delta_index,
                     )
                 }
-                _ => {
-                    format!(
-                        "revision-{:020}-{:020}-{:010}",
-                        inode_id.0, revision_no.0, delta_index
-                    )
-                }
+                _ => lookup_keys::revision_row_key(*inode_id, *revision_no, *delta_index),
             },
             Self::Tombstone {
                 root_inode_id,
                 generation,
-                // The action and binding context live in the value: revoke
-                // rows sort exactly like the deletions they cancel, so
-                // newest-per-root scans see them in one prefix pass.
                 ..
-            } => {
-                format!(
-                    "tombstone-{:020}-{:020}-{:010}",
-                    root_inode_id.0, generation.seq.0, generation.delta_index
-                )
-            }
+            } => lookup_keys::tombstone_row_key(*root_inode_id, *generation),
             Self::ActiveDeletion {
                 root_inode_id,
                 deletion_seq,
@@ -520,10 +501,7 @@ impl MetadataRow {
                 committed_seq,
                 commit_id,
                 ..
-            } => {
-                let commit_id = hex_encode_row_key_component(commit_id.as_str());
-                format!("commit-receipt-{commit_id}-{:020}", committed_seq.0)
-            }
+            } => lookup_keys::commit_receipt_row_key(commit_id.as_str(), *committed_seq),
             Self::AttributesRevision {
                 inode_id,
                 attributes_revision_no,
@@ -540,11 +518,11 @@ impl MetadataRow {
     }
 
     /// The exact lookup prefix a point read probes for this row in `family`,
-    /// and therefore the key inserted into the segment's bloom filter. The
-    /// two sides must agree byte-for-byte — a filter is an exact-match
-    /// structure — so both are defined here, next to the row keys they
-    /// shorten. Range scans at coarser granularity (a whole directory, a
-    /// wave of names) do not consult filters.
+    /// and therefore the key inserted into the segment's bloom filter. A
+    /// filter is an exact-match structure, so the probe a reader builds and
+    /// the key a writer stores both come from [`lookup_keys`]. Range scans
+    /// at coarser granularity (a whole directory, a wave of names) do not
+    /// consult filters.
     pub fn filter_key_for_family(&self, family: MetadataRowFamily) -> String {
         match self {
             Self::Inode { .. } => self.row_key_for_family(family),
@@ -555,36 +533,27 @@ impl MetadataRow {
                 ..
             } => match family {
                 MetadataRowFamily::DirentryChildBinds => {
-                    format!("direntry-child-bind-{:020}", child_inode_id.0)
+                    lookup_keys::direntry_child_probe(*child_inode_id)
                 }
-                _ => {
-                    let name_key = hex_encode_row_key_component(name_key.as_str());
-                    format!("direntry-bind-{:020}-{name_key}", parent_inode_id.0)
-                }
+                _ => lookup_keys::direntry_bind_probe(*parent_inode_id, name_key.as_str()),
             },
             Self::DirentryUnbind {
                 parent_inode_id,
                 name_key,
                 ..
-            } => {
-                let name_key = hex_encode_row_key_component(name_key.as_str());
-                format!("direntry-unbind-{:020}-{name_key}", parent_inode_id.0)
-            }
+            } => lookup_keys::direntry_unbind_probe(*parent_inode_id, name_key.as_str()),
             Self::FileRevision { inode_id, .. } => match family {
                 MetadataRowFamily::RevisionsByInodeDesc => {
-                    format!("revision-by-inode-desc-{:020}", inode_id.0)
+                    lookup_keys::revision_by_inode_desc_probe(*inode_id)
                 }
-                _ => format!("revision-{:020}", inode_id.0),
+                _ => lookup_keys::revision_probe(*inode_id),
             },
-            Self::Tombstone { root_inode_id, .. } => {
-                format!("tombstone-{:020}", root_inode_id.0)
-            }
+            Self::Tombstone { root_inode_id, .. } => lookup_keys::tombstone_probe(*root_inode_id),
             // The family is only ever range-scanned in key order, never
             // probed for one deletion, so the filter key is the row key.
             Self::ActiveDeletion { .. } => self.row_key_for_family(family),
             Self::CommitReceipt { commit_id, .. } => {
-                let commit_id = hex_encode_row_key_component(commit_id.as_str());
-                format!("commit-receipt-{commit_id}")
+                lookup_keys::commit_receipt_probe(commit_id.as_str())
             }
             Self::AttributesRevision { inode_id, .. } => lookup_keys::attributes_probe(*inode_id),
         }
@@ -598,14 +567,13 @@ pub fn hex_encode_row_key_component(value: &str) -> String {
     crate::hex::hex_encode_bytes(value.as_bytes())
 }
 
-/// Reader-side lookup grammar: the probes, prefixes, and resume keys that
-/// point lookups and scans build per family. Defined beside
-/// `row_key_for_family` and `filter_key_for_family` because the pairing is
-/// byte-for-byte — a probe must equal the filter key the writer stored, and
-/// a prefix must be a prefix of the row keys it selects. Change a key
-/// format and its lookup grammar together, here.
+/// The metadata row-key grammar: every row key, bloom-filter probe, range
+/// prefix, and resume bound the families use. [`MetadataRow::row_key_for_family`]
+/// and [`MetadataRow::filter_key_for_family`] build their answers from here,
+/// so a probe cannot drift from the filter key the writer stored and a
+/// prefix cannot drift from the row keys it selects.
 pub mod lookup_keys {
-    use super::hex_encode_row_key_component;
+    use super::{hex_encode_row_key_component, TombstoneGeneration};
     use crate::{AttributeRevisionNo, ChangeSeq, InodeId, RevisionNo};
 
     /// The prefix every inode row key starts with. Inode ids are
@@ -621,6 +589,18 @@ pub mod lookup_keys {
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub const REVISION_ROW_PREFIX: &str = "revision-";
+
+    // The remaining family prefixes. No consumer outside this crate scans
+    // these families by prefix, so they stay internal;
+    // `MetadataRowFamily::row_key_prefix` is how the rest of the workspace
+    // asks for one.
+    pub(super) const DIRENTRY_BIND_ROW_PREFIX: &str = "direntry-bind-";
+    pub(super) const DIRENTRY_CHILD_BIND_ROW_PREFIX: &str = "direntry-child-bind-";
+    pub(super) const DIRENTRY_UNBIND_ROW_PREFIX: &str = "direntry-unbind-";
+    pub(super) const REVISION_BY_INODE_DESC_ROW_PREFIX: &str = "revision-by-inode-desc-";
+    pub(super) const TOMBSTONE_ROW_PREFIX: &str = "tombstone-";
+    pub(super) const COMMIT_RECEIPT_ROW_PREFIX: &str = "commit-receipt-";
+    pub(super) const ATTRIBUTE_ROW_PREFIX: &str = "attribute-";
 
     /// Builds the exact point-lookup key for an inode row.
     ///
@@ -641,7 +621,7 @@ pub mod lookup_keys {
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn direntry_parent_prefix(parent_inode_id: InodeId) -> String {
-        format!("direntry-bind-{:020}-", parent_inode_id.0)
+        format!("{DIRENTRY_BIND_ROW_PREFIX}{:020}-", parent_inode_id.0)
     }
 
     /// Builds the bloom-filter probe shared by all generations of one parent/name binding.
@@ -649,8 +629,8 @@ pub mod lookup_keys {
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn direntry_bind_probe(parent_inode_id: InodeId, name_key: &str) -> String {
         format!(
-            "direntry-bind-{:020}-{}",
-            parent_inode_id.0,
+            "{}{}",
+            direntry_parent_prefix(parent_inode_id),
             hex_encode_row_key_component(name_key)
         )
     }
@@ -662,11 +642,27 @@ pub mod lookup_keys {
         format!("{}-", direntry_bind_probe(parent_inode_id, name_key))
     }
 
+    /// Builds the full row key for one generation of a parent/name binding.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn direntry_bind_row_key(
+        parent_inode_id: InodeId,
+        name_key: &str,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+    ) -> String {
+        format!(
+            "{}{:020}-{bind_delta_index:010}",
+            direntry_bind_prefix(parent_inode_id, name_key),
+            bind_seq.0
+        )
+    }
+
     /// Builds the bloom-filter probe shared by bindings that target one child inode.
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn direntry_child_probe(child_inode_id: InodeId) -> String {
-        format!("direntry-child-bind-{:020}", child_inode_id.0)
+        format!("{DIRENTRY_CHILD_BIND_ROW_PREFIX}{:020}", child_inode_id.0)
     }
 
     /// Builds the reverse-index range prefix selecting bindings to one child inode.
@@ -676,13 +672,33 @@ pub mod lookup_keys {
         format!("{}-", direntry_child_probe(child_inode_id))
     }
 
+    /// Builds the full row key one binding generation takes in the by-child
+    /// re-index.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn direntry_child_bind_row_key(
+        child_inode_id: InodeId,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> String {
+        format!(
+            "{}{:020}-{bind_delta_index:010}-{:020}-{}",
+            direntry_child_prefix(child_inode_id),
+            bind_seq.0,
+            parent_inode_id.0,
+            hex_encode_row_key_component(name_key)
+        )
+    }
+
     /// Builds the bloom-filter probe shared by unbinds for one parent/name pair.
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn direntry_unbind_probe(parent_inode_id: InodeId, name_key: &str) -> String {
         format!(
-            "direntry-unbind-{:020}-{}",
-            parent_inode_id.0,
+            "{}{}",
+            direntry_unbind_parent_prefix(parent_inode_id),
             hex_encode_row_key_component(name_key)
         )
     }
@@ -697,10 +713,27 @@ pub mod lookup_keys {
         bind_delta_index: u32,
     ) -> String {
         format!(
-            "{}-{:020}-{:010}-",
-            direntry_unbind_probe(parent_inode_id, name_key),
-            bind_seq.0,
-            bind_delta_index
+            "{}{:020}-{bind_delta_index:010}-",
+            direntry_unbind_name_prefix(parent_inode_id, name_key),
+            bind_seq.0
+        )
+    }
+
+    /// Builds the full row key for one unbind event.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn direntry_unbind_row_key(
+        parent_inode_id: InodeId,
+        name_key: &str,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+        unbind_seq: ChangeSeq,
+        unbind_delta_index: u32,
+    ) -> String {
+        format!(
+            "{}{:020}-{unbind_delta_index:010}",
+            direntry_unbind_binding_prefix(parent_inode_id, name_key, bind_seq, bind_delta_index),
+            unbind_seq.0
         )
     }
 
@@ -708,25 +741,21 @@ pub mod lookup_keys {
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn direntry_unbind_parent_prefix(parent_inode_id: InodeId) -> String {
-        format!("direntry-unbind-{:020}-", parent_inode_id.0)
+        format!("{DIRENTRY_UNBIND_ROW_PREFIX}{:020}-", parent_inode_id.0)
     }
 
     /// Builds the range prefix selecting unbinds for one parent/name pair.
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn direntry_unbind_name_prefix(parent_inode_id: InodeId, name_key: &str) -> String {
-        format!(
-            "{}{}-",
-            direntry_unbind_parent_prefix(parent_inode_id),
-            hex_encode_row_key_component(name_key)
-        )
+        format!("{}-", direntry_unbind_probe(parent_inode_id, name_key))
     }
 
     /// Builds the bloom-filter probe shared by tombstone events for one root inode.
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn tombstone_probe(root_inode_id: InodeId) -> String {
-        format!("tombstone-{:020}", root_inode_id.0)
+        format!("{TOMBSTONE_ROW_PREFIX}{:020}", root_inode_id.0)
     }
 
     /// Builds the range prefix selecting the tombstone history of one root inode.
@@ -734,6 +763,20 @@ pub mod lookup_keys {
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn tombstone_prefix(root_inode_id: InodeId) -> String {
         format!("{}-", tombstone_probe(root_inode_id))
+    }
+
+    /// Builds the full row key for one tombstone event. The event's action
+    /// stays in the value, so a revoke sorts exactly like the deletion it
+    /// cancels and a newest-per-root scan reads both in one prefix pass.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn tombstone_row_key(root_inode_id: InodeId, generation: TombstoneGeneration) -> String {
+        format!(
+            "{}{:020}-{:010}",
+            tombstone_prefix(root_inode_id),
+            generation.seq.0,
+            generation.delta_index
+        )
     }
 
     /// The prefix every active-deletion row key starts with. Deletion
@@ -785,7 +828,10 @@ pub mod lookup_keys {
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn commit_receipt_probe(commit_id: &str) -> String {
-        format!("commit-receipt-{}", hex_encode_row_key_component(commit_id))
+        format!(
+            "{COMMIT_RECEIPT_ROW_PREFIX}{}",
+            hex_encode_row_key_component(commit_id)
+        )
     }
 
     /// Builds the range prefix selecting durable receipts for one commit id.
@@ -795,11 +841,44 @@ pub mod lookup_keys {
         format!("{}-", commit_receipt_probe(commit_id))
     }
 
+    /// Builds the full row key for one commit receipt.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn commit_receipt_row_key(commit_id: &str, committed_seq: ChangeSeq) -> String {
+        format!(
+            "{}{:020}",
+            commit_receipt_prefix(commit_id),
+            committed_seq.0
+        )
+    }
+
+    /// Builds the bloom-filter probe shared by every canonical revision of one inode.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn revision_probe(inode_id: InodeId) -> String {
+        format!("{REVISION_ROW_PREFIX}{:020}", inode_id.0)
+    }
+
+    /// Builds the full canonical revision row key.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn revision_row_key(
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        delta_index: u32,
+    ) -> String {
+        format!(
+            "{}-{:020}-{delta_index:010}",
+            revision_probe(inode_id),
+            revision_no.0
+        )
+    }
+
     /// Builds the bloom-filter probe shared by newest-first revisions of one inode.
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn revision_by_inode_desc_probe(inode_id: InodeId) -> String {
-        format!("revision-by-inode-desc-{:020}", inode_id.0)
+        format!("{REVISION_BY_INODE_DESC_ROW_PREFIX}{:020}", inode_id.0)
     }
 
     /// Builds the range prefix selecting newest-first revisions of one inode.
@@ -834,9 +913,8 @@ pub mod lookup_keys {
         delta_index: u32,
     ) -> String {
         format!(
-            "{}{:020}-{:020}-{:010}",
-            revision_by_inode_desc_prefix(inode_id),
-            u64::MAX - revision_no.0,
+            "{}{:020}-{:010}",
+            revision_by_inode_desc_revision_prefix(inode_id, revision_no),
             u64::MAX - committed_seq.0,
             u32::MAX - delta_index
         )
@@ -847,7 +925,7 @@ pub mod lookup_keys {
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn attributes_probe(inode_id: InodeId) -> String {
-        format!("attribute-{:020}", inode_id.0)
+        format!("{ATTRIBUTE_ROW_PREFIX}{:020}", inode_id.0)
     }
 
     /// Builds the range prefix selecting one inode's attribute revisions,

--- a/crates/loonfs-api/src/public_inode_id.rs
+++ b/crates/loonfs-api/src/public_inode_id.rs
@@ -3,6 +3,7 @@
 //! Public IDs use the form `ino_<number>`. They are scoped to a namespace and
 //! should be treated as identifiers rather than numbers.
 
+use crate::ids::validation_error;
 use crate::InodeId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
@@ -21,25 +22,7 @@ pub const DESCRIPTION: &str = "Stable inode ID within a namespace";
 
 const INVALID_REASON: &str = "must use `ino_` followed by a nonzero u64 without leading zeroes";
 
-/// Explains why a string is not a valid public inode ID.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error("invalid inode id {value:?}: {reason}")]
-pub struct PublicInodeIdError {
-    value: String,
-    reason: String,
-}
-
-impl PublicInodeIdError {
-    /// Returns the rejected input.
-    pub fn value(&self) -> &str {
-        &self.value
-    }
-
-    /// Returns the validation rule that the input failed.
-    pub fn reason(&self) -> &str {
-        &self.reason
-    }
-}
+validation_error!(PublicInodeIdError, "invalid inode id {value:?}: {reason}");
 
 /// Converts an inode ID to its public API string.
 pub fn encode(id: InodeId) -> String {

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -710,14 +710,22 @@ pub struct DeletedObjectCounts {
 }
 
 impl DeletedObjectCounts {
-    /// Adds counts from another pass.
+    /// Adds counts from another pass. Exhaustive so a new field cannot escape the sum.
     pub fn add(&mut self, other: &Self) {
-        self.wal_segments += other.wal_segments;
-        self.metadata_segments += other.metadata_segments;
-        self.manifests += other.manifests;
-        self.checkpoint_records += other.checkpoint_records;
-        self.upload_sessions += other.upload_sessions;
-        self.content_objects += other.content_objects;
+        let Self {
+            wal_segments,
+            metadata_segments,
+            manifests,
+            checkpoint_records,
+            upload_sessions,
+            content_objects,
+        } = other;
+        self.wal_segments += wal_segments;
+        self.metadata_segments += metadata_segments;
+        self.manifests += manifests;
+        self.checkpoint_records += checkpoint_records;
+        self.upload_sessions += upload_sessions;
+        self.content_objects += content_objects;
     }
 }
 
@@ -741,11 +749,16 @@ pub struct ReleasedCheckpointCounts {
 }
 
 impl ReleasedCheckpointCounts {
-    /// Adds counts from another pass.
+    /// Adds counts from another pass. Exhaustive so a new field cannot escape the sum.
     pub fn add(&mut self, other: &Self) {
-        self.fork += other.fork;
-        self.expired += other.expired;
-        self.missing_basis += other.missing_basis;
+        let Self {
+            fork,
+            expired,
+            missing_basis,
+        } = other;
+        self.fork += fork;
+        self.expired += expired;
+        self.missing_basis += missing_basis;
     }
 }
 
@@ -862,34 +875,59 @@ impl RetainedReason {
 
 impl RetainedCandidates {
     /// Every reason and its count, in a fixed order, for callers that
-    /// report the breakdown rather than read one field of it.
+    /// report the breakdown rather than read one field of it. The labels are the serialized field
+    /// names; exhaustive so a new field cannot escape the breakdown.
     pub fn by_reason(&self) -> [(&'static str, u64); 10] {
+        let Self {
+            referenced,
+            within_grace_window,
+            no_provider_timestamp,
+            no_reference_manifest,
+            degraded_roots,
+            unrecognized_key,
+            checkpoint_not_releasable,
+            upload_session_window,
+            upload_session_undecided,
+            content_scan_deferred,
+        } = *self;
         [
-            ("referenced", self.referenced),
-            ("within_grace_window", self.within_grace_window),
-            ("no_provider_timestamp", self.no_provider_timestamp),
-            ("no_reference_manifest", self.no_reference_manifest),
-            ("degraded_roots", self.degraded_roots),
-            ("unrecognized_key", self.unrecognized_key),
-            ("checkpoint_not_releasable", self.checkpoint_not_releasable),
-            ("upload_session_window", self.upload_session_window),
-            ("upload_session_undecided", self.upload_session_undecided),
-            ("content_scan_deferred", self.content_scan_deferred),
+            ("referenced", referenced),
+            ("within_grace_window", within_grace_window),
+            ("no_provider_timestamp", no_provider_timestamp),
+            ("no_reference_manifest", no_reference_manifest),
+            ("degraded_roots", degraded_roots),
+            ("unrecognized_key", unrecognized_key),
+            ("checkpoint_not_releasable", checkpoint_not_releasable),
+            ("upload_session_window", upload_session_window),
+            ("upload_session_undecided", upload_session_undecided),
+            ("content_scan_deferred", content_scan_deferred),
         ]
     }
 
-    /// Folds another pass's breakdown into this one.
+    /// Folds another pass's breakdown into this one. Exhaustive so a new field cannot escape the sum.
     pub fn add(&mut self, other: &Self) {
-        self.referenced += other.referenced;
-        self.within_grace_window += other.within_grace_window;
-        self.no_provider_timestamp += other.no_provider_timestamp;
-        self.no_reference_manifest += other.no_reference_manifest;
-        self.degraded_roots += other.degraded_roots;
-        self.unrecognized_key += other.unrecognized_key;
-        self.checkpoint_not_releasable += other.checkpoint_not_releasable;
-        self.upload_session_window += other.upload_session_window;
-        self.upload_session_undecided += other.upload_session_undecided;
-        self.content_scan_deferred += other.content_scan_deferred;
+        let Self {
+            referenced,
+            within_grace_window,
+            no_provider_timestamp,
+            no_reference_manifest,
+            degraded_roots,
+            unrecognized_key,
+            checkpoint_not_releasable,
+            upload_session_window,
+            upload_session_undecided,
+            content_scan_deferred,
+        } = other;
+        self.referenced += referenced;
+        self.within_grace_window += within_grace_window;
+        self.no_provider_timestamp += no_provider_timestamp;
+        self.no_reference_manifest += no_reference_manifest;
+        self.degraded_roots += degraded_roots;
+        self.unrecognized_key += unrecognized_key;
+        self.checkpoint_not_releasable += checkpoint_not_releasable;
+        self.upload_session_window += upload_session_window;
+        self.upload_session_undecided += upload_session_undecided;
+        self.content_scan_deferred += content_scan_deferred;
     }
 
     /// The reason with the highest count, and that count. `None` when

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -710,7 +710,7 @@ pub struct DeletedObjectCounts {
 }
 
 impl DeletedObjectCounts {
-    /// Adds counts from another pass. Exhaustive so a new field cannot escape the sum.
+    /// Adds counts from another pass.
     pub fn add(&mut self, other: &Self) {
         let Self {
             wal_segments,
@@ -749,7 +749,7 @@ pub struct ReleasedCheckpointCounts {
 }
 
 impl ReleasedCheckpointCounts {
-    /// Adds counts from another pass. Exhaustive so a new field cannot escape the sum.
+    /// Adds counts from another pass.
     pub fn add(&mut self, other: &Self) {
         let Self {
             fork,
@@ -874,9 +874,7 @@ impl RetainedReason {
 }
 
 impl RetainedCandidates {
-    /// Every reason and its count, in a fixed order, for callers that
-    /// report the breakdown rather than read one field of it. The labels are the serialized field
-    /// names; exhaustive so a new field cannot escape the breakdown.
+    /// Returns every reason and count in a fixed order.
     pub fn by_reason(&self) -> [(&'static str, u64); 10] {
         let Self {
             referenced,
@@ -904,7 +902,7 @@ impl RetainedCandidates {
         ]
     }
 
-    /// Folds another pass's breakdown into this one. Exhaustive so a new field cannot escape the sum.
+    /// Adds counts from another pass.
     pub fn add(&mut self, other: &Self) {
         let Self {
             referenced,


### PR DESCRIPTION
Moves metadata row keys, lookup prefixes, and Bloom filter probes into one set of builders so readers and writers use the same durable format.

Also replaces handwritten ActorId, ContentId, and public inode error code with existing macros, shares lowercase hex validation, and makes GC counter aggregation exhaustive. OpenAPI and durable bytes are unchanged.