### PR TITLE
fix(server): reject unrelated Cloudflare paths

### DIFF
--- a/crates/loonfs-server/deploy/cloudflare/README.md
+++ b/crates/loonfs-server/deploy/cloudflare/README.md
@@ -73,4 +73,4 @@ The test checks the server, R2 access, and an upload and download.
 - Keep `max_instances` set to `1`. LoonFS expects one active server writer.
 - The first request may take a few minutes while the Container starts.
 - The Container stops after ten idle minutes and starts again on demand.
-- `/health` and `/readiness` are public. All other routes require the auth token.
+- `/health` and `/readiness` are public. `/metrics` and `/v0/*` require the auth token.

--- a/crates/loonfs-server/deploy/cloudflare/src/index.ts
+++ b/crates/loonfs-server/deploy/cloudflare/src/index.ts
@@ -72,7 +72,13 @@ export class LoonFSContainer extends Container<Env> {
 }
 
 export default {
-  fetch(request: Request, env: Env): Promise<Response> {
+  fetch(request: Request, env: Env) {
+    const path = new URL(request.url).pathname;
+    const isLoonFSPath =
+      ["/health", "/readiness", "/metrics"].includes(path) || path.startsWith("/v0/");
+    if (!isLoonFSPath) {
+      return new Response("Not Found", { status: 404 });
+    }
     return getContainer(env.LOONFS_CONTAINER, "primary").fetch(request);
   },
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
Rejects requests outside the LoonFS HTTP surface at the Worker edge so unrelated traffic does not start or keep the Container alive. Health, readiness, metrics, and versioned API requests continue to reach LoonFS.

Validated with TypeScript checking, a Wrangler dry-run build, and a local request that returned 404 without reaching the Container.