### PR TITLE
refactor(core): distinguish manifest publication outcomes

### DIFF
--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -61,8 +61,8 @@ pub(super) enum TryFlushWal {
     /// The attempt finished with a valid basis, whether or not it published
     /// that basis itself.
     Settled(Box<FlushedBasis>),
-    /// The root compare-and-swap raced another publisher to exhaustion;
-    /// retry against a fresh projection.
+    /// The root moved to a manifest that does not cover this attempt's
+    /// target; retry against a fresh projection.
     RaceLost,
 }
 
@@ -183,26 +183,23 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
     )
     .await?
     {
-        ManifestPublicationOutcome::Published(_) => (
+        ManifestPublicationOutcome::Installed(_)
+        | ManifestPublicationOutcome::AlreadyCurrent(_) => (
             FlushWalOutcome::Published,
             manifest.payload.manifest_no,
             manifest.payload.head_seq,
         ),
-        ManifestPublicationOutcome::Superseded(current) => {
-            // A same-sequence reorganization can replace our predecessor
-            // without covering the newer WAL head this flush targeted. That
-            // root safely wins, but it has not satisfied the flush: reload
-            // its equivalent runs, replay the tail, and try again.
-            if current.manifest.manifest_head_seq < head_seq {
-                return Ok(TryFlushWal::RaceLost);
-            }
-            (
-                FlushWalOutcome::RootAdvanced,
-                current.manifest.manifest_no,
-                current.manifest.manifest_head_seq,
-            )
-        }
-        ManifestPublicationOutcome::RootCasRaceLost => {
+        // The candidate's head sequence is this flush's target, so a root
+        // that covers the candidate covers the target too.
+        ManifestPublicationOutcome::CoveredByCurrent(current) => (
+            FlushWalOutcome::RootAdvanced,
+            current.manifest.manifest_no,
+            current.manifest.manifest_head_seq,
+        ),
+        // A same-sequence reorganization can replace the predecessor without
+        // covering the newer WAL head. That root safely wins, but it has not
+        // satisfied the flush: reload its runs, replay the tail, try again.
+        ManifestPublicationOutcome::PredecessorChanged(_) => {
             return Ok(TryFlushWal::RaceLost);
         }
     };

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -183,8 +183,7 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
     )
     .await?
     {
-        ManifestPublicationOutcome::Installed(_)
-        | ManifestPublicationOutcome::AlreadyCurrent(_) => (
+        ManifestPublicationOutcome::Published(_) => (
             FlushWalOutcome::Published,
             manifest.payload.manifest_no,
             manifest.payload.head_seq,
@@ -202,6 +201,7 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
         ManifestPublicationOutcome::PredecessorChanged(_) => {
             return Ok(TryFlushWal::RaceLost);
         }
+        ManifestPublicationOutcome::RootCasRaceLost => return Ok(TryFlushWal::RaceLost),
     };
     Ok(TryFlushWal::Settled(Box::new(FlushedBasis {
         manifest: manifest_ref_for(namespace_id, &manifest),

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -2,8 +2,6 @@
 //! advance `metadata/root.json` by monotonic compare-and-swap.
 
 use super::error::ManifestLoadError;
-use crate::commit::CommitHeadPublishError;
-use crate::control_update::{retry_while_contended, CasAttempt};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::control::load_metadata_root_object_if_present;
@@ -16,21 +14,17 @@ use loonfs_api::{ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_manifest_object, metadata_root};
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
 
-/// What a publication attempt did to `metadata/root.json`.
+/// The result of trying to publish a manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ManifestPublicationOutcome {
-    /// This call installed the candidate.
-    Installed(MetadataRootState),
-    /// The root already names this exact candidate, which is how an unknown
-    /// write outcome resolves when the swap did land.
-    AlreadyCurrent(MetadataRootState),
-    /// The current root dominates the candidate, so it already covers the
-    /// candidate's work. The candidate manifest stays durable and unreferenced.
+    /// The candidate is the current root.
+    Published(MetadataRootState),
+    /// The current root already covers the candidate's state.
     CoveredByCurrent(MetadataRootState),
-    /// The expected predecessor is no longer current and the root that
-    /// replaced it does not cover the candidate. The caller must rebuild
-    /// against this root.
+    /// The expected predecessor changed without covering the candidate.
     PredecessorChanged(MetadataRootState),
+    /// The root changed during the compare-and-swap and should be retried.
+    RootCasRaceLost,
 }
 
 #[tracing::instrument(
@@ -118,63 +112,33 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
     expected_predecessor: Option<ManifestObjectId>,
     updated_at_ms: u64,
 ) -> Result<ManifestPublicationOutcome> {
-    // Manifest publication CASes metadata/root.json, never the WAL head:
-    // head watchers see only commits. Updates are monotonic in
-    // manifest_head_seq; a same-seq replacement may reference a different
-    // manifest (pure compaction), and a lower-seq attempt no-ops in favor of
-    // whatever newer root someone else already published.
-    //
-    // A swap that loses while the expected predecessor is still current is
-    // contention on this one object, and it is retried here. Every semantic
-    // outcome goes back to the caller, because rebuilding costs vary by
-    // operation.
+    // Manifest publication updates the metadata root, not the WAL head. A
+    // candidate may replace only the predecessor it was built from.
     let candidate = manifest_ref_for(namespace_id, manifest);
-    let candidate = &candidate;
-    let expected_predecessor = expected_predecessor.as_ref();
-    let published = retry_while_contended(|| async move {
-        try_publish_metadata_root(
-            store,
-            namespace_id,
-            candidate,
-            expected_predecessor,
-            updated_at_ms,
-        )
-        .await
-    })
-    .await?;
-    // Losing every attempt is the same signal a flush reports when it loses
-    // every rebuild, so callers keep one retry classification.
-    published.ok_or(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
-}
-
-/// One read, decision, and swap against the root loaded with its ETag.
-async fn try_publish_metadata_root<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    candidate: &ManifestRef,
-    expected_predecessor: Option<&ManifestObjectId>,
-    updated_at_ms: u64,
-) -> Result<CasAttempt<ManifestPublicationOutcome>> {
     let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?
     else {
-        return match create_first_metadata_root(store, namespace_id, candidate, updated_at_ms)
+        return match create_first_metadata_root(store, namespace_id, &candidate, updated_at_ms)
             .await?
         {
-            Some(installed) => Ok(CasAttempt::Settled(ManifestPublicationOutcome::Installed(
-                installed,
-            ))),
+            Some(root) => Ok(ManifestPublicationOutcome::Published(root)),
             None => {
-                classify_current_root(store, namespace_id, candidate, expected_predecessor).await
+                classify_current_root(
+                    store,
+                    namespace_id,
+                    &candidate,
+                    expected_predecessor.as_ref(),
+                )
+                .await
             }
         };
     };
-    match root_transition(&loaded.state, candidate, expected_predecessor) {
+    match root_transition(&loaded.state, &candidate, expected_predecessor.as_ref()) {
         RootTransition::InstallAgainstCurrent => {}
-        decided => return Ok(attempt_from(loaded.state, decided)),
+        transition => return Ok(outcome_from(loaded.state, transition)),
     }
-    ensure_legal_successor(namespace_id, candidate, &loaded.state.manifest)?;
+    ensure_legal_successor(namespace_id, &candidate, &loaded.state.manifest)?;
     let next = MetadataRootState {
         namespace_id: namespace_id.clone(),
         manifest: candidate.clone(),
@@ -191,47 +155,51 @@ async fn try_publish_metadata_root<S: ObjectStore + ?Sized>(
         .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
         .await
     {
-        Ok(_) => Ok(CasAttempt::Settled(ManifestPublicationOutcome::Installed(
-            next,
-        ))),
+        Ok(_) => Ok(ManifestPublicationOutcome::Published(next)),
         Err(ObjectStoreError::PreconditionFailed { .. }) => {
-            classify_current_root(store, namespace_id, candidate, expected_predecessor).await
+            classify_current_root(
+                store,
+                namespace_id,
+                &candidate,
+                expected_predecessor.as_ref(),
+            )
+            .await
         }
-        // An unknown outcome is resolved by reading the root, never by
-        // repeating the swap. The store error stands only while the root
-        // still shows the untouched predecessor.
+        // Re-read the root to resolve an unknown write outcome.
         Err(error) => {
-            match classify_current_root(store, namespace_id, candidate, expected_predecessor)
-                .await?
+            match classify_current_root(
+                store,
+                namespace_id,
+                &candidate,
+                expected_predecessor.as_ref(),
+            )
+            .await?
             {
-                CasAttempt::Contended => Err(CoreError::store(&loaded.object_key, &error)),
-                settled => Ok(settled),
+                ManifestPublicationOutcome::RootCasRaceLost => {
+                    Err(CoreError::store(&loaded.object_key, &error))
+                }
+                outcome => Ok(outcome),
             }
         }
     }
 }
 
-/// The four states a candidate can be in against the current root.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RootTransition {
     InstallAgainstCurrent,
-    AlreadyCurrent,
+    Published,
     CoveredByCurrent,
     PredecessorChanged,
 }
 
-/// Classifies the current root against the candidate and its expected
-/// predecessor.
-///
-/// A candidate may replace only its expected predecessor. This prevents stale
-/// work from overwriting a sibling publication, even at a higher head sequence.
+/// A candidate may replace only the predecessor it was built from.
 fn root_transition(
     root: &MetadataRootState,
     candidate: &ManifestRef,
     expected_predecessor: Option<&ManifestObjectId>,
 ) -> RootTransition {
     if root.manifest == *candidate {
-        return RootTransition::AlreadyCurrent;
+        return RootTransition::Published;
     }
     if root_supersedes_candidate(root, candidate) {
         return RootTransition::CoveredByCurrent;
@@ -244,48 +212,33 @@ fn root_transition(
     }
 }
 
-/// Maps a decided transition onto one attempt's result. An expected
-/// predecessor that is still current after a swap attempt is contention on
-/// this one object, so the attempt repeats instead of reporting a race.
-fn attempt_from(
-    root: MetadataRootState,
-    transition: RootTransition,
-) -> CasAttempt<ManifestPublicationOutcome> {
+fn outcome_from(root: MetadataRootState, transition: RootTransition) -> ManifestPublicationOutcome {
     match transition {
-        RootTransition::InstallAgainstCurrent => CasAttempt::Contended,
-        RootTransition::AlreadyCurrent => {
-            CasAttempt::Settled(ManifestPublicationOutcome::AlreadyCurrent(root))
-        }
-        RootTransition::CoveredByCurrent => {
-            CasAttempt::Settled(ManifestPublicationOutcome::CoveredByCurrent(root))
-        }
-        RootTransition::PredecessorChanged => {
-            CasAttempt::Settled(ManifestPublicationOutcome::PredecessorChanged(root))
-        }
+        RootTransition::InstallAgainstCurrent => ManifestPublicationOutcome::RootCasRaceLost,
+        RootTransition::Published => ManifestPublicationOutcome::Published(root),
+        RootTransition::CoveredByCurrent => ManifestPublicationOutcome::CoveredByCurrent(root),
+        RootTransition::PredecessorChanged => ManifestPublicationOutcome::PredecessorChanged(root),
     }
 }
 
-/// Re-reads the root after a lost or unconfirmed swap and classifies it.
+/// Re-reads the root after a lost or unconfirmed compare-and-swap.
 async fn classify_current_root<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     candidate: &ManifestRef,
     expected_predecessor: Option<&ManifestObjectId>,
-) -> Result<CasAttempt<ManifestPublicationOutcome>> {
+) -> Result<ManifestPublicationOutcome> {
     let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?
     else {
-        return Ok(CasAttempt::Contended);
+        return Ok(ManifestPublicationOutcome::RootCasRaceLost);
     };
     let transition = root_transition(&loaded.state, candidate, expected_predecessor);
-    Ok(attempt_from(loaded.state, transition))
+    Ok(outcome_from(loaded.state, transition))
 }
 
-/// Rejects a candidate that may not replace the predecessor it names.
-///
-/// Every caller derives its candidate from the predecessor's own manifest, so
-/// a violation is a construction bug rather than a race.
+/// Rejects a candidate that does not advance its predecessor.
 fn ensure_legal_successor(
     namespace_id: &NamespaceId,
     candidate: &ManifestRef,
@@ -350,102 +303,4 @@ fn root_supersedes_candidate(current: &MetadataRootState, candidate: &ManifestRe
     current.manifest.manifest_head_seq > candidate.manifest_head_seq
         || (current.manifest.manifest_head_seq == candidate.manifest_head_seq
             && current.manifest.manifest_no >= candidate.manifest_no)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use loonfs_api::{ChangeSeq, ManifestNo};
-
-    /// One root shape the candidate can meet. A reread after a lost or
-    /// unconfirmed swap lands on these same rows; `tests/cas_recovery.rs`
-    /// drives the store plumbing that reaches them.
-    struct TransitionCase {
-        name: &'static str,
-        root: ManifestRef,
-        expected_predecessor: Option<ManifestObjectId>,
-        expected: RootTransition,
-    }
-
-    fn namespace_id() -> NamespaceId {
-        NamespaceId::parse("demo").expect("valid namespace id")
-    }
-
-    fn manifest_ref(manifest_no: u64, head_seq: u64, distinguisher: u64) -> ManifestRef {
-        ManifestRef {
-            owner_namespace_id: namespace_id(),
-            manifest_no: ManifestNo(manifest_no),
-            manifest_object_id: ManifestObjectId::parse(format!(
-                "man_{manifest_no:020}-{distinguisher:016x}"
-            ))
-            .expect("valid manifest object id"),
-            manifest_head_seq: ChangeSeq(head_seq),
-            manifest_payload_checksum: "checksum".to_owned(),
-        }
-    }
-
-    #[test]
-    fn each_current_root_shape_classifies_the_candidate_it_faces() {
-        let candidate = manifest_ref(2, 20, 1);
-        let predecessor = manifest_ref(1, 10, 2);
-        let after_predecessor = Some(predecessor.manifest_object_id.clone());
-        let cases = [
-            TransitionCase {
-                name: "the root already names the candidate",
-                root: candidate.clone(),
-                expected_predecessor: after_predecessor.clone(),
-                expected: RootTransition::AlreadyCurrent,
-            },
-            TransitionCase {
-                name: "the root is at a higher head sequence",
-                root: manifest_ref(1, 30, 3),
-                expected_predecessor: after_predecessor.clone(),
-                expected: RootTransition::CoveredByCurrent,
-            },
-            TransitionCase {
-                name: "the root is at the same head sequence with a higher manifest number",
-                root: manifest_ref(3, 20, 4),
-                expected_predecessor: after_predecessor.clone(),
-                expected: RootTransition::CoveredByCurrent,
-            },
-            TransitionCase {
-                name: "the root is a same-generation sibling of the candidate",
-                root: manifest_ref(2, 20, 5),
-                expected_predecessor: after_predecessor.clone(),
-                expected: RootTransition::CoveredByCurrent,
-            },
-            TransitionCase {
-                name: "the expected predecessor is still current",
-                root: predecessor.clone(),
-                expected_predecessor: after_predecessor.clone(),
-                expected: RootTransition::InstallAgainstCurrent,
-            },
-            TransitionCase {
-                name: "the predecessor was replaced by a root behind the candidate",
-                root: manifest_ref(2, 10, 6),
-                expected_predecessor: after_predecessor,
-                expected: RootTransition::PredecessorChanged,
-            },
-            TransitionCase {
-                name: "another writer won the first root and it is behind the candidate",
-                root: manifest_ref(1, 10, 7),
-                expected_predecessor: None,
-                expected: RootTransition::PredecessorChanged,
-            },
-        ];
-
-        for case in cases {
-            let root = MetadataRootState {
-                namespace_id: namespace_id(),
-                manifest: case.root,
-                updated_at_ms: 1,
-            };
-            assert_eq!(
-                root_transition(&root, &candidate, case.expected_predecessor.as_ref()),
-                case.expected,
-                "{}",
-                case.name
-            );
-        }
-    }
 }

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -2,6 +2,8 @@
 //! advance `metadata/root.json` by monotonic compare-and-swap.
 
 use super::error::ManifestLoadError;
+use crate::commit::CommitHeadPublishError;
+use crate::control_update::{retry_while_contended, CasAttempt};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::control::load_metadata_root_object_if_present;
@@ -11,17 +13,24 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::wire::manifest::{encode_namespace_manifest_json, NamespaceManifestEnvelope};
 use loonfs_api::{ManifestObjectId, NamespaceId};
-use loonfs_objectstore::keys::metadata_manifest_object;
+use loonfs_objectstore::keys::{metadata_manifest_object, metadata_root};
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
 
+/// What a publication attempt did to `metadata/root.json`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ManifestPublicationOutcome {
-    Published(MetadataRootState),
-    /// Someone already published something at least as new; the caller's
-    /// manifest stays durable and valid, the newer root simply wins.
-    Superseded(MetadataRootState),
-    /// The root changed, but the candidate can still be retried.
-    RootCasRaceLost,
+    /// This call installed the candidate.
+    Installed(MetadataRootState),
+    /// The root already names this exact candidate, which is how an unknown
+    /// write outcome resolves when the swap did land.
+    AlreadyCurrent(MetadataRootState),
+    /// The current root dominates the candidate, so it already covers the
+    /// candidate's work. The candidate manifest stays durable and unreferenced.
+    CoveredByCurrent(MetadataRootState),
+    /// The expected predecessor is no longer current and the root that
+    /// replaced it does not cover the candidate. The caller must rebuild
+    /// against this root.
+    PredecessorChanged(MetadataRootState),
 }
 
 #[tracing::instrument(
@@ -115,25 +124,57 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
     // manifest (pure compaction), and a lower-seq attempt no-ops in favor of
     // whatever newer root someone else already published.
     //
-    // Callers own the retry policy because rebuilding costs vary by operation.
+    // A swap that loses while the expected predecessor is still current is
+    // contention on this one object, and it is retried here. Every semantic
+    // outcome goes back to the caller, because rebuilding costs vary by
+    // operation.
     let candidate = manifest_ref_for(namespace_id, manifest);
+    let candidate = &candidate;
+    let expected_predecessor = expected_predecessor.as_ref();
+    let published = retry_while_contended(|| async move {
+        try_publish_metadata_root(
+            store,
+            namespace_id,
+            candidate,
+            expected_predecessor,
+            updated_at_ms,
+        )
+        .await
+    })
+    .await?;
+    // Losing every attempt is the same signal a flush reports when it loses
+    // every rebuild, so callers keep one retry classification.
+    published.ok_or(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
+}
+
+/// One read, decision, and swap against the root loaded with its ETag.
+async fn try_publish_metadata_root<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidate: &ManifestRef,
+    expected_predecessor: Option<&ManifestObjectId>,
+    updated_at_ms: u64,
+) -> Result<CasAttempt<ManifestPublicationOutcome>> {
     let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?
     else {
-        return match create_first_metadata_root(store, namespace_id, &candidate, updated_at_ms)
+        return match create_first_metadata_root(store, namespace_id, candidate, updated_at_ms)
             .await?
         {
-            Some(published) => Ok(ManifestPublicationOutcome::Published(published)),
+            Some(installed) => Ok(CasAttempt::Settled(ManifestPublicationOutcome::Installed(
+                installed,
+            ))),
             None => {
-                resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor).await
+                classify_current_root(store, namespace_id, candidate, expected_predecessor).await
             }
         };
     };
-    match root_decision(loaded.state, &candidate, &expected_predecessor) {
-        ManifestPublicationOutcome::RootCasRaceLost => {}
-        decided => return Ok(decided),
+    match root_transition(&loaded.state, candidate, expected_predecessor) {
+        RootTransition::InstallAgainstCurrent => {}
+        decided => return Ok(attempt_from(loaded.state, decided)),
     }
+    ensure_legal_successor(namespace_id, candidate, &loaded.state.manifest)?;
     let next = MetadataRootState {
         namespace_id: namespace_id.clone(),
         manifest: candidate.clone(),
@@ -150,61 +191,116 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
         .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
         .await
     {
-        Ok(_) => Ok(ManifestPublicationOutcome::Published(next)),
+        Ok(_) => Ok(CasAttempt::Settled(ManifestPublicationOutcome::Installed(
+            next,
+        ))),
         Err(ObjectStoreError::PreconditionFailed { .. }) => {
-            resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor).await
+            classify_current_root(store, namespace_id, candidate, expected_predecessor).await
         }
-        // Re-read the root to resolve an unknown write outcome.
+        // An unknown outcome is resolved by reading the root, never by
+        // repeating the swap. The store error stands only while the root
+        // still shows the untouched predecessor.
         Err(error) => {
-            match resolve_lost_root_swap(store, namespace_id, &candidate, &expected_predecessor)
+            match classify_current_root(store, namespace_id, candidate, expected_predecessor)
                 .await?
             {
-                ManifestPublicationOutcome::RootCasRaceLost => {
-                    Err(CoreError::store(&loaded.object_key, &error))
-                }
-                outcome => Ok(outcome),
+                CasAttempt::Contended => Err(CoreError::store(&loaded.object_key, &error)),
+                settled => Ok(settled),
             }
         }
     }
 }
 
-/// Decides whether the current root accepts, supersedes, or leaves the candidate retryable.
+/// The four states a candidate can be in against the current root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RootTransition {
+    InstallAgainstCurrent,
+    AlreadyCurrent,
+    CoveredByCurrent,
+    PredecessorChanged,
+}
+
+/// Classifies the current root against the candidate and its expected
+/// predecessor.
 ///
 /// A candidate may replace only its expected predecessor. This prevents stale
 /// work from overwriting a sibling publication, even at a higher head sequence.
-fn root_decision(
-    root: MetadataRootState,
+fn root_transition(
+    root: &MetadataRootState,
     candidate: &ManifestRef,
-    expected_predecessor: &Option<ManifestObjectId>,
-) -> ManifestPublicationOutcome {
+    expected_predecessor: Option<&ManifestObjectId>,
+) -> RootTransition {
     if root.manifest == *candidate {
-        return ManifestPublicationOutcome::Published(root);
+        return RootTransition::AlreadyCurrent;
     }
-    if root_supersedes_candidate(&root, candidate) {
-        return ManifestPublicationOutcome::Superseded(root);
+    if root_supersedes_candidate(root, candidate) {
+        return RootTransition::CoveredByCurrent;
     }
     match expected_predecessor {
         Some(predecessor) if root.manifest.manifest_object_id == *predecessor => {
-            ManifestPublicationOutcome::RootCasRaceLost
+            RootTransition::InstallAgainstCurrent
         }
-        _ => ManifestPublicationOutcome::Superseded(root),
+        _ => RootTransition::PredecessorChanged,
     }
 }
 
-/// Re-reads the root after a lost or unconfirmed swap.
-async fn resolve_lost_root_swap<S: ObjectStore + ?Sized>(
+/// Maps a decided transition onto one attempt's result. An expected
+/// predecessor that is still current after a swap attempt is contention on
+/// this one object, so the attempt repeats instead of reporting a race.
+fn attempt_from(
+    root: MetadataRootState,
+    transition: RootTransition,
+) -> CasAttempt<ManifestPublicationOutcome> {
+    match transition {
+        RootTransition::InstallAgainstCurrent => CasAttempt::Contended,
+        RootTransition::AlreadyCurrent => {
+            CasAttempt::Settled(ManifestPublicationOutcome::AlreadyCurrent(root))
+        }
+        RootTransition::CoveredByCurrent => {
+            CasAttempt::Settled(ManifestPublicationOutcome::CoveredByCurrent(root))
+        }
+        RootTransition::PredecessorChanged => {
+            CasAttempt::Settled(ManifestPublicationOutcome::PredecessorChanged(root))
+        }
+    }
+}
+
+/// Re-reads the root after a lost or unconfirmed swap and classifies it.
+async fn classify_current_root<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     candidate: &ManifestRef,
-    expected_predecessor: &Option<ManifestObjectId>,
-) -> Result<ManifestPublicationOutcome> {
+    expected_predecessor: Option<&ManifestObjectId>,
+) -> Result<CasAttempt<ManifestPublicationOutcome>> {
     let Some(loaded) = load_metadata_root_object_if_present(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?
     else {
-        return Ok(ManifestPublicationOutcome::RootCasRaceLost);
+        return Ok(CasAttempt::Contended);
     };
-    Ok(root_decision(loaded.state, candidate, expected_predecessor))
+    let transition = root_transition(&loaded.state, candidate, expected_predecessor);
+    Ok(attempt_from(loaded.state, transition))
+}
+
+/// Rejects a candidate that may not replace the predecessor it names.
+///
+/// Every caller derives its candidate from the predecessor's own manifest, so
+/// a violation is a construction bug rather than a race.
+fn ensure_legal_successor(
+    namespace_id: &NamespaceId,
+    candidate: &ManifestRef,
+    predecessor: &ManifestRef,
+) -> Result<()> {
+    if candidate.owner_namespace_id == *namespace_id
+        && candidate.manifest_no > predecessor.manifest_no
+        && candidate.manifest_head_seq >= predecessor.manifest_head_seq
+    {
+        return Ok(());
+    }
+    Err(CoreError::Internal(format!(
+        "manifest `{}` is not a legal successor of `{}` in namespace `{namespace_id}`",
+        candidate.manifest_object_id, predecessor.manifest_object_id
+    )))
 }
 
 /// Publishes the namespace's first `metadata/root.json`.
@@ -216,7 +312,7 @@ async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
     candidate: &ManifestRef,
     updated_at_ms: u64,
 ) -> Result<Option<MetadataRootState>> {
-    let object_key = loonfs_objectstore::keys::metadata_root(namespace_id);
+    let object_key = metadata_root(namespace_id);
     let next = MetadataRootState {
         namespace_id: namespace_id.clone(),
         manifest: candidate.clone(),
@@ -254,4 +350,102 @@ fn root_supersedes_candidate(current: &MetadataRootState, candidate: &ManifestRe
     current.manifest.manifest_head_seq > candidate.manifest_head_seq
         || (current.manifest.manifest_head_seq == candidate.manifest_head_seq
             && current.manifest.manifest_no >= candidate.manifest_no)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loonfs_api::{ChangeSeq, ManifestNo};
+
+    /// One root shape the candidate can meet. A reread after a lost or
+    /// unconfirmed swap lands on these same rows; `tests/cas_recovery.rs`
+    /// drives the store plumbing that reaches them.
+    struct TransitionCase {
+        name: &'static str,
+        root: ManifestRef,
+        expected_predecessor: Option<ManifestObjectId>,
+        expected: RootTransition,
+    }
+
+    fn namespace_id() -> NamespaceId {
+        NamespaceId::parse("demo").expect("valid namespace id")
+    }
+
+    fn manifest_ref(manifest_no: u64, head_seq: u64, distinguisher: u64) -> ManifestRef {
+        ManifestRef {
+            owner_namespace_id: namespace_id(),
+            manifest_no: ManifestNo(manifest_no),
+            manifest_object_id: ManifestObjectId::parse(format!(
+                "man_{manifest_no:020}-{distinguisher:016x}"
+            ))
+            .expect("valid manifest object id"),
+            manifest_head_seq: ChangeSeq(head_seq),
+            manifest_payload_checksum: "checksum".to_owned(),
+        }
+    }
+
+    #[test]
+    fn each_current_root_shape_classifies_the_candidate_it_faces() {
+        let candidate = manifest_ref(2, 20, 1);
+        let predecessor = manifest_ref(1, 10, 2);
+        let after_predecessor = Some(predecessor.manifest_object_id.clone());
+        let cases = [
+            TransitionCase {
+                name: "the root already names the candidate",
+                root: candidate.clone(),
+                expected_predecessor: after_predecessor.clone(),
+                expected: RootTransition::AlreadyCurrent,
+            },
+            TransitionCase {
+                name: "the root is at a higher head sequence",
+                root: manifest_ref(1, 30, 3),
+                expected_predecessor: after_predecessor.clone(),
+                expected: RootTransition::CoveredByCurrent,
+            },
+            TransitionCase {
+                name: "the root is at the same head sequence with a higher manifest number",
+                root: manifest_ref(3, 20, 4),
+                expected_predecessor: after_predecessor.clone(),
+                expected: RootTransition::CoveredByCurrent,
+            },
+            TransitionCase {
+                name: "the root is a same-generation sibling of the candidate",
+                root: manifest_ref(2, 20, 5),
+                expected_predecessor: after_predecessor.clone(),
+                expected: RootTransition::CoveredByCurrent,
+            },
+            TransitionCase {
+                name: "the expected predecessor is still current",
+                root: predecessor.clone(),
+                expected_predecessor: after_predecessor.clone(),
+                expected: RootTransition::InstallAgainstCurrent,
+            },
+            TransitionCase {
+                name: "the predecessor was replaced by a root behind the candidate",
+                root: manifest_ref(2, 10, 6),
+                expected_predecessor: after_predecessor,
+                expected: RootTransition::PredecessorChanged,
+            },
+            TransitionCase {
+                name: "another writer won the first root and it is behind the candidate",
+                root: manifest_ref(1, 10, 7),
+                expected_predecessor: None,
+                expected: RootTransition::PredecessorChanged,
+            },
+        ];
+
+        for case in cases {
+            let root = MetadataRootState {
+                namespace_id: namespace_id(),
+                manifest: case.root,
+                updated_at_ms: 1,
+            };
+            assert_eq!(
+                root_transition(&root, &candidate, case.expected_predecessor.as_ref()),
+                case.expected,
+                "{}",
+                case.name
+            );
+        }
+    }
 }

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -326,8 +326,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     )
     .await?
     {
-        ManifestPublicationOutcome::Installed(_)
-        | ManifestPublicationOutcome::AlreadyCurrent(_) => Ok(report(
+        ManifestPublicationOutcome::Published(_) => Ok(report(
             namespace_id,
             MetadataReorganizeOutcome::UnitPublished {
                 group,
@@ -340,7 +339,8 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             },
         )),
         ManifestPublicationOutcome::CoveredByCurrent(_)
-        | ManifestPublicationOutcome::PredecessorChanged(_) => {
+        | ManifestPublicationOutcome::PredecessorChanged(_)
+        | ManifestPublicationOutcome::RootCasRaceLost => {
             Ok(report(namespace_id, MetadataReorganizeOutcome::Superseded))
         }
     }

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -326,7 +326,8 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     )
     .await?
     {
-        ManifestPublicationOutcome::Published(_) => Ok(report(
+        ManifestPublicationOutcome::Installed(_)
+        | ManifestPublicationOutcome::AlreadyCurrent(_) => Ok(report(
             namespace_id,
             MetadataReorganizeOutcome::UnitPublished {
                 group,
@@ -338,7 +339,8 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
                 bottom_anchored_merge_blocked,
             },
         )),
-        ManifestPublicationOutcome::Superseded(_) | ManifestPublicationOutcome::RootCasRaceLost => {
+        ManifestPublicationOutcome::CoveredByCurrent(_)
+        | ManifestPublicationOutcome::PredecessorChanged(_) => {
             Ok(report(namespace_id, MetadataReorganizeOutcome::Superseded))
         }
     }

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -669,11 +669,12 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         .await?;
         drop(segments);
         let lost_to = match published {
-            ManifestPublicationOutcome::Published(_) => {
+            ManifestPublicationOutcome::Installed(_)
+            | ManifestPublicationOutcome::AlreadyCurrent(_) => {
                 return Ok(Finalization::Published(manifest.payload.manifest_no))
             }
-            ManifestPublicationOutcome::Superseded(_) => "a newer root",
-            ManifestPublicationOutcome::RootCasRaceLost => "the root compare-and-swap",
+            ManifestPublicationOutcome::CoveredByCurrent(_) => "covered_by_current",
+            ManifestPublicationOutcome::PredecessorChanged(_) => "predecessor_changed",
         };
         tracing::debug!(
             namespace_id = namespace_id.as_str(),

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -669,12 +669,12 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         .await?;
         drop(segments);
         let lost_to = match published {
-            ManifestPublicationOutcome::Installed(_)
-            | ManifestPublicationOutcome::AlreadyCurrent(_) => {
+            ManifestPublicationOutcome::Published(_) => {
                 return Ok(Finalization::Published(manifest.payload.manifest_no))
             }
             ManifestPublicationOutcome::CoveredByCurrent(_) => "covered_by_current",
             ManifestPublicationOutcome::PredecessorChanged(_) => "predecessor_changed",
+            ManifestPublicationOutcome::RootCasRaceLost => "root_cas_race",
         };
         tracing::debug!(
             namespace_id = namespace_id.as_str(),

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -566,12 +566,21 @@ async fn same_root_checkpoint_builders_write_distinct_manifest_objects_and_loser
     let materialization = load_current_projection(&store, &namespace_id)
         .await
         .expect("materialization");
-    let first_manifest =
-        build_manifest_from_projection(&store, &namespace_id, &materialization, ManifestNo(1))
-            .await;
-    let second_manifest =
-        build_manifest_from_projection(&store, &namespace_id, &materialization, ManifestNo(1))
-            .await;
+    let sibling_manifest_no = ManifestNo(materialization.root.manifest.manifest_no.0 + 1);
+    let first_manifest = build_manifest_from_projection(
+        &store,
+        &namespace_id,
+        &materialization,
+        sibling_manifest_no,
+    )
+    .await;
+    let second_manifest = build_manifest_from_projection(
+        &store,
+        &namespace_id,
+        &materialization,
+        sibling_manifest_no,
+    )
+    .await;
     assert_eq!(
         first_manifest.payload.manifest_no,
         second_manifest.payload.manifest_no
@@ -598,7 +607,7 @@ async fn same_root_checkpoint_builders_write_distinct_manifest_objects_and_loser
     .await
     .expect("first publication succeeds");
     match first_outcome {
-        ManifestPublicationOutcome::Published(root) => {
+        ManifestPublicationOutcome::Installed(root) => {
             assert_eq!(
                 root.manifest.manifest_object_id,
                 first_manifest.payload.manifest_object_id
@@ -617,13 +626,13 @@ async fn same_root_checkpoint_builders_write_distinct_manifest_objects_and_loser
     .await
     .expect("second publication should yield to the published root");
     match second_outcome {
-        ManifestPublicationOutcome::Superseded(root) => {
+        ManifestPublicationOutcome::CoveredByCurrent(root) => {
             assert_eq!(
                 root.manifest.manifest_object_id,
                 first_manifest.payload.manifest_object_id
             );
         }
-        other => panic!("expected second publication to be superseded, got {other:?}"),
+        other => panic!("expected the second publication to be covered, got {other:?}"),
     }
 
     let manifest_objects = store
@@ -796,10 +805,10 @@ async fn lower_seq_root_publication_yields_to_the_newer_root() {
     .expect("manifest publication should classify the newer root");
 
     match outcome {
-        ManifestPublicationOutcome::Superseded(current) => {
+        ManifestPublicationOutcome::CoveredByCurrent(current) => {
             assert_eq!(current.manifest.manifest_no, later_checkpoint.manifest_no);
         }
-        other => panic!("expected superseded outcome, got {other:?}"),
+        other => panic!("expected a covering root, got {other:?}"),
     }
 }
 
@@ -840,7 +849,7 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
             metadata_state: &materialization.metadata_state,
         },
         MetadataLsmPolicy::default(),
-        ManifestNo(1),
+        ManifestNo(materialization.root.manifest.manifest_no.0 + 1),
     )
     .await
     .expect("build manifest");
@@ -849,7 +858,7 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
         .expect("write manifest");
 
     store.fail_all();
-    let outcome = publish_metadata_root(
+    let error = publish_metadata_root(
         &store,
         &namespace_id,
         &manifest,
@@ -857,9 +866,12 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
         context.now_ms,
     )
     .await
-    .expect("root publication should report CAS race");
+    .expect_err("root publication should exhaust its contention retries");
 
-    assert_eq!(outcome, ManifestPublicationOutcome::RootCasRaceLost);
+    assert!(matches!(
+        error,
+        CoreError::HeadPublish(crate::commit::CommitHeadPublishError::StaleHead)
+    ));
 }
 
 #[tokio::test]
@@ -897,7 +909,7 @@ async fn root_cas_transport_error_recovers_when_candidate_was_published() {
             metadata_state: &materialization.metadata_state,
         },
         MetadataLsmPolicy::default(),
-        ManifestNo(1),
+        ManifestNo(materialization.root.manifest.manifest_no.0 + 1),
     )
     .await
     .expect("build manifest");
@@ -917,14 +929,14 @@ async fn root_cas_transport_error_recovers_when_candidate_was_published() {
     .expect("root publication should recover after ambiguous CAS");
 
     match outcome {
-        ManifestPublicationOutcome::Published(root) => {
+        ManifestPublicationOutcome::AlreadyCurrent(root) => {
             assert_eq!(root.manifest.manifest_no, manifest.payload.manifest_no);
             assert_eq!(
                 root.manifest.manifest_object_id,
                 manifest.payload.manifest_object_id
             );
         }
-        other => panic!("expected recovered published root, got {other:?}"),
+        other => panic!("expected the candidate to be found current, got {other:?}"),
     }
 }
 
@@ -951,12 +963,21 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
     let materialization = load_current_projection(&raw_store, &namespace_id)
         .await
         .expect("materialization");
-    let candidate_manifest =
-        build_manifest_from_projection(&raw_store, &namespace_id, &materialization, ManifestNo(1))
-            .await;
-    let competing_manifest =
-        build_manifest_from_projection(&raw_store, &namespace_id, &materialization, ManifestNo(2))
-            .await;
+    let candidate_manifest_no = ManifestNo(materialization.root.manifest.manifest_no.0 + 1);
+    let candidate_manifest = build_manifest_from_projection(
+        &raw_store,
+        &namespace_id,
+        &materialization,
+        candidate_manifest_no,
+    )
+    .await;
+    let competing_manifest = build_manifest_from_projection(
+        &raw_store,
+        &namespace_id,
+        &materialization,
+        ManifestNo(candidate_manifest_no.0 + 1),
+    )
+    .await;
     write_namespace_manifest(&raw_store, &candidate_manifest)
         .await
         .expect("write candidate manifest");
@@ -992,7 +1013,7 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
     .expect("root publication should recover by observing the competing root");
 
     match outcome {
-        ManifestPublicationOutcome::Superseded(root) => {
+        ManifestPublicationOutcome::CoveredByCurrent(root) => {
             assert_eq!(
                 root.manifest.manifest_no,
                 competing_manifest.payload.manifest_no
@@ -1002,7 +1023,7 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
                 competing_manifest.payload.manifest_object_id
             );
         }
-        other => panic!("expected superseded root after ambiguous CAS, got {other:?}"),
+        other => panic!("expected a covering root after an ambiguous CAS, got {other:?}"),
     }
 }
 
@@ -1112,14 +1133,14 @@ async fn same_seq_root_replacement_publishes_a_compacted_manifest() {
     .await
     .expect("same-seq replacement publishes");
     match outcome {
-        ManifestPublicationOutcome::Published(root) => {
+        ManifestPublicationOutcome::Installed(root) => {
             assert_eq!(root.manifest.manifest_no, compacted.payload.manifest_no);
             assert_eq!(
                 root.manifest.manifest_head_seq,
                 materialization.root.manifest.manifest_head_seq
             );
         }
-        other => panic!("expected published compacted root, got {other:?}"),
+        other => panic!("expected the compacted root to install, got {other:?}"),
     }
     // Reads keep working against the replaced root.
     let after = load_current_projection(&store, &namespace_id)
@@ -1306,7 +1327,7 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
     .expect("sibling publication");
     assert!(matches!(
         sibling_outcome,
-        ManifestPublicationOutcome::Published(_)
+        ManifestPublicationOutcome::Installed(_)
     ));
 
     let stale_outcome = publish_metadata_root(
@@ -1319,13 +1340,13 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
     .await
     .expect("stale publication");
     match stale_outcome {
-        ManifestPublicationOutcome::Superseded(root) => {
+        ManifestPublicationOutcome::PredecessorChanged(root) => {
             assert_eq!(
                 root.manifest.manifest_object_id, sibling.payload.manifest_object_id,
                 "the sibling's acknowledged publication must survive"
             );
         }
-        other => panic!("a stale-basis candidate must be superseded, got {other:?}"),
+        other => panic!("a stale-basis candidate must not install, got {other:?}"),
     }
 
     let root_after = load_metadata_root_object(&store, &namespace_id)

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -544,7 +544,7 @@ async fn create_checkpoint_fails_when_its_manifest_key_holds_a_different_payload
 }
 
 #[tokio::test]
-async fn same_root_checkpoint_builders_write_distinct_manifest_objects_and_loser_is_superseded() {
+async fn same_root_publications_keep_the_first_candidate() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -607,7 +607,7 @@ async fn same_root_checkpoint_builders_write_distinct_manifest_objects_and_loser
     .await
     .expect("first publication succeeds");
     match first_outcome {
-        ManifestPublicationOutcome::Installed(root) => {
+        ManifestPublicationOutcome::Published(root) => {
             assert_eq!(
                 root.manifest.manifest_object_id,
                 first_manifest.payload.manifest_object_id
@@ -813,7 +813,7 @@ async fn lower_seq_root_publication_yields_to_the_newer_root() {
 }
 
 #[tokio::test]
-async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
+async fn root_cas_conflict_reports_a_race() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
@@ -858,7 +858,7 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
         .expect("write manifest");
 
     store.fail_all();
-    let error = publish_metadata_root(
+    let outcome = publish_metadata_root(
         &store,
         &namespace_id,
         &manifest,
@@ -866,12 +866,9 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
         context.now_ms,
     )
     .await
-    .expect_err("root publication should exhaust its contention retries");
+    .expect("root publication should report CAS contention");
 
-    assert!(matches!(
-        error,
-        CoreError::HeadPublish(crate::commit::CommitHeadPublishError::StaleHead)
-    ));
+    assert_eq!(outcome, ManifestPublicationOutcome::RootCasRaceLost);
 }
 
 #[tokio::test]
@@ -929,7 +926,7 @@ async fn root_cas_transport_error_recovers_when_candidate_was_published() {
     .expect("root publication should recover after ambiguous CAS");
 
     match outcome {
-        ManifestPublicationOutcome::AlreadyCurrent(root) => {
+        ManifestPublicationOutcome::Published(root) => {
             assert_eq!(root.manifest.manifest_no, manifest.payload.manifest_no);
             assert_eq!(
                 root.manifest.manifest_object_id,
@@ -1133,7 +1130,7 @@ async fn same_seq_root_replacement_publishes_a_compacted_manifest() {
     .await
     .expect("same-seq replacement publishes");
     match outcome {
-        ManifestPublicationOutcome::Installed(root) => {
+        ManifestPublicationOutcome::Published(root) => {
             assert_eq!(root.manifest.manifest_no, compacted.payload.manifest_no);
             assert_eq!(
                 root.manifest.manifest_head_seq,
@@ -1263,10 +1260,8 @@ async fn namespace_status_and_change_feed_reload_a_head_behind_the_floor() {
 
 #[tokio::test]
 async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
-    // The review's flush race: a publisher builds from root A while a
-    // sibling publishes B from the same basis, then tries to win on a
-    // higher head. Its carried-forward state predates B, so head ordering
-    // must not decide the winner — the predecessor gate must.
+    // Build two candidates from the same root. The candidate with the newer
+    // WAL head must not overwrite a sibling whose state it does not include.
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1281,7 +1276,7 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
         .await
         .expect("sibling basis");
 
-    // The stale publisher observes a newer head against the same root.
+    // The second candidate observes a newer head against the same root.
     write_file_bytes(&store, &namespace_id, "/two.txt", b"two\n", &context, None)
         .await
         .expect("write two");
@@ -1327,7 +1322,7 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
     .expect("sibling publication");
     assert!(matches!(
         sibling_outcome,
-        ManifestPublicationOutcome::Installed(_)
+        ManifestPublicationOutcome::Published(_)
     ));
 
     let stale_outcome = publish_metadata_root(

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -977,6 +977,7 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
     let materialization = load_current_projection(&store, &namespace_id)
         .await
         .expect("materialization");
+    let covering_manifest_no = ManifestNo(materialization.root.manifest.manifest_no.0 + 1);
     let manifest_without_checkpoint = build_namespace_manifest_from_metadata_state(
         &store,
         &namespace_id,
@@ -987,7 +988,7 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
             metadata_state: &materialization.metadata_state,
         },
         MetadataLsmPolicy::default(),
-        ManifestNo(1),
+        covering_manifest_no,
     )
     .await
     .expect("build manifest");
@@ -1011,13 +1012,13 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
     // With standalone records, pinning a basis that already covers the head
     // writes a checkpoint file against it instead of building a new
     // manifest.
-    assert_eq!(checkpoint.manifest_no, ManifestNo(1));
+    assert_eq!(checkpoint.manifest_no, covering_manifest_no);
     let record = load_checkpoint_record(&store, &namespace_id, &checkpoint.checkpoint_id)
         .await
         .expect("read checkpoint record")
         .expect("record exists")
         .state;
-    assert_eq!(record.manifest.manifest_no, ManifestNo(1));
+    assert_eq!(record.manifest.manifest_no, covering_manifest_no);
     assert_eq!(
         record.manifest.manifest_payload_checksum,
         manifest_without_checkpoint.payload_checksum

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -3319,48 +3319,13 @@ async fn a_cancellation_after_the_last_row_publishes_nothing() {
     );
 }
 
-/// Loses every root compare-and-swap to a competing publisher, and cancels
-/// the job the first time it tries one. Every other compare-and-swap — the
-/// job's own lease heartbeat — goes through, because losing that one would
-/// fence the job instead.
-///
-/// That is the shape a shutdown takes during finalization: attempts are still
-/// available, the races are still there to take, and the job must stop taking
-/// them.
+/// Cancels the job when its first root compare-and-swap fails. Lease updates
+/// still succeed so cancellation, rather than fencing, stops the job.
 #[derive(Debug)]
 struct CancelAtTheFirstPublicationStore {
     inner: LocalFsStore,
-    namespace_id: NamespaceId,
     cancellation: MetadataCompactionCancellation,
     manifests: AtomicUsize,
-}
-
-impl CancelAtTheFirstPublicationStore {
-    /// Republishes the current root one manifest number ahead, which is what
-    /// the swap under it then loses to. The root keeps naming the same
-    /// manifest object, so nothing this job wrote becomes reachable.
-    async fn supersede_the_root(&self) {
-        let loaded = load_metadata_root_object(&self.inner, &self.namespace_id)
-            .await
-            .expect("read the root to supersede");
-        let mut root = loaded.state;
-        root.manifest.manifest_no = ManifestNo(root.manifest.manifest_no.0 + 1);
-        let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
-            loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-            root,
-        )
-        .expect("root envelope");
-        let bytes =
-            loonfs_api::wire::control::encode_control_object(&envelope).expect("root bytes");
-        self.inner
-            .put(
-                &loonfs_objectstore::keys::metadata_root(&self.namespace_id),
-                Bytes::from(bytes),
-                PutMode::Overwrite,
-            )
-            .await
-            .expect("supersede the root");
-    }
 }
 
 #[async_trait]
@@ -3391,8 +3356,10 @@ impl ObjectStore for CancelAtTheFirstPublicationStore {
             self.manifests.fetch_add(1, Ordering::SeqCst);
         }
         if key.ends_with("/metadata/root.json") && matches!(mode, PutMode::CompareAndSwap { .. }) {
-            self.supersede_the_root().await;
             self.cancellation.cancel();
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
         }
         self.inner.put(key, bytes, mode).await
     }
@@ -3435,7 +3402,6 @@ async fn a_cancelled_finalization_does_not_take_the_races_it_has_left() {
 
     let cancelling_store = CancelAtTheFirstPublicationStore {
         inner: LocalFsStore::new(temp_dir.path()).expect("store"),
-        namespace_id: namespace_id.clone(),
         cancellation: cancellation.clone(),
         manifests: AtomicUsize::new(0),
     };

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -3319,9 +3319,10 @@ async fn a_cancellation_after_the_last_row_publishes_nothing() {
     );
 }
 
-/// Fails every root compare-and-swap, and cancels the job the first time it
-/// tries one. Every other compare-and-swap — the job's own lease heartbeat —
-/// goes through, because losing that one would fence the job instead.
+/// Loses every root compare-and-swap to a competing publisher, and cancels
+/// the job the first time it tries one. Every other compare-and-swap — the
+/// job's own lease heartbeat — goes through, because losing that one would
+/// fence the job instead.
 ///
 /// That is the shape a shutdown takes during finalization: attempts are still
 /// available, the races are still there to take, and the job must stop taking
@@ -3329,8 +3330,37 @@ async fn a_cancellation_after_the_last_row_publishes_nothing() {
 #[derive(Debug)]
 struct CancelAtTheFirstPublicationStore {
     inner: LocalFsStore,
+    namespace_id: NamespaceId,
     cancellation: MetadataCompactionCancellation,
     manifests: AtomicUsize,
+}
+
+impl CancelAtTheFirstPublicationStore {
+    /// Republishes the current root one manifest number ahead, which is what
+    /// the swap under it then loses to. The root keeps naming the same
+    /// manifest object, so nothing this job wrote becomes reachable.
+    async fn supersede_the_root(&self) {
+        let loaded = load_metadata_root_object(&self.inner, &self.namespace_id)
+            .await
+            .expect("read the root to supersede");
+        let mut root = loaded.state;
+        root.manifest.manifest_no = ManifestNo(root.manifest.manifest_no.0 + 1);
+        let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+            loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
+            root,
+        )
+        .expect("root envelope");
+        let bytes =
+            loonfs_api::wire::control::encode_control_object(&envelope).expect("root bytes");
+        self.inner
+            .put(
+                &loonfs_objectstore::keys::metadata_root(&self.namespace_id),
+                Bytes::from(bytes),
+                PutMode::Overwrite,
+            )
+            .await
+            .expect("supersede the root");
+    }
 }
 
 #[async_trait]
@@ -3361,10 +3391,8 @@ impl ObjectStore for CancelAtTheFirstPublicationStore {
             self.manifests.fetch_add(1, Ordering::SeqCst);
         }
         if key.ends_with("/metadata/root.json") && matches!(mode, PutMode::CompareAndSwap { .. }) {
+            self.supersede_the_root().await;
             self.cancellation.cancel();
-            return Err(ObjectStoreError::PreconditionFailed {
-                object_key: key.to_owned(),
-            });
         }
         self.inner.put(key, bytes, mode).await
     }
@@ -3407,6 +3435,7 @@ async fn a_cancelled_finalization_does_not_take_the_races_it_has_left() {
 
     let cancelling_store = CancelAtTheFirstPublicationStore {
         inner: LocalFsStore::new(temp_dir.path()).expect("store"),
+        namespace_id: namespace_id.clone(),
         cancellation: cancellation.clone(),
         manifests: AtomicUsize::new(0),
     };


### PR DESCRIPTION
Separates the manifest publication results that callers need to handle differently: the candidate is current, another root already covers it, its expected predecessor changed, or the root compare-and-swap lost a race.

Flushes rebuild only when the current root does not cover their target. Reorganization and streaming compaction can continue treating covered or stale work as superseded, while ambiguous write outcomes are resolved by rereading the root. A candidate must also advance its predecessor's manifest number without moving the head sequence backward.