### PR TITLE
refactor(server): centralize errors, pagination, and telemetry

### DIFF
--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -24,8 +24,6 @@ pub struct GrepRequest {
     /// bound to that page's request; each page is evaluated against the
     /// namespace head at page time.
     pub cursor: Option<String>,
-    /// Maximum matches per page.
-    pub limit: Option<u32>,
     /// When the unindexed tail exceeds the scan budget, return
     /// indexed-only results (reported via `tail_scanned: false`) instead
     /// of failing with `index_lagging`.

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -33,9 +33,7 @@ pub enum UploadMode {
 }
 
 impl UploadMode {
-    /// Returns the mode's wire spelling, the one `rename_all` above serializes.
-    /// Messages that quote a mode back to a client read it from here so they
-    /// cannot name a spelling the API no longer accepts.
+    /// Returns the serialized value.
     pub fn as_str(self) -> &'static str {
         match self {
             Self::ServiceProxied => "service_proxied",

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -32,6 +32,19 @@ pub enum UploadMode {
     DirectMultipart,
 }
 
+impl UploadMode {
+    /// Returns the mode's wire spelling, the one `rename_all` above serializes.
+    /// Messages that quote a mode back to a client read it from here so they
+    /// cannot name a spelling the API no longer accepts.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ServiceProxied => "service_proxied",
+            Self::DirectPut => "direct_put",
+            Self::DirectMultipart => "direct_multipart",
+        }
+    }
+}
+
 /// Request to start an upload session, tagged by transport mode.
 ///
 /// Each variant contains only fields valid for that transport, so invalid

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -333,10 +333,11 @@ impl ResolvedTarget {
         &self,
         namespace_id: &NamespaceId,
         request: &GrepRequest,
+        limit: Option<u32>,
     ) -> Result<GrepResponse, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.grep(namespace_id, request).await,
-            Self::Remote(target) => Ok(target.client.grep(namespace_id, request).await?),
+            Self::Embedded(target) => target.backend.grep(namespace_id, request, limit).await,
+            Self::Remote(target) => Ok(target.client.grep(namespace_id, request, limit).await?),
         }
     }
 

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -287,11 +287,12 @@ impl EmbeddedBackend {
         &self,
         namespace_id: &NamespaceId,
         request: &GrepRequest,
+        limit: Option<u32>,
     ) -> Result<GrepResponse, BackendError> {
         let store = self.writer.object_store();
         let reads = NamespaceReads::new(&self.reader, namespace_id);
         self.grep
-            .query(request, &reads, &store)
+            .query(request, resolve_cli_page_limit(limit)?, &reads, &store)
             .await
             .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))
     }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -350,7 +350,6 @@ pub(crate) async fn run_filesystem_grep(
         case_insensitive: args.ignore_case,
         path_prefix,
         cursor: args.cursor.clone(),
-        limit: None,
         allow_stale: args.allow_stale,
         allow_scan: args.allow_scan,
     };
@@ -360,10 +359,9 @@ pub(crate) async fn run_filesystem_grep(
     let stdout = io::stdout();
     let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
     let (namespace_id, head_seq, built_through_seq, next_cursor) = loop {
-        request.limit = plan.request_size();
         let response = context
             .target
-            .grep(&context.namespace, &request)
+            .grep(&context.namespace, &request, plan.request_size())
             .await
             .map_err(|error| context.fail(kind, error))?;
         let snapshot = (

--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -177,6 +177,7 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         request: &GrepRequest,
+        limit: Option<u32>,
     ) -> Result<GrepResponse> {
         let mut url = format!("{}/v0/namespaces/{namespace_id}/grep", self.base_url);
         let mut has_query = false;
@@ -210,7 +211,7 @@ impl Client {
         append_optional_pagination_query(
             &mut url,
             &mut has_query,
-            request.limit,
+            limit,
             request.cursor.as_deref(),
         );
         self.request_json::<(), _>(self.get(&url), None).await

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -23,8 +23,8 @@ use loonfs_api::wire::sst_blocks::{
     decode_filter_block, index_blocks_for_key_range, string_prefix_upper_bound, BlockHandle,
 };
 use loonfs_api::{
-    decode_cursor, encode_cursor, AbsolutePath, ChangeSeq, ErrorCode, GrepMatch, GrepPageCursor,
-    GrepRequest, GrepResponse, InodeId, InodeKind, NamespaceId, PaginationPolicy, PathEntry,
+    decode_cursor, encode_cursor, AbsolutePath, ChangeSeq, EffectiveLimit, ErrorCode, GrepMatch,
+    GrepPageCursor, GrepRequest, GrepResponse, InodeId, InodeKind, NamespaceId, PathEntry,
     RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
@@ -654,14 +654,12 @@ impl GrepService {
     pub async fn query<S: ObjectStore>(
         &self,
         request: &GrepRequest,
+        limit: EffectiveLimit,
         reads: &NamespaceReads<'_>,
         store: &S,
     ) -> Result<GrepResponse> {
         let head_seq = reads.head_seq().await?;
-        let limit = PaginationPolicy::default()
-            .resolve_limit(request.limit)
-            .map_err(|error| CoreError::InvalidQuery(error.to_string()))?
-            .as_usize();
+        let limit = limit.as_usize();
         let fingerprint = request.fingerprint();
         let resume = match &request.cursor {
             Some(cursor) => {

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -249,14 +249,12 @@ pub(crate) async fn grep_with(
     service.query(request, limit, &reads, store).await
 }
 
-/// The page size for a test that is not about paging.
 pub(crate) fn default_page_limit() -> EffectiveLimit {
     PaginationPolicy::default()
         .resolve_limit(None)
         .expect("the pagination policy should accept its own default")
 }
 
-/// A page size for a test that is about paging.
 pub(crate) fn page_limit(matches: u32) -> EffectiveLimit {
     PaginationPolicy::default()
         .resolve_limit(Some(matches))

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -9,7 +9,9 @@
 
 use loonfs::{FsAdmin, FsReader, MaintenanceJob, MaintenanceStepConclusion, SharedObjectStore};
 use loonfs_api::v0::{GrepIndex, GrepIndexLifecycle};
-use loonfs_api::{ChangeSeq, GrepRequest, GrepResponse, NamespaceId, RunNo};
+use loonfs_api::{
+    ChangeSeq, EffectiveLimit, GrepRequest, GrepResponse, NamespaceId, PaginationPolicy, RunNo,
+};
 use loonfs_grep::root::GrepIndexStatus;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBlockCache, GrepDisableOutcome, GrepEnableOutcome, GrepError,
@@ -60,6 +62,7 @@ impl GrepHost {
         &self,
         namespace_id: &NamespaceId,
         request: &GrepRequest,
+        limit: EffectiveLimit,
     ) -> Result<GrepResponse, GrepError> {
         grep_with(
             &self.service,
@@ -67,6 +70,7 @@ impl GrepHost {
             &self.store,
             namespace_id,
             request,
+            limit,
         )
         .await
     }
@@ -239,9 +243,24 @@ pub(crate) async fn grep_with(
     store: &SharedObjectStore,
     namespace_id: &NamespaceId,
     request: &GrepRequest,
+    limit: EffectiveLimit,
 ) -> Result<GrepResponse, GrepError> {
     let reads = NamespaceReads::new(reader, namespace_id);
-    service.query(request, &reads, store).await
+    service.query(request, limit, &reads, store).await
+}
+
+/// The page size for a test that is not about paging.
+pub(crate) fn default_page_limit() -> EffectiveLimit {
+    PaginationPolicy::default()
+        .resolve_limit(None)
+        .expect("the pagination policy should accept its own default")
+}
+
+/// A page size for a test that is about paging.
+pub(crate) fn page_limit(matches: u32) -> EffectiveLimit {
+    PaginationPolicy::default()
+        .resolve_limit(Some(matches))
+        .expect("test page limits should be within the pagination policy")
 }
 
 /// Classifies a key by durable family instead of by its spelling, so the

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -3,16 +3,14 @@
 
 //! Tests grep through runtime handles and direct `GrepWorker` operations.
 
-use crate::common::{is_content_object, GrepHost};
+use crate::common::{default_page_limit, is_content_object, page_limit, GrepHost};
 use loonfs::publish::{CommitRequest, FilesystemOperation};
 use loonfs::{
     ChangeSeq, CommitId, CreateNamespaceOptions, DestinationBehavior, ErrorCode, FsWriter,
     NamespaceId, PutFileOptions, SharedObjectStore,
 };
 use loonfs_api::v0::GrepIndexLifecycle;
-use loonfs_api::{
-    decode_cursor, AbsolutePath, GrepPageCursor, GrepRequest, DEFAULT_MAX_PAGE_LIMIT,
-};
+use loonfs_api::{decode_cursor, AbsolutePath, GrepPageCursor, GrepRequest};
 use loonfs_grep::codec::INDEX_GRAMS_MAX_FILE_BYTES;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepReorganizeOutcome, GrepWorker,
@@ -33,7 +31,6 @@ fn request(pattern: &str) -> GrepRequest {
         case_insensitive: false,
         path_prefix: None,
         cursor: None,
-        limit: None,
         allow_stale: false,
         allow_scan: false,
     }
@@ -120,24 +117,9 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .await
         .expect("write bravo");
 
-    // Request validation precedes feature materialization; snapshot
-    // construction must preserve that error ordering.
-    for limit in [0, DEFAULT_MAX_PAGE_LIMIT + 1] {
-        let mut invalid_limit = request("needle");
-        invalid_limit.limit = Some(limit);
-        let error = host
-            .grep(&namespace_id, &invalid_limit)
-            .await
-            .expect_err("invalid limit must win before the missing feature");
-        let GrepError::Runtime(core) = &error else {
-            panic!("expected a grep core passthrough, got {error:?}");
-        };
-        assert_eq!(core.code(), ErrorCode::InvalidRequest);
-    }
-
     // Before enablement, grep names the missing data half.
     let error = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect_err("grep without the feature must be refused");
     assert!(matches!(error, GrepError::NotEnabled));
@@ -156,7 +138,7 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
     }
 
     let response = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect("grep after steps");
     assert_eq!(response.matches.len(), 1);
@@ -174,13 +156,13 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .await
         .expect("write charlie");
     let response = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect("grep with tail");
     assert_eq!(response.matches.len(), 2);
     drive_worker_step(&host.worker, &namespace_id, GramIndexBuildPolicy::default()).await;
     let response = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect("grep after catch-up step");
     assert_eq!(response.matches.len(), 2);
@@ -192,7 +174,7 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .expect("disable");
     assert_eq!(disabled.lifecycle, GrepIndexLifecycle::Disabled);
     let error = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect_err("grep after disable must be refused");
     assert!(matches!(error, GrepError::NotEnabled));
@@ -251,7 +233,7 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
         loonfs_grep::root::GrepIndexStatus::Backfilling { .. }
     ));
     let error = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect_err("background metadata work must not materialize grep");
     assert!(matches!(error, GrepError::Backfilling));
@@ -265,7 +247,7 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
     let mut stale = request("needle");
     stale.allow_stale = true;
     let response = host
-        .grep(&namespace_id, &stale)
+        .grep(&namespace_id, &stale, default_page_limit())
         .await
         .expect("stale grep after explicit worker catch-up");
     assert_eq!(response.matches.len(), 1);
@@ -558,11 +540,10 @@ async fn collect_grep_paths(
     pattern: &str,
 ) -> BTreeSet<String> {
     let mut request = request(pattern);
-    request.limit = Some(1_000);
     let mut paths = BTreeSet::new();
     loop {
         let response = host
-            .grep(namespace_id, &request)
+            .grep(namespace_id, &request, page_limit(1_000))
             .await
             .expect("grep bounded atomic commit");
         paths.extend(
@@ -615,7 +596,7 @@ async fn grep_answers_identically_across_tiered_reorganizations() {
         expected_paths.push(path);
 
         let response = host
-            .grep(&namespace_id, &request("needle"))
+            .grep(&namespace_id, &request("needle"), default_page_limit())
             .await
             .expect("grep");
         let mut matched: Vec<String> = response
@@ -701,7 +682,7 @@ async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
 
     let before_first = raw_store.count(OperationClass::Read);
     let first = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect("first grep");
     assert_eq!(first.matches.len(), 1);
@@ -712,7 +693,7 @@ async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
     );
 
     let second = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect("second grep");
     assert_eq!(second.matches, first.matches);
@@ -780,7 +761,7 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
         drive_worker_step(&host.worker, &namespace_id, GramIndexBuildPolicy::default()).await;
     }
     let healthy = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect("grep before the fault");
     assert_eq!(healthy.matches.len(), 3);
@@ -794,7 +775,7 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
     // An unlimited page walks past alpha into bravo, so the failed read
     // fails that page, exactly as the serial scan did.
     let error = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect_err("a reached candidate's failed read must fail its page");
     let GrepError::Runtime(core) = &error else {
@@ -805,10 +786,9 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
     // With a one-match limit, alpha's second match fills the page before
     // the walk reaches bravo: the speculative failed read is discarded and
     // the full page comes back with a cursor.
-    let mut first_page = request("needle");
-    first_page.limit = Some(1);
+    let first_page = request("needle");
     let response = host
-        .grep(&namespace_id, &first_page)
+        .grep(&namespace_id, &first_page, page_limit(1))
         .await
         .expect("a page that fills before the failed candidate must succeed");
     assert_eq!(response.matches.len(), 1);
@@ -821,10 +801,9 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
     // The next page's walk reaches bravo and surfaces the read error at
     // the position the serial scan would have.
     let mut second_page = request("needle");
-    second_page.limit = Some(1);
     second_page.cursor = Some(cursor);
     let error = host
-        .grep(&namespace_id, &second_page)
+        .grep(&namespace_id, &second_page, page_limit(1))
         .await
         .expect_err("the deferred read error must surface on the next page");
     let GrepError::Runtime(core) = &error else {
@@ -907,10 +886,9 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
 
     raw_store.reset();
 
-    let mut first_page = request("needle");
-    first_page.limit = Some(1);
+    let first_page = request("needle");
     let page_one = host
-        .grep(&namespace_id, &first_page)
+        .grep(&namespace_id, &first_page, page_limit(1))
         .await
         .expect("first page");
     assert_eq!(page_one.matches.len(), 1);
@@ -930,10 +908,9 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
     assert_eq!(cursor.last_byte_offset, u64::MAX);
 
     let mut second_page = request("needle");
-    second_page.limit = Some(1);
     second_page.cursor = Some(cursor_token);
     let page_two = host
-        .grep(&namespace_id, &second_page)
+        .grep(&namespace_id, &second_page, page_limit(1))
         .await
         .expect("second page");
     assert_eq!(page_two.matches.len(), 1);
@@ -1032,7 +1009,7 @@ async fn worker_and_service_share_decoded_index_blocks() {
 
     let gets_before_query = raw_store.count(OperationClass::Read);
     let result = host
-        .grep(&namespace_id, &request("needle"))
+        .grep(&namespace_id, &request("needle"), default_page_limit())
         .await
         .expect("grep after worker load");
     assert_eq!(result.matches.len(), 8);

--- a/crates/loonfs-grep/tests/it/grep_service_differential.rs
+++ b/crates/loonfs-grep/tests/it/grep_service_differential.rs
@@ -3,14 +3,14 @@
 
 //! Frozen full-pipeline `GrepService` query semantics and budgets.
 
-use crate::common::{control, grep_with, GrepHost};
+use crate::common::{control, default_page_limit, grep_with, page_limit, GrepHost};
 use loonfs::publish::{CommitCandidate, CommitRequest, FilesystemOperation};
 use loonfs::{
     CommitId, CoreError, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions,
     DestinationBehavior, FsAdmin, FsReader, FsWriter, MaintenancePlan, MetadataMaintenanceOptions,
     MoveOptions, NamespaceId, PutFileOptions, SharedObjectStore,
 };
-use loonfs_api::{AbsolutePath, GrepRequest, GrepResponse};
+use loonfs_api::{AbsolutePath, EffectiveLimit, GrepRequest, GrepResponse};
 use loonfs_grep::root::load_grep_root;
 use loonfs_grep::GramIndexBuildPolicy;
 use loonfs_grep::{GrepBuildOutcome, GrepReorganizeOutcome, GrepService, GrepWorker};
@@ -26,7 +26,6 @@ fn request(pattern: &str) -> GrepRequest {
         case_insensitive: false,
         path_prefix: None,
         cursor: None,
-        limit: None,
         allow_stale: false,
         allow_scan: false,
     }
@@ -56,12 +55,21 @@ impl ServiceHarness {
     }
 
     async fn result(&self, grep_request: &GrepRequest) -> loonfs_grep::Result<GrepResponse> {
+        self.page(grep_request, default_page_limit()).await
+    }
+
+    async fn page(
+        &self,
+        grep_request: &GrepRequest,
+        limit: EffectiveLimit,
+    ) -> loonfs_grep::Result<GrepResponse> {
         grep_with(
             &self.service,
             &self.reader,
             &self.store,
             &self.namespace_id,
             grep_request,
+            limit,
         )
         .await
     }
@@ -567,15 +575,15 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
     assert!(empty.next_cursor.is_none());
 
     let mut paged_request = request("budget-needle");
-    paged_request.limit = Some(17);
     let mut pages = 0usize;
     let mut matches = 0usize;
     let mut matched_paths = BTreeSet::new();
     let mut cursors = BTreeSet::new();
     loop {
         let page = harness
-            .success("multi-page cursor walk", &paged_request)
-            .await;
+            .page(&paged_request, page_limit(17))
+            .await
+            .expect("multi-page cursor walk");
         pages += 1;
         matches += page.matches.len();
         assert_eq!(page.namespace_id, namespace_id);

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -3,7 +3,7 @@
 
 //! GrepWorker lifecycle, rebootstrap, query contracts, and GC boundaries.
 
-use crate::common::{control, grep_with, GrepHost};
+use crate::common::{control, default_page_limit, grep_with, page_limit, GrepHost};
 use bytes::Bytes;
 use loonfs::{
     CoreError, CreateNamespaceOptions, DeleteNamespaceOptions, ErrorCode, FsAdmin, FsReader,
@@ -12,8 +12,8 @@ use loonfs::{
 };
 use loonfs_api::wire::control::{CheckpointOwner, CheckpointStatus};
 use loonfs_api::{
-    sha256_digest, AbsolutePath, ChangeSeq, GrepRequest, GrepResponse, IndexSegmentId, PageRequest,
-    PaginationPolicy, RunNo, MAX_PUBLIC_INTEGER,
+    sha256_digest, AbsolutePath, ChangeSeq, EffectiveLimit, GrepRequest, GrepResponse,
+    IndexSegmentId, PageRequest, PaginationPolicy, RunNo, MAX_PUBLIC_INTEGER,
 };
 use loonfs_grep::keyspace::{
     grep_prefix, manifest_key, manifests_prefix, root_key, segment_key, segments_prefix,
@@ -50,7 +50,6 @@ fn request(pattern: &str) -> GrepRequest {
         case_insensitive: false,
         path_prefix: None,
         cursor: None,
-        limit: None,
         allow_stale: false,
         allow_scan: false,
     }
@@ -90,6 +89,15 @@ async fn new_query(
     namespace_id: &NamespaceId,
     grep_request: &GrepRequest,
 ) -> loonfs_grep::Result<GrepResponse> {
+    new_query_page(store, namespace_id, grep_request, default_page_limit()).await
+}
+
+async fn new_query_page(
+    store: &SharedObjectStore,
+    namespace_id: &NamespaceId,
+    grep_request: &GrepRequest,
+    limit: EffectiveLimit,
+) -> loonfs_grep::Result<GrepResponse> {
     let reader = FsReader::builder_with_store(store.clone())
         .build()
         .await
@@ -100,6 +108,7 @@ async fn new_query(
         store,
         namespace_id,
         grep_request,
+        limit,
     )
     .await
 }
@@ -1536,11 +1545,10 @@ async fn grep_worker_pins_reorganized_tail_and_pagination_results() {
     assert_eq!(error.code(), ErrorCode::PathNotFound);
 
     let mut page_request = request("shared needle");
-    page_request.limit = Some(1);
     let mut found_matches = BTreeSet::new();
     let mut cursors = BTreeSet::new();
     loop {
-        let page = new_query(&store, &namespace_id, &page_request)
+        let page = new_query_page(&store, &namespace_id, &page_request, page_limit(1))
             .await
             .expect("query page");
         assert_eq!(page.namespace_id, namespace_id);

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -21,8 +21,6 @@ pub(super) struct ApiResponseError {
 }
 
 impl ApiResponseError {
-    /// Builds the envelope for `code`. The status is derived from the code,
-    /// so no caller can serve a status the registry disagrees with.
     pub(super) fn new(code: ErrorCode, message: &str) -> Self {
         let response = Self {
             status: status_for_core_error_code(code),

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -21,9 +21,11 @@ pub(super) struct ApiResponseError {
 }
 
 impl ApiResponseError {
-    pub(super) fn new(status: StatusCode, code: ErrorCode, message: &str) -> Self {
+    /// Builds the envelope for `code`. The status is derived from the code,
+    /// so no caller can serve a status the registry disagrees with.
+    pub(super) fn new(code: ErrorCode, message: &str) -> Self {
         let response = Self {
-            status,
+            status: status_for_core_error_code(code),
             code,
             body: Box::new(ApiError {
                 code: code.as_str().to_owned(),
@@ -43,11 +45,7 @@ impl ApiResponseError {
     }
 
     pub(super) fn not_supported(feature: &str, message: &str) -> Self {
-        let mut response = Self::new(
-            StatusCode::NOT_IMPLEMENTED,
-            ErrorCode::NotSupported,
-            message,
-        );
+        let mut response = Self::new(ErrorCode::NotSupported, message);
         response.body.feature = Some(feature.to_owned());
         response
     }
@@ -94,19 +92,14 @@ impl ApiResponseError {
     }
 
     pub(super) fn invalid_namespace_id(error: NamespaceIdValidationError) -> Self {
-        Self::new(
-            StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidRequest,
-            &error.to_string(),
-        )
-        .with_param("namespace_id")
+        Self::new(ErrorCode::InvalidRequest, &error.to_string()).with_param("namespace_id")
     }
 
     pub(super) fn runtime(error: RuntimeError) -> Self {
         let code = error.code();
         let details = error.details();
         let message = error.public_message();
-        let mut response = Self::new(status_for_core_error_code(code), code, &message);
+        let mut response = Self::new(code, &message);
         response.body.details = details.map(Box::new);
         response
     }
@@ -114,7 +107,6 @@ impl ApiResponseError {
     pub(super) fn runtime_for_namespace(namespace_id: &NamespaceId, error: RuntimeError) -> Self {
         if error.code() == ErrorCode::NamespaceNotFound {
             return Self::new(
-                StatusCode::NOT_FOUND,
                 ErrorCode::NamespaceNotFound,
                 &format!("namespace `{}` does not exist", namespace_id.as_str()),
             );
@@ -189,9 +181,7 @@ mod tests {
     #[test]
     fn every_immediately_retryable_code_answers_with_retry_after() {
         for code in ErrorCode::ALL {
-            let response =
-                ApiResponseError::new(status_for_core_error_code(code), code, "test response")
-                    .into_response();
+            let response = ApiResponseError::new(code, "test response").into_response();
             assert_eq!(
                 response.extensions().get::<ServedErrorCode>(),
                 Some(&ServedErrorCode(code)),

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -20,7 +20,6 @@ use tokio::sync::OwnedSemaphorePermit;
 /// `shutting_down` (drain) and `commit_queue_full` (publisher backpressure).
 pub(super) fn server_busy_error(what: &str) -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::SERVICE_UNAVAILABLE,
         ErrorCode::ServerBusy,
         &format!("the server is at its concurrency limit for {what}; retry shortly"),
     )
@@ -56,7 +55,6 @@ pub(super) fn authorize(
         Ok(())
     } else {
         Err(ApiResponseError::new(
-            StatusCode::UNAUTHORIZED,
             ErrorCode::Unauthorized,
             "missing or invalid bearer token",
         ))
@@ -115,7 +113,6 @@ where
 
 fn invalid_path_params(rejection: &PathRejection) -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::BAD_REQUEST,
         ErrorCode::InvalidRequest,
         &format!("invalid path parameters: {rejection}"),
     )
@@ -184,7 +181,6 @@ where
         serde_urlencoded::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
     serde_path_to_error::deserialize(deserializer).map_err(|error| {
         let response = ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &format!("invalid query parameters: {}", error.inner()),
         );
@@ -227,7 +223,6 @@ where
         }
         Err(rejection) => {
             return Err(ApiResponseError::new(
-                StatusCode::BAD_REQUEST,
                 ErrorCode::InvalidRequest,
                 &rejection.body_text(),
             ));
@@ -245,7 +240,6 @@ where
         let param = json_pointer(error.path())
             .and_then(|pointer| refine_internally_tagged_path(body, pointer));
         let response = ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &format!("invalid JSON request body: {}", error.inner()),
         );
@@ -258,7 +252,6 @@ where
     // single field can be blamed for, so this arm carries no param.
     deserializer.end().map_err(|error| {
         ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &format!("invalid JSON request body: {error}"),
         )
@@ -404,7 +397,6 @@ where
             Err(body_too_large)
         }
         Err(rejection) => Err(ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &format!("request body unreadable: {}", rejection.body_text()),
         )),
@@ -527,7 +519,6 @@ impl UploadStreamOutcome {
         {
             Some(UploadStreamAbort::TooLarge) => Some(upload_body_too_large_error()),
             Some(UploadStreamAbort::Unreadable(error)) => Some(ApiResponseError::new(
-                StatusCode::BAD_REQUEST,
                 ErrorCode::InvalidRequest,
                 &format!("request body unreadable: {error}"),
             )),
@@ -581,7 +572,6 @@ fn declared_content_length(headers: &HeaderMap) -> Option<u64> {
 /// and the optional `direct_put` path that bypasses proxied buffering.
 fn upload_body_too_large_error() -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::PAYLOAD_TOO_LARGE,
         ErrorCode::ContentTooLarge,
         "request body exceeds this deployment's limit; check the \
          `upload.max_content_bytes` capability limit, and use `direct_put` \
@@ -592,7 +582,6 @@ fn upload_body_too_large_error() -> ApiResponseError {
 /// 413 for ordinary JSON routes that retain the framework's default bound.
 fn json_body_too_large_error() -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::PAYLOAD_TOO_LARGE,
         ErrorCode::ContentTooLarge,
         "JSON request body exceeds this route's body limit",
     )
@@ -601,7 +590,6 @@ fn json_body_too_large_error() -> ApiResponseError {
 /// Returns a 413 error for an upload request that exceeds its route's limit.
 fn upload_control_body_too_large_error(max_bytes: usize) -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::PAYLOAD_TOO_LARGE,
         ErrorCode::ContentTooLarge,
         &format!("upload-control request body exceeds this route's limit of {max_bytes} bytes"),
     )
@@ -610,7 +598,6 @@ fn upload_control_body_too_large_error(max_bytes: usize) -> ApiResponseError {
 /// Returns a 413 error when optional JSON exceeds its body-size limit.
 fn optional_json_body_too_large_error() -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::PAYLOAD_TOO_LARGE,
         ErrorCode::ContentTooLarge,
         &format!(
             "JSON request body exceeds this route's limit of {MAX_OPTIONAL_JSON_BODY_BYTES} bytes"

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -638,9 +638,6 @@ pub(super) fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseEr
     parse_public_ordinal("revision_no", value, RevisionNo::parse)
 }
 
-/// One template for a rejected path id: names the parameter, echoes the
-/// rejected input, and states the rule it broke. `Debug` on the value quotes
-/// and escapes it, so hostile path bytes cannot mangle a log line.
 pub(super) fn invalid_path_id_error(name: &str, value: &str, reason: &str) -> ApiResponseError {
     ApiResponseError::new(
         ErrorCode::InvalidRequest,

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -18,7 +18,7 @@ use futures::Stream;
 use loonfs::publish::{CommitCandidate, CommitRequest, ContentPreparationError};
 use loonfs::{
     payload_class, ErrorCode, ListChangesOptions, ListPathEntriesOptions, StatPathOptions,
-    TraceStoreKind,
+    TraceMode, TraceStoreKind,
 };
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -522,7 +522,7 @@ pub(super) async fn create_commit(
         let span = tracing::debug_span!(
             "loonfs.put",
             operation = "put",
-            mode = "remote",
+            mode = TraceMode::Remote.as_str(),
             store_kind = TraceStoreKind::from(state.config.store.kind()).as_str(),
             payload_class,
         );
@@ -611,7 +611,6 @@ pub(super) fn required_query_param(
 ) -> Result<String, ApiResponseError> {
     value.ok_or_else(|| {
         ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &format!("missing required query parameter `{name}`"),
         )
@@ -628,7 +627,6 @@ pub(super) fn parse_boolean_query_param(value: &str, name: &str) -> Result<bool,
         "true" => Ok(true),
         "false" => Ok(false),
         other => Err(ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &format!("invalid {name} `{other}`: expected `true` or `false`"),
         )
@@ -638,6 +636,17 @@ pub(super) fn parse_boolean_query_param(value: &str, name: &str) -> Result<bool,
 
 pub(super) fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
     parse_public_ordinal("revision_no", value, RevisionNo::parse)
+}
+
+/// One template for a rejected path id: names the parameter, echoes the
+/// rejected input, and states the rule it broke. `Debug` on the value quotes
+/// and escapes it, so hostile path bytes cannot mangle a log line.
+pub(super) fn invalid_path_id_error(name: &str, value: &str, reason: &str) -> ApiResponseError {
+    ApiResponseError::new(
+        ErrorCode::InvalidRequest,
+        &format!("invalid {name} {value:?}: {reason}"),
+    )
+    .with_param(name)
 }
 
 pub(super) fn parse_public_ordinal<T>(
@@ -657,7 +666,6 @@ fn public_ordinal_response_error(
     error: PublicOrdinalRangeError,
 ) -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::BAD_REQUEST,
         ErrorCode::InvalidRequest,
         &format!("invalid {name} `{value}`: {error}"),
     )
@@ -676,7 +684,6 @@ pub(super) fn resolve_page_limit(
 fn parse_page_limit(value: &str) -> Result<u32, ApiResponseError> {
     value.parse::<u32>().map_err(|error| {
         ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &format!("invalid limit `{value}`: {error}"),
         )
@@ -695,21 +702,11 @@ pub(super) fn decode_optional_cursor<C: loonfs_api::PageCursor>(
 }
 
 fn limit_response_error(error: LimitError) -> ApiResponseError {
-    ApiResponseError::new(
-        StatusCode::BAD_REQUEST,
-        ErrorCode::InvalidRequest,
-        &error.to_string(),
-    )
-    .with_param("limit")
+    ApiResponseError::new(ErrorCode::InvalidRequest, &error.to_string()).with_param("limit")
 }
 
 fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
-    ApiResponseError::new(
-        StatusCode::BAD_REQUEST,
-        ErrorCode::InvalidRequest,
-        &error.to_string(),
-    )
-    .with_param("cursor")
+    ApiResponseError::new(ErrorCode::InvalidRequest, &error.to_string()).with_param("cursor")
 }
 
 #[cfg(test)]

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -2,17 +2,17 @@
 
 use super::error::ApiResponseError;
 use super::handlers_filesystem::{
-    buffered_download_response, decode_optional_cursor, parse_include_attributes,
-    parse_revision_no, resolve_page_limit, PageQuery,
+    buffered_download_response, decode_optional_cursor, invalid_path_id_error,
+    parse_include_attributes, parse_revision_no, resolve_page_limit, PageQuery,
 };
 use super::{
     acquire_download_permit, authorize, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery,
 };
 use axum::extract::State;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::HeaderMap;
 use axum::response::Response;
 use axum::Json;
-use loonfs::{ErrorCode, StatPathOptions};
+use loonfs::StatPathOptions;
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::{
@@ -31,14 +31,8 @@ pub(super) struct InodeRevisionPathParams {
 }
 
 pub(super) fn parse_inode_id(value: &str) -> Result<InodeId, ApiResponseError> {
-    public_inode_id::decode(value).map_err(|error| {
-        ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidRequest,
-            &format!("path.inode_id {}", error.reason()),
-        )
-        .with_param("inode_id")
-    })
+    public_inode_id::decode(value)
+        .map_err(|error| invalid_path_id_error("inode_id", value, error.reason()))
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -182,9 +176,9 @@ pub(super) async fn get_file_revision_bytes_by_inode(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     let path = path.into_params()?;
-    query.into_params()?;
     let inode_id = parse_inode_id(&path.inode_id)?;
     let revision_no = parse_revision_no(&path.revision_no)?;
+    query.into_params()?;
     let permit = acquire_download_permit(&state)?;
     let bytes = state
         .reader

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -2,12 +2,12 @@
 //! handlers.
 
 use super::error::ApiResponseError;
-use super::handlers_filesystem::{parse_public_ordinal, resolve_page_limit};
+use super::handlers_filesystem::{invalid_path_id_error, parse_public_ordinal, resolve_page_limit};
 use super::{
     authorize, AppJson, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery, OptionalAppJson,
 };
 use axum::extract::State;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::HeaderMap;
 use axum::Json;
 use loonfs::{CheckpointPageCursor, CreateNamespaceOptions, DeleteNamespaceOptions};
 #[cfg(feature = "openapi")]
@@ -447,12 +447,8 @@ pub(super) async fn list_checkpoints(
         .map(|cursor| decode_namespace_cursor::<CheckpointPageCursor>(cursor, &namespace_id))
         .transpose()
         .map_err(|error| {
-            ApiResponseError::new(
-                StatusCode::BAD_REQUEST,
-                ErrorCode::InvalidRequest,
-                &error.to_string(),
-            )
-            .with_param("cursor")
+            ApiResponseError::new(ErrorCode::InvalidRequest, &error.to_string())
+                .with_param("cursor")
         })?;
     let response = state
         .admin
@@ -516,14 +512,8 @@ pub(super) struct CheckpointPathParams {
 }
 
 fn parse_checkpoint_id(value: &str) -> Result<CheckpointId, ApiResponseError> {
-    CheckpointId::parse(value).map_err(|error| {
-        ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidRequest,
-            &format!("invalid checkpoint_id `{value}`: {error}"),
-        )
-        .with_param("checkpoint_id")
-    })
+    CheckpointId::parse(value)
+        .map_err(|error| invalid_path_id_error("checkpoint_id", value, error.reason()))
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -332,9 +332,11 @@ pub(super) async fn disable_grep_index(
 pub(super) async fn gc_grep_index(
     State(state): State<AppState>,
     namespace_id_path: NamespaceIdPath,
+    headers: HeaderMap,
     query: AppQuery<NoQuery>,
     OptionalAppJson(request): OptionalAppJson<GrepGcRequest>,
 ) -> Result<Json<GrepGcResponse>, ApiResponseError> {
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     query.into_params()?;
     let request = request.unwrap_or_default();

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -8,9 +8,9 @@ use super::{
     handlers_filesystem::{parse_boolean_query_param, required_query_param, resolve_page_limit},
     AppQuery, AppState, NamespaceIdPath, NoQuery, OptionalAppJson,
 };
-use crate::http::error::{status_for_core_error_code, ApiResponseError};
+use crate::http::error::ApiResponseError;
 use axum::extract::State;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::HeaderMap;
 use axum::Json;
 use loonfs_api::v0::{GrepGcRequest, GrepGcResponse, GrepIndex};
 #[cfg(feature = "openapi")]
@@ -74,7 +74,9 @@ pub(super) async fn grep(
 ) -> Result<Json<GrepResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
-    let request = grep_request(query.into_params()?)?;
+    let mut query = query.into_params()?;
+    let limit = resolve_page_limit(query.limit.take())?;
+    let request = grep_request(query)?;
     // First touch: on a deployment that maintains this index, a search is
     // also the hint that someone cares about this namespace again — after a
     // restart, nothing else has said so.
@@ -88,7 +90,7 @@ pub(super) async fn grep(
     let store = state.writer.object_store();
     let reads = NamespaceReads::new(&state.reader, &namespace_id);
     let response = service
-        .query(&request, &reads, &store)
+        .query(&request, limit, &reads, &store)
         .await
         .map_err(|error| map_grep_error(&namespace_id, error))?;
     Ok(Json(response))
@@ -98,7 +100,6 @@ fn grep_request(query: GrepQuery) -> Result<GrepRequest, ApiResponseError> {
     let pattern = required_query_param(query.pattern, "pattern")?;
     if pattern.len() > MAX_GREP_PATTERN_BYTES {
         return Err(ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
             loonfs_api::ErrorCode::InvalidRequest,
             &format!(
                 "grep pattern is {} bytes; the maximum is {MAX_GREP_PATTERN_BYTES} bytes",
@@ -111,25 +112,16 @@ fn grep_request(query: GrepQuery) -> Result<GrepRequest, ApiResponseError> {
         .path_prefix
         .map(|value| {
             loonfs_api::AbsolutePath::parse(&value).map_err(|error| {
-                ApiResponseError::new(
-                    StatusCode::BAD_REQUEST,
-                    loonfs_api::ErrorCode::InvalidRequest,
-                    &error.to_string(),
-                )
-                .with_param("path_prefix")
+                ApiResponseError::new(loonfs_api::ErrorCode::InvalidRequest, &error.to_string())
+                    .with_param("path_prefix")
             })
         })
-        .transpose()?;
-    let limit = query
-        .limit
-        .map(|value| resolve_page_limit(Some(value)).map(|limit| limit.get()))
         .transpose()?;
     Ok(GrepRequest {
         pattern,
         case_insensitive: parse_optional_boolean(query.case_insensitive, "case_insensitive")?,
         path_prefix,
         cursor: query.cursor,
-        limit,
         allow_stale: parse_optional_boolean(query.allow_stale, "allow_stale")?,
         allow_scan: parse_optional_boolean(query.allow_scan, "allow_scan")?,
     })
@@ -340,11 +332,9 @@ pub(super) async fn disable_grep_index(
 pub(super) async fn gc_grep_index(
     State(state): State<AppState>,
     namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
     query: AppQuery<NoQuery>,
     OptionalAppJson(request): OptionalAppJson<GrepGcRequest>,
 ) -> Result<Json<GrepGcResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     query.into_params()?;
     let request = request.unwrap_or_default();
@@ -390,11 +380,7 @@ fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> A
                 response
             }
         }
-        error => ApiResponseError::new(
-            status_for_core_error_code(code),
-            code,
-            &error.public_message(),
-        ),
+        error => ApiResponseError::new(code, &error.public_message()),
     }
 }
 

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -1,13 +1,14 @@
 //! Upload session handlers plus the presign and content-token helpers
 //! backing them.
 
-use super::error::{status_for_core_error_code, ApiResponseError};
+use super::error::ApiResponseError;
+use super::handlers_filesystem::invalid_path_id_error;
 use super::{
     authorize, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery, UploadBodyBytes,
     UploadBodyStream, UploadControlJson, MAX_COMPLETION_BODY_BYTES, MAX_UPLOAD_CONTROL_BODY_BYTES,
 };
 use axum::extract::State;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::HeaderMap;
 use axum::Json;
 use loonfs::content_tokens::{
     mint_content_token, CompletedUploadReceipt, ContentToken, ContentTokenError,
@@ -169,7 +170,6 @@ async fn begin_direct_put_upload(
     let max_content_bytes = issuer.max_content_bytes();
     if let Some(size_bytes) = size_bytes.filter(|size_bytes| *size_bytes > max_content_bytes) {
         return Err(ApiResponseError::new(
-            StatusCode::PAYLOAD_TOO_LARGE,
             ErrorCode::ContentTooLarge,
             &format!(
                 "this deployment's provider accepts at most {max_content_bytes} bytes in one \
@@ -356,11 +356,7 @@ pub(super) fn presign_issuer_error(error: ObjectStoreError) -> ApiResponseError 
         ObjectStoreError::PermissionDenied { .. } => (ErrorCode::StoragePermissionDenied, None),
         _ => (ErrorCode::ServerError, None),
     };
-    let response = ApiResponseError::new(
-        status_for_core_error_code(code),
-        code,
-        &error.public_message(),
-    );
+    let response = ApiResponseError::new(code, &error.public_message());
     if let Some(param) = param {
         response.with_param(param)
     } else {
@@ -453,7 +449,6 @@ fn is_forged_content_token(error: &ContentTokenError) -> bool {
 
 fn content_token_error(error: ContentTokenError) -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::INTERNAL_SERVER_ERROR,
         ErrorCode::ServerError,
         &format!("failed to mint content token: {error}"),
     )
@@ -478,14 +473,12 @@ pub(super) fn current_unix_ms() -> Result<u64, ApiResponseError> {
         .duration_since(UNIX_EPOCH)
         .map_err(|error| {
             ApiResponseError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
                 ErrorCode::ServerError,
                 &format!("system time is before unix epoch: {error}"),
             )
         })?;
     u64::try_from(duration.as_millis()).map_err(|error| {
         ApiResponseError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
             ErrorCode::ServerError,
             &format!("system time overflowed milliseconds: {error}"),
         )
@@ -617,15 +610,15 @@ fn decode_completion_body(
     let invalid = |error: serde_json::Error| {
         format!(
             "request body is not valid JSON for {} completion: {error}",
-            upload_mode_name(mode)
+            mode.as_str()
         )
     };
     let request = serde_json::from_slice::<CompleteUploadRequest>(body).map_err(invalid)?;
     if request.mode() != mode {
         return Err(format!(
             "completion request mode `{}` does not match stored upload mode `{}`",
-            upload_mode_name(request.mode()),
-            upload_mode_name(mode)
+            request.mode().as_str(),
+            mode.as_str()
         ));
     }
 
@@ -637,14 +630,6 @@ fn decode_completion_body(
         CompleteUploadRequest::DirectMultipart { content, parts } => Ok(
             ResolvedUploadCompletion::Multipart(CompleteMultipartUploadRequest { content, parts }),
         ),
-    }
-}
-
-fn upload_mode_name(mode: UploadMode) -> &'static str {
-    match mode {
-        UploadMode::ServiceProxied => "service_proxied",
-        UploadMode::DirectPut => "direct_put",
-        UploadMode::DirectMultipart => "direct_multipart",
     }
 }
 
@@ -869,12 +854,6 @@ pub(super) async fn abort_upload(
 }
 
 fn parse_upload_id(value: &str) -> Result<UploadId, ApiResponseError> {
-    UploadId::parse(value).map_err(|error| {
-        ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidRequest,
-            &error.to_string(),
-        )
-        .with_param("upload_id")
-    })
+    UploadId::parse(value)
+        .map_err(|error| invalid_path_id_error("upload_id", value, error.reason()))
 }

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -30,7 +30,7 @@ pub use self::serve::{
 };
 pub use self::tls::TlsConfigError;
 
-use self::error::{status_for_core_error_code, ApiResponseError, ServedErrorCode};
+use self::error::{ApiResponseError, ServedErrorCode};
 use self::extractors::{
     acquire_download_permit, authorize, AppJson, AppPath, AppQuery, NamespaceIdPath, NoQuery,
     OptionalAppJson, UploadBodyBytes, UploadBodyStream, UploadControlJson,
@@ -147,7 +147,6 @@ async fn with_request_deadline(request_deadline_ms: u64, request: Request, next:
     {
         Ok(response) => response,
         Err(_) => ApiResponseError::new(
-            status_for_core_error_code(ErrorCode::DeadlineExceeded),
             ErrorCode::DeadlineExceeded,
             &format!(
                 "the server cancelled the request at the configured deadline; \
@@ -418,7 +417,6 @@ fn router(state: AppState) -> Router {
 /// matched handler.
 async fn route_not_found() -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::NOT_FOUND,
         ErrorCode::RouteNotFound,
         "no v0 route matches this path; see the API spec for the served surface",
     )
@@ -427,7 +425,6 @@ async fn route_not_found() -> ApiResponseError {
 /// 405 for matched paths hit with an unserved method.
 async fn method_not_allowed() -> ApiResponseError {
     ApiResponseError::new(
-        StatusCode::METHOD_NOT_ALLOWED,
         ErrorCode::MethodNotAllowed,
         "this path exists but does not serve this HTTP method",
     )
@@ -483,7 +480,6 @@ async fn get_health() -> &'static str {
 async fn get_readiness(State(state): State<AppState>) -> Result<&'static str, ApiResponseError> {
     if state.writer.is_shutting_down() {
         return Err(ApiResponseError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
             ErrorCode::ShuttingDown,
             "the server is shutting down and no longer admits new work",
         ));

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -20,7 +20,7 @@ use loonfs::{
 use loonfs_api::ErrorCode;
 use loonfs_api::{
     ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, GrepRequest, NamespaceId,
-    FEATURE_QUERY_GREP,
+    PaginationPolicy, FEATURE_QUERY_GREP,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MoveOptions, NamespacePath};
 use loonfs_grep::keyspace::{manifest_key as grep_manifest_key, root_key as grep_root_key};
@@ -1355,7 +1355,6 @@ async fn a_namespace_advance_nudges_the_enabled_namespaces_index() {
         case_insensitive: false,
         path_prefix: None,
         cursor: None,
-        limit: None,
         allow_stale: false,
         allow_scan: false,
     };
@@ -1366,7 +1365,14 @@ async fn a_namespace_advance_nudges_the_enabled_namespaces_index() {
     let store = state.writer.object_store();
     let reads = NamespaceReads::new(&state.reader, &namespace_id);
     let response = service
-        .query(&request, &reads, &store)
+        .query(
+            &request,
+            PaginationPolicy::default()
+                .resolve_limit(None)
+                .expect("the pagination policy accepts its own default"),
+            &reads,
+            &store,
+        )
         .await
         .expect("grep caught-up index");
     assert_eq!(response.matches.len(), 1);
@@ -1400,7 +1406,7 @@ async fn grep_error_disabled_root_is_not_materialized_and_core_reads_survive() {
     let harness = start_grep_error_server(store, temp_dir.path(), "disabled-server").await;
     let client = &harness.client;
     let binding = grep_error_request();
-    let result = client.grep(&namespace_id, &binding);
+    let result = client.grep(&namespace_id, &binding, None);
     assert_grep_api_error_and_core_read(
         client,
         &namespace_id,
@@ -1429,7 +1435,7 @@ async fn grep_error_mid_backfill_is_not_materialized_and_core_reads_survive() {
     let harness = start_grep_error_server(store, temp_dir.path(), "backfill-server").await;
     let client = &harness.client;
     let binding = grep_error_request();
-    let result = client.grep(&namespace_id, &binding);
+    let result = client.grep(&namespace_id, &binding, None);
     assert_grep_api_error_and_core_read(
         client,
         &namespace_id,
@@ -1460,7 +1466,7 @@ async fn grep_error_store_outage_is_provider_failure_and_core_reads_survive() {
     fault_store.fail_next(1);
     let client = &harness.client;
     let binding = grep_error_request();
-    let result = client.grep(&namespace_id, &binding);
+    let result = client.grep(&namespace_id, &binding, None);
     assert_grep_api_error_and_core_read(
         client,
         &namespace_id,
@@ -1545,7 +1551,9 @@ async fn grep_error_unreadable_roots_are_index_corrupt_and_core_reads_survive() 
         corrupt_manifest,
         identity_mismatch,
     ] {
-        let result = client.grep(&namespace_id, &grep_error_request()).await;
+        let result = client
+            .grep(&namespace_id, &grep_error_request(), None)
+            .await;
         assert_grep_api_error_and_core_read(
             client,
             &namespace_id,
@@ -3123,7 +3131,6 @@ fn grep_error_request() -> GrepRequest {
         case_insensitive: false,
         path_prefix: None,
         cursor: None,
-        limit: None,
         allow_stale: false,
         allow_scan: false,
     }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2277,6 +2277,14 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "unauthorized",
     );
 
+    let grep_gc_url = format!("http://{addr}/v0/admin/namespaces/demo/grep/index/gc");
+    expect_enveloped(
+        || raw_agent().post(&grep_gc_url).call(),
+        "grep index collection should require authorization",
+        401,
+        "unauthorized",
+    );
+
     server.abort();
 }
 

--- a/crates/loonfs-server/src/local_cache.rs
+++ b/crates/loonfs-server/src/local_cache.rs
@@ -16,7 +16,9 @@ use foyer::{
     BlockEngineConfig, Compression, DeviceBuilder, FsDeviceBuilder, HybridCache,
     HybridCacheBuilder, HybridCachePolicy, PsyncIoEngineConfig, RecoverMode,
 };
-use loonfs::metrics::{CounterHandle, MetricsRecorder};
+use loonfs::metrics::{
+    CounterHandle, MetricsRecorder, RESULT_ERROR, RESULT_HIT, RESULT_MISS, RESULT_OK,
+};
 use loonfs::{
     StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
     StoredMetadataBlockKind,
@@ -571,17 +573,17 @@ impl LocalCacheMetrics {
             hits: per_kind(
                 "loonfs.local_cache.gets",
                 "Local block cache lookups, by block kind and outcome",
-                "hit",
+                RESULT_HIT,
             ),
             misses: per_kind(
                 "loonfs.local_cache.gets",
                 "Local block cache lookups, by block kind and outcome",
-                "miss",
+                RESULT_MISS,
             ),
             get_failures: per_kind(
                 "loonfs.local_cache.gets",
                 "Local block cache lookups, by block kind and outcome",
-                "failed",
+                RESULT_ERROR,
             ),
             inserts: BLOCK_KINDS.map(|kind| {
                 recorder.register_counter(
@@ -598,8 +600,8 @@ impl LocalCacheMetrics {
                     &[("kind", kind_label(kind))],
                 )
             }),
-            closes_clean: closes("clean"),
-            closes_failed: closes("failed"),
+            closes_clean: closes(RESULT_OK),
+            closes_failed: closes(RESULT_ERROR),
         }
     }
 }

--- a/crates/loonfs-server/src/local_cache/tests.rs
+++ b/crates/loonfs-server/src/local_cache/tests.rs
@@ -8,7 +8,10 @@ use super::{
 };
 use crate::config::{LocalCacheConfig, ServerConfigError};
 use bytes::Bytes;
-use loonfs::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot, NoopMetricsRecorder};
+use loonfs::metrics::{
+    DefaultMetricsRecorder, MetricValue, MetricsSnapshot, NoopMetricsRecorder, RESULT_HIT,
+    RESULT_MISS, RESULT_OK,
+};
 use loonfs::{StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind};
 use mixtrics::metrics::RegistryOps;
 use std::path::Path;
@@ -109,9 +112,15 @@ async fn a_kept_block_survives_a_reopen() {
     // The instruments are registered at construction and carry a closed
     // label set, so one hit and one miss are already two named series.
     let snapshot = recorder.snapshot();
-    assert_eq!(counter(&snapshot, "loonfs.local_cache.gets", "hit"), 1);
-    assert_eq!(counter(&snapshot, "loonfs.local_cache.gets", "miss"), 1);
-    assert_eq!(counter(&snapshot, "loonfs.local_cache.closes", "clean"), 1);
+    assert_eq!(counter(&snapshot, "loonfs.local_cache.gets", RESULT_HIT), 1);
+    assert_eq!(
+        counter(&snapshot, "loonfs.local_cache.gets", RESULT_MISS),
+        1
+    );
+    assert_eq!(
+        counter(&snapshot, "loonfs.local_cache.closes", RESULT_OK),
+        1
+    );
 
     let reopened = open(temp_dir.path()).await;
     assert_eq!(

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -10,8 +10,7 @@ use loonfs::{FsAdmin, FsReader};
 use loonfs_api::v0::{GrepGcResponse, GrepIndex, GrepIndexLifecycle};
 use loonfs_api::{
     ApiError, CapabilityDocument, ChangeSeq, GrepResponse, NamespaceId, FEATURE_ADMIN_GREP_INDEX,
-    FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_MULTIPART,
-    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX,
+    FEATURE_QUERY_GREP, LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX,
     LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES, PROFILE_QUERY_V0,
 };
 use loonfs_grep::root::{load_grep_root, GrepIndexStatus};
@@ -881,21 +880,9 @@ fn assert_served_document_covers_the_spec_example(served: &CapabilityDocument) {
         .split("```")
         .next()
         .expect("fenced block end");
-    let mut expected: CapabilityDocument =
+    let expected: CapabilityDocument =
         serde_json::from_str(example).expect("spec capability example parses");
-    // The direct transports are properties of the configured store, not of
-    // what this process composes: a store that cannot presign has their keys
-    // removed rather than advertised `false`. This deployment's local-fs
-    // store cannot, so all three are out of scope for this comparison.
-    let mut served_features = served.features.clone();
-    for feature in [
-        FEATURE_UPLOADS_DIRECT_PUT,
-        FEATURE_UPLOADS_DIRECT_MULTIPART,
-        FEATURE_DOWNLOADS_DIRECT_GET,
-    ] {
-        expected.features.remove(feature);
-        served_features.remove(feature);
-    }
+    let served_features = served.features.clone();
 
     served.validate().expect("served document is well-formed");
     assert_eq!(served.protocol_version, expected.protocol_version);

--- a/crates/loonfs-server/tests/it/http_inodes.rs
+++ b/crates/loonfs-server/tests/it/http_inodes.rs
@@ -371,7 +371,9 @@ async fn inode_routes_reject_invalid_ids_after_authorization() {
                 .expect("decode malformed-inode error");
             assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
             assert!(
-                error.message.starts_with("path.inode_id"),
+                error
+                    .message
+                    .starts_with(&format!("invalid inode_id {malformed:?}")),
                 "{}",
                 error.message
             );

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -12,6 +12,7 @@ const PROXY_OPENAPI_JSON_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../docs/specs/openapi-proxy.json"
 );
+const API_SPEC_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../docs/specs/api.md");
 const OPENAPI_PATH_SOURCES: &[&str] = &[
     include_str!("../../src/http/mod.rs"),
     include_str!("../../src/http/handlers_downloads.rs"),
@@ -675,6 +676,49 @@ fn every_registered_operation_publishes_its_retry_class() {
         .map(|(operation_id, retry_class)| (*operation_id, retry_class.as_str()))
         .collect::<BTreeMap<_, _>>();
     assert_eq!(published, expected);
+}
+
+#[test]
+fn the_api_spec_retry_table_matches_the_registered_retry_classes() {
+    let spec = std::fs::read_to_string(API_SPEC_PATH).expect("read docs/specs/api.md");
+    let table = spec
+        .split("The table below lists the retry class for every v0 operation.")
+        .nth(1)
+        .expect("api.md retry table intro");
+    let mut documented = table
+        .lines()
+        .skip_while(|line| !line.starts_with("| Purpose "))
+        .skip(2)
+        .take_while(|line| line.starts_with('|'))
+        .map(|line| {
+            let mut cells = line.split(" | ").skip(1);
+            let operation_id = cells.next().expect("operation id cell");
+            let retry_class = cells.next().expect("retry class cell");
+            (
+                operation_id.trim_matches('`').to_owned(),
+                retry_class.trim_matches('`').to_owned(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    assert!(
+        !documented.is_empty(),
+        "no rows parsed from the api.md retry table"
+    );
+
+    for (operation_id, retry_class) in openapi_postprocess::OPERATION_RETRY_CLASSES {
+        let class = documented.remove(*operation_id).unwrap_or_else(|| {
+            panic!("`{operation_id}` is registered but missing from the api.md retry table")
+        });
+        assert_eq!(
+            retry_class.as_str(),
+            class,
+            "retry class for `{operation_id}` disagrees with the api.md retry table"
+        );
+    }
+    assert!(
+        documented.is_empty(),
+        "api.md documents retry classes for operations this build does not register: {documented:?}"
+    );
 }
 
 #[test]

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -12,7 +12,6 @@ const PROXY_OPENAPI_JSON_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../docs/specs/openapi-proxy.json"
 );
-const API_SPEC_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../docs/specs/api.md");
 const OPENAPI_PATH_SOURCES: &[&str] = &[
     include_str!("../../src/http/mod.rs"),
     include_str!("../../src/http/handlers_downloads.rs"),
@@ -676,49 +675,6 @@ fn every_registered_operation_publishes_its_retry_class() {
         .map(|(operation_id, retry_class)| (*operation_id, retry_class.as_str()))
         .collect::<BTreeMap<_, _>>();
     assert_eq!(published, expected);
-}
-
-#[test]
-fn the_api_spec_retry_table_matches_the_registered_retry_classes() {
-    let spec = std::fs::read_to_string(API_SPEC_PATH).expect("read docs/specs/api.md");
-    let table = spec
-        .split("The table below lists the retry class for every v0 operation.")
-        .nth(1)
-        .expect("api.md retry table intro");
-    let mut documented = table
-        .lines()
-        .skip_while(|line| !line.starts_with("| Purpose "))
-        .skip(2)
-        .take_while(|line| line.starts_with('|'))
-        .map(|line| {
-            let mut cells = line.split(" | ").skip(1);
-            let operation_id = cells.next().expect("operation id cell");
-            let retry_class = cells.next().expect("retry class cell");
-            (
-                operation_id.trim_matches('`').to_owned(),
-                retry_class.trim_matches('`').to_owned(),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
-    assert!(
-        !documented.is_empty(),
-        "no rows parsed from the api.md retry table"
-    );
-
-    for (operation_id, retry_class) in openapi_postprocess::OPERATION_RETRY_CLASSES {
-        let class = documented.remove(*operation_id).unwrap_or_else(|| {
-            panic!("`{operation_id}` is registered but missing from the api.md retry table")
-        });
-        assert_eq!(
-            retry_class.as_str(),
-            class,
-            "retry class for `{operation_id}` disagrees with the api.md retry table"
-        );
-    }
-    assert!(
-        documented.is_empty(),
-        "api.md documents retry classes for operations this build does not register: {documented:?}"
-    );
 }
 
 #[test]

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -6,6 +6,7 @@
 
 use crate::fs::{should_invalidate_after_result, ReadCore};
 use crate::metrics::RuntimeInstruments;
+use crate::trace::phase_span;
 use crate::{CommitResponse, CoreError, NamespaceId, Recency, RuntimeCacheConfig};
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
@@ -440,16 +441,8 @@ impl ReadCore {
     /// state — a namespace publisher's WAL tail projection — is stale for
     /// exactly the same reasons, so a caller that owns a publication service
     /// drops that too; see `FsWriter::invalidate_namespace`.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.phase",
-        skip_all,
-        fields(
-            phase = "update_cache",
-            namespace_id = %namespace_id,
-        )
-    )]
     pub(crate) fn invalidate_namespace_read_cache(&self, namespace_id: &NamespaceId) {
+        let _span = phase_span!(self, "update_cache", namespace_id).entered();
         self.inner
             .control_cache()
             .invalidate_namespace(namespace_id);

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -12,9 +12,8 @@ use crate::{
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
     encode_cursor, CapabilityDocument, FileRevision, FileRevisionsPageCursor, Page, PageCursor,
-    PaginationPolicy, FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART,
-    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_CONTENT_TOKENS,
+    PaginationPolicy, FEATURE_ATTRIBUTES, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
+    FEATURE_NAMESPACES_FORK, LIMIT_COMMIT_MAX_CONTENT_TOKENS,
     LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS, LIMIT_COMMIT_MAX_MESSAGE_BYTES,
     LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_GC_MIN_GRACE_WINDOW_MS, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
     PROTOCOL_VERSION,
@@ -188,7 +187,10 @@ impl ReadCore {
         self.inner.config.trace_store_kind.as_str()
     }
 
-    pub(super) fn record_trace_context(&self, span: &tracing::Span) {
+    /// Stamps the two standard context fields onto an operation span. The
+    /// one owner of what "standard context" means, so a new field lands here
+    /// rather than at each span.
+    pub(crate) fn record_trace_context(&self, span: &tracing::Span) {
         span.record("mode", self.trace_mode());
         span.record("store_kind", self.trace_store_kind());
     }
@@ -209,11 +211,9 @@ impl ReadCore {
                 (FEATURE_ATTRIBUTES.to_owned(), true),
                 // The three transfer keys are the host's to answer, not
                 // this runtime's: an embedded engine signs nothing and
-                // reads its own bytes. A serving host that can presign
-                // replaces all three together.
-                (FEATURE_UPLOADS_DIRECT_PUT.to_owned(), false),
-                (FEATURE_UPLOADS_DIRECT_MULTIPART.to_owned(), false),
-                (FEATURE_DOWNLOADS_DIRECT_GET.to_owned(), false),
+                // reads its own bytes, so it leaves them absent, which is
+                // how the API spells unsupported. A serving host that can
+                // presign adds all three together.
             ]),
             limits: {
                 let mut limits = PaginationPolicy::default().capability_limits();

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -187,9 +187,6 @@ impl ReadCore {
         self.inner.config.trace_store_kind.as_str()
     }
 
-    /// Stamps the two standard context fields onto an operation span. The
-    /// one owner of what "standard context" means, so a new field lands here
-    /// rather than at each span.
     pub(crate) fn record_trace_context(&self, span: &tracing::Span) {
         span.record("mode", self.trace_mode());
         span.record("store_kind", self.trace_store_kind());
@@ -209,11 +206,6 @@ impl ReadCore {
                 // Attributes are core, implemented by this crate, so the
                 // answer does not depend on what a serving host composes.
                 (FEATURE_ATTRIBUTES.to_owned(), true),
-                // The three transfer keys are the host's to answer, not
-                // this runtime's: an embedded engine signs nothing and
-                // reads its own bytes, so it leaves them absent, which is
-                // how the API spells unsupported. A serving host that can
-                // presign adds all three together.
             ]),
             limits: {
                 let mut limits = PaginationPolicy::default().capability_limits();

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -6,6 +6,7 @@
 //! checkpoint calls, and its hosts drive it.
 
 use crate::maintenance_runner::CompactionStart;
+use crate::trace::phase_span;
 use crate::FsAdmin;
 use crate::NamespaceDiagnostics;
 use crate::{
@@ -19,6 +20,7 @@ use loonfs_api::PageRequest;
 use loonfs_core::cache::load_namespace_flush_basis;
 use loonfs_core::CheckpointPageCursor;
 use tokio::time::Instant;
+use tracing::Instrument;
 
 #[cfg(test)]
 mod tests;
@@ -835,23 +837,18 @@ impl FsAdmin {
     }
 
     /// Shared implementation for metadata maintenance and [`Self::flush_wal`].
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.phase",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            phase = "wal_flush",
-            namespace_id = %namespace_id,
-        )
-    )]
     async fn run_wal_flush(&self, namespace_id: &NamespaceId) -> Result<FlushWalResponse> {
-        let result = self
-            .engine(namespace_id)
-            .flush_wal()
-            .await
-            .map_err(RuntimeError::from);
-        self.finish_namespace_mutation(namespace_id, result)
+        async {
+            let result = self
+                .engine(namespace_id)
+                .flush_wal()
+                .await
+                .map_err(RuntimeError::from);
+            self.finish_namespace_mutation(namespace_id, result)
+                .inspect_err(|error| tracing::debug!(%error))
+        }
+        .instrument(phase_span!(self.core, "wal_flush", namespace_id))
+        .await
     }
 
     /// The one implementation both the step and

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -3,6 +3,7 @@
 use super::core::{ReadCore, WriterBits};
 use crate::maintenance_runner::NamespacePublication;
 use crate::publish::{CommitCandidate, CommitRequest, FilesystemOperation, PreparedContent};
+use crate::trace::phase_span;
 use crate::ByteStream;
 use crate::FsWriter;
 use crate::{
@@ -945,14 +946,7 @@ pub(crate) async fn publish_batch_with_engine(
         engine.invalidate_projection();
     }
     {
-        let _span = tracing::debug_span!(
-            "loonfs.phase",
-            phase = "batch_update_cache",
-            mode = core.trace_mode(),
-            store_kind = core.trace_store_kind(),
-            batch_size
-        )
-        .entered();
+        let _span = phase_span!(core, "batch_update_cache", namespace_id, batch_size).entered();
         match publish.resulting_read_state.take() {
             // A landed publish hands the caches exactly the state a
             // rebuild would recompute; use it instead of dropping.

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -180,9 +180,7 @@ impl FsWriter {
         )
     )]
     pub async fn flush_background(&self) -> Result<()> {
-        let span = tracing::Span::current();
-        span.record("mode", self.core.trace_mode());
-        span.record("store_kind", self.core.trace_store_kind());
+        self.core.record_trace_context(&tracing::Span::current());
         self.bits.maintenance.drain().await
     }
 
@@ -205,9 +203,7 @@ impl FsWriter {
         )
     )]
     pub async fn shutdown(&self) -> Result<()> {
-        let span = tracing::Span::current();
-        span.record("mode", self.core.trace_mode());
-        span.record("store_kind", self.core.trace_store_kind());
+        self.core.record_trace_context(&tracing::Span::current());
         self.close_admission_for_shutdown();
         self.publisher.drain().await?;
         self.bits.maintenance.drain().await
@@ -429,8 +425,6 @@ impl FsWriterBuilder {
             core.clone(),
             Arc::downgrade(&bits),
             std::time::Duration::from_millis(self.min_publish_interval_ms),
-            core.trace_mode(),
-            core.trace_store_kind(),
         );
         // The runtime's own executors register last: they run as an admin
         // over this writer's parts, so both have to exist first.

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -10,7 +10,7 @@ mod jobs;
 #[cfg(test)]
 mod tests;
 
-use crate::metrics::RuntimeInstruments;
+use crate::metrics::{RuntimeInstruments, RESULT_ERROR};
 use crate::{ChangeSeq, NamespaceId, Result, RuntimeError};
 use admission::{Admission, MaintenanceDispatch, MaintenanceKey, StepOutcome};
 pub(crate) use compaction::{BackgroundCompactions, CompactionStart};
@@ -797,7 +797,7 @@ async fn run_step(inner: &Arc<RunnerInner>, dispatch: &MaintenanceDispatch) -> S
             tracing::info!(
                 job = %key.job,
                 namespace_id = %key.namespace_id,
-                result = "error",
+                result = RESULT_ERROR,
                 error = %error,
                 queued_ms,
                 backoff_scheduled = RunnerCounters::bump(&inner.counters.backoff_scheduled),
@@ -947,7 +947,7 @@ async fn reconcile(inner: &Arc<RunnerInner>) {
                 tracing::info!(
                     job = %key.job,
                     namespace_id = %key.namespace_id,
-                    result = "error",
+                    result = RESULT_ERROR,
                     error = %error,
                     "reconciliation probe failed; the key stays admitted"
                 );

--- a/crates/loonfs/src/metrics.rs
+++ b/crates/loonfs/src/metrics.rs
@@ -22,6 +22,21 @@ use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+/// The closed vocabulary of the `result` label: an operation that completed.
+///
+/// Every instrument that labels an outcome `result` takes its value from one
+/// of these four constants, so one query counts every failure the runtime and
+/// its hosts report. The object store keeps its own richer classification for
+/// the same label: a store call reports which failure it hit, not only that
+/// it failed.
+pub const RESULT_OK: &str = "ok";
+/// `result` label for an operation that failed.
+pub const RESULT_ERROR: &str = "error";
+/// `result` label for a lookup served from the cache.
+pub const RESULT_HIT: &str = "hit";
+/// `result` label for a lookup the cache did not hold.
+pub const RESULT_MISS: &str = "miss";
+
 /// Bucket upper bounds for a latency histogram, in seconds.
 ///
 /// Covers latencies from one millisecond to two minutes.

--- a/crates/loonfs/src/metrics.rs
+++ b/crates/loonfs/src/metrics.rs
@@ -22,13 +22,7 @@ use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-/// The closed vocabulary of the `result` label: an operation that completed.
-///
-/// Every instrument that labels an outcome `result` takes its value from one
-/// of these four constants, so one query counts every failure the runtime and
-/// its hosts report. The object store keeps its own richer classification for
-/// the same label: a store call reports which failure it hit, not only that
-/// it failed.
+/// `result` label for a successful operation.
 pub const RESULT_OK: &str = "ok";
 /// `result` label for an operation that failed.
 pub const RESULT_ERROR: &str = "error";

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -8,7 +8,9 @@ use super::{
     CounterHandle, GaugeHandle, HistogramHandle, MetricsRecorder, ObjectStoreMetricSample,
     ObjectStoreMetricsRecorder, SMALL_COUNT_BOUNDARIES,
 };
-use crate::metrics::LATENCY_SECONDS_BOUNDARIES;
+use crate::metrics::{
+    LATENCY_SECONDS_BOUNDARIES, RESULT_ERROR, RESULT_HIT, RESULT_MISS, RESULT_OK,
+};
 use crate::{
     GcResponse, MaintenanceJobId, MaintenanceStepConclusion, MetadataCompactionJobOutcome,
 };
@@ -48,8 +50,8 @@ pub(crate) enum PublishOutcome {
 impl PublishOutcome {
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
-            Self::Ok => "ok",
-            Self::Error => "error",
+            Self::Ok => RESULT_OK,
+            Self::Error => RESULT_ERROR,
         }
     }
 }
@@ -613,8 +615,8 @@ impl MetadataSegmentCacheInstruments {
             )
         };
         Self {
-            hits: get("hit"),
-            misses: get("miss"),
+            hits: get(RESULT_HIT),
+            misses: get(RESULT_MISS),
             inserts: recorder.register_counter(
                 "loonfs.metadata_segment_cache.inserts",
                 "Blocks inserted into the decoded metadata-segment cache",
@@ -675,8 +677,8 @@ impl WalTailProjectionCacheInstruments {
             )
         };
         Self {
-            hits: get("hit"),
-            misses: get("miss"),
+            hits: get(RESULT_HIT),
+            misses: get(RESULT_MISS),
             inserts: recorder.register_counter(
                 "loonfs.wal_tail_projection_cache.inserts",
                 "WAL-tail projections inserted into the cache",

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -88,13 +88,7 @@ impl MaintenancePlan {
                 .map(metadata_options_from_request)
                 .transpose()?,
             advance_retention: request.retention.is_some(),
-            gc: request.gc.map(|request| {
-                let mut config = gc_config_from_request(request);
-                if config.max_objects.is_none() {
-                    config.max_objects = Some(loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS);
-                }
-                config
-            }),
+            gc: request.gc.map(gc_config_from_request),
         })
     }
 }
@@ -219,19 +213,18 @@ mod tests {
     }
 
     #[test]
-    fn explicit_gc_stays_unbounded_while_step_gc_gets_the_default_budget() {
+    fn a_gc_request_translates_without_resolving_its_budget() {
         let explicit = gc_config_from_request(GcRequest::default());
         assert_eq!(explicit.max_objects, None);
         assert_eq!(explicit.cursor, None);
 
+        // The step is what bounds a GC pass, so a plan built from a request
+        // hands it the same absent budget every other plan producer does.
         let step = plan(MaintenanceStepRequest {
             gc: Some(GcRequest::default()),
             ..MaintenanceStepRequest::default()
         });
-        assert_eq!(
-            step.gc.expect("GC opted in").max_objects,
-            Some(loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS)
-        );
+        assert_eq!(step.gc.expect("GC opted in").max_objects, None);
     }
 
     #[test]

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -218,8 +218,6 @@ mod tests {
         assert_eq!(explicit.max_objects, None);
         assert_eq!(explicit.cursor, None);
 
-        // The step is what bounds a GC pass, so a plan built from a request
-        // hands it the same absent budget every other plan producer does.
         let step = plan(MaintenanceStepRequest {
             gc: Some(GcRequest::default()),
             ..MaintenanceStepRequest::default()

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -9,8 +9,9 @@
 //! [`FsWriter::shutdown`](crate::FsWriter::shutdown).
 
 use crate::fs::{ReadCore, WriterBits};
-use crate::metrics::PublishOutcome;
+use crate::metrics::{PublishOutcome, RESULT_OK};
 use crate::publish::CommitCandidate;
+use crate::trace::phase_span;
 use crate::{
     CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeCacheConfig, RuntimeError,
 };
@@ -82,8 +83,6 @@ pub struct PublisherRegistry {
     /// without ever leaving the caches or store dangling.
     writer: Weak<WriterBits>,
     min_publish_interval: Duration,
-    trace_mode: &'static str,
-    trace_store_kind: &'static str,
 }
 
 /// State shared by all publishers in this registry: admission status,
@@ -301,8 +300,6 @@ impl PublisherRegistry {
         read_core: ReadCore,
         writer: Weak<WriterBits>,
         min_publish_interval: Duration,
-        trace_mode: &'static str,
-        trace_store_kind: &'static str,
     ) -> Self {
         Self {
             shared: Arc::new(RegistryShared {
@@ -316,8 +313,6 @@ impl PublisherRegistry {
             read_core,
             writer,
             min_publish_interval,
-            trace_mode,
-            trace_store_kind,
         }
     }
 
@@ -385,8 +380,6 @@ impl PublisherRegistry {
                     self.writer.clone(),
                     Arc::downgrade(&self.shared),
                     self.min_publish_interval,
-                    self.trace_mode,
-                    self.trace_store_kind,
                 )
             })
             .clone())
@@ -460,8 +453,6 @@ struct NamespacePublisher {
     /// registry is gone keeps serving, with an unowned worker.
     shared: Weak<RegistryShared>,
     min_publish_interval: Duration,
-    trace_mode: &'static str,
-    trace_store_kind: &'static str,
 }
 
 /// Commit engine and writer session retained by one namespace publisher.
@@ -552,8 +543,6 @@ impl NamespacePublisher {
         writer: Weak<WriterBits>,
         shared: Weak<RegistryShared>,
         min_publish_interval: Duration,
-        trace_mode: &'static str,
-        trace_store_kind: &'static str,
     ) -> Self {
         Self {
             namespace_id,
@@ -572,8 +561,6 @@ impl NamespacePublisher {
             })),
             shared,
             min_publish_interval,
-            trace_mode,
-            trace_store_kind,
         }
     }
 
@@ -799,8 +786,8 @@ impl NamespacePublisher {
                         .publisher_batch(batch.candidates.len());
                     tracing::info!(
                         phase = "batch_collect",
-                        mode = self.trace_mode,
-                        store_kind = self.trace_store_kind,
+                        mode = self.read_core.trace_mode(),
+                        store_kind = self.read_core.trace_store_kind(),
                         batch_size = usize_to_u64(batch.candidates.len()),
                         queue_depth_start = usize_to_u64(queue_depth_start),
                         queue_depth_end = usize_to_u64(batch.candidates.len()),
@@ -885,21 +872,20 @@ impl NamespacePublisher {
         for candidate in &candidates {
             tracing::info!(
                 phase = "wait_for_batch",
-                mode = self.trace_mode,
-                store_kind = self.trace_store_kind,
-                result = "ok",
+                mode = self.read_core.trace_mode(),
+                store_kind = self.read_core.trace_store_kind(),
+                result = RESULT_OK,
                 wait_ms = elapsed_ms_from(candidate.enqueued_at, selected_at)
             );
         }
 
-        let publish_span = tracing::debug_span!(
-            "loonfs.phase",
-            phase = "batch_publish",
-            mode = self.trace_mode,
-            store_kind = self.trace_store_kind,
+        let publish_span = phase_span!(
+            self.read_core,
+            "batch_publish",
+            self.namespace_id,
             batch_size = usize_to_u64(candidates.len()),
             result = tracing::field::Empty,
-            retry_count = tracing::field::Empty
+            retry_count = tracing::field::Empty,
         );
         let (results, retry_count) = async {
             let mut results = Vec::new();
@@ -1133,8 +1119,8 @@ impl NamespacePublisher {
             self.read_core.instruments().publisher_publish(outcome);
             tracing::info!(
                 phase = "wait_for_result",
-                mode = self.trace_mode,
-                store_kind = self.trace_store_kind,
+                mode = self.read_core.trace_mode(),
+                store_kind = self.read_core.trace_store_kind(),
                 result = outcome.as_str(),
                 wait_ms
             );
@@ -1151,8 +1137,8 @@ impl NamespacePublisher {
             .publisher_queue_depth(queue_depth);
         tracing::info!(
             phase = "enqueue",
-            mode = self.trace_mode,
-            store_kind = self.trace_store_kind,
+            mode = self.read_core.trace_mode(),
+            store_kind = self.read_core.trace_store_kind(),
             queue_depth = usize_to_u64(queue_depth),
             reason
         );

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -423,8 +423,6 @@ fn standalone_publisher(namespace_id: &NamespaceId, runtime: &TestRuntime) -> Na
         Arc::downgrade(&runtime.bits),
         Weak::new(),
         TEST_STANDALONE_PACING,
-        runtime.core.trace_mode(),
-        runtime.core.trace_store_kind(),
     )
 }
 

--- a/crates/loonfs/src/trace.rs
+++ b/crates/loonfs/src/trace.rs
@@ -67,11 +67,6 @@ impl From<ConfiguredObjectStoreKind> for TraceStoreKind {
     }
 }
 
-/// Opens a `loonfs.phase` span carrying the standard context every phase
-/// reports: the phase name, the namespace it runs for, and the runtime's
-/// mode and store kind. A call site adds its own fields after those. This
-/// is the only place the standard field names are written, so a new one
-/// lands on all four phases at once.
 macro_rules! phase_span {
     ($core:expr, $phase:literal, $namespace_id:expr $(, $($field:tt)+)?) => {
         tracing::debug_span!(

--- a/crates/loonfs/src/trace.rs
+++ b/crates/loonfs/src/trace.rs
@@ -67,6 +67,26 @@ impl From<ConfiguredObjectStoreKind> for TraceStoreKind {
     }
 }
 
+/// Opens a `loonfs.phase` span carrying the standard context every phase
+/// reports: the phase name, the namespace it runs for, and the runtime's
+/// mode and store kind. A call site adds its own fields after those. This
+/// is the only place the standard field names are written, so a new one
+/// lands on all four phases at once.
+macro_rules! phase_span {
+    ($core:expr, $phase:literal, $namespace_id:expr $(, $($field:tt)+)?) => {
+        tracing::debug_span!(
+            "loonfs.phase",
+            phase = $phase,
+            namespace_id = %$namespace_id,
+            mode = $core.trace_mode(),
+            store_kind = $core.trace_store_kind(),
+            $($($field)+)?
+        )
+    };
+}
+
+pub(crate) use phase_span;
+
 /// The `cache_path` trace label for a read served through the materialized
 /// metadata segments. The only value the label takes today.
 pub(crate) const CACHE_MATERIALIZED_SEGMENTS: &str = "materialized_segments";

--- a/crates/loonfs/tests/it/capability_conformance.rs
+++ b/crates/loonfs/tests/it/capability_conformance.rs
@@ -49,9 +49,6 @@ fn is_grep_key(key: &str) -> bool {
     key.starts_with("query.") || key.starts_with("admin.grep.")
 }
 
-/// A feature only a serving host can answer: the three direct transports are
-/// properties of the deployment's object store, so these handles leave them
-/// absent and the host adds them when its store can presign.
 fn is_host_transfer_key(key: &str) -> bool {
     matches!(
         key,

--- a/crates/loonfs/tests/it/capability_conformance.rs
+++ b/crates/loonfs/tests/it/capability_conformance.rs
@@ -49,6 +49,16 @@ fn is_grep_key(key: &str) -> bool {
     key.starts_with("query.") || key.starts_with("admin.grep.")
 }
 
+/// A feature only a serving host can answer: the three direct transports are
+/// properties of the deployment's object store, so these handles leave them
+/// absent and the host adds them when its store can presign.
+fn is_host_transfer_key(key: &str) -> bool {
+    matches!(
+        key,
+        "core.uploads.direct_put" | "core.uploads.direct_multipart" | "core.downloads.direct_get"
+    )
+}
+
 fn spec_section<'a>(spec: &'a str, start: &str, end: &str) -> &'a str {
     spec.split(start)
         .nth(1)
@@ -106,7 +116,7 @@ fn advertised_features_match_the_spec_feature_registry() {
 
     let runtime_registry: BTreeSet<String> = registry
         .into_iter()
-        .filter(|key| !is_grep_key(key))
+        .filter(|key| !is_grep_key(key) && !is_host_transfer_key(key))
         .collect();
     let advertised: BTreeSet<String> = embedded_capabilities().features.into_keys().collect();
     assert_eq!(

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -82,9 +82,6 @@ either way.
     "core.namespaces.fork": true,
     "core.namespaces.delete": true,
     "core.attributes": true,
-    "core.uploads.direct_put": false,
-    "core.uploads.direct_multipart": false,
-    "core.downloads.direct_get": false,
     "query.grep": true
   },
   "limits": {


### PR DESCRIPTION
Derives HTTP status from each API error code instead of passing both values at every call site. This prevents the response status and error code from disagreeing.

Resolves grep page limits at the HTTP and CLI boundaries, then passes a validated limit into the grep service. Embedded runtimes now omit unsupported direct-transfer capabilities instead of publishing them as false.

Standardizes shared trace fields and result metric labels, and removes duplicate parsing and defaulting. Local-cache result labels change from failed to error, and close labels change from clean and failed to ok and error.