### PR TITLE
refactor(core): stream content imports instead of buffering

### DIFF
--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -764,13 +764,18 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
         let (object_key, pump, body) =
             open_content_import_reader(&self.store, catalog.content_store_id(), content_ref)
                 .await?;
-        let ((), staged) = futures::future::join(
+        let (source_checksum, staged) = futures::future::join(
             pump,
             crate::protocol::stage_owned_stream(&self.store, catalog, body, &context),
         )
         .await;
         let prepared = staged?;
-        ensure_imported_ref_matches(object_key, content_ref, prepared.content_ref())?;
+        ensure_imported_ref_matches(
+            object_key,
+            content_ref,
+            prepared.content_ref(),
+            &source_checksum,
+        )?;
         Ok(prepared)
     }
 

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -18,7 +18,9 @@ use crate::protocol::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
     MultipartPartTargets, ResolvedUploadCompletion,
 };
-use crate::storage::content::{load_durable_content_bytes_for_import, FileContentStream};
+use crate::storage::content::{
+    ensure_imported_ref_matches, open_content_import_reader, FileContentStream,
+};
 use crate::storage::content_admission::{CompletedUploadReceipt, PreparedContent};
 use crate::time::current_time_ms;
 use loonfs_api::options::{DirectMultipartUploadOptions, ListPathEntriesOptions, StatPathOptions};
@@ -748,23 +750,28 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
     /// namespace.
     ///
     /// A content reference locates bytes but does not identify the namespace
-    /// whose upload session keeps them alive. This reads and verifies the
-    /// complete source object, then stages those bytes through a new local
-    /// upload session so collection in the source namespace cannot invalidate
-    /// a later publication here.
+    /// whose upload session keeps them alive. This streams the source object
+    /// chunk by chunk into a new local upload session, verifying the claimed
+    /// size and checksum against what was staged, so collection in the source
+    /// namespace cannot invalidate a later publication here.
     pub async fn import_content_ref(
         &self,
         catalog: &VerifiedNamespaceCatalogEntry,
         content_ref: &ContentRef,
     ) -> Result<PreparedContent> {
         let catalog = self.own_catalog(catalog)?;
-        let bytes = load_durable_content_bytes_for_import(
-            &self.store,
-            catalog.content_store_id(),
-            content_ref,
+        let context = self.mutation_context()?;
+        let (object_key, pump, body) =
+            open_content_import_reader(&self.store, catalog.content_store_id(), content_ref)
+                .await?;
+        let ((), staged) = futures::future::join(
+            pump,
+            crate::protocol::stage_owned_stream(&self.store, catalog, body, &context),
         )
-        .await?;
-        self.stage_owned_bytes(catalog, &bytes).await
+        .await;
+        let prepared = staged?;
+        ensure_imported_ref_matches(object_key, content_ref, prepared.content_ref())?;
+        Ok(prepared)
     }
 
     /// Stages a streamed payload as content a session owns, hashing it on

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -9,7 +9,7 @@ use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 #[cfg(any(test, feature = "test-support"))]
 use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 #[cfg(any(test, feature = "test-support"))]
 use loonfs_api::NamespaceId;
 use loonfs_api::{
@@ -96,24 +96,81 @@ pub(crate) async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     content_store_id: &ContentStoreId,
     content_ref: &ContentRef,
 ) -> Result<(), DurableContentValidationError> {
-    load_durable_content_bytes_for_import(store, content_store_id, content_ref)
-        .await
-        .map(|_| ())
-}
-
-/// Loads and verifies an existing object before copying it under new
-/// namespace-owned content identity.
-pub(crate) async fn load_durable_content_bytes_for_import<S: ObjectStore + ?Sized>(
-    store: &S,
-    content_store_id: &ContentStoreId,
-    content_ref: &ContentRef,
-) -> Result<Vec<u8>, DurableContentValidationError> {
     let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
     validate_content_size(store, &object_key, content_ref).await?;
-
     let bytes = load_required_object(store, &object_key).await?;
-    validate_loaded_content_bytes(object_key, content_ref, &bytes)?;
-    Ok(bytes)
+    validate_loaded_content_bytes(object_key, content_ref, &bytes)
+}
+
+/// Opens a chunked reader over an existing object for import: one HEAD, then
+/// ranged reads pumped through a one-chunk channel, so nothing holds the
+/// whole object. Drive the pump and the staging consumer together.
+pub(crate) async fn open_content_import_reader<'a, S: ObjectStore + ?Sized>(
+    store: &'a S,
+    content_store_id: &ContentStoreId,
+    content_ref: &ContentRef,
+) -> Result<
+    (
+        String,
+        impl std::future::Future<Output = ()> + 'a,
+        ByteStream,
+    ),
+    DurableContentValidationError,
+> {
+    let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
+    validate_content_size(store, &object_key, content_ref).await?;
+    let size_bytes = content_ref.size_bytes;
+    let (mut sender, receiver) = futures::channel::mpsc::channel(1);
+    let pump_key = object_key.clone();
+    let pump = async move {
+        let mut offset = 0u64;
+        while offset < size_bytes {
+            let end = offset
+                .saturating_add(CONTENT_READ_CHUNK_BYTES)
+                .min(size_bytes);
+            let range = ByteRange {
+                start_inclusive: offset,
+                end_exclusive: end,
+            };
+            let chunk = match store.get(&pump_key, Some(range)).await {
+                Ok(Some(bytes)) => Ok(bytes),
+                Ok(None) => Err(ObjectStoreError::transport(
+                    &pump_key,
+                    "content object disappeared during import",
+                )),
+                Err(error) => Err(error),
+            };
+            let failed = chunk.is_err();
+            if sender.send(chunk).await.is_err() || failed {
+                return;
+            }
+            offset = end;
+        }
+    };
+    Ok((object_key, pump, receiver.boxed()))
+}
+
+/// Checks that a staged import carries the bytes the source ref claimed.
+pub(crate) fn ensure_imported_ref_matches(
+    object_key: String,
+    expected: &ContentRef,
+    staged: &ContentRef,
+) -> Result<(), DurableContentValidationError> {
+    if staged.size_bytes != expected.size_bytes {
+        return Err(DurableContentValidationError::ContentLengthMismatch {
+            object_key,
+            expected: expected.size_bytes,
+            actual: staged.size_bytes,
+        });
+    }
+    if staged.checksum != expected.checksum {
+        return Err(DurableContentValidationError::ContentChecksumMismatch {
+            object_key,
+            expected: describe_checksum(&expected.checksum),
+            actual: describe_checksum(&staged.checksum),
+        });
+    }
+    Ok(())
 }
 
 /// Prepares content from an acknowledged LoonFS-managed durable write.

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -112,7 +112,7 @@ pub(crate) async fn open_content_import_reader<'a, S: ObjectStore + ?Sized>(
 ) -> Result<
     (
         String,
-        impl std::future::Future<Output = ()> + 'a,
+        impl std::future::Future<Output = Checksum> + 'a,
         ByteStream,
     ),
     DurableContentValidationError,
@@ -120,9 +120,11 @@ pub(crate) async fn open_content_import_reader<'a, S: ObjectStore + ?Sized>(
     let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
     validate_content_size(store, &object_key, content_ref).await?;
     let size_bytes = content_ref.size_bytes;
+    let checksum_algorithm = content_ref.checksum.algorithm;
     let (mut sender, receiver) = futures::channel::mpsc::channel(1);
     let pump_key = object_key.clone();
     let pump = async move {
+        let mut checksum = StreamingChecksum::for_algorithm(checksum_algorithm);
         let mut offset = 0u64;
         while offset < size_bytes {
             let end = offset
@@ -141,11 +143,15 @@ pub(crate) async fn open_content_import_reader<'a, S: ObjectStore + ?Sized>(
                 Err(error) => Err(error),
             };
             let failed = chunk.is_err();
+            if let Ok(bytes) = &chunk {
+                checksum.update(bytes);
+            }
             if sender.send(chunk).await.is_err() || failed {
-                return;
+                return checksum.finish();
             }
             offset = end;
         }
+        checksum.finish()
     };
     Ok((object_key, pump, receiver.boxed()))
 }
@@ -155,6 +161,7 @@ pub(crate) fn ensure_imported_ref_matches(
     object_key: String,
     expected: &ContentRef,
     staged: &ContentRef,
+    source_checksum: &Checksum,
 ) -> Result<(), DurableContentValidationError> {
     if staged.size_bytes != expected.size_bytes {
         return Err(DurableContentValidationError::ContentLengthMismatch {
@@ -163,11 +170,11 @@ pub(crate) fn ensure_imported_ref_matches(
             actual: staged.size_bytes,
         });
     }
-    if staged.checksum != expected.checksum {
+    if source_checksum != &expected.checksum {
         return Err(DurableContentValidationError::ContentChecksumMismatch {
             object_key,
             expected: describe_checksum(&expected.checksum),
-            actual: describe_checksum(&staged.checksum),
+            actual: describe_checksum(source_checksum),
         });
     }
     Ok(())

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -2,6 +2,10 @@
 
 #![allow(dead_code)]
 #![allow(clippy::panic)]
+#![allow(
+    clippy::result_large_err,
+    reason = "test helpers preserve the client's structured error type"
+)]
 
 use loonfs_api::{ListCheckpointsResponse, ListPathEntriesResponse, NamespaceId};
 use loonfs_client::{Client, ClientConfig, ListPathEntriesOptions, NamespacePath};

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -461,6 +461,25 @@ async fn fork_and_source_reject_each_others_prepared_content() {
 }
 
 #[tokio::test]
+async fn prepare_content_ref_rejects_bytes_that_do_not_match_the_ref() {
+    let harness = TestHarness::new("content-import-mismatch").await;
+    let content_ref = harness.stage_content(b"real bytes").await;
+    let mut lying_ref = content_ref.clone();
+    lying_ref.checksum =
+        loonfs_api::Checksum::compute(lying_ref.checksum.algorithm, b"other bytes");
+
+    let error = harness
+        .writer
+        .prepare_content_ref(&harness.namespace_id, lying_ref)
+        .await
+        .expect_err("import must reject a ref whose checksum does not match the bytes");
+    assert!(
+        error.to_string().contains("content checksum mismatch"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn prepare_content_ref_reads_once_and_prepared_publication_reads_nothing() {
     let harness = TestHarness::new("prepare-content-ref").await;
     let bytes = b"externally staged content";

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -9,7 +9,7 @@ use loonfs::publish::{
 use loonfs::{
     BeginUploadRequest, CommitId, CoreError, CreateDirectoryOptions, CreateNamespaceOptions,
     DestinationBehavior, ErrorCode, FsWriter, NamespaceId, PutFileOptions, RevisionNo,
-    RuntimeError, SharedObjectStore,
+    RuntimeError, SharedObjectStore, CONTENT_READ_CHUNK_BYTES,
 };
 use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
 use loonfs_api::{ContentId, ContentStoreId};
@@ -465,8 +465,7 @@ async fn prepare_content_ref_rejects_bytes_that_do_not_match_the_ref() {
     let harness = TestHarness::new("content-import-mismatch").await;
     let content_ref = harness.stage_content(b"real bytes").await;
     let mut lying_ref = content_ref.clone();
-    lying_ref.checksum =
-        loonfs_api::Checksum::compute(lying_ref.checksum.algorithm, b"other bytes");
+    lying_ref.checksum = loonfs_api::Checksum::crc64nvme(b"other bytes");
 
     let error = harness
         .writer
@@ -477,6 +476,48 @@ async fn prepare_content_ref_rejects_bytes_that_do_not_match_the_ref() {
         error.to_string().contains("content checksum mismatch"),
         "unexpected error: {error}"
     );
+}
+
+#[tokio::test]
+async fn prepare_content_ref_accepts_a_matching_crc64nvme_ref() {
+    let harness = TestHarness::new("content-import-crc64nvme").await;
+    let bytes = b"direct-uploaded bytes";
+    let mut content_ref = harness.stage_content(bytes).await;
+    content_ref.checksum = loonfs_api::Checksum::crc64nvme(bytes);
+
+    let prepared = harness
+        .writer
+        .prepare_content_ref(&harness.namespace_id, content_ref)
+        .await
+        .expect("import must validate with the source ref's checksum algorithm");
+
+    assert_eq!(prepared.content_ref().size_bytes, bytes.len() as u64);
+    assert_eq!(
+        prepared.content_ref().checksum,
+        loonfs_api::Checksum::sha256(bytes),
+        "the destination may use its own checksum algorithm"
+    );
+}
+
+#[tokio::test]
+async fn prepare_content_ref_reads_large_sources_in_bounded_ranges() {
+    let harness = TestHarness::new("content-import-ranges").await;
+    let bytes = vec![b'x'; CONTENT_READ_CHUNK_BYTES as usize + 17];
+    let content_ref = harness.stage_content(&bytes).await;
+    harness.recording.reset();
+
+    let prepared = harness
+        .writer
+        .prepare_content_ref(&harness.namespace_id, content_ref)
+        .await
+        .expect("import a source larger than one read chunk");
+
+    assert_eq!(prepared.content_ref().size_bytes, bytes.len() as u64);
+    assert_eq!(
+        prepared.content_ref().checksum,
+        loonfs_api::Checksum::sha256(&bytes)
+    );
+    assert_content_counts(harness.recording.snapshot(), 1, 2, 1, bytes.len());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Stream existing content imports through bounded ranged reads into the destination staging path. Validate the source bytes with the checksum algorithm carried by the source ref while giving the staged copy a fresh destination-owned identity.

This avoids buffering the complete source object in memory and rejects size or checksum mismatches before returning prepared content.