### PR TITLE
fix(tests): retry transient macOS HTTP teardown errors

### DIFF
--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -12,7 +12,7 @@ use loonfs_api::{
 use loonfs_client::{ClientError, NamespacePath};
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::{ConfiguredObjectStore, ObjectStore};
-use loonfs_test_support::http::raw_agent;
+use loonfs_test_support::http::{raw_agent, retry_result_on_macos_teardown_einval};
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
 
@@ -112,10 +112,12 @@ fn post_retention_advance(
 }
 
 fn post_admin_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> ApiResult<T> {
-    let request = raw_agent()
-        .post(url)
-        .set("authorization", &format!("Bearer {auth_token}"));
-    decode_admin_response(request.call())
+    retry_result_on_macos_teardown_einval(|| {
+        let request = raw_agent()
+            .post(url)
+            .set("authorization", &format!("Bearer {auth_token}"));
+        decode_admin_response(request.call())
+    })
 }
 
 fn post_admin_json_body<T: serde::de::DeserializeOwned>(
@@ -123,10 +125,12 @@ fn post_admin_json_body<T: serde::de::DeserializeOwned>(
     auth_token: &str,
     body: serde_json::Value,
 ) -> ApiResult<T> {
-    let request = raw_agent()
-        .post(url)
-        .set("authorization", &format!("Bearer {auth_token}"));
-    decode_admin_response(request.send_json(body))
+    retry_result_on_macos_teardown_einval(|| {
+        let request = raw_agent()
+            .post(url)
+            .set("authorization", &format!("Bearer {auth_token}"));
+        decode_admin_response(request.send_json(body.clone()))
+    })
 }
 
 fn decode_admin_response<T: serde::de::DeserializeOwned>(

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -43,22 +43,18 @@ fn post_gc(server_url: &str, namespace: &str) -> ApiResult<loonfs_api::GcRespons
     post_gc_with(server_url, namespace, serde_json::json!({}))
 }
 
-/// The upkeep report a step that selected metadata is obliged to carry.
 fn upkeep(step: &loonfs_api::MaintenanceStepResponse) -> &loonfs_api::MetadataMaintenanceResponse {
     step.metadata_maintenance
         .as_ref()
         .expect("a step selecting metadata upkeep reports it")
 }
 
-/// The floor a step that selected the retention advance is obliged to report.
 fn retention_floor(step: loonfs_api::MaintenanceStepResponse) -> ChangeSeq {
     step.retention
         .expect("a step selecting the retention advance reports it")
         .retention_floor_seq
 }
 
-/// One garbage-collection pass, as the collapsed surface runs it: a
-/// maintenance step selecting `gc` and nothing else.
 fn post_gc_with(
     server_url: &str,
     namespace: &str,
@@ -75,7 +71,6 @@ fn post_gc_with(
     })
 }
 
-/// One metadata-upkeep step at the server's default threshold.
 fn post_maintenance_step(
     server_url: &str,
     namespace: &str,
@@ -87,7 +82,6 @@ fn post_maintenance_step(
     )
 }
 
-/// A step body that selects nothing, which the route refuses.
 fn post_empty_maintenance_step(
     server_url: &str,
     namespace: &str,
@@ -99,7 +93,6 @@ fn post_empty_maintenance_step(
     )
 }
 
-/// One retention-floor advance, as the collapsed surface runs it.
 fn post_retention_advance(
     server_url: &str,
     namespace: &str,
@@ -208,8 +201,7 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
         .expect("list first checkpoint");
     assert_eq!(listed.checkpoints, vec![first.clone()]);
 
-    // Creating again over the same head is a second pin, not a second name
-    // for the first: a new record under a new id, over the same basis.
+    // A second checkpoint at the same head creates a new record.
     let repeated = post_checkpoint(&server_url, namespace.as_str()).expect("repeat checkpoint");
     assert_ne!(repeated.checkpoint_id, first.checkpoint_id);
     assert_eq!(repeated.namespace_id, first.namespace_id);
@@ -219,8 +211,7 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
     assert_eq!(repeated.expires_at_ms, first.expires_at_ms);
     assert!(repeated.created_at_ms >= first.created_at_ms);
 
-    // Release is idempotent: the first call flips the record one way, and
-    // the repeat observes the settled end state.
+    // Releasing a checkpoint twice returns the same result.
     let released = post_checkpoint_release(
         &server_url,
         namespace.as_str(),
@@ -246,8 +237,7 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
             .expect_err("malformed checkpoint id");
     assert_eq!(bogus_release.code, "invalid_request");
 
-    // The GC grace window's derived safety floor is enforced at the API:
-    // a sub-minimum override is rejected, not honored.
+    // Reject grace periods below the safety minimum.
     let unsafe_gc = post_gc_with(
         &server_url,
         namespace.as_str(),
@@ -262,8 +252,7 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
     );
     assert_eq!(advanced, ChangeSeq(1));
 
-    // Idempotent in the floor it lands on. `status_before` legitimately
-    // differs: the first call observed the floor it then advanced past.
+    // Both calls reach the same floor, although they start from different floors.
     let repeated =
         post_retention_advance(&server_url, namespace.as_str()).expect("repeat retention");
     assert_eq!(repeated.status_before.retention_floor_seq, advanced);
@@ -310,10 +299,7 @@ async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
         .expect("write file");
     post_checkpoint(&server_url, namespace.as_str()).expect("checkpoint");
 
-    // A bounded pass returns an opaque cursor, and the route accepts it
-    // on the next invocation without carrying any safety state. The budget
-    // covers the roots this namespace marks before it walks, so what is
-    // left over is what bounds the walk.
+    // Resume a bounded pass with its returned cursor.
     let bounded = post_gc_with(
         &server_url,
         namespace.as_str(),
@@ -329,9 +315,7 @@ async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
     .expect("resumed gc pass");
     assert!(resumed.next_cursor.is_some());
 
-    // A freshly written namespace sits entirely inside the grace
-    // window: the unbounded pass completes, deletes nothing, and reads
-    // keep working.
+    // Objects inside the grace window remain readable.
     let report = post_gc(&server_url, namespace.as_str()).expect("gc pass");
     assert_eq!(report.deleted.wal_segments, 0);
     assert_eq!(report.deleted.metadata_segments, 0);
@@ -369,13 +353,11 @@ async fn http_admin_maintenance_step_reports_outcomes_not_errors() {
         .await
         .expect("write file");
 
-    // A body that names no action is not a step.
     let empty = post_empty_maintenance_step(&server_url, namespace.as_str())
         .expect_err("a body selecting nothing is refused");
     assert_eq!(empty.code, "invalid_request");
     assert!(empty.message.contains("at least one action"));
 
-    // One WAL segment sits far below the default threshold.
     let idle = post_maintenance_step(&server_url, namespace.as_str()).expect("idle step");
     assert_eq!(idle.namespace_id, namespace);
     assert_eq!(idle.status_before.wal_tail_segments, 1);
@@ -383,12 +365,11 @@ async fn http_admin_maintenance_step_reports_outcomes_not_errors() {
         upkeep(&idle).wal_flush,
         loonfs_api::WalFlushStepOutcome::NotNeeded
     );
-    // Unnamed actions report nothing at all.
+    // Only requested actions appear in the response.
     assert!(idle.gc.is_none());
     assert!(idle.retention.is_none());
 
-    // Forcing the threshold to one segment flushes the WAL tail, and the
-    // named retention and collection actions run behind it.
+    // A one-segment threshold flushes the WAL before retention and GC run.
     let forced: loonfs_api::MaintenanceStepResponse = client
         .run_maintenance(
             &namespace,
@@ -408,8 +389,7 @@ async fn http_admin_maintenance_step_reports_outcomes_not_errors() {
             manifest_head_seq: ChangeSeq(1),
         }
     );
-    // The floor is reported because the step named the advance, and it never
-    // goes backwards.
+    // Retention advances monotonically.
     assert!(retention_floor(forced.clone()) >= forced.status_before.retention_floor_seq);
     assert_eq!(
         upkeep(&forced).reorganize,
@@ -461,10 +441,7 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
         "http-admin-corrupt",
     ))
     .await;
-    // A second server on the same store reads cold: it must consume the
-    // manifest and notice the corruption. The first server's reads are
-    // pinned to the head-plus-manifest pair its own publish seeded, which
-    // stays valid without touching the corrupted object.
+    // A new server must read the corrupted manifest; the first server has a valid cached snapshot.
     let cold = start_server(test_config(
         store_root,
         "loonfs-server-cold-reader",
@@ -513,8 +490,6 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "namespace_corrupt"),
         other => panic!("expected namespace_corrupt, got {other:?}"),
     }
-    // The warm server keeps serving its pinned pair; the corruption is
-    // surfaced by whoever actually consumes the manifest.
     client
         .get_path_entry(&target, &Default::default())
         .await
@@ -562,8 +537,7 @@ async fn http_admin_store_probe_reports_unique_successes_from_the_configured_sto
         assert_eq!(check.message, None);
     }
 
-    // A probe leaves the store as it found it: emptying the run's scratch
-    // prefix is its own last check, and nothing else here wrote there.
+    // The probe removes its temporary objects.
     let store = ConfiguredObjectStore::local_fs(
         harness.store_root.as_ref().expect("local-fs test store"),
         harness.store_key_prefix.as_deref(),
@@ -597,8 +571,7 @@ async fn http_admin_store_probe_requires_a_token_and_accepts_a_bodyless_request(
         "unauthorized"
     );
 
-    // Body handling matches the maintenance-step route: an absent body is
-    // the same request as `{}`.
+    // An absent body is treated as an empty object.
     let bodyless: loonfs_api::v0::StoreProbeResponse =
         post_admin_json(&url, "test-token").expect("probe with no body");
     assert!(

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -451,8 +451,7 @@ async fn http_restore_revision_appends_new_head_and_reports_change() {
         changes.changes[2].commit_id,
         CommitId::parse("req-restore-restore").expect("valid commit id")
     );
-    // The restore reports as a content change: one durable fact for a put
-    // over an existing file and a revision restore alike.
+    // Restoring a revision emits the same event as a regular content update.
     assert_eq!(changes.changes[2].events.len(), 1);
     assert!(matches!(
         &changes.changes[2].events[0],
@@ -573,7 +572,7 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         harness.client.list_file_revisions_page(&target, None, None).await,
         Err(ClientError::Api { code, .. }) if code == "path_not_found"
     ));
-    // The revision history follows the inode to its new binding.
+    // Revision history follows the inode after a move.
     let moved_revisions = harness
         .client
         .list_file_revisions_page(&moved, None, None)

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -13,7 +13,7 @@ use loonfs_client::{
     ClientError, CreateDirectoryOptions, MoveOptions, NamespacePath, PutFileOptions,
     RestoreRevisionOptions,
 };
-use loonfs_test_support::http::raw_agent;
+use loonfs_test_support::http::{raw_agent, retry_result_on_macos_teardown_einval};
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
 
@@ -160,41 +160,43 @@ fn get_json<T: serde::de::DeserializeOwned>(
     url: &str,
     auth_token: &str,
 ) -> Result<T, Box<ApiError>> {
-    let request = raw_agent()
-        .get(url)
-        .set("authorization", &format!("Bearer {auth_token}"));
-    match request.call() {
-        Ok(response) => serde_json::from_reader(response.into_reader()).map_err(|err| {
-            Box::new(ApiError {
-                code: "invalid_json".to_owned(),
-                feature: None,
-                message: err.to_string(),
-                param: None,
-                request_id: None,
-                details: None,
-            })
-        }),
-        Err(ureq::Error::Status(_, response)) => Err(Box::new(
-            serde_json::from_reader::<_, ApiError>(response.into_reader()).unwrap_or_else(|err| {
-                ApiError {
+    retry_result_on_macos_teardown_einval(|| {
+        let request = raw_agent()
+            .get(url)
+            .set("authorization", &format!("Bearer {auth_token}"));
+        match request.call() {
+            Ok(response) => serde_json::from_reader(response.into_reader()).map_err(|err| {
+                Box::new(ApiError {
                     code: "invalid_json".to_owned(),
                     feature: None,
                     message: err.to_string(),
                     param: None,
                     request_id: None,
                     details: None,
-                }
+                })
             }),
-        )),
-        Err(ureq::Error::Transport(error)) => Err(Box::new(ApiError {
-            code: "transport".to_owned(),
-            feature: None,
-            message: error.to_string(),
-            param: None,
-            request_id: None,
-            details: None,
-        })),
-    }
+            Err(ureq::Error::Status(_, response)) => Err(Box::new(
+                serde_json::from_reader::<_, ApiError>(response.into_reader()).unwrap_or_else(
+                    |err| ApiError {
+                        code: "invalid_json".to_owned(),
+                        feature: None,
+                        message: err.to_string(),
+                        param: None,
+                        request_id: None,
+                        details: None,
+                    },
+                ),
+            )),
+            Err(ureq::Error::Transport(error)) => Err(Box::new(ApiError {
+                code: "transport".to_owned(),
+                feature: None,
+                message: error.to_string(),
+                param: None,
+                request_id: None,
+                details: None,
+            })),
+        }
+    })
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -14,7 +14,9 @@ use loonfs_api::{
     LIMIT_UPLOAD_COMPLETION_MAX_BODY_BYTES,
 };
 use loonfs_client::{ClientError, NamespacePath};
-use loonfs_test_support::http::raw_agent;
+use loonfs_test_support::http::{
+    raw_agent, retry_on_macos_teardown_einval, retry_result_on_macos_teardown_einval,
+};
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
 
@@ -538,27 +540,31 @@ async fn complete_upload_session(
 }
 
 fn get_upload(server_url: &str, upload_id: &loonfs_api::UploadId) -> UploadSession {
-    let response = raw_agent()
-        .get(&format!(
-            "{server_url}/v0/namespaces/demo/uploads/{upload_id}"
-        ))
-        .set("authorization", "Bearer test-token")
-        .call()
-        .expect("get upload status");
-    serde_json::from_reader(response.into_reader()).expect("decode upload status")
+    retry_on_macos_teardown_einval(|| {
+        let response = raw_agent()
+            .get(&format!(
+                "{server_url}/v0/namespaces/demo/uploads/{upload_id}"
+            ))
+            .set("authorization", "Bearer test-token")
+            .call()
+            .expect("get upload status");
+        serde_json::from_reader(response.into_reader()).expect("decode upload status")
+    })
 }
 
 fn abort_upload(
     server_url: &str,
     upload_id: &loonfs_api::UploadId,
 ) -> Result<UploadSession, Box<ureq::Error>> {
-    let response = raw_agent()
-        .post(&format!(
-            "{server_url}/v0/namespaces/demo/uploads/{upload_id}/abort"
-        ))
-        .set("authorization", "Bearer test-token")
-        .set("content-type", "application/json")
-        .send_string("{}")
-        .map_err(Box::new)?;
-    Ok(serde_json::from_reader(response.into_reader()).expect("decode abort response"))
+    retry_result_on_macos_teardown_einval(|| {
+        let response = raw_agent()
+            .post(&format!(
+                "{server_url}/v0/namespaces/demo/uploads/{upload_id}/abort"
+            ))
+            .set("authorization", "Bearer test-token")
+            .set("content-type", "application/json")
+            .send_string("{}")
+            .map_err(Box::new)?;
+        Ok(serde_json::from_reader(response.into_reader()).expect("decode abort response"))
+    })
 }

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -74,15 +74,11 @@ async fn http_begin_upload_rejects_a_body_that_mixes_transports() {
         .expect("create namespace");
 
     for body in [
-        // A proxied begin has no geometry to ask for.
+        // Reject fields that belong to another upload mode.
         r#"{"mode":"service_proxied","part_size_bytes":8388608}"#,
-        // A direct put cannot carry multipart geometry.
         r#"{"mode":"direct_put","part_size_bytes":8388608}"#,
-        // Nor does a multipart begin take a direct put's size hint.
         r#"{"mode":"direct_multipart","size_bytes":5}"#,
-        // A multipart begin promises nothing about its payload.
         r#"{"mode":"direct_multipart","content":{"size_bytes":5,"sha256":"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"}}"#,
-        // And a request that does not say how it moves its bytes.
         "{}",
     ] {
         let result = raw_agent()
@@ -305,7 +301,6 @@ async fn completion_content_token_passes_unchanged_into_http_commit() {
     let completed = stage_uploaded_content(&harness.client, &namespace, file_bytes).await;
     let content_ref = completed.content_ref.clone();
 
-    // Copy the completion token directly into the commit request.
     let put_request = CommitRequest {
         commit_id: CommitId::parse("req-phase-2a-create-file").expect("valid commit id"),
         actor: loonfs_test_support::test_actor(),
@@ -362,8 +357,7 @@ async fn completion_content_token_passes_unchanged_into_http_commit() {
     assert_eq!(change.commit_id, commit.commit_id);
     assert_eq!(change.commit_id, put_request.commit_id);
     assert_eq!(change.message.as_deref(), Some("upload over http"));
-    // One semantic event per request operation: the file creation with its
-    // binding and first revision.
+    // The commit emits one file-created event with its initial revision.
     assert_eq!(change.events.len(), 1);
     assert!(matches!(
         &change.events[0],
@@ -403,7 +397,6 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
         .await
         .expect("create namespace");
 
-    // An open session reports itself and mints nothing.
     let open = harness
         .client
         .create_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
@@ -415,7 +408,7 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     assert_eq!(status.mode, UploadMode::ServiceProxied);
     assert!(matches!(status.status, UploadSessionStatus::Open { .. }));
 
-    // Aborting it is terminal, repeatable, and observable.
+    // Abort is idempotent.
     let aborted = abort_upload(&harness.server_url, open.upload_id()).expect("abort");
     let repeated = abort_upload(&harness.server_url, open.upload_id()).expect("repeated abort");
     assert_eq!(repeated, aborted);
@@ -435,8 +428,7 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     };
     assert_eq!(aborted_at_ms, response_aborted_at_ms);
 
-    // Completing an aborted session reports the same absence its eventual
-    // deletion will.
+    // An aborted session cannot be completed.
     let completion = harness
         .client
         .complete_upload(
@@ -448,10 +440,7 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
         .expect_err("an aborted session cannot complete");
     assert_eq!(completion.code(), Some(ErrorCode::UploadNotFound));
 
-    // A completed session re-mints on every read, and refuses to be aborted.
-    // The client here is one that lost its commit response and threw the
-    // completion's receipt away: it reads the session and commits with what
-    // the read hands back, without sending a byte of content again.
+    // A client can recover a lost completion response by reading the session and using its new token.
     let (upload_id, content_ref, completed_at_ms) =
         complete_upload_session(&harness, &namespace, b"status re-mint").await;
     let status = get_upload(&harness.server_url, &upload_id);
@@ -501,8 +490,6 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     harness.server.abort();
 }
 
-/// Stages content and hands back the session id, which the shared helper
-/// does not expose.
 async fn complete_upload_session(
     harness: &crate::common::TestServer,
     namespace: &loonfs_api::NamespaceId,

--- a/crates/loonfs-test-support/src/http.rs
+++ b/crates/loonfs-test-support/src/http.rs
@@ -36,6 +36,38 @@ pub fn retry_on_macos_teardown_einval<T>(exchange: impl Fn() -> T) -> T {
     exchange()
 }
 
+/// Retries an HTTP exchange that returns its failures instead of panicking.
+///
+/// This gates the same macOS socket error as the helper above, on returned
+/// errors as well as panics.
+#[allow(clippy::print_stderr)]
+pub fn retry_result_on_macos_teardown_einval<T, E: std::fmt::Debug>(
+    exchange: impl Fn() -> Result<T, E>,
+) -> Result<T, E> {
+    if !cfg!(target_os = "macos") {
+        return exchange();
+    }
+    const ATTEMPTS: usize = 3;
+    for _ in 1..ATTEMPTS {
+        match catch_unwind(AssertUnwindSafe(&exchange)) {
+            Ok(Ok(value)) => return Ok(value),
+            Ok(Err(error)) => {
+                if !message_is_teardown_einval(&format!("{error:?}")) {
+                    return Err(error);
+                }
+                eprintln!("retrying: macOS reset the connection before the client's timeout reset");
+            }
+            Err(payload) => {
+                if !panic_is_teardown_einval(payload.as_ref()) {
+                    resume_unwind(payload);
+                }
+                eprintln!("retrying: macOS reset the connection before the client's timeout reset");
+            }
+        }
+    }
+    exchange()
+}
+
 /// Returns true for the ureq panic caused by the macOS socket error.
 fn panic_is_teardown_einval(payload: &(dyn std::any::Any + Send)) -> bool {
     let message = if let Some(owned) = payload.downcast_ref::<String>() {
@@ -45,5 +77,10 @@ fn panic_is_teardown_einval(payload: &(dyn std::any::Any + Send)) -> bool {
     } else {
         return false;
     };
-    message.contains("kind: InvalidInput") && message.contains("Invalid argument")
+    message_is_teardown_einval(message)
+}
+
+fn message_is_teardown_einval(message: &str) -> bool {
+    message.contains("Invalid argument")
+        && (message.contains("kind: InvalidInput") || message.contains("os error 22"))
 }

--- a/crates/loonfs-test-support/src/http.rs
+++ b/crates/loonfs-test-support/src/http.rs
@@ -11,35 +11,15 @@ pub fn raw_agent() -> ureq::Agent {
         .build()
 }
 
-/// Retries an HTTP exchange when ureq hits a known macOS socket error.
-///
-/// This can happen when the server rejects a request before reading its body.
-/// Only the matching EINVAL panic is retried. Other panics are rethrown, and
-/// the final attempt runs normally so a persistent failure keeps its message.
-#[allow(clippy::print_stderr)]
+/// Retries the known macOS socket panic caused by an early server disconnect.
 pub fn retry_on_macos_teardown_einval<T>(exchange: impl Fn() -> T) -> T {
-    if !cfg!(target_os = "macos") {
-        return exchange();
+    match retry_result_on_macos_teardown_einval(|| Ok::<T, std::convert::Infallible>(exchange())) {
+        Ok(value) => value,
+        Err(never) => match never {},
     }
-    const ATTEMPTS: usize = 3;
-    for _ in 1..ATTEMPTS {
-        match catch_unwind(AssertUnwindSafe(&exchange)) {
-            Ok(value) => return value,
-            Err(payload) => {
-                if !panic_is_teardown_einval(payload.as_ref()) {
-                    resume_unwind(payload);
-                }
-                eprintln!("retrying: macOS reset the connection before the client's timeout reset");
-            }
-        }
-    }
-    exchange()
 }
 
-/// Retries an HTTP exchange that returns its failures instead of panicking.
-///
-/// This gates the same macOS socket error as the helper above, on returned
-/// errors as well as panics.
+/// Retries the same macOS socket failure when an HTTP exchange returns it.
 #[allow(clippy::print_stderr)]
 pub fn retry_result_on_macos_teardown_einval<T, E: std::fmt::Debug>(
     exchange: impl Fn() -> Result<T, E>,
@@ -55,20 +35,18 @@ pub fn retry_result_on_macos_teardown_einval<T, E: std::fmt::Debug>(
                 if !message_is_teardown_einval(&format!("{error:?}")) {
                     return Err(error);
                 }
-                eprintln!("retrying: macOS reset the connection before the client's timeout reset");
             }
             Err(payload) => {
                 if !panic_is_teardown_einval(payload.as_ref()) {
                     resume_unwind(payload);
                 }
-                eprintln!("retrying: macOS reset the connection before the client's timeout reset");
             }
         }
+        eprintln!("retrying: macOS reset the connection before the client's timeout reset");
     }
     exchange()
 }
 
-/// Returns true for the ureq panic caused by the macOS socket error.
 fn panic_is_teardown_einval(payload: &(dyn std::any::Any + Send)) -> bool {
     let message = if let Some(owned) = payload.downcast_ref::<String>() {
         owned.as_str()


### PR DESCRIPTION
Some server tests intermittently fail on macOS when the server closes a connection before ureq finishes sending the request. The existing test helper retried this EINVAL failure only when ureq panicked, but several helpers return the same failure as an error.

This extends the helper to handle both forms. It retries only the known macOS error and leaves other platforms and failures unchanged. Each retry rebuilds the request, and the affected operations are safe to repeat.