### PR TITLE
fix(core): verify manifest segments before advancing retention

### DIFF
--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -1,6 +1,8 @@
 //! Retention floor advancement against the current verified manifest.
 
+use super::error::ManifestLoadError;
 use super::load::{ensure_root_matches_manifest, load_verified_manifest_segments};
+use super::runs::MAX_MAINTENANCE_SEGMENT_IO;
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::control_update::{retry_while_contended, CasAttempt};
@@ -12,8 +14,44 @@ use crate::namespace::control::{
 };
 use bytes::Bytes;
 use loonfs_api::wire::control::{encode_control_state, ControlObjectKind, WalFloorState};
+use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
 use loonfs_api::{AdvanceRetentionResponse, NamespaceId};
+use loonfs_objectstore::keys::metadata_segment_object_key;
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+use std::collections::BTreeSet;
+
+async fn verify_manifest_segments_exist<S: ObjectStore + ?Sized>(
+    store: &S,
+    manifest: &NamespaceManifestEnvelope,
+) -> std::result::Result<(), ManifestLoadError> {
+    let object_keys = manifest
+        .payload
+        .segments
+        .iter()
+        .map(metadata_segment_object_key)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    for chunk in object_keys.chunks(MAX_MAINTENANCE_SEGMENT_IO) {
+        futures::future::try_join_all(chunk.iter().map(|object_key| async move {
+            match store
+                .head(object_key)
+                .await
+                .map_err(|error| ManifestLoadError::ReadSegment {
+                    object_key: object_key.clone(),
+                    message: error.public_message().into_owned(),
+                })? {
+                Some(_) => Ok(()),
+                None => Err(ManifestLoadError::MissingSegment {
+                    object_key: object_key.clone(),
+                }),
+            }
+        }))
+        .await?;
+    }
+    Ok(())
+}
 
 pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
@@ -26,13 +64,10 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     // commits land. Root monotonicity keeps a mid-flight root swap benign:
     // any replacement covers at least this basis's coverage above the floor.
     //
-    // Nothing here probes the basis manifest's segments before the floor
-    // moves. Advancing surrenders the WAL replay promise below the target,
-    // and what keeps that safe is the deleter: GC must never remove an
-    // object reachable from the current manifest or a retained checkpoint or
-    // pin (format spec, "Garbage collection"). Corruption that slips past it
-    // is caught by read-path checksums, which an existence probe here could
-    // not have caught anyway.
+    // The deleter's reachability checks provide the atomic safety guarantee,
+    // but an advisory existence probe below prevents a segment that has
+    // already disappeared from surrendering the WAL recovery path. Read-path
+    // checksums still detect corruption that an existence probe cannot.
     let head = load_head_object(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?
@@ -69,6 +104,11 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
             retention_floor_seq: current_floor,
         });
     }
+    verify_manifest_segments_exist(store, manifest_segments.manifest())
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
 
     // Monotonic floor publication: never decrease. The first advance
     // creates the object, because create and fork write no floor.

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -331,6 +331,21 @@ async fn retention_advancement_uses_published_manifest_and_updates_floor_only() 
     create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("create checkpoint");
+    let root = load_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("load metadata root")
+        .state;
+    let referenced_segment_count =
+        load_verified_manifest_segments(&store, &namespace_id, &root.manifest.manifest_object_id)
+            .await
+            .expect("load current manifest")
+            .manifest()
+            .payload
+            .segments
+            .iter()
+            .map(metadata_segment_object_key)
+            .collect::<BTreeSet<_>>()
+            .len();
     store.reset();
     let advanced = advance_retention_floor(&store, &namespace_id, &context)
         .await
@@ -340,6 +355,11 @@ async fn retention_advancement_uses_published_manifest_and_updates_floor_only() 
         store.count(OperationClass::Read),
         0,
         "retention should advance from manifest descriptors without materializing rows"
+    );
+    assert_eq!(
+        store.count(OperationClass::Head),
+        referenced_segment_count,
+        "retention should verify each distinct referenced segment"
     );
 
     assert_eq!(read_floor_seq(&store, &namespace_id).await, ChangeSeq(1));
@@ -359,6 +379,138 @@ async fn retention_advancement_uses_published_manifest_and_updates_floor_only() 
         .await
         .expect("manifest head")
         .is_some());
+}
+
+#[tokio::test]
+async fn retention_floor_does_not_advance_past_a_missing_basis_segment() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+
+    let root = load_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("load metadata root")
+        .state;
+    let segments =
+        load_verified_manifest_segments(&store, &namespace_id, &root.manifest.manifest_object_id)
+            .await
+            .expect("load current manifest");
+    let missing_key = segments
+        .manifest()
+        .payload
+        .segments
+        .first()
+        .map(metadata_segment_object_key)
+        .expect("current manifest references a segment");
+    store
+        .delete(&missing_key)
+        .await
+        .expect("delete referenced segment");
+
+    let error = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect_err("missing basis segment blocks floor advancement");
+    assert!(matches!(
+        error,
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(
+            ManifestLoadError::MissingSegment { object_key }
+        )) if object_key == missing_key
+    ));
+    assert_eq!(
+        read_floor_seq(&store, &namespace_id).await,
+        ChangeSeq(0),
+        "the missing basis remains replayable from the prior floor"
+    );
+}
+
+#[tokio::test]
+async fn retention_floor_does_not_advance_when_a_basis_segment_cannot_be_checked() {
+    let temp_dir = tempdir().expect("tempdir");
+    let setup_store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&setup_store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &setup_store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&setup_store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+
+    let root = load_metadata_root_object(&setup_store, &namespace_id)
+        .await
+        .expect("load metadata root")
+        .state;
+    let segments = load_verified_manifest_segments(
+        &setup_store,
+        &namespace_id,
+        &root.manifest.manifest_object_id,
+    )
+    .await
+    .expect("load current manifest");
+    let selected_key = segments
+        .manifest()
+        .payload
+        .segments
+        .first()
+        .map(metadata_segment_object_key)
+        .expect("current manifest references a segment");
+    let failed_key = selected_key.clone();
+    let store = FailStore::matching(
+        setup_store,
+        move |operation| {
+            operation.key() == selected_key
+                && matches!(
+                    operation.kind(),
+                    loonfs_test_support::stores::OperationKind::Head
+                )
+        },
+        InjectedError::Transport("injected segment probe failure".to_owned()),
+    );
+    store.fail_next(1);
+
+    let error = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect_err("failed basis probe blocks floor advancement");
+    assert_eq!(error.code(), ErrorCode::ServerError);
+    assert!(matches!(
+        error,
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(
+            ManifestLoadError::ReadSegment { object_key, .. }
+        )) if object_key == failed_key
+    ));
+    assert_eq!(store.attempts(), 1);
+    assert_eq!(
+        read_floor_seq(store.inner(), &namespace_id).await,
+        ChangeSeq(0),
+        "the failed probe leaves the prior floor in place"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Before advancing the retention floor, check that every metadata segment referenced by the current root still exists. If a segment is missing or cannot be checked, leave the floor unchanged and return the storage or projection error.

This keeps the retained WAL available when the materialized basis is incomplete, so the missing state can still be rebuilt.