### PR TITLE
fix(core): renew fork checkpoints before creating targets

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -238,10 +238,10 @@ pub enum CheckpointOwner {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         expires_at_ms: Option<u64>,
     },
-    /// A fork target keeping its source basis alive. Released once the
-    /// target namespace is terminally deleted, or once the attempt's lease
-    /// expires with no target head to show for it. A live target keeps the
-    /// record whatever the lease says.
+    /// A fork target keeping its source basis alive. Released once no target
+    /// head reads through this record any more, or once the attempt's lease
+    /// expires with no target head to show for it. A target head whose
+    /// `fork_basis` names this record keeps it whatever the lease says.
     Fork {
         /// Fork namespace whose continued existence keeps the source basis pinned.
         target_namespace_id: NamespaceId,
@@ -1327,6 +1327,23 @@ mod tests {
         assert_eq!(
             head.ensure_successor_identity(&forked)
                 .expect_err("gaining a fork basis is rejected")
+                .field,
+            "fork_basis"
+        );
+
+        // Retention matches a fork basis against the source checkpoint record
+        // it names, so an ordinary commit cannot re-point one either.
+        let mut rebased = forked.clone();
+        rebased.fork_basis = forked.fork_basis.clone().map(|mut basis| {
+            basis.source_checkpoint_id =
+                CheckpointId::parse("chk_00000000000000000000000000000003")
+                    .expect("valid checkpoint id");
+            basis
+        });
+        assert_eq!(
+            forked
+                .ensure_successor_identity(&rebased)
+                .expect_err("re-pointing a fork basis is rejected")
                 .field,
             "fork_basis"
         );

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -238,10 +238,9 @@ pub enum CheckpointOwner {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         expires_at_ms: Option<u64>,
     },
-    /// A fork target keeping its source basis alive. Released once no target
-    /// head reads through this record any more, or once the attempt's lease
-    /// expires with no target head to show for it. A target head whose
-    /// `fork_basis` names this record keeps it whatever the lease says.
+    /// Keeps a source basis alive for a fork target. GC releases it once the
+    /// target no longer references it, or when its lease expires before the
+    /// target is created.
     Fork {
         /// Fork namespace whose continued existence keeps the source basis pinned.
         target_namespace_id: NamespaceId,
@@ -1327,23 +1326,6 @@ mod tests {
         assert_eq!(
             head.ensure_successor_identity(&forked)
                 .expect_err("gaining a fork basis is rejected")
-                .field,
-            "fork_basis"
-        );
-
-        // Retention matches a fork basis against the source checkpoint record
-        // it names, so an ordinary commit cannot re-point one either.
-        let mut rebased = forked.clone();
-        rebased.fork_basis = forked.fork_basis.clone().map(|mut basis| {
-            basis.source_checkpoint_id =
-                CheckpointId::parse("chk_00000000000000000000000000000003")
-                    .expect("valid checkpoint id");
-            basis
-        });
-        assert_eq!(
-            forked
-                .ensure_successor_identity(&rebased)
-                .expect_err("re-pointing a fork basis is rejected")
                 .field,
             "fork_basis"
         );

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -198,24 +198,17 @@ pub(crate) async fn release_checkpoint_record<S: ObjectStore + ?Sized>(
     released.ok_or_else(|| CoreError::contention_exhausted(object_key))
 }
 
-/// Renews a fork-owned lease under the record's etag, immediately before the
-/// forker installs its target head.
+/// Renews a fork checkpoint immediately before installing its target.
 ///
-/// The compare-and-swap is the handoff with garbage collection: a release
-/// that lands first makes this reload a terminal record and fail before any
-/// target exists, and a renewal always rewrites the record to a strictly
-/// later expiry, so a collector's stale release fails against bytes that no
-/// longer match what it read. Renewing a whole lease
-/// beats proving that a narrow margin covers one more write; a crash after
-/// renewal only keeps an orphaned pin a while longer. `docs/specs/format.md`
-/// section 3.9.2 names the one window this does not fence.
+/// This compare-and-swap races with GC release. The new expiry must differ
+/// from the stored value so a stale release cannot use the old ETag.
 pub(crate) async fn renew_fork_checkpoint_for_install<S: ObjectStore + ?Sized>(
     store: &S,
     source_namespace_id: &NamespaceId,
     checkpoint_id: &CheckpointId,
     expected_target_namespace_id: &NamespaceId,
     now_ms: u64,
-) -> Result<()> {
+) -> Result<u64> {
     let object_key = &checkpoint_record(source_namespace_id, checkpoint_id);
     let unavailable = &|reason: String| {
         CoreError::CheckpointUnavailable(format!(
@@ -245,21 +238,19 @@ pub(crate) async fn renew_fork_checkpoint_for_install<S: ObjectStore + ?Sized>(
                 "the record pins target `{target_namespace_id}`"
             )));
         }
-        // Strictly later than the stored expiry, so the rewrite always
-        // changes the record and a stale release CAS cannot land on a
-        // content-derived etag.
-        *expires_at_ms = expires_at_ms
-            .saturating_add(1)
-            .max(now_ms.saturating_add(FORK_CHECKPOINT_LEASE_MS));
+        let later_expiry = expires_at_ms
+            .checked_add(1)
+            .ok_or_else(|| unavailable("the lease expiry cannot be extended".to_owned()))?;
+        *expires_at_ms = later_expiry.max(now_ms.saturating_add(FORK_CHECKPOINT_LEASE_MS));
+        let renewed_expiry = *expires_at_ms;
         let encoded = encode_checkpoint_record(&next)?;
         match store
             .compare_and_swap(object_key, &loaded.etag, encoded)
             .await
         {
-            Ok(_) => Ok(CasAttempt::Settled(())),
+            Ok(_) => Ok(CasAttempt::Settled(renewed_expiry)),
             Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            // An unknown outcome fails here rather than installing a target
-            // this attempt cannot prove is pinned.
+            // Do not install a target unless the renewal is confirmed.
             Err(error) => Err(CoreError::store(object_key, &error)),
         }
     })

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -15,11 +15,13 @@ use crate::control_update::{
     create_control_object_under_generated_id, retry_while_contended, CasAttempt,
 };
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
+use crate::limits::FORK_CHECKPOINT_LEASE_MS;
 use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::load_head_object;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
-    encode_control_state, CheckpointRecordState, CheckpointStatus, ControlObjectKind,
+    encode_control_state, CheckpointOwner, CheckpointRecordState, CheckpointStatus,
+    ControlObjectKind,
 };
 use loonfs_api::{CheckpointId, NamespaceId};
 use loonfs_objectstore::keys::checkpoint_record;
@@ -194,6 +196,75 @@ pub(crate) async fn release_checkpoint_record<S: ObjectStore + ?Sized>(
     })
     .await?;
     released.ok_or_else(|| CoreError::contention_exhausted(object_key))
+}
+
+/// Renews a fork-owned lease under the record's etag, immediately before the
+/// forker installs its target head.
+///
+/// The compare-and-swap is the handoff with garbage collection: a release
+/// that lands first makes this reload a terminal record and fail before any
+/// target exists, and a renewal always rewrites the record to a strictly
+/// later expiry, so a collector's stale release fails against bytes that no
+/// longer match what it read. Renewing a whole lease
+/// beats proving that a narrow margin covers one more write; a crash after
+/// renewal only keeps an orphaned pin a while longer. `docs/specs/format.md`
+/// section 3.9.2 names the one window this does not fence.
+pub(crate) async fn renew_fork_checkpoint_for_install<S: ObjectStore + ?Sized>(
+    store: &S,
+    source_namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+    expected_target_namespace_id: &NamespaceId,
+    now_ms: u64,
+) -> Result<()> {
+    let object_key = &checkpoint_record(source_namespace_id, checkpoint_id);
+    let unavailable = &|reason: String| {
+        CoreError::CheckpointUnavailable(format!(
+            "fork of `{source_namespace_id}` into `{expected_target_namespace_id}` cannot renew \
+             its source checkpoint `{checkpoint_id}`: {reason}"
+        ))
+    };
+    let renewed = retry_while_contended(|| async move {
+        let Some(loaded) =
+            load_checkpoint_record(store, source_namespace_id, checkpoint_id).await?
+        else {
+            return Err(unavailable("the record is gone".to_owned()));
+        };
+        let mut next = loaded.state;
+        if next.status != (CheckpointStatus::Active {}) {
+            return Err(unavailable(format!("the record is `{}`", next.status)));
+        }
+        let CheckpointOwner::Fork {
+            target_namespace_id,
+            expires_at_ms,
+        } = &mut next.owner
+        else {
+            return Err(unavailable("the record is not fork-owned".to_owned()));
+        };
+        if target_namespace_id != expected_target_namespace_id {
+            return Err(unavailable(format!(
+                "the record pins target `{target_namespace_id}`"
+            )));
+        }
+        // Strictly later than the stored expiry, so the rewrite always
+        // changes the record and a stale release CAS cannot land on a
+        // content-derived etag.
+        *expires_at_ms = expires_at_ms
+            .saturating_add(1)
+            .max(now_ms.saturating_add(FORK_CHECKPOINT_LEASE_MS));
+        let encoded = encode_checkpoint_record(&next)?;
+        match store
+            .compare_and_swap(object_key, &loaded.etag, encoded)
+            .await
+        {
+            Ok(_) => Ok(CasAttempt::Settled(())),
+            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
+            // An unknown outcome fails here rather than installing a target
+            // this attempt cannot prove is pinned.
+            Err(error) => Err(CoreError::store(object_key, &error)),
+        }
+    })
+    .await?;
+    renewed.ok_or_else(|| CoreError::contention_exhausted(object_key))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -8,7 +8,9 @@ use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::control::load_head_object;
-use loonfs_api::wire::control::{CheckpointOwner, CheckpointStatus, NamespaceStatus};
+use loonfs_api::wire::control::{
+    CheckpointOwner, CheckpointRecordState, CheckpointStatus, NamespaceStatus,
+};
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
@@ -16,8 +18,9 @@ use loonfs_objectstore::ObjectStore;
 pub(super) enum ForkCheckpointSweep {
     /// The record was flipped `active -> released` under its etag.
     Released,
-    /// The record must survive this pass (target ambiguous or still live, or
-    /// the release compare-and-swap lost a race).
+    /// The record must survive this pass (its target still reaches it, an
+    /// attempt may still install one, the head did not read, or the release
+    /// compare-and-swap lost a race).
     Retained,
     /// Not an active fork-owned record; the normal delete path decides.
     NotAnActiveFork,
@@ -63,10 +66,9 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
 }
 
 /// Decides one fork-owned sweep candidate immediately before acting
-/// (rule 3): re-reads the record, re-proves the target namespace is gone,
-/// and releases the record by compare-and-swap on the just-observed etag.
-/// The etag check means one pass releases and any other observes it; the
-/// forking side is serialized by its own lease, not by this swap.
+/// (rule 3): re-reads the record, re-classifies its target, and releases the
+/// record by compare-and-swap on the just-observed etag. That swap is what a
+/// forker's renewal contends with.
 pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     key: &str,
@@ -87,12 +89,22 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
     else {
         return Ok(ForkCheckpointSweep::NotAnActiveFork);
     };
-    if !fork_target_proven_gone(store, &target_namespace_id, expires_at_ms, context).await? {
-        return Ok(ForkCheckpointSweep::Retained);
+    match classify_fork_checkpoint(
+        store,
+        &loaded.state,
+        &target_namespace_id,
+        expires_at_ms,
+        context,
+    )
+    .await?
+    {
+        ForkCheckpointReachability::Reclaimable => {}
+        ForkCheckpointReachability::ReferencedByLiveTarget
+        | ForkCheckpointReachability::InFlight
+        | ForkCheckpointReachability::Ambiguous => return Ok(ForkCheckpointSweep::Retained),
     }
-    // A released fork record may have acquired a live target between an
-    // earlier target-head read and release CAS. Prove the target gone before
-    // allowing the normal released-record path to consider reaping it.
+    // Classification runs before this so a released record whose target still
+    // names it exactly is retained, not handed to the released-record reaper.
     if loaded.state.status != (CheckpointStatus::Active {}) {
         return Ok(ForkCheckpointSweep::NotAnActiveFork);
     }
@@ -104,34 +116,50 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Proves a fork target namespace is gone (rule 10's fork arm). Either its
-/// head says the namespace is terminally deleted, or the head is absent —
-/// and since the head is the target's only installation write, an absent
-/// head means the fork never landed.
+/// Where one fork-owned record stands against its target namespace.
+pub(super) enum ForkCheckpointReachability {
+    /// The target head is active and its fork basis names this exact record.
+    ReferencedByLiveTarget,
+    /// No target head yet, and the attempt's lease has not passed.
+    InFlight,
+    /// No target can ever read through this record again.
+    Reclaimable,
+    /// The target head did not read, so this pass decides nothing.
+    Ambiguous,
+}
+
+/// Classifies a fork-owned record against the durable evidence its target
+/// leaves behind (rule 10's fork arm).
 ///
-/// The absent case waits for the record's lease. A fork in flight right now
-/// has not written its head yet, and its lease covers the whole attempt with
-/// margin to spare, so only an attempt that is really gone can have let the
-/// lease pass. Other objects under the target prefix prove nothing either
-/// way, because no installation writes any before the head.
+/// The target head is the only object a fork installation writes, and
+/// `HeadState::ensure_successor_identity` refuses to rewrite `fork_basis`, so
+/// a head naming this record is permanent proof the basis is reachable and a
+/// head naming anything else is permanent proof it is not. Name existence is
+/// not enough on its own: a second fork attempt against a target that already
+/// exists creates a record no target will ever read through.
 ///
-/// A live target is the other half of the rule, and it is unconditional: a
-/// target head that exists and is not deleted keeps the record whatever the
-/// lease says. That is what protects a fork that published just before its
-/// lease ran out, and it is why nothing has to clear the lease afterwards.
-pub(super) async fn fork_target_proven_gone<S: ObjectStore + ?Sized>(
+/// An absent head means no attempt has landed, and the lease decides whether
+/// one still can. The forker renews the lease under this record's etag
+/// immediately before installing, so a collector reading an expired lease has
+/// already won the race against every attempt that could still install.
+pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
+    record: &CheckpointRecordState,
     target_namespace_id: &NamespaceId,
     lease_expires_at_ms: u64,
     context: &MutationContext,
-) -> Result<bool> {
-    match load_head_object(store, target_namespace_id).await {
-        Ok(loaded) => Ok(loaded.state.status == NamespaceStatus::Deleted {}),
+) -> Result<ForkCheckpointReachability> {
+    let head = match load_head_object(store, target_namespace_id).await {
+        Ok(loaded) => loaded.state,
         Err(ControlObjectLoadError::MissingObject { .. }) => {
-            Ok(lease_expires_at_ms <= context.now_ms)
+            return Ok(if lease_expires_at_ms <= context.now_ms {
+                ForkCheckpointReachability::Reclaimable
+            } else {
+                ForkCheckpointReachability::InFlight
+            })
         }
         Err(error) => match &error {
-            // An unreadable target head is not verifiably deleted; retain.
+            // An unreadable target head is not evidence of anything; retain.
             ControlObjectLoadError::Store { object_key, .. } => {
                 tracing::warn!(
                     namespace_id = %target_namespace_id,
@@ -139,11 +167,30 @@ pub(super) async fn fork_target_proven_gone<S: ObjectStore + ?Sized>(
                     error = %error,
                     "the fork target head did not read; retaining its source checkpoint"
                 );
-                Ok(false)
+                return Ok(ForkCheckpointReachability::Ambiguous);
             }
-            _ => Err(CoreError::NamespaceCorrupt(format!(
-                "the fork target head does not load: {error}"
-            ))),
+            _ => {
+                return Err(CoreError::NamespaceCorrupt(format!(
+                    "the fork target head does not load: {error}"
+                )))
+            }
         },
+    };
+    if head.status == (NamespaceStatus::Deleted {}) {
+        return Ok(ForkCheckpointReachability::Reclaimable);
     }
+    let Some(basis) = head.fork_basis else {
+        return Ok(ForkCheckpointReachability::Reclaimable);
+    };
+    if basis.source_checkpoint_id != record.checkpoint_id {
+        return Ok(ForkCheckpointReachability::Reclaimable);
+    }
+    if basis.manifest != record.manifest {
+        return Err(CoreError::NamespaceCorrupt(format!(
+            "the fork target `{target_namespace_id}` reads through checkpoint `{}` but names a \
+             different manifest reference",
+            record.checkpoint_id
+        )));
+    }
+    Ok(ForkCheckpointReachability::ReferencedByLiveTarget)
 }

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -16,13 +16,11 @@ use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 
 pub(super) enum ForkCheckpointSweep {
-    /// The record was flipped `active -> released` under its etag.
+    /// The record was released.
     Released,
-    /// The record must survive this pass (its target still reaches it, an
-    /// attempt may still install one, the head did not read, or the release
-    /// compare-and-swap lost a race).
+    /// The record must survive this pass.
     Retained,
-    /// Not an active fork-owned record; the normal delete path decides.
+    /// The normal checkpoint path handles this record.
     NotAnActiveFork,
 }
 
@@ -65,10 +63,7 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
     Ok(true)
 }
 
-/// Decides one fork-owned sweep candidate immediately before acting
-/// (rule 3): re-reads the record, re-classifies its target, and releases the
-/// record by compare-and-swap on the just-observed etag. That swap is what a
-/// forker's renewal contends with.
+/// Rechecks a fork checkpoint and releases it if its target no longer uses it.
 pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     key: &str,
@@ -103,8 +98,6 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
         | ForkCheckpointReachability::InFlight
         | ForkCheckpointReachability::Ambiguous => return Ok(ForkCheckpointSweep::Retained),
     }
-    // Classification runs before this so a released record whose target still
-    // names it exactly is retained, not handed to the released-record reaper.
     if loaded.state.status != (CheckpointStatus::Active {}) {
         return Ok(ForkCheckpointSweep::NotAnActiveFork);
     }
@@ -116,32 +109,16 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Where one fork-owned record stands against its target namespace.
+/// Whether a fork checkpoint is still needed.
 pub(super) enum ForkCheckpointReachability {
-    /// The target head is active and its fork basis names this exact record.
     ReferencedByLiveTarget,
-    /// No target head yet, and the attempt's lease has not passed.
     InFlight,
-    /// No target can ever read through this record again.
     Reclaimable,
-    /// The target head did not read, so this pass decides nothing.
     Ambiguous,
 }
 
-/// Classifies a fork-owned record against the durable evidence its target
-/// leaves behind (rule 10's fork arm).
-///
-/// The target head is the only object a fork installation writes, and
-/// `HeadState::ensure_successor_identity` refuses to rewrite `fork_basis`, so
-/// a head naming this record is permanent proof the basis is reachable and a
-/// head naming anything else is permanent proof it is not. Name existence is
-/// not enough on its own: a second fork attempt against a target that already
-/// exists creates a record no target will ever read through.
-///
-/// An absent head means no attempt has landed, and the lease decides whether
-/// one still can. The forker renews the lease under this record's etag
-/// immediately before installing, so a collector reading an expired lease has
-/// already won the race against every attempt that could still install.
+/// Compares a fork checkpoint with the target head that may reference it.
+/// An absent target remains in flight until the checkpoint lease expires.
 pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     record: &CheckpointRecordState,
@@ -159,7 +136,6 @@ pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
             })
         }
         Err(error) => match &error {
-            // An unreadable target head is not evidence of anything; retain.
             ControlObjectLoadError::Store { object_key, .. } => {
                 tracing::warn!(
                     namespace_id = %target_namespace_id,
@@ -182,7 +158,9 @@ pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
     let Some(basis) = head.fork_basis else {
         return Ok(ForkCheckpointReachability::Reclaimable);
     };
-    if basis.source_checkpoint_id != record.checkpoint_id {
+    if basis.manifest.owner_namespace_id != record.namespace_id
+        || basis.source_checkpoint_id != record.checkpoint_id
+    {
         return Ok(ForkCheckpointReachability::Reclaimable);
     }
     if basis.manifest != record.manifest {

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -395,9 +395,7 @@ async fn checkpoint_is_candidate<S: ObjectStore + ?Sized>(
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> CollectResult<bool> {
-    // User checkpoints expire by time. A fork checkpoint remains a root while
-    // its target head still reads through it, even if a racing pass already
-    // moved the record to `released`.
+    // A fork checkpoint remains a root while its target still references it.
     match &record.owner {
         CheckpointOwner::User { .. } => {
             Ok(record.status != (CheckpointStatus::Active {})

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -3,7 +3,7 @@
 //! Garbage collection refreshes this set in bounded chunks while sweeping.
 
 use super::budget::PassBudget;
-use super::fork_checkpoints::fork_target_proven_gone;
+use super::fork_checkpoints::{classify_fork_checkpoint, ForkCheckpointReachability};
 use super::reap::{lease_expired, manifest_object_id_of};
 use crate::checkpoint::record::load_checkpoint_record_at_key;
 use crate::checkpoint::{load_namespace_manifest_envelope_if_present, ManifestLoadFailureClass};
@@ -396,9 +396,8 @@ async fn checkpoint_is_candidate<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> CollectResult<bool> {
     // User checkpoints expire by time. A fork checkpoint remains a root while
-    // its target namespace exists even if a racing pass already moved the
-    // record to `released`: the target head can land between that pass's head
-    // read and checkpoint CAS, and the forker can then crash before its guard.
+    // its target head still reads through it, even if a racing pass already
+    // moved the record to `released`.
     match &record.owner {
         CheckpointOwner::User { .. } => {
             Ok(record.status != (CheckpointStatus::Active {})
@@ -409,10 +408,17 @@ async fn checkpoint_is_candidate<S: ObjectStore + ?Sized>(
             expires_at_ms,
         } => {
             charge(budget)?;
-            Ok(
-                fork_target_proven_gone(store, target_namespace_id, *expires_at_ms, context)
-                    .await?,
-            )
+            Ok(matches!(
+                classify_fork_checkpoint(
+                    store,
+                    record,
+                    target_namespace_id,
+                    *expires_at_ms,
+                    context
+                )
+                .await?,
+                ForkCheckpointReachability::Reclaimable
+            ))
         }
     }
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -3819,7 +3819,41 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         CheckpointStatus::Active {}
     );
 
+    // A target that reads through this record but names another manifest is
+    // not a stale reference; nothing legal writes that head.
     store.clear();
+    let head_key = wal_head(&clone);
+    let bytes = store
+        .get(&head_key, None)
+        .await
+        .expect("read target head")
+        .expect("target head exists");
+    let mut head = decode_control_object::<loonfs_api::wire::control::HeadState>(
+        &bytes,
+        ControlObjectKind::WalHead,
+    )
+    .expect("decode target head")
+    .state;
+    let basis = head.fork_basis.as_mut().expect("a fork target has a basis");
+    basis.manifest.manifest_no = ManifestNo(basis.manifest.manifest_no.0 + 1);
+    let drifted =
+        loonfs_api::wire::control::HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head)
+            .expect("drifted head envelope");
+    store
+        .put_overwrite(
+            &head_key,
+            Bytes::from(
+                loonfs_api::wire::control::encode_control_object(&drifted).expect("encode head"),
+            ),
+        )
+        .await
+        .expect("write drifted target head");
+    let error = gc_namespace(&store, &source, &config(), &setup)
+        .await
+        .expect_err("a target naming this record with another manifest is corruption");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(error.message().contains(fork_record.checkpoint_id.as_str()));
+
     store
         .put_overwrite(&wal_head(&clone), Bytes::from_static(b"not json"))
         .await
@@ -3928,11 +3962,11 @@ async fn a_fork_pin_with_a_missing_basis_survives_the_missing_basis_pass() {
     );
 }
 
-/// The target-head read and checkpoint release CAS are separate object-store
-/// operations. If the target lands between them and the forker then crashes,
-/// GC can observe a released fork record beside a live target. The owner still
-/// protects the target's foreign basis in that state; both the record and its
-/// basis must survive later passes.
+/// The renewal fences an attempt whose lease still runs, but an attempt that
+/// stalled past its lease can install a target after a pass released its
+/// record. GC then observes a released fork record beside a live target that
+/// names it exactly. Both the record and its basis must survive later passes:
+/// collection must not turn a damaged state into data loss.
 #[tokio::test]
 async fn gc_retains_a_released_fork_record_when_its_target_lives() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3949,9 +3983,8 @@ async fn gc_retains_a_released_fork_record_when_its_target_lives() {
         .expect("fork");
     let fork_record = read_fork_record(&store, &source).await;
 
-    // Move the source root beyond the fork basis, then synthesize the durable
-    // state left by the model-checked race: target active, source pin released,
-    // and no forker left to run the post-install guard.
+    // Move the source root beyond the fork basis, then synthesize that state:
+    // target active, source pin released.
     write_test_file(&store, &source, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &source, &setup)
         .await
@@ -4119,11 +4152,25 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
     assert_eq!(
         checkpoint_lifecycle(&store, &source, &abandoned.checkpoint_id).await,
         CheckpointStatus::Active {},
-        "the abandoned record is untouched; its lease ends it"
+        "the retry leaves the abandoned record alone"
+    );
+
+    // The target now reads through the retry's checkpoint, so the abandoned
+    // record protects nothing and is reclaimable inside its own lease.
+    let inside_the_lease = context(setup.now_ms + 1);
+    let report = gc_namespace(&store, &source, &config(), &inside_the_lease)
+        .await
+        .expect("gc pass with a target that reads through another record");
+    assert_eq!(report.released_checkpoints.fork, 1);
+    assert_eq!(
+        checkpoint_lifecycle(&store, &source, &abandoned.checkpoint_id).await,
+        CheckpointStatus::Released {
+            released_at_ms: inside_the_lease.now_ms
+        }
     );
     load_current_metadata_view(&store, &clone)
         .await
-        .expect("target readable after retry")
+        .expect("target readable after retry and collection")
         .resolve_path("/docs/one.txt", AttributeInclusion::Omit)
         .await
         .expect("forked file readable");

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -3819,8 +3819,6 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         CheckpointStatus::Active {}
     );
 
-    // A target that reads through this record but names another manifest is
-    // not a stale reference; nothing legal writes that head.
     store.clear();
     let head_key = wal_head(&clone);
     let bytes = store
@@ -3962,11 +3960,7 @@ async fn a_fork_pin_with_a_missing_basis_survives_the_missing_basis_pass() {
     );
 }
 
-/// The renewal fences an attempt whose lease still runs, but an attempt that
-/// stalled past its lease can install a target after a pass released its
-/// record. GC then observes a released fork record beside a live target that
-/// names it exactly. Both the record and its basis must survive later passes:
-/// collection must not turn a damaged state into data loss.
+/// A released fork checkpoint still protects a live target that names it.
 #[tokio::test]
 async fn gc_retains_a_released_fork_record_when_its_target_lives() {
     let temp_dir = tempdir().expect("tempdir");
@@ -3983,8 +3977,7 @@ async fn gc_retains_a_released_fork_record_when_its_target_lives() {
         .expect("fork");
     let fork_record = read_fork_record(&store, &source).await;
 
-    // Move the source root beyond the fork basis, then synthesize that state:
-    // target active, source pin released.
+    // Move the source root beyond the fork basis, then release its checkpoint.
     write_test_file(&store, &source, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &source, &setup)
         .await

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -188,9 +188,12 @@ pub const MAX_SIGNED_PARTS_PER_REQUEST: usize = 1_000;
 
 /// Lease for the source checkpoint created by a fork attempt.
 ///
-/// Two GC grace windows cover checkpoint creation followed by target-head
-/// installation and verification.
+/// Two GC grace windows cover checkpoint creation and target installation.
 pub const FORK_CHECKPOINT_LEASE_MS: u64 = 2 * GC_MIN_GRACE_WINDOW_MS;
+
+/// Time reserved for the target-head write after renewing a fork checkpoint.
+pub const FORK_INSTALL_MARGIN_MS: u64 =
+    PROVIDER_OPERATION_DEADLINE_MS + PROVIDER_ATTEMPT_TIMEOUT_MS;
 
 /// Lease duration for an upload session.
 pub const UPLOAD_SESSION_LEASE_MS: u64 = 24 * 60 * 60 * 1000;
@@ -229,6 +232,10 @@ const _: () = assert!(
 const _: () = assert!(
     FORK_CHECKPOINT_LEASE_MS >= GC_MIN_GRACE_WINDOW_MS,
     "a fork attempt may take as long as any other publication"
+);
+const _: () = assert!(
+    FORK_INSTALL_MARGIN_MS < FORK_CHECKPOINT_LEASE_MS,
+    "a renewed fork checkpoint must outlast target installation"
 );
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -223,28 +223,12 @@ const _: () = assert!(
      the commit that receipt admits, and that commit's publication"
 );
 
-/// Margin the post-publish fork guard requires between now and the source
-/// record's lease expiry before it lets a target stand.
-///
-/// The guard's evidence is one record read, and one provider operation's
-/// total wall time is `PROVIDER_OPERATION_DEADLINE_MS +
-/// PROVIDER_ATTEMPT_TIMEOUT_MS` (the deadline gates starting an attempt
-/// rather than preempting one). A record observed with more lease than that
-/// left cannot have been legally expiry-released while the guard was
-/// looking at it, so the observation still holds when the guard acts on it.
-pub const FORK_GUARD_MARGIN_MS: u64 = PROVIDER_OPERATION_DEADLINE_MS + PROVIDER_ATTEMPT_TIMEOUT_MS;
-
-// The fork lease has two jobs, and both are inequalities over the constants
-// above rather than judgement calls, so they are checked where a broken
-// derivation is a compile error instead of a test failure: it must cover a
-// whole fork attempt, and it must leave the guard something to check.
+// The fork lease must cover a whole fork attempt, which is an inequality over
+// the constants above rather than a judgement call, so it is checked where a
+// broken derivation is a compile error instead of a test failure.
 const _: () = assert!(
     FORK_CHECKPOINT_LEASE_MS >= GC_MIN_GRACE_WINDOW_MS,
     "a fork attempt may take as long as any other publication"
-);
-const _: () = assert!(
-    FORK_GUARD_MARGIN_MS < FORK_CHECKPOINT_LEASE_MS,
-    "a fork that finishes promptly must still clear the guard margin"
 );
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -1,19 +1,25 @@
 //! Namespace forking: installs a target namespace whose head points at a
 //! fork-owned source checkpoint, sharing content bytes and reading the
 //! source's metadata until the target flushes its own.
+//!
+//! One window is not fenced: an attempt that stalls longer than a full
+//! fresh lease between its renewal and its head write can still install a
+//! target after a collector released the record. Garbage collection's
+//! backstop is that a live target naming a record exactly retains it
+//! whatever the record's status says.
 
+use crate::checkpoint::record::renew_fork_checkpoint_for_install;
 use crate::checkpoint::{
     create_checkpoint, load_checkpoint_record, load_namespace_manifest_envelope,
 };
 use crate::context::MutationContext;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
-use crate::limits::{FORK_CHECKPOINT_LEASE_MS, FORK_GUARD_MARGIN_MS};
+use crate::limits::FORK_CHECKPOINT_LEASE_MS;
 use crate::namespace::bootstrap::{install_namespace_head, NamespaceHeadInstall};
-use crate::options::DeleteNamespaceOptions;
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::control::{
-    CheckpointOwner, CheckpointStatus, ForkBasis, HeadState, NamespaceStatus, WriterBlock,
+    CheckpointOwner, ForkBasis, HeadState, NamespaceStatus, WriterBlock,
 };
 use loonfs_api::{Namespace, NamespaceId, WriterEpoch};
 use loonfs_objectstore::ObjectStore;
@@ -24,8 +30,8 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     new_namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<Namespace> {
-    // The guard at the end needs to know how long this attempt has been
-    // running, so it starts here, before the first write.
+    // The renewal stamps how long this attempt has already run, so the
+    // timer starts before the first write.
     let timer = StdMonotonicTimer::default();
     let started_ms = timer.monotonic_now_ms();
     // Fork routes through a fork-owned source checkpoint: the record is the
@@ -93,6 +99,18 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         recent_segments: Vec::new(),
         status: NamespaceStatus::Active {},
     };
+    // The handoff: the target head is written only after a compare-and-swap
+    // proved this attempt still owns an active pin.
+    renew_fork_checkpoint_for_install(
+        store,
+        source_namespace_id,
+        &source_record.checkpoint_id,
+        new_namespace_id,
+        context
+            .now_ms
+            .saturating_add(timer.monotonic_now_ms().saturating_sub(started_ms)),
+    )
+    .await?;
     match install_namespace_head(store, new_namespace_id, &head).await? {
         NamespaceHeadInstall::Landed => {}
         NamespaceHeadInstall::Exists => {
@@ -107,90 +125,5 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         }
     }
 
-    // A forker that stalled between creating the record and publishing the
-    // target could have slept past its own lease, and a garbage-collection
-    // pass could have released the pin, leaving a target whose basis nothing
-    // protects. The guard closes that window: an inactive record, or one too
-    // close to its lease to trust, means this target must not exist, so it
-    // is deleted through the ordinary delete path and the checkpoint failure
-    // is what the caller sees.
-    if let Err(error) = ensure_fork_checkpoint_lease_holds(
-        store,
-        source_namespace_id,
-        &source_record.checkpoint_id,
-        new_namespace_id,
-        context
-            .now_ms
-            .saturating_add(timer.monotonic_now_ms().saturating_sub(started_ms)),
-    )
-    .await
-    {
-        if let Err(delete_error) = crate::commit_engine::delete_namespace(
-            store,
-            new_namespace_id,
-            DeleteNamespaceOptions::default(),
-            context,
-        )
-        .await
-        {
-            // Both halves failed. The caller hears why the fork failed,
-            // which is the actionable half; the target that could not be
-            // deleted is left for an operator, named here.
-            tracing::error!(
-                namespace_id = %new_namespace_id,
-                source_namespace_id = %source_namespace_id,
-                %delete_error,
-                "fork could not delete the target it published after losing its source checkpoint",
-            );
-        }
-        return Err(error);
-    }
-
     crate::namespace::status::load_namespace(store, new_namespace_id).await
-}
-
-/// Proves, after the target head is durable, that the source record still
-/// pins the basis and will keep pinning it long enough for the new target to
-/// take over that job.
-///
-/// The record must be active, and its lease must outlast this read by
-/// [`FORK_GUARD_MARGIN_MS`]. The margin is what makes the check sound where a
-/// bare re-read raced: garbage collection releases a fork record only once
-/// its lease has passed, so a lease with more than one provider operation
-/// left cannot legally be released between the read and the caller acting on
-/// it. After that point the target head itself is the protection — a fork
-/// record whose target namespace exists and is not deleted is retained by
-/// every pass, lease or no lease.
-async fn ensure_fork_checkpoint_lease_holds<S: ObjectStore + ?Sized>(
-    store: &S,
-    source_namespace_id: &NamespaceId,
-    checkpoint_id: &loonfs_api::CheckpointId,
-    new_namespace_id: &NamespaceId,
-    now_ms: u64,
-) -> Result<()> {
-    let lost = |reason: String| {
-        Err(CoreError::CheckpointUnavailable(format!(
-            "fork of `{source_namespace_id}` into `{new_namespace_id}` lost its source \
-             checkpoint `{checkpoint_id}`: {reason}"
-        )))
-    };
-    let Some(record) = load_checkpoint_record(store, source_namespace_id, checkpoint_id)
-        .await?
-        .map(|loaded| loaded.state)
-    else {
-        return lost("the record is gone".to_owned());
-    };
-    if record.status != (CheckpointStatus::Active {}) {
-        return lost(format!("the record is `{}`", record.status));
-    }
-    let CheckpointOwner::Fork { expires_at_ms, .. } = record.owner else {
-        return lost("the record is not fork-owned".to_owned());
-    };
-    if expires_at_ms <= now_ms.saturating_add(FORK_GUARD_MARGIN_MS) {
-        return lost(format!(
-            "its lease expires at {expires_at_ms} ms, inside the \
-             {FORK_GUARD_MARGIN_MS}ms guard margin at {now_ms}"
-        ));
-    }
-    Ok(())
 }

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -1,12 +1,6 @@
 //! Namespace forking: installs a target namespace whose head points at a
 //! fork-owned source checkpoint, sharing content bytes and reading the
 //! source's metadata until the target flushes its own.
-//!
-//! One window is not fenced: an attempt that stalls longer than a full
-//! fresh lease between its renewal and its head write can still install a
-//! target after a collector released the record. Garbage collection's
-//! backstop is that a live target naming a record exactly retains it
-//! whatever the record's status says.
 
 use crate::checkpoint::record::renew_fork_checkpoint_for_install;
 use crate::checkpoint::{
@@ -15,7 +9,7 @@ use crate::checkpoint::{
 use crate::context::MutationContext;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
-use crate::limits::FORK_CHECKPOINT_LEASE_MS;
+use crate::limits::{FORK_CHECKPOINT_LEASE_MS, FORK_INSTALL_MARGIN_MS};
 use crate::namespace::bootstrap::{install_namespace_head, NamespaceHeadInstall};
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::control::{
@@ -30,18 +24,11 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     new_namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<Namespace> {
-    // The renewal stamps how long this attempt has already run, so the
-    // timer starts before the first write.
+    // Include time already spent on the fork when renewing its lease.
     let timer = StdMonotonicTimer::default();
     let started_ms = timer.monotonic_now_ms();
-    // Fork routes through a fork-owned source checkpoint: the record is the
-    // reachability root protecting every source-owned metadata file the
-    // target will reference, for as long as the target lives.
-    //
-    // Every attempt creates its own leased record. There is no reuse of an
-    // earlier attempt's record and no way back from a release, so an attempt
-    // that dies before publishing its target simply lets the lease pass, and
-    // garbage collection releases and reaps the record on that alone.
+    // Each attempt creates a checkpoint that keeps the target's source
+    // metadata alive. GC removes abandoned checkpoints after their lease.
     let checkpoint = create_checkpoint(
         store,
         source_namespace_id,
@@ -73,15 +60,13 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         .await
         .map_err(CoreError::ControlObjectLoad)?
         .state;
-    // Start the target from the manifest pinned by the source checkpoint.
     let fork_basis = ForkBasis {
         manifest: source_record.manifest.clone(),
         source_checkpoint_id: source_record.checkpoint_id.clone(),
     };
     let fork_seq = fork_basis.manifest.manifest_head_seq;
 
-    // The target shares the source's content store and begins from the source
-    // manifest until it publishes its own.
+    // The target shares content bytes and starts from the source manifest.
     let head = HeadState {
         namespace_id: new_namespace_id.clone(),
         content_store_id: source_head.content_store_id.clone(),
@@ -99,9 +84,8 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         recent_segments: Vec::new(),
         status: NamespaceStatus::Active {},
     };
-    // The handoff: the target head is written only after a compare-and-swap
-    // proved this attempt still owns an active pin.
-    renew_fork_checkpoint_for_install(
+    // Renew before creating the target so this races safely with GC release.
+    let checkpoint_expires_at_ms = renew_fork_checkpoint_for_install(
         store,
         source_namespace_id,
         &source_record.checkpoint_id,
@@ -111,6 +95,16 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             .saturating_add(timer.monotonic_now_ms().saturating_sub(started_ms)),
     )
     .await?;
+    let install_started_at_ms = context
+        .now_ms
+        .saturating_add(timer.monotonic_now_ms().saturating_sub(started_ms));
+    if checkpoint_expires_at_ms <= install_started_at_ms.saturating_add(FORK_INSTALL_MARGIN_MS) {
+        return Err(CoreError::CheckpointUnavailable(format!(
+            "fork of `{source_namespace_id}` into `{new_namespace_id}` cannot install before its \
+             source checkpoint `{}` expires",
+            source_record.checkpoint_id
+        )));
+    }
     match install_namespace_head(store, new_namespace_id, &head).await? {
         NamespaceHeadInstall::Landed => {}
         NamespaceHeadInstall::Exists => {

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -644,12 +644,8 @@ async fn a_fork_that_loses_its_source_pin_installs_no_target() {
     assert_eq!(error.code(), ErrorCode::CheckpointUnavailable);
     assert!(
         namespace_keys(&store, &clone).await.is_empty(),
-        "the fence runs before the target head, so nothing is published to undo"
+        "the target is not installed"
     );
-    let retry = fork_namespace(&store, &source, &clone, &context)
-        .await
-        .expect_err("the retry loses its own pin the same way");
-    assert_eq!(retry.code(), ErrorCode::CheckpointUnavailable);
 }
 
 #[tokio::test]
@@ -967,8 +963,7 @@ async fn gc_handles_a_namespace_with_no_root_and_then_its_tombstone() {
         .is_none());
 }
 
-/// A store that releases the fork's source pin the instant the fork tries to
-/// renew it, standing in for a collection pass that won the same record.
+/// Releases a fork checkpoint before its renewal can complete.
 #[derive(Debug)]
 struct ReleasePinBeforeRenewalStore {
     inner: LocalFsStore,

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -628,13 +628,10 @@ async fn checkpointing_an_unflushed_fork_materializes_its_first_manifest() {
 }
 
 #[tokio::test]
-async fn a_fork_whose_source_pin_is_released_deletes_its_own_target() {
+async fn a_fork_that_loses_its_source_pin_installs_no_target() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ReleasePinAfterHeadStore::new(
-        LocalFsStore::new(temp_dir.path()).expect("store"),
-        NamespaceId::parse("clone").expect("valid namespace id"),
-        ForkPinAfterHead::Released,
-    );
+    let store =
+        ReleasePinBeforeRenewalStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
     let context = mutation_context();
     let source = namespace_id("source");
     let clone = NamespaceId::parse("clone").expect("valid namespace id");
@@ -643,46 +640,20 @@ async fn a_fork_whose_source_pin_is_released_deletes_its_own_target() {
     let error = fork_namespace(&store, &source, &clone, &context)
         .await
         .expect_err("a released source pin fails the fork");
+
     assert_eq!(error.code(), ErrorCode::CheckpointUnavailable);
-    assert_eq!(
-        head_state(&store, &clone).await.status,
-        loonfs_api::wire::control::NamespaceStatus::Deleted {},
-        "the fork deletes the target it published"
+    assert!(
+        namespace_keys(&store, &clone).await.is_empty(),
+        "the fence runs before the target head, so nothing is published to undo"
     );
     let retry = fork_namespace(&store, &source, &clone, &context)
         .await
-        .expect_err("the deleted id is retired");
-    assert_eq!(retry.code(), ErrorCode::NamespaceDeleted);
+        .expect_err("the retry loses its own pin the same way");
+    assert_eq!(retry.code(), ErrorCode::CheckpointUnavailable);
 }
 
 #[tokio::test]
-async fn a_fork_whose_source_lease_runs_out_deletes_its_own_target() {
-    let temp_dir = tempdir().expect("tempdir");
-    let context = mutation_context();
-    let store = ReleasePinAfterHeadStore::new(
-        LocalFsStore::new(temp_dir.path()).expect("store"),
-        NamespaceId::parse("clone").expect("valid namespace id"),
-        ForkPinAfterHead::LeaseAtTheGuardMargin {
-            now_ms: context.now_ms,
-        },
-    );
-    let source = namespace_id("source");
-    let clone = NamespaceId::parse("clone").expect("valid namespace id");
-    seed_source_namespace_for_fork(&store, &source, &context).await;
-
-    let error = fork_namespace(&store, &source, &clone, &context)
-        .await
-        .expect_err("a lease inside the guard margin fails the fork");
-    assert_eq!(error.code(), ErrorCode::CheckpointUnavailable);
-    assert_eq!(
-        head_state(&store, &clone).await.status,
-        loonfs_api::wire::control::NamespaceStatus::Deleted {},
-        "the fork deletes the target it published"
-    );
-}
-
-#[tokio::test]
-async fn a_fork_with_lease_to_spare_survives_a_concurrent_gc_pass() {
+async fn a_fork_survives_a_concurrent_collection_pass() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
     let context = mutation_context();
@@ -694,7 +665,7 @@ async fn a_fork_with_lease_to_spare_survives_a_concurrent_gc_pass() {
     let forking = fork_namespace(store.as_ref(), &source, &clone, &context);
     let collecting = loonfs_core::gc_namespace(store.as_ref(), &source, &gc_config, &context);
     let (forked, collected) = tokio::join!(forking, collecting);
-    forked.expect("a fresh lease survives a concurrent pass");
+    forked.expect("the renewal fences the pass");
     collected.expect("the pass finishes");
     assert_eq!(
         head_state(store.as_ref(), &clone).await.status,
@@ -996,92 +967,51 @@ async fn gc_handles_a_namespace_with_no_root_and_then_its_tombstone() {
         .is_none());
 }
 
-/// What happens to the fork's source pin the moment the target head lands.
-#[derive(Debug, Clone, Copy)]
-enum ForkPinAfterHead {
-    /// A garbage-collection pass released the pin while a stalled forker
-    /// slept.
-    Released,
-    /// The forker stalled until its lease was all but gone: the record is
-    /// still active, but with exactly the guard margin left, which is not
-    /// margin enough to trust.
-    LeaseAtTheGuardMargin { now_ms: u64 },
-}
-
-/// A store that rewrites the fork's source checkpoint the moment the target
-/// head lands, standing in for the window between the two writes.
+/// A store that releases the fork's source pin the instant the fork tries to
+/// renew it, standing in for a collection pass that won the same record.
 #[derive(Debug)]
-struct ReleasePinAfterHeadStore {
+struct ReleasePinBeforeRenewalStore {
     inner: LocalFsStore,
-    target_head_key: String,
-    after_head: ForkPinAfterHead,
 }
 
-impl ReleasePinAfterHeadStore {
-    fn new(
-        inner: LocalFsStore,
-        target_namespace_id: NamespaceId,
-        after_head: ForkPinAfterHead,
-    ) -> Self {
-        Self {
-            inner,
-            target_head_key: wal_head(&target_namespace_id),
-            after_head,
-        }
+impl ReleasePinBeforeRenewalStore {
+    fn new(inner: LocalFsStore) -> Self {
+        Self { inner }
     }
 
-    async fn rewrite_every_fork_pin(&self) {
-        for key in self
+    async fn release_record(&self, key: &str) {
+        let bytes = self
             .inner
-            .list_prefix("namespaces/")
+            .get(key, None)
             .await
-            .expect("list namespaces")
-            .into_iter()
-            .filter(|key| key.contains("/checkpoints/"))
-        {
-            let Some(bytes) = self.inner.get(&key, None).await.expect("read record") else {
-                continue;
-            };
-            let Ok(envelope) = decode_control_object::<
-                loonfs_api::wire::control::CheckpointRecordState,
-            >(&bytes, ControlObjectKind::CheckpointRecord) else {
-                continue;
-            };
-            let mut record = envelope.state;
-            if !matches!(record.owner, CheckpointOwner::Fork { .. }) {
-                continue;
-            }
-            match self.after_head {
-                ForkPinAfterHead::Released => {
-                    record.status = CheckpointStatus::Released {
-                        released_at_ms: 2_000,
-                    };
-                }
-                ForkPinAfterHead::LeaseAtTheGuardMargin { now_ms } => {
-                    let CheckpointOwner::Fork { expires_at_ms, .. } = &mut record.owner else {
-                        panic!("the record was checked as fork-owned")
-                    };
-                    *expires_at_ms = now_ms + loonfs_core::limits::FORK_GUARD_MARGIN_MS;
-                }
-            }
-            let rewritten = loonfs_api::wire::control::CheckpointRecordEnvelope::from_state(
-                ControlObjectKind::CheckpointRecord,
-                record,
+            .expect("read record")
+            .expect("record exists");
+        let mut record = decode_control_object::<loonfs_api::wire::control::CheckpointRecordState>(
+            &bytes,
+            ControlObjectKind::CheckpointRecord,
+        )
+        .expect("decode record")
+        .state;
+        record.status = CheckpointStatus::Released {
+            released_at_ms: 2_000,
+        };
+        let released = loonfs_api::wire::control::CheckpointRecordEnvelope::from_state(
+            ControlObjectKind::CheckpointRecord,
+            record,
+        )
+        .expect("released record envelope");
+        self.inner
+            .put_overwrite(
+                key,
+                Bytes::from(encode_control_object(&released).expect("encode record")),
             )
-            .expect("rewritten record envelope");
-            self.inner
-                .put_overwrite(
-                    &key,
-                    Bytes::from(encode_control_object(&rewritten).expect("encode record")),
-                )
-                .await
-                .expect("rewrite record");
-        }
+            .await
+            .expect("release record");
     }
 }
 
 #[async_trait::async_trait]
-impl ObjectStore for ReleasePinAfterHeadStore {
+impl ObjectStore for ReleasePinBeforeRenewalStore {
     async fn head(
         &self,
         key: &str,
@@ -1111,11 +1041,12 @@ impl ObjectStore for ReleasePinAfterHeadStore {
         bytes: Bytes,
         mode: loonfs_objectstore::PutMode,
     ) -> Result<loonfs_objectstore::ObjectMetadata, loonfs_objectstore::ObjectStoreError> {
-        let metadata = self.inner.put(key, bytes, mode).await?;
-        if key == self.target_head_key {
-            self.rewrite_every_fork_pin().await;
+        if matches!(mode, loonfs_objectstore::PutMode::CompareAndSwap { .. })
+            && key.contains("/checkpoints/")
+        {
+            self.release_record(key).await;
         }
-        Ok(metadata)
+        self.inner.put(key, bytes, mode).await
     }
 
     async fn delete(&self, key: &str) -> Result<(), loonfs_objectstore::ObjectStoreError> {

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2325,9 +2325,9 @@ The server forks from the source namespace's current head. The new namespace
 shares the source namespace's content store and starts with independent future
 namespace metadata. The fork creates a fork-owned source checkpoint so the
 source-owned immutable metadata segments stay available for as long as the
-target may still read them, renews that checkpoint's lease under the etag it
-was read with, then installs the target namespace's head in one conditional
-write. That head carries the fork provenance for the target's whole life.
+target may still read them. It renews the checkpoint with compare-and-swap,
+then installs the target namespace's head in one conditional write. That head
+records the source checkpoint for the target's lifetime.
 
 The response contains the new namespace's initial state. Its head
 sequence and retention floor are set to the source namespace's sequence at

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -870,8 +870,8 @@ For example, a create response is:
 `GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` returns active
 checkpoints in ascending `checkpoint_id` order. Each entry is the same
 checkpoint object returned by create. User checkpoints can be released by
-id. Fork checkpoints retain their `fork` owner and remain until their target
-namespace is deleted.
+id. Fork checkpoints retain their `fork` owner and remain while their target
+namespace still reads through them.
 
 ```json
 {"namespace_id":"demo","checkpoints":[{"namespace_id":"demo","checkpoint_id":"chk_00000000000000000000000000000009","owner":{"kind":"user","name":"release"},"created_at_ms":1752623000000,"expires_at_ms":1752626600000,"checkpoint_seq":12,"manifest_no":9}]}
@@ -973,7 +973,7 @@ that reason, and the fields sum to the total:
 | `no_reference_manifest` | Unreachable and aged, but the namespace has published no manifest old enough to say what it referenced when the grace window opened. A reader that pinned its anchor inside the window may still be reading the object, so the pass keeps it until a manifest ages past the window. |
 | `degraded_roots` | Root resolution failed somewhere in the pass, so manifest and segment deletion was suppressed wholesale. `retention_degraded` is set too. |
 | `unrecognized_key` | A key under a swept family that this collector does not recognize as one of its own. Never deleted, whatever its age. |
-| `checkpoint_not_releasable` | A checkpoint record the pass could not advance: a lost compare-and-swap, an unreadable record, a fork target not provably gone, a released record still inside its grace, or an active pin doing its job. |
+| `checkpoint_not_releasable` | A checkpoint record the pass could not advance: a lost compare-and-swap, an unreadable record, a fork record its target may still reach, a released record still inside its grace, or an active pin doing its job. |
 | `upload_session_window` | An upload session waiting out a window a clock resolves — the same waits `next_reclamation_at_ms` reports. |
 | `upload_session_undecided` | An upload session held for a reason no clock resolves: a lost compare-and-swap, a record that vanished mid-pass, or a reference set the pass could not establish. |
 | `content_scan_deferred` | A completed session whose content reclamation was skipped because the reference scan did not fit in `max_objects`. `content_reclamation_deferred` is set too. |
@@ -2325,9 +2325,9 @@ The server forks from the source namespace's current head. The new namespace
 shares the source namespace's content store and starts with independent future
 namespace metadata. The fork creates a fork-owned source checkpoint so the
 source-owned immutable metadata segments stay available for as long as the
-target may still read them, then installs the target namespace's head in one
-conditional write, then checks that the source checkpoint still holds. That
-head carries the fork provenance for the target's whole life.
+target may still read them, renews that checkpoint's lease under the etag it
+was read with, then installs the target namespace's head in one conditional
+write. That head carries the fork provenance for the target's whole life.
 
 The response contains the new namespace's initial state. Its head
 sequence and retention floor are set to the source namespace's sequence at
@@ -2335,8 +2335,8 @@ the fork point.
 
 If the target ID already exists or has been deleted, the server returns the
 same `namespace_exists` or `namespace_deleted` error as namespace creation.
-If the source checkpoint disappears before the operation completes, the
-server deletes the new target and returns `checkpoint_unavailable`.
+If the source checkpoint cannot be renewed, the server returns
+`checkpoint_unavailable` and no target namespace is installed.
 
 ### 6.13 `GET /grep`
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1683,14 +1683,9 @@ context. The protocol is:
    `expires_at_ms = now + FORK_CHECKPOINT_LEASE_MS`. This record is the
    reachability root that keeps the source's basis manifest and segments alive
    for as long as the target lives; nothing under the target's prefix protects
-   them. Every attempt takes its own record; no attempt reuses, refreshes, or
-   revives an earlier one's.
+   them. Each attempt creates a new record.
 3. Read the pinned manifest to get the target's next inode id. Build the active target head with the source's `content_store_id` and a `fork_basis` containing the record's `manifest` reference and checkpoint id. The reference's `manifest_head_seq` is the target's fork sequence.
-4. Renew the source checkpoint record by compare-and-swap on the etag it was
-   read with, setting `expires_at_ms` to at least
-   `now + FORK_CHECKPOINT_LEASE_MS`. The renewal requires an active,
-   fork-owned record whose owner names this target. A terminal, missing, or
-   foreign record fails the fork, and so does an unknown write outcome.
+4. Renew the source checkpoint with compare-and-swap. The record must be active, fork-owned, and assigned to this target. The new expiry must be later than the stored expiry and at least `now + FORK_CHECKPOINT_LEASE_MS`. The remaining lease must cover the target-head write. If either check fails, the fork stops before creating the target.
 5. Write the target head with create-if-absent.
 
 The target copies the source's `content_store_id` because a fork shares file
@@ -1698,35 +1693,9 @@ bytes copy-on-write. It inherits the source's materialized name keys
 unchanged, which is sound because name-key folding is a fixed rule of the
 format (section 2.3.1) rather than a per-namespace choice.
 
-Step 4 is the handoff between the forker and garbage collection, and it is
-the reason no step after the head write has anything left to check. Both
-sides transition the same record from the same observed etag:
+The renewal races with garbage collection on the same record. If GC releases the record first, the renewal fails. If the renewal succeeds first, its later expiry changes the record and causes a stale release to fail its compare-and-swap. Once the target exists, its `fork_basis` keeps the checkpoint reachable. An abandoned attempt leaves only a checkpoint that GC can release after its lease expires.
 
-```text
-GC:     active C@etag -> released C
-Fork:   active C@etag -> active C with a fresh lease
-```
-
-If the release lands first, the renewal reloads a terminal record and the
-fork fails before any target exists. If the renewal lands first, the
-collector's release fails: a renewal always writes a strictly later expiry
-(a wall-clock lease adjusted for how long the attempt has run, and never
-below the stored expiry plus one), so the record's bytes and etag no longer
-match what the collector read. A crash after renewal leaves an orphaned pin that its
-own lease ends. A crash after the head write needs no cleanup: the head's
-`fork_basis` is durable evidence that this exact record is reachable, and
-every successor head carries it forward verbatim (section 2.9).
-
-One window is not fenced. An attempt that stalls longer than a full fresh
-lease between its renewal and its head write can still install a target
-after a collector released the record. The rule
-that a live target exactly referencing a record retains it (section 6,
-rule 10) is the backstop: the record survives as an anomaly rather than
-being reaped under a live target.
-
-`FORK_CHECKPOINT_LEASE_MS` is derived, not tuned: two GC grace floors
-(section 6, rule 1), one for the create and one for everything after it, each
-being one publication plus provider bounds plus clock skew.
+`FORK_CHECKPOINT_LEASE_MS` is two GC grace windows (section 6, rule 1): one for checkpoint creation and one for target installation.
 
 The fork does not copy content blobs or source metadata segments, and it does not write a target manifest, root, or floor. The target starts its own WAL one sequence above `fork_basis.manifest.manifest_head_seq`. New WAL segments, checkpoints, and metadata segments are stored under the target namespace. Until the first target flush creates a root, readers resolve the basis from the head (section 2.9.1).
 
@@ -2451,32 +2420,9 @@ publishing CAS) — under these rules:
    a later pass. Content objects are never enumerated by listing the content
    store, which is shared by every namespace whose head names it; they are
    reached only through the upload session that owns them (rule 11).
-10. **Fork pins are held by exact reference.** A fork-owned record is a root
-   only while its target head is active and that head's `fork_basis` names
-   this record's checkpoint id and its manifest reference. The head is the
-   only object a fork installation writes and no successor head may rewrite
-   its `fork_basis` (section 2.9), so it is permanent evidence either way.
-   A target that is absent, terminally deleted, carries no fork basis, or
-   reads through some other checkpoint releases the record. Two of those
-   arms need care:
+10. **Fork checkpoints require an exact reference.** A fork-owned record remains a root while its active target's `fork_basis` names the record's source namespace, checkpoint id, and manifest. An absent target keeps the record until its lease expires. A deleted target, a target without a fork basis, or a target that names another source or checkpoint makes the record releasable immediately. This also allows GC to release records created by failed fork attempts against an existing target.
 
-   *Absent target.* Releasing waits for the record's own lease. The forker
-   renews that lease by compare-and-swap on the record immediately before
-   installing (section 3.9.2), so a collector that observes an expired lease
-   has already won against every attempt that could still install. This is
-   the only debris an interrupted install can leave, and it lives on the
-   source, never under the target's prefix — the target either has a
-   complete head or has nothing.
-
-   *Target that reads through another checkpoint.* A second fork attempt
-   against a name that is already taken pins a basis no target will ever
-   read. Its record is reclaimable at once; the lease has nothing to say
-   about a target that already exists.
-
-   A target head the store will not hand over is not evidence of anything,
-   and retains the record until a later pass can read it. A head that names
-   this record's checkpoint id with a different manifest reference is
-   namespace corruption and fails the pass.
+    If the target head cannot be read, GC retains the record. If the source namespace and checkpoint id match but the manifest differs, the namespace is corrupt and the pass fails.
 11. **Uploads and content, split at `completed`.** One sweep of `uploads/`
    owns both halves, because a session record is the only handle on the
    content object it created.
@@ -2616,13 +2562,10 @@ orphaned data for the next pass rather than a record whose data vanished.
 To keep that true, every readable checkpoint record roots its basis for the
 duration of a pass, whatever its lifecycle, expiry, or owner — no exceptions.
 State, expiry, and owner fate gate only whether the record itself is a
-candidate. A fork-owned record no target reads through any more (rule 10) is
-released by compare-and-swap on the record's freshly observed etag,
-re-classified immediately before that swap — never deleted while active. A
-released fork record whose target still names it exactly is retained instead:
-that pairing is an anomaly the fork handoff makes rare, and collection must
-not turn a damaged state into data loss. A released
-record is deleted outright once its `released_at_ms` is a grace window old;
+candidate. A fork-owned record that no target uses (rule 10) is rechecked and
+released with compare-and-swap on its current ETag. An active record is never
+deleted directly, and a released fork record is retained if its target still
+names it. A released record is deleted once its `released_at_ms` is a grace window old;
 because release is terminal, no second state is needed between deciding to
 delete and deleting, and a crash between the release CAS and the delete
 leaves a record the next pass reaps unconditionally.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1685,42 +1685,48 @@ context. The protocol is:
    for as long as the target lives; nothing under the target's prefix protects
    them. Every attempt takes its own record; no attempt reuses, refreshes, or
    revives an earlier one's.
-3. Read the pinned manifest to get the target's next inode id. Build the active target head with the source's `content_store_id` and a `fork_basis` containing the record's `manifest` reference and checkpoint id. The reference's `manifest_head_seq` is the target's fork sequence. Write the head with create-if-absent.
-4. Read the source checkpoint record once. The fork succeeds only if the
-   record is active **and** its fork owner's
-   `expires_at_ms > now + FORK_GUARD_MARGIN_MS`.
-   Otherwise delete the target through the ordinary namespace-delete path and
-   return the checkpoint failure.
+3. Read the pinned manifest to get the target's next inode id. Build the active target head with the source's `content_store_id` and a `fork_basis` containing the record's `manifest` reference and checkpoint id. The reference's `manifest_head_seq` is the target's fork sequence.
+4. Renew the source checkpoint record by compare-and-swap on the etag it was
+   read with, setting `expires_at_ms` to at least
+   `now + FORK_CHECKPOINT_LEASE_MS`. The renewal requires an active,
+   fork-owned record whose owner names this target. A terminal, missing, or
+   foreign record fails the fork, and so does an unknown write outcome.
+5. Write the target head with create-if-absent.
 
 The target copies the source's `content_store_id` because a fork shares file
 bytes copy-on-write. It inherits the source's materialized name keys
 unchanged, which is sound because name-key folding is a fixed rule of the
 format (section 2.3.1) rather than a per-namespace choice.
 
-Step 4 exists because steps 2 and 3 are two separate writes to two different
-objects. A forker that stalls between them can have its record released
-underneath it, and without the check the target would survive with an
-unprotected basis — a namespace that reads correctly today and reports
-corruption after the next GC pass. The margin is what makes the check sound
-where a bare re-read raced: garbage collection releases a fork record only
-once its lease has passed, so a lease with more than one provider operation
-left cannot legally be released between the read and the caller acting on it.
-Past that point the target head is the protection — a fork record whose
-target namespace exists and is not deleted is retained by every pass,
-whatever its lease says, so nothing has to clear the lease afterwards. The
-owner rule precedes the record status: if the target lands between a GC
-target-head read and the checkpoint release CAS, that now-`released` fork
-record is still retained while the target is live. This covers a forker that
-crashes before its post-install guard can observe the raced release.
-Deleting the target through the ordinary delete path, rather than erasing the
-head, keeps the failure inside the one lifecycle every other operation
-already understands.
+Step 4 is the handoff between the forker and garbage collection, and it is
+the reason no step after the head write has anything left to check. Both
+sides transition the same record from the same observed etag:
+
+```text
+GC:     active C@etag -> released C
+Fork:   active C@etag -> active C with a fresh lease
+```
+
+If the release lands first, the renewal reloads a terminal record and the
+fork fails before any target exists. If the renewal lands first, the
+collector's release fails: a renewal always writes a strictly later expiry
+(a wall-clock lease adjusted for how long the attempt has run, and never
+below the stored expiry plus one), so the record's bytes and etag no longer
+match what the collector read. A crash after renewal leaves an orphaned pin that its
+own lease ends. A crash after the head write needs no cleanup: the head's
+`fork_basis` is durable evidence that this exact record is reachable, and
+every successor head carries it forward verbatim (section 2.9).
+
+One window is not fenced. An attempt that stalls longer than a full fresh
+lease between its renewal and its head write can still install a target
+after a collector released the record. The rule
+that a live target exactly referencing a record retains it (section 6,
+rule 10) is the backstop: the record survives as an anomaly rather than
+being reaped under a live target.
 
 `FORK_CHECKPOINT_LEASE_MS` is derived, not tuned: two GC grace floors
 (section 6, rule 1), one for the create and one for everything after it, each
 being one publication plus provider bounds plus clock skew.
-`FORK_GUARD_MARGIN_MS` is one provider operation's total wall time — the
-staleness bound on the guard's own read.
 
 The fork does not copy content blobs or source metadata segments, and it does not write a target manifest, root, or floor. The target starts its own WAL one sequence above `fork_basis.manifest.manifest_head_seq`. New WAL segments, checkpoints, and metadata segments are stored under the target namespace. Until the first target flush creates a root, readers resolve the basis from the head (section 2.9.1).
 
@@ -2410,8 +2416,8 @@ publishing CAS) — under these rules:
    decisions, so no deletion consults an arbitrarily stale root set.
 4. Roots: `metadata/root.json`; the reference manifest R (rule 1); active
    checkpoint records whose owner still
-   stands — a user pin until its expiry passes, a fork pin until its target
-   is provably gone (rule 10), whatever its lease says; and the visible chain from
+   stands — a user pin until its expiry passes, a fork pin until nothing can
+   read through it any more (rule 10); and the visible chain from
    `wal/head.json.visible_wal_tip` down to the floor. A namespace with no
    root of its own has no manifest or segment to protect under its own prefix;
    its basis, if it has a foreign one, is protected on the source side by
@@ -2445,15 +2451,32 @@ publishing CAS) — under these rules:
    a later pass. Content objects are never enumerated by listing the content
    store, which is shared by every namespace whose head names it; they are
    reached only through the upload session that owns them (rule 11).
-10. **Abandoned forks.** A fork that crashes after writing its leased source
-   checkpoint record but before installing its target head leaves that
-   record with no target at all. Such a record is released once its lease
-   has passed and the target head is still absent: the lease covers a whole
-   fork attempt with margin to spare (section 3.9.2), so only an attempt
-   that is really gone can have let it pass. This is the only debris an
-   interrupted install can leave, and it lives on the source, never under
-   the target's prefix — the target either has a complete head or has
-   nothing.
+10. **Fork pins are held by exact reference.** A fork-owned record is a root
+   only while its target head is active and that head's `fork_basis` names
+   this record's checkpoint id and its manifest reference. The head is the
+   only object a fork installation writes and no successor head may rewrite
+   its `fork_basis` (section 2.9), so it is permanent evidence either way.
+   A target that is absent, terminally deleted, carries no fork basis, or
+   reads through some other checkpoint releases the record. Two of those
+   arms need care:
+
+   *Absent target.* Releasing waits for the record's own lease. The forker
+   renews that lease by compare-and-swap on the record immediately before
+   installing (section 3.9.2), so a collector that observes an expired lease
+   has already won against every attempt that could still install. This is
+   the only debris an interrupted install can leave, and it lives on the
+   source, never under the target's prefix — the target either has a
+   complete head or has nothing.
+
+   *Target that reads through another checkpoint.* A second fork attempt
+   against a name that is already taken pins a basis no target will ever
+   read. Its record is reclaimable at once; the lease has nothing to say
+   about a target that already exists.
+
+   A target head the store will not hand over is not evidence of anything,
+   and retains the record until a later pass can read it. A head that names
+   this record's checkpoint id with a different manifest reference is
+   namespace corruption and fails the pass.
 11. **Uploads and content, split at `completed`.** One sweep of `uploads/`
    owns both halves, because a session record is the only handle on the
    content object it created.
@@ -2593,10 +2616,12 @@ orphaned data for the next pass rather than a record whose data vanished.
 To keep that true, every readable checkpoint record roots its basis for the
 duration of a pass, whatever its lifecycle, expiry, or owner — no exceptions.
 State, expiry, and owner fate gate only whether the record itself is a
-candidate. A fork-owned record whose target namespace is verifiably
-terminally deleted (target head `state = deleted`, re-checked at delete time)
-or provably abandoned (rule 10) is released by compare-and-swap on the
-record's freshly observed etag — never deleted while active. A released
+candidate. A fork-owned record no target reads through any more (rule 10) is
+released by compare-and-swap on the record's freshly observed etag,
+re-classified immediately before that swap — never deleted while active. A
+released fork record whose target still names it exactly is retained instead:
+that pairing is an anomaly the fork handoff makes rare, and collection must
+not turn a damaged state into data loss. A released
 record is deleted outright once its `released_at_ms` is a grace window old;
 because release is terminal, no second state is needed between deciding to
 delete and deleting, and a crash between the release CAS and the delete


### PR DESCRIPTION
Renews a fork's source checkpoint with compare-and-swap immediately before creating the target namespace. The remaining lease must cover target installation, so garbage collection cannot release the checkpoint while the target head is being written.

Garbage collection now retains a fork checkpoint only when the target head names the same source namespace, checkpoint ID, and manifest. This lets abandoned attempts be collected promptly while preserving checkpoints used by live targets.