### PR TITLE
feat(server): accept inline TOML configuration

### DIFF
--- a/crates/loonfs-server/README.md
+++ b/crates/loonfs-server/README.md
@@ -51,6 +51,11 @@ Validate a config without starting the server:
 loonfs-server --config /etc/loonfs/server.toml --check-config
 ```
 
+Container hosts without configuration-file mounts may supply the same TOML
+through `LOONFS_SERVER_CONFIG_TOML` and omit `--config`. Keep credentials and
+the two server secrets in their dedicated environment variables rather than
+putting them in the inline TOML.
+
 The command prints one line and exits. It runs the checks a start runs
 before it serves: the config fields, the TLS certificate and key, and the
 local block cache directory. It does not bind the configured address and it

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -554,6 +554,15 @@ pub fn load_server_config(path: impl AsRef<Path>) -> Result<ServerConfig, Server
     let bytes = fs::read(path.as_ref()).map_err(|err| ServerConfigError::Io(err.to_string()))?;
     let source =
         std::str::from_utf8(&bytes).map_err(|err| ServerConfigError::Decode(err.to_string()))?;
+    parse_server_config(source)
+}
+
+/// Parses and validates a server configuration supplied directly as TOML.
+///
+/// Container hosts that cannot mount a configuration file use this entry
+/// point. Provider and server secrets should still come from their dedicated
+/// environment variables instead of being included in `source`.
+pub fn parse_server_config(source: &str) -> Result<ServerConfig, ServerConfigError> {
     let mut config: ServerConfig =
         toml::from_str(source).map_err(|err| ServerConfigError::Decode(err.to_string()))?;
     config.apply_env_fallbacks(

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -11,8 +11,9 @@ mod local_cache;
 mod trace;
 
 pub use config::{
-    load_server_config, GrepConfig, GrepMode, LocalCacheConfig, MaintenanceMode,
-    RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig, TlsServerConfig,
+    load_server_config, parse_server_config, GrepConfig, GrepMode, LocalCacheConfig,
+    MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig,
+    TlsServerConfig,
 };
 #[cfg(feature = "test-support")]
 pub use http::app_with_test_transfers;

--- a/crates/loonfs-server/src/main.rs
+++ b/crates/loonfs-server/src/main.rs
@@ -1,16 +1,29 @@
 //! The reference server binary: load config, open the runtime, serve HTTP
 //! until shutdown.
 
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use std::io::Write as _;
 use std::process::ExitCode;
 
 #[derive(Debug, Parser)]
-#[command(name = "loonfs-server", version)]
+#[command(
+    name = "loonfs-server",
+    version,
+    group(
+        ArgGroup::new("config_source")
+            .required(true)
+            .multiple(false)
+            .args(["config", "config_toml"])
+    )
+)]
 struct Args {
     /// Config file to load.
     #[arg(long)]
-    config: String,
+    config: Option<String>,
+    /// Inline config TOML. Prefer LOONFS_SERVER_CONFIG_TOML so the value does
+    /// not appear in process arguments.
+    #[arg(long, env = "LOONFS_SERVER_CONFIG_TOML", hide_env_values = true)]
+    config_toml: Option<String>,
     /// Validate the startup config and exit without serving.
     #[arg(long)]
     check_config: bool,
@@ -26,7 +39,14 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
     // when `LOONFS_TRACE` holds a value this build rejects.
     let args = Args::parse();
     loonfs_server::init_tracing_from_env()?;
-    let config = loonfs_server::load_server_config(&args.config)?;
+    let config = match args.config {
+        Some(path) => loonfs_server::load_server_config(path)?,
+        None => loonfs_server::parse_server_config(
+            args.config_toml
+                .as_deref()
+                .expect("clap should require exactly one config source"),
+        )?,
+    };
     let mut exit_code = ExitCode::SUCCESS;
     if args.check_config || args.probe_store {
         // Either flag includes the startup checks, and combined flags run

--- a/crates/loonfs-server/tests/it/check_config.rs
+++ b/crates/loonfs-server/tests/it/check_config.rs
@@ -65,8 +65,20 @@ fn write_tls_identity(dir: &Path) -> (PathBuf, PathBuf) {
 
 fn run_server(config_path: &Path, flags: &[&str]) -> std::process::Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_loonfs-server"));
-    command.arg("--config").arg(config_path).args(flags);
+    command
+        .env_remove("LOONFS_SERVER_CONFIG_TOML")
+        .arg("--config")
+        .arg(config_path)
+        .args(flags);
     command.output().expect("run loonfs-server")
+}
+
+fn run_server_from_toml(config_toml: &str, flags: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_loonfs-server"))
+        .env("LOONFS_SERVER_CONFIG_TOML", config_toml)
+        .args(flags)
+        .output()
+        .expect("run loonfs-server with inline config")
 }
 
 #[tokio::test]
@@ -166,6 +178,43 @@ fn check_config_accepts_a_valid_config_and_names_what_it_validated() {
     );
     // The documented caveat: constructing a local-fs store creates its root.
     assert!(store_root.is_dir(), "local-fs check creates the store root");
+}
+
+#[test]
+fn check_config_accepts_toml_from_the_environment() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store_root = dir.path().join("store");
+    let config_toml = format!(
+        r#"
+bind = "127.0.0.1:9400"
+auth_token = "inline-config-token"
+content_token_secret = "inline-content-secret"
+writer_id = "inline-config-writer"
+
+[store]
+kind = "local-fs"
+root = "{}"
+"#,
+        store_root.display()
+    );
+
+    let output = run_server_from_toml(&config_toml, &["--check-config"]);
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        output.status.success(),
+        "expected success, got {:?}: {stdout}{stderr}",
+        output.status
+    );
+    assert_eq!(
+        stdout.trim(),
+        "config ok: bind 127.0.0.1:9400, store local-fs"
+    );
+    assert!(!stdout.contains("inline-config-token"), "{stdout}");
+    assert!(!stdout.contains("inline-content-secret"), "{stdout}");
+    assert!(!stderr.contains("inline-config-token"), "{stderr}");
+    assert!(!stderr.contains("inline-content-secret"), "{stderr}");
 }
 
 #[test]


### PR DESCRIPTION
This allows loonfs-server to read TOML configuration from the LOONFS_SERVER_CONFIG_TOML environment variable. Existing file-based configuration is unchanged. An integration test covers the new configuration path.

Validated with cargo fmt and the loonfs-server configuration tests.