### PR TITLE
fix(gc): retain every manifest in a live root generation

### DIFF
--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -66,6 +66,8 @@ pub(crate) use self::load::{
     load_namespace_manifest_envelope_if_present, load_verified_manifest_segments,
     LoadedMetadataBasis,
 };
+#[cfg(test)]
+pub(crate) use self::publish::write_namespace_manifest;
 pub(crate) use self::record::load_checkpoint_record;
 pub(crate) use self::release::release_checkpoint;
 pub(crate) use self::reorganize::reorganize_metadata_step;

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -171,10 +171,10 @@ pub(crate) async fn write_test_file<S: ObjectStore>(
 }
 
 #[derive(Debug)]
-struct CurrentProjection {
-    head: HeadState,
-    root: MetadataRootState,
-    metadata_state: MetadataState,
+pub(crate) struct CurrentProjection {
+    pub(crate) head: HeadState,
+    pub(crate) root: MetadataRootState,
+    pub(crate) metadata_state: MetadataState,
 }
 
 /// Creates a namespace and publishes its first manifest.
@@ -521,7 +521,7 @@ fn manifest_object_id(manifest_no: ManifestNo) -> ManifestObjectId {
         .expect("valid manifest object id")
 }
 
-async fn load_current_projection<S: ObjectStore + ?Sized>(
+pub(crate) async fn load_current_projection<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> Result<CurrentProjection, CoreError> {
@@ -798,10 +798,10 @@ use super::runs::delta_run_count;
 // author arbitrary layouts without driving the full checkpoint pipeline.
 #[cfg(test)]
 pub(crate) struct ManifestMetadataSource<'a> {
-    pub(super) head: &'a HeadState,
-    pub(super) basis_manifest_no: Option<ManifestNo>,
-    pub(super) retention_floor_seq: ChangeSeq,
-    pub(super) metadata_state: &'a MetadataState,
+    pub(crate) head: &'a HeadState,
+    pub(crate) basis_manifest_no: Option<ManifestNo>,
+    pub(crate) retention_floor_seq: ChangeSeq,
+    pub(crate) metadata_state: &'a MetadataState,
 }
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -19,7 +19,10 @@ use loonfs_api::wire::control::{
     CheckpointOwner, CheckpointRecordState, CheckpointStatus, HeadState, NamespaceStatus,
 };
 use loonfs_api::wire::wal::WalDelta;
-use loonfs_api::{wal_segment_id_start_seq, ChangeSeq, ContentId, ManifestObjectId, NamespaceId};
+use loonfs_api::{
+    manifest_object_id_manifest_no, wal_segment_id_start_seq, ChangeSeq, ContentId,
+    ManifestObjectId, NamespaceId,
+};
 use loonfs_objectstore::keys::{
     checkpoint_prefix, metadata_manifest_object, metadata_manifest_prefix,
     metadata_segment_object_key, wal_segment_id_from_key,
@@ -101,11 +104,13 @@ pub(super) enum ReferenceAnchor {
 /// Information from one manifest needed during sweeping.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct AnchoredManifest {
-    manifest_object_id: ManifestObjectId,
-    /// Highest sequence materialized by the anchor. Readers pinned to it may
-    /// still replay later WAL segments.
+    /// Every same-generation manifest candidate. One may have been the
+    /// published root; immutable losers cannot be distinguished later.
+    manifest_object_ids: BTreeSet<ManifestObjectId>,
+    /// Lowest sequence materialized by any candidate. Retaining WAL above
+    /// this point covers every candidate in the generation.
     head_seq: ChangeSeq,
-    /// Object keys of the metadata segments the anchor named.
+    /// Union of the metadata segments the generation's candidates named.
     segments: BTreeSet<String>,
 }
 
@@ -493,7 +498,8 @@ async fn collect_reference_anchor<S: ObjectStore + ?Sized>(
     // Protect the anchor's segments and manifest so later passes can use the
     // same evidence.
     if let ReferenceAnchor::Manifest(anchor) = &live.anchor {
-        live.manifests.insert(anchor.manifest_object_id.clone());
+        live.manifests
+            .extend(anchor.manifest_object_ids.iter().cloned());
         live.segments.extend(anchor.segments.iter().cloned());
     }
     Ok(())
@@ -559,15 +565,19 @@ async fn collect_retained_wal<S: ObjectStore + ?Sized>(
     Ok(())
 }
 
-/// Finds the reference manifest R and reads what it named.
+/// Finds the reference manifest generation R and reads what it named.
 ///
-/// Manifest keys sort by logical manifest position, which is publication
-/// order, so the scan walks the listing from the oldest manifest and stops at
-/// the first one the window still covers. The last aged manifest before that
-/// is R. Stopping at the first young one rather than taking the newest aged
-/// timestamp is the conservative reading of a provider clock: one manifest
-/// reporting an early stamp cannot pull the anchor forward past a manifest
-/// that reads as young.
+/// Manifest keys sort by manifest number, which is publication generation.
+/// A lost root CAS can leave several immutable candidates at one number, and
+/// the current root does not record which sibling won in an older generation.
+/// The scan therefore advances only past a generation whose surviving
+/// candidates are all old. R protects the union of that generation's
+/// references and WAL above its lowest head sequence.
+///
+/// Stopping the whole generation at the first young candidate is the
+/// conservative reading of a provider clock: one sibling reporting an early
+/// stamp cannot pull the anchor forward past another sibling that reads as
+/// young.
 ///
 /// The age test is the sweep's own (`gc/reap.rs`), on the same provider
 /// timestamp, so a manifest with no timestamp reads as young here exactly as
@@ -582,8 +592,11 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
 ) -> CollectResult<ReferenceAnchor> {
     let prefix = metadata_manifest_prefix(namespace_id);
     let mut keys = store.list_prefix_stream(&prefix);
-    let mut published_any = false;
-    let mut aged = None;
+    let mut manifest_candidate_seen = false;
+    let mut current_generation_no = None;
+    let mut current_generation = Vec::new();
+    let mut aged_generation = Vec::new();
+    let mut found_young = false;
     while let Some(item) = keys.next().await {
         let key = item.map_err(|error| CoreError::store(&prefix, &error))?;
         // Keys this collector does not recognize are never manifests of
@@ -591,7 +604,17 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
         let Some(Ok(manifest_object_id)) = manifest_object_id_of(&key) else {
             continue;
         };
-        published_any = true;
+        let manifest_no = manifest_object_id_manifest_no(manifest_object_id.as_str())
+            .expect("a parsed manifest object id carries its manifest number");
+        if current_generation_no.is_some_and(|current| current != manifest_no) {
+            if !current_generation.is_empty() {
+                aged_generation = std::mem::take(&mut current_generation);
+            }
+            current_generation_no = Some(manifest_no);
+        } else if current_generation_no.is_none() {
+            current_generation_no = Some(manifest_no);
+        }
+        manifest_candidate_seen = true;
         charge(budget)?;
         let Some(metadata) = store
             .head(&key)
@@ -604,57 +627,75 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
             context.now_ms.saturating_sub(written_at_ms) >= grace_window_ms
         });
         if !aged_out {
+            found_young = true;
             break;
         }
-        aged = Some((manifest_object_id, key));
+        current_generation.push((manifest_object_id, key));
+    }
+    if !found_young && !current_generation.is_empty() {
+        aged_generation = current_generation;
     }
 
-    let Some((manifest_object_id, key)) = aged else {
+    if aged_generation.is_empty() {
         // Nothing published, nothing unreferenced: a namespace with no
         // manifest of its own has never taken an object out of a file set,
         // and its floor cannot have advanced past its birth without a root.
-        return Ok(match published_any {
+        return Ok(match manifest_candidate_seen {
             true => ReferenceAnchor::Missing,
             false => ReferenceAnchor::NotNeeded,
         });
-    };
-    charge(budget)?;
-    let manifest = match load_namespace_manifest_envelope_if_present(
-        store,
-        namespace_id,
-        &manifest_object_id,
-        &key,
-    )
-    .await
-    {
-        Ok(Some(manifest)) => manifest,
-        Ok(None) => return Ok(ReferenceAnchor::Missing),
-        Err(error) => match error.failure_class() {
-            ManifestLoadFailureClass::Store => {
-                tracing::warn!(
-                    namespace_id = %namespace_id,
-                    object_key = key,
-                    error = %error,
-                    "the reference manifest did not read; retaining every aged candidate"
-                );
-                return Ok(ReferenceAnchor::Missing);
-            }
-            ManifestLoadFailureClass::Corrupt => {
-                return Err(CoreError::NamespaceCorrupt(format!(
-                    "the reference manifest does not load: {error}"
-                ))
-                .into());
-            }
-        },
-    };
+    }
+
+    let mut manifest_object_ids = BTreeSet::new();
+    let mut head_seq = None;
+    let mut segments = BTreeSet::new();
+    for (manifest_object_id, key) in aged_generation {
+        charge(budget)?;
+        let manifest = match load_namespace_manifest_envelope_if_present(
+            store,
+            namespace_id,
+            &manifest_object_id,
+            &key,
+        )
+        .await
+        {
+            Ok(Some(manifest)) => manifest,
+            Ok(None) => return Ok(ReferenceAnchor::Missing),
+            Err(error) => match error.failure_class() {
+                ManifestLoadFailureClass::Store => {
+                    tracing::warn!(
+                        namespace_id = %namespace_id,
+                        object_key = key,
+                        error = %error,
+                        "a reference-generation manifest did not read; retaining every aged candidate"
+                    );
+                    return Ok(ReferenceAnchor::Missing);
+                }
+                ManifestLoadFailureClass::Corrupt => {
+                    return Err(CoreError::NamespaceCorrupt(format!(
+                        "a reference-generation manifest does not load: {error}"
+                    ))
+                    .into());
+                }
+            },
+        };
+        manifest_object_ids.insert(manifest_object_id);
+        head_seq = Some(
+            head_seq.map_or(manifest.payload.head_seq, |current: ChangeSeq| {
+                current.min(manifest.payload.head_seq)
+            }),
+        );
+        segments.extend(
+            manifest
+                .payload
+                .segments
+                .iter()
+                .map(metadata_segment_object_key),
+        );
+    }
     Ok(ReferenceAnchor::Manifest(Box::new(AnchoredManifest {
-        manifest_object_id,
-        head_seq: manifest.payload.head_seq,
-        segments: manifest
-            .payload
-            .segments
-            .iter()
-            .map(metadata_segment_object_key)
-            .collect(),
+        manifest_object_ids,
+        head_seq: head_seq.expect("a nonempty reference generation has a head sequence"),
+        segments,
     })))
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -11,7 +11,9 @@ use super::uploads::{collect_referenced_content, CollectedReferences};
 use crate::checkpoint::advance_retention_floor;
 use crate::checkpoint::record::release_checkpoint_record;
 use crate::checkpoint::tests::{
-    compact_a_family_group_into_staging, create_checkpoint, mutation_context, write_test_file,
+    build_namespace_manifest_from_metadata_state, compact_a_family_group_into_staging,
+    create_checkpoint, load_current_projection, mutation_context, write_test_file,
+    ManifestMetadataSource,
 };
 use crate::checkpoint::MetadataCompactionView;
 use crate::commit_engine::{CommitCandidate, NamespaceCommitEngine};
@@ -30,7 +32,8 @@ use loonfs_api::wire::control::{
     UploadSessionState,
 };
 use loonfs_api::{
-    CheckpointId, ContentRef, ContentStoreId, ManifestObjectId, NamespaceId, UploadId,
+    ChangeSeq, CheckpointId, ContentRef, ContentStoreId, ManifestNo, ManifestObjectId, NamespaceId,
+    UploadId,
 };
 use loonfs_objectstore::keys::{
     checkpoint_prefix, metadata_compaction_lease, metadata_compaction_segment,
@@ -2022,6 +2025,96 @@ async fn a_read_pinned_before_a_fold_still_reads_after_the_sweep() {
         "folded-away segments must still be reclaimed, one window later"
     );
     stat_root(&store, &namespace_id).await;
+}
+
+#[tokio::test]
+async fn an_old_unpublished_manifest_cannot_replace_the_published_grace_anchor() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    for round in 0..3 {
+        write_test_file(
+            &inner,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            &format!("gc-orphan-anchor-{round}"),
+            &setup,
+        )
+        .await;
+        crate::checkpoint::flush_wal(&inner, &namespace_id, &setup)
+            .await
+            .expect("flush wal");
+    }
+
+    let projection = load_current_projection(&inner, &namespace_id)
+        .await
+        .expect("load current projection");
+    let next_manifest_no = ManifestNo(projection.root.manifest.manifest_no.0 + 1);
+    let mut orphan = build_namespace_manifest_from_metadata_state(
+        &inner,
+        &namespace_id,
+        ManifestMetadataSource {
+            head: &projection.head,
+            basis_manifest_no: Some(projection.root.manifest.manifest_no),
+            retention_floor_seq: ChangeSeq(0),
+            metadata_state: &projection.metadata_state,
+        },
+        crate::checkpoint::MetadataLsmPolicy {
+            max_delta_runs: NonZeroUsize::MIN,
+            ..Default::default()
+        },
+        next_manifest_no,
+    )
+    .await
+    .expect("build unpublished manifest");
+    orphan.payload.manifest_object_id =
+        ManifestObjectId::parse(format!("man_{:020}-0000000000000000", next_manifest_no.0))
+            .expect("ordered orphan manifest id");
+    orphan = loonfs_api::wire::manifest::NamespaceManifestEnvelope::from_payload(orphan.payload)
+        .expect("re-envelope orphan manifest");
+    crate::checkpoint::write_namespace_manifest(&inner, &orphan)
+        .await
+        .expect("write unpublished manifest");
+
+    let already_written = namespace_key_set(&inner, &namespace_id).await;
+    let store = aged_before_now(inner, already_written);
+    let pinned = load_current_metadata_view(&store, &namespace_id)
+        .await
+        .expect("pin the published root");
+
+    let report = crate::checkpoint::reorganize_metadata_step(
+        &store,
+        &namespace_id,
+        &setup,
+        crate::checkpoint::MetadataLsmPolicy {
+            max_delta_runs: NonZeroUsize::MIN,
+            ..Default::default()
+        },
+        MetadataCompactionView::default(),
+    )
+    .await
+    .expect("publish one replacement manifest");
+    assert!(matches!(
+        report.outcome,
+        crate::checkpoint::MetadataReorganizeOutcome::UnitPublished { .. }
+    ));
+
+    let after_publication = context(now_after_newest_object(store.inner(), &namespace_id, 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &after_publication)
+        .await
+        .expect("gc pass after replacement publication");
+    assert!(
+        report.deleted.metadata_segments > 0,
+        "the pass should find old segments the replacement no longer references"
+    );
+    pinned
+        .resolve_path("/docs/file-0.txt", AttributeInclusion::Omit)
+        .await
+        .expect("the published grace anchor remains readable");
 }
 
 /// Every reason's count, summed — what `retained_candidates` must equal.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2381,13 +2381,17 @@ publishing CAS) — under these rules:
    An object's provider timestamp says when it appeared, not when it stopped
    being referenced, and those differ for every object a publication once
    named. `T` therefore also runs from the unreferencing, which the
-   **reference manifest** dates. Call R the newest surviving manifest under
-   the namespace's own prefix whose provider timestamp is at least `T` old:
-   it is a durable snapshot of what the namespace referenced when the window
-   opened. R roots what it names exactly as `metadata/root.json` does — its
-   own key, its `segments`, its content references, and every WAL
-   segment above its `head_seq` — so an unreferenced object is deleted only
-   when the current root set, R, and the object's own age all agree. A
+   **reference manifest generation** dates. A lost root compare-and-swap can
+   leave multiple immutable manifest candidates with one `manifest_no`, and
+   an older root no longer records which candidate won. Call R the newest
+   manifest generation under the namespace's own prefix whose surviving
+   candidates all have provider timestamps at least `T` old. R roots every
+   candidate key in that generation, the union of their `segments` and
+   content references, and every WAL segment above the lowest `head_seq` any
+   candidate carries. The published candidate is therefore included even
+   when its same-generation siblings are abandoned. An unreferenced object
+   is deleted only when the current root set, R, and the object's own age all
+   agree. A
    namespace that has published no manifest needs no R: nothing has ever
    stopped referencing anything under it, and its floor cannot have advanced
    past its birth sequence without a root. A namespace whose manifests are


### PR DESCRIPTION
Treat all manifest candidates with the same manifest number as one reference generation. Advance past a generation only when every surviving candidate is old, and retain the union of their manifests and segments plus WAL above the lowest candidate head.

This prevents an old root publication loser from replacing the published grace anchor and letting GC delete objects needed by a read pinned before a root replacement.