### PR TITLE
fix(core): expire upload content proofs

### DIFF
--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -639,7 +639,8 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
             .response)
     }
 
-    /// Completes an upload session and returns proof for later publication.
+    /// Completes an upload session and returns time-bounded proof for later
+    /// publication.
     ///
     /// Service-proxied completion performs no content-blob I/O. Direct-put
     /// completion performs one content-blob HEAD and no content-blob GET.
@@ -648,7 +649,8 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
             .await
     }
 
-    /// Completes a multipart upload and returns proof for later publication.
+    /// Completes a multipart upload and returns time-bounded proof for later
+    /// publication.
     pub async fn complete_multipart_upload_prepared(
         &self,
         upload_id: &UploadId,

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -204,16 +204,21 @@ pub const CONTENT_RECEIPT_TTL_MS: u64 = 60 * 60 * 1000;
 /// Time during which a completed upload may issue new content receipts.
 pub const COMPLETED_UPLOAD_RECEIPT_WINDOW_MS: u64 = 7 * 24 * 60 * 60 * 1000;
 
+/// Latest admission horizon for proof derived from one completed upload.
+/// This covers its receipt window and the lifetime of the final token.
+pub const COMPLETED_UPLOAD_ADMISSION_WINDOW_MS: u64 =
+    COMPLETED_UPLOAD_RECEIPT_WINDOW_MS + CONTENT_RECEIPT_TTL_MS;
+
 /// Minimum age of unreferenced content from a completed upload before
 /// collection. The value covers the receipt window, receipt lifetime, and a
 /// final publication.
 pub const CONTENT_RECLAMATION_GRACE_MS: u64 =
-    COMPLETED_UPLOAD_RECEIPT_WINDOW_MS + CONTENT_RECEIPT_TTL_MS + GC_MIN_GRACE_WINDOW_MS;
+    COMPLETED_UPLOAD_ADMISSION_WINDOW_MS + GC_MIN_GRACE_WINDOW_MS;
 
 /// The grace floor's inequality, shared by the compile-time assertion below
 /// and the test that proves the assertion has teeth.
 const fn outlasts_every_receipt(grace_ms: u64) -> bool {
-    grace_ms >= COMPLETED_UPLOAD_RECEIPT_WINDOW_MS + CONTENT_RECEIPT_TTL_MS + GC_MIN_GRACE_WINDOW_MS
+    grace_ms >= COMPLETED_UPLOAD_ADMISSION_WINDOW_MS + GC_MIN_GRACE_WINDOW_MS
 }
 
 // Content reclamation is the one sweep that deletes bytes a user handed us,
@@ -247,8 +252,12 @@ mod tests {
     fn the_content_grace_floor_rejects_a_window_one_receipt_short() {
         assert!(outlasts_every_receipt(CONTENT_RECLAMATION_GRACE_MS));
         assert!(!outlasts_every_receipt(CONTENT_RECLAMATION_GRACE_MS - 1));
-        assert!(!outlasts_every_receipt(
+        assert_eq!(
+            COMPLETED_UPLOAD_ADMISSION_WINDOW_MS,
             COMPLETED_UPLOAD_RECEIPT_WINDOW_MS + CONTENT_RECEIPT_TTL_MS
+        );
+        assert!(!outlasts_every_receipt(
+            COMPLETED_UPLOAD_ADMISSION_WINDOW_MS
         ));
         // 7 days of re-minting + 1 hour of receipt life + 20.5 minutes of
         // publication.

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -145,9 +145,11 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             let allocation = candidate_request.allocation;
             // Validation first, uniformly: coverage is checked once the
             // whole request has planned and validated.
-            if let Err(error) =
-                validate_commit_content_references(candidate, view.content_store_id())
-            {
+            if let Err(error) = validate_commit_content_references(
+                candidate,
+                view.content_store_id(),
+                context.now_ms,
+            ) {
                 session.discard_candidate(allocation);
                 slots[index] = BatchOutcomeSlot::SettledIndependent(Err(error));
                 continue;

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -212,13 +212,14 @@ async fn commit_response_from_commit_receipt<S: ObjectStore + ?Sized>(
 struct CommitContentAdmissions<'a> {
     content_store_id: &'a ContentStoreId,
     admissions: &'a [ContentAdmission],
+    now_ms: u64,
 }
 
 impl CommitContentAdmissions<'_> {
     fn admits(&self, content_ref: &ContentRef) -> bool {
         self.admissions
             .iter()
-            .any(|admission| admission.admits(self.content_store_id, content_ref))
+            .any(|admission| admission.admits(self.content_store_id, content_ref, self.now_ms))
     }
 }
 
@@ -226,9 +227,11 @@ impl CommitContentAdmissions<'_> {
 pub(super) fn validate_commit_content_references(
     candidate: &CommitCandidate,
     content_store_id: &ContentStoreId,
+    now_ms: u64,
 ) -> Result<()> {
     let admissions = CommitContentAdmissions {
         content_store_id,
+        now_ms,
         admissions: match candidate.content_preparation() {
             ContentPreparation::Ready(admissions) => admissions,
             ContentPreparation::Rejected(_) => {

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -16,8 +16,9 @@ use crate::control_update::{
 };
 use crate::error::{CoreError, Result};
 use crate::limits::{
-    COMPLETED_UPLOAD_RECEIPT_WINDOW_MS, MAX_MULTIPART_PARTS, MAX_MULTIPART_PART_BYTES,
-    MAX_SIGNED_PARTS_PER_REQUEST, MIN_MULTIPART_PART_BYTES, UPLOAD_SESSION_LEASE_MS,
+    COMPLETED_UPLOAD_ADMISSION_WINDOW_MS, COMPLETED_UPLOAD_RECEIPT_WINDOW_MS, MAX_MULTIPART_PARTS,
+    MAX_MULTIPART_PART_BYTES, MAX_SIGNED_PARTS_PER_REQUEST, MIN_MULTIPART_PART_BYTES,
+    UPLOAD_SESSION_LEASE_MS,
 };
 use crate::namespace::catalog::{load_namespace_content_store_id, VerifiedNamespaceCatalogEntry};
 use crate::namespace::control::load_namespace_head_control;
@@ -1193,7 +1194,8 @@ pub(crate) async fn get_upload_status<S: ObjectStore + ?Sized>(
 pub struct CompletedUpload {
     /// Wire response for the completion or its idempotent replay.
     pub response: UploadSession,
-    /// Admission for a publication in this process, which needs no token.
+    /// Admission for a publication in this process, which needs no token but
+    /// expires at the completed session's final admission horizon.
     pub prepared: PreparedContent,
     /// Receipt for a publication elsewhere, or `None` once the session has
     /// stopped minting them.
@@ -1216,9 +1218,10 @@ fn completed_upload(
             mode,
             status: completed_status(content_ref, completed_at_ms),
         },
-        prepared: PreparedContent::from_admission(ContentAdmission::for_durable_content_write(
+        prepared: PreparedContent::from_admission(ContentAdmission::for_completed_upload(
             content_store_id.clone(),
             content_ref.clone(),
+            completed_at_ms.saturating_add(COMPLETED_UPLOAD_ADMISSION_WINDOW_MS),
         )),
         receipt: receipt_within_window(
             namespace_id,

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -54,6 +54,8 @@ pub(crate) struct ContentAdmission {
 }
 
 impl ContentAdmission {
+    /// Unbounded admission for a ref the caller keeps externally rooted;
+    /// no deadline is derivable from the reference alone.
     pub(crate) fn for_durable_content_write(
         content_store_id: ContentStoreId,
         content_ref: ContentRef,

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -2,8 +2,8 @@
 //!
 //! A token can be created only from a durable, completed upload session. It
 //! proves that the named content was verified before publication. Token
-//! expiry is checked once when converting it to [`PreparedContent`]. The
-//! resulting in-process proof remains valid for that process lifetime.
+//! expiry is preserved when converting it to [`PreparedContent`] and checked
+//! again when a publish batch admits the proof.
 
 use crate::limits::CONTENT_RECEIPT_TTL_MS;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
@@ -50,6 +50,7 @@ impl CompletedUploadReceipt {
 pub(crate) struct ContentAdmission {
     content_store_id: ContentStoreId,
     content_ref: ContentRef,
+    expires_at_ms: u64,
 }
 
 impl ContentAdmission {
@@ -60,6 +61,19 @@ impl ContentAdmission {
         Self {
             content_store_id,
             content_ref,
+            expires_at_ms: u64::MAX,
+        }
+    }
+
+    pub(crate) fn for_completed_upload(
+        content_store_id: ContentStoreId,
+        content_ref: ContentRef,
+        expires_at_ms: u64,
+    ) -> Self {
+        Self {
+            content_store_id,
+            content_ref,
+            expires_at_ms,
         }
     }
 
@@ -67,8 +81,11 @@ impl ContentAdmission {
         &self,
         content_store_id: &ContentStoreId,
         content_ref: &ContentRef,
+        now_ms: u64,
     ) -> bool {
-        self.content_store_id == *content_store_id && self.content_ref == *content_ref
+        self.content_store_id == *content_store_id
+            && self.content_ref == *content_ref
+            && now_ms <= self.expires_at_ms
     }
 }
 
@@ -198,8 +215,11 @@ pub fn verify_content_token(
         return Err(ContentTokenError::Expired);
     }
 
-    let admission =
-        ContentAdmission::for_durable_content_write(payload.content_store_id, payload.content_ref);
+    let admission = ContentAdmission::for_completed_upload(
+        payload.content_store_id,
+        payload.content_ref,
+        payload.expires_at_ms,
+    );
     Ok(PreparedContent::from_admission(admission))
 }
 
@@ -271,7 +291,7 @@ mod tests {
         assert_eq!(prepared.content_ref(), &content);
         assert!(prepared
             .into_admission()
-            .admits(catalog.content_store_id(), &content));
+            .admits(catalog.content_store_id(), &content, 1_000));
     }
 
     #[test]
@@ -299,7 +319,7 @@ mod tests {
     }
 
     #[test]
-    fn verified_token_admission_does_not_decay_after_token_expiry() {
+    fn verified_token_admission_expires_with_the_token() {
         let namespace = NamespaceId::parse("demo").expect("namespace");
         let content = ContentRef::blob_v1(ContentId::generate(), b"hello");
         let issued_at_ms = 1_000;
@@ -318,11 +338,17 @@ mod tests {
         )
         .expect("verify token before expiry");
 
-        // The prepared proof carries no clock: expiry was the token's
-        // concern, checked exactly once by the verification above.
-        assert!(prepared
-            .into_admission()
-            .admits(catalog.content_store_id(), &content));
+        let admission = prepared.into_admission();
+        assert!(admission.admits(
+            catalog.content_store_id(),
+            &content,
+            issued_at_ms + CONTENT_RECEIPT_TTL_MS,
+        ));
+        assert!(!admission.admits(
+            catalog.content_store_id(),
+            &content,
+            issued_at_ms + CONTENT_RECEIPT_TTL_MS + 1,
+        ));
     }
 
     #[test]

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -18,7 +18,7 @@ use loonfs_api::{
 use loonfs_core::content::{
     mint_content_token, store_bytes_as_content, verify_content_token, ContentTokenError,
 };
-use loonfs_core::limits::CONTENT_RECEIPT_TTL_MS;
+use loonfs_core::limits::{COMPLETED_UPLOAD_ADMISSION_WINDOW_MS, CONTENT_RECEIPT_TTL_MS};
 use loonfs_core::publish::{CommitCandidate, CommitRequest, FilesystemOperation};
 use loonfs_core::{Error as CoreError, ErrorCode};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -276,6 +276,70 @@ async fn valid_content_admission_skips_durable_content_validation() {
 
     responses[0].as_ref().expect("admitted put commits");
     // A live admission is the fast path: no content read at all.
+    assert_eq!(store.count(OperationClass::Read), 0);
+}
+
+#[tokio::test]
+async fn completed_upload_proof_is_rejected_after_its_admission_deadline() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = content_blob_counting_store(temp_dir.path());
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    let engine = namespace_engine(&store, &namespace_id, &context);
+    let upload = engine
+        .begin_upload(loonfs_api::v0::BeginUploadRequest::ServiceProxied {})
+        .await
+        .expect("begin upload");
+    engine
+        .upload_content(upload.upload_id(), b"deadline")
+        .await
+        .expect("stage content");
+    let completed = engine
+        .complete_upload_prepared(upload.upload_id())
+        .await
+        .expect("complete upload");
+    let completed_at_ms = match &completed.response.status {
+        UploadSessionStatus::Completed {
+            completed_at_ms, ..
+        } => *completed_at_ms,
+        status => panic!("expected completed upload, got {status:?}"),
+    };
+    let content_ref = completed
+        .response
+        .content_ref()
+        .expect("completed content ref")
+        .clone();
+    let expired_context = loonfs_core::MutationContext {
+        writer_id: context.writer_id.clone(),
+        now_ms: completed_at_ms
+            .saturating_add(COMPLETED_UPLOAD_ADMISSION_WINDOW_MS)
+            .saturating_add(1),
+    };
+
+    store.reset();
+    let error = publish_namespace_commits_batch(
+        &store,
+        &namespace_id,
+        vec![CommitCandidate::prepared(
+            CommitRequest::single(
+                commit_id("put-expired-prepared-content"),
+                loonfs_test_support::test_actor(),
+                None,
+                put_file("/docs/expired.txt", content_ref),
+            ),
+            vec![completed.prepared],
+        )],
+        &expired_context,
+    )
+    .await
+    .remove(0)
+    .expect_err("expired prepared proof must not admit content");
+
+    assert_eq!(error.code(), ErrorCode::ContentNotPrepared);
     assert_eq!(store.count(OperationClass::Read), 0);
 }
 

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -450,7 +450,9 @@ impl FsWriter {
     ///
     /// Preparation performs one content HEAD followed by one full content
     /// GET and digest check. Later prepared publication performs no content
-    /// I/O.
+    /// I/O. The proof asserts binding, not longevity: it stays safe only
+    /// while an existing revision keeps the ref referenced, since only
+    /// unreferenced content is ever reclaimed.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.prepare",

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -255,9 +255,9 @@ impl FsWriter {
     /// unpublished object is reclaimed after the content-reclamation grace
     /// period.
     ///
-    /// `PreparedContent` has no local expiry, but callers should publish it
-    /// promptly because garbage collection protects the object only for that
-    /// grace period while it remains unpublished.
+    /// The returned proof remains valid through the completed upload's receipt
+    /// horizon. Publication rejects it after that deadline so garbage
+    /// collection cannot reclaim the object before a later commit uses it.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.prepare",

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -133,7 +133,8 @@ pub mod publish {
 ///
 /// A server mints a short-lived token after durable upload completion.
 /// [`FsWriter::prepare_content_token`] verifies the token against the
-/// namespace catalog and returns process-local proof that remains valid.
+/// namespace catalog and returns process-local proof that keeps the token's
+/// publication deadline.
 /// Most embedded applications do not need this module.
 pub mod content_tokens {
     pub use loonfs_api::v0::ContentToken;

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -406,15 +406,12 @@ tokens on the existing wire requests.
 
 Staging is staging wherever it happens, so `prepare_file_bytes` opens an
 upload session for the object it writes, exactly as a remote upload does: the
-session record lands before the bytes and completes after them, and the
-reference the caller receives is a completed session's content. That is what
-bounds how long the value is worth holding. A prepared reference carries no
-clock and never expires by itself, but the bytes behind it are protected only
-while its session is inside the content-reclamation grace — the same window
-that bounds a remote upload's receipts (section 6.3; format spec, "Garbage
-collection", rule 11). Past it, content nothing references is reclaimed
-whether the reference that named it is still in a caller's hands or not, so
-prepared content is for publishing now rather than for keeping.
+session record lands before the bytes and completes after them. The opaque
+prepared value carries an admission deadline no later than the completed
+session's last possible receipt, and publication checks it again when the
+batch is admitted. This is the same horizon that bounds remote upload tokens
+(section 6.3; format spec, "Garbage collection", rule 11), so content cannot
+be reclaimed and then admitted through an older in-process proof.
 
 ### 5.1 Commit identity and race guards
 
@@ -1261,11 +1258,11 @@ window remains open. The separate `content_ref` remains available afterward.
 
 Path-oriented `put_file` operations then reference the completed `content_ref`.
 The client includes the matching `content_token` in `content_tokens` unchanged;
-the server verifies it before admission and publication checks only the
-resulting in-memory proof. A missing proof answers `content_not_prepared`
-without reading the content object. A malformed or expired token that names
-the put's ref also answers `content_not_prepared`; tokens naming other refs are
-ignored.
+the server verifies it before admission and publication checks the resulting
+in-memory proof's binding and deadline. A missing or expired proof answers
+`content_not_prepared` without reading the content object. A malformed or
+expired token that names the put's ref also answers `content_not_prepared`;
+tokens naming other refs are ignored.
 
 ```json
 {

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -407,8 +407,8 @@ tokens on the existing wire requests.
 Staging is staging wherever it happens, so `prepare_file_bytes` opens an
 upload session for the object it writes, exactly as a remote upload does: the
 session record lands before the bytes and completes after them. The opaque
-prepared value carries an admission deadline no later than the completed
-session's last possible receipt, and publication checks it again when the
+prepared value carries an admission deadline no later than the expiry of the
+last token the completed session could issue, and publication checks it when the
 batch is admitted. This is the same horizon that bounds remote upload tokens
 (section 6.3; format spec, "Garbage collection", rule 11), so content cannot
 be reclaimed and then admitted through an older in-process proof.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2469,15 +2469,14 @@ publishing CAS) — under these rules:
    needs no delete-time re-verification. The constants live beside `T` in
    `loonfs-core`'s `limits` module and the inequality is a compile-time
    assertion. A publication in the same process that completed the session
-   holds its admission directly instead of carrying a receipt, so nothing
-   expires it; what bounds it is the same grace, and a host that stages
-   content and publishes it much later has to publish inside that grace for
-   the same reason a remote client has to re-read its session for a fresh
-   receipt. The reasoning above assumes a content object is referenced
-   only by the namespace whose session created it and by fork descendants
-   reading through a pinned basis; a same-content-store copy across
-   namespaces (section 2.8) would have to root the reference on the source
-   side the way a fork does.
+   holds its admission directly instead of carrying a receipt, but that proof
+   carries a deadline no later than the last token the session could issue.
+   Batch admission checks the deadline again, so the same inequality covers
+   both local proofs and remote tokens. The reasoning above assumes a content
+   object is referenced only by the namespace whose session created it and by
+   fork descendants reading through a pinned basis; a same-content-store copy
+   across namespaces (section 2.8) would have to root the reference on the
+   source side the way a fork does.
 12. **A compaction job's objects are decided by its lease.** A streaming
    compaction ("Compaction") publishes nothing until it finishes and is paced
    by no budget, so its output is unreferenced for as long as the job runs.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2470,7 +2470,8 @@ publishing CAS) — under these rules:
    `loonfs-core`'s `limits` module and the inequality is a compile-time
    assertion. A publication in the same process that completed the session
    holds its admission directly instead of carrying a receipt, but that proof
-   carries a deadline no later than the last token the session could issue.
+   carries a deadline no later than the expiry of the last token the session
+   could issue.
    Batch admission checks the deadline again, so the same inequality covers
    both local proofs and remote tokens. The reasoning above assumes a content
    object is referenced only by the namespace whose session created it and by


### PR DESCRIPTION
Carry upload content-proof deadlines into prepared publication and check them when a batch is admitted. Derive the in-process deadline from the same receipt and token window used by content reclamation.

This prevents retained prepared content from publishing a reference after garbage collection can reclaim the object.