### PR TITLE
refactor(core): load namespace control state consistently

### DIFF
--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -23,9 +23,8 @@ use crate::error::MetadataProjectionLoadError;
 use crate::error::Result;
 use crate::limits::METADATA_PUBLICATION_BUDGET_MS;
 use crate::metadata::MetadataState;
-use crate::namespace::basis::{
-    load_head_and_metadata_basis, resolve_retention_floor_seq, MetadataBasis,
-};
+use crate::namespace::basis::MetadataBasis;
+use crate::namespace::control_snapshot::load_control_snapshot;
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use crate::wal::{
     ensure_replayed_head_matches, load_validated_wal_chain, project_validated_wal_tail,
@@ -227,10 +226,12 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     namespace_id: &NamespaceId,
 ) -> Result<RootProjection<'a, S>> {
-    let loaded = load_head_and_metadata_basis(store, namespace_id)
+    let snapshot = load_control_snapshot(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    let head = loaded.head.state;
+    let basis = snapshot.basis();
+    let floor_seq = snapshot.retention_floor_seq;
+    let head = snapshot.head.state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::MetadataProjection(
             MetadataProjectionLoadError::NamespaceDeleted {
@@ -238,13 +239,9 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
             },
         ));
     }
-    let floor_seq = resolve_retention_floor_seq(store, &head)
-        .await
-        .map_err(CoreError::ControlObjectLoad)?;
-    let basis =
-        load_basis_metadata_segments(store, None, namespace_id, &loaded.basis, head.created_at_ms)
-            .await?;
-    let manifest_segments = basis.segments;
+    let loaded_basis =
+        load_basis_metadata_segments(store, None, namespace_id, &basis, head.created_at_ms).await?;
+    let manifest_segments = loaded_basis.segments;
     let manifest_head = head_from_manifest(&head, manifest_segments.manifest());
     let wal_chain = load_validated_wal_chain(
         store,
@@ -266,7 +263,7 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
             tracing::debug_span!("loonfs.phase", phase = "project_metadata_state").entered();
         project_validated_wal_tail(
             &manifest_head,
-            &basis.base_state,
+            &loaded_basis.base_state,
             Some(head.writer_epoch),
             &wal_chain,
         )
@@ -276,7 +273,7 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
     ensure_replayed_head_matches(&head, &replayed.resulting_head)?;
     Ok(RootProjection {
         head,
-        basis: loaded.basis,
+        basis,
         floor_seq,
         manifest_segments,
         tail_state: replayed.resulting_metadata_state,

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -16,8 +16,8 @@ use crate::control_update::{
 };
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::limits::FORK_CHECKPOINT_LEASE_MS;
-use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::load_head_object;
+use crate::namespace::control_snapshot::resolve_retention_floor_seq;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_state, CheckpointOwner, CheckpointRecordState, CheckpointStatus,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -24,8 +24,7 @@ use super::scan::VerifiedMetadataSegments;
 use super::streaming_compaction::{merge_group_in_step, MetadataCompactionSpec};
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
-use crate::namespace::basis::resolve_retention_floor_seq;
-use crate::namespace::control::{load_head_object, load_metadata_root_object_if_present};
+use crate::namespace::control_snapshot::load_control_snapshot;
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::manifest::{
     MetadataSegmentRef, NamespaceManifestEnvelope, NamespaceManifestPayload,
@@ -192,13 +191,17 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     // before any segment object is written and gates the root
     // compare-and-swap below.
     let publication_started_ms = timer.monotonic_now_ms();
+    // The floor is read with the root rather than after the plan, because a
+    // plan that hands the group to a streaming compaction carries the floor
+    // that job will judge every row against, and the spec it carries is
+    // immutable for the job's life.
+    let snapshot = load_control_snapshot(store, namespace_id)
+        .await
+        .map_err(CoreError::ControlObjectLoad)?;
+    let floor_seq = snapshot.retention_floor_seq;
     // A namespace that has published no manifest of its own has no runs to
     // fold: reorganization has nothing to do until its first flush.
-    let Some(root) = load_metadata_root_object_if_present(store, namespace_id)
-        .await
-        .map_err(CoreError::ControlObjectLoad)?
-        .map(|loaded| loaded.state)
-    else {
+    let Some(root) = snapshot.root.map(|loaded| loaded.state) else {
         return Ok(report(
             namespace_id,
             MetadataReorganizeOutcome::NotNeeded { delta_runs: 0 },
@@ -232,17 +235,6 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             MetadataReorganizeOutcome::NotNeeded { delta_runs },
         ));
     };
-    // The floor is read before the plan rather than after it, because a plan
-    // that hands the group to a streaming compaction carries the floor that
-    // job will judge every row against, and the spec it carries is immutable
-    // for the job's life.
-    let head = load_head_object(store, namespace_id)
-        .await
-        .map_err(CoreError::ControlObjectLoad)?
-        .state;
-    let floor_seq = resolve_retention_floor_seq(store, &head)
-        .await
-        .map_err(CoreError::ControlObjectLoad)?;
     let selection = select_reorganization_input(
         &segments,
         group,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -191,10 +191,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     // before any segment object is written and gates the root
     // compare-and-swap below.
     let publication_started_ms = timer.monotonic_now_ms();
-    // The floor is read with the root rather than after the plan, because a
-    // plan that hands the group to a streaming compaction carries the floor
-    // that job will judge every row against, and the spec it carries is
-    // immutable for the job's life.
+    // A streaming compaction keeps the floor read with this root.
     let snapshot = load_control_snapshot(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -8,10 +8,10 @@ use crate::control_object::ControlObjectLoadError;
 use crate::control_update::{retry_while_contended, CasAttempt};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
-use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::{
     load_head_object, load_metadata_root_object_if_present, load_wal_floor_object,
 };
+use crate::namespace::control_snapshot::resolve_retention_floor_seq;
 use bytes::Bytes;
 use loonfs_api::wire::control::{encode_control_state, ControlObjectKind, WalFloorState};
 use loonfs_api::wire::manifest::NamespaceManifestEnvelope;

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -225,15 +225,17 @@ impl ObjectStore for FloorRaiseOnCasConflictStore {
     }
 }
 
+/// Serves one captured version of `key` to the first reader, then the store's
+/// own current bytes.
 #[derive(Debug)]
-struct StaleHeadOnceStore {
+struct StaleObjectOnceStore {
     inner: LocalFsStore,
-    head_key: String,
-    stale_head: std::sync::Mutex<Option<ObjectBody>>,
+    key: String,
+    stale: std::sync::Mutex<Option<ObjectBody>>,
 }
 
 #[async_trait]
-impl ObjectStore for StaleHeadOnceStore {
+impl ObjectStore for StaleObjectOnceStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         self.inner.head(key).await
     }
@@ -247,8 +249,8 @@ impl ObjectStore for StaleHeadOnceStore {
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        if key == self.head_key {
-            if let Some(stale) = self.stale_head.lock().expect("stale head lock").take() {
+        if key == self.key {
+            if let Some(stale) = self.stale.lock().expect("stale object lock").take() {
                 return Ok(Some(stale));
             }
         }
@@ -1184,10 +1186,10 @@ async fn read_anchor_reloads_the_head_when_the_root_is_ahead() {
         .await
         .expect("create checkpoint");
 
-    let store = StaleHeadOnceStore {
+    let store = StaleObjectOnceStore {
         inner,
-        head_key: wal_head(&namespace_id),
-        stale_head: std::sync::Mutex::new(Some(stale_head)),
+        key: wal_head(&namespace_id),
+        stale: std::sync::Mutex::new(Some(stale_head)),
     };
     let projection = load_current_projection(&store, &namespace_id)
         .await
@@ -1230,10 +1232,10 @@ async fn namespace_status_and_change_feed_reload_a_head_behind_the_floor() {
         .await
         .expect("advance retention");
 
-    let status_store = StaleHeadOnceStore {
+    let status_store = StaleObjectOnceStore {
         inner: LocalFsStore::new(temp_dir.path()).expect("status store"),
-        head_key: wal_head(&namespace_id),
-        stale_head: std::sync::Mutex::new(Some(stale_head.clone())),
+        key: wal_head(&namespace_id),
+        stale: std::sync::Mutex::new(Some(stale_head.clone())),
     };
     let namespace = load_namespace(&status_store, &namespace_id)
         .await
@@ -1241,10 +1243,10 @@ async fn namespace_status_and_change_feed_reload_a_head_behind_the_floor() {
     assert_eq!(namespace.head_seq, ChangeSeq(1));
     assert_eq!(namespace.retention_floor_seq, ChangeSeq(1));
 
-    let feed_store = StaleHeadOnceStore {
+    let feed_store = StaleObjectOnceStore {
         inner: LocalFsStore::new(temp_dir.path()).expect("change-feed store"),
-        head_key: wal_head(&namespace_id),
-        stale_head: std::sync::Mutex::new(Some(stale_head)),
+        key: wal_head(&namespace_id),
+        stale: std::sync::Mutex::new(Some(stale_head)),
     };
     let changes = list_changes_after(
         &feed_store,
@@ -1256,6 +1258,110 @@ async fn namespace_status_and_change_feed_reload_a_head_behind_the_floor() {
     .expect("change feed reloads the stale head");
     assert_eq!(changes.through_seq, ChangeSeq(1));
     assert!(changes.changes.is_empty());
+}
+
+#[tokio::test]
+async fn diagnostics_reload_a_root_behind_the_floor() {
+    // Retention only advances the floor to what the current root covers, so a
+    // floor above the observed root proves the root read is stale. One reread
+    // must settle it rather than reporting the superseded manifest.
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&inner, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(&inner, &namespace_id, "/one.txt", b"one\n", &context, None)
+        .await
+        .expect("write one");
+    create_checkpoint(&inner, &namespace_id, &context)
+        .await
+        .expect("first checkpoint");
+    let stale_root = inner
+        .get_with_metadata(&metadata_root(&namespace_id))
+        .await
+        .expect("read first root")
+        .expect("first root exists");
+
+    write_file_bytes(&inner, &namespace_id, "/two.txt", b"two\n", &context, None)
+        .await
+        .expect("write two");
+    create_checkpoint(&inner, &namespace_id, &context)
+        .await
+        .expect("second checkpoint");
+    advance_retention_floor(&inner, &namespace_id, &context)
+        .await
+        .expect("advance retention");
+    let current_manifest_no = load_metadata_root_object(&inner, &namespace_id)
+        .await
+        .expect("read current root")
+        .state
+        .manifest
+        .manifest_no;
+
+    let store = StaleObjectOnceStore {
+        inner,
+        key: metadata_root(&namespace_id),
+        stale: std::sync::Mutex::new(Some(stale_root)),
+    };
+    let diagnostics = load_namespace_diagnostics(&store, &namespace_id)
+        .await
+        .expect("diagnostics reload the stale root");
+    assert_eq!(diagnostics.retention_floor_seq, ChangeSeq(2));
+    assert_eq!(diagnostics.current_manifest_no, Some(current_manifest_no));
+    assert_eq!(diagnostics.wal_tail_segments, 0);
+}
+
+#[tokio::test]
+async fn steady_state_reads_stay_off_the_objects_they_do_not_need() {
+    // The consolidated snapshot must not quietly widen these paths: namespace
+    // status never reads the root, and a rooted basis load never reads the
+    // floor.
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&inner, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(&inner, &namespace_id, "/one.txt", b"one\n", &context, None)
+        .await
+        .expect("write one");
+    create_checkpoint(&inner, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+
+    let store = CountingStore::new(inner, KeyPredicate::exact(metadata_root(&namespace_id)));
+    load_namespace(&store, &namespace_id)
+        .await
+        .expect("load namespace");
+    list_changes_after(
+        &store,
+        &namespace_id,
+        ChangeSeq(0),
+        EffectiveLimit::new(NonZeroU32::new(10).expect("nonzero")),
+    )
+    .await
+    .expect("list changes");
+    assert_eq!(
+        store.snapshot().operations(OperationClass::Read),
+        0,
+        "status and the change feed resolve from head and floor alone"
+    );
+
+    let basis_store = CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("basis store"),
+        KeyPredicate::exact(wal_floor(&namespace_id)),
+    );
+    load_current_metadata_view(&basis_store, &namespace_id)
+        .await
+        .expect("basis load");
+    assert_eq!(
+        basis_store.snapshot().operations(OperationClass::Read),
+        0,
+        "a basis load with a root present never reads the floor"
+    );
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -225,8 +225,7 @@ impl ObjectStore for FloorRaiseOnCasConflictStore {
     }
 }
 
-/// Serves one captured version of `key` to the first reader, then the store's
-/// own current bytes.
+/// Returns one stale response for a selected key.
 #[derive(Debug)]
 struct StaleObjectOnceStore {
     inner: LocalFsStore,
@@ -1262,9 +1261,7 @@ async fn namespace_status_and_change_feed_reload_a_head_behind_the_floor() {
 
 #[tokio::test]
 async fn diagnostics_reload_a_root_behind_the_floor() {
-    // Retention only advances the floor to what the current root covers, so a
-    // floor above the observed root proves the root read is stale. One reread
-    // must settle it rather than reporting the superseded manifest.
+    // A floor above the observed root proves that the root read is stale.
     let temp_dir = tempdir().expect("tempdir");
     let inner = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1315,9 +1312,6 @@ async fn diagnostics_reload_a_root_behind_the_floor() {
 
 #[tokio::test]
 async fn steady_state_reads_stay_off_the_objects_they_do_not_need() {
-    // The consolidated snapshot must not quietly widen these paths: namespace
-    // status never reads the root, and a rooted basis load never reads the
-    // floor.
     let temp_dir = tempdir().expect("tempdir");
     let inner = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -86,8 +86,8 @@ use loonfs_api::{
     ManifestNo, ManifestObjectId, NameKey, NamespaceId, RevisionNo, RunNo,
 };
 use loonfs_objectstore::keys::{
-    metadata_manifest_object, metadata_manifest_prefix, metadata_segment_object_key, wal_head,
-    wal_segment,
+    metadata_manifest_object, metadata_manifest_prefix, metadata_root, metadata_segment_object_key,
+    wal_floor, wal_head, wal_segment,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
@@ -212,7 +212,7 @@ async fn read_floor_seq<S: ObjectStore + ?Sized>(
         .await
         .expect("read head")
         .state;
-    crate::namespace::basis::resolve_retention_floor_seq(store, &head)
+    crate::namespace::control_snapshot::resolve_retention_floor_seq(store, &head)
         .await
         .expect("resolve retention floor")
 }

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1798,7 +1798,7 @@ async fn a_missing_floor_reads_as_retain_everything() {
         .await
         .expect("head")
         .state;
-    let floor = crate::namespace::basis::resolve_retention_floor_seq(&store, &head)
+    let floor = crate::namespace::control_snapshot::resolve_retention_floor_seq(&store, &head)
         .await
         .expect("missing floor defaults");
     assert_eq!(floor, ChangeSeq(0));

--- a/crates/loonfs-core/src/control_object/error.rs
+++ b/crates/loonfs-core/src/control_object/error.rs
@@ -22,7 +22,7 @@ pub enum ControlObjectLoadError {
         head_seq: loonfs_api::ChangeSeq,
     },
     #[error(
-        "retention floor seq `{floor_seq}` is beyond the seq `{root_manifest_head_seq}` covered by the reloaded metadata root"
+        "retention floor seq `{floor_seq}` is beyond metadata root seq `{root_manifest_head_seq}`"
     )]
     FloorAheadOfRoot {
         floor_seq: loonfs_api::ChangeSeq,

--- a/crates/loonfs-core/src/control_object/error.rs
+++ b/crates/loonfs-core/src/control_object/error.rs
@@ -22,6 +22,13 @@ pub enum ControlObjectLoadError {
         head_seq: loonfs_api::ChangeSeq,
     },
     #[error(
+        "retention floor seq `{floor_seq}` is beyond the seq `{root_manifest_head_seq}` covered by the reloaded metadata root"
+    )]
+    FloorAheadOfRoot {
+        floor_seq: loonfs_api::ChangeSeq,
+        root_manifest_head_seq: loonfs_api::ChangeSeq,
+    },
+    #[error(
         "namespace `{namespace_id}` retention floor stands at `{floor_seq}`, but its metadata root object is missing"
     )]
     MissingRootAfterFloor {

--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -15,31 +15,6 @@ pub(crate) struct LoadedControl<T> {
     pub(crate) state: T,
 }
 
-pub(crate) const CONTROL_READ_RELOADS: usize = 3;
-
-/// Reloads a value until it is consistent or the retry limit is reached.
-pub(crate) async fn reload_until_consistent<T, E, F, Fut>(
-    mut loaded: T,
-    mut reload: F,
-    is_consistent: impl Fn(&T) -> bool,
-    on_exhausted: impl FnOnce(T) -> E,
-) -> Result<T, E>
-where
-    F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = Result<T, E>>,
-{
-    if is_consistent(&loaded) {
-        return Ok(loaded);
-    }
-    for _ in 0..CONTROL_READ_RELOADS {
-        loaded = reload().await?;
-        if is_consistent(&loaded) {
-            return Ok(loaded);
-        }
-    }
-    Err(on_exhausted(loaded))
-}
-
 pub(crate) enum EmbeddedIdentityMismatch {
     Namespace {
         expected: NamespaceId,

--- a/crates/loonfs-core/src/control_object/mod.rs
+++ b/crates/loonfs-core/src/control_object/mod.rs
@@ -6,5 +6,5 @@ mod load;
 pub use error::ControlObjectLoadError;
 pub(crate) use load::{
     expect_foreign_fork_basis, expect_identity_field, expect_namespace, expect_own_manifest,
-    load_control_object, reload_until_consistent, LoadedControl, CONTROL_READ_RELOADS,
+    load_control_object, LoadedControl,
 };

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -689,7 +689,8 @@ pub(crate) fn classify_control_object_load_error(error: &ControlObjectLoadError)
     match error {
         ControlObjectLoadError::MissingObject { .. } => ErrorCode::NamespaceNotFound,
         ControlObjectLoadError::RootAheadOfHead { .. }
-        | ControlObjectLoadError::FloorAheadOfHead { .. } => ErrorCode::StaleHead,
+        | ControlObjectLoadError::FloorAheadOfHead { .. }
+        | ControlObjectLoadError::FloorAheadOfRoot { .. } => ErrorCode::StaleHead,
         ControlObjectLoadError::MissingRootAfterFloor { .. }
         | ControlObjectLoadError::NamespaceMismatch { .. }
         | ControlObjectLoadError::IdentityMismatch { .. }

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -4,10 +4,8 @@
 ///
 /// One unit is charged for:
 ///
-/// * the head and the metadata root together — one unit for the pair,
-///   because they are read concurrently and neither is a root without the
-///   other;
-/// * the retention floor;
+/// * the namespace control snapshot: head, metadata root, and retention floor
+///   read concurrently;
 /// * one checkpoint record read while marking, plus one more for the fork
 ///   target head that decides whether that record's target is gone;
 /// * one manifest opened, whether to mark its segments or by the content

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -287,8 +287,6 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     });
     let namespace_deleted = head.status == NamespaceStatus::Deleted {};
     let collected: CollectResult<LiveSet> = async {
-        // Charge for the floor read the snapshot already performed.
-        charge(budget)?;
         let floor_seq = snapshot.retention_floor_seq;
         let mut live = LiveSet::collecting(namespace_deleted);
         let mut manifest_object_ids = BTreeSet::new();

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -10,9 +10,7 @@ use crate::checkpoint::{load_namespace_manifest_envelope_if_present, ManifestLoa
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
-use crate::namespace::basis::{
-    load_head_and_metadata_basis, resolve_retention_floor_seq, LoadedNamespaceBasis,
-};
+use crate::namespace::control_snapshot::{load_control_snapshot, NamespaceControlSnapshot};
 use crate::wal::{load_wal_chain_within, WalChainLoad, WalChainLoadRequest};
 use futures::StreamExt;
 use loonfs_api::wire::control::{
@@ -237,7 +235,7 @@ impl SweepVerifier {
     }
 }
 
-/// Reloads the namespace head and basis before collecting a new live set.
+/// Reloads the namespace control objects before collecting a new live set.
 pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -249,13 +247,13 @@ pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
     if !budget.try_charge() {
         return Ok(LiveSetCollection::BudgetExhausted);
     }
-    let loaded = load_head_and_metadata_basis(store, namespace_id)
+    let snapshot = load_control_snapshot(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
     collect_live_set(
         store,
         namespace_id,
-        &loaded,
+        &snapshot,
         grace_window_ms,
         reused_anchor,
         budget,
@@ -264,24 +262,24 @@ pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
     .await
 }
 
-/// Collects from the head and basis the pass already read and charged for.
+/// Collects from the control snapshot the pass already read and charged for.
 pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    loaded: &LoadedNamespaceBasis,
+    snapshot: &NamespaceControlSnapshot,
     grace_window_ms: u64,
     reused_anchor: Option<ReferenceAnchor>,
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> Result<LiveSetCollection> {
-    let head = &loaded.head.state;
+    let head = &snapshot.head.state;
     // A namespace with no root of its own roots no manifest here: the
     // genesis basis has none, and a fork target's basis is a source-prefix
     // object that the source's own pass protects through the fork-owned
     // checkpoint record. Neither is ever a candidate of this pass.
-    let root_manifest_object_id = loaded.basis.is_owned_by(namespace_id).then(|| {
-        loaded
-            .basis
+    let basis = snapshot.basis();
+    let root_manifest_object_id = basis.is_owned_by(namespace_id).then(|| {
+        basis
             .manifest()
             .expect("owned basis")
             .manifest_object_id
@@ -289,12 +287,9 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     });
     let namespace_deleted = head.status == NamespaceStatus::Deleted {};
     let collected: CollectResult<LiveSet> = async {
-        // Without a stored floor, retain WAL from the namespace's first
-        // sequence.
+        // Charge for the floor read the snapshot already performed.
         charge(budget)?;
-        let floor_seq = resolve_retention_floor_seq(store, head)
-            .await
-            .map_err(CoreError::ControlObjectLoad)?;
+        let floor_seq = snapshot.retention_floor_seq;
         let mut live = LiveSet::collecting(namespace_deleted);
         let mut manifest_object_ids = BTreeSet::new();
         if !namespace_deleted {

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -17,7 +17,7 @@ use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
 use crate::limits::METADATA_COMPACTION_STAGING_GRACE_MS;
-use crate::namespace::basis::load_head_and_metadata_basis;
+use crate::namespace::control_snapshot::load_control_snapshot;
 use futures::StreamExt;
 use loonfs_api::{ContentStoreId, GcResponse, NamespaceId, RetainedReason, UploadId};
 use loonfs_objectstore::ObjectStore;
@@ -65,22 +65,23 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     // The head is the namespace: without one there is nothing to collect,
     // and nothing could have been written under the prefix either, because
     // the head is every installation's first and only write. It also names
-    // the content store a session's object lives in. The metadata root is
-    // read alongside it and charged with it as one unit.
+    // the content store a session's object lives in. The snapshot reads the
+    // root and floor alongside it: this unit covers the head and root, and
+    // collection charges for the floor.
     budget.charge();
-    let loaded = match load_head_and_metadata_basis(store, namespace_id).await {
-        Ok(loaded) => loaded,
+    let snapshot = match load_control_snapshot(store, namespace_id).await {
+        Ok(snapshot) => snapshot,
         Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(report),
         Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
-    let content_store_id = loaded.head.state.content_store_id.clone();
+    let content_store_id = snapshot.head.state.content_store_id.clone();
 
     // Every invocation rebuilds all roots before interpreting the cursor.
     // The cursor can skip enumeration only; it never carries safety state.
     let initial_live = match collect_live_set(
         store,
         namespace_id,
-        &loaded,
+        &snapshot,
         policy.grace_window_ms,
         None,
         &mut budget,

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -62,12 +62,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     // comes after.
     let mut budget = PassBudget::new(policy.max_objects);
 
-    // The head is the namespace: without one there is nothing to collect,
-    // and nothing could have been written under the prefix either, because
-    // the head is every installation's first and only write. It also names
-    // the content store a session's object lives in. The snapshot reads the
-    // root and floor alongside it: this unit covers the head and root, and
-    // collection charges for the floor.
+    // Read the namespace's head, root, and floor as one budget unit.
     budget.charge();
     let snapshot = match load_control_snapshot(store, namespace_id).await {
         Ok(snapshot) => snapshot,

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1442,7 +1442,7 @@ async fn a_budget_below_the_roots_reads_no_chain_and_says_it_ran_out() {
             wal_floor(&namespace_id),
             wal_head(&namespace_id)
         ],
-        "the control snapshot the pass opens with is all it read"
+        "one budget unit covers the concurrent control snapshot"
     );
 }
 
@@ -1774,8 +1774,8 @@ async fn a_budget_that_dies_among_the_checkpoint_records_decides_nothing() {
     );
     assert_eq!(
         store.count(OperationClass::Read),
-        1,
-        "the third unit bought exactly one record read"
+        2,
+        "two units remain after the control snapshot"
     );
 }
 

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -38,7 +38,7 @@ use loonfs_api::{
 use loonfs_objectstore::keys::{
     checkpoint_prefix, metadata_compaction_lease, metadata_compaction_segment,
     metadata_manifest_object, metadata_manifest_prefix, metadata_root, metadata_segment,
-    metadata_segment_object_key, metadata_segment_prefix, wal_head, wal_segment,
+    metadata_segment_object_key, metadata_segment_prefix, wal_floor, wal_head, wal_segment,
     wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
@@ -1437,8 +1437,12 @@ async fn a_budget_below_the_roots_reads_no_chain_and_says_it_ran_out() {
     read.sort();
     assert_eq!(
         read,
-        vec![metadata_root(&namespace_id), wal_head(&namespace_id)],
-        "the pair the pass charged itself for is all it read"
+        vec![
+            metadata_root(&namespace_id),
+            wal_floor(&namespace_id),
+            wal_head(&namespace_id)
+        ],
+        "the control snapshot the pass opens with is all it read"
     );
 }
 

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -5,17 +5,9 @@
 //! the first flush. A fork basis must match the identity and checksum stored
 //! in the head.
 
-use crate::control_object::{
-    reload_until_consistent, ControlObjectLoadError, CONTROL_READ_RELOADS,
-};
-use crate::namespace::control::{
-    load_head_and_metadata_root_if_present, load_head_object, load_wal_floor_object,
-    LoadedHeadObject,
-};
 use loonfs_api::wire::control::{HeadState, ManifestRef};
 use loonfs_api::NamespaceId;
 use loonfs_api::{ChangeSeq, ManifestNo};
-use loonfs_objectstore::ObjectStore;
 
 /// The materialized starting point every read and flush builds on.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,45 +76,6 @@ impl MetadataBasis {
     }
 }
 
-/// The head and its resolved basis, read together.
-pub(crate) struct LoadedNamespaceBasis {
-    pub(crate) head: LoadedHeadObject,
-    pub(crate) basis: MetadataBasis,
-}
-
-/// Reads the head and resolves the basis it authorizes.
-pub(crate) async fn load_head_and_metadata_basis<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-) -> Result<LoadedNamespaceBasis, ControlObjectLoadError> {
-    let mut reloads = 0;
-    loop {
-        let (head, root) = load_head_and_metadata_root_if_present(store, namespace_id).await?;
-        if let Some(root) = root {
-            return Ok(LoadedNamespaceBasis {
-                head,
-                basis: MetadataBasis::Manifest(root.state.manifest),
-            });
-        }
-
-        // At the birth sequence, genesis or the fork source is still a complete
-        // basis. A later floor proves a root was published, so retry before
-        // reporting it missing.
-        let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
-        if floor_seq <= namespace_birth_seq(&head.state) {
-            let basis = metadata_basis_without_root(&head.state);
-            return Ok(LoadedNamespaceBasis { head, basis });
-        }
-        if reloads == CONTROL_READ_RELOADS {
-            return Err(ControlObjectLoadError::MissingRootAfterFloor {
-                namespace_id: namespace_id.clone(),
-                floor_seq,
-            });
-        }
-        reloads += 1;
-    }
-}
-
 /// Resolves the basis of a namespace whose `metadata/root.json` is absent:
 /// the built-in genesis state, or the fork source's manifest the head
 /// authorizes.
@@ -145,45 +98,4 @@ pub(crate) fn namespace_birth_seq(head: &HeadState) -> ChangeSeq {
     head.fork_basis.as_ref().map_or(ChangeSeq(0), |fork_basis| {
         fork_basis.manifest.manifest_head_seq
     })
-}
-
-/// Reads the retention floor, treating a missing floor object as the
-/// namespace's birth sequence.
-///
-/// A namespace has no WAL history below its birth sequence, so "retain from
-/// birth" is the most conservative reading of an absent floor: create and
-/// fork write no floor, and the first advance publishes one.
-pub(crate) async fn resolve_retention_floor_seq<S: ObjectStore + ?Sized>(
-    store: &S,
-    head: &HeadState,
-) -> Result<ChangeSeq, ControlObjectLoadError> {
-    match load_wal_floor_object(store, &head.namespace_id).await {
-        Ok(loaded) => Ok(loaded.state.floor_seq),
-        Err(ControlObjectLoadError::MissingObject { .. }) => Ok(namespace_birth_seq(head)),
-        Err(error) => Err(error),
-    }
-}
-
-/// Reads a head and retention floor that could have existed together.
-///
-/// The objects advance independently. A floor newer than the first head read
-/// can therefore be a benign cross-read race, but it must not escape as a
-/// snapshot with history retained beyond the reported namespace head.
-pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-) -> Result<(LoadedHeadObject, ChangeSeq), ControlObjectLoadError> {
-    let head = load_head_object(store, namespace_id).await?;
-    let floor_seq = resolve_retention_floor_seq(store, &head.state).await?;
-    let head = reload_until_consistent(
-        head,
-        || load_head_object(store, namespace_id),
-        |head| floor_seq <= head.state.seq,
-        |head| ControlObjectLoadError::FloorAheadOfHead {
-            floor_seq,
-            head_seq: head.state.seq,
-        },
-    )
-    .await?;
-    Ok((head, floor_seq))
 }

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -3,9 +3,10 @@
 
 use crate::control_object::{
     expect_foreign_fork_basis, expect_namespace, expect_own_manifest, load_control_object,
-    reload_until_consistent, ControlObjectLoadError, LoadedControl,
+    ControlObjectLoadError, LoadedControl,
 };
-use crate::namespace::basis::{load_head_and_metadata_basis, MetadataBasis};
+use crate::namespace::basis::MetadataBasis;
+use crate::namespace::control_snapshot::load_head_and_metadata_basis;
 use loonfs_api::wire::control::{ControlObjectKind, HeadState, MetadataRootState, WalFloorState};
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::keys::{metadata_root, wal_floor, wal_head};
@@ -75,37 +76,6 @@ pub(crate) async fn load_metadata_root_object_if_present<S: ObjectStore + ?Sized
         Err(ControlObjectLoadError::MissingObject { .. }) => Ok(None),
         Err(error) => Err(error),
     }
-}
-
-/// Reads the WAL head and metadata root concurrently.
-///
-/// A new namespace may not have a root until its first flush. If the root is
-/// ahead of the head read at the same time, reload the head because the two
-/// reads may have occurred on opposite sides of a commit.
-pub(crate) async fn load_head_and_metadata_root_if_present<S: ObjectStore + ?Sized>(
-    store: &S,
-    expected_namespace_id: &NamespaceId,
-) -> Result<(LoadedHeadObject, Option<LoadedMetadataRootObject>), ControlObjectLoadError> {
-    let (head, root) = futures::join!(
-        load_head_object(store, expected_namespace_id),
-        load_metadata_root_object_if_present(store, expected_namespace_id)
-    );
-    let head = head?;
-    let Some(root) = root? else {
-        return Ok((head, None));
-    };
-    let root_seq = root.state.manifest.manifest_head_seq;
-    let head = reload_until_consistent(
-        head,
-        || load_head_object(store, expected_namespace_id),
-        |head| root_seq <= head.state.seq,
-        |head| ControlObjectLoadError::RootAheadOfHead {
-            root_manifest_head_seq: root_seq,
-            head_seq: head.state.seq,
-        },
-    )
-    .await?;
-    Ok((head, Some(root)))
 }
 
 pub(crate) async fn load_head_object<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/namespace/control_snapshot.rs
+++ b/crates/loonfs-core/src/namespace/control_snapshot.rs
@@ -1,0 +1,459 @@
+//! One reconciled read of a namespace's control objects: `wal/head.json`,
+//! `metadata/root.json`, and `wal/floor.json`. Every reconciliation of that
+//! tuple lives here.
+
+use crate::control_object::ControlObjectLoadError;
+use crate::namespace::basis::{metadata_basis_without_root, namespace_birth_seq, MetadataBasis};
+use crate::namespace::control::{
+    load_head_object, load_metadata_root_object_if_present, load_wal_floor_object,
+    LoadedHeadObject, LoadedMetadataRootObject,
+};
+use loonfs_api::wire::control::HeadState;
+use loonfs_api::{ChangeSeq, NamespaceId};
+use loonfs_objectstore::ObjectStore;
+
+/// Reconciliation rounds one load may spend.
+///
+/// Each round rereads the one object monotonicity implicates, and per-key
+/// read-after-write means that reread cannot return the version the
+/// observation already contradicts. Only two objects are ever implicated, so
+/// a quiet namespace settles within two rounds; the third is slack for one
+/// written throughout the load.
+const RECONCILE_ROUNDS: usize = 3;
+
+/// The namespace's control objects, read as one reconciled observation.
+pub(crate) struct NamespaceControlSnapshot {
+    pub(crate) head: LoadedHeadObject,
+    pub(crate) root: Option<LoadedMetadataRootObject>,
+    pub(crate) retention_floor_seq: ChangeSeq,
+}
+
+impl NamespaceControlSnapshot {
+    /// The metadata basis this snapshot authorizes.
+    pub(crate) fn basis(&self) -> MetadataBasis {
+        basis_of(&self.head.state, self.root.as_ref())
+    }
+}
+
+/// The head and its resolved basis, read together.
+pub(crate) struct LoadedNamespaceBasis {
+    pub(crate) head: LoadedHeadObject,
+    pub(crate) basis: MetadataBasis,
+}
+
+/// Reads the head and retention floor, reconciled with each other.
+///
+/// The metadata root is not read: callers that only report namespace state do
+/// not need it.
+pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<(LoadedHeadObject, ChangeSeq), ControlObjectLoadError> {
+    let (head, floor) = futures::join!(
+        load_head_object(store, namespace_id),
+        load_floor_seq_if_present(store, namespace_id)
+    );
+    let head = head?;
+    let floor_seq = Some(resolve_floor(floor?, &head.state));
+    let reads = reconcile_reads(
+        store,
+        namespace_id,
+        ControlReads {
+            head,
+            root: RootObservation::Unread,
+            floor_seq,
+        },
+    )
+    .await?;
+    let retention_floor_seq = reads.retention_floor_seq();
+    Ok((reads.head, retention_floor_seq))
+}
+
+/// Reads the head and the basis it authorizes.
+///
+/// The floor is read only when no root exists, where it separates a namespace
+/// that has published no root from one whose root was lost.
+pub(crate) async fn load_head_and_metadata_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<LoadedNamespaceBasis, ControlObjectLoadError> {
+    let (head, root) = futures::join!(
+        load_head_object(store, namespace_id),
+        load_metadata_root_object_if_present(store, namespace_id)
+    );
+    let reads = reconcile_reads(
+        store,
+        namespace_id,
+        ControlReads {
+            head: head?,
+            root: RootObservation::of(root?),
+            floor_seq: None,
+        },
+    )
+    .await?;
+    let head = reads.head;
+    let root = reads.root.into_loaded();
+    Ok(LoadedNamespaceBasis {
+        basis: basis_of(&head.state, root.as_ref()),
+        head,
+    })
+}
+
+/// Reads the head, metadata root, and retention floor as one snapshot.
+pub(crate) async fn load_control_snapshot<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<NamespaceControlSnapshot, ControlObjectLoadError> {
+    let (head, root, floor) = futures::join!(
+        load_head_object(store, namespace_id),
+        load_metadata_root_object_if_present(store, namespace_id),
+        load_floor_seq_if_present(store, namespace_id)
+    );
+    let head = head?;
+    let floor_seq = Some(resolve_floor(floor?, &head.state));
+    let reads = reconcile_reads(
+        store,
+        namespace_id,
+        ControlReads {
+            head,
+            root: RootObservation::of(root?),
+            floor_seq,
+        },
+    )
+    .await?;
+    Ok(NamespaceControlSnapshot {
+        retention_floor_seq: reads.retention_floor_seq(),
+        root: reads.root.into_loaded(),
+        head: reads.head,
+    })
+}
+
+/// Reads the retention floor, treating a missing floor object as the
+/// namespace's birth sequence.
+pub(crate) async fn resolve_retention_floor_seq<S: ObjectStore + ?Sized>(
+    store: &S,
+    head: &HeadState,
+) -> Result<ChangeSeq, ControlObjectLoadError> {
+    let stored = load_floor_seq_if_present(store, &head.namespace_id).await?;
+    Ok(resolve_floor(stored, head))
+}
+
+/// The basis a head authorizes: its own root when it has one, otherwise the
+/// fork source's manifest or genesis.
+fn basis_of(head: &HeadState, root: Option<&LoadedMetadataRootObject>) -> MetadataBasis {
+    match root {
+        Some(root) => MetadataBasis::Manifest(root.state.manifest.clone()),
+        None => metadata_basis_without_root(head),
+    }
+}
+
+/// What a load observed of `metadata/root.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RootObservation<T> {
+    /// This load does not read the root, so invariants that need it go
+    /// unchecked rather than reading absence into it.
+    Unread,
+    Absent,
+    Present(T),
+}
+
+impl RootObservation<LoadedMetadataRootObject> {
+    fn of(root: Option<LoadedMetadataRootObject>) -> Self {
+        root.map_or(Self::Absent, Self::Present)
+    }
+
+    fn coverage(&self) -> RootObservation<ChangeSeq> {
+        match self {
+            Self::Unread => RootObservation::Unread,
+            Self::Absent => RootObservation::Absent,
+            Self::Present(root) => RootObservation::Present(root.state.manifest.manifest_head_seq),
+        }
+    }
+
+    /// The loaded root, if this load read one and found it.
+    fn into_loaded(self) -> Option<LoadedMetadataRootObject> {
+        match self {
+            Self::Unread | Self::Absent => None,
+            Self::Present(root) => Some(root),
+        }
+    }
+}
+
+/// The control objects one load holds so far.
+struct ControlReads {
+    head: LoadedHeadObject,
+    root: RootObservation<LoadedMetadataRootObject>,
+    /// `None` while this load has not read the floor.
+    floor_seq: Option<ChangeSeq>,
+}
+
+impl ControlReads {
+    fn seqs(&self) -> ControlSeqs {
+        ControlSeqs {
+            head_seq: self.head.state.seq,
+            birth_seq: namespace_birth_seq(&self.head.state),
+            root: self.root.coverage(),
+            floor_seq: self.floor_seq,
+        }
+    }
+
+    /// The floor this load resolved. A load that never read the floor
+    /// resolves it the way an absent floor object resolves: the namespace's
+    /// birth sequence, below which it has no history to retain.
+    fn retention_floor_seq(&self) -> ChangeSeq {
+        resolve_floor(self.floor_seq, &self.head.state)
+    }
+}
+
+/// Rereads implicated objects until the tuple is one the protocol can
+/// produce, or reports the state that remains impossible.
+async fn reconcile_reads<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    mut reads: ControlReads,
+) -> Result<ControlReads, ControlObjectLoadError> {
+    let mut rounds = 0;
+    loop {
+        // A basis load reads the floor only once it finds no root: there the
+        // floor is what separates a namespace that has published none from
+        // one whose root was lost.
+        if reads.floor_seq.is_none() && matches!(reads.root, RootObservation::Absent) {
+            reads.floor_seq = Some(resolve_retention_floor_seq(store, &reads.head.state).await?);
+        }
+        let inconsistency = match reconcile(namespace_id, reads.seqs()) {
+            Ok(()) => return Ok(reads),
+            Err(inconsistency) => inconsistency,
+        };
+        if rounds == RECONCILE_ROUNDS {
+            return Err(inconsistency.error);
+        }
+        rounds += 1;
+        match inconsistency.stale {
+            StaleObject::Head => reads.head = load_head_object(store, namespace_id).await?,
+            StaleObject::Root => {
+                let root = load_metadata_root_object_if_present(store, namespace_id).await?;
+                reads.root = RootObservation::of(root);
+            }
+        }
+    }
+}
+
+/// The sequences one observation of the control objects carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ControlSeqs {
+    head_seq: ChangeSeq,
+    birth_seq: ChangeSeq,
+    root: RootObservation<ChangeSeq>,
+    /// `None` while the floor is unread.
+    floor_seq: Option<ChangeSeq>,
+}
+
+/// The object a reread can still explain an impossible observation by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StaleObject {
+    Head,
+    Root,
+}
+
+/// An observation the protocol cannot produce, with the object to reread and
+/// the error it settles into if rereading does not explain it.
+struct ControlInconsistency {
+    stale: StaleObject,
+    error: ControlObjectLoadError,
+}
+
+/// Checks the namespace control invariants over one observation.
+///
+/// Each object advances monotonically, so whichever one sits behind another
+/// is the stale read:
+///
+/// ```text
+/// namespace_birth_seq <= retention_floor_seq <= head.seq
+/// retention_floor_seq <= root.manifest_head_seq <= head.seq   (with a root)
+/// retention_floor_seq == namespace_birth_seq                  (without one)
+/// ```
+///
+/// A floor below the birth sequence is not reported: retaining history the
+/// namespace never wrote is conservative.
+fn reconcile(namespace_id: &NamespaceId, seqs: ControlSeqs) -> Result<(), ControlInconsistency> {
+    if let RootObservation::Present(root_seq) = seqs.root {
+        if root_seq > seqs.head_seq {
+            return Err(ControlInconsistency {
+                stale: StaleObject::Head,
+                error: ControlObjectLoadError::RootAheadOfHead {
+                    root_manifest_head_seq: root_seq,
+                    head_seq: seqs.head_seq,
+                },
+            });
+        }
+    }
+    let Some(floor_seq) = seqs.floor_seq else {
+        return Ok(());
+    };
+    if floor_seq > seqs.head_seq {
+        return Err(ControlInconsistency {
+            stale: StaleObject::Head,
+            error: ControlObjectLoadError::FloorAheadOfHead {
+                floor_seq,
+                head_seq: seqs.head_seq,
+            },
+        });
+    }
+    match seqs.root {
+        RootObservation::Present(root_seq) if floor_seq > root_seq => Err(ControlInconsistency {
+            stale: StaleObject::Root,
+            error: ControlObjectLoadError::FloorAheadOfRoot {
+                floor_seq,
+                root_manifest_head_seq: root_seq,
+            },
+        }),
+        // Only a published root can carry the floor above the birth sequence,
+        // so an absent root under a raised floor was read stale or is lost.
+        RootObservation::Absent if floor_seq > seqs.birth_seq => Err(ControlInconsistency {
+            stale: StaleObject::Root,
+            error: ControlObjectLoadError::MissingRootAfterFloor {
+                namespace_id: namespace_id.clone(),
+                floor_seq,
+            },
+        }),
+        _ => Ok(()),
+    }
+}
+
+/// Reads the floor object's sequence, or `None` when no floor object exists.
+async fn load_floor_seq_if_present<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<Option<ChangeSeq>, ControlObjectLoadError> {
+    match load_wal_floor_object(store, namespace_id).await {
+        Ok(loaded) => Ok(Some(loaded.state.floor_seq)),
+        Err(ControlObjectLoadError::MissingObject { .. }) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Resolves an unread or absent floor object to the namespace's birth
+/// sequence.
+///
+/// A namespace has no WAL history below its birth sequence, so "retain from
+/// birth" is the most conservative reading of an absent floor: create and
+/// fork write no floor, and the first advance publishes one.
+fn resolve_floor(stored: Option<ChangeSeq>, head: &HeadState) -> ChangeSeq {
+    stored.unwrap_or_else(|| namespace_birth_seq(head))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn namespace() -> NamespaceId {
+        NamespaceId::parse("demo").expect("valid namespace id")
+    }
+
+    fn seqs(
+        head_seq: u64,
+        birth_seq: u64,
+        root: RootObservation<ChangeSeq>,
+        floor_seq: Option<u64>,
+    ) -> ControlSeqs {
+        ControlSeqs {
+            head_seq: ChangeSeq(head_seq),
+            birth_seq: ChangeSeq(birth_seq),
+            root,
+            floor_seq: floor_seq.map(ChangeSeq),
+        }
+    }
+
+    /// The object to reread and the error the observation settles into, or
+    /// `None` when the observation is one the protocol can produce.
+    type Verdict = Option<(StaleObject, ControlObjectLoadError)>;
+
+    #[test]
+    fn the_reconciler_classifies_every_control_state() {
+        let namespace_id = namespace();
+        let root_at = |seq: u64| RootObservation::Present(ChangeSeq(seq));
+        let cases: Vec<(&str, ControlSeqs, Verdict)> = vec![
+            (
+                "rootless namespace at birth",
+                seqs(0, 0, RootObservation::Absent, Some(0)),
+                None,
+            ),
+            (
+                "rootless fork target at its fork point",
+                seqs(7, 7, RootObservation::Absent, Some(7)),
+                None,
+            ),
+            (
+                "rooted namespace whose floor trails its root",
+                seqs(9, 0, root_at(6), Some(4)),
+                None,
+            ),
+            (
+                "status load that never reads the root",
+                seqs(9, 0, RootObservation::Unread, Some(9)),
+                None,
+            ),
+            (
+                "raised floor beside an unread root",
+                seqs(9, 0, RootObservation::Unread, Some(6)),
+                None,
+            ),
+            (
+                "basis load that has not read the floor",
+                seqs(9, 0, root_at(6), None),
+                None,
+            ),
+            (
+                "root ahead of a stale head",
+                seqs(4, 0, root_at(6), Some(0)),
+                Some((
+                    StaleObject::Head,
+                    ControlObjectLoadError::RootAheadOfHead {
+                        root_manifest_head_seq: ChangeSeq(6),
+                        head_seq: ChangeSeq(4),
+                    },
+                )),
+            ),
+            (
+                "floor ahead of a stale head",
+                seqs(4, 0, root_at(4), Some(6)),
+                Some((
+                    StaleObject::Head,
+                    ControlObjectLoadError::FloorAheadOfHead {
+                        floor_seq: ChangeSeq(6),
+                        head_seq: ChangeSeq(4),
+                    },
+                )),
+            ),
+            (
+                "floor ahead of a stale root",
+                seqs(9, 0, root_at(4), Some(6)),
+                Some((
+                    StaleObject::Root,
+                    ControlObjectLoadError::FloorAheadOfRoot {
+                        floor_seq: ChangeSeq(6),
+                        root_manifest_head_seq: ChangeSeq(4),
+                    },
+                )),
+            ),
+            (
+                "root absent under a raised floor",
+                seqs(9, 0, RootObservation::Absent, Some(6)),
+                Some((
+                    StaleObject::Root,
+                    ControlObjectLoadError::MissingRootAfterFloor {
+                        namespace_id: namespace(),
+                        floor_seq: ChangeSeq(6),
+                    },
+                )),
+            ),
+        ];
+
+        for (name, observation, expected) in cases {
+            let verdict = reconcile(&namespace_id, observation)
+                .err()
+                .map(|inconsistency| (inconsistency.stale, inconsistency.error));
+            assert_eq!(verdict, expected, "{name}");
+        }
+    }
+}

--- a/crates/loonfs-core/src/namespace/control_snapshot.rs
+++ b/crates/loonfs-core/src/namespace/control_snapshot.rs
@@ -1,6 +1,5 @@
-//! One reconciled read of a namespace's control objects: `wal/head.json`,
-//! `metadata/root.json`, and `wal/floor.json`. Every reconciliation of that
-//! tuple lives here.
+//! Loads consistent combinations of a namespace's head, metadata root, and
+//! retention floor.
 
 use crate::control_object::ControlObjectLoadError;
 use crate::namespace::basis::{metadata_basis_without_root, namespace_birth_seq, MetadataBasis};
@@ -12,13 +11,7 @@ use loonfs_api::wire::control::HeadState;
 use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 
-/// Reconciliation rounds one load may spend.
-///
-/// Each round rereads the one object monotonicity implicates, and per-key
-/// read-after-write means that reread cannot return the version the
-/// observation already contradicts. Only two objects are ever implicated, so
-/// a quiet namespace settles within two rounds; the third is slack for one
-/// written throughout the load.
+/// Maximum targeted rereads before returning the remaining inconsistency.
 const RECONCILE_ROUNDS: usize = 3;
 
 /// The namespace's control objects, read as one reconciled observation.
@@ -29,7 +22,6 @@ pub(crate) struct NamespaceControlSnapshot {
 }
 
 impl NamespaceControlSnapshot {
-    /// The metadata basis this snapshot authorizes.
     pub(crate) fn basis(&self) -> MetadataBasis {
         basis_of(&self.head.state, self.root.as_ref())
     }
@@ -41,10 +33,7 @@ pub(crate) struct LoadedNamespaceBasis {
     pub(crate) basis: MetadataBasis,
 }
 
-/// Reads the head and retention floor, reconciled with each other.
-///
-/// The metadata root is not read: callers that only report namespace state do
-/// not need it.
+/// Reads a consistent head and retention floor without reading the root.
 pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -69,10 +58,8 @@ pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
     Ok((reads.head, retention_floor_seq))
 }
 
-/// Reads the head and the basis it authorizes.
-///
-/// The floor is read only when no root exists, where it separates a namespace
-/// that has published no root from one whose root was lost.
+/// Reads the head and its metadata basis. The floor is read only when the root
+/// is absent.
 pub(crate) async fn load_head_and_metadata_basis<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -99,7 +86,7 @@ pub(crate) async fn load_head_and_metadata_basis<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Reads the head, metadata root, and retention floor as one snapshot.
+/// Reads all three namespace control objects as one snapshot.
 pub(crate) async fn load_control_snapshot<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -128,8 +115,7 @@ pub(crate) async fn load_control_snapshot<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Reads the retention floor, treating a missing floor object as the
-/// namespace's birth sequence.
+/// Reads the retention floor, defaulting to the namespace's birth sequence.
 pub(crate) async fn resolve_retention_floor_seq<S: ObjectStore + ?Sized>(
     store: &S,
     head: &HeadState,
@@ -138,8 +124,6 @@ pub(crate) async fn resolve_retention_floor_seq<S: ObjectStore + ?Sized>(
     Ok(resolve_floor(stored, head))
 }
 
-/// The basis a head authorizes: its own root when it has one, otherwise the
-/// fork source's manifest or genesis.
 fn basis_of(head: &HeadState, root: Option<&LoadedMetadataRootObject>) -> MetadataBasis {
     match root {
         Some(root) => MetadataBasis::Manifest(root.state.manifest.clone()),
@@ -148,10 +132,7 @@ fn basis_of(head: &HeadState, root: Option<&LoadedMetadataRootObject>) -> Metada
 }
 
 /// What a load observed of `metadata/root.json`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RootObservation<T> {
-    /// This load does not read the root, so invariants that need it go
-    /// unchecked rather than reading absence into it.
     Unread,
     Absent,
     Present(T),
@@ -170,7 +151,6 @@ impl RootObservation<LoadedMetadataRootObject> {
         }
     }
 
-    /// The loaded root, if this load read one and found it.
     fn into_loaded(self) -> Option<LoadedMetadataRootObject> {
         match self {
             Self::Unread | Self::Absent => None,
@@ -179,11 +159,9 @@ impl RootObservation<LoadedMetadataRootObject> {
     }
 }
 
-/// The control objects one load holds so far.
 struct ControlReads {
     head: LoadedHeadObject,
     root: RootObservation<LoadedMetadataRootObject>,
-    /// `None` while this load has not read the floor.
     floor_seq: Option<ChangeSeq>,
 }
 
@@ -197,16 +175,12 @@ impl ControlReads {
         }
     }
 
-    /// The floor this load resolved. A load that never read the floor
-    /// resolves it the way an absent floor object resolves: the namespace's
-    /// birth sequence, below which it has no history to retain.
     fn retention_floor_seq(&self) -> ChangeSeq {
         resolve_floor(self.floor_seq, &self.head.state)
     }
 }
 
-/// Rereads implicated objects until the tuple is one the protocol can
-/// produce, or reports the state that remains impossible.
+/// Rereads stale objects until the snapshot is consistent.
 async fn reconcile_reads<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -214,9 +188,8 @@ async fn reconcile_reads<S: ObjectStore + ?Sized>(
 ) -> Result<ControlReads, ControlObjectLoadError> {
     let mut rounds = 0;
     loop {
-        // A basis load reads the floor only once it finds no root: there the
-        // floor is what separates a namespace that has published none from
-        // one whose root was lost.
+        // A raised floor distinguishes a missing root from a namespace that
+        // has never published one.
         if reads.floor_seq.is_none() && matches!(reads.root, RootObservation::Absent) {
             reads.floor_seq = Some(resolve_retention_floor_seq(store, &reads.head.state).await?);
         }
@@ -238,34 +211,24 @@ async fn reconcile_reads<S: ObjectStore + ?Sized>(
     }
 }
 
-/// The sequences one observation of the control objects carries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ControlSeqs {
     head_seq: ChangeSeq,
     birth_seq: ChangeSeq,
     root: RootObservation<ChangeSeq>,
-    /// `None` while the floor is unread.
     floor_seq: Option<ChangeSeq>,
 }
 
-/// The object a reread can still explain an impossible observation by.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StaleObject {
     Head,
     Root,
 }
 
-/// An observation the protocol cannot produce, with the object to reread and
-/// the error it settles into if rereading does not explain it.
 struct ControlInconsistency {
     stale: StaleObject,
     error: ControlObjectLoadError,
 }
 
-/// Checks the namespace control invariants over one observation.
-///
-/// Each object advances monotonically, so whichever one sits behind another
-/// is the stale read:
+/// Checks the sequence relationships between the control objects.
 ///
 /// ```text
 /// namespace_birth_seq <= retention_floor_seq <= head.seq
@@ -273,8 +236,7 @@ struct ControlInconsistency {
 /// retention_floor_seq == namespace_birth_seq                  (without one)
 /// ```
 ///
-/// A floor below the birth sequence is not reported: retaining history the
-/// namespace never wrote is conservative.
+/// A floor below the birth sequence is conservative and remains valid.
 fn reconcile(namespace_id: &NamespaceId, seqs: ControlSeqs) -> Result<(), ControlInconsistency> {
     if let RootObservation::Present(root_seq) = seqs.root {
         if root_seq > seqs.head_seq {
@@ -307,8 +269,7 @@ fn reconcile(namespace_id: &NamespaceId, seqs: ControlSeqs) -> Result<(), Contro
                 root_manifest_head_seq: root_seq,
             },
         }),
-        // Only a published root can carry the floor above the birth sequence,
-        // so an absent root under a raised floor was read stale or is lost.
+        // A raised floor requires a published root.
         RootObservation::Absent if floor_seq > seqs.birth_seq => Err(ControlInconsistency {
             stale: StaleObject::Root,
             error: ControlObjectLoadError::MissingRootAfterFloor {
@@ -320,7 +281,6 @@ fn reconcile(namespace_id: &NamespaceId, seqs: ControlSeqs) -> Result<(), Contro
     }
 }
 
-/// Reads the floor object's sequence, or `None` when no floor object exists.
 async fn load_floor_seq_if_present<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -332,128 +292,7 @@ async fn load_floor_seq_if_present<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Resolves an unread or absent floor object to the namespace's birth
-/// sequence.
-///
-/// A namespace has no WAL history below its birth sequence, so "retain from
-/// birth" is the most conservative reading of an absent floor: create and
-/// fork write no floor, and the first advance publishes one.
+/// A namespace without a floor retains history from its birth sequence.
 fn resolve_floor(stored: Option<ChangeSeq>, head: &HeadState) -> ChangeSeq {
     stored.unwrap_or_else(|| namespace_birth_seq(head))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn namespace() -> NamespaceId {
-        NamespaceId::parse("demo").expect("valid namespace id")
-    }
-
-    fn seqs(
-        head_seq: u64,
-        birth_seq: u64,
-        root: RootObservation<ChangeSeq>,
-        floor_seq: Option<u64>,
-    ) -> ControlSeqs {
-        ControlSeqs {
-            head_seq: ChangeSeq(head_seq),
-            birth_seq: ChangeSeq(birth_seq),
-            root,
-            floor_seq: floor_seq.map(ChangeSeq),
-        }
-    }
-
-    /// The object to reread and the error the observation settles into, or
-    /// `None` when the observation is one the protocol can produce.
-    type Verdict = Option<(StaleObject, ControlObjectLoadError)>;
-
-    #[test]
-    fn the_reconciler_classifies_every_control_state() {
-        let namespace_id = namespace();
-        let root_at = |seq: u64| RootObservation::Present(ChangeSeq(seq));
-        let cases: Vec<(&str, ControlSeqs, Verdict)> = vec![
-            (
-                "rootless namespace at birth",
-                seqs(0, 0, RootObservation::Absent, Some(0)),
-                None,
-            ),
-            (
-                "rootless fork target at its fork point",
-                seqs(7, 7, RootObservation::Absent, Some(7)),
-                None,
-            ),
-            (
-                "rooted namespace whose floor trails its root",
-                seqs(9, 0, root_at(6), Some(4)),
-                None,
-            ),
-            (
-                "status load that never reads the root",
-                seqs(9, 0, RootObservation::Unread, Some(9)),
-                None,
-            ),
-            (
-                "raised floor beside an unread root",
-                seqs(9, 0, RootObservation::Unread, Some(6)),
-                None,
-            ),
-            (
-                "basis load that has not read the floor",
-                seqs(9, 0, root_at(6), None),
-                None,
-            ),
-            (
-                "root ahead of a stale head",
-                seqs(4, 0, root_at(6), Some(0)),
-                Some((
-                    StaleObject::Head,
-                    ControlObjectLoadError::RootAheadOfHead {
-                        root_manifest_head_seq: ChangeSeq(6),
-                        head_seq: ChangeSeq(4),
-                    },
-                )),
-            ),
-            (
-                "floor ahead of a stale head",
-                seqs(4, 0, root_at(4), Some(6)),
-                Some((
-                    StaleObject::Head,
-                    ControlObjectLoadError::FloorAheadOfHead {
-                        floor_seq: ChangeSeq(6),
-                        head_seq: ChangeSeq(4),
-                    },
-                )),
-            ),
-            (
-                "floor ahead of a stale root",
-                seqs(9, 0, root_at(4), Some(6)),
-                Some((
-                    StaleObject::Root,
-                    ControlObjectLoadError::FloorAheadOfRoot {
-                        floor_seq: ChangeSeq(6),
-                        root_manifest_head_seq: ChangeSeq(4),
-                    },
-                )),
-            ),
-            (
-                "root absent under a raised floor",
-                seqs(9, 0, RootObservation::Absent, Some(6)),
-                Some((
-                    StaleObject::Root,
-                    ControlObjectLoadError::MissingRootAfterFloor {
-                        namespace_id: namespace(),
-                        floor_seq: ChangeSeq(6),
-                    },
-                )),
-            ),
-        ];
-
-        for (name, observation, expected) in cases {
-            let verdict = reconcile(&namespace_id, observation)
-                .err()
-                .map(|inconsistency| (inconsistency.stale, inconsistency.error));
-            assert_eq!(verdict, expected, "{name}");
-        }
-    }
 }

--- a/crates/loonfs-core/src/namespace/mod.rs
+++ b/crates/loonfs-core/src/namespace/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod basis;
 pub(crate) mod bootstrap;
 pub(crate) mod catalog;
 pub(crate) mod control;
+pub(crate) mod control_snapshot;
 pub(crate) mod delete;
 pub(crate) mod fork;
 pub(crate) mod status;

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -1,12 +1,9 @@
 //! Reads namespace state and storage diagnostics.
 
 use crate::checkpoint::load_namespace_manifest_envelope;
-use crate::control_object::{reload_until_consistent, ControlObjectLoadError};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
-use crate::namespace::basis::{
-    load_head_and_metadata_basis, load_head_and_retention_floor, resolve_retention_floor_seq,
-};
+use crate::namespace::control_snapshot::{load_control_snapshot, load_head_and_retention_floor};
 use crate::wal::{count_visible_wal_tail_segments, WalChainLoadRequest};
 use loonfs_api::wire::control::{HeadState, NamespaceStatus};
 use loonfs_api::{ChangeSeq, ManifestNo, Namespace, NamespaceDiagnostics, NamespaceId};
@@ -29,73 +26,47 @@ struct LoadedHeadBasis {
     retention_floor_seq: ChangeSeq,
 }
 
-async fn load_namespace_head_basis_once<S: ObjectStore + ?Sized>(
+async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedHeadBasis> {
-    let loaded = load_head_and_metadata_basis(store, expected_namespace_id)
+    let snapshot = load_control_snapshot(store, expected_namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    let head = loaded.head.state;
+    let basis = snapshot.basis();
+    let retention_floor_seq = snapshot.retention_floor_seq;
+    let head = snapshot.head.state;
     if head.status == (NamespaceStatus::Deleted {}) {
         return Err(CoreError::NamespaceDeleted {
             namespace_id: expected_namespace_id.clone(),
         });
     }
-    // The floor object is addressed by the head alone, so it is read beside
-    // the basis manifest rather than after it. The tail is measured from the
-    // basis manifest's coverage, whoever owns it: a fork target that has not
-    // flushed measures from its fork point.
-    let (basis, retention_floor_seq) = futures::join!(
-        async {
-            match loaded.basis.manifest() {
-                Some(basis) => load_namespace_manifest_envelope(
-                    store,
-                    &basis.owner_namespace_id,
-                    &basis.manifest_object_id,
-                )
-                .await
-                .map(|manifest| {
-                    let own_manifest_no = loaded
-                        .basis
-                        .is_owned_by(expected_namespace_id)
-                        .then_some(basis.manifest_no);
-                    (own_manifest_no, manifest.payload.head_seq)
-                }),
-                None => Ok((None, ChangeSeq(0))),
-            }
-        },
-        resolve_retention_floor_seq(store, &head)
-    );
-    let (current_manifest_no, basis_head_seq) = basis.map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-    })?;
-    let retention_floor_seq = retention_floor_seq.map_err(CoreError::ControlObjectLoad)?;
+    // The tail is measured from the basis manifest's coverage, whoever owns
+    // it: a fork target that has not flushed measures from its fork point.
+    let (current_manifest_no, basis_head_seq) = match basis.manifest() {
+        Some(manifest) => {
+            let envelope = load_namespace_manifest_envelope(
+                store,
+                &manifest.owner_namespace_id,
+                &manifest.manifest_object_id,
+            )
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+            })?;
+            let own_manifest_no = basis
+                .is_owned_by(expected_namespace_id)
+                .then_some(manifest.manifest_no);
+            (own_manifest_no, envelope.payload.head_seq)
+        }
+        None => (None, ChangeSeq(0)),
+    };
     Ok(LoadedHeadBasis {
         head,
         current_manifest_no,
         basis_head_seq,
         retention_floor_seq,
     })
-}
-
-async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
-    store: &S,
-    expected_namespace_id: &NamespaceId,
-) -> Result<LoadedHeadBasis> {
-    let loaded = load_namespace_head_basis_once(store, expected_namespace_id).await?;
-    reload_until_consistent(
-        loaded,
-        || load_namespace_head_basis_once(store, expected_namespace_id),
-        |loaded: &LoadedHeadBasis| loaded.retention_floor_seq <= loaded.head.seq,
-        |loaded| {
-            CoreError::ControlObjectLoad(ControlObjectLoadError::FloorAheadOfHead {
-                floor_seq: loaded.retention_floor_seq,
-                head_seq: loaded.head.seq,
-            })
-        },
-    )
-    .await
 }
 
 /// Loads the current state of a live namespace.

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -41,8 +41,7 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
             namespace_id: expected_namespace_id.clone(),
         });
     }
-    // The tail is measured from the basis manifest's coverage, whoever owns
-    // it: a fork target that has not flushed measures from its fork point.
+    // An unflushed fork measures its WAL tail from the fork point.
     let (current_manifest_no, basis_head_seq) = match basis.manifest() {
         Some(manifest) => {
             let envelope = load_namespace_manifest_envelope(

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -13,10 +13,10 @@ use crate::metadata::{
     LeafRevisionPrefetch, MetadataState, MetadataView, MetadataViewSession, ResolvedVisiblePath,
     RevisionRecord, VisibleChildEntry, METADATA_VIEW_SESSION_COUNTER_FIELDS,
 };
-#[cfg(test)]
-use crate::namespace::basis::load_head_and_metadata_basis;
 use crate::namespace::basis::MetadataBasis;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
+#[cfg(test)]
+use crate::namespace::control_snapshot::load_head_and_metadata_basis;
 use crate::path::mutation_path::{map_path_error_to_core, parse_absolute_path_for_core};
 use crate::storage::content::{content_object_key_for_ref, get_durable_content_bytes};
 use crate::wal::{

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -2,7 +2,7 @@
 //! commit's durable WAL deltas mapped to semantic filesystem events.
 
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
-use crate::namespace::basis::load_head_and_retention_floor;
+use crate::namespace::control_snapshot::load_head_and_retention_floor;
 use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
 use loonfs_api::v0::{CommittedChange, FilesystemChange, ListChangesResponse};
 use loonfs_api::wire::control::NamespaceStatus;

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -10,9 +10,10 @@ use crate::control_object::ControlObjectLoadError;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
-use crate::namespace::basis::{load_head_and_metadata_basis, MetadataBasis, MetadataBasisIdentity};
+use crate::namespace::basis::{MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::control::load_head_object;
+use crate::namespace::control_snapshot::load_head_and_metadata_basis;
 use crate::namespace::writer_epoch::ensure_writer_not_fenced;
 use crate::wal::{
     ensure_replayed_head_matches, load_validated_wal_chain, project_validated_wal_tail,

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -359,6 +359,13 @@ pub(crate) async fn collect_stream(mut body: ByteStream) -> Result<Bytes> {
 ///
 /// Implementations must satisfy the
 /// [required guarantees](../../../docs/specs/format.md#11-required-guarantees).
+///
+/// Those guarantees hold per key: after a successful create, overwrite, or
+/// compare-and-swap of one key, a later direct read of that key never returns
+/// an older version. Namespace control objects are reconciled against each
+/// other on that basis, so one targeted reread settles a read that straddled
+/// another writer's transition. Prefix listings are weaker and may still lag a
+/// write that a direct read of the same key already reflects.
 #[async_trait]
 pub trait ObjectStore: Send + Sync + Debug {
     /// Reads metadata for one key, returning `None` when the object is absent.

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -360,12 +360,8 @@ pub(crate) async fn collect_stream(mut body: ByteStream) -> Result<Bytes> {
 /// Implementations must satisfy the
 /// [required guarantees](../../../docs/specs/format.md#11-required-guarantees).
 ///
-/// Those guarantees hold per key: after a successful create, overwrite, or
-/// compare-and-swap of one key, a later direct read of that key never returns
-/// an older version. Namespace control objects are reconciled against each
-/// other on that basis, so one targeted reread settles a read that straddled
-/// another writer's transition. Prefix listings are weaker and may still lag a
-/// write that a direct read of the same key already reflects.
+/// Direct reads are read-after-write consistent for each key. Prefix listings
+/// may lag behind direct reads.
 #[async_trait]
 pub trait ObjectStore: Send + Sync + Debug {
     /// Reads metadata for one key, returning `None` when the object is absent.


### PR DESCRIPTION
Moves reads of the namespace head, metadata root, and retention floor into one snapshot module. The module reads the required objects concurrently and rereads only the head or root when their sequence numbers show that an observation is stale.

The shared validation now rejects a retention floor that is ahead of the metadata root. Status and change-feed reads still skip the root, and basis reads skip the floor when a root exists, so callers do not make reads they do not need. Garbage collection counts the concurrent control snapshot as one budget unit.