### PR TITLE
fix(core): reject a missing root after retention advances

### DIFF
--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -24,8 +24,7 @@ use crate::error::Result;
 use crate::limits::METADATA_PUBLICATION_BUDGET_MS;
 use crate::metadata::MetadataState;
 use crate::namespace::basis::{
-    advanced_floor_without_root, load_head_and_metadata_basis, namespace_birth_seq,
-    resolve_retention_floor_seq, MetadataBasis,
+    load_head_and_metadata_basis, resolve_retention_floor_seq, MetadataBasis,
 };
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use crate::wal::{
@@ -236,12 +235,6 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
     let floor_seq = resolve_retention_floor_seq(store, &head)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    // The floor never advances past the materialized root, so a floor above
-    // the namespace's birth sequence with no root of its own means the root
-    // was lost.
-    if !loaded.basis.is_owned_by(namespace_id) && floor_seq > namespace_birth_seq(&head) {
-        return Err(advanced_floor_without_root(namespace_id, floor_seq));
-    }
     let basis =
         load_basis_metadata_segments(store, None, namespace_id, &loaded.basis, head.created_at_ms)
             .await?;

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -235,6 +235,48 @@ async fn recovery_rejects_a_root_head_seq_that_disagrees_with_its_manifest() {
 }
 
 #[tokio::test]
+async fn current_reads_reject_a_missing_root_after_retention_advances() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("materialize the committed state");
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance retention");
+
+    store
+        .delete(&loonfs_objectstore::keys::metadata_root(&namespace_id))
+        .await
+        .expect("lose the recovery root");
+
+    let error = match load_current_metadata_view(&store, &namespace_id).await {
+        Ok(_) => panic!("retained WAL must not mask a root lost after floor advancement"),
+        Err(error) => error,
+    };
+    assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+    assert!(
+        error.to_string().contains("root object is missing"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
 async fn create_checkpoint_surfaces_conflicting_invalid_manifest() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");

--- a/crates/loonfs-core/src/control_object/error.rs
+++ b/crates/loonfs-core/src/control_object/error.rs
@@ -22,6 +22,13 @@ pub enum ControlObjectLoadError {
         head_seq: loonfs_api::ChangeSeq,
     },
     #[error(
+        "namespace `{namespace_id}` retention floor stands at `{floor_seq}`, but its metadata root object is missing"
+    )]
+    MissingRootAfterFloor {
+        namespace_id: NamespaceId,
+        floor_seq: loonfs_api::ChangeSeq,
+    },
+    #[error(
         "control object namespace mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
     )]
     NamespaceMismatch {

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -690,7 +690,8 @@ pub(crate) fn classify_control_object_load_error(error: &ControlObjectLoadError)
         ControlObjectLoadError::MissingObject { .. } => ErrorCode::NamespaceNotFound,
         ControlObjectLoadError::RootAheadOfHead { .. }
         | ControlObjectLoadError::FloorAheadOfHead { .. } => ErrorCode::StaleHead,
-        ControlObjectLoadError::NamespaceMismatch { .. }
+        ControlObjectLoadError::MissingRootAfterFloor { .. }
+        | ControlObjectLoadError::NamespaceMismatch { .. }
         | ControlObjectLoadError::IdentityMismatch { .. }
         | ControlObjectLoadError::ForkBasisOwnerIsSelf { .. }
         | ControlObjectLoadError::KeyLayout { .. }

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -6,7 +6,6 @@
 //! in the head.
 
 use crate::control_object::ControlObjectLoadError;
-use crate::error::CoreError;
 use crate::namespace::control::{
     load_head_and_metadata_root_if_present, load_head_object, load_wal_floor_object,
     LoadedHeadObject,
@@ -94,12 +93,35 @@ pub(crate) async fn load_head_and_metadata_basis<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> Result<LoadedNamespaceBasis, ControlObjectLoadError> {
-    let (head, root) = load_head_and_metadata_root_if_present(store, namespace_id).await?;
-    let basis = match root {
-        Some(root) => MetadataBasis::Manifest(root.state.manifest),
-        None => metadata_basis_without_root(&head.state),
-    };
-    Ok(LoadedNamespaceBasis { head, basis })
+    const MISSING_ROOT_RELOADS: usize = 3;
+    let mut reloads = 0;
+    loop {
+        let (head, root) = load_head_and_metadata_root_if_present(store, namespace_id).await?;
+        if let Some(root) = root {
+            return Ok(LoadedNamespaceBasis {
+                head,
+                basis: MetadataBasis::Manifest(root.state.manifest),
+            });
+        }
+
+        // A missing floor means this namespace has never advanced retention,
+        // so genesis or the fork source is still a complete recovery basis.
+        // An advanced floor proves a root was published. Reload the pair once
+        // more in case these reads straddled that first publication; if the
+        // root remains absent, it was lost and replay is no longer authority.
+        let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
+        if floor_seq <= namespace_birth_seq(&head.state) {
+            let basis = metadata_basis_without_root(&head.state);
+            return Ok(LoadedNamespaceBasis { head, basis });
+        }
+        if reloads == MISSING_ROOT_RELOADS {
+            return Err(ControlObjectLoadError::MissingRootAfterFloor {
+                namespace_id: namespace_id.clone(),
+                floor_seq,
+            });
+        }
+        reloads += 1;
+    }
 }
 
 /// Resolves the basis of a namespace whose `metadata/root.json` is absent:
@@ -168,19 +190,4 @@ pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
         floor_seq,
         head_seq: head.state.seq,
     })
-}
-
-/// Reports a basis that resolved past a materialized root that is not there.
-///
-/// The retention invariant keeps the floor at or below the materialized
-/// root, so a floor above the namespace's birth sequence with no root object
-/// means the root was lost, not that the namespace is young.
-pub(crate) fn advanced_floor_without_root(
-    namespace_id: &NamespaceId,
-    floor_seq: ChangeSeq,
-) -> CoreError {
-    CoreError::NamespaceCorrupt(format!(
-        "namespace `{namespace_id}` has no materialized metadata root but its retention floor \
-         stands at `{floor_seq}`; the root object is missing"
-    ))
 }

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -486,9 +486,10 @@ async fn read_after_write_is_served_from_seeded_caches() {
         )
         .await
         .expect("steady-state put");
-    // The publish must read the live head and root for freshness, and the
-    // upload session that owns the staged content has to be read to be
-    // completed on its own etag. One of each, and nothing else.
+    // The publish must read the live head and root for freshness. Because no
+    // root has been published yet, it also reads the floor to distinguish a
+    // young namespace from a lost recovery root. The upload session that owns
+    // the staged content has to be read to be completed on its own etag.
     let write_gets = recording.take_get_keys();
     let uploads_prefix = loonfs_objectstore::keys::upload_session_prefix(&namespace_id);
     let classify = |suffix: &str| {
@@ -499,6 +500,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
     };
     assert_eq!(classify("/wal/head.json"), 1, "got {write_gets:?}");
     assert_eq!(classify("/metadata/root.json"), 1, "got {write_gets:?}");
+    assert_eq!(classify("/wal/floor.json"), 1, "got {write_gets:?}");
     assert_eq!(
         write_gets
             .iter()
@@ -509,8 +511,8 @@ async fn read_after_write_is_served_from_seeded_caches() {
     );
     assert_eq!(
         write_gets.len(),
-        3,
-        "a steady-state write reads nothing beyond those three, got {write_gets:?}"
+        4,
+        "a steady-state write reads nothing beyond those controls, got {write_gets:?}"
     );
 
     reader


### PR DESCRIPTION
When a namespace has no metadata root, read its retention floor before falling back to the genesis or fork basis. Reload the head and root if the floor indicates a concurrent first publication, and report corruption if the root remains absent after retention advanced.

This prevents recovery from masking a lost root by replaying WAL history the floor no longer promises to retain.