### PR TITLE
fix(core): preserve recoverable multipart completions

### DIFF
--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -843,6 +843,13 @@ where
 
     let verified = match completion_outcome(store, content_store_id, plan).await? {
         CompletionOutcome::Verified(content_ref) => content_ref,
+        // The provider upload was already consumed, so this request cannot
+        // establish what consumed it. Reject only this claim: a retry with
+        // the claim that describes the assembled object may still recover
+        // a completion whose response was lost.
+        CompletionOutcome::Rejected(reason) => {
+            return Err(CoreError::InvalidUploadContent(reason));
+        }
         // The bytes that landed are not the bytes that were promised, and
         // the provider upload that could have produced them is consumed.
         // Nothing can rescue this session, so it stops here rather than
@@ -1307,6 +1314,9 @@ fn already_completed_outcome(
 enum CompletionOutcome {
     /// The stored object matches the completion claim.
     Verified(ContentRef),
+    /// This claim does not match the evidence left by an upload that was
+    /// already consumed. Another claim may still recover the session.
+    Rejected(String),
     /// The upload is invalid and must be aborted.
     Unusable(String),
 }
@@ -1478,14 +1488,13 @@ async fn assemble_multipart_upload<S: ObjectStore + ?Sized>(
     let parts = multipart_parts(parts, checksum_algorithm)?;
     let object_key = content_blob(content_store_id, &expected.content_id);
 
-    match store
+    let completion = match store
         .complete_multipart_upload(&object_key, provider_upload_id, &parts, &expected.checksum)
         .await
     {
-        // Either the provider assembled the object on this call, or it had
-        // already consumed the upload. Both questions are answered by the
-        // same read of the object, so neither needs its own path.
-        Ok(MultipartCompletion::Assembled | MultipartCompletion::UnknownUpload) => {}
+        Ok(completion @ (MultipartCompletion::Assembled | MultipartCompletion::UnknownUpload)) => {
+            completion
+        }
         Err(err) => {
             // The object was not assembled on this call. The provider may
             // have refused the parts, or the call may not have completed at
@@ -1496,11 +1505,22 @@ async fn assemble_multipart_upload<S: ObjectStore + ?Sized>(
             // what a repeated completion reconciles from.
             return Err(CoreError::store(&object_key, &err));
         }
-    }
+    };
 
     match verify_durable_content_checksum(store, content_store_id, expected).await {
         Ok(()) => Ok(CompletionOutcome::Verified(expected.clone())),
-        Err(err) => Ok(CompletionOutcome::Unusable(content_failure_reason(err)?)),
+        Err(err) => {
+            let reason = content_failure_reason(err)?;
+            Ok(match completion {
+                // This call consumed the provider upload, so a confirmed
+                // mismatch makes the session unusable.
+                MultipartCompletion::Assembled => CompletionOutcome::Unusable(reason),
+                // An earlier completion or abort consumed the upload. A
+                // mismatch rejects this request but is not evidence that a
+                // different completion claim cannot describe the object.
+                MultipartCompletion::UnknownUpload => CompletionOutcome::Rejected(reason),
+            })
+        }
     }
 }
 

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -720,6 +720,78 @@ mod direct_multipart {
     }
 
     #[tokio::test]
+    async fn a_conflicting_retry_cannot_destroy_a_recoverable_assembly() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = MultipartStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+        let context = mutation_context();
+        let session = open_session(&store, &context).await;
+        let request = complete_request(&session, upload_every_part(&store, &session));
+        let provider_parts = request
+            .parts
+            .iter()
+            .map(|part| loonfs_objectstore::MultipartPart {
+                part_number: part.part_number,
+                etag: part.etag.clone(),
+                checksum: part.checksum.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        // The provider completed the upload, but LoonFS never received the
+        // answer and therefore still has an open session.
+        store
+            .complete_multipart_upload(
+                &session.object_key,
+                &session.provider_upload_id,
+                &provider_parts,
+                &request.content.checksum,
+            )
+            .await
+            .expect("provider assembly whose response was lost");
+
+        let conflicting = CompleteMultipartUploadRequest {
+            content: UploadContentClaim {
+                size_bytes: request.content.size_bytes,
+                checksum: Checksum::crc64nvme(&vec![b'x'; session.payload.len()]),
+            },
+            parts: request.parts.clone(),
+        };
+        let error = complete_upload(
+            &store,
+            &session.namespace_id,
+            &session.upload_id,
+            &conflicting,
+            &context,
+        )
+        .await
+        .expect_err("a conflicting completion claim is rejected");
+        assert_eq!(error.code(), ErrorCode::InvalidRequest);
+        assert!(matches!(
+            session_state(&store, &session.namespace_id, &session.upload_id)
+                .await
+                .status,
+            UploadSessionRecordStatus::Open { .. }
+        ));
+        assert_eq!(
+            store
+                .get(&session.object_key, None)
+                .await
+                .expect("read recoverable object")
+                .expect("recoverable object survives"),
+            Bytes::from(session.payload.clone())
+        );
+
+        complete_upload(
+            &store,
+            &session.namespace_id,
+            &session.upload_id,
+            &request,
+            &context,
+        )
+        .await
+        .expect("the original claim recovers the lost completion");
+    }
+
+    #[tokio::test]
     async fn a_completion_that_does_not_verify_ends_the_session_and_deletes_the_object() {
         let temp_dir = tempdir().expect("tempdir");
         let store = MultipartStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
@@ -787,7 +859,7 @@ mod direct_multipart {
     }
 
     #[tokio::test]
-    async fn a_refused_assembly_is_a_store_failure_and_the_retry_is_terminal() {
+    async fn a_refused_assembly_stays_open_without_object_evidence() {
         let temp_dir = tempdir().expect("tempdir");
         let store = MultipartStore::with_enforcement(
             LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -834,13 +906,13 @@ mod direct_multipart {
             &context,
         )
         .await
-        .expect_err("neither an upload nor an object is left to complete");
+        .expect_err("neither an upload nor matching object evidence is available");
         assert_eq!(error.code(), ErrorCode::InvalidRequest);
         assert!(matches!(
             session_state(&store, &session.namespace_id, &session.upload_id)
                 .await
                 .status,
-            UploadSessionRecordStatus::Aborted { .. }
+            UploadSessionRecordStatus::Open { .. }
         ));
         assert!(store
             .head(&session.object_key)


### PR DESCRIPTION
When a multipart provider reports that an upload ID is already consumed, reject a mismatching completion claim without aborting the session. Keep mismatches from an assembly performed by the current request terminal.

This lets a retry with the original claim recover a completion whose response was lost.