### PR TITLE
docs(api): document change feed rebootstrap responses

### DIFF
--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -573,6 +573,7 @@ pub(super) async fn create_commit(
             (status = 400, description = "Invalid change cursor or limit", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 409, description = "The cursor is below the retention floor; rebootstrap required", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             crate::http::openapi::UnavailableResponses
         )

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -573,7 +573,7 @@ pub(super) async fn create_commit(
             (status = 400, description = "Invalid change cursor or limit", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
-            (status = 409, description = "The cursor is below the retention floor; rebootstrap required", body = ApiError),
+            (status = 409, description = "The cursor is older than the retained change history and requires a fresh snapshot", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             crate::http::openapi::UnavailableResponses
         )

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -139,7 +139,7 @@
             }
           },
           "409": {
-            "description": "The cursor is below the retention floor; rebootstrap required",
+            "description": "The cursor is older than the retained change history and requires a fresh snapshot",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -138,6 +138,16 @@
               }
             }
           },
+          "409": {
+            "description": "The cursor is below the retention floor; rebootstrap required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1315,7 +1315,7 @@
             }
           },
           "409": {
-            "description": "The cursor is below the retention floor; rebootstrap required",
+            "description": "The cursor is older than the retained change history and requires a fresh snapshot",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1314,6 +1314,16 @@
               }
             }
           },
+          "409": {
+            "description": "The cursor is below the retention floor; rebootstrap required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {


### PR DESCRIPTION
Documents the `409 Conflict` returned when a change feed cursor is older than the retained history. Generated clients now include the `rebootstrap_required` response instead of treating it as undocumented.

Regenerates the full and proxy OpenAPI documents.