### PR TITLE
fix(core): keep independent commit results when a batch fails

### DIFF
--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -4,6 +4,7 @@
 
 use super::candidates::{
     prepare_candidate_request, validate_commit_content_references, BatchDedup, CandidateAdmission,
+    SettlementStability,
 };
 use super::changes::committed_change_from_wal_record;
 use super::publish_view::PublishMetadataView;
@@ -89,6 +90,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         ]);
     }
     let mut outcomes: Vec<Option<Result<ApiCommitResponse>>> = vec![None; candidates.len()];
+    let mut stable_outcomes = vec![false; candidates.len()];
     let mut session = PublishPlanningSession::new(&view.head);
     let mut accepted_indexes = Vec::new();
     let mut accepted_commits = Vec::new();
@@ -116,14 +118,15 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 phase = "prepare_commit"
             ))
             .await
-            .unwrap_or_else(|error| CandidateAdmission::Settled(Err(error)));
+            .unwrap_or_else(|error| CandidateAdmission::contingent(Err(error)));
             let candidate_request = match admission {
                 CandidateAdmission::Prepared(candidate_request) => candidate_request,
                 CandidateAdmission::AliasOf(primary_index) => {
                     dedup.record_alias(index, primary_index);
                     continue;
                 }
-                CandidateAdmission::Settled(outcome) => {
+                CandidateAdmission::Settled { outcome, stability } => {
+                    stable_outcomes[index] = stability == SettlementStability::Stable;
                     outcomes[index] = Some(outcome);
                     continue;
                 }
@@ -136,6 +139,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 validate_commit_content_references(candidate, view.content_store_id())
             {
                 session.discard_candidate(allocation);
+                stable_outcomes[index] = true;
                 outcomes[index] = Some(Err(error));
                 continue;
             }
@@ -195,7 +199,15 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     .await
     {
         Ok(wal) => wal,
-        Err(error) => return abort_batch(outcomes, &dedup, &accepted_indexes, &error),
+        Err(error) => {
+            return abort_batch(
+                outcomes,
+                &stable_outcomes,
+                &dedup,
+                &accepted_indexes,
+                &error,
+            )
+        }
     };
 
     let last_plan = &accepted_commits
@@ -206,7 +218,13 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         Ok(value) => value,
         Err(error) => {
             let error = CoreError::Internal(format!("head publish preparation failed: {error}"));
-            return abort_batch(outcomes, &dedup, &accepted_indexes, &error);
+            return abort_batch(
+                outcomes,
+                &stable_outcomes,
+                &dedup,
+                &accepted_indexes,
+                &error,
+            );
         }
     };
     let elapsed_ms = timer.monotonic_now_ms().saturating_sub(put_started_ms);
@@ -215,7 +233,13 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             elapsed_ms,
             budget_ms: WAL_PUBLISH_BUDGET_MS,
         });
-        return abort_batch(outcomes, &dedup, &accepted_indexes, &error);
+        return abort_batch(
+            outcomes,
+            &stable_outcomes,
+            &dedup,
+            &accepted_indexes,
+            &error,
+        );
     }
     let head_etag = match cas_batch_head(
         store,
@@ -227,7 +251,15 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     .await
     {
         Ok(metadata) => metadata.etag,
-        Err(error) => return abort_batch(outcomes, &dedup, &accepted_indexes, &error),
+        Err(error) => {
+            return abort_batch(
+                outcomes,
+                &stable_outcomes,
+                &dedup,
+                &accepted_indexes,
+                &error,
+            )
+        }
     };
 
     let wal_records = wal.envelope.payload.records.clone();
@@ -254,11 +286,17 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
 /// the remaining slots and invalidates the caller's loaded projection.
 fn abort_batch(
     mut outcomes: Vec<Option<Result<ApiCommitResponse>>>,
+    stable_outcomes: &[bool],
     dedup: &BatchDedup,
     accepted_indexes: &[usize],
     error: &CoreError,
 ) -> PublishBatchAgainstViewResult {
-    fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, accepted_indexes, error);
+    fail_outcomes_contingent_on_unpublished_batch(
+        &mut outcomes,
+        stable_outcomes,
+        accepted_indexes,
+        error,
+    );
     PublishBatchAgainstViewResult {
         results: dedup.finish(outcomes),
         effect: PublishViewEffect::Invalidated,
@@ -364,11 +402,13 @@ async fn cas_batch_head<S: ObjectStore + ?Sized>(
 /// that was never durably true (format.md section 3.1.5).
 ///
 /// Rejections recorded before any acceptance were decided against the loaded
-/// durable publish view and stand. Idempotent `Ok` completions replay durable
-/// commit receipts and stand. Alias slots stay unfilled here and inherit
-/// their primary's final outcome.
+/// durable publish view and stand. So do explicitly stable decisions such as
+/// durable receipt results, request-shape failures, content-proof failures,
+/// and same-batch commit-id conflicts. Alias slots stay unfilled here and
+/// inherit their primary's final outcome.
 fn fail_outcomes_contingent_on_unpublished_batch(
     outcomes: &mut [Option<Result<ApiCommitResponse>>],
+    stable_outcomes: &[bool],
     accepted_indexes: &[usize],
     error: &CoreError,
 ) {
@@ -378,8 +418,12 @@ fn fail_outcomes_contingent_on_unpublished_batch(
     for &index in accepted_indexes {
         outcomes[index] = Some(Err(error.clone()));
     }
-    for outcome in outcomes.iter_mut().skip(first_accepted_index + 1) {
-        if matches!(outcome, Some(Err(_))) {
+    for (index, outcome) in outcomes
+        .iter_mut()
+        .enumerate()
+        .skip(first_accepted_index + 1)
+    {
+        if !stable_outcomes[index] && matches!(outcome, Some(Err(_))) {
             *outcome = Some(Err(error.clone()));
         }
     }

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -4,7 +4,6 @@
 
 use super::candidates::{
     prepare_candidate_request, validate_commit_content_references, BatchDedup, CandidateAdmission,
-    SettlementStability,
 };
 use super::changes::committed_change_from_wal_record;
 use super::publish_view::PublishMetadataView;
@@ -90,7 +89,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         ]);
     }
     let mut outcomes: Vec<Option<Result<ApiCommitResponse>>> = vec![None; candidates.len()];
-    let mut stable_outcomes = vec![false; candidates.len()];
+    let mut independent_outcomes = vec![false; candidates.len()];
     let mut session = PublishPlanningSession::new(&view.head);
     let mut accepted_indexes = Vec::new();
     let mut accepted_commits = Vec::new();
@@ -117,16 +116,18 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 "loonfs.phase",
                 phase = "prepare_commit"
             ))
-            .await
-            .unwrap_or_else(|error| CandidateAdmission::contingent(Err(error)));
+            .await;
             let candidate_request = match admission {
                 CandidateAdmission::Prepared(candidate_request) => candidate_request,
                 CandidateAdmission::AliasOf(primary_index) => {
                     dedup.record_alias(index, primary_index);
                     continue;
                 }
-                CandidateAdmission::Settled { outcome, stability } => {
-                    stable_outcomes[index] = stability == SettlementStability::Stable;
+                CandidateAdmission::Settled {
+                    outcome,
+                    independent,
+                } => {
+                    independent_outcomes[index] = independent;
                     outcomes[index] = Some(outcome);
                     continue;
                 }
@@ -139,7 +140,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 validate_commit_content_references(candidate, view.content_store_id())
             {
                 session.discard_candidate(allocation);
-                stable_outcomes[index] = true;
+                independent_outcomes[index] = true;
                 outcomes[index] = Some(Err(error));
                 continue;
             }
@@ -202,7 +203,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         Err(error) => {
             return abort_batch(
                 outcomes,
-                &stable_outcomes,
+                &independent_outcomes,
                 &dedup,
                 &accepted_indexes,
                 &error,
@@ -220,7 +221,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             let error = CoreError::Internal(format!("head publish preparation failed: {error}"));
             return abort_batch(
                 outcomes,
-                &stable_outcomes,
+                &independent_outcomes,
                 &dedup,
                 &accepted_indexes,
                 &error,
@@ -235,7 +236,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         });
         return abort_batch(
             outcomes,
-            &stable_outcomes,
+            &independent_outcomes,
             &dedup,
             &accepted_indexes,
             &error,
@@ -254,7 +255,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         Err(error) => {
             return abort_batch(
                 outcomes,
-                &stable_outcomes,
+                &independent_outcomes,
                 &dedup,
                 &accepted_indexes,
                 &error,
@@ -263,7 +264,6 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     };
 
     let wal_records = wal.envelope.payload.records.clone();
-    // Build responses from the WAL records already in memory.
     for (outcome_index, record) in accepted_indexes.into_iter().zip(&wal_records) {
         outcomes[outcome_index] =
             Some(committed_change_from_wal_record(record).map(|change| {
@@ -280,20 +280,17 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     }
 }
 
-/// Aborts a batch whose accepted candidates never became durable.
-///
-/// Fails every outcome contingent on the unpublished batch, then finalizes
-/// the remaining slots and invalidates the caller's loaded projection.
+/// Applies the publication error and invalidates the loaded projection.
 fn abort_batch(
     mut outcomes: Vec<Option<Result<ApiCommitResponse>>>,
-    stable_outcomes: &[bool],
+    independent_outcomes: &[bool],
     dedup: &BatchDedup,
     accepted_indexes: &[usize],
     error: &CoreError,
 ) -> PublishBatchAgainstViewResult {
     fail_outcomes_contingent_on_unpublished_batch(
         &mut outcomes,
-        stable_outcomes,
+        independent_outcomes,
         accepted_indexes,
         error,
     );
@@ -391,24 +388,11 @@ async fn cas_batch_head<S: ObjectStore + ?Sized>(
     result.map_err(CoreError::from)
 }
 
-/// Fails every outcome that was contingent on this batch publishing durably.
-///
-/// The accepted candidates take the batch error: they never committed. So do
-/// rejections recorded after the first acceptance, because their verdicts
-/// were decided against session state advanced by tentatively accepted
-/// candidates — state that never became durable. Reporting them would hand a
-/// client a definitive semantic error (path conflict, missing path, stale
-/// revision, ...) it correctly treats as non-retryable, for a precondition
-/// that was never durably true (format.md section 3.1.5).
-///
-/// Rejections recorded before any acceptance were decided against the loaded
-/// durable publish view and stand. So do explicitly stable decisions such as
-/// durable receipt results, request-shape failures, content-proof failures,
-/// and same-batch commit-id conflicts. Alias slots stay unfilled here and
-/// inherit their primary's final outcome.
+/// Replaces outcomes that depended on tentative batch state with the
+/// publication error. Independent outcomes remain unchanged.
 fn fail_outcomes_contingent_on_unpublished_batch(
     outcomes: &mut [Option<Result<ApiCommitResponse>>],
-    stable_outcomes: &[bool],
+    independent_outcomes: &[bool],
     accepted_indexes: &[usize],
     error: &CoreError,
 ) {
@@ -423,7 +407,7 @@ fn fail_outcomes_contingent_on_unpublished_batch(
         .enumerate()
         .skip(first_accepted_index + 1)
     {
-        if !stable_outcomes[index] && matches!(outcome, Some(Err(_))) {
+        if !independent_outcomes[index] && matches!(outcome, Some(Err(_))) {
             *outcome = Some(Err(error.clone()));
         }
     }

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -28,8 +28,36 @@ pub(super) enum CandidateAdmission {
     /// alias slot inherits the primary's final outcome.
     AliasOf(usize),
     /// The outcome was decided during admission: an idempotent replay of a
-    /// durable commit receipt, or a rejection.
-    Settled(Result<ApiCommitResponse>),
+    /// durable commit receipt, or a rejection. Stability records whether the
+    /// decision can stand if tentative earlier candidates fail to publish.
+    Settled {
+        outcome: Result<ApiCommitResponse>,
+        stability: SettlementStability,
+    },
+}
+
+impl CandidateAdmission {
+    fn stable(outcome: Result<ApiCommitResponse>) -> Self {
+        Self::Settled {
+            outcome,
+            stability: SettlementStability::Stable,
+        }
+    }
+
+    pub(super) fn contingent(outcome: Result<ApiCommitResponse>) -> Self {
+        Self::Settled {
+            outcome,
+            stability: SettlementStability::Contingent,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SettlementStability {
+    /// Decided without relying on tentative filesystem state.
+    Stable,
+    /// May have been decided against state advanced by an earlier candidate.
+    Contingent,
 }
 
 #[derive(Debug, Clone)]
@@ -76,7 +104,7 @@ impl BatchDedup {
             // Neither claim has committed, so there is no landed commit to
             // name: the caller cannot reconcile this one by reading the
             // feed, and the conflict is the whole answer.
-            return Some(CandidateAdmission::Settled(Err(
+            return Some(CandidateAdmission::stable(Err(
                 CoreError::CommitIdReuseConflict {
                     commit_id: commit_id.to_string(),
                     committed_seq: None,
@@ -134,7 +162,10 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     dedup: &mut BatchDedup,
 ) -> Result<CandidateAdmission> {
     let mutation = candidate.request();
-    let semantic_identity = candidate.semantic_identity(namespace_id)?;
+    let semantic_identity = match candidate.semantic_identity(namespace_id) {
+        Ok(semantic_identity) => semantic_identity,
+        Err(error) => return Ok(CandidateAdmission::stable(Err(error))),
+    };
     if let Some(admission) = resolve_commit_id_reuse(
         namespace_id,
         view,
@@ -147,7 +178,9 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     {
         return Ok(admission);
     }
-    validate_new_primary(candidate)?;
+    if let Err(error) = validate_new_primary(candidate) {
+        return Ok(CandidateAdmission::stable(Err(error)));
+    }
     let mut allocation = session.begin_candidate();
     match session
         .prepare_commit(
@@ -165,7 +198,7 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         })),
         Err(error) => {
             session.discard_candidate(allocation);
-            Err(error)
+            Ok(CandidateAdmission::contingent(Err(error)))
         }
     }
 }
@@ -194,7 +227,7 @@ async fn resolve_commit_id_reuse<S: ObjectStore + ?Sized>(
     semantic_identity: &CommitFingerprint,
 ) -> Result<Option<CandidateAdmission>> {
     if let Some(existing) = view.find_commit_receipt(commit_id).await? {
-        return Ok(Some(CandidateAdmission::Settled(
+        return Ok(Some(CandidateAdmission::stable(
             if existing.semantic_commit_fingerprint != semantic_identity.as_str() {
                 // The receipt holds where the id landed and what landed
                 // there; reporting both is what turns a caller's

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -21,43 +21,32 @@ pub(super) struct PreparedCandidateCommit {
 
 /// How one batch candidate resolved during admission.
 pub(super) enum CandidateAdmission {
-    /// A new primary request, planned and validated in one pass, ready for
-    /// content coverage and materialization.
+    /// A new request ready for content validation and materialization.
     Prepared(PreparedCandidateCommit),
-    /// A same-batch duplicate of the primary at the given outcome slot; the
-    /// alias slot inherits the primary's final outcome.
+    /// A duplicate that receives the earlier request's outcome.
     AliasOf(usize),
-    /// The outcome was decided during admission: an idempotent replay of a
-    /// durable commit receipt, or a rejection. Stability records whether the
-    /// decision can stand if tentative earlier candidates fail to publish.
+    /// An outcome decided during admission. Independent outcomes do not rely
+    /// on tentative changes from earlier requests in the batch.
     Settled {
         outcome: Result<ApiCommitResponse>,
-        stability: SettlementStability,
+        independent: bool,
     },
 }
 
 impl CandidateAdmission {
-    fn stable(outcome: Result<ApiCommitResponse>) -> Self {
+    fn independent(outcome: Result<ApiCommitResponse>) -> Self {
         Self::Settled {
             outcome,
-            stability: SettlementStability::Stable,
+            independent: true,
         }
     }
 
     pub(super) fn contingent(outcome: Result<ApiCommitResponse>) -> Self {
         Self::Settled {
             outcome,
-            stability: SettlementStability::Contingent,
+            independent: false,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum SettlementStability {
-    /// Decided without relying on tentative filesystem state.
-    Stable,
-    /// May have been decided against state advanced by an earlier candidate.
-    Contingent,
 }
 
 #[derive(Debug, Clone)]
@@ -66,11 +55,7 @@ struct InBatchRequest {
     semantic_identity: CommitFingerprint,
 }
 
-/// Duplicate-commit-id bookkeeping for one publish batch.
-///
-/// Tracks which outcome slot first claimed each commit id (the primary) and
-/// which later slots alias it, so alias slots can inherit their primary's
-/// final outcome once the batch resolves.
+/// Tracks the first request for each commit ID and any aliases.
 #[derive(Default)]
 pub(super) struct BatchDedup {
     in_batch_requests: HashMap<CommitId, InBatchRequest>,
@@ -78,12 +63,7 @@ pub(super) struct BatchDedup {
 }
 
 impl BatchDedup {
-    /// Admits the candidate at `index` against earlier same-batch requests.
-    ///
-    /// Returns `None` for a new primary (recorded for later duplicates to
-    /// find) and `Some` when the commit id was already claimed in this batch:
-    /// an alias when the semantic identity matches, a settled rejection when
-    /// it conflicts. The caller records aliases with [`Self::record_alias`].
+    /// Returns an alias or conflict when the commit ID already exists in the batch.
     fn admit(
         &mut self,
         index: usize,
@@ -101,10 +81,8 @@ impl BatchDedup {
             return None;
         };
         if existing.semantic_identity != *semantic_identity {
-            // Neither claim has committed, so there is no landed commit to
-            // name: the caller cannot reconcile this one by reading the
-            // feed, and the conflict is the whole answer.
-            return Some(CandidateAdmission::stable(Err(
+            // No commit has landed, so the conflict has no sequence.
+            return Some(CandidateAdmission::independent(Err(
                 CoreError::CommitIdReuseConflict {
                     commit_id: commit_id.to_string(),
                     committed_seq: None,
@@ -115,8 +93,6 @@ impl BatchDedup {
         Some(CandidateAdmission::AliasOf(existing.primary_index))
     }
 
-    /// Records that the slot at `alias_index` inherits the outcome of the
-    /// primary slot at `primary_index` when the batch resolves.
     pub(super) fn record_alias(&mut self, alias_index: usize, primary_index: usize) {
         self.aliases.push((alias_index, primary_index));
     }
@@ -147,11 +123,7 @@ impl BatchDedup {
     }
 }
 
-/// Prepares one batch candidate as a validated commit plan, resolving
-/// commit-id reuse against durable receipts and same-batch primaries.
-///
-/// Hard failures return `Err`; the caller settles the candidate's outcome
-/// slot with them exactly as with [`CandidateAdmission::Settled`].
+/// Prepares a request and resolves commit-ID reuse.
 pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     view: &PublishMetadataView<'_, S>,
@@ -160,13 +132,13 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     index: usize,
     committed_at_ms: u64,
     dedup: &mut BatchDedup,
-) -> Result<CandidateAdmission> {
+) -> CandidateAdmission {
     let mutation = candidate.request();
     let semantic_identity = match candidate.semantic_identity(namespace_id) {
         Ok(semantic_identity) => semantic_identity,
-        Err(error) => return Ok(CandidateAdmission::stable(Err(error))),
+        Err(error) => return CandidateAdmission::independent(Err(error)),
     };
-    if let Some(admission) = resolve_commit_id_reuse(
+    match resolve_commit_id_reuse(
         namespace_id,
         view,
         dedup,
@@ -174,12 +146,14 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         &mutation.commit_id,
         &semantic_identity,
     )
-    .await?
+    .await
     {
-        return Ok(admission);
+        Ok(Some(admission)) => return admission,
+        Ok(None) => {}
+        Err(error) => return CandidateAdmission::independent(Err(error)),
     }
     if let Err(error) = validate_new_primary(candidate) {
-        return Ok(CandidateAdmission::stable(Err(error)));
+        return CandidateAdmission::independent(Err(error));
     }
     let mut allocation = session.begin_candidate();
     match session
@@ -192,19 +166,19 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         )
         .await
     {
-        Ok(validated) => Ok(CandidateAdmission::Prepared(PreparedCandidateCommit {
+        Ok(validated) => CandidateAdmission::Prepared(PreparedCandidateCommit {
             validated,
             allocation,
-        })),
+        }),
         Err(error) => {
             session.discard_candidate(allocation);
-            Ok(CandidateAdmission::contingent(Err(error)))
+            CandidateAdmission::contingent(Err(error))
         }
     }
 }
 
 fn validate_new_primary(candidate: &CommitCandidate) -> Result<()> {
-    // For new primaries, request limits precede rejected content preparation.
+    // Check request limits before content preparation errors.
     candidate.validate_request_limits()?;
     match candidate.content_preparation() {
         ContentPreparation::Ready(_) => Ok(()),
@@ -212,12 +186,7 @@ fn validate_new_primary(candidate: &CommitCandidate) -> Result<()> {
     }
 }
 
-/// Settles a candidate whose commit id was already used, either by a durable
-/// commit receipt (idempotent replay or reuse conflict) or by an earlier
-/// candidate in the same batch (alias or reuse conflict).
-///
-/// Returns `None` when the commit id is new: the candidate is recorded as
-/// the primary for that id and must be prepared.
+/// Resolves a commit ID against durable receipts and earlier requests in the batch.
 async fn resolve_commit_id_reuse<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     view: &PublishMetadataView<'_, S>,
@@ -227,11 +196,8 @@ async fn resolve_commit_id_reuse<S: ObjectStore + ?Sized>(
     semantic_identity: &CommitFingerprint,
 ) -> Result<Option<CandidateAdmission>> {
     if let Some(existing) = view.find_commit_receipt(commit_id).await? {
-        return Ok(Some(CandidateAdmission::stable(
+        return Ok(Some(CandidateAdmission::independent(
             if existing.semantic_commit_fingerprint != semantic_identity.as_str() {
-                // The receipt holds where the id landed and what landed
-                // there; reporting both is what turns a caller's
-                // reconciliation into one feed read and one comparison.
                 Err(CoreError::CommitIdReuseConflict {
                     commit_id: commit_id.to_string(),
                     committed_seq: Some(existing.committed_seq),
@@ -299,10 +265,7 @@ impl CommitContentAdmissions<'_> {
     }
 }
 
-/// Checks every new external content ref against in-memory preparation proofs.
-///
-/// Copy and restore reuse content already retained by the namespace, whose
-/// durability is guaranteed; only a put introduces bytes that need proof.
+/// Checks that each put has a matching content preparation proof.
 pub(super) fn validate_commit_content_references(
     candidate: &CommitCandidate,
     content_store_id: &ContentStoreId,

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -722,7 +722,6 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
 
     let batch = || async {
         vec![
-            // Rejected against the durable materialization: nothing was accepted yet.
             CommitCandidate::new(commit_request(
                 "reject-materialization",
                 FilesystemOperation::DeletePath {
@@ -731,7 +730,6 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                     expected_inode_id: None,
                 },
             )),
-            // Accepted into the batch.
             prepared_candidate(
                 &store,
                 &namespace_id,
@@ -746,8 +744,6 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                 ),
             )
             .await,
-            // Rejected only because of the accepted candidate's speculative
-            // in-batch create.
             prepared_candidate(
                 &store,
                 &namespace_id,
@@ -762,7 +758,6 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                 ),
             )
             .await,
-            // Alias of the materialization-decided rejection.
             CommitCandidate::new(commit_request(
                 "reject-materialization",
                 FilesystemOperation::DeletePath {
@@ -792,8 +787,6 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
     let alias = failed[3].as_ref().expect_err("alias mirrors its primary");
     assert_eq!(alias.code(), ErrorCode::PathNotFound);
 
-    // Nothing became durable, so the retry the batch error asks for derives
-    // every verdict from durable state.
     let head = load_namespace_head_control(&store, &namespace_id)
         .await
         .expect("load head");
@@ -821,17 +814,17 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
 }
 
 #[tokio::test]
-async fn failed_wal_write_preserves_later_durable_receipt_conflict() {
+async fn failed_batch_preserves_an_independent_commit_id_conflict() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
-    let durable_store = LocalFsStore::new(temp_dir.path()).expect("store");
-    bootstrap_namespace(&durable_store, &namespace_id, &context, false)
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
         .expect("bootstrap");
 
-    let committed = submit_commit(
-        &durable_store,
+    submit_commit(
+        &store,
         &namespace_id,
         commit_request(
             "durable-receipt",
@@ -844,10 +837,9 @@ async fn failed_wal_write_preserves_later_durable_receipt_conflict() {
     )
     .await
     .expect("publish durable receipt");
-    assert_eq!(committed.committed_seq, ChangeSeq(1));
 
     let store = InjectCreateFailureStore::new(
-        LocalFsStore::new(temp_dir.path()).expect("store"),
+        store,
         KeyMatcher::Prefix("namespaces/demo/wal/segments/".to_owned()),
         InjectedCreateFailure::PreconditionFailed {
             write_attempted_object: false,
@@ -878,20 +870,13 @@ async fn failed_wal_write_preserves_later_durable_receipt_conflict() {
     .await;
 
     assert!(matches!(failed[0], Err(CoreError::WalWrite { .. })));
-    match failed[1]
-        .as_ref()
-        .expect_err("durable receipt conflict must stand")
-    {
-        CoreError::CommitIdReuseConflict {
-            committed_seq,
-            committed_fingerprint,
-            ..
-        } => {
-            assert_eq!(*committed_seq, Some(ChangeSeq(1)));
-            assert!(committed_fingerprint.is_some());
-        }
-        error => panic!("expected durable receipt conflict, got {error:?}"),
-    }
+    assert_eq!(
+        failed[1]
+            .as_ref()
+            .expect_err("commit ID conflict must stand")
+            .code(),
+        ErrorCode::CommitIdReuseConflict
+    );
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -821,6 +821,80 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
 }
 
 #[tokio::test]
+async fn failed_wal_write_preserves_later_durable_receipt_conflict() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    let durable_store = LocalFsStore::new(temp_dir.path()).expect("store");
+    bootstrap_namespace(&durable_store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    let committed = submit_commit(
+        &durable_store,
+        &namespace_id,
+        commit_request(
+            "durable-receipt",
+            FilesystemOperation::CreateDirectory {
+                path: AbsolutePath::parse("/durable").expect("path"),
+                parents: false,
+            },
+        ),
+        &context,
+    )
+    .await
+    .expect("publish durable receipt");
+    assert_eq!(committed.committed_seq, ChangeSeq(1));
+
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Prefix("namespaces/demo/wal/segments/".to_owned()),
+        InjectedCreateFailure::PreconditionFailed {
+            write_attempted_object: false,
+            additional_writes: Vec::new(),
+        },
+    );
+    let failed = publish_namespace_commits_batch(
+        &store,
+        &namespace_id,
+        vec![
+            CommitCandidate::new(commit_request(
+                "accepted-before-receipt-conflict",
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/accepted").expect("path"),
+                    parents: false,
+                },
+            )),
+            CommitCandidate::new(commit_request(
+                "durable-receipt",
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/different").expect("path"),
+                    parents: false,
+                },
+            )),
+        ],
+        &context,
+    )
+    .await;
+
+    assert!(matches!(failed[0], Err(CoreError::WalWrite { .. })));
+    match failed[1]
+        .as_ref()
+        .expect_err("durable receipt conflict must stand")
+    {
+        CoreError::CommitIdReuseConflict {
+            committed_seq,
+            committed_fingerprint,
+            ..
+        } => {
+            assert_eq!(*committed_seq, Some(ChangeSeq(1)));
+            assert!(committed_fingerprint.is_some());
+        }
+        error => panic!("expected durable receipt conflict, got {error:?}"),
+    }
+}
+
+#[tokio::test]
 async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");


### PR DESCRIPTION
When a commit batch fails to publish, return the publication error for requests whose results depended on tentative changes in that batch. Keep results determined independently, including durable receipt replays, commit ID conflicts, invalid requests, and missing content proofs.

This prevents a failed WAL write or head update from hiding a result that would be the same if the request were retried on its own.