### PR TITLE
fix(core): reload heads observed behind retention

### DIFF
--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -1104,6 +1104,68 @@ async fn read_anchor_reloads_the_head_when_the_root_is_ahead() {
 }
 
 #[tokio::test]
+async fn namespace_status_and_change_feed_reload_a_head_behind_the_floor() {
+    // Retention publishes the floor independently of the head. A reader that
+    // straddles those writes must not report a floor newer than its head.
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&inner, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    let stale_head = inner
+        .get_with_metadata(&wal_head(&namespace_id))
+        .await
+        .expect("read bootstrap head")
+        .expect("bootstrap head exists");
+
+    write_file_bytes(
+        &inner,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&inner, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    advance_retention_floor(&inner, &namespace_id, &context)
+        .await
+        .expect("advance retention");
+
+    let status_store = StaleHeadOnceStore {
+        inner: LocalFsStore::new(temp_dir.path()).expect("status store"),
+        head_key: wal_head(&namespace_id),
+        stale_head: std::sync::Mutex::new(Some(stale_head.clone())),
+    };
+    let namespace = load_namespace(&status_store, &namespace_id)
+        .await
+        .expect("status reloads the stale head");
+    assert_eq!(namespace.head_seq, ChangeSeq(1));
+    assert_eq!(namespace.retention_floor_seq, ChangeSeq(1));
+
+    let feed_store = StaleHeadOnceStore {
+        inner: LocalFsStore::new(temp_dir.path()).expect("change-feed store"),
+        head_key: wal_head(&namespace_id),
+        stale_head: std::sync::Mutex::new(Some(stale_head)),
+    };
+    let changes = list_changes_after(
+        &feed_store,
+        &namespace_id,
+        ChangeSeq(1),
+        EffectiveLimit::new(NonZeroU32::new(10).expect("nonzero")),
+    )
+    .await
+    .expect("change feed reloads the stale head");
+    assert_eq!(changes.through_seq, ChangeSeq(1));
+    assert!(changes.changes.is_empty());
+}
+
+#[tokio::test]
 async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
     // The review's flush race: a publisher builds from root A while a
     // sibling publishes B from the same basis, then tries to win on a

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -55,7 +55,7 @@ use crate::namespace::catalog::load_namespace_catalog_entry;
 use crate::namespace::control::{
     load_head_object, load_metadata_root_object, load_wal_floor_object,
 };
-use crate::namespace::status::load_namespace_diagnostics;
+use crate::namespace::status::{load_namespace, load_namespace_diagnostics};
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::read::{load_current_metadata_view, resolve_current_files, CurrentFileState};
 use crate::protocol::list_changes_after;

--- a/crates/loonfs-core/src/control_object/error.rs
+++ b/crates/loonfs-core/src/control_object/error.rs
@@ -16,6 +16,11 @@ pub enum ControlObjectLoadError {
         root_manifest_head_seq: loonfs_api::ChangeSeq,
         head_seq: loonfs_api::ChangeSeq,
     },
+    #[error("retention floor seq `{floor_seq}` is beyond the reloaded head seq `{head_seq}`")]
+    FloorAheadOfHead {
+        floor_seq: loonfs_api::ChangeSeq,
+        head_seq: loonfs_api::ChangeSeq,
+    },
     #[error(
         "control object namespace mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
     )]

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -688,7 +688,8 @@ fn classify_metadata_projection_load_error(error: &MetadataProjectionLoadError) 
 pub(crate) fn classify_control_object_load_error(error: &ControlObjectLoadError) -> ErrorCode {
     match error {
         ControlObjectLoadError::MissingObject { .. } => ErrorCode::NamespaceNotFound,
-        ControlObjectLoadError::RootAheadOfHead { .. } => ErrorCode::StaleHead,
+        ControlObjectLoadError::RootAheadOfHead { .. }
+        | ControlObjectLoadError::FloorAheadOfHead { .. } => ErrorCode::StaleHead,
         ControlObjectLoadError::NamespaceMismatch { .. }
         | ControlObjectLoadError::IdentityMismatch { .. }
         | ControlObjectLoadError::ForkBasisOwnerIsSelf { .. }

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -8,7 +8,8 @@
 use crate::control_object::ControlObjectLoadError;
 use crate::error::CoreError;
 use crate::namespace::control::{
-    load_head_and_metadata_root_if_present, load_wal_floor_object, LoadedHeadObject,
+    load_head_and_metadata_root_if_present, load_head_object, load_wal_floor_object,
+    LoadedHeadObject,
 };
 use loonfs_api::wire::control::{HeadState, ManifestRef};
 use loonfs_api::NamespaceId;
@@ -140,6 +141,33 @@ pub(crate) async fn resolve_retention_floor_seq<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => Ok(namespace_birth_seq(head)),
         Err(error) => Err(error),
     }
+}
+
+/// Reads a head and retention floor that could have existed together.
+///
+/// The objects advance independently. A floor newer than the first head read
+/// can therefore be a benign cross-read race, but it must not escape as a
+/// snapshot with history retained beyond the reported namespace head.
+pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<(LoadedHeadObject, ChangeSeq), ControlObjectLoadError> {
+    const FLOOR_AHEAD_HEAD_RELOADS: usize = 3;
+    let mut head = load_head_object(store, namespace_id).await?;
+    let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
+    for _reload in 0..FLOOR_AHEAD_HEAD_RELOADS {
+        if floor_seq <= head.state.seq {
+            return Ok((head, floor_seq));
+        }
+        head = load_head_object(store, namespace_id).await?;
+    }
+    if floor_seq <= head.state.seq {
+        return Ok((head, floor_seq));
+    }
+    Err(ControlObjectLoadError::FloorAheadOfHead {
+        floor_seq,
+        head_seq: head.state.seq,
+    })
 }
 
 /// Reports a basis that resolved past a materialized root that is not there.

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -3,7 +3,9 @@
 use crate::checkpoint::load_namespace_manifest_envelope;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
-use crate::namespace::basis::{load_head_and_metadata_basis, resolve_retention_floor_seq};
+use crate::namespace::basis::{
+    load_head_and_metadata_basis, load_head_and_retention_floor, resolve_retention_floor_seq,
+};
 use crate::wal::{count_visible_wal_tail_segments, WalChainLoadRequest};
 use loonfs_api::wire::control::{HeadState, NamespaceStatus};
 use loonfs_api::{ChangeSeq, ManifestNo, Namespace, NamespaceDiagnostics, NamespaceId};
@@ -26,7 +28,7 @@ struct LoadedHeadBasis {
     retention_floor_seq: ChangeSeq,
 }
 
-async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
+async fn load_namespace_head_basis_once<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedHeadBasis> {
@@ -76,23 +78,43 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
     })
 }
 
+async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace_id: &NamespaceId,
+) -> Result<LoadedHeadBasis> {
+    const FLOOR_AHEAD_HEAD_RELOADS: usize = 3;
+    let mut loaded = load_namespace_head_basis_once(store, expected_namespace_id).await?;
+    for _reload in 0..FLOOR_AHEAD_HEAD_RELOADS {
+        if loaded.retention_floor_seq <= loaded.head.seq {
+            return Ok(loaded);
+        }
+        loaded = load_namespace_head_basis_once(store, expected_namespace_id).await?;
+    }
+    if loaded.retention_floor_seq <= loaded.head.seq {
+        return Ok(loaded);
+    }
+    Err(CoreError::ControlObjectLoad(
+        crate::control_object::ControlObjectLoadError::FloorAheadOfHead {
+            floor_seq: loaded.retention_floor_seq,
+            head_seq: loaded.head.seq,
+        },
+    ))
+}
+
 /// Loads the current state of a live namespace.
 pub async fn load_namespace<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<Namespace> {
-    let head = crate::namespace::control::load_head_object(store, expected_namespace_id)
+    let (head, retention_floor_seq) = load_head_and_retention_floor(store, expected_namespace_id)
         .await
-        .map_err(CoreError::ControlObjectLoad)?
-        .state;
+        .map_err(CoreError::ControlObjectLoad)?;
+    let head = head.state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::NamespaceDeleted {
             namespace_id: expected_namespace_id.clone(),
         });
     }
-    let retention_floor_seq = resolve_retention_floor_seq(store, &head)
-        .await
-        .map_err(CoreError::ControlObjectLoad)?;
     Ok(Namespace {
         namespace_id: head.namespace_id,
         head_seq: head.seq,
@@ -154,18 +176,15 @@ pub async fn load_deleted_namespace_diagnostics<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<NamespaceDiagnostics> {
-    let head = crate::namespace::control::load_head_object(store, expected_namespace_id)
+    let (head, retention_floor_seq) = load_head_and_retention_floor(store, expected_namespace_id)
         .await
-        .map_err(CoreError::ControlObjectLoad)?
-        .state;
+        .map_err(CoreError::ControlObjectLoad)?;
+    let head = head.state;
     if head.status != (NamespaceStatus::Deleted {}) {
         return Err(CoreError::Internal(format!(
             "namespace `{expected_namespace_id}` is live; deleted diagnostics require a deleted namespace"
         )));
     }
-    let retention_floor_seq = resolve_retention_floor_seq(store, &head)
-        .await
-        .map_err(CoreError::ControlObjectLoad)?;
     Ok(NamespaceDiagnostics {
         namespace_id: head.namespace_id,
         head_seq: head.seq,

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -2,8 +2,7 @@
 //! commit's durable WAL deltas mapped to semantic filesystem events.
 
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
-use crate::namespace::basis::resolve_retention_floor_seq;
-use crate::namespace::control::load_namespace_head_control;
+use crate::namespace::basis::load_head_and_retention_floor;
 use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
 use loonfs_api::v0::{CommittedChange, FilesystemChange, ListChangesResponse};
 use loonfs_api::wire::control::NamespaceStatus;
@@ -18,19 +17,16 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     after_seq: ChangeSeq,
     limit: EffectiveLimit,
 ) -> Result<ListChangesResponse> {
-    let head = load_namespace_head_control(store, namespace_id)
+    let (head, retention_floor_seq) = load_head_and_retention_floor(store, namespace_id)
         .await
-        .map_err(CoreError::ControlObjectLoad)?
-        .state;
+        .map_err(CoreError::ControlObjectLoad)?;
+    let head = head.state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::NamespaceDeleted {
             namespace_id: namespace_id.clone(),
         });
     }
 
-    let retention_floor_seq = resolve_retention_floor_seq(store, &head)
-        .await
-        .map_err(CoreError::ControlObjectLoad)?;
     if after_seq < retention_floor_seq {
         return Err(CoreError::RebootstrapRequired {
             after_seq,


### PR DESCRIPTION
When a retention floor is newer than the concurrently loaded namespace head, reload the head before returning status, diagnostics, or change-feed results. Bound the reloads and return a stale-head error if the pair never converges.

This prevents independently updated control objects from producing a snapshot whose retention floor is ahead of its head.