### PR TITLE
fix(core): verify every manifest reference coordinate

### DIFF
--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -9,7 +9,7 @@
 
 use super::cache::MetadataSegmentCache;
 use super::error::ManifestLoadError;
-use super::load::load_verified_manifest_segments_with_cache;
+use super::load::{ensure_manifest_reference_matches, load_verified_manifest_segments_with_cache};
 use super::record::load_checkpoint_record;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::metadata::MetadataView;
@@ -94,13 +94,11 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
         other => CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(other)),
     })?;
     let manifest = segments.manifest();
-    if manifest.payload_checksum != record.manifest.manifest_payload_checksum
-        || manifest.payload.head_seq != record.manifest.manifest_head_seq
-    {
-        return Err(CoreError::NamespaceCorrupt(format!(
-            "checkpoint `{checkpoint_id}` basis does not match its manifest"
-        )));
-    }
+    ensure_manifest_reference_matches(
+        &format!("checkpoint `{checkpoint_id}` basis"),
+        &record.manifest,
+        manifest,
+    )?;
 
     let checkpoint_seq = record.manifest.manifest_head_seq;
     let view = MetadataView::over_manifest_segments(&segments, checkpoint_seq);

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -24,7 +24,7 @@ use crate::error::{CoreError, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
 use crate::namespace::basis::{genesis_next_inode_id, MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::bootstrap::bootstrap_metadata_state;
-use loonfs_api::wire::control::{genesis_commit_id, HeadState, MetadataRootState};
+use loonfs_api::wire::control::{genesis_commit_id, HeadState, ManifestRef, MetadataRootState};
 use loonfs_api::wire::manifest::{
     decode_namespace_manifest_json, MetadataRowFamily, MetadataSegmentRef,
     NamespaceManifestEnvelope, NamespaceManifestKind, NamespaceManifestPayload,
@@ -53,15 +53,67 @@ pub(super) fn ensure_root_matches_manifest(
     root: &MetadataRootState,
     manifest: &NamespaceManifestEnvelope,
 ) -> crate::error::Result<()> {
-    if manifest.payload_checksum != root.manifest.manifest_payload_checksum {
-        return Err(CoreError::NamespaceCorrupt(format!(
-            "metadata root for namespace `{namespace_id}` references manifest `{}` with checksum `{}`, but the manifest carries `{}`",
-            root.manifest.manifest_no,
-            root.manifest.manifest_payload_checksum,
-            manifest.payload_checksum,
-        )));
-    }
-    Ok(())
+    ensure_manifest_reference_matches(
+        &format!("metadata root for namespace `{namespace_id}`"),
+        &root.manifest,
+        manifest,
+    )
+}
+
+/// Verifies every coordinate by which a durable control object binds one
+/// immutable manifest.
+///
+/// Loading by owner and object id already proves the object's storage
+/// location. The remaining fields are still authority: callers use the
+/// manifest number for future allocation and the head sequence for replay
+/// and retention boundaries. A checksum match alone must not let those
+/// coordinates disagree with the payload it pins.
+pub(crate) fn ensure_manifest_reference_matches(
+    reference_name: &str,
+    reference: &ManifestRef,
+    manifest: &NamespaceManifestEnvelope,
+) -> crate::error::Result<()> {
+    let payload = &manifest.payload;
+    let mismatch = if reference.owner_namespace_id != payload.namespace_id {
+        Some((
+            "owner_namespace_id",
+            reference.owner_namespace_id.to_string(),
+            payload.namespace_id.to_string(),
+        ))
+    } else if reference.manifest_no != payload.manifest_no {
+        Some((
+            "manifest_no",
+            reference.manifest_no.to_string(),
+            payload.manifest_no.to_string(),
+        ))
+    } else if reference.manifest_object_id != payload.manifest_object_id {
+        Some((
+            "manifest_object_id",
+            reference.manifest_object_id.to_string(),
+            payload.manifest_object_id.to_string(),
+        ))
+    } else if reference.manifest_head_seq != payload.head_seq {
+        Some((
+            "manifest_head_seq",
+            reference.manifest_head_seq.to_string(),
+            payload.head_seq.to_string(),
+        ))
+    } else if reference.manifest_payload_checksum != manifest.payload_checksum {
+        Some((
+            "manifest_payload_checksum",
+            reference.manifest_payload_checksum.clone(),
+            manifest.payload_checksum.clone(),
+        ))
+    } else {
+        None
+    };
+    let Some((field, referenced, actual)) = mismatch else {
+        return Ok(());
+    };
+    Err(CoreError::NamespaceCorrupt(format!(
+        "{reference_name} records manifest `{}` field `{field}` as `{referenced}`, but the manifest carries `{actual}`",
+        reference.manifest_object_id,
+    )))
 }
 
 /// The genesis basis: one root-inode row and no metadata files.
@@ -139,16 +191,11 @@ pub(crate) async fn load_basis_metadata_segments<'a, S: ObjectStore + ?Sized>(
     .map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
     })?;
-    if segments.manifest().payload_checksum != manifest.manifest_payload_checksum {
-        return Err(CoreError::NamespaceCorrupt(format!(
-            "namespace `{namespace_id}` resolves its metadata basis to manifest `{}` in namespace \
-             `{}` with checksum `{}`, but the manifest carries `{}`",
-            manifest.manifest_object_id,
-            manifest.owner_namespace_id,
-            manifest.manifest_payload_checksum,
-            segments.manifest().payload_checksum,
-        )));
-    }
+    ensure_manifest_reference_matches(
+        &format!("namespace `{namespace_id}` metadata basis"),
+        manifest,
+        segments.manifest(),
+    )?;
     let manifest_head_seq = segments.manifest().payload.head_seq;
     Ok(LoadedMetadataBasis {
         identity: MetadataBasisIdentity::from_verified_basis(basis.clone(), manifest_head_seq),

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -5,7 +5,7 @@
 //! retention floor. Failed verification releases the record. Release is
 //! one-way, and garbage collection later removes aged released records.
 
-use super::load::load_namespace_manifest_envelope;
+use super::load::{ensure_manifest_reference_matches, load_namespace_manifest_envelope};
 use super::ManifestLoadError;
 use crate::control_object::{
     expect_identity_field, expect_namespace, expect_own_manifest, load_control_object,
@@ -241,18 +241,16 @@ pub(crate) async fn verify_checkpoint_basis<S: ObjectStore + ?Sized>(
             ))
         }
     };
-    if manifest.payload_checksum != record.manifest.manifest_payload_checksum {
-        // Both durable objects loaded successfully, so their disagreement is
-        // corruption rather than a retention race that a new checkpoint can fix.
-        return Err(CoreError::NamespaceCorrupt(format!(
-            "checkpoint `{}` for namespace `{}` records manifest `{}` payload checksum `{}`, but the manifest carries `{}`",
-            record.checkpoint_id,
-            record.namespace_id,
-            record.manifest.manifest_object_id,
-            record.manifest.manifest_payload_checksum,
-            manifest.payload_checksum,
-        )));
-    }
+    // Both durable objects loaded successfully, so any disagreement is
+    // corruption rather than a retention race that a new checkpoint can fix.
+    ensure_manifest_reference_matches(
+        &format!(
+            "checkpoint `{}` for namespace `{}`",
+            record.checkpoint_id, record.namespace_id
+        ),
+        &record.manifest,
+        &manifest,
+    )?;
     Ok(CheckpointBasisVerification::Verified)
 }
 

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -180,6 +180,61 @@ async fn strict_manifest_consumption_fails_when_manifest_is_corrupted() {
 }
 
 #[tokio::test]
+async fn recovery_rejects_a_root_head_seq_that_disagrees_with_its_manifest() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("materialize the committed state");
+
+    let loaded_root = load_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("load root");
+    assert_eq!(loaded_root.state.manifest.manifest_head_seq, ChangeSeq(1));
+    let mut root = loaded_root.state;
+    root.manifest.manifest_head_seq = ChangeSeq(0);
+    let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+        loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
+        root,
+    )
+    .expect("root envelope");
+    let bytes = loonfs_api::wire::control::encode_control_object(&envelope)
+        .expect("encode contradictory root");
+    store
+        .put_overwrite(
+            &loonfs_objectstore::keys::metadata_root(&namespace_id),
+            Bytes::from(bytes),
+        )
+        .await
+        .expect("install contradictory root");
+
+    let error = load_current_projection(&store, &namespace_id)
+        .await
+        .expect_err("the root coordinates must bind the manifest payload");
+    match error {
+        CoreError::NamespaceCorrupt(message) => {
+            assert!(message.contains("manifest_head_seq"), "{message}");
+        }
+        other => panic!("expected namespace corruption, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn create_checkpoint_surfaces_conflicting_invalid_manifest() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");


### PR DESCRIPTION
When recovery loads a manifest reference, verify its owner, manifest number, object ID, head sequence, and payload checksum against the manifest.

This prevents a well-formed root, fork basis, or checkpoint record with contradictory coordinates from being accepted as an authoritative recovery basis.