### PR TITLE
fix(core): verify fork checkpoint before creating target

### DIFF
--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -223,15 +223,11 @@ const _: () = assert!(
      the commit that receipt admits, and that commit's publication"
 );
 
-/// Margin the post-publish fork guard requires between now and the source
-/// record's lease expiry before it lets a target stand.
+/// Time a fork checkpoint must remain valid after it is checked.
 ///
-/// The guard's evidence is one record read, and one provider operation's
-/// total wall time is `PROVIDER_OPERATION_DEADLINE_MS +
-/// PROVIDER_ATTEMPT_TIMEOUT_MS` (the deadline gates starting an attempt
-/// rather than preempting one). A record observed with more lease than that
-/// left cannot have been legally expiry-released while the guard was
-/// looking at it, so the observation still holds when the guard acts on it.
+/// This covers the full wall time of the next provider operation. The
+/// deadline limits when an attempt may start, and the attempt timeout limits
+/// how long that final attempt may run.
 pub const FORK_GUARD_MARGIN_MS: u64 = PROVIDER_OPERATION_DEADLINE_MS + PROVIDER_ATTEMPT_TIMEOUT_MS;
 
 // The fork lease has two jobs, and both are inequalities over the constants

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -93,6 +93,20 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         recent_segments: Vec::new(),
         status: NamespaceStatus::Active {},
     };
+    // The same check runs on both sides of the install. Before: a forker
+    // that stalled since creating the record must not install a target whose
+    // pin garbage collection may already have reaped. The margin covers the
+    // one provider operation the install is.
+    ensure_fork_checkpoint_lease_holds(
+        store,
+        source_namespace_id,
+        &source_record.checkpoint_id,
+        new_namespace_id,
+        context
+            .now_ms
+            .saturating_add(timer.monotonic_now_ms().saturating_sub(started_ms)),
+    )
+    .await?;
     match install_namespace_head(store, new_namespace_id, &head).await? {
         NamespaceHeadInstall::Landed => {}
         NamespaceHeadInstall::Exists => {
@@ -149,9 +163,9 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     crate::namespace::status::load_namespace(store, new_namespace_id).await
 }
 
-/// Proves, after the target head is durable, that the source record still
-/// pins the basis and will keep pinning it long enough for the new target to
-/// take over that job.
+/// Proves, immediately before and again after the target head install, that
+/// the source record still pins the basis and will keep pinning it long
+/// enough for the new target to take over that job.
 ///
 /// The record must be active, and its lease must outlast this read by
 /// [`FORK_GUARD_MARGIN_MS`]. The margin is what makes the check sound where a

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -1,6 +1,4 @@
-//! Namespace forking: installs a target namespace whose head points at a
-//! fork-owned source checkpoint, sharing content bytes and reading the
-//! source's metadata until the target flushes its own.
+//! Forks a namespace from a checkpoint of the source.
 
 use crate::checkpoint::{
     create_checkpoint, load_checkpoint_record, load_namespace_manifest_envelope,
@@ -24,18 +22,11 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     new_namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<Namespace> {
-    // The guard at the end needs to know how long this attempt has been
-    // running, so it starts here, before the first write.
+    // Include the whole fork in the lease-age calculation.
     let timer = StdMonotonicTimer::default();
     let started_ms = timer.monotonic_now_ms();
-    // Fork routes through a fork-owned source checkpoint: the record is the
-    // reachability root protecting every source-owned metadata file the
-    // target will reference, for as long as the target lives.
-    //
-    // Every attempt creates its own leased record. There is no reuse of an
-    // earlier attempt's record and no way back from a release, so an attempt
-    // that dies before publishing its target simply lets the lease pass, and
-    // garbage collection releases and reaps the record on that alone.
+    // The checkpoint keeps source metadata alive while the target refers to it.
+    // Garbage collection removes the checkpoint if the fork fails.
     let checkpoint = create_checkpoint(
         store,
         source_namespace_id,
@@ -67,15 +58,13 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         .await
         .map_err(CoreError::ControlObjectLoad)?
         .state;
-    // Start the target from the manifest pinned by the source checkpoint.
     let fork_basis = ForkBasis {
         manifest: source_record.manifest.clone(),
         source_checkpoint_id: source_record.checkpoint_id.clone(),
     };
     let fork_seq = fork_basis.manifest.manifest_head_seq;
 
-    // The target shares the source's content store and begins from the source
-    // manifest until it publishes its own.
+    // The target shares the source's content and starts from its pinned manifest.
     let head = HeadState {
         namespace_id: new_namespace_id.clone(),
         content_store_id: source_head.content_store_id.clone(),
@@ -93,10 +82,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         recent_segments: Vec::new(),
         status: NamespaceStatus::Active {},
     };
-    // The same check runs on both sides of the install. Before: a forker
-    // that stalled since creating the record must not install a target whose
-    // pin garbage collection may already have reaped. The margin covers the
-    // one provider operation the install is.
+    // Refuse to create a target if its checkpoint may expire during installation.
     ensure_fork_checkpoint_lease_holds(
         store,
         source_namespace_id,
@@ -121,13 +107,8 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         }
     }
 
-    // A forker that stalled between creating the record and publishing the
-    // target could have slept past its own lease, and a garbage-collection
-    // pass could have released the pin, leaving a target whose basis nothing
-    // protects. The guard closes that window: an inactive record, or one too
-    // close to its lease to trust, means this target must not exist, so it
-    // is deleted through the ordinary delete path and the checkpoint failure
-    // is what the caller sees.
+    // Confirm that the checkpoint remained valid while the target was installed.
+    // If it did not, retire the target before returning the error.
     if let Err(error) = ensure_fork_checkpoint_lease_holds(
         store,
         source_namespace_id,
@@ -147,9 +128,6 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         )
         .await
         {
-            // Both halves failed. The caller hears why the fork failed,
-            // which is the actionable half; the target that could not be
-            // deleted is left for an operator, named here.
             tracing::error!(
                 namespace_id = %new_namespace_id,
                 source_namespace_id = %source_namespace_id,
@@ -163,18 +141,8 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     crate::namespace::status::load_namespace(store, new_namespace_id).await
 }
 
-/// Proves, immediately before and again after the target head install, that
-/// the source record still pins the basis and will keep pinning it long
-/// enough for the new target to take over that job.
-///
-/// The record must be active, and its lease must outlast this read by
-/// [`FORK_GUARD_MARGIN_MS`]. The margin is what makes the check sound where a
-/// bare re-read raced: garbage collection releases a fork record only once
-/// its lease has passed, so a lease with more than one provider operation
-/// left cannot legally be released between the read and the caller acting on
-/// it. After that point the target head itself is the protection — a fork
-/// record whose target namespace exists and is not deleted is retained by
-/// every pass, lease or no lease.
+/// Checks that the fork checkpoint is active and remains valid through one
+/// provider operation.
 async fn ensure_fork_checkpoint_lease_holds<S: ObjectStore + ?Sized>(
     store: &S,
     source_namespace_id: &NamespaceId,

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -628,16 +628,17 @@ async fn checkpointing_an_unflushed_fork_materializes_its_first_manifest() {
 }
 
 #[tokio::test]
-async fn a_fork_whose_source_pin_is_released_deletes_its_own_target() {
+async fn fork_deletes_target_when_source_checkpoint_is_released() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ReleasePinAfterHeadStore::new(
-        LocalFsStore::new(temp_dir.path()).expect("store"),
-        NamespaceId::parse("clone").expect("valid namespace id"),
-        ForkPinAfterHead::Released,
-    );
-    let context = mutation_context();
     let source = namespace_id("source");
     let clone = NamespaceId::parse("clone").expect("valid namespace id");
+    let store = RewriteForkCheckpointStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        source.clone(),
+        clone.clone(),
+        ForkCheckpointRewrite::ReleaseAfterTargetInstall,
+    );
+    let context = mutation_context();
     seed_source_namespace_for_fork(&store, &source, &context).await;
 
     let error = fork_namespace(&store, &source, &clone, &context)
@@ -656,33 +657,37 @@ async fn a_fork_whose_source_pin_is_released_deletes_its_own_target() {
 }
 
 #[tokio::test]
-async fn a_fork_whose_source_lease_runs_out_deletes_its_own_target() {
+async fn fork_does_not_create_target_when_source_checkpoint_is_expiring() {
     let temp_dir = tempdir().expect("tempdir");
     let context = mutation_context();
-    let store = ReleasePinAfterHeadStore::new(
+    let source = namespace_id("source");
+    let clone = NamespaceId::parse("clone").expect("valid namespace id");
+    let store = RewriteForkCheckpointStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        NamespaceId::parse("clone").expect("valid namespace id"),
-        ForkPinAfterHead::LeaseAtTheGuardMargin {
+        source.clone(),
+        clone.clone(),
+        ForkCheckpointRewrite::ShortenBeforeTargetInstall {
             now_ms: context.now_ms,
         },
     );
-    let source = namespace_id("source");
-    let clone = NamespaceId::parse("clone").expect("valid namespace id");
     seed_source_namespace_for_fork(&store, &source, &context).await;
 
     let error = fork_namespace(&store, &source, &clone, &context)
         .await
         .expect_err("a lease inside the guard margin fails the fork");
     assert_eq!(error.code(), ErrorCode::CheckpointUnavailable);
-    assert_eq!(
-        head_state(&store, &clone).await.status,
-        loonfs_api::wire::control::NamespaceStatus::Deleted {},
-        "the fork deletes the target it published"
+    assert!(
+        store
+            .head(&wal_head(&clone))
+            .await
+            .expect("probe target head")
+            .is_none(),
+        "the fork must not create a target when its checkpoint may expire during installation"
     );
 }
 
 #[tokio::test]
-async fn a_fork_with_lease_to_spare_survives_a_concurrent_gc_pass() {
+async fn fork_survives_concurrent_gc_with_sufficient_lease() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
     let context = mutation_context();
@@ -996,41 +1001,36 @@ async fn gc_handles_a_namespace_with_no_root_and_then_its_tombstone() {
         .is_none());
 }
 
-/// What happens to the fork's source pin the moment the target head lands.
 #[derive(Debug, Clone, Copy)]
-enum ForkPinAfterHead {
-    /// A garbage-collection pass released the pin while a stalled forker
-    /// slept.
-    Released,
-    /// The forker stalled until its lease was all but gone: the record is
-    /// still active, but with exactly the guard margin left, which is not
-    /// margin enough to trust.
-    LeaseAtTheGuardMargin { now_ms: u64 },
+enum ForkCheckpointRewrite {
+    ReleaseAfterTargetInstall,
+    ShortenBeforeTargetInstall { now_ms: u64 },
 }
 
-/// A store that rewrites the fork's source checkpoint the moment the target
-/// head lands, standing in for the window between the two writes.
 #[derive(Debug)]
-struct ReleasePinAfterHeadStore {
+struct RewriteForkCheckpointStore {
     inner: LocalFsStore,
+    source_head_key: String,
     target_head_key: String,
-    after_head: ForkPinAfterHead,
+    rewrite: ForkCheckpointRewrite,
 }
 
-impl ReleasePinAfterHeadStore {
+impl RewriteForkCheckpointStore {
     fn new(
         inner: LocalFsStore,
+        source_namespace_id: NamespaceId,
         target_namespace_id: NamespaceId,
-        after_head: ForkPinAfterHead,
+        rewrite: ForkCheckpointRewrite,
     ) -> Self {
         Self {
             inner,
+            source_head_key: wal_head(&source_namespace_id),
             target_head_key: wal_head(&target_namespace_id),
-            after_head,
+            rewrite,
         }
     }
 
-    async fn rewrite_every_fork_pin(&self) {
+    async fn rewrite_fork_checkpoints(&self) {
         for key in self
             .inner
             .list_prefix("namespaces/")
@@ -1051,13 +1051,13 @@ impl ReleasePinAfterHeadStore {
             if !matches!(record.owner, CheckpointOwner::Fork { .. }) {
                 continue;
             }
-            match self.after_head {
-                ForkPinAfterHead::Released => {
+            match self.rewrite {
+                ForkCheckpointRewrite::ReleaseAfterTargetInstall => {
                     record.status = CheckpointStatus::Released {
                         released_at_ms: 2_000,
                     };
                 }
-                ForkPinAfterHead::LeaseAtTheGuardMargin { now_ms } => {
+                ForkCheckpointRewrite::ShortenBeforeTargetInstall { now_ms } => {
                     let CheckpointOwner::Fork { expires_at_ms, .. } = &mut record.owner else {
                         panic!("the record was checked as fork-owned")
                     };
@@ -1081,7 +1081,7 @@ impl ReleasePinAfterHeadStore {
 }
 
 #[async_trait::async_trait]
-impl ObjectStore for ReleasePinAfterHeadStore {
+impl ObjectStore for RewriteForkCheckpointStore {
     async fn head(
         &self,
         key: &str,
@@ -1102,7 +1102,16 @@ impl ObjectStore for ReleasePinAfterHeadStore {
         &self,
         key: &str,
     ) -> Result<Option<loonfs_objectstore::ObjectBody>, loonfs_objectstore::ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
+        let body = self.inner.get_with_metadata(key).await?;
+        if key == self.source_head_key
+            && matches!(
+                self.rewrite,
+                ForkCheckpointRewrite::ShortenBeforeTargetInstall { .. }
+            )
+        {
+            self.rewrite_fork_checkpoints().await;
+        }
+        Ok(body)
     }
 
     async fn put(
@@ -1112,8 +1121,13 @@ impl ObjectStore for ReleasePinAfterHeadStore {
         mode: loonfs_objectstore::PutMode,
     ) -> Result<loonfs_objectstore::ObjectMetadata, loonfs_objectstore::ObjectStoreError> {
         let metadata = self.inner.put(key, bytes, mode).await?;
-        if key == self.target_head_key {
-            self.rewrite_every_fork_pin().await;
+        if key == self.target_head_key
+            && matches!(
+                self.rewrite,
+                ForkCheckpointRewrite::ReleaseAfterTargetInstall
+            )
+        {
+            self.rewrite_fork_checkpoints().await;
         }
         Ok(metadata)
     }


### PR DESCRIPTION
Checks the source checkpoint immediately before creating a fork target, as well as after creation. A fork that has stalled until its checkpoint is close to expiring now fails without publishing a target.

This closes a race where garbage collection could release the checkpoint before the target existed, leaving the target without protection for its source metadata. Each fork performs one additional checkpoint read.