### PR TITLE
refactor(core): store each batch result in one outcome slot

### DIFF
--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -66,6 +66,34 @@ impl PublishBatchAgainstViewResult {
     }
 }
 
+/// One candidate's slot in the batch outcome table. The variant records what
+/// the outcome rests on, so a publication failure needs no positional
+/// reasoning about which slots it may replace.
+#[derive(Debug, Clone)]
+pub(super) enum BatchOutcomeSlot {
+    /// Admission has not decided this candidate yet.
+    Pending,
+    /// Accepted into tentative session state, awaiting WAL and head
+    /// publication.
+    Accepted,
+    /// Decided against durable state or the request itself.
+    SettledIndependent(Result<ApiCommitResponse>),
+    /// Decided against tentative mutations accepted earlier in this batch.
+    SettledContingent(Result<ApiCommitResponse>),
+    /// Takes the final result of the earlier candidate it names.
+    AliasOf(usize),
+}
+
+impl BatchOutcomeSlot {
+    /// The decided result, absent while the slot still awaits one.
+    fn settled(&self) -> Option<&Result<ApiCommitResponse>> {
+        match self {
+            Self::SettledIndependent(outcome) | Self::SettledContingent(outcome) => Some(outcome),
+            Self::Pending | Self::Accepted | Self::AliasOf(_) => None,
+        }
+    }
+}
+
 pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     S: ObjectStore + ?Sized,
 >(
@@ -88,10 +116,8 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             candidates.len()
         ]);
     }
-    let mut outcomes: Vec<Option<Result<ApiCommitResponse>>> = vec![None; candidates.len()];
-    let mut independent_outcomes = vec![false; candidates.len()];
+    let mut slots = vec![BatchOutcomeSlot::Pending; candidates.len()];
     let mut session = PublishPlanningSession::new(&view.head);
-    let mut accepted_indexes = Vec::new();
     let mut accepted_commits = Vec::new();
     let mut dedup = BatchDedup::default();
 
@@ -119,16 +145,8 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             .await;
             let candidate_request = match admission {
                 CandidateAdmission::Prepared(candidate_request) => candidate_request,
-                CandidateAdmission::AliasOf(primary_index) => {
-                    dedup.record_alias(index, primary_index);
-                    continue;
-                }
-                CandidateAdmission::Settled {
-                    outcome,
-                    independent,
-                } => {
-                    independent_outcomes[index] = independent;
-                    outcomes[index] = Some(outcome);
+                CandidateAdmission::Settled(slot) => {
+                    slots[index] = settled_admission(slot, accepted_commits.is_empty());
                     continue;
                 }
             };
@@ -140,14 +158,16 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 validate_commit_content_references(candidate, view.content_store_id())
             {
                 session.discard_candidate(allocation);
-                independent_outcomes[index] = true;
-                outcomes[index] = Some(Err(error));
+                slots[index] = BatchOutcomeSlot::SettledIndependent(Err(error));
                 continue;
             }
             let resulting_next_inode_id = match session.commit_candidate(allocation) {
                 Ok(resulting_next_inode_id) => resulting_next_inode_id,
                 Err(error) => {
-                    outcomes[index] = Some(Err(error));
+                    slots[index] = settled_admission(
+                        BatchOutcomeSlot::SettledContingent(Err(error)),
+                        accepted_commits.is_empty(),
+                    );
                     continue;
                 }
             };
@@ -172,7 +192,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                         .entered();
                 session.apply_accepted_commit(&preview, &materialized.commit);
             }
-            accepted_indexes.push(index);
+            slots[index] = BatchOutcomeSlot::Accepted;
             accepted_commits.push(materialized);
         }
     }
@@ -185,7 +205,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     drop(prepare_span);
 
     if accepted_commits.is_empty() {
-        return PublishBatchAgainstViewResult::unchanged(dedup.finish(outcomes));
+        return PublishBatchAgainstViewResult::unchanged(finish_batch_outcomes(&slots));
     }
     let accepted_count = u64::try_from(accepted_commits.len()).unwrap_or(u64::MAX);
     let put_started_ms = timer.monotonic_now_ms();
@@ -200,15 +220,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     .await
     {
         Ok(wal) => wal,
-        Err(error) => {
-            return abort_batch(
-                outcomes,
-                &independent_outcomes,
-                &dedup,
-                &accepted_indexes,
-                &error,
-            )
-        }
+        Err(error) => return abort_batch(slots, &error),
     };
 
     let last_plan = &accepted_commits
@@ -219,13 +231,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         Ok(value) => value,
         Err(error) => {
             let error = CoreError::Internal(format!("head publish preparation failed: {error}"));
-            return abort_batch(
-                outcomes,
-                &independent_outcomes,
-                &dedup,
-                &accepted_indexes,
-                &error,
-            );
+            return abort_batch(slots, &error);
         }
     };
     let elapsed_ms = timer.monotonic_now_ms().saturating_sub(put_started_ms);
@@ -234,13 +240,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             elapsed_ms,
             budget_ms: WAL_PUBLISH_BUDGET_MS,
         });
-        return abort_batch(
-            outcomes,
-            &independent_outcomes,
-            &dedup,
-            &accepted_indexes,
-            &error,
-        );
+        return abort_batch(slots, &error);
     }
     let head_etag = match cas_batch_head(
         store,
@@ -252,26 +252,21 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     .await
     {
         Ok(metadata) => metadata.etag,
-        Err(error) => {
-            return abort_batch(
-                outcomes,
-                &independent_outcomes,
-                &dedup,
-                &accepted_indexes,
-                &error,
-            )
-        }
+        Err(error) => return abort_batch(slots, &error),
     };
 
     let wal_records = wal.envelope.payload.records.clone();
-    for (outcome_index, record) in accepted_indexes.into_iter().zip(&wal_records) {
-        outcomes[outcome_index] =
-            Some(committed_change_from_wal_record(record).map(|change| {
-                ApiCommitResponse::from_committed_change(namespace_id.clone(), change)
-            }));
+    let accepted_slots = slots
+        .iter_mut()
+        .filter(|slot| matches!(slot, BatchOutcomeSlot::Accepted));
+    for (slot, record) in accepted_slots.zip(&wal_records) {
+        *slot =
+            BatchOutcomeSlot::SettledIndependent(committed_change_from_wal_record(record).map(
+                |change| ApiCommitResponse::from_committed_change(namespace_id.clone(), change),
+            ));
     }
     PublishBatchAgainstViewResult {
-        results: dedup.finish(outcomes),
+        results: finish_batch_outcomes(&slots),
         effect: PublishViewEffect::Advanced {
             records: wal_records,
             head: head_publish.resulting_head,
@@ -282,20 +277,12 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
 
 /// Applies the publication error and invalidates the loaded projection.
 fn abort_batch(
-    mut outcomes: Vec<Option<Result<ApiCommitResponse>>>,
-    independent_outcomes: &[bool],
-    dedup: &BatchDedup,
-    accepted_indexes: &[usize],
+    mut slots: Vec<BatchOutcomeSlot>,
     error: &CoreError,
 ) -> PublishBatchAgainstViewResult {
-    fail_outcomes_contingent_on_unpublished_batch(
-        &mut outcomes,
-        independent_outcomes,
-        accepted_indexes,
-        error,
-    );
+    fail_slots_contingent_on_unpublished_batch(&mut slots, error);
     PublishBatchAgainstViewResult {
-        results: dedup.finish(outcomes),
+        results: finish_batch_outcomes(&slots),
         effect: PublishViewEffect::Invalidated,
     }
 }
@@ -388,29 +375,47 @@ async fn cas_batch_head<S: ObjectStore + ?Sized>(
     result.map_err(CoreError::from)
 }
 
-/// Replaces outcomes that depended on tentative batch state with the
-/// publication error. Independent outcomes remain unchanged.
-fn fail_outcomes_contingent_on_unpublished_batch(
-    outcomes: &mut [Option<Result<ApiCommitResponse>>],
-    independent_outcomes: &[bool],
-    accepted_indexes: &[usize],
-    error: &CoreError,
-) {
-    let Some(first_accepted_index) = accepted_indexes.first().copied() else {
-        return;
-    };
-    for &index in accepted_indexes {
-        outcomes[index] = Some(Err(error.clone()));
+/// Classifies an outcome decided during admission. Until the batch accepts a
+/// candidate the planning session shows only durable state, so a rejection
+/// decided there was decided against that view alone.
+fn settled_admission(slot: BatchOutcomeSlot, accepted_nothing_yet: bool) -> BatchOutcomeSlot {
+    match slot {
+        BatchOutcomeSlot::SettledContingent(outcome) if accepted_nothing_yet => {
+            BatchOutcomeSlot::SettledIndependent(outcome)
+        }
+        slot => slot,
     }
-    for (index, outcome) in outcomes
-        .iter_mut()
-        .enumerate()
-        .skip(first_accepted_index + 1)
-    {
-        if !independent_outcomes[index] && matches!(outcome, Some(Err(_))) {
-            *outcome = Some(Err(error.clone()));
+}
+
+/// Gives the publication error to every outcome that rests on the unpublished
+/// batch. Outcomes decided against durable state stand.
+fn fail_slots_contingent_on_unpublished_batch(slots: &mut [BatchOutcomeSlot], error: &CoreError) {
+    for slot in slots {
+        if matches!(
+            slot,
+            BatchOutcomeSlot::Accepted | BatchOutcomeSlot::SettledContingent(_)
+        ) {
+            *slot = BatchOutcomeSlot::SettledIndependent(Err(error.clone()));
         }
     }
+}
+
+/// Resolves aliases to the result of the slot they name. A slot that never
+/// settled is an internal invariant failure, not a fabricated response.
+fn finish_batch_outcomes(slots: &[BatchOutcomeSlot]) -> Vec<Result<ApiCommitResponse>> {
+    slots
+        .iter()
+        .map(|slot| {
+            match slot {
+                BatchOutcomeSlot::AliasOf(primary_index) => slots
+                    .get(*primary_index)
+                    .and_then(BatchOutcomeSlot::settled),
+                slot => slot.settled(),
+            }
+            .cloned()
+            .unwrap_or_else(|| Err(CoreError::Internal("unsettled batch outcome".to_owned())))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -426,6 +431,17 @@ mod tests {
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::ObjectStore;
     use tempfile::tempdir;
+
+    #[test]
+    fn unsettled_slots_finish_as_an_internal_failure() {
+        let results =
+            finish_batch_outcomes(&[BatchOutcomeSlot::Pending, BatchOutcomeSlot::AliasOf(0)]);
+        for result in results {
+            let error = result.expect_err("an unsettled slot must not fabricate a response");
+            assert_eq!(error.code(), loonfs_api::ErrorCode::ServerError);
+            assert!(error.to_string().contains("unsettled batch outcome"));
+        }
+    }
 
     #[tokio::test]
     async fn sequence_exhaustion_writes_neither_wal_nor_head() {

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -66,26 +66,17 @@ impl PublishBatchAgainstViewResult {
     }
 }
 
-/// One candidate's slot in the batch outcome table. The variant records what
-/// the outcome rests on, so a publication failure needs no positional
-/// reasoning about which slots it may replace.
+/// Tracks one candidate's result and whether publication can change it.
 #[derive(Debug, Clone)]
 pub(super) enum BatchOutcomeSlot {
-    /// Admission has not decided this candidate yet.
     Pending,
-    /// Accepted into tentative session state, awaiting WAL and head
-    /// publication.
     Accepted,
-    /// Decided against durable state or the request itself.
     SettledIndependent(Result<ApiCommitResponse>),
-    /// Decided against tentative mutations accepted earlier in this batch.
     SettledContingent(Result<ApiCommitResponse>),
-    /// Takes the final result of the earlier candidate it names.
     AliasOf(usize),
 }
 
 impl BatchOutcomeSlot {
-    /// The decided result, absent while the slot still awaits one.
     fn settled(&self) -> Option<&Result<ApiCommitResponse>> {
         match self {
             Self::SettledIndependent(outcome) | Self::SettledContingent(outcome) => Some(outcome),
@@ -146,7 +137,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             let candidate_request = match admission {
                 CandidateAdmission::Prepared(candidate_request) => candidate_request,
                 CandidateAdmission::Settled(slot) => {
-                    slots[index] = settled_admission(slot, accepted_commits.is_empty());
+                    slots[index] = settle_admission(slot, !accepted_commits.is_empty());
                     continue;
                 }
             };
@@ -164,9 +155,9 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             let resulting_next_inode_id = match session.commit_candidate(allocation) {
                 Ok(resulting_next_inode_id) => resulting_next_inode_id,
                 Err(error) => {
-                    slots[index] = settled_admission(
+                    slots[index] = settle_admission(
                         BatchOutcomeSlot::SettledContingent(Err(error)),
-                        accepted_commits.is_empty(),
+                        !accepted_commits.is_empty(),
                     );
                     continue;
                 }
@@ -280,7 +271,7 @@ fn abort_batch(
     mut slots: Vec<BatchOutcomeSlot>,
     error: &CoreError,
 ) -> PublishBatchAgainstViewResult {
-    fail_slots_contingent_on_unpublished_batch(&mut slots, error);
+    fail_unpublished_slots(&mut slots, error);
     PublishBatchAgainstViewResult {
         results: finish_batch_outcomes(&slots),
         effect: PublishViewEffect::Invalidated,
@@ -375,21 +366,18 @@ async fn cas_batch_head<S: ObjectStore + ?Sized>(
     result.map_err(CoreError::from)
 }
 
-/// Classifies an outcome decided during admission. Until the batch accepts a
-/// candidate the planning session shows only durable state, so a rejection
-/// decided there was decided against that view alone.
-fn settled_admission(slot: BatchOutcomeSlot, accepted_nothing_yet: bool) -> BatchOutcomeSlot {
+/// Before the first accepted commit, admission uses durable state only.
+fn settle_admission(slot: BatchOutcomeSlot, has_accepted_commits: bool) -> BatchOutcomeSlot {
     match slot {
-        BatchOutcomeSlot::SettledContingent(outcome) if accepted_nothing_yet => {
+        BatchOutcomeSlot::SettledContingent(outcome) if !has_accepted_commits => {
             BatchOutcomeSlot::SettledIndependent(outcome)
         }
         slot => slot,
     }
 }
 
-/// Gives the publication error to every outcome that rests on the unpublished
-/// batch. Outcomes decided against durable state stand.
-fn fail_slots_contingent_on_unpublished_batch(slots: &mut [BatchOutcomeSlot], error: &CoreError) {
+/// Replaces results that depend on unpublished changes with the publication error.
+fn fail_unpublished_slots(slots: &mut [BatchOutcomeSlot], error: &CoreError) {
     for slot in slots {
         if matches!(
             slot,
@@ -400,8 +388,7 @@ fn fail_slots_contingent_on_unpublished_batch(slots: &mut [BatchOutcomeSlot], er
     }
 }
 
-/// Resolves aliases to the result of the slot they name. A slot that never
-/// settled is an internal invariant failure, not a fabricated response.
+/// Resolves aliases and rejects any slot that did not settle.
 fn finish_batch_outcomes(slots: &[BatchOutcomeSlot]) -> Vec<Result<ApiCommitResponse>> {
     slots
         .iter()
@@ -431,17 +418,6 @@ mod tests {
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::ObjectStore;
     use tempfile::tempdir;
-
-    #[test]
-    fn unsettled_slots_finish_as_an_internal_failure() {
-        let results =
-            finish_batch_outcomes(&[BatchOutcomeSlot::Pending, BatchOutcomeSlot::AliasOf(0)]);
-        for result in results {
-            let error = result.expect_err("an unsettled slot must not fabricate a response");
-            assert_eq!(error.code(), loonfs_api::ErrorCode::ServerError);
-            assert!(error.to_string().contains("unsettled batch outcome"));
-        }
-    }
 
     #[tokio::test]
     async fn sequence_exhaustion_writes_neither_wal_nor_head() {

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -24,12 +24,11 @@ pub(super) struct PreparedCandidateCommit {
 pub(super) enum CandidateAdmission {
     /// A new request ready for content validation and materialization.
     Prepared(PreparedCandidateCommit),
-    /// A candidate whose slot admission already decided.
+    /// A result decided during admission.
     Settled(BatchOutcomeSlot),
 }
 
 impl CandidateAdmission {
-    /// Decided against durable state or the request itself.
     fn independent(outcome: Result<ApiCommitResponse>) -> Self {
         Self::Settled(BatchOutcomeSlot::SettledIndependent(outcome))
     }

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -2,6 +2,7 @@
 //! preparation, commit-id validation, and duplicate resolution against
 //! durable receipts and same-batch primaries.
 
+use super::batch::BatchOutcomeSlot;
 use super::publish_view::PublishMetadataView;
 use crate::commit::{CandidateAllocation, CommitFingerprint, ValidatedCommitPlan};
 use crate::commit_engine::{CommitCandidate, ContentPreparation, ContentPreparationError};
@@ -23,29 +24,14 @@ pub(super) struct PreparedCandidateCommit {
 pub(super) enum CandidateAdmission {
     /// A new request ready for content validation and materialization.
     Prepared(PreparedCandidateCommit),
-    /// A duplicate that receives the earlier request's outcome.
-    AliasOf(usize),
-    /// An outcome decided during admission. Independent outcomes do not rely
-    /// on tentative changes from earlier requests in the batch.
-    Settled {
-        outcome: Result<ApiCommitResponse>,
-        independent: bool,
-    },
+    /// A candidate whose slot admission already decided.
+    Settled(BatchOutcomeSlot),
 }
 
 impl CandidateAdmission {
+    /// Decided against durable state or the request itself.
     fn independent(outcome: Result<ApiCommitResponse>) -> Self {
-        Self::Settled {
-            outcome,
-            independent: true,
-        }
-    }
-
-    pub(super) fn contingent(outcome: Result<ApiCommitResponse>) -> Self {
-        Self::Settled {
-            outcome,
-            independent: false,
-        }
+        Self::Settled(BatchOutcomeSlot::SettledIndependent(outcome))
     }
 }
 
@@ -55,11 +41,10 @@ struct InBatchRequest {
     semantic_identity: CommitFingerprint,
 }
 
-/// Tracks the first request for each commit ID and any aliases.
+/// Tracks the first request for each commit ID in the batch.
 #[derive(Default)]
 pub(super) struct BatchDedup {
     in_batch_requests: HashMap<CommitId, InBatchRequest>,
-    aliases: Vec<(usize, usize)>,
 }
 
 impl BatchDedup {
@@ -90,36 +75,9 @@ impl BatchDedup {
                 },
             )));
         }
-        Some(CandidateAdmission::AliasOf(existing.primary_index))
-    }
-
-    pub(super) fn record_alias(&mut self, alias_index: usize, primary_index: usize) {
-        self.aliases.push((alias_index, primary_index));
-    }
-
-    /// Resolves alias slots to their primary's outcome and unwraps the rest.
-    pub(super) fn finish(
-        &self,
-        mut outcomes: Vec<Option<Result<ApiCommitResponse>>>,
-    ) -> Vec<Result<ApiCommitResponse>> {
-        for (alias_index, primary_index) in &self.aliases {
-            let primary_outcome = outcomes
-                .get(*primary_index)
-                .and_then(Clone::clone)
-                .unwrap_or_else(|| {
-                    Err(CoreError::Internal(
-                        "missing primary batch outcome".to_owned(),
-                    ))
-                });
-            outcomes[*alias_index] = Some(primary_outcome);
-        }
-        outcomes
-            .into_iter()
-            .map(|outcome| {
-                outcome
-                    .unwrap_or_else(|| Err(CoreError::Internal("missing batch outcome".to_owned())))
-            })
-            .collect()
+        Some(CandidateAdmission::Settled(BatchOutcomeSlot::AliasOf(
+            existing.primary_index,
+        )))
     }
 }
 
@@ -172,7 +130,7 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         }),
         Err(error) => {
             session.discard_candidate(allocation);
-            CandidateAdmission::contingent(Err(error))
+            CandidateAdmission::Settled(BatchOutcomeSlot::SettledContingent(Err(error)))
         }
     }
 }

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -766,6 +766,20 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                     expected_inode_id: None,
                 },
             )),
+            prepared_candidate(
+                &store,
+                &namespace_id,
+                commit_request(
+                    "accept-a",
+                    FilesystemOperation::PutFile {
+                        path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                        content_ref: content.content_ref().clone(),
+                        behavior: DestinationBehavior::NoReplace,
+                        expected_revision_no: None,
+                    },
+                ),
+            )
+            .await,
         ]
     };
 
@@ -786,6 +800,10 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
     );
     let alias = failed[3].as_ref().expect_err("alias mirrors its primary");
     assert_eq!(alias.code(), ErrorCode::PathNotFound);
+    let accepted_alias = failed[4]
+        .as_ref()
+        .expect_err("alias of an accepted candidate fails with it");
+    assert!(matches!(accepted_alias, CoreError::WalWrite { .. }));
 
     let head = load_namespace_head_control(&store, &namespace_id)
         .await
@@ -810,6 +828,10 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
     assert_eq!(
         retried[3].as_ref().expect_err("still missing").code(),
         ErrorCode::PathNotFound
+    );
+    assert_eq!(
+        retried[4].as_ref().expect("alias lands with its primary"),
+        committed
     );
 }
 


### PR DESCRIPTION
Stores each candidate's result in one BatchOutcomeSlot instead of maintaining separate collections for results, dependencies, accepted candidates, and aliases. Each slot records whether its result depends on unpublished changes from earlier candidates in the batch.

If WAL or head publication fails, accepted candidates and dependent rejections receive the publication error. Results based only on durable state stay unchanged, and duplicate requests receive the same final result as the original candidate.