### PR TITLE
refactor(core): share retry logic for metadata consistency checks

### DIFF
--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -15,6 +15,37 @@ pub(crate) struct LoadedControl<T> {
     pub(crate) state: T,
 }
 
+/// Reads state assembled from control objects that advance independently,
+/// reloading until one read is coherent.
+///
+/// The objects have no shared snapshot, so two reads can straddle a write and
+/// observe a pair that never existed together. Every such observation site
+/// declares its coherence rule here and reloads through this one bound; a
+/// read that never converges returns the site's incoherence error instead of
+/// escaping as an impossible snapshot.
+pub(crate) async fn load_coherent<T, E, F, Fut>(
+    mut load: F,
+    coherent: impl Fn(&T) -> bool,
+    incoherent: impl FnOnce(T) -> E,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    const COHERENCE_RELOADS: usize = 3;
+    let mut loaded = load().await?;
+    for _reload in 0..COHERENCE_RELOADS {
+        if coherent(&loaded) {
+            return Ok(loaded);
+        }
+        loaded = load().await?;
+    }
+    if coherent(&loaded) {
+        return Ok(loaded);
+    }
+    Err(incoherent(loaded))
+}
+
 pub(crate) enum EmbeddedIdentityMismatch {
     Namespace {
         expected: NamespaceId,

--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -15,35 +15,29 @@ pub(crate) struct LoadedControl<T> {
     pub(crate) state: T,
 }
 
-/// Reads state assembled from control objects that advance independently,
-/// reloading until one read is coherent.
-///
-/// The objects have no shared snapshot, so two reads can straddle a write and
-/// observe a pair that never existed together. Every such observation site
-/// declares its coherence rule here and reloads through this one bound; a
-/// read that never converges returns the site's incoherence error instead of
-/// escaping as an impossible snapshot.
-pub(crate) async fn load_coherent<T, E, F, Fut>(
-    mut load: F,
-    coherent: impl Fn(&T) -> bool,
-    incoherent: impl FnOnce(T) -> E,
+pub(crate) const CONTROL_READ_RELOADS: usize = 3;
+
+/// Reloads a value until it is consistent or the retry limit is reached.
+pub(crate) async fn reload_until_consistent<T, E, F, Fut>(
+    mut loaded: T,
+    mut reload: F,
+    is_consistent: impl Fn(&T) -> bool,
+    on_exhausted: impl FnOnce(T) -> E,
 ) -> Result<T, E>
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<T, E>>,
 {
-    const COHERENCE_RELOADS: usize = 3;
-    let mut loaded = load().await?;
-    for _reload in 0..COHERENCE_RELOADS {
-        if coherent(&loaded) {
-            return Ok(loaded);
-        }
-        loaded = load().await?;
-    }
-    if coherent(&loaded) {
+    if is_consistent(&loaded) {
         return Ok(loaded);
     }
-    Err(incoherent(loaded))
+    for _ in 0..CONTROL_READ_RELOADS {
+        loaded = reload().await?;
+        if is_consistent(&loaded) {
+            return Ok(loaded);
+        }
+    }
+    Err(on_exhausted(loaded))
 }
 
 pub(crate) enum EmbeddedIdentityMismatch {

--- a/crates/loonfs-core/src/control_object/mod.rs
+++ b/crates/loonfs-core/src/control_object/mod.rs
@@ -6,5 +6,5 @@ mod load;
 pub use error::ControlObjectLoadError;
 pub(crate) use load::{
     expect_foreign_fork_basis, expect_identity_field, expect_namespace, expect_own_manifest,
-    load_coherent, load_control_object, LoadedControl,
+    load_control_object, reload_until_consistent, LoadedControl, CONTROL_READ_RELOADS,
 };

--- a/crates/loonfs-core/src/control_object/mod.rs
+++ b/crates/loonfs-core/src/control_object/mod.rs
@@ -6,5 +6,5 @@ mod load;
 pub use error::ControlObjectLoadError;
 pub(crate) use load::{
     expect_foreign_fork_basis, expect_identity_field, expect_namespace, expect_own_manifest,
-    load_control_object, LoadedControl,
+    load_coherent, load_control_object, LoadedControl,
 };

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -5,10 +5,12 @@
 //! the first flush. A fork basis must match the identity and checksum stored
 //! in the head.
 
-use crate::control_object::{load_coherent, ControlObjectLoadError};
+use crate::control_object::{
+    reload_until_consistent, ControlObjectLoadError, CONTROL_READ_RELOADS,
+};
 use crate::namespace::control::{
     load_head_and_metadata_root_if_present, load_head_object, load_wal_floor_object,
-    LoadedHeadObject, LoadedMetadataRootObject,
+    LoadedHeadObject,
 };
 use loonfs_api::wire::control::{HeadState, ManifestRef};
 use loonfs_api::NamespaceId;
@@ -93,58 +95,32 @@ pub(crate) async fn load_head_and_metadata_basis<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> Result<LoadedNamespaceBasis, ControlObjectLoadError> {
-    // A missing floor means this namespace has never advanced retention, so
-    // genesis or the fork source is still a complete recovery basis. An
-    // advanced floor proves a root was published: a read with no root is
-    // coherent only below the floor, and one that never converges means the
-    // root was lost and replay is no longer authority.
-    enum RootObservation {
-        WithRoot(LoadedHeadObject, LoadedMetadataRootObject),
-        NoRoot(LoadedHeadObject, ChangeSeq),
-    }
-    impl RootObservation {
-        fn missing_root_floor(&self) -> Option<ChangeSeq> {
-            match self {
-                Self::WithRoot(..) => None,
-                Self::NoRoot(_, floor_seq) => Some(*floor_seq),
-            }
+    let mut reloads = 0;
+    loop {
+        let (head, root) = load_head_and_metadata_root_if_present(store, namespace_id).await?;
+        if let Some(root) = root {
+            return Ok(LoadedNamespaceBasis {
+                head,
+                basis: MetadataBasis::Manifest(root.state.manifest),
+            });
         }
-    }
-    let observed = load_coherent(
-        || async {
-            let (head, root) = load_head_and_metadata_root_if_present(store, namespace_id).await?;
-            match root {
-                Some(root) => Ok(RootObservation::WithRoot(head, root)),
-                None => {
-                    let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
-                    Ok(RootObservation::NoRoot(head, floor_seq))
-                }
-            }
-        },
-        |observed| match observed {
-            RootObservation::WithRoot(..) => true,
-            RootObservation::NoRoot(head, floor_seq) => {
-                *floor_seq <= namespace_birth_seq(&head.state)
-            }
-        },
-        |observed| ControlObjectLoadError::MissingRootAfterFloor {
-            namespace_id: namespace_id.clone(),
-            floor_seq: observed
-                .missing_root_floor()
-                .expect("only a rootless read can be incoherent"),
-        },
-    )
-    .await?;
-    Ok(match observed {
-        RootObservation::WithRoot(head, root) => LoadedNamespaceBasis {
-            head,
-            basis: MetadataBasis::Manifest(root.state.manifest),
-        },
-        RootObservation::NoRoot(head, _) => {
+
+        // At the birth sequence, genesis or the fork source is still a complete
+        // basis. A later floor proves a root was published, so retry before
+        // reporting it missing.
+        let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
+        if floor_seq <= namespace_birth_seq(&head.state) {
             let basis = metadata_basis_without_root(&head.state);
-            LoadedNamespaceBasis { head, basis }
+            return Ok(LoadedNamespaceBasis { head, basis });
         }
-    })
+        if reloads == CONTROL_READ_RELOADS {
+            return Err(ControlObjectLoadError::MissingRootAfterFloor {
+                namespace_id: namespace_id.clone(),
+                floor_seq,
+            });
+        }
+        reloads += 1;
+    }
 }
 
 /// Resolves the basis of a namespace whose `metadata/root.json` is absent:
@@ -197,17 +173,17 @@ pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> Result<(LoadedHeadObject, ChangeSeq), ControlObjectLoadError> {
-    load_coherent(
-        || async {
-            let head = load_head_object(store, namespace_id).await?;
-            let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
-            Ok((head, floor_seq))
-        },
-        |(head, floor_seq): &(LoadedHeadObject, ChangeSeq)| *floor_seq <= head.state.seq,
-        |(head, floor_seq)| ControlObjectLoadError::FloorAheadOfHead {
+    let head = load_head_object(store, namespace_id).await?;
+    let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
+    let head = reload_until_consistent(
+        head,
+        || load_head_object(store, namespace_id),
+        |head| floor_seq <= head.state.seq,
+        |head| ControlObjectLoadError::FloorAheadOfHead {
             floor_seq,
             head_seq: head.state.seq,
         },
     )
-    .await
+    .await?;
+    Ok((head, floor_seq))
 }

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -5,10 +5,10 @@
 //! the first flush. A fork basis must match the identity and checksum stored
 //! in the head.
 
-use crate::control_object::ControlObjectLoadError;
+use crate::control_object::{load_coherent, ControlObjectLoadError};
 use crate::namespace::control::{
     load_head_and_metadata_root_if_present, load_head_object, load_wal_floor_object,
-    LoadedHeadObject,
+    LoadedHeadObject, LoadedMetadataRootObject,
 };
 use loonfs_api::wire::control::{HeadState, ManifestRef};
 use loonfs_api::NamespaceId;
@@ -93,35 +93,58 @@ pub(crate) async fn load_head_and_metadata_basis<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> Result<LoadedNamespaceBasis, ControlObjectLoadError> {
-    const MISSING_ROOT_RELOADS: usize = 3;
-    let mut reloads = 0;
-    loop {
-        let (head, root) = load_head_and_metadata_root_if_present(store, namespace_id).await?;
-        if let Some(root) = root {
-            return Ok(LoadedNamespaceBasis {
-                head,
-                basis: MetadataBasis::Manifest(root.state.manifest),
-            });
-        }
-
-        // A missing floor means this namespace has never advanced retention,
-        // so genesis or the fork source is still a complete recovery basis.
-        // An advanced floor proves a root was published. Reload the pair once
-        // more in case these reads straddled that first publication; if the
-        // root remains absent, it was lost and replay is no longer authority.
-        let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
-        if floor_seq <= namespace_birth_seq(&head.state) {
-            let basis = metadata_basis_without_root(&head.state);
-            return Ok(LoadedNamespaceBasis { head, basis });
-        }
-        if reloads == MISSING_ROOT_RELOADS {
-            return Err(ControlObjectLoadError::MissingRootAfterFloor {
-                namespace_id: namespace_id.clone(),
-                floor_seq,
-            });
-        }
-        reloads += 1;
+    // A missing floor means this namespace has never advanced retention, so
+    // genesis or the fork source is still a complete recovery basis. An
+    // advanced floor proves a root was published: a read with no root is
+    // coherent only below the floor, and one that never converges means the
+    // root was lost and replay is no longer authority.
+    enum RootObservation {
+        WithRoot(LoadedHeadObject, LoadedMetadataRootObject),
+        NoRoot(LoadedHeadObject, ChangeSeq),
     }
+    impl RootObservation {
+        fn missing_root_floor(&self) -> Option<ChangeSeq> {
+            match self {
+                Self::WithRoot(..) => None,
+                Self::NoRoot(_, floor_seq) => Some(*floor_seq),
+            }
+        }
+    }
+    let observed = load_coherent(
+        || async {
+            let (head, root) = load_head_and_metadata_root_if_present(store, namespace_id).await?;
+            match root {
+                Some(root) => Ok(RootObservation::WithRoot(head, root)),
+                None => {
+                    let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
+                    Ok(RootObservation::NoRoot(head, floor_seq))
+                }
+            }
+        },
+        |observed| match observed {
+            RootObservation::WithRoot(..) => true,
+            RootObservation::NoRoot(head, floor_seq) => {
+                *floor_seq <= namespace_birth_seq(&head.state)
+            }
+        },
+        |observed| ControlObjectLoadError::MissingRootAfterFloor {
+            namespace_id: namespace_id.clone(),
+            floor_seq: observed
+                .missing_root_floor()
+                .expect("only a rootless read can be incoherent"),
+        },
+    )
+    .await?;
+    Ok(match observed {
+        RootObservation::WithRoot(head, root) => LoadedNamespaceBasis {
+            head,
+            basis: MetadataBasis::Manifest(root.state.manifest),
+        },
+        RootObservation::NoRoot(head, _) => {
+            let basis = metadata_basis_without_root(&head.state);
+            LoadedNamespaceBasis { head, basis }
+        }
+    })
 }
 
 /// Resolves the basis of a namespace whose `metadata/root.json` is absent:
@@ -174,20 +197,17 @@ pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> Result<(LoadedHeadObject, ChangeSeq), ControlObjectLoadError> {
-    const FLOOR_AHEAD_HEAD_RELOADS: usize = 3;
-    let mut head = load_head_object(store, namespace_id).await?;
-    let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
-    for _reload in 0..FLOOR_AHEAD_HEAD_RELOADS {
-        if floor_seq <= head.state.seq {
-            return Ok((head, floor_seq));
-        }
-        head = load_head_object(store, namespace_id).await?;
-    }
-    if floor_seq <= head.state.seq {
-        return Ok((head, floor_seq));
-    }
-    Err(ControlObjectLoadError::FloorAheadOfHead {
-        floor_seq,
-        head_seq: head.state.seq,
-    })
+    load_coherent(
+        || async {
+            let head = load_head_object(store, namespace_id).await?;
+            let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
+            Ok((head, floor_seq))
+        },
+        |(head, floor_seq): &(LoadedHeadObject, ChangeSeq)| *floor_seq <= head.state.seq,
+        |(head, floor_seq)| ControlObjectLoadError::FloorAheadOfHead {
+            floor_seq,
+            head_seq: head.state.seq,
+        },
+    )
+    .await
 }

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -2,8 +2,8 @@
 //! and WAL floor.
 
 use crate::control_object::{
-    expect_foreign_fork_basis, expect_namespace, expect_own_manifest, load_control_object,
-    ControlObjectLoadError, LoadedControl,
+    expect_foreign_fork_basis, expect_namespace, expect_own_manifest, load_coherent,
+    load_control_object, ControlObjectLoadError, LoadedControl,
 };
 use crate::namespace::basis::{load_head_and_metadata_basis, MetadataBasis};
 use loonfs_api::wire::control::{ControlObjectKind, HeadState, MetadataRootState, WalFloorState};
@@ -86,25 +86,28 @@ pub(crate) async fn load_head_and_metadata_root_if_present<S: ObjectStore + ?Siz
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<(LoadedHeadObject, Option<LoadedMetadataRootObject>), ControlObjectLoadError> {
-    const ROOT_AHEAD_HEAD_RELOADS: usize = 3;
-    let (head, root) = futures::join!(
-        load_head_object(store, expected_namespace_id),
-        load_metadata_root_object_if_present(store, expected_namespace_id)
-    );
-    let mut head = head?;
-    let Some(root) = root? else {
-        return Ok((head, None));
-    };
-    for _reload in 0..=ROOT_AHEAD_HEAD_RELOADS {
-        if root.state.manifest.manifest_head_seq <= head.state.seq {
-            return Ok((head, Some(root)));
-        }
-        head = load_head_object(store, expected_namespace_id).await?;
-    }
-    Err(ControlObjectLoadError::RootAheadOfHead {
-        root_manifest_head_seq: root.state.manifest.manifest_head_seq,
-        head_seq: head.state.seq,
-    })
+    load_coherent(
+        || async {
+            let (head, root) = futures::join!(
+                load_head_object(store, expected_namespace_id),
+                load_metadata_root_object_if_present(store, expected_namespace_id)
+            );
+            Ok((head?, root?))
+        },
+        |(head, root): &(LoadedHeadObject, Option<LoadedMetadataRootObject>)| {
+            root.as_ref()
+                .is_none_or(|root| root.state.manifest.manifest_head_seq <= head.state.seq)
+        },
+        |(head, root)| ControlObjectLoadError::RootAheadOfHead {
+            root_manifest_head_seq: root
+                .expect("an incoherent read carries a root")
+                .state
+                .manifest
+                .manifest_head_seq,
+            head_seq: head.state.seq,
+        },
+    )
+    .await
 }
 
 pub(crate) async fn load_head_object<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -2,8 +2,8 @@
 //! and WAL floor.
 
 use crate::control_object::{
-    expect_foreign_fork_basis, expect_namespace, expect_own_manifest, load_coherent,
-    load_control_object, ControlObjectLoadError, LoadedControl,
+    expect_foreign_fork_basis, expect_namespace, expect_own_manifest, load_control_object,
+    reload_until_consistent, ControlObjectLoadError, LoadedControl,
 };
 use crate::namespace::basis::{load_head_and_metadata_basis, MetadataBasis};
 use loonfs_api::wire::control::{ControlObjectKind, HeadState, MetadataRootState, WalFloorState};
@@ -86,28 +86,26 @@ pub(crate) async fn load_head_and_metadata_root_if_present<S: ObjectStore + ?Siz
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<(LoadedHeadObject, Option<LoadedMetadataRootObject>), ControlObjectLoadError> {
-    load_coherent(
-        || async {
-            let (head, root) = futures::join!(
-                load_head_object(store, expected_namespace_id),
-                load_metadata_root_object_if_present(store, expected_namespace_id)
-            );
-            Ok((head?, root?))
-        },
-        |(head, root): &(LoadedHeadObject, Option<LoadedMetadataRootObject>)| {
-            root.as_ref()
-                .is_none_or(|root| root.state.manifest.manifest_head_seq <= head.state.seq)
-        },
-        |(head, root)| ControlObjectLoadError::RootAheadOfHead {
-            root_manifest_head_seq: root
-                .expect("an incoherent read carries a root")
-                .state
-                .manifest
-                .manifest_head_seq,
+    let (head, root) = futures::join!(
+        load_head_object(store, expected_namespace_id),
+        load_metadata_root_object_if_present(store, expected_namespace_id)
+    );
+    let head = head?;
+    let Some(root) = root? else {
+        return Ok((head, None));
+    };
+    let root_seq = root.state.manifest.manifest_head_seq;
+    let head = reload_until_consistent(
+        head,
+        || load_head_object(store, expected_namespace_id),
+        |head| root_seq <= head.state.seq,
+        |head| ControlObjectLoadError::RootAheadOfHead {
+            root_manifest_head_seq: root_seq,
             head_seq: head.state.seq,
         },
     )
-    .await
+    .await?;
+    Ok((head, Some(root)))
 }
 
 pub(crate) async fn load_head_object<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -1,6 +1,7 @@
 //! Reads namespace state and storage diagnostics.
 
 use crate::checkpoint::load_namespace_manifest_envelope;
+use crate::control_object::load_coherent;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::basis::{
@@ -82,23 +83,19 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedHeadBasis> {
-    const FLOOR_AHEAD_HEAD_RELOADS: usize = 3;
-    let mut loaded = load_namespace_head_basis_once(store, expected_namespace_id).await?;
-    for _reload in 0..FLOOR_AHEAD_HEAD_RELOADS {
-        if loaded.retention_floor_seq <= loaded.head.seq {
-            return Ok(loaded);
-        }
-        loaded = load_namespace_head_basis_once(store, expected_namespace_id).await?;
-    }
-    if loaded.retention_floor_seq <= loaded.head.seq {
-        return Ok(loaded);
-    }
-    Err(CoreError::ControlObjectLoad(
-        crate::control_object::ControlObjectLoadError::FloorAheadOfHead {
-            floor_seq: loaded.retention_floor_seq,
-            head_seq: loaded.head.seq,
+    load_coherent(
+        || load_namespace_head_basis_once(store, expected_namespace_id),
+        |loaded: &LoadedHeadBasis| loaded.retention_floor_seq <= loaded.head.seq,
+        |loaded| {
+            CoreError::ControlObjectLoad(
+                crate::control_object::ControlObjectLoadError::FloorAheadOfHead {
+                    floor_seq: loaded.retention_floor_seq,
+                    head_seq: loaded.head.seq,
+                },
+            )
         },
-    ))
+    )
+    .await
 }
 
 /// Loads the current state of a live namespace.

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -1,7 +1,7 @@
 //! Reads namespace state and storage diagnostics.
 
 use crate::checkpoint::load_namespace_manifest_envelope;
-use crate::control_object::load_coherent;
+use crate::control_object::{reload_until_consistent, ControlObjectLoadError};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::basis::{
@@ -83,16 +83,16 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedHeadBasis> {
-    load_coherent(
+    let loaded = load_namespace_head_basis_once(store, expected_namespace_id).await?;
+    reload_until_consistent(
+        loaded,
         || load_namespace_head_basis_once(store, expected_namespace_id),
         |loaded: &LoadedHeadBasis| loaded.retention_floor_seq <= loaded.head.seq,
         |loaded| {
-            CoreError::ControlObjectLoad(
-                crate::control_object::ControlObjectLoadError::FloorAheadOfHead {
-                    floor_seq: loaded.retention_floor_seq,
-                    head_seq: loaded.head.seq,
-                },
-            )
+            CoreError::ControlObjectLoad(ControlObjectLoadError::FloorAheadOfHead {
+                floor_seq: loaded.retention_floor_seq,
+                head_seq: loaded.head.seq,
+            })
         },
     )
     .await


### PR DESCRIPTION
Uses one retry helper and one limit for metadata reads that can briefly observe related control objects at different points in time. Each caller still decides what to reload, what counts as a consistent result, and which error to return when the retry limit is reached.

The metadata-root and retention-floor paths keep the newer value fixed and reload only the stale head. The missing-root path keeps its direct loop because it also chooses between a published root, the namespace's initial basis, and an error.

This is an internal refactor. It does not change the storage format or accepted read results.