### PR TITLE
fix(core): bind prepared content to its namespace

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -638,6 +638,7 @@ mod tests {
 
         let content_ref = ContentRef::blob_v1(ContentId::generate(), b"proof");
         let admission = ContentAdmission::for_durable_content_write(
+            namespace_id.clone(),
             ContentStoreId::parse("cs_00000000000000000000000000000001").expect("content store id"),
             content_ref,
         );

--- a/crates/loonfs-core/src/content.rs
+++ b/crates/loonfs-core/src/content.rs
@@ -4,11 +4,11 @@
 // resolves the namespace's content store from the pinned head and applies
 // the caller's byte budget, so no consumer needs the raw store read.
 pub use crate::protocol::CompletedUpload;
-pub use crate::storage::content::{
-    prepare_existing_content_ref, DurableContentValidationError, StoredContent,
-};
 #[cfg(any(test, feature = "test-support"))]
-pub use crate::storage::content::{prepare_stored_content, store_bytes_as_content};
+pub use crate::storage::content::{
+    prepare_existing_content_ref, prepare_stored_content, store_bytes_as_content,
+};
+pub use crate::storage::content::{DurableContentValidationError, StoredContent};
 pub use crate::storage::content_admission::{
     mint_content_token, verify_content_token, CompletedUploadReceipt, ContentTokenError,
     PreparedContent,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -18,7 +18,7 @@ use crate::protocol::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
     MultipartPartTargets, ResolvedUploadCompletion,
 };
-use crate::storage::content::FileContentStream;
+use crate::storage::content::{load_durable_content_bytes_for_import, FileContentStream};
 use crate::storage::content_admission::{CompletedUploadReceipt, PreparedContent};
 use crate::time::current_time_ms;
 use loonfs_api::options::{DirectMultipartUploadOptions, ListPathEntriesOptions, StatPathOptions};
@@ -742,6 +742,29 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
             &self.mutation_context()?,
         )
         .await
+    }
+
+    /// Imports an existing object under a fresh identity owned by this
+    /// namespace.
+    ///
+    /// A content reference locates bytes but does not identify the namespace
+    /// whose upload session keeps them alive. This reads and verifies the
+    /// complete source object, then stages those bytes through a new local
+    /// upload session so collection in the source namespace cannot invalidate
+    /// a later publication here.
+    pub async fn import_content_ref(
+        &self,
+        catalog: &VerifiedNamespaceCatalogEntry,
+        content_ref: &ContentRef,
+    ) -> Result<PreparedContent> {
+        let catalog = self.own_catalog(catalog)?;
+        let bytes = load_durable_content_bytes_for_import(
+            &self.store,
+            catalog.content_store_id(),
+            content_ref,
+        )
+        .await?;
+        self.stage_owned_bytes(catalog, &bytes).await
     }
 
     /// Stages a streamed payload as content a session owns, hashing it on

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -142,6 +142,7 @@ mod tests {
         content_ref: loonfs_api::ContentRef,
     ) -> CommitCandidate {
         let admission = ContentAdmission::for_durable_content_write(
+            NamespaceId::parse("demo").expect("namespace id"),
             content_store_id.clone(),
             content_ref.clone(),
         );

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -147,6 +147,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             // whole request has planned and validated.
             if let Err(error) = validate_commit_content_references(
                 candidate,
+                namespace_id,
                 view.content_store_id(),
                 context.now_ms,
             ) {

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -210,6 +210,7 @@ async fn commit_response_from_commit_receipt<S: ObjectStore + ?Sized>(
 }
 
 struct CommitContentAdmissions<'a> {
+    namespace_id: &'a NamespaceId,
     content_store_id: &'a ContentStoreId,
     admissions: &'a [ContentAdmission],
     now_ms: u64,
@@ -217,19 +218,26 @@ struct CommitContentAdmissions<'a> {
 
 impl CommitContentAdmissions<'_> {
     fn admits(&self, content_ref: &ContentRef) -> bool {
-        self.admissions
-            .iter()
-            .any(|admission| admission.admits(self.content_store_id, content_ref, self.now_ms))
+        self.admissions.iter().any(|admission| {
+            admission.admits(
+                self.namespace_id,
+                self.content_store_id,
+                content_ref,
+                self.now_ms,
+            )
+        })
     }
 }
 
 /// Checks that each put has a matching content preparation proof.
 pub(super) fn validate_commit_content_references(
     candidate: &CommitCandidate,
+    namespace_id: &NamespaceId,
     content_store_id: &ContentStoreId,
     now_ms: u64,
 ) -> Result<()> {
     let admissions = CommitContentAdmissions {
+        namespace_id,
         content_store_id,
         now_ms,
         admissions: match candidate.content_preparation() {

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -1219,6 +1219,7 @@ fn completed_upload(
             status: completed_status(content_ref, completed_at_ms),
         },
         prepared: PreparedContent::from_admission(ContentAdmission::for_completed_upload(
+            namespace_id.clone(),
             content_store_id.clone(),
             content_ref.clone(),
             completed_at_ms.saturating_add(COMPLETED_UPLOAD_ADMISSION_WINDOW_MS),

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -4,7 +4,9 @@
 use crate::error::CoreError;
 #[cfg(any(test, feature = "test-support"))]
 use crate::namespace::catalog::load_namespace_content_store_id;
+#[cfg(any(test, feature = "test-support"))]
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
+#[cfg(any(test, feature = "test-support"))]
 use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use futures::StreamExt;
@@ -88,16 +90,30 @@ pub enum DurableContentValidationError {
     Store { object_key: String, message: String },
 }
 
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
     content_ref: &ContentRef,
 ) -> Result<(), DurableContentValidationError> {
+    load_durable_content_bytes_for_import(store, content_store_id, content_ref)
+        .await
+        .map(|_| ())
+}
+
+/// Loads and verifies an existing object before copying it under new
+/// namespace-owned content identity.
+pub(crate) async fn load_durable_content_bytes_for_import<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: &ContentStoreId,
+    content_ref: &ContentRef,
+) -> Result<Vec<u8>, DurableContentValidationError> {
     let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
     validate_content_size(store, &object_key, content_ref).await?;
 
     let bytes = load_required_object(store, &object_key).await?;
-    validate_loaded_content_bytes(object_key, content_ref, &bytes)
+    validate_loaded_content_bytes(object_key, content_ref, &bytes)?;
+    Ok(bytes)
 }
 
 /// Prepares content from an acknowledged LoonFS-managed durable write.
@@ -119,7 +135,11 @@ pub fn prepare_stored_content(
     }
     let content_store_id = stored_content.content_store_id;
     let content_ref = stored_content.content_ref;
-    let admission = ContentAdmission::for_durable_content_write(content_store_id, content_ref);
+    let admission = ContentAdmission::for_durable_content_write(
+        catalog.namespace_id().clone(),
+        content_store_id,
+        content_ref,
+    );
     Ok(PreparedContent::from_admission(admission))
 }
 
@@ -127,6 +147,7 @@ pub fn prepare_stored_content(
 ///
 /// The verified catalog selects the store to validate. This performs one
 /// object HEAD followed by one full GET and checksum check.
+#[cfg(any(test, feature = "test-support"))]
 pub async fn prepare_existing_content_ref<S: ObjectStore + ?Sized>(
     store: &S,
     catalog: &VerifiedNamespaceCatalogEntry,
@@ -134,8 +155,11 @@ pub async fn prepare_existing_content_ref<S: ObjectStore + ?Sized>(
 ) -> Result<PreparedContent, DurableContentValidationError> {
     let content_store_id = catalog.content_store_id();
     validate_durable_content_reference(store, content_store_id, &content_ref).await?;
-    let admission =
-        ContentAdmission::for_durable_content_write(content_store_id.clone(), content_ref);
+    let admission = ContentAdmission::for_durable_content_write(
+        catalog.namespace_id().clone(),
+        content_store_id.clone(),
+        content_ref,
+    );
     Ok(PreparedContent::from_admission(admission))
 }
 

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -1,9 +1,10 @@
 //! Content preparation proofs and short-lived tokens used by producers.
 //!
 //! A token can be created only from a durable, completed upload session. It
-//! proves that the named content was verified before publication. Token
-//! expiry is preserved when converting it to [`PreparedContent`] and checked
-//! again when a publish batch admits the proof.
+//! proves that the named content was verified before publication. Namespace
+//! and store binding plus token expiry are preserved when converting it to
+//! [`PreparedContent`] and checked again when a publish batch admits the
+//! proof.
 
 use crate::limits::CONTENT_RECEIPT_TTL_MS;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
@@ -48,6 +49,7 @@ impl CompletedUploadReceipt {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ContentAdmission {
+    namespace_id: NamespaceId,
     content_store_id: ContentStoreId,
     content_ref: ContentRef,
     expires_at_ms: u64,
@@ -56,11 +58,14 @@ pub(crate) struct ContentAdmission {
 impl ContentAdmission {
     /// Unbounded admission for a ref the caller keeps externally rooted;
     /// no deadline is derivable from the reference alone.
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) fn for_durable_content_write(
+        namespace_id: NamespaceId,
         content_store_id: ContentStoreId,
         content_ref: ContentRef,
     ) -> Self {
         Self {
+            namespace_id,
             content_store_id,
             content_ref,
             expires_at_ms: u64::MAX,
@@ -68,11 +73,13 @@ impl ContentAdmission {
     }
 
     pub(crate) fn for_completed_upload(
+        namespace_id: NamespaceId,
         content_store_id: ContentStoreId,
         content_ref: ContentRef,
         expires_at_ms: u64,
     ) -> Self {
         Self {
+            namespace_id,
             content_store_id,
             content_ref,
             expires_at_ms,
@@ -81,11 +88,13 @@ impl ContentAdmission {
 
     pub(crate) fn admits(
         &self,
+        namespace_id: &NamespaceId,
         content_store_id: &ContentStoreId,
         content_ref: &ContentRef,
         now_ms: u64,
     ) -> bool {
-        self.content_store_id == *content_store_id
+        self.namespace_id == *namespace_id
+            && self.content_store_id == *content_store_id
             && self.content_ref == *content_ref
             && now_ms <= self.expires_at_ms
     }
@@ -218,6 +227,7 @@ pub fn verify_content_token(
     }
 
     let admission = ContentAdmission::for_completed_upload(
+        payload.namespace_id,
         payload.content_store_id,
         payload.content_ref,
         payload.expires_at_ms,
@@ -291,9 +301,36 @@ mod tests {
             verify_content_token("secret", &catalog, &token, 1_000).expect("verify token");
 
         assert_eq!(prepared.content_ref(), &content);
-        assert!(prepared
-            .into_admission()
-            .admits(catalog.content_store_id(), &content, 1_000));
+        assert!(prepared.into_admission().admits(
+            catalog.namespace_id(),
+            catalog.content_store_id(),
+            &content,
+            1_000,
+        ));
+    }
+
+    #[test]
+    fn prepared_admission_remains_bound_to_its_namespace() {
+        let namespace = NamespaceId::parse("source").expect("namespace");
+        let other_namespace = NamespaceId::parse("target").expect("namespace");
+        let content = ContentRef::blob_v1(ContentId::generate(), b"hello");
+        let token = mint_content_token(
+            "secret",
+            &receipt(&namespace, CONTENT_STORE, &content),
+            1_000,
+        )
+        .expect("mint");
+        let catalog = catalog_entry(namespace, CONTENT_STORE);
+        let admission = verify_content_token("secret", &catalog, &token, 1_000)
+            .expect("verify token")
+            .into_admission();
+
+        assert!(!admission.admits(
+            &other_namespace,
+            catalog.content_store_id(),
+            &content,
+            1_000,
+        ));
     }
 
     #[test]
@@ -342,11 +379,13 @@ mod tests {
 
         let admission = prepared.into_admission();
         assert!(admission.admits(
+            catalog.namespace_id(),
             catalog.content_store_id(),
             &content,
             issued_at_ms + CONTENT_RECEIPT_TTL_MS,
         ));
         assert!(!admission.admits(
+            catalog.namespace_id(),
             catalog.content_store_id(),
             &content,
             issued_at_ms + CONTENT_RECEIPT_TTL_MS + 1,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -7,7 +7,7 @@ use crate::trace::phase_span;
 use crate::ByteStream;
 use crate::FsWriter;
 use crate::{
-    ChangeSeq, CommitId, CommitOptions, CommitResponse, ContentRef, CopyOptions, CoreError,
+    ChangeSeq, CommitId, CommitOptions, CommitResponse, ContentRef, CopyOptions,
     CreateDirectoryOptions, DeleteOptions, InodeId, MoveOptions, NamespaceId, PutFileOptions,
     RestoreRevisionOptions, RevisionNo, UndeleteOptions, UpdateAttributesOptions,
 };
@@ -405,11 +405,13 @@ impl FsWriter {
         .await
     }
 
-    /// Publishes a file revision that points at an already-durable content ref.
+    /// Publishes a file revision from an already-durable content ref.
     ///
-    /// This explicitly slow helper reads the full object to prove durability
-    /// before publication. Callers that already hold proof should prefer
-    /// [`Self::put_file_prepared`].
+    /// This explicitly slow helper reads and verifies the full source object,
+    /// then stages a fresh copy owned by this namespace before publication.
+    /// Callers that already hold same-namespace proof should prefer
+    /// [`Self::put_file_prepared`]. The published revision points at the fresh
+    /// prepared ref, not the input ref.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.put",
@@ -446,13 +448,13 @@ impl FsWriter {
             .await
     }
 
-    /// Fully validates an existing content ref for later publication.
+    /// Imports an existing content ref for later publication.
     ///
-    /// Preparation performs one content HEAD followed by one full content
-    /// GET and digest check. Later prepared publication performs no content
-    /// I/O. The proof asserts binding, not longevity: it stays safe only
-    /// while an existing revision keeps the ref referenced, since only
-    /// unreferenced content is ever reclaimed.
+    /// Preparation performs one content HEAD, one full GET and digest check,
+    /// and one content PUT under a fresh identity owned by this namespace.
+    /// Later prepared publication performs no content I/O. The returned
+    /// prepared ref therefore differs from the input ref while describing the
+    /// same bytes.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.prepare",
@@ -492,13 +494,10 @@ impl FsWriter {
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
-        Ok(loonfs_core::content::prepare_existing_content_ref(
-            &self.core.inner.store,
-            &catalog,
-            content_ref,
-        )
-        .await
-        .map_err(CoreError::from)?)
+        Ok(self
+            .engine(namespace_id)
+            .import_content_ref(&catalog, &content_ref)
+            .await?)
     }
 
     /// Verifies an authorized content token against the namespace's durable

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -263,7 +263,7 @@ async fn put_file_content_ref_validates_content_before_publication() {
         .await
         .expect("publish content ref");
 
-    assert_content_counts(harness.recording.snapshot(), 1, 1, 0, bytes.len());
+    assert_content_counts(harness.recording.snapshot(), 1, 1, 1, bytes.len());
 }
 
 #[tokio::test]
@@ -357,7 +357,7 @@ async fn prepared_content_for_another_store_is_rejected_without_content_io() {
 }
 
 #[tokio::test]
-async fn independent_namespaces_sharing_a_store_share_prepared_content() {
+async fn independent_namespaces_sharing_a_store_reject_each_others_prepared_content() {
     let temp_dir = tempdir().expect("tempdir");
     let recording = RequestLog::new(temp_dir.path());
     let store = recording.store();
@@ -387,7 +387,8 @@ async fn independent_namespaces_sharing_a_store_share_prepared_content() {
         .expect("prepare through source namespace");
     recording.reset();
 
-    writer
+    let content_ref = prepared.content_ref().clone();
+    let error = writer
         .put_file_prepared(
             &target,
             "/shared.txt",
@@ -395,13 +396,14 @@ async fn independent_namespaces_sharing_a_store_share_prepared_content() {
             PutFileOptions::new(loonfs_test_support::test_actor()),
         )
         .await
-        .expect("shared-store target accepts source proof");
+        .expect_err("shared-store target must reject source proof");
 
+    assert_content_not_prepared(error, &content_ref);
     assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
 }
 
 #[tokio::test]
-async fn fork_and_source_share_prepared_content_in_both_directions() {
+async fn fork_and_source_reject_each_others_prepared_content() {
     let temp_dir = tempdir().expect("tempdir");
     let recording = RequestLog::new(temp_dir.path());
     let store = recording.store();
@@ -426,7 +428,8 @@ async fn fork_and_source_share_prepared_content_in_both_directions() {
         .expect("warm fork catalog");
     recording.reset();
 
-    writer
+    let source_content_ref = prepared_for_fork.content_ref().clone();
+    let error = writer
         .put_file_prepared(
             &fork,
             "/from-source.txt",
@@ -434,7 +437,8 @@ async fn fork_and_source_share_prepared_content_in_both_directions() {
             PutFileOptions::new(loonfs_test_support::test_actor()),
         )
         .await
-        .expect("fork accepts source proof");
+        .expect_err("fork must reject source proof");
+    assert_content_not_prepared(error, &source_content_ref);
     assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
 
     let prepared_for_source = writer
@@ -442,7 +446,8 @@ async fn fork_and_source_share_prepared_content_in_both_directions() {
         .await
         .expect("prepare through fork namespace");
     recording.reset();
-    writer
+    let fork_content_ref = prepared_for_source.content_ref().clone();
+    let error = writer
         .put_file_prepared(
             &source,
             "/from-fork.txt",
@@ -450,7 +455,8 @@ async fn fork_and_source_share_prepared_content_in_both_directions() {
             PutFileOptions::new(loonfs_test_support::test_actor()),
         )
         .await
-        .expect("source accepts fork proof");
+        .expect_err("source must reject fork proof");
+    assert_content_not_prepared(error, &fork_content_ref);
     assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
 }
 
@@ -463,11 +469,18 @@ async fn prepare_content_ref_reads_once_and_prepared_publication_reads_nothing()
 
     let prepared = harness
         .writer
-        .prepare_content_ref(&harness.namespace_id, content_ref)
+        .prepare_content_ref(&harness.namespace_id, content_ref.clone())
         .await
         .expect("prepare content ref");
 
-    assert_content_counts(harness.recording.snapshot(), 1, 1, 0, bytes.len());
+    assert_ne!(
+        prepared.content_ref().content_id,
+        content_ref.content_id,
+        "import must mint a target-owned content identity"
+    );
+    assert_eq!(prepared.content_ref().checksum, content_ref.checksum);
+    assert_eq!(prepared.content_ref().size_bytes, content_ref.size_bytes);
+    assert_content_counts(harness.recording.snapshot(), 1, 1, 1, bytes.len());
     harness.recording.reset();
 
     harness

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -202,6 +202,69 @@ async fn a_published_put_keeps_its_content_and_loses_only_the_session_record() {
 }
 
 #[tokio::test]
+async fn imported_content_survives_collection_in_the_source_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let runtime = open_runtime_async(store.clone(), "content-import").await;
+    let source = namespace(&runtime).await;
+    let target = NamespaceId::parse("target").expect("valid namespace id");
+    runtime
+        .writer
+        .fork_namespace(&source, &target)
+        .await
+        .expect("fork namespace");
+
+    let source_prepared = runtime
+        .writer
+        .prepare_file_bytes(&source, b"owned by the target after import")
+        .await
+        .expect("prepare source content");
+    let source_ref = source_prepared.content_ref().clone();
+    let source_key = content_key(&store, &source, &source_ref).await;
+    let imported = runtime
+        .writer
+        .prepare_content_ref(&target, source_ref)
+        .await
+        .expect("import source content");
+    let imported_ref = imported.content_ref().clone();
+    let imported_key = content_key(&store, &target, &imported_ref).await;
+    assert_ne!(
+        source_key, imported_key,
+        "import must mint a fresh identity"
+    );
+
+    runtime
+        .writer
+        .put_file_prepared(
+            &target,
+            "/imported.txt",
+            imported,
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("publish imported content");
+
+    let after_reclamation =
+        loonfs::current_time_ms().expect("wall clock") + CONTENT_RECLAMATION_GRACE_MS + 1;
+    let source_report = collect(&store, &source, after_reclamation).await;
+    assert_eq!(source_report.deleted.content_objects, 1);
+    assert!(!exists(&store, &source_key).await);
+
+    let target_report = collect(&store, &target, after_reclamation).await;
+    assert_eq!(target_report.deleted.content_objects, 0);
+    assert!(exists(&store, &imported_key).await);
+    assert_eq!(
+        runtime
+            .reader
+            .get_file_bytes(&target, "/imported.txt")
+            .await
+            .expect("read imported file")
+            .bytes,
+        b"owned by the target after import"
+    );
+}
+
+#[tokio::test]
 async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survives() {
     let temp_dir = tempdir().expect("tempdir");
     let store = store(temp_dir.path());

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -397,12 +397,13 @@ accepted into a WAL batch, without yet being a committed or successful change.
 
 The embedded `loonfs::FsWriter` makes the first two stages independently
 drivable. `prepare_file_bytes` stages bytes, while `prepare_content_ref`
-fully validates an existing reference; both return opaque prepared content.
-`put_file_prepared` consumes that evidence without content-store I/O during
-publication. `complete_upload_prepared` returns the ordinary completion
-response together with the same evidence. These are embedded conveniences,
-not HTTP operations; hosted clients continue to carry validated content
-tokens on the existing wire requests.
+fully validates an existing reference and re-homes its bytes under a fresh
+content identity owned by the target namespace; both return opaque prepared
+content. `put_file_prepared` consumes that evidence without content-store I/O
+during publication. `complete_upload_prepared` returns the ordinary
+completion response together with the same evidence. These are embedded
+conveniences, not HTTP operations; hosted clients continue to carry validated
+content tokens on the existing wire requests.
 
 Staging is staging wherever it happens, so `prepare_file_bytes` opens an
 upload session for the object it writes, exactly as a remote upload does: the
@@ -412,6 +413,13 @@ last token the completed session could issue, and publication checks it when the
 batch is admitted. This is the same horizon that bounds remote upload tokens
 (section 6.3; format spec, "Garbage collection", rule 11), so content cannot
 be reclaimed and then admitted through an older in-process proof.
+
+Prepared evidence is bound to both the namespace and its content store. Two
+namespaces sharing a content store therefore cannot exchange prepared values:
+their collectors have different metadata roots and upload-session records.
+The explicit `prepare_content_ref` import is the safe handoff when only a ref
+is available; the returned prepared value names the fresh target-owned ref,
+not the input ref.
 
 ### 5.1 Commit identity and race guards
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -885,10 +885,13 @@ Identity is namespace-local. A true inode-preserving rename is therefore
 namespace-local as well.
 
 Across namespaces, a move is modeled as a copy plus a delete from the source
-namespace. Same-content-store copies may reuse `content_ref`. Cross-content-
-store copies are not supported in v0 unless the content is first imported into
-the destination content store. Inode identity does not cross the namespace
-boundary.
+namespace. Sharing a content store does not by itself authorize reuse of a
+`content_ref`: each namespace's collector sees only its own metadata roots and
+upload sessions. A fork may keep refs already reachable through its pinned
+basis. Other copies re-home the bytes under a fresh destination-owned content
+identity unless a future protocol installs a durable source-side root first.
+Cross-content-store copies likewise require import into the destination
+content store. Inode identity does not cross the namespace boundary.
 
 ### 2.9 Recovery view
 
@@ -2475,9 +2478,11 @@ publishing CAS) — under these rules:
    Batch admission checks the deadline again, so the same inequality covers
    both local proofs and remote tokens. The reasoning above assumes a content
    object is referenced only by the namespace whose session created it and by
-   fork descendants reading through a pinned basis; a same-content-store copy
-   across namespaces (section 2.8) would have to root the reference on the
-   source side the way a fork does.
+   fork descendants reading through a pinned basis. Prepared evidence is
+   therefore namespace-bound even when catalogs share a content store, and an
+   embedded raw-ref import (section 2.8) writes the verified bytes under a
+   fresh destination-owned identity. A future identity-preserving copy would
+   have to root the reference on the source side the way a fork does.
 12. **A compaction job's objects are decided by its lease.** A streaming
    compaction ("Compaction") publishes nothing until it finishes and is paced
    by no budget, so its output is unreferenced for as long as the job runs.


### PR DESCRIPTION
Bind prepared content to the namespace whose upload session owns it, even when namespaces share a content store. Import an existing content ref by verifying its bytes and staging a fresh target-owned copy.

This prevents one namespace's completed-upload collector from deleting content that another namespace published through a borrowed proof or raw ref.