### PR TITLE
refactor(core): centralize control-object retries

### DIFF
--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -11,6 +11,7 @@
 use crate::control_object::{
     expect_identity_field, expect_namespace, load_control_object, ControlObjectLoadError,
 };
+use crate::control_update::create_control_object_under_generated_id;
 use crate::error::{CoreError, Result};
 use crate::limits::{
     METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS, METADATA_COMPACTION_LEASE_EXPIRY_MS,
@@ -186,24 +187,10 @@ impl<'a> CompactionLease<'a> {
 
     /// Writes the lease for the first time, before the job's first output
     /// object, so no object under the prefix is ever unclaimed.
-    ///
-    /// Create-if-absent, like every other object written under a freshly
-    /// generated id: an occupied key means two generated job ids collided,
-    /// which is a broken generator rather than a lifecycle a caller could
-    /// resolve.
     pub(super) async fn create<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
         let encoded = encode_lease(&self.state)?;
-        // A lease is mutable control state, so its first lifecycle state is a conditional create.
-        let metadata = match store.put_if_absent(&self.object_key, encoded).await {
-            Ok(metadata) => metadata,
-            Err(ObjectStoreError::PreconditionFailed { .. }) => {
-                return Err(CoreError::Internal(format!(
-                    "generated compaction job id collided with the existing lease `{}`",
-                    self.object_key
-                )))
-            }
-            Err(error) => return Err(CoreError::store(&self.object_key, &error)),
-        };
+        let metadata =
+            create_control_object_under_generated_id(store, &self.object_key, encoded).await?;
         self.etag = Some(self.required_etag(metadata.etag)?);
         Ok(())
     }

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -56,8 +56,6 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     validate_checkpoint_owner(&owner)?;
     let timer = &StdMonotonicTimer::default();
     let owner = &owner;
-    // Each attempt runs as its own future, so the record of a lost root race
-    // has to sit outside them all.
     let saw_root_cas_race = &AtomicBool::new(false);
     let created = retry_while_contended(|| async move {
         let basis = match try_flush_wal(store, namespace_id, context, timer).await? {
@@ -116,8 +114,7 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
 
     match (created, saw_root_cas_race.load(Ordering::Relaxed)) {
         (Some(checkpoint), _) => Ok(checkpoint),
-        // A lost root race is contention on the namespace, which the caller
-        // retries; every other exhaustion means no basis ever verified.
+        // Root contention is retryable; other exhaustion means no basis verified.
         (None, true) => Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead)),
         (None, false) => Err(CoreError::CheckpointUnavailable(
             "checkpoint publication retry exhausted".to_owned(),

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -12,15 +12,16 @@ use super::row::manifest_rows_for_family;
 use super::runs::CHECKPOINT_ROW_FAMILIES;
 use crate::commit::CommitHeadPublishError;
 use crate::context::MutationContext;
+use crate::control_update::{retry_while_contended, CasAttempt};
 use crate::error::CoreError;
 use crate::error::Result;
-use crate::limits::CONTENTION_RETRY_LIMIT;
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
 #[cfg(test)]
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::control::{CheckpointOwner, CheckpointRecordState, CheckpointStatus};
 use loonfs_api::{Checkpoint, CheckpointId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(test)]
 use super::load::append_rows_to_metadata;
@@ -53,14 +54,17 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     // 4. On verification failure, release the record — terminally — and
     //    retry against a newer basis under a new id.
     validate_checkpoint_owner(&owner)?;
-    let timer = StdMonotonicTimer::default();
-    let mut saw_root_cas_race = false;
-    for _publication_attempt in 0..CONTENTION_RETRY_LIMIT {
-        let basis = match try_flush_wal(store, namespace_id, context, &timer).await? {
+    let timer = &StdMonotonicTimer::default();
+    let owner = &owner;
+    // Each attempt runs as its own future, so the record of a lost root race
+    // has to sit outside them all.
+    let saw_root_cas_race = &AtomicBool::new(false);
+    let created = retry_while_contended(|| async move {
+        let basis = match try_flush_wal(store, namespace_id, context, timer).await? {
             TryFlushWal::Settled(basis) => basis,
             TryFlushWal::RaceLost => {
-                saw_root_cas_race = true;
-                continue;
+                saw_root_cas_race.store(true, Ordering::Relaxed);
+                return Ok(CasAttempt::Contended);
             }
         };
 
@@ -100,20 +104,24 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
         let within_budget = timer.monotonic_now_ms().saturating_sub(verify_started_ms)
             <= CHECKPOINT_VERIFY_BUDGET_MS;
         if verification == CheckpointBasisVerification::Verified && within_budget {
-            return Ok(super::checkpoint_summary(record));
+            return Ok(CasAttempt::Settled(super::checkpoint_summary(record)));
         }
 
         // Overrunning the budget counts as verification failure: the record
         // may have raced the grace window, so it must not stand as a root.
         release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms).await?;
-    }
+        Ok(CasAttempt::Contended)
+    })
+    .await?;
 
-    if saw_root_cas_race {
-        Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
-    } else {
-        Err(CoreError::CheckpointUnavailable(
+    match (created, saw_root_cas_race.load(Ordering::Relaxed)) {
+        (Some(checkpoint), _) => Ok(checkpoint),
+        // A lost root race is contention on the namespace, which the caller
+        // retries; every other exhaustion means no basis ever verified.
+        (None, true) => Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead)),
+        (None, false) => Err(CoreError::CheckpointUnavailable(
             "checkpoint publication retry exhausted".to_owned(),
-        ))
+        )),
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -103,8 +103,6 @@ pub(super) async fn flush_wal_with_timer<S: ObjectStore + ?Sized>(
         )
     })
     .await?;
-    // A flush that lost every root race is a namespace under active
-    // publication, which the caller retries as a stale head.
     flushed.ok_or(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
 }
 

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -17,10 +17,11 @@ use super::runs::{flatten_manifest_segments, MetadataLsmPolicy, CHECKPOINT_BASE_
 use super::scan::VerifiedMetadataSegments;
 use crate::commit::CommitHeadPublishError;
 use crate::context::MutationContext;
+use crate::control_update::{retry_while_contended, CasAttempt};
 use crate::error::CoreError;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::Result;
-use crate::limits::{CONTENTION_RETRY_LIMIT, METADATA_PUBLICATION_BUDGET_MS};
+use crate::limits::METADATA_PUBLICATION_BUDGET_MS;
 use crate::metadata::MetadataState;
 use crate::namespace::basis::{
     advanced_floor_without_root, load_head_and_metadata_basis, namespace_birth_seq,
@@ -87,21 +88,24 @@ pub(super) async fn flush_wal_with_timer<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     timer: &dyn MonotonicTimer,
 ) -> Result<FlushWalResponse> {
-    for _attempt in 0..CONTENTION_RETRY_LIMIT {
-        match try_flush_wal(store, namespace_id, context, timer).await? {
-            TryFlushWal::Settled(basis) => {
-                return Ok(FlushWalResponse {
+    let flushed = retry_while_contended(|| async move {
+        Result::Ok(
+            match try_flush_wal(store, namespace_id, context, timer).await? {
+                TryFlushWal::Settled(basis) => CasAttempt::Settled(FlushWalResponse {
                     namespace_id: namespace_id.clone(),
                     target_head_seq: basis.target_head_seq,
                     manifest_no: basis.root_after_manifest_no,
                     manifest_head_seq: basis.root_after_head_seq,
                     outcome: basis.outcome,
-                });
-            }
-            TryFlushWal::RaceLost => continue,
-        }
-    }
-    Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
+                }),
+                TryFlushWal::RaceLost => CasAttempt::Contended,
+            },
+        )
+    })
+    .await?;
+    // A flush that lost every root race is a namespace under active
+    // publication, which the caller retries as a stale head.
+    flushed.ok_or(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
 }
 
 /// One flush attempt against one fresh projection.

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -4,8 +4,7 @@
 use super::error::ManifestLoadError;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
-use crate::limits::CONTENTION_RETRY_LIMIT;
-use crate::namespace::control::{load_metadata_root_object, load_metadata_root_object_if_present};
+use crate::namespace::control::load_metadata_root_object_if_present;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_state, ControlObjectKind, ManifestRef, MetadataRootState,
@@ -21,6 +20,8 @@ pub(super) enum ManifestPublicationOutcome {
     /// Someone already published something at least as new; the caller's
     /// manifest stays durable and valid, the newer root simply wins.
     Superseded(MetadataRootState),
+    /// The root moved under this attempt but still names the predecessor the
+    /// candidate was built on, so nothing decided it. The caller rebases.
     RootCasRaceLost,
 }
 
@@ -115,83 +116,122 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
     // manifest (pure compaction), and a lower-seq attempt no-ops in favor of
     // whatever newer root someone else already published.
     //
-    // `expected_predecessor` is the root manifest the caller read when it
-    // built this successor, or `None` when the caller built on a basis this
-    // namespace had not published a root for — a young namespace's genesis
-    // or fork basis, whose successor creates the root object. Head ordering
-    // alone is not enough to decide the winner: every manifest carries
-    // forward the retention floor, so a candidate built from a superseded
-    // basis could win on a higher head while silently reverting a sibling's
-    // acknowledged publication. A root that no longer names the predecessor
-    // therefore supersedes the candidate, whatever the head ordering says;
-    // the caller rebases against the current root and retries.
+    // This is one attempt. A loser's next move is to rebase on the winner's
+    // root, and only the caller knows what rebuilding its candidate costs.
+    // Every caller already runs a bounded loop, so a budget here would
+    // silently multiply theirs.
     let candidate = manifest_ref_for(namespace_id, manifest);
-    for _attempt in 0..CONTENTION_RETRY_LIMIT {
-        let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
-            .await
-            .map_err(CoreError::ControlObjectLoad)?
-        else {
-            match create_first_metadata_root(store, namespace_id, &candidate, updated_at_ms).await?
-            {
-                Some(published) => return Ok(ManifestPublicationOutcome::Published(published)),
-                // Another publisher created the root first; re-read and let
-                // the ordinary rules decide.
-                None => continue,
+    let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
+        .await
+        .map_err(CoreError::ControlObjectLoad)?
+    else {
+        return match create_first_metadata_root(store, namespace_id, &candidate, updated_at_ms)
+            .await?
+        {
+            Some(published) => Ok(ManifestPublicationOutcome::Published(published)),
+            // Another publisher created the root first; its state decides.
+            None => {
+                resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor).await
             }
         };
-        let current = &loaded.state;
-        if current.manifest == candidate {
-            // Idempotent re-publication: the root already names this
-            // candidate (a retried call, or a racing writer of the same
-            // bytes).
-            return Ok(ManifestPublicationOutcome::Published(current.clone()));
+    };
+    match root_decision(loaded.state, &candidate, &expected_predecessor) {
+        // The root still names the predecessor, so this attempt may swap.
+        ManifestPublicationOutcome::RootCasRaceLost => {}
+        decided => return Ok(decided),
+    }
+    let next = MetadataRootState {
+        namespace_id: namespace_id.clone(),
+        manifest: candidate.clone(),
+        updated_at_ms,
+    };
+    let encoded =
+        encode_control_state(ControlObjectKind::MetadataRoot, &next).map_err(|error| {
+            CoreError::Codec {
+                object_key: loaded.object_key.clone(),
+                message: error.to_string(),
+            }
+        })?;
+    match store
+        .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
+        .await
+    {
+        Ok(_) => Ok(ManifestPublicationOutcome::Published(next)),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => {
+            resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor).await
         }
-        if root_supersedes_candidate(current, &candidate) {
-            return Ok(ManifestPublicationOutcome::Superseded(current.clone()));
-        }
-        match &expected_predecessor {
-            Some(expected_predecessor)
-                if current.manifest.manifest_object_id == *expected_predecessor => {}
-            // Either the root moved off the basis this candidate was built
-            // on, or the candidate was built on no root at all and one now
-            // exists.
-            _ => return Ok(ManifestPublicationOutcome::Superseded(current.clone())),
-        }
-
-        let next = MetadataRootState {
-            namespace_id: namespace_id.clone(),
-            manifest: candidate.clone(),
-            updated_at_ms,
-        };
-        let encoded =
-            encode_control_state(ControlObjectKind::MetadataRoot, &next).map_err(|error| {
-                CoreError::Codec {
-                    object_key: loaded.object_key.clone(),
-                    message: error.to_string(),
+        // The swap's outcome is unobserved, so the published root answers it.
+        // A root that still names the predecessor answers nothing, and then
+        // the store failure stands.
+        Err(error) => {
+            match resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor)
+                .await?
+            {
+                ManifestPublicationOutcome::RootCasRaceLost => {
+                    Err(CoreError::store(&loaded.object_key, &error))
                 }
-            })?;
-        match store
-            .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
-            .await
-        {
-            Ok(_) => return Ok(ManifestPublicationOutcome::Published(next)),
-            Err(ObjectStoreError::PreconditionFailed { .. }) => continue,
-            Err(error) => {
-                let recovered = load_metadata_root_object(store, namespace_id)
-                    .await
-                    .map_err(CoreError::ControlObjectLoad)?
-                    .state;
-                if recovered.manifest == candidate {
-                    return Ok(ManifestPublicationOutcome::Published(recovered));
-                }
-                if root_supersedes_candidate(&recovered, &candidate) {
-                    return Ok(ManifestPublicationOutcome::Superseded(recovered));
-                }
-                return Err(CoreError::store(&loaded.object_key, &error));
+                outcome => Ok(outcome),
             }
         }
     }
-    Ok(ManifestPublicationOutcome::RootCasRaceLost)
+}
+
+/// What the currently published `root` decides about `candidate`.
+///
+/// [`ManifestPublicationOutcome::RootCasRaceLost`] means the root decided
+/// nothing: it still names the predecessor, so the swap is the caller's to
+/// attempt or to report.
+///
+/// `expected_predecessor` is the root manifest the caller read when it built
+/// this successor, or `None` when the caller built on a basis this namespace
+/// had not published a root for — a young namespace's genesis or fork basis,
+/// whose successor creates the root object. Head ordering alone is not enough
+/// to decide the winner: every manifest carries forward the retention floor,
+/// so a candidate built from a superseded basis could win on a higher head
+/// while silently reverting a sibling's acknowledged publication. A root that
+/// no longer names the predecessor therefore supersedes the candidate,
+/// whatever the head ordering says.
+fn root_decision(
+    root: MetadataRootState,
+    candidate: &ManifestRef,
+    expected_predecessor: &Option<ManifestObjectId>,
+) -> ManifestPublicationOutcome {
+    if root.manifest == *candidate {
+        // Idempotent re-publication: a retried call, or a racing writer of
+        // the same bytes.
+        return ManifestPublicationOutcome::Published(root);
+    }
+    if root_supersedes_candidate(&root, candidate) {
+        return ManifestPublicationOutcome::Superseded(root);
+    }
+    match expected_predecessor {
+        Some(predecessor) if root.manifest.manifest_object_id == *predecessor => {
+            ManifestPublicationOutcome::RootCasRaceLost
+        }
+        // Either the root moved off the basis this candidate was built on, or
+        // the candidate was built on no root at all and one now exists.
+        _ => ManifestPublicationOutcome::Superseded(root),
+    }
+}
+
+/// Re-reads the root after a swap this attempt did not win and says what its
+/// current state decides.
+///
+/// A root that is still absent decides nothing either: the winner of a lost
+/// create raced this attempt and has not landed yet.
+async fn resolve_lost_root_swap<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidate: &ManifestRef,
+    expected_predecessor: &Option<ManifestObjectId>,
+) -> Result<ManifestPublicationOutcome> {
+    let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
+        .await
+        .map_err(CoreError::ControlObjectLoad)?
+    else {
+        return Ok(ManifestPublicationOutcome::RootCasRaceLost);
+    };
+    Ok(root_decision(loaded.state, candidate, expected_predecessor))
 }
 
 /// Publishes the namespace's first `metadata/root.json`.

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -20,8 +20,7 @@ pub(super) enum ManifestPublicationOutcome {
     /// Someone already published something at least as new; the caller's
     /// manifest stays durable and valid, the newer root simply wins.
     Superseded(MetadataRootState),
-    /// The root moved under this attempt but still names the predecessor the
-    /// candidate was built on, so nothing decided it. The caller rebases.
+    /// The root changed, but the candidate can still be retried.
     RootCasRaceLost,
 }
 
@@ -116,10 +115,7 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
     // manifest (pure compaction), and a lower-seq attempt no-ops in favor of
     // whatever newer root someone else already published.
     //
-    // This is one attempt. A loser's next move is to rebase on the winner's
-    // root, and only the caller knows what rebuilding its candidate costs.
-    // Every caller already runs a bounded loop, so a budget here would
-    // silently multiply theirs.
+    // Callers own the retry policy because rebuilding costs vary by operation.
     let candidate = manifest_ref_for(namespace_id, manifest);
     let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
         .await
@@ -129,14 +125,12 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
             .await?
         {
             Some(published) => Ok(ManifestPublicationOutcome::Published(published)),
-            // Another publisher created the root first; its state decides.
             None => {
                 resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor).await
             }
         };
     };
     match root_decision(loaded.state, &candidate, &expected_predecessor) {
-        // The root still names the predecessor, so this attempt may swap.
         ManifestPublicationOutcome::RootCasRaceLost => {}
         decided => return Ok(decided),
     }
@@ -160,9 +154,7 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
         Err(ObjectStoreError::PreconditionFailed { .. }) => {
             resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor).await
         }
-        // The swap's outcome is unobserved, so the published root answers it.
-        // A root that still names the predecessor answers nothing, and then
-        // the store failure stands.
+        // Re-read the root to resolve an unknown write outcome.
         Err(error) => {
             match resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor)
                 .await?
@@ -176,29 +168,16 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
     }
 }
 
-/// What the currently published `root` decides about `candidate`.
+/// Decides whether the current root accepts, supersedes, or leaves the candidate retryable.
 ///
-/// [`ManifestPublicationOutcome::RootCasRaceLost`] means the root decided
-/// nothing: it still names the predecessor, so the swap is the caller's to
-/// attempt or to report.
-///
-/// `expected_predecessor` is the root manifest the caller read when it built
-/// this successor, or `None` when the caller built on a basis this namespace
-/// had not published a root for — a young namespace's genesis or fork basis,
-/// whose successor creates the root object. Head ordering alone is not enough
-/// to decide the winner: every manifest carries forward the retention floor,
-/// so a candidate built from a superseded basis could win on a higher head
-/// while silently reverting a sibling's acknowledged publication. A root that
-/// no longer names the predecessor therefore supersedes the candidate,
-/// whatever the head ordering says.
+/// A candidate may replace only its expected predecessor. This prevents stale
+/// work from overwriting a sibling publication, even at a higher head sequence.
 fn root_decision(
     root: MetadataRootState,
     candidate: &ManifestRef,
     expected_predecessor: &Option<ManifestObjectId>,
 ) -> ManifestPublicationOutcome {
     if root.manifest == *candidate {
-        // Idempotent re-publication: a retried call, or a racing writer of
-        // the same bytes.
         return ManifestPublicationOutcome::Published(root);
     }
     if root_supersedes_candidate(&root, candidate) {
@@ -208,17 +187,11 @@ fn root_decision(
         Some(predecessor) if root.manifest.manifest_object_id == *predecessor => {
             ManifestPublicationOutcome::RootCasRaceLost
         }
-        // Either the root moved off the basis this candidate was built on, or
-        // the candidate was built on no root at all and one now exists.
         _ => ManifestPublicationOutcome::Superseded(root),
     }
 }
 
-/// Re-reads the root after a swap this attempt did not win and says what its
-/// current state decides.
-///
-/// A root that is still absent decides nothing either: the winner of a lost
-/// create raced this attempt and has not landed yet.
+/// Re-reads the root after a lost or unconfirmed swap.
 async fn resolve_lost_root_swap<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -236,10 +209,7 @@ async fn resolve_lost_root_swap<S: ObjectStore + ?Sized>(
 
 /// Publishes the namespace's first `metadata/root.json`.
 ///
-/// A namespace that has never flushed has no root object to compare and
-/// swap, so its first publication is a create-if-absent. Losing that race
-/// returns `None`: the winner's root is then read and the ordinary
-/// supersession rules apply.
+/// Returns `None` when another publisher wins the conditional create.
 async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -259,7 +229,6 @@ async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
                 message: error.to_string(),
             }
         })?;
-    // The metadata root is mutable control state, so its first publication is a conditional create.
     match store.put_if_absent(&object_key, Bytes::from(encoded)).await {
         Ok(_) => Ok(Some(next)),
         Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(None),

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -140,24 +140,13 @@ pub(crate) async fn load_checkpoint_record<S: ObjectStore + ?Sized>(
     }
 }
 
-/// What one release compare-and-swap did.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CheckpointRelease {
-    /// This caller wrote the release.
     Released,
-    /// The record changed under the etag that was inspected, so nothing was
-    /// written. Whether to look again is the caller's policy.
     LostRace,
 }
 
-/// Moves one inspected record `active -> released` by compare-and-swap on the
-/// etag it was read at, stamping `released_at_ms`.
-///
-/// This is the only state change a checkpoint record ever makes, and it is
-/// one-way, so every caller converges: the owner asking for it and garbage
-/// collection acting on a passed expiry reach the same end state. Callers
-/// differ only in what they do with a lost race — garbage collection acts on
-/// one inspection and retains, while [`release_checkpoint_record`] reloads.
+/// Tries one `active -> released` transition using the loaded ETag.
 pub(crate) async fn release_inspected_checkpoint_record<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
@@ -177,8 +166,7 @@ pub(crate) async fn release_inspected_checkpoint_record<S: ObjectStore + ?Sized>
     }
 }
 
-/// Releases the record named by `checkpoint_id`, reloading while it keeps
-/// losing the race.
+/// Releases a checkpoint record, retrying CAS conflicts.
 pub(crate) async fn release_checkpoint_record<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -11,6 +11,9 @@ use crate::control_object::{
     expect_identity_field, expect_namespace, expect_own_manifest, load_control_object,
     ControlObjectLoadError, LoadedControl,
 };
+use crate::control_update::{
+    create_control_object_under_generated_id, retry_while_contended, CasAttempt,
+};
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::load_head_object;
@@ -35,25 +38,15 @@ pub(crate) fn encode_checkpoint_record(
         })
 }
 
-/// Writes a record under its freshly generated id with create-if-absent.
-///
-/// The id comes from [`CheckpointId::generate`], so the key is this pin's
-/// alone: an occupied key means two generated ids collided, which is a
-/// broken generator rather than a lifecycle a caller could resolve.
+/// Writes a record under its freshly generated [`CheckpointId`].
 pub(crate) async fn write_checkpoint_record<S: ObjectStore + ?Sized>(
     store: &S,
     record: &CheckpointRecordState,
 ) -> Result<()> {
     let encoded = encode_checkpoint_record(record)?;
     let object_key = checkpoint_record(&record.namespace_id, &record.checkpoint_id);
-    // A checkpoint record is mutable control state, so its first lifecycle state is a conditional create.
-    match store.put_if_absent(&object_key, encoded).await {
-        Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => Err(CoreError::Internal(format!(
-            "generated checkpoint id collided with the existing record `{object_key}`"
-        ))),
-        Err(error) => Err(CoreError::store(&object_key, &error)),
-    }
+    create_control_object_under_generated_id(store, &object_key, encoded).await?;
+    Ok(())
 }
 
 pub(crate) type LoadedCheckpointRecord = LoadedControl<CheckpointRecordState>;
@@ -147,45 +140,72 @@ pub(crate) async fn load_checkpoint_record<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Moves a record `active -> released` by compare-and-swap, stamping
-/// `released_at_ms`.
+/// What one release compare-and-swap did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckpointRelease {
+    /// This caller wrote the release.
+    Released,
+    /// The record changed under the etag that was inspected, so nothing was
+    /// written. Whether to look again is the caller's policy.
+    LostRace,
+}
+
+/// Moves one inspected record `active -> released` by compare-and-swap on the
+/// etag it was read at, stamping `released_at_ms`.
 ///
 /// This is the only state change a checkpoint record ever makes, and it is
 /// one-way, so every caller converges: the owner asking for it and garbage
-/// collection acting on a passed expiry reach the same end state, and a
-/// record that is already released is left exactly as the winner wrote it.
+/// collection acting on a passed expiry reach the same end state. Callers
+/// differ only in what they do with a lost race — garbage collection acts on
+/// one inspection and retains, while [`release_checkpoint_record`] reloads.
+pub(crate) async fn release_inspected_checkpoint_record<S: ObjectStore + ?Sized>(
+    store: &S,
+    object_key: &str,
+    loaded: LoadedCheckpointRecord,
+    released_at_ms: u64,
+) -> Result<CheckpointRelease> {
+    let mut next = loaded.state;
+    next.status = CheckpointStatus::Released { released_at_ms };
+    let encoded = encode_checkpoint_record(&next)?;
+    match store
+        .compare_and_swap(object_key, &loaded.etag, encoded)
+        .await
+    {
+        Ok(_) => Ok(CheckpointRelease::Released),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CheckpointRelease::LostRace),
+        Err(error) => Err(CoreError::store(object_key, &error)),
+    }
+}
+
+/// Releases the record named by `checkpoint_id`, reloading while it keeps
+/// losing the race.
 pub(crate) async fn release_checkpoint_record<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     checkpoint_id: &CheckpointId,
     released_at_ms: u64,
 ) -> Result<()> {
-    const RELEASE_CAS_ATTEMPTS: usize = 4;
-    let object_key = checkpoint_record(namespace_id, checkpoint_id);
-    for _attempt in 0..RELEASE_CAS_ATTEMPTS {
-        let Some(loaded) = load_checkpoint_record(store, namespace_id, checkpoint_id).await? else {
-            // Reaped underneath us: no active pin under this id is exactly
-            // what the release asked for.
-            return Ok(());
+    let object_key = &checkpoint_record(namespace_id, checkpoint_id);
+    let released = retry_while_contended(|| async move {
+        let Some(loaded) = load_checkpoint_record(store, namespace_id, checkpoint_id)
+            .await?
+            .filter(|loaded| loaded.state.status == (CheckpointStatus::Active {}))
+        else {
+            // Reaped or released underneath us: either way no active pin
+            // stands under this id, which is what the release asked for.
+            return Ok::<_, CoreError>(CasAttempt::Settled(()));
         };
-        if matches!(loaded.state.status, CheckpointStatus::Released { .. }) {
-            return Ok(());
-        }
-        let mut next = loaded.state;
-        next.status = CheckpointStatus::Released { released_at_ms };
-        let encoded = encode_checkpoint_record(&next)?;
-        match store
-            .compare_and_swap(&object_key, &loaded.etag, encoded)
-            .await
-        {
-            Ok(_) => return Ok(()),
-            Err(ObjectStoreError::PreconditionFailed { .. }) => continue,
-            Err(error) => return Err(CoreError::store(&object_key, &error)),
-        }
-    }
-    Err(CoreError::Internal(format!(
-        "checkpoint record `{object_key}` release retries exhausted"
-    )))
+        Ok(
+            match release_inspected_checkpoint_record(store, object_key, loaded, released_at_ms)
+                .await?
+            {
+                CheckpointRelease::Released => CasAttempt::Settled(()),
+                CheckpointRelease::LostRace => CasAttempt::Contended,
+            },
+        )
+    })
+    .await?;
+    released.ok_or_else(|| CoreError::contention_exhausted(object_key))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -774,16 +774,9 @@ fn group_delta_rows(payload: &NamespaceManifestPayload, group: MetadataFamilyGro
         .sum()
 }
 
-/// Writes the manifest that replaces `previous`: the descriptors that survived
-/// the merge, then the merge's own output.
+/// Writes a replacement manifest from surviving and newly produced segments.
 ///
-/// `next_run_no` and `base_seq` are manifest invariants, so they are derived
-/// here rather than at each caller. A merge whose rows all fell to retention
-/// writes no segment, and a run nothing names takes no number. `base_seq` is
-/// the oldest-run marker: every referenced run sits at or above it, including
-/// delta runs other groups have not folded yet. Which descriptors survive
-/// stays the caller's question, because a bounded merge and a streaming
-/// compaction select their inputs differently.
+/// The resulting segments determine the base sequence and next run number.
 pub(super) async fn write_replacement_manifest<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -297,7 +297,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     )
     .await?;
 
-    let mut next_segments: Vec<_> = previous
+    let surviving: Vec<_> = previous
         .payload
         .segments
         .iter()
@@ -306,31 +306,13 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         })
         .cloned()
         .collect();
-    // A merge whose rows all fell to retention writes no segment, and a run
-    // nothing names takes no number.
-    let next_run_no = if merged.output_segments.is_empty() {
-        previous.payload.next_run_no
-    } else {
-        next_run_no_after(run_no)?
-    };
-    next_segments.extend(merged.output_segments);
-    // `base_seq` is the manifest's oldest-run marker: every referenced run
-    // must sit at or above it, including delta runs other groups have not
-    // folded yet.
-    let base_seq = next_segments
-        .iter()
-        .map(|descriptor| descriptor.run_seq)
-        .min()
-        .unwrap_or(previous.payload.base_seq);
-
-    let manifest = write_reorganized_manifest(
+    let manifest = write_replacement_manifest(
         store,
         namespace_id,
         previous,
-        next_segments,
-        base_seq,
-        next_run_no,
-        previous.payload.retention_floor_seq.max(floor_seq),
+        surviving,
+        merged.output_segments,
+        floor_seq,
     )
     .await?;
 
@@ -792,15 +774,36 @@ fn group_delta_rows(payload: &NamespaceManifestPayload, group: MetadataFamilyGro
         .sum()
 }
 
-pub(super) async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
+/// Writes the manifest that replaces `previous`: the descriptors that survived
+/// the merge, then the merge's own output.
+///
+/// `next_run_no` and `base_seq` are manifest invariants, so they are derived
+/// here rather than at each caller. A merge whose rows all fell to retention
+/// writes no segment, and a run nothing names takes no number. `base_seq` is
+/// the oldest-run marker: every referenced run sits at or above it, including
+/// delta runs other groups have not folded yet. Which descriptors survive
+/// stays the caller's question, because a bounded merge and a streaming
+/// compaction select their inputs differently.
+pub(super) async fn write_replacement_manifest<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     previous: &NamespaceManifestEnvelope,
-    segments: Vec<MetadataSegmentRef>,
-    base_seq: ChangeSeq,
-    next_run_no: RunNo,
-    retention_floor_seq: ChangeSeq,
+    surviving: Vec<MetadataSegmentRef>,
+    outputs: Vec<MetadataSegmentRef>,
+    floor_seq: ChangeSeq,
 ) -> Result<NamespaceManifestEnvelope> {
+    let next_run_no = if outputs.is_empty() {
+        previous.payload.next_run_no
+    } else {
+        next_run_no_after(previous.payload.next_run_no)?
+    };
+    let segments: Vec<MetadataSegmentRef> = surviving.into_iter().chain(outputs).collect();
+    let base_seq = segments
+        .iter()
+        .map(|descriptor| descriptor.run_seq)
+        .min()
+        .unwrap_or(previous.payload.base_seq);
+    let retention_floor_seq = previous.payload.retention_floor_seq.max(floor_seq);
     // One generated object id, one write. The generated id ends in 16 random
     // hex characters, so the key is this unit's alone and a conflict under it
     // is corruption rather than contention.

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -3,9 +3,9 @@
 use super::load::{ensure_root_matches_manifest, load_verified_manifest_segments};
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
+use crate::control_update::{retry_while_contended, CasAttempt};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
-use crate::limits::CONTENTION_RETRY_LIMIT;
 use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::{
     load_head_object, load_metadata_root_object_if_present, load_wal_floor_object,
@@ -72,7 +72,8 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
 
     // Monotonic floor publication: never decrease. The first advance
     // creates the object, because create and fork write no floor.
-    for _attempt in 0..CONTENTION_RETRY_LIMIT {
+    let object_key = &loonfs_objectstore::keys::wal_floor(namespace_id);
+    let advanced = retry_while_contended(|| async move {
         let loaded = match load_wal_floor_object(store, namespace_id).await {
             Ok(loaded) => Some(loaded),
             Err(ControlObjectLoadError::MissingObject { .. }) => None,
@@ -80,16 +81,13 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         };
         let published_floor = loaded.as_ref().map(|loaded| loaded.state.floor_seq);
         if let Some(floor_seq) = published_floor.filter(|floor_seq| *floor_seq >= target_floor) {
-            return Ok(AdvanceRetentionResponse {
-                retention_floor_seq: floor_seq,
-            });
+            return Ok(CasAttempt::Settled(floor_seq));
         }
         let next = WalFloorState {
             namespace_id: namespace_id.clone(),
             floor_seq: target_floor,
             updated_at_ms: context.now_ms,
         };
-        let object_key = loonfs_objectstore::keys::wal_floor(namespace_id);
         let encoded =
             encode_control_state(ControlObjectKind::WalFloor, &next).map_err(|error| {
                 CoreError::Codec {
@@ -100,23 +98,20 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         let published = match &loaded {
             Some(loaded) => {
                 store
-                    .compare_and_swap(&object_key, &loaded.etag, Bytes::from(encoded))
+                    .compare_and_swap(object_key, &loaded.etag, Bytes::from(encoded))
                     .await
             }
             // The retention floor is mutable control state, so its first publication is a conditional create.
-            None => store.put_if_absent(&object_key, Bytes::from(encoded)).await,
+            None => store.put_if_absent(object_key, Bytes::from(encoded)).await,
         };
         match published {
-            Ok(_) => {
-                return Ok(AdvanceRetentionResponse {
-                    retention_floor_seq: target_floor,
-                })
-            }
-            Err(ObjectStoreError::PreconditionFailed { .. }) => continue,
-            Err(error) => return Err(CoreError::store(&object_key, &error)),
+            Ok(_) => Ok(CasAttempt::Settled(target_floor)),
+            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
+            Err(error) => Err(CoreError::store(object_key, &error)),
         }
-    }
-    Err(CoreError::Internal(
-        "retention floor compare-and-swap retry exhausted".to_owned(),
-    ))
+    })
+    .await?;
+    Ok(AdvanceRetentionResponse {
+        retention_floor_seq: advanced.ok_or_else(|| CoreError::contention_exhausted(object_key))?,
+    })
 }

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -20,7 +20,7 @@ use super::compaction_merge::{
 use super::compaction_output::MergeSegmentWriter;
 use super::compaction_retention::{KeptRow, RetentionRule};
 use super::error::ManifestLoadError;
-use super::flush::{ensure_metadata_publication_budget, next_run_no_after};
+use super::flush::ensure_metadata_publication_budget;
 use super::frozen_floor::{
     bind_survives_frozen_floor, unbinding_at_or_below_floor, unbindings_at_or_below_floor,
     BindingGeneration,
@@ -29,7 +29,7 @@ use super::load::{
     load_manifest_segment_rows_in_key_range_with_cache, load_verified_manifest_segments,
 };
 use super::publish::{publish_metadata_root, ManifestPublicationOutcome};
-use super::reorganize::{group_run_descriptors, write_reorganized_manifest, MergePlacement};
+use super::reorganize::{group_run_descriptors, write_replacement_manifest, MergePlacement};
 use super::runs::{MetadataFamilyGroup, MetadataLsmPolicy, MetadataRunManifest};
 use super::scan::{descriptor_may_intersect_range, Readahead, VerifiedMetadataSegments};
 use crate::context::MutationContext;
@@ -622,7 +622,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         }
 
         let previous = segments.manifest();
-        let mut next_segments: Vec<MetadataSegmentRef> = previous
+        let surviving: Vec<MetadataSegmentRef> = previous
             .payload
             .segments
             .iter()
@@ -634,35 +634,22 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         // started. So the number is taken here, from the manifest this
         // attempt replaces, and stamped onto the output the job wrote.
         let run_no = previous.payload.next_run_no;
-        next_segments.extend(result.output_segments.iter().cloned().map(|descriptor| {
-            MetadataSegmentRef {
+        let outputs: Vec<MetadataSegmentRef> = result
+            .output_segments
+            .iter()
+            .cloned()
+            .map(|descriptor| MetadataSegmentRef {
                 run_no,
                 ..descriptor
-            }
-        }));
-        // A job whose rows all fell to retention writes no segment, and a run
-        // nothing names takes no number.
-        let next_run_no = if result.output_segments.is_empty() {
-            previous.payload.next_run_no
-        } else {
-            next_run_no_after(run_no)?
-        };
-        let base_seq = next_segments
-            .iter()
-            .map(|descriptor| descriptor.run_seq)
-            .min()
-            .unwrap_or(previous.payload.base_seq);
-        let manifest = write_reorganized_manifest(
+            })
+            .collect();
+        let manifest = write_replacement_manifest(
             store,
             namespace_id,
             previous,
-            next_segments,
-            base_seq,
-            next_run_no,
-            previous
-                .payload
-                .retention_floor_seq
-                .max(spec.frozen_floor_seq()),
+            surviving,
+            outputs,
+            spec.frozen_floor_seq(),
         )
         .await?;
 
@@ -681,29 +668,28 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         )
         .await?;
         drop(segments);
-        match published {
+        let lost_to = match published {
             ManifestPublicationOutcome::Published(_) => {
                 return Ok(Finalization::Published(manifest.payload.manifest_no))
             }
-            ManifestPublicationOutcome::Superseded(_)
-            | ManifestPublicationOutcome::RootCasRaceLost => {
-                tracing::debug!(
-                    namespace_id = namespace_id.as_str(),
-                    families = ?spec.families(),
-                    attempt,
-                    attempts = MAX_FINALIZATION_ATTEMPTS,
-                    "a publication landed while a streaming metadata compaction was finalizing; \
-                     reloading"
-                );
-            }
-        }
+            ManifestPublicationOutcome::Superseded(_) => "a newer root",
+            ManifestPublicationOutcome::RootCasRaceLost => "the root compare-and-swap",
+        };
+        tracing::debug!(
+            namespace_id = namespace_id.as_str(),
+            families = ?spec.families(),
+            attempt,
+            attempts = MAX_FINALIZATION_ATTEMPTS,
+            lost_to,
+            "a streaming metadata compaction lost its finalizing publication; reloading"
+        );
     }
     tracing::info!(
         namespace_id = namespace_id.as_str(),
         families = ?spec.families(),
         attempts = MAX_FINALIZATION_ATTEMPTS,
-        "streaming metadata compaction superseded at every publication attempt; a later step \
-         plans it again"
+        "streaming metadata compaction lost every publication attempt; a later step plans it \
+         again"
     );
     Ok(Finalization::Superseded)
 }

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -529,9 +529,7 @@ async fn load_current_projection<S: ObjectStore + ?Sized>(
         load_checkpoint_projection_metadata_state(store, namespace_id).await?;
     let root = load_metadata_root_object(store, namespace_id)
         .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     Ok(CurrentProjection {
         head,

--- a/crates/loonfs-core/src/commit/inode_allocator.rs
+++ b/crates/loonfs-core/src/commit/inode_allocator.rs
@@ -3,6 +3,15 @@
 use crate::error::{CoreError, Result};
 use loonfs_api::InodeId;
 
+/// The allocator position that follows `inode_id`, or `None` at the ceiling.
+///
+/// WAL replay re-derives the same position from the `CreateInode` deltas the
+/// write path emitted, and the two answers are compared on every projection
+/// load, so they have to advance by the same rule (`wal::replay`).
+pub(crate) fn next_inode_after(inode_id: InodeId) -> Option<InodeId> {
+    inode_id.0.checked_add(1).map(InodeId)
+}
+
 /// The one authoritative next-inode position for a tentative publish batch.
 #[derive(Debug)]
 pub(crate) struct InodeAllocator {
@@ -53,11 +62,7 @@ impl InodeAllocator {
 impl CandidateAllocation {
     pub(crate) fn allocate(&mut self) -> Result<InodeId> {
         let allocated = self.next;
-        self.next = self
-            .next
-            .0
-            .checked_add(1)
-            .map(InodeId)
+        self.next = next_inode_after(allocated)
             .ok_or_else(|| CoreError::Internal("next inode id counter overflow".to_owned()))?;
         Ok(allocated)
     }

--- a/crates/loonfs-core/src/commit/inode_allocator.rs
+++ b/crates/loonfs-core/src/commit/inode_allocator.rs
@@ -3,11 +3,7 @@
 use crate::error::{CoreError, Result};
 use loonfs_api::InodeId;
 
-/// The allocator position that follows `inode_id`, or `None` at the ceiling.
-///
-/// WAL replay re-derives the same position from the `CreateInode` deltas the
-/// write path emitted, and the two answers are compared on every projection
-/// load, so they have to advance by the same rule (`wal::replay`).
+/// Returns the next inode ID, or `None` at the limit.
 pub(crate) fn next_inode_after(inode_id: InodeId) -> Option<InodeId> {
     inode_id.0.checked_add(1).map(InodeId)
 }

--- a/crates/loonfs-core/src/commit/mod.rs
+++ b/crates/loonfs-core/src/commit/mod.rs
@@ -18,7 +18,7 @@ mod validate;
 mod wal_payload;
 
 pub use self::identity::CommitFingerprint;
-pub(crate) use self::inode_allocator::{CandidateAllocation, InodeAllocator};
+pub(crate) use self::inode_allocator::{next_inode_after, CandidateAllocation, InodeAllocator};
 pub use self::materialize::MaterializedCommitDelta;
 pub(crate) use self::materialize::{materialize_commit, MaterializedCommit};
 pub(crate) use self::ops::{CommitOp, CommitPrecondition, PlannedOp};

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -83,9 +83,6 @@ pub(crate) fn prepare_commit_head_publish(
         next_inode_id: plan.resulting_next_inode_id,
         recent_segments: next_recent_segments(current_head),
         visible_wal_tip: Some(new_tip),
-        // The head is the only durable home of the namespace's content
-        // store, name policy, and fork provenance: every successor carries
-        // them forward verbatim, and the assertion below proves it did.
         ..current_head.clone()
     };
     current_head

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -78,21 +78,15 @@ pub(crate) fn prepare_commit_head_publish(
     let object_key = wal_head(&current_head.namespace_id);
     let new_tip = wal.envelope.pointer();
     let resulting_head = HeadState {
-        namespace_id: current_head.namespace_id.clone(),
-        // The head is the only durable home of the namespace's content
-        // store, name policy, and fork provenance: every successor carries
-        // them forward verbatim, and the assertion below proves it did.
-        content_store_id: current_head.content_store_id.clone(),
-        created_at_ms: current_head.created_at_ms,
-        fork_basis: current_head.fork_basis.clone(),
         seq: plan.assigned_seq,
         head_commit_id: plan.commit_id.clone(),
-        writer_epoch: current_head.writer_epoch,
-        writer: current_head.writer.clone(),
         next_inode_id: plan.resulting_next_inode_id,
         recent_segments: next_recent_segments(current_head),
         visible_wal_tip: Some(new_tip),
-        status: current_head.status,
+        // The head is the only durable home of the namespace's content
+        // store, name policy, and fork provenance: every successor carries
+        // them forward verbatim, and the assertion below proves it did.
+        ..current_head.clone()
     };
     current_head
         .ensure_successor_identity(&resulting_head)

--- a/crates/loonfs-core/src/commit/validate/error.rs
+++ b/crates/loonfs-core/src/commit/validate/error.rs
@@ -260,8 +260,6 @@ pub enum CommitValidationError {
     },
     #[error("validated preview apply failed: {0}")]
     ValidatedPreviewApplyFailed(String),
-    #[error("next inode id counter overflow")]
-    NextInodeOverflow,
     #[error("op index overflow")]
     OpIndexOverflow,
     #[error("delta index overflow")]

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -1,21 +1,77 @@
-//! Read-modify-write loops for control objects: load, edit, and
-//! compare-and-swap the head or an upload session on its etag.
+//! Writes to mutable control objects: the conditional create that installs
+//! one under a generated id, and the read-modify-write loops that load, edit,
+//! and compare-and-swap the head or an upload session on its etag.
 
 use crate::control_object::{
     expect_identity_field, expect_namespace, load_control_object, ControlObjectLoadError,
     LoadedControl,
 };
 use crate::error::{CoreError, StoreFailureClass};
+use crate::limits::CONTENTION_RETRY_LIMIT;
 use crate::namespace::control::{load_head_object, LoadedHeadObject};
 use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_state, ControlObjectKind, HeadState, UploadSessionState,
 };
 use loonfs_api::{NamespaceId, UploadId};
-use loonfs_objectstore::keys::upload_session;
-use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+use loonfs_objectstore::keys::{upload_session, wal_head};
+use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::future::Future;
 use thiserror::Error;
+
+/// What one attempt of a bounded compare-and-swap loop decided.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CasAttempt<T> {
+    /// The attempt reached an outcome, whether or not it wrote anything.
+    Settled(T),
+    /// The object moved under the etag this attempt read it at, so the whole
+    /// read-decide-swap cycle has to run again against the current state.
+    Contended,
+}
+
+/// Runs `attempt` until it settles, at most [`CONTENTION_RETRY_LIMIT`] times.
+///
+/// No control object is worth a different number of tries than its
+/// neighbours, so the bound is one number for all of them. `None` means every
+/// attempt lost its race, and what that means to a caller belongs to the
+/// operation rather than to this loop: publication reports a lost root race,
+/// deletion a stale head, everything else
+/// [`CoreError::contention_exhausted`]. Attempts run back to back; whether
+/// contention should be paced is a decision this crate has not made anywhere.
+pub(crate) async fn retry_while_contended<T, E, F, Fut>(
+    mut attempt: F,
+) -> std::result::Result<Option<T>, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = std::result::Result<CasAttempt<T>, E>>,
+{
+    for _attempt in 0..CONTENTION_RETRY_LIMIT {
+        if let CasAttempt::Settled(outcome) = attempt().await? {
+            return Ok(Some(outcome));
+        }
+    }
+    Ok(None)
+}
+
+/// Installs a control object under a freshly generated id.
+///
+/// Every generated id ends in 16 random hex characters, so the key is this
+/// object's alone: an occupied key means two ids collided, which is a broken
+/// generator rather than a lifecycle a caller could resolve.
+pub(crate) async fn create_control_object_under_generated_id<S: ObjectStore + ?Sized>(
+    store: &S,
+    object_key: &str,
+    encoded: Bytes,
+) -> crate::error::Result<ObjectMetadata> {
+    // Mutable control state, so its first lifecycle state is a conditional create.
+    match store.put_if_absent(object_key, encoded).await {
+        Ok(metadata) => Ok(metadata),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => Err(CoreError::Internal(format!(
+            "a generated id collided with the existing control object `{object_key}`"
+        ))),
+        Err(error) => Err(CoreError::store(object_key, &error)),
+    }
+}
 
 /// Replacement head state and the value returned after its CAS succeeds.
 /// An update that should not write must return an error instead.
@@ -34,12 +90,6 @@ pub(crate) enum UploadSessionUpdate<T> {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum UploadSessionCas<T> {
-    Applied(T),
-    Conflict,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub(crate) enum ControlUpdateError {
     #[error(transparent)]
@@ -52,8 +102,8 @@ pub(crate) enum ControlUpdateError {
         message: String,
         class: StoreFailureClass,
     },
-    #[error("control object update retries exhausted after {attempts} attempts")]
-    RetryExhausted { attempts: usize },
+    #[error("{}", crate::error::contention_message(object_key))]
+    RetryExhausted { object_key: String },
 }
 
 /// Reads the head, asks `update` to build a replacement, and applies it with
@@ -63,15 +113,15 @@ pub(crate) enum ControlUpdateError {
 pub(crate) async fn update_head<S, T, E, F>(
     store: &S,
     namespace_id: &NamespaceId,
-    max_attempts: usize,
-    mut update: F,
+    update: F,
 ) -> Result<T, E>
 where
     S: ObjectStore + ?Sized,
     E: From<ControlUpdateError>,
-    F: FnMut(&LoadedHeadObject) -> Result<HeadReplacement<T>, E>,
+    F: Fn(&LoadedHeadObject) -> Result<HeadReplacement<T>, E>,
 {
-    for _attempt in 0..max_attempts {
+    let update = &update;
+    let updated = retry_while_contended(|| async move {
         let loaded = load_head_object(store, namespace_id)
             .await
             .map_err(|error| E::from(ControlUpdateError::LoadHead(error)))?;
@@ -81,59 +131,55 @@ where
             .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
             .await
         {
-            Ok(_) => return Ok(outcome),
-            Err(ObjectStoreError::PreconditionFailed { .. }) => {
-                continue;
-            }
-            Err(error) => {
-                return Err(E::from(ControlUpdateError::Store {
-                    object_key: loaded.object_key,
-                    message: error.public_message().into_owned(),
-                    class: StoreFailureClass::of(&error),
-                }))
-            }
+            Ok(_) => Ok(CasAttempt::Settled(outcome)),
+            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
+            // The head is the one control object whose unobserved swap is not
+            // retried: acquisition bumps the epoch on every attempt, so a
+            // blind retry would bump it twice.
+            Err(error) => Err(E::from(ControlUpdateError::Store {
+                object_key: loaded.object_key,
+                message: error.public_message().into_owned(),
+                class: StoreFailureClass::of(&error),
+            })),
         }
-    }
-
-    Err(E::from(ControlUpdateError::RetryExhausted {
-        attempts: max_attempts,
-    }))
+    })
+    .await?;
+    updated.ok_or_else(|| {
+        E::from(ControlUpdateError::RetryExhausted {
+            object_key: wal_head(namespace_id),
+        })
+    })
 }
 
 pub(crate) async fn update_upload_session<S, T, F, Fut>(
     store: &S,
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
-    max_attempts: usize,
-    mut update: F,
+    update: F,
 ) -> crate::error::Result<T>
 where
     S: ObjectStore + ?Sized,
-    F: FnMut(UploadSessionState) -> Fut,
+    F: Fn(UploadSessionState) -> Fut,
     Fut: Future<Output = crate::error::Result<UploadSessionUpdate<T>>>,
 {
-    for _attempt in 0..max_attempts {
-        match try_update_upload_session(store, namespace_id, upload_id, &mut update).await? {
-            UploadSessionCas::Applied(outcome) => return Ok(outcome),
-            UploadSessionCas::Conflict => continue,
-        }
-    }
-
-    Err(CoreError::Internal(
-        "upload session compare-and-swap retry exhausted".to_owned(),
-    ))
+    let update = &update;
+    let updated = retry_while_contended(|| async move {
+        try_update_upload_session(store, namespace_id, upload_id, update).await
+    })
+    .await?;
+    updated.ok_or_else(|| CoreError::contention_exhausted(&upload_session(namespace_id, upload_id)))
 }
 
 /// Applies at most one upload-session compare-and-swap against the state and
 /// metadata loaded together. Callers that must act only on one inspection
-/// (garbage collection) retain on [`UploadSessionCas::Conflict`]; ordinary
-/// upload operations wrap this helper in their bounded retry loop above.
+/// (garbage collection) retain on [`CasAttempt::Contended`]; ordinary upload
+/// operations wrap this helper in the bounded retry loop above.
 pub(crate) async fn try_update_upload_session<S, T, F, Fut>(
     store: &S,
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
     update: F,
-) -> crate::error::Result<UploadSessionCas<T>>
+) -> crate::error::Result<CasAttempt<T>>
 where
     S: ObjectStore + ?Sized,
     F: FnOnce(UploadSessionState) -> Fut,
@@ -141,7 +187,7 @@ where
 {
     let loaded = load_upload_session_object(store, namespace_id, upload_id).await?;
     match update(loaded.state).await? {
-        UploadSessionUpdate::Noop(outcome) => Ok(UploadSessionCas::Applied(outcome)),
+        UploadSessionUpdate::Noop(outcome) => Ok(CasAttempt::Settled(outcome)),
         UploadSessionUpdate::Replace { next, outcome } => {
             let encoded = encode_control_state(ControlObjectKind::UploadSession, next.as_ref())
                 .map_err(|error| CoreError::Codec {
@@ -152,8 +198,8 @@ where
                 .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
                 .await
             {
-                Ok(_) => Ok(UploadSessionCas::Applied(outcome)),
-                Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(UploadSessionCas::Conflict),
+                Ok(_) => Ok(CasAttempt::Settled(outcome)),
+                Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
                 Err(error) => Err(CoreError::store(&loaded.object_key, &error)),
             }
         }
@@ -252,7 +298,7 @@ mod tests {
         );
         store.fail_next(1);
 
-        let outcome = update_head(&store, &namespace_id, 3, |loaded| {
+        let outcome = update_head(&store, &namespace_id, |loaded| {
             let mut next = loaded.state.clone();
             next.seq.0 += 1;
             Ok::<_, ControlUpdateError>(HeadReplacement {
@@ -276,7 +322,7 @@ mod tests {
         let store = MetadataMapStore::without_etag(inner, KeyPredicate::any());
 
         let closure_called = AtomicBool::new(false);
-        let error = update_head(&store, &namespace_id, 3, |loaded| {
+        let error = update_head(&store, &namespace_id, |loaded| {
             closure_called.store(true, Ordering::SeqCst);
             Ok::<_, ControlUpdateError>(HeadReplacement {
                 next: Box::new(loaded.state.clone()),

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -1,6 +1,4 @@
-//! Writes to mutable control objects: the conditional create that installs
-//! one under a generated id, and the read-modify-write loops that load, edit,
-//! and compare-and-swap the head or an upload session on its etag.
+//! Shared writes and compare-and-swap loops for mutable control objects.
 
 use crate::control_object::{
     expect_identity_field, expect_namespace, load_control_object, ControlObjectLoadError,
@@ -19,25 +17,15 @@ use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::future::Future;
 use thiserror::Error;
 
-/// What one attempt of a bounded compare-and-swap loop decided.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CasAttempt<T> {
-    /// The attempt reached an outcome, whether or not it wrote anything.
     Settled(T),
-    /// The object moved under the etag this attempt read it at, so the whole
-    /// read-decide-swap cycle has to run again against the current state.
     Contended,
 }
 
-/// Runs `attempt` until it settles, at most [`CONTENTION_RETRY_LIMIT`] times.
+/// Runs up to [`CONTENTION_RETRY_LIMIT`] attempts.
 ///
-/// No control object is worth a different number of tries than its
-/// neighbours, so the bound is one number for all of them. `None` means every
-/// attempt lost its race, and what that means to a caller belongs to the
-/// operation rather than to this loop: publication reports a lost root race,
-/// deletion a stale head, everything else
-/// [`CoreError::contention_exhausted`]. Attempts run back to back; whether
-/// contention should be paced is a decision this crate has not made anywhere.
+/// Returns `None` if every attempt encounters contention.
 pub(crate) async fn retry_while_contended<T, E, F, Fut>(
     mut attempt: F,
 ) -> std::result::Result<Option<T>, E>
@@ -53,17 +41,12 @@ where
     Ok(None)
 }
 
-/// Installs a control object under a freshly generated id.
-///
-/// Every generated id ends in 16 random hex characters, so the key is this
-/// object's alone: an occupied key means two ids collided, which is a broken
-/// generator rather than a lifecycle a caller could resolve.
+/// Creates a control object and reports a generated-ID collision as an internal error.
 pub(crate) async fn create_control_object_under_generated_id<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
     encoded: Bytes,
 ) -> crate::error::Result<ObjectMetadata> {
-    // Mutable control state, so its first lifecycle state is a conditional create.
     match store.put_if_absent(object_key, encoded).await {
         Ok(metadata) => Ok(metadata),
         Err(ObjectStoreError::PreconditionFailed { .. }) => Err(CoreError::Internal(format!(
@@ -133,9 +116,7 @@ where
         {
             Ok(_) => Ok(CasAttempt::Settled(outcome)),
             Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            // The head is the one control object whose unobserved swap is not
-            // retried: acquisition bumps the epoch on every attempt, so a
-            // blind retry would bump it twice.
+            // Do not retry an unknown outcome because each attempt allocates a new epoch.
             Err(error) => Err(E::from(ControlUpdateError::Store {
                 object_key: loaded.object_key,
                 message: error.public_message().into_owned(),
@@ -170,10 +151,7 @@ where
     updated.ok_or_else(|| CoreError::contention_exhausted(&upload_session(namespace_id, upload_id)))
 }
 
-/// Applies at most one upload-session compare-and-swap against the state and
-/// metadata loaded together. Callers that must act only on one inspection
-/// (garbage collection) retain on [`CasAttempt::Contended`]; ordinary upload
-/// operations wrap this helper in the bounded retry loop above.
+/// Tries one upload-session update against the state and ETag loaded together.
 pub(crate) async fn try_update_upload_session<S, T, F, Fut>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -344,6 +344,12 @@ impl CoreError {
         }
     }
 
+    /// The one answer a bounded compare-and-swap loop gives when it loses
+    /// every race it runs (`crate::control_update`).
+    pub(crate) fn contention_exhausted(object_key: &str) -> Self {
+        Self::Internal(contention_message(object_key))
+    }
+
     pub fn kind(&self) -> ErrorKind {
         self.code().kind()
     }
@@ -498,6 +504,18 @@ impl CoreError {
             _ => None,
         }
     }
+}
+
+/// The one sentence for a bounded compare-and-swap loop that lost every race.
+///
+/// Contention is not something the caller did wrong, but it is also not a
+/// lifecycle answer, so it is reported as what it is. Enums with their own
+/// exhaustion variant display through this, so the sentence stays one.
+pub(crate) fn contention_message(object_key: &str) -> String {
+    format!(
+        "`{object_key}` lost all {} compare-and-swap attempts to contention",
+        crate::limits::CONTENTION_RETRY_LIMIT
+    )
 }
 
 fn metadata_projection_store_message(
@@ -726,9 +744,7 @@ impl From<crate::control_update::ControlUpdateError> for CoreError {
     fn from(value: crate::control_update::ControlUpdateError) -> Self {
         use crate::control_update::ControlUpdateError;
         match value {
-            ControlUpdateError::LoadHead(error) => {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-            }
+            ControlUpdateError::LoadHead(error) => CoreError::ControlObjectLoad(error),
             ControlUpdateError::Store {
                 object_key,
                 message,
@@ -751,7 +767,8 @@ fn classify_writer_epoch_acquire_error(error: &WriterEpochAcquireError) -> Error
         WriterEpochAcquireError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
         WriterEpochAcquireError::EmptyWriterId
         | WriterEpochAcquireError::WriterEpochOverflow { .. }
-        | WriterEpochAcquireError::RetryExhausted { .. } => ErrorCode::ServerError,
+        | WriterEpochAcquireError::RetryExhausted { .. }
+        | WriterEpochAcquireError::HeadIdentityDrift(_) => ErrorCode::ServerError,
         WriterEpochAcquireError::HeadWrite { class, .. } => classify_store_failure(*class),
     }
 }
@@ -834,7 +851,6 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> ErrorCode 
         CommitValidationError::ValidatedPreviewApplyFailed(_)
         | CommitValidationError::RestoreRevisionOverflow { .. }
         | CommitValidationError::ReplaceFileRevisionOverflow { .. }
-        | CommitValidationError::NextInodeOverflow
         | CommitValidationError::OpIndexOverflow
         | CommitValidationError::DeltaIndexOverflow => ErrorCode::ServerError,
     }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -344,8 +344,6 @@ impl CoreError {
         }
     }
 
-    /// The one answer a bounded compare-and-swap loop gives when it loses
-    /// every race it runs (`crate::control_update`).
     pub(crate) fn contention_exhausted(object_key: &str) -> Self {
         Self::Internal(contention_message(object_key))
     }
@@ -506,11 +504,6 @@ impl CoreError {
     }
 }
 
-/// The one sentence for a bounded compare-and-swap loop that lost every race.
-///
-/// Contention is not something the caller did wrong, but it is also not a
-/// lifecycle answer, so it is reported as what it is. Enums with their own
-/// exhaustion variant display through this, so the sentence stays one.
 pub(crate) fn contention_message(object_key: &str) -> String {
     format!(
         "`{object_key}` lost all {} compare-and-swap attempts to contention",

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -1,5 +1,6 @@
 //! Opaque, namespace-bound cursors for bounded GC enumeration.
 
+use super::reap::manifest_object_id_of;
 use crate::error::{CoreError, Result};
 use loonfs_api::{
     decode_namespace_cursor, encode_cursor, NamespaceCursor, NamespaceCursorError, NamespaceId,
@@ -9,6 +10,7 @@ use loonfs_objectstore::keys::{
     checkpoint_prefix, metadata_compaction_prefix, metadata_manifest_prefix,
     metadata_segment_prefix, upload_session_prefix, wal_segment_prefix,
 };
+use loonfs_objectstore::layout::{parse_object_key, DurableObjectFamily};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -43,6 +45,33 @@ impl CandidateFamily {
             .iter()
             .position(|family| *family == self)
             .expect("every family is listed in ALL")
+    }
+
+    /// True when `key` has this family's durable shape.
+    ///
+    /// A prefix listing returns whatever is under the prefix, and only the
+    /// key grammar says which of those objects this protocol wrote. A pass
+    /// deletes only what it wrote: a future sidecar, an extension's own
+    /// keyspace, and an operator's stray file are none of its business.
+    pub(super) fn recognizes(self, key: &str) -> bool {
+        let Some(family) = parse_object_key(key).map(|parsed| parsed.family()) else {
+            return false;
+        };
+        match self {
+            Self::WalSegments => family == DurableObjectFamily::WalSegment,
+            Self::MetadataSegments => family == DurableObjectFamily::MetadataSegment,
+            Self::CompactionStaging => matches!(
+                family,
+                DurableObjectFamily::MetadataCompactionStaging
+                    | DurableObjectFamily::MetadataCompactionLease
+            ),
+            // The sweep reads a manifest key back through
+            // `manifest_object_id_of`, which is stricter than the grammar: it
+            // wants the `.manifest.json` suffix the writer emits.
+            Self::Manifests => matches!(manifest_object_id_of(key), Some(Ok(_))),
+            Self::Checkpoints => family == DurableObjectFamily::CheckpointRecord,
+            Self::UploadSessions => family == DurableObjectFamily::UploadSession,
+        }
     }
 
     pub(super) fn prefix(self, namespace_id: &NamespaceId) -> String {

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -47,12 +47,7 @@ impl CandidateFamily {
             .expect("every family is listed in ALL")
     }
 
-    /// True when `key` has this family's durable shape.
-    ///
-    /// A prefix listing returns whatever is under the prefix, and only the
-    /// key grammar says which of those objects this protocol wrote. A pass
-    /// deletes only what it wrote: a future sidecar, an extension's own
-    /// keyspace, and an operator's stray file are none of its business.
+    /// Returns whether `key` matches this family's durable grammar.
     pub(super) fn recognizes(self, key: &str) -> bool {
         let Some(family) = parse_object_key(key).map(|parsed| parsed.family()) else {
             return false;
@@ -65,9 +60,6 @@ impl CandidateFamily {
                 DurableObjectFamily::MetadataCompactionStaging
                     | DurableObjectFamily::MetadataCompactionLease
             ),
-            // The sweep reads a manifest key back through
-            // `manifest_object_id_of`, which is stricter than the grammar: it
-            // wants the `.manifest.json` suffix the writer emits.
             Self::Manifests => matches!(manifest_object_id_of(key), Some(Ok(_))),
             Self::Checkpoints => family == DurableObjectFamily::CheckpointRecord,
             Self::UploadSessions => family == DurableObjectFamily::UploadSession,

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -1,7 +1,8 @@
 //! Release rules for fork-owned and missing-basis checkpoint records.
 
 use crate::checkpoint::record::{
-    encode_checkpoint_record, load_checkpoint_record_at_key, release_checkpoint_record,
+    load_checkpoint_record_at_key, release_checkpoint_record, release_inspected_checkpoint_record,
+    CheckpointRelease,
 };
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
@@ -79,33 +80,24 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
         }
         Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
-    let record = loaded.state;
-    if record.status != (CheckpointStatus::Active {}) {
+    if loaded.state.status != (CheckpointStatus::Active {}) {
         return Ok(ForkCheckpointSweep::NotAnActiveFork);
     }
     let CheckpointOwner::Fork {
         target_namespace_id,
         expires_at_ms,
-    } = &record.owner
+    } = loaded.state.owner.clone()
     else {
         return Ok(ForkCheckpointSweep::NotAnActiveFork);
     };
-    if !fork_target_proven_gone(store, target_namespace_id, *expires_at_ms, context).await? {
+    if !fork_target_proven_gone(store, &target_namespace_id, expires_at_ms, context).await? {
         return Ok(ForkCheckpointSweep::Retained);
     }
-    let mut released = record;
-    released.status = CheckpointStatus::Released {
-        released_at_ms: context.now_ms,
-    };
-    let encoded = encode_checkpoint_record(&released)?;
-    match store.compare_and_swap(key, &loaded.etag, encoded).await {
-        Ok(_) => Ok(ForkCheckpointSweep::Released),
+    match release_inspected_checkpoint_record(store, key, loaded, context.now_ms).await? {
+        CheckpointRelease::Released => Ok(ForkCheckpointSweep::Released),
         // Another pass won the record; retain and let a later pass re-decide
         // against the fresh state.
-        Err(loonfs_objectstore::ObjectStoreError::PreconditionFailed { .. }) => {
-            Ok(ForkCheckpointSweep::Retained)
-        }
-        Err(error) => Err(CoreError::store(key, &error)),
+        CheckpointRelease::LostRace => Ok(ForkCheckpointSweep::Retained),
     }
 }
 

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -4,7 +4,9 @@
 //! lifecycle timestamps stored in their records. The namespace sweep combines
 //! object age with the reference anchor from `gc/live_set.rs`.
 
-use crate::checkpoint::record::{encode_checkpoint_record, load_checkpoint_record_at_key};
+use crate::checkpoint::record::{
+    load_checkpoint_record_at_key, release_inspected_checkpoint_record, CheckpointRelease,
+};
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
@@ -57,7 +59,7 @@ pub(super) async fn sweep_checkpoint_record<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(CheckpointSweep::Retain),
         Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
-    let record = loaded.state;
+    let record = &loaded.state;
     if let CheckpointStatus::Released { released_at_ms } = record.status {
         let aged = context.now_ms.saturating_sub(released_at_ms) >= grace_window_ms;
         return Ok(if aged {
@@ -76,20 +78,15 @@ pub(super) async fn sweep_checkpoint_record<S: ObjectStore + ?Sized>(
     // for. On a tombstone every pin is dead weight, but a create still in
     // flight must not be raced, so that arm waits out the grace window from
     // the record's own creation stamp.
-    let releasable = lease_expired(&record, context.now_ms)
+    let releasable = lease_expired(record, context.now_ms)
         || (namespace_deleted
             && context.now_ms.saturating_sub(record.created_at_ms) >= grace_window_ms);
     if !releasable {
         return Ok(CheckpointSweep::Retain);
     }
-    let mut released = record;
-    released.status = CheckpointStatus::Released {
-        released_at_ms: context.now_ms,
-    };
-    let bytes = encode_checkpoint_record(&released)?;
-    match store.compare_and_swap(key, &loaded.etag, bytes).await {
-        Ok(_) => Ok(CheckpointSweep::Released),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => {
+    match release_inspected_checkpoint_record(store, key, loaded, context.now_ms).await? {
+        CheckpointRelease::Released => Ok(CheckpointSweep::Released),
+        CheckpointRelease::LostRace => {
             tracing::debug!(
                 namespace_id = %namespace_id,
                 object_key = key,
@@ -97,7 +94,6 @@ pub(super) async fn sweep_checkpoint_record<S: ObjectStore + ?Sized>(
             );
             Ok(CheckpointSweep::Retain)
         }
-        Err(error) => Err(CoreError::store(key, &error)),
     }
 }
 

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -324,8 +324,6 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
                 self.report.retain(RetainedReason::UnrecognizedKey);
             }
             StagedObject::ClaimedLease => {}
-            // A job's own lease is not a segment, so the shape has to decide
-            // before the delete rather than only before the counter.
             StagedObject::Orphaned => {
                 if key.ends_with(".sst.zst")
                     && self

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -208,6 +208,10 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
 
     /// Decides one candidate using the pass-owned verifier and family state.
     async fn process_candidate(&mut self, family: CandidateFamily, key: &str) -> Result<SweepStep> {
+        if !family.recognizes(key) {
+            self.report.retain(RetainedReason::UnrecognizedKey);
+            return Ok(SweepStep::Continue);
+        }
         let family = match family {
             CandidateFamily::UploadSessions => {
                 self.process_upload_session(key).await?;
@@ -320,11 +324,13 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
                 self.report.retain(RetainedReason::UnrecognizedKey);
             }
             StagedObject::ClaimedLease => {}
+            // A job's own lease is not a segment, so the shape has to decide
+            // before the delete rather than only before the counter.
             StagedObject::Orphaned => {
-                if self
-                    .sweep_aged(key, METADATA_COMPACTION_STAGING_GRACE_MS)
-                    .await?
-                    && key.ends_with(".sst.zst")
+                if key.ends_with(".sst.zst")
+                    && self
+                        .sweep_aged(key, METADATA_COMPACTION_STAGING_GRACE_MS)
+                        .await?
                 {
                     self.report.deleted.metadata_segments += 1;
                 }

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -14,7 +14,7 @@ use super::live_set::LiveSet;
 use crate::checkpoint::{load_verified_manifest_segments, ManifestLoadFailureClass};
 use crate::context::MutationContext;
 use crate::control_update::{
-    load_upload_session_state, try_update_upload_session, UploadSessionCas, UploadSessionUpdate,
+    load_upload_session_state, try_update_upload_session, CasAttempt, UploadSessionUpdate,
 };
 use crate::error::{CoreError, Result};
 use crate::limits::CONTENT_RECLAMATION_GRACE_MS;
@@ -200,12 +200,12 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
     .await;
     match aborted {
         // Keep the newly aborted record until its post-abort grace period expires.
-        Ok(UploadSessionCas::Applied(Some(abandoned))) => {
+        Ok(CasAttempt::Settled(Some(abandoned))) => {
             abandoned.release(store, content_store_id).await;
             Ok(retain_until(context.now_ms.saturating_add(grace_window_ms)))
         }
-        Ok(UploadSessionCas::Applied(None)) => Ok(retain_undated()),
-        Ok(UploadSessionCas::Conflict) => {
+        Ok(CasAttempt::Settled(None)) => Ok(retain_undated()),
+        Ok(CasAttempt::Contended) => {
             tracing::debug!(
                 namespace_id = %namespace_id,
                 upload_id = %upload_id,

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -1,8 +1,9 @@
 //! Namespace deletion: a fenced, terminal head-state transition.
 
+use crate::control_update::{retry_while_contended, CasAttempt};
 use crate::error::CoreError;
-use crate::limits::CONTENTION_RETRY_LIMIT;
 use crate::namespace::control::load_head_object;
+use crate::namespace::writer_epoch::ensure_writer_not_fenced;
 use crate::options::DeleteNamespaceOptions;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
@@ -10,6 +11,7 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::{DeleteNamespaceResponse, NamespaceId};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError, PutMode};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Marks a namespace as deleted with a compare-and-swap on its head.
 ///
@@ -23,38 +25,32 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
     options: DeleteNamespaceOptions,
     acquired_writer: AcquiredWriter,
 ) -> Result<DeleteNamespaceResponse, CoreError> {
-    let mut attempted_swap = false;
-    for _attempt in 0..CONTENTION_RETRY_LIMIT {
+    // Each attempt runs as its own future, so the record of an unobserved
+    // swap has to sit outside them all.
+    let attempted_swap = &AtomicBool::new(false);
+    let acquired_writer = &acquired_writer;
+    let deleted = retry_while_contended(|| async move {
         let loaded = load_head_object(store, namespace_id)
             .await
-            .map_err(|error| CoreError::MetadataProjection(error.into()))?;
+            .map_err(CoreError::ControlObjectLoad)?;
         let head = loaded.state.clone();
 
         // Check the terminal state before the writer fence because a deleted
         // namespace requires no further write.
         if head.status == (NamespaceStatus::Deleted {}) {
             // A deleted head resolves an earlier ambiguous swap as success.
-            if attempted_swap {
-                return Ok(DeleteNamespaceResponse {
+            if attempted_swap.load(Ordering::Relaxed) {
+                return Ok(CasAttempt::Settled(DeleteNamespaceResponse {
                     namespace_id: namespace_id.clone(),
                     head_seq: head.seq,
-                });
+                }));
             }
             return Err(CoreError::NamespaceDeleted {
                 namespace_id: namespace_id.clone(),
             });
         }
 
-        // The epoch is the fence: any takeover bumps it, so a mismatch means
-        // another writer owns the namespace and this delete must not land.
-        if head.writer_epoch != acquired_writer.writer_epoch {
-            return Err(CoreError::WriterFenced(crate::error::WriterFence {
-                fenced_epoch: acquired_writer.writer_epoch,
-                active_epoch: head.writer_epoch,
-                active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
-                active_acquired_at_ms: head.writer.as_ref().map(|writer| writer.acquired_at_ms),
-            }));
-        }
+        ensure_writer_not_fenced(&head, acquired_writer)?;
 
         if let Some(expected) = options.expected_head_seq {
             if head.seq != expected {
@@ -88,26 +84,27 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
             )
             .await;
         match swap {
-            Ok(_) => {
-                return Ok(DeleteNamespaceResponse {
-                    namespace_id: namespace_id.clone(),
-                    head_seq: head.seq,
-                });
-            }
+            Ok(_) => Ok(CasAttempt::Settled(DeleteNamespaceResponse {
+                namespace_id: namespace_id.clone(),
+                head_seq: head.seq,
+            })),
             // The head moved (a commit, fence takeover, or another deleter
             // landed first). Reload and re-evaluate.
-            Err(ObjectStoreError::PreconditionFailed { .. }) => continue,
-            // Outcome unobserved; the reload at the top of the loop resolves
-            // it, because the target state is terminal.
+            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
+            // Outcome unobserved; the reload at the top of the next attempt
+            // resolves it, because the target state is terminal.
             Err(ObjectStoreError::Transport { .. }) => {
-                attempted_swap = true;
-                continue;
+                attempted_swap.store(true, Ordering::Relaxed);
+                Ok(CasAttempt::Contended)
             }
-            Err(other) => return Err(CoreError::store(&loaded.object_key, &other)),
+            Err(other) => Err(CoreError::store(&loaded.object_key, &other)),
         }
-    }
+    })
+    .await?;
 
-    Err(CoreError::HeadPublish(
+    // A delete that lost every race is a head under active contention, which
+    // is the caller's `stale_head` to retry rather than a server fault.
+    deleted.ok_or(CoreError::HeadPublish(
         crate::commit::CommitHeadPublishError::StaleHead,
     ))
 }

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -25,8 +25,6 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
     options: DeleteNamespaceOptions,
     acquired_writer: AcquiredWriter,
 ) -> Result<DeleteNamespaceResponse, CoreError> {
-    // Each attempt runs as its own future, so the record of an unobserved
-    // swap has to sit outside them all.
     let attempted_swap = &AtomicBool::new(false);
     let acquired_writer = &acquired_writer;
     let deleted = retry_while_contended(|| async move {
@@ -91,8 +89,7 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
             // The head moved (a commit, fence takeover, or another deleter
             // landed first). Reload and re-evaluate.
             Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            // Outcome unobserved; the reload at the top of the next attempt
-            // resolves it, because the target state is terminal.
+            // Reload to determine whether an unconfirmed delete succeeded.
             Err(ObjectStoreError::Transport { .. }) => {
                 attempted_swap.store(true, Ordering::Relaxed);
                 Ok(CasAttempt::Contended)
@@ -102,8 +99,6 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
     })
     .await?;
 
-    // A delete that lost every race is a head under active contention, which
-    // is the caller's `stale_head` to retry rather than a server fault.
     deleted.ok_or(CoreError::HeadPublish(
         crate::commit::CommitHeadPublishError::StaleHead,
     ))

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -32,9 +32,7 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
 ) -> Result<LoadedHeadBasis> {
     let loaded = load_head_and_metadata_basis(store, expected_namespace_id)
         .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?;
+        .map_err(CoreError::ControlObjectLoad)?;
     let head = loaded.head.state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::NamespaceDeleted {
@@ -69,9 +67,7 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
     let (current_manifest_no, basis_head_seq) = basis.map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
     })?;
-    let retention_floor_seq = retention_floor_seq.map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-    })?;
+    let retention_floor_seq = retention_floor_seq.map_err(CoreError::ControlObjectLoad)?;
     Ok(LoadedHeadBasis {
         head,
         current_manifest_no,
@@ -160,9 +156,7 @@ pub async fn load_deleted_namespace_diagnostics<S: ObjectStore + ?Sized>(
 ) -> Result<NamespaceDiagnostics> {
     let head = crate::namespace::control::load_head_object(store, expected_namespace_id)
         .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     if head.status != (NamespaceStatus::Deleted {}) {
         return Err(CoreError::Internal(format!(
@@ -171,9 +165,7 @@ pub async fn load_deleted_namespace_diagnostics<S: ObjectStore + ?Sized>(
     }
     let retention_floor_seq = resolve_retention_floor_seq(store, &head)
         .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?;
+        .map_err(CoreError::ControlObjectLoad)?;
     Ok(NamespaceDiagnostics {
         namespace_id: head.namespace_id,
         head_seq: head.seq,

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -34,9 +34,7 @@ pub enum WriterEpochAcquireError {
     },
     #[error("{}", crate::error::contention_message(object_key))]
     RetryExhausted { object_key: String },
-    /// The successor head this acquisition built does not carry the
-    /// namespace's immutable identity forward. A construction bug, caught
-    /// before the compare-and-swap so it can never become durable.
+    /// The successor head changed immutable namespace identity.
     #[error("{0}")]
     HeadIdentityDrift(HeadIdentityDrift),
 }
@@ -86,10 +84,7 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
     .await
 }
 
-/// Checks that the head still carries the epoch this session acquired.
-///
-/// The epoch is the fence: any takeover bumps it, so a mismatch means another
-/// writer owns the namespace and this session's write must not land.
+/// Rejects a write when another writer has acquired a newer epoch.
 pub(crate) fn ensure_writer_not_fenced(
     head: &HeadState,
     acquired_writer: &AcquiredWriter,
@@ -124,8 +119,6 @@ fn head_with_writer(
         }),
         ..current_head.clone()
     };
-    // Epoch acquisition rewrites the head, so it carries the namespace's
-    // immutable identity forward like every other successor.
     current_head
         .ensure_successor_identity(&successor)
         .map_err(WriterEpochAcquireError::HeadIdentityDrift)?;

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -4,9 +4,10 @@
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::control_update::{update_head, ControlUpdateError, HeadReplacement};
-use crate::error::StoreFailureClass;
-use crate::limits::CONTENTION_RETRY_LIMIT;
-use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceStatus, WriterBlock};
+use crate::error::{CoreError, StoreFailureClass, WriterFence};
+use loonfs_api::wire::control::{
+    AcquiredWriter, HeadIdentityDrift, HeadState, NamespaceStatus, WriterBlock,
+};
 use loonfs_api::{next_public_ordinal, NamespaceId, WriterEpoch};
 use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
@@ -31,8 +32,13 @@ pub enum WriterEpochAcquireError {
         message: String,
         class: StoreFailureClass,
     },
-    #[error("writer epoch acquire retries exhausted after {attempts} attempts")]
-    RetryExhausted { attempts: usize },
+    #[error("{}", crate::error::contention_message(object_key))]
+    RetryExhausted { object_key: String },
+    /// The successor head this acquisition built does not carry the
+    /// namespace's immutable identity forward. A construction bug, caught
+    /// before the compare-and-swap so it can never become durable.
+    #[error("{0}")]
+    HeadIdentityDrift(HeadIdentityDrift),
 }
 
 /// Acquires the namespace writer epoch for one writer session.
@@ -58,7 +64,7 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
         return Err(WriterEpochAcquireError::EmptyWriterId);
     }
 
-    update_head(store, namespace_id, CONTENTION_RETRY_LIMIT, |loaded_head| {
+    update_head(store, namespace_id, |loaded_head| {
         let head = &loaded_head.state;
         // A deleted namespace cannot grant another writer epoch, even to the
         // writer recorded in its tombstone.
@@ -70,7 +76,7 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
 
         let next_epoch = next_writer_epoch(head.writer_epoch)?;
         Ok(HeadReplacement {
-            next: Box::new(head_with_writer(head, next_epoch, context)),
+            next: Box::new(head_with_writer(head, next_epoch, context)?),
             outcome: AcquiredWriter {
                 writer_id: context.writer_id.clone(),
                 writer_epoch: next_epoch,
@@ -78,6 +84,25 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
         })
     })
     .await
+}
+
+/// Checks that the head still carries the epoch this session acquired.
+///
+/// The epoch is the fence: any takeover bumps it, so a mismatch means another
+/// writer owns the namespace and this session's write must not land.
+pub(crate) fn ensure_writer_not_fenced(
+    head: &HeadState,
+    acquired_writer: &AcquiredWriter,
+) -> Result<(), CoreError> {
+    if head.writer_epoch == acquired_writer.writer_epoch {
+        return Ok(());
+    }
+    Err(CoreError::WriterFenced(WriterFence {
+        fenced_epoch: acquired_writer.writer_epoch,
+        active_epoch: head.writer_epoch,
+        active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
+        active_acquired_at_ms: head.writer.as_ref().map(|writer| writer.acquired_at_ms),
+    }))
 }
 
 fn next_writer_epoch(active: WriterEpoch) -> Result<WriterEpoch, WriterEpochAcquireError> {
@@ -90,27 +115,21 @@ fn head_with_writer(
     current_head: &HeadState,
     writer_epoch: WriterEpoch,
     context: &MutationContext,
-) -> HeadState {
-    HeadState {
-        namespace_id: current_head.namespace_id.clone(),
-        // Epoch acquisition rewrites the head, so it carries the
-        // namespace's immutable identity forward like every other
-        // successor.
-        content_store_id: current_head.content_store_id.clone(),
-        created_at_ms: current_head.created_at_ms,
-        fork_basis: current_head.fork_basis.clone(),
-        seq: current_head.seq,
-        head_commit_id: current_head.head_commit_id.clone(),
+) -> Result<HeadState, WriterEpochAcquireError> {
+    let successor = HeadState {
         writer_epoch,
         writer: Some(WriterBlock {
             writer_id: context.writer_id.clone(),
             acquired_at_ms: context.now_ms,
         }),
-        next_inode_id: current_head.next_inode_id,
-        visible_wal_tip: current_head.visible_wal_tip.clone(),
-        recent_segments: current_head.recent_segments.clone(),
-        status: current_head.status,
-    }
+        ..current_head.clone()
+    };
+    // Epoch acquisition rewrites the head, so it carries the namespace's
+    // immutable identity forward like every other successor.
+    current_head
+        .ensure_successor_identity(&successor)
+        .map_err(WriterEpochAcquireError::HeadIdentityDrift)?;
+    Ok(successor)
 }
 
 impl From<ControlUpdateError> for WriterEpochAcquireError {
@@ -134,7 +153,9 @@ impl From<ControlUpdateError> for WriterEpochAcquireError {
                 message,
                 class,
             },
-            ControlUpdateError::RetryExhausted { attempts } => Self::RetryExhausted { attempts },
+            ControlUpdateError::RetryExhausted { object_key } => {
+                Self::RetryExhausted { object_key }
+            }
         }
     }
 }

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -20,9 +20,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
 ) -> Result<ListChangesResponse> {
     let head = load_namespace_head_control(store, namespace_id)
         .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::NamespaceDeleted {
@@ -32,9 +30,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
 
     let retention_floor_seq = resolve_retention_floor_seq(store, &head)
         .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?;
+        .map_err(CoreError::ControlObjectLoad)?;
     if after_seq < retention_floor_seq {
         return Err(CoreError::RebootstrapRequired {
             after_seq,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -13,6 +13,7 @@ use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
 use crate::namespace::basis::{load_head_and_metadata_basis, MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::control::load_head_object;
+use crate::namespace::writer_epoch::ensure_writer_not_fenced;
 use crate::wal::{
     ensure_replayed_head_matches, load_validated_wal_chain, project_validated_wal_tail,
     WalChainLoadRequest,
@@ -158,9 +159,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
 ) -> Result<(PublishMetadataView<'a, S>, PublishTailProjection)> {
     let loaded = load_head_and_metadata_basis(store, namespace_id)
         .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?;
+        .map_err(CoreError::ControlObjectLoad)?;
     let head_etag = loaded.head.etag;
     let head = loaded.head.state;
     if head.status == (NamespaceStatus::Deleted {}) {
@@ -170,7 +169,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
             },
         ));
     }
-    ensure_publish_head_matches_acquired_writer(&head, &acquired_writer)?;
+    ensure_writer_not_fenced(&head, &acquired_writer)?;
     let catalog_entry = VerifiedNamespaceCatalogEntry::from_head(&head);
     let loaded_basis = load_basis_metadata_segments(
         store,
@@ -212,21 +211,6 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
         },
         projection,
     ))
-}
-
-fn ensure_publish_head_matches_acquired_writer(
-    head: &HeadState,
-    acquired_writer: &AcquiredWriter,
-) -> Result<()> {
-    if head.writer_epoch != acquired_writer.writer_epoch {
-        return Err(CoreError::WriterFenced(crate::error::WriterFence {
-            fenced_epoch: acquired_writer.writer_epoch,
-            active_epoch: head.writer_epoch,
-            active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
-            active_acquired_at_ms: head.writer.as_ref().map(|writer| writer.acquired_at_ms),
-        }));
-    }
-    Ok(())
 }
 
 async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
@@ -288,20 +272,16 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
         .head(&object_key)
         .await
         .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(
-                ControlObjectLoadError::Store {
-                    object_key: object_key.clone(),
-                    message: error.public_message().into_owned(),
-                    class: StoreFailureClass::of(&error),
-                },
-            ))
+            CoreError::ControlObjectLoad(ControlObjectLoadError::Store {
+                object_key: object_key.clone(),
+                message: error.public_message().into_owned(),
+                class: StoreFailureClass::of(&error),
+            })
         })?
         .ok_or_else(|| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(
-                ControlObjectLoadError::MissingObject {
-                    object_key: object_key.clone(),
-                },
-            ))
+            CoreError::ControlObjectLoad(ControlObjectLoadError::MissingObject {
+                object_key: object_key.clone(),
+            })
         })?;
     let current_head_etag = metadata.etag.ok_or_else(|| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::MissingHeadEtag {
@@ -311,11 +291,9 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
     if current_head_etag != loaded_head_etag {
         let moved_head = load_head_object(store, namespace_id)
             .await
-            .map_err(|error| {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-            })?
+            .map_err(CoreError::ControlObjectLoad)?
             .state;
-        ensure_publish_head_matches_acquired_writer(&moved_head, acquired_writer)?;
+        ensure_writer_not_fenced(&moved_head, acquired_writer)?;
         return Err(CoreError::MetadataProjection(
             MetadataProjectionLoadError::HeadChangedDuringLoad {
                 object_key,

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -528,8 +528,6 @@ async fn claim_staging_slot<S: ObjectStore + ?Sized>(
                         outcome: StagingSlot::Claimed,
                     })
                 }
-                // Another request is writing the object right now. Its
-                // bytes and digest are not this request's to displace.
                 ProxiedStaging::Claimed => Err(CoreError::UploadContentConflict { upload_id }),
                 ProxiedStaging::Staged(content_ref) => Ok(UploadSessionUpdate::Noop(
                     StagingSlot::AlreadyStaged(content_ref.clone()),
@@ -893,9 +891,6 @@ async fn freeze_completed_session<S: ObjectStore + ?Sized>(
         let upload_id = upload_id.to_owned();
         let verified = verified.clone();
         async move {
-            // A racing abort or a peer's completion may have landed
-            // between the read above and this swap. Whatever the durable
-            // record says now is what happened.
             if let Some(completed) = already_completed_outcome(
                 &state.status,
                 &namespace_id,
@@ -908,9 +903,6 @@ async fn freeze_completed_session<S: ObjectStore + ?Sized>(
                 return Ok(UploadSessionUpdate::Noop(completed));
             }
 
-            // The completed state is where a session's reference lives,
-            // and the only place: whatever the open state was holding
-            // is replaced by it rather than kept beside it.
             state.status = UploadSessionRecordStatus::Completed {
                 completed_at_ms: now_ms,
                 content_ref: verified.clone(),

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -11,14 +11,13 @@
 
 use crate::context::MutationContext;
 use crate::control_update::{
-    load_upload_session_state, update_upload_session, UploadSessionUpdate,
+    create_control_object_under_generated_id, load_upload_session_state, update_upload_session,
+    UploadSessionUpdate,
 };
-use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::limits::{
-    COMPLETED_UPLOAD_RECEIPT_WINDOW_MS, CONTENTION_RETRY_LIMIT, MAX_MULTIPART_PARTS,
-    MAX_MULTIPART_PART_BYTES, MAX_SIGNED_PARTS_PER_REQUEST, MIN_MULTIPART_PART_BYTES,
-    UPLOAD_SESSION_LEASE_MS,
+    COMPLETED_UPLOAD_RECEIPT_WINDOW_MS, MAX_MULTIPART_PARTS, MAX_MULTIPART_PART_BYTES,
+    MAX_SIGNED_PARTS_PER_REQUEST, MIN_MULTIPART_PART_BYTES, UPLOAD_SESSION_LEASE_MS,
 };
 use crate::namespace::catalog::{load_namespace_content_store_id, VerifiedNamespaceCatalogEntry};
 use crate::namespace::control::load_namespace_head_control;
@@ -444,11 +443,7 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
                 message: error.to_string(),
             }
         })?;
-    // An upload session is mutable control state, so its first lifecycle state is a conditional create.
-    store
-        .put_if_absent(&object_key, Bytes::from(encoded))
-        .await
-        .map_err(|err| CoreError::store(&object_key, &err))?;
+    create_control_object_under_generated_id(store, &object_key, Bytes::from(encoded)).await?;
     Ok(upload_id)
 }
 
@@ -462,9 +457,7 @@ async fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
 ) -> Result<()> {
     let head = load_namespace_head_control(store, namespace_id)
         .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?
+        .map_err(CoreError::ControlObjectLoad)?
         .state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::NamespaceDeleted {
@@ -516,40 +509,34 @@ async fn claim_staging_slot<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
 ) -> Result<StagingSlot> {
-    update_upload_session(
-        store,
-        namespace_id,
-        upload_id,
-        CONTENTION_RETRY_LIMIT,
-        |mut state| {
-            let upload_id = upload_id.to_owned();
-            async move {
-                if let Some(error) = terminal_session_error(&state.status, upload_id.clone()) {
-                    return Err(error);
-                }
-                let UploadSessionMode::ServiceProxied { staging } = &mut state.mode else {
-                    return Err(CoreError::Internal(
-                        "staging slot requested from a direct upload session".to_owned(),
-                    ));
-                };
-                match staging {
-                    ProxiedStaging::Idle => {
-                        *staging = ProxiedStaging::Claimed;
-                        Ok(UploadSessionUpdate::Replace {
-                            next: Box::new(state),
-                            outcome: StagingSlot::Claimed,
-                        })
-                    }
-                    // Another request is writing the object right now. Its
-                    // bytes and digest are not this request's to displace.
-                    ProxiedStaging::Claimed => Err(CoreError::UploadContentConflict { upload_id }),
-                    ProxiedStaging::Staged(content_ref) => Ok(UploadSessionUpdate::Noop(
-                        StagingSlot::AlreadyStaged(content_ref.clone()),
-                    )),
-                }
+    update_upload_session(store, namespace_id, upload_id, |mut state| {
+        let upload_id = upload_id.to_owned();
+        async move {
+            if let Some(error) = terminal_session_error(&state.status, upload_id.clone()) {
+                return Err(error);
             }
-        },
-    )
+            let UploadSessionMode::ServiceProxied { staging } = &mut state.mode else {
+                return Err(CoreError::Internal(
+                    "staging slot requested from a direct upload session".to_owned(),
+                ));
+            };
+            match staging {
+                ProxiedStaging::Idle => {
+                    *staging = ProxiedStaging::Claimed;
+                    Ok(UploadSessionUpdate::Replace {
+                        next: Box::new(state),
+                        outcome: StagingSlot::Claimed,
+                    })
+                }
+                // Another request is writing the object right now. Its
+                // bytes and digest are not this request's to displace.
+                ProxiedStaging::Claimed => Err(CoreError::UploadContentConflict { upload_id }),
+                ProxiedStaging::Staged(content_ref) => Ok(UploadSessionUpdate::Noop(
+                    StagingSlot::AlreadyStaged(content_ref.clone()),
+                )),
+            }
+        }
+    })
     .await
 }
 
@@ -564,28 +551,22 @@ async fn release_staging_claim<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
 ) {
-    let released = update_upload_session(
-        store,
-        namespace_id,
-        upload_id,
-        CONTENTION_RETRY_LIMIT,
-        |mut state| async move {
-            if !matches!(state.status, UploadSessionRecordStatus::Open { .. }) {
-                return Ok(UploadSessionUpdate::Noop(()));
-            }
-            let UploadSessionMode::ServiceProxied { staging } = &mut state.mode else {
-                return Ok(UploadSessionUpdate::Noop(()));
-            };
-            if !matches!(staging, ProxiedStaging::Claimed) {
-                return Ok(UploadSessionUpdate::Noop(()));
-            }
-            *staging = ProxiedStaging::Idle;
-            Ok(UploadSessionUpdate::Replace {
-                next: Box::new(state),
-                outcome: (),
-            })
-        },
-    )
+    let released = update_upload_session(store, namespace_id, upload_id, |mut state| async move {
+        if !matches!(state.status, UploadSessionRecordStatus::Open { .. }) {
+            return Ok(UploadSessionUpdate::Noop(()));
+        }
+        let UploadSessionMode::ServiceProxied { staging } = &mut state.mode else {
+            return Ok(UploadSessionUpdate::Noop(()));
+        };
+        if !matches!(staging, ProxiedStaging::Claimed) {
+            return Ok(UploadSessionUpdate::Noop(()));
+        }
+        *staging = ProxiedStaging::Idle;
+        Ok(UploadSessionUpdate::Replace {
+            next: Box::new(state),
+            outcome: (),
+        })
+    })
     .await;
     if let Err(error) = released {
         tracing::warn!(
@@ -692,51 +673,45 @@ async fn record_staged_content<S: ObjectStore + ?Sized>(
     content_ref: ContentRef,
     already_present: bool,
 ) -> Result<UploadContentResponse> {
-    update_upload_session(
-        store,
-        namespace_id,
-        upload_id,
-        CONTENTION_RETRY_LIMIT,
-        |mut state| {
-            let namespace_id = namespace_id.clone();
-            let upload_id = upload_id.to_owned();
-            let content_ref = content_ref.clone();
-            async move {
-                if let Some(error) = terminal_session_error(&state.status, upload_id.clone()) {
-                    return Err(error);
-                }
-                let UploadSessionMode::ServiceProxied { staging } = &mut state.mode else {
-                    return Err(CoreError::Internal(
-                        "staged content recorded for a direct upload session".to_owned(),
-                    ));
-                };
-                let response = UploadContentResponse {
-                    namespace_id,
-                    upload_id: upload_id.clone(),
-                    content_ref: content_ref.clone(),
-                };
-                if already_present && !matches!(staging, ProxiedStaging::Staged(_)) {
-                    return Err(CoreError::UploadContentConflict { upload_id });
-                }
-                match staging {
-                    ProxiedStaging::Staged(existing) => {
-                        if existing == &content_ref {
-                            Ok(UploadSessionUpdate::Noop(response))
-                        } else {
-                            Err(CoreError::UploadContentConflict { upload_id })
-                        }
+    update_upload_session(store, namespace_id, upload_id, |mut state| {
+        let namespace_id = namespace_id.clone();
+        let upload_id = upload_id.to_owned();
+        let content_ref = content_ref.clone();
+        async move {
+            if let Some(error) = terminal_session_error(&state.status, upload_id.clone()) {
+                return Err(error);
+            }
+            let UploadSessionMode::ServiceProxied { staging } = &mut state.mode else {
+                return Err(CoreError::Internal(
+                    "staged content recorded for a direct upload session".to_owned(),
+                ));
+            };
+            let response = UploadContentResponse {
+                namespace_id,
+                upload_id: upload_id.clone(),
+                content_ref: content_ref.clone(),
+            };
+            if already_present && !matches!(staging, ProxiedStaging::Staged(_)) {
+                return Err(CoreError::UploadContentConflict { upload_id });
+            }
+            match staging {
+                ProxiedStaging::Staged(existing) => {
+                    if existing == &content_ref {
+                        Ok(UploadSessionUpdate::Noop(response))
+                    } else {
+                        Err(CoreError::UploadContentConflict { upload_id })
                     }
-                    ProxiedStaging::Idle | ProxiedStaging::Claimed => {
-                        *staging = ProxiedStaging::Staged(content_ref);
-                        Ok(UploadSessionUpdate::Replace {
-                            next: Box::new(state),
-                            outcome: response,
-                        })
-                    }
+                }
+                ProxiedStaging::Idle | ProxiedStaging::Claimed => {
+                    *staging = ProxiedStaging::Staged(content_ref);
+                    Ok(UploadSessionUpdate::Replace {
+                        next: Box::new(state),
+                        outcome: response,
+                    })
                 }
             }
-        },
-    )
+        }
+    })
     .await
 }
 
@@ -912,55 +887,49 @@ async fn freeze_completed_session<S: ObjectStore + ?Sized>(
     verified: &ContentRef,
     now_ms: u64,
 ) -> Result<CompletedUpload> {
-    update_upload_session(
-        store,
-        namespace_id,
-        upload_id,
-        CONTENTION_RETRY_LIMIT,
-        |mut state| {
-            let namespace_id = namespace_id.clone();
-            let content_store_id = content_store_id.clone();
-            let upload_id = upload_id.to_owned();
-            let verified = verified.clone();
-            async move {
-                // A racing abort or a peer's completion may have landed
-                // between the read above and this swap. Whatever the durable
-                // record says now is what happened.
-                if let Some(completed) = already_completed_outcome(
-                    &state.status,
-                    &namespace_id,
-                    &content_store_id,
-                    &upload_id,
-                    Some(&verified),
-                    upload_mode(&state.mode),
-                    now_ms,
-                )? {
-                    return Ok(UploadSessionUpdate::Noop(completed));
-                }
-
-                // The completed state is where a session's reference lives,
-                // and the only place: whatever the open state was holding
-                // is replaced by it rather than kept beside it.
-                state.status = UploadSessionRecordStatus::Completed {
-                    completed_at_ms: now_ms,
-                    content_ref: verified.clone(),
-                };
-                let outcome = completed_upload(
-                    &namespace_id,
-                    &content_store_id,
-                    &upload_id,
-                    &verified,
-                    upload_mode(&state.mode),
-                    now_ms,
-                    now_ms,
-                );
-                Ok(UploadSessionUpdate::Replace {
-                    next: Box::new(state),
-                    outcome,
-                })
+    update_upload_session(store, namespace_id, upload_id, |mut state| {
+        let namespace_id = namespace_id.clone();
+        let content_store_id = content_store_id.clone();
+        let upload_id = upload_id.to_owned();
+        let verified = verified.clone();
+        async move {
+            // A racing abort or a peer's completion may have landed
+            // between the read above and this swap. Whatever the durable
+            // record says now is what happened.
+            if let Some(completed) = already_completed_outcome(
+                &state.status,
+                &namespace_id,
+                &content_store_id,
+                &upload_id,
+                Some(&verified),
+                upload_mode(&state.mode),
+                now_ms,
+            )? {
+                return Ok(UploadSessionUpdate::Noop(completed));
             }
-        },
-    )
+
+            // The completed state is where a session's reference lives,
+            // and the only place: whatever the open state was holding
+            // is replaced by it rather than kept beside it.
+            state.status = UploadSessionRecordStatus::Completed {
+                completed_at_ms: now_ms,
+                content_ref: verified.clone(),
+            };
+            let outcome = completed_upload(
+                &namespace_id,
+                &content_store_id,
+                &upload_id,
+                &verified,
+                upload_mode(&state.mode),
+                now_ms,
+                now_ms,
+            );
+            Ok(UploadSessionUpdate::Replace {
+                next: Box::new(state),
+                outcome,
+            })
+        }
+    })
     .await
 }
 
@@ -1095,12 +1064,8 @@ pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<UploadSession> {
     let now_ms = context.now_ms;
-    let (response, abandoned) = update_upload_session(
-        store,
-        namespace_id,
-        upload_id,
-        CONTENTION_RETRY_LIMIT,
-        |mut state| {
+    let (response, abandoned) =
+        update_upload_session(store, namespace_id, upload_id, |mut state| {
             let namespace_id = namespace_id.clone();
             let upload_id = upload_id.to_owned();
             async move {
@@ -1133,9 +1098,8 @@ pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
                     }
                 }
             }
-        },
-    )
-    .await?;
+        })
+        .await?;
 
     abandoned.release(store, content_store_id).await;
     Ok(response)

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -2,6 +2,7 @@
 
 pub(crate) use super::frame::WalReplayError;
 use super::{DecodedWalRecord, ReplayedWalTail, ValidatedWalChain};
+use crate::commit::next_inode_after;
 use crate::error::MetadataProjectionLoadError;
 use crate::metadata::{CommitReceiptRecord, MetadataState};
 use loonfs_api::wire::control::HeadState;
@@ -184,8 +185,11 @@ fn replay_next_inode_id_from_commit_deltas(
         .iter()
         .fold(current_next_inode_id, |next_inode_id, delta| {
             match &delta.delta {
+                // At the ceiling the allocator has already refused to hand
+                // out another id, so clamping here reconstructs exactly the
+                // position the write path stopped at.
                 WalDelta::CreateInode { inode_id, .. } => {
-                    InodeId(next_inode_id.0.max(inode_id.0.saturating_add(1)))
+                    next_inode_id.max(next_inode_after(*inode_id).unwrap_or(*inode_id))
                 }
                 // Other delta types reference existing inodes and do not
                 // allocate IDs.

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -185,9 +185,7 @@ fn replay_next_inode_id_from_commit_deltas(
         .iter()
         .fold(current_next_inode_id, |next_inode_id, delta| {
             match &delta.delta {
-                // At the ceiling the allocator has already refused to hand
-                // out another id, so clamping here reconstructs exactly the
-                // position the write path stopped at.
+                // At the limit, allocation stops at the current ID.
                 WalDelta::CreateInode { inode_id, .. } => {
                     next_inode_id.max(next_inode_after(*inode_id).unwrap_or(*inode_id))
                 }


### PR DESCRIPTION
Runs head, checkpoint, retention, and upload control-object updates through one bounded compare-and-swap helper. Metadata-root publication now makes one attempt, so each caller owns its retry budget instead of multiplying nested limits.

Also shares checkpoint release, replacement-manifest construction, generated-ID creation, writer-fence checks, and inode allocation helpers.

Garbage collection now deletes only keys that match the durable grammar and validates staging-object shape before deletion. Unknown keys under managed prefixes are retained.