### PR TITLE
fix(gc): retain released fork pins for live targets

### DIFF
--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -62,7 +62,7 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
     Ok(true)
 }
 
-/// Decides one active fork-owned sweep candidate immediately before acting
+/// Decides one fork-owned sweep candidate immediately before acting
 /// (rule 3): re-reads the record, re-proves the target namespace is gone,
 /// and releases the record by compare-and-swap on the just-observed etag.
 /// The etag check means one pass releases and any other observes it; the
@@ -80,9 +80,6 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
         }
         Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
-    if loaded.state.status != (CheckpointStatus::Active {}) {
-        return Ok(ForkCheckpointSweep::NotAnActiveFork);
-    }
     let CheckpointOwner::Fork {
         target_namespace_id,
         expires_at_ms,
@@ -92,6 +89,12 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
     };
     if !fork_target_proven_gone(store, &target_namespace_id, expires_at_ms, context).await? {
         return Ok(ForkCheckpointSweep::Retained);
+    }
+    // A released fork record may have acquired a live target between an
+    // earlier target-head read and release CAS. Prove the target gone before
+    // allowing the normal released-record path to consider reaping it.
+    if loaded.state.status != (CheckpointStatus::Active {}) {
+        return Ok(ForkCheckpointSweep::NotAnActiveFork);
     }
     match release_inspected_checkpoint_record(store, key, loaded, context.now_ms).await? {
         CheckpointRelease::Released => Ok(ForkCheckpointSweep::Released),

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -390,11 +390,15 @@ async fn checkpoint_is_candidate<S: ObjectStore + ?Sized>(
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> CollectResult<bool> {
-    // User checkpoints expire by time. Fork checkpoints remain active while
-    // their target namespace exists.
+    // User checkpoints expire by time. A fork checkpoint remains a root while
+    // its target namespace exists even if a racing pass already moved the
+    // record to `released`: the target head can land between that pass's head
+    // read and checkpoint CAS, and the forker can then crash before its guard.
     match &record.owner {
-        _ if record.status != (CheckpointStatus::Active {}) => Ok(true),
-        CheckpointOwner::User { .. } => Ok(lease_expired(record, context.now_ms)),
+        CheckpointOwner::User { .. } => {
+            Ok(record.status != (CheckpointStatus::Active {})
+                || lease_expired(record, context.now_ms))
+        }
         CheckpointOwner::Fork {
             target_namespace_id,
             expires_at_ms,

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -3835,6 +3835,68 @@ async fn a_fork_pin_with_a_missing_basis_survives_the_missing_basis_pass() {
     );
 }
 
+/// The target-head read and checkpoint release CAS are separate object-store
+/// operations. If the target lands between them and the forker then crashes,
+/// GC can observe a released fork record beside a live target. The owner still
+/// protects the target's foreign basis in that state; both the record and its
+/// basis must survive later passes.
+#[tokio::test]
+async fn gc_retains_a_released_fork_record_when_its_target_lives() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let source = NamespaceId::parse("source").expect("namespace id");
+    let clone = NamespaceId::parse("clone").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &source, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    fork_namespace(&store, &source, &clone, &setup)
+        .await
+        .expect("fork");
+    let fork_record = read_fork_record(&store, &source).await;
+
+    // Move the source root beyond the fork basis, then synthesize the durable
+    // state left by the model-checked race: target active, source pin released,
+    // and no forker left to run the post-install guard.
+    write_test_file(&store, &source, "/docs/two.txt", "gc-two", &setup).await;
+    create_checkpoint(&store, &source, &setup)
+        .await
+        .expect("advance root past the fork basis");
+    release_checkpoint_record(&store, &source, &fork_record.checkpoint_id, setup.now_ms)
+        .await
+        .expect("simulate the racing checkpoint release");
+    delete_namespace(&store, &source, DeleteNamespaceOptions::default(), &setup)
+        .await
+        .expect("delete source so only the fork pin protects its basis");
+
+    let aged = context(now_after_newest_object(&store, &source, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &source, &config(), &aged)
+        .await
+        .expect("gc with a released fork record and live target");
+    assert_eq!(report.deleted.checkpoint_records, 0);
+    assert_eq!(report.released_checkpoints.fork, 0);
+    assert_eq!(
+        checkpoint_lifecycle(&store, &source, &fork_record.checkpoint_id).await,
+        CheckpointStatus::Released {
+            released_at_ms: setup.now_ms
+        }
+    );
+    assert!(crate::checkpoint::load_namespace_manifest_envelope(
+        &store,
+        &source,
+        &fork_record.manifest.manifest_object_id,
+    )
+    .await
+    .is_ok());
+    load_current_metadata_view(&store, &clone)
+        .await
+        .expect("target remains readable after source collection")
+        .resolve_path("/docs/one.txt", AttributeInclusion::Omit)
+        .await
+        .expect("forked file remains readable");
+}
+
 #[tokio::test]
 async fn gc_releases_abandoned_fork_checkpoints_once_the_lease_expires() {
     let temp_dir = tempdir().expect("tempdir");

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1707,7 +1707,11 @@ once its lease has passed, so a lease with more than one provider operation
 left cannot legally be released between the read and the caller acting on it.
 Past that point the target head is the protection — a fork record whose
 target namespace exists and is not deleted is retained by every pass,
-whatever its lease says, so nothing has to clear the lease afterwards.
+whatever its lease says, so nothing has to clear the lease afterwards. The
+owner rule precedes the record status: if the target lands between a GC
+target-head read and the checkpoint release CAS, that now-`released` fork
+record is still retained while the target is live. This covers a forker that
+crashes before its post-install guard can observe the raced release.
 Deleting the target through the ordinary delete path, rather than erasing the
 head, keeps the failure inside the one lifecycle every other operation
 already understands.


### PR DESCRIPTION
Fixes a GC race where a released fork checkpoint could be reaped after its target becomes live. (Discovered during formal verification)