### PR TITLE
fix(core): retry failed upload cleanup

### DIFF
--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -762,6 +762,50 @@ async fn upload_gc_aborts_an_expired_session_then_reaps_it() {
 }
 
 #[tokio::test]
+async fn aborted_upload_cleanup_failure_keeps_the_session_for_retry() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::content_blob(),
+        OperationClass::Delete,
+        InjectedError::Transport("content delete timed out".to_owned()),
+    );
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (upload_id, _, _) = stage_upload(&store, &namespace_id, &setup).await;
+
+    let expired = context(setup.now_ms + UPLOAD_SESSION_LEASE_MS + GRACE_MS + 1);
+    gc_namespace(&store, &namespace_id, &config(), &expired)
+        .await
+        .expect("abort expired upload");
+
+    store.fail_next(1);
+    let reaped = context(expired.now_ms + GRACE_MS + 1);
+    let report = gc_namespace(&store, &namespace_id, &config(), &reaped)
+        .await
+        .expect("retain after failed cleanup");
+    assert_eq!(report.deleted.upload_sessions, 0);
+    assert!(matches!(
+        read_upload_session(&store, &namespace_id, &upload_id)
+            .await
+            .expect("aborted session retained")
+            .status,
+        UploadSessionRecordStatus::Aborted { .. }
+    ));
+
+    let report = gc_namespace(&store, &namespace_id, &config(), &reaped)
+        .await
+        .expect("retry cleanup");
+    assert_eq!(report.deleted.upload_sessions, 1);
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_none());
+}
+
+#[tokio::test]
 async fn a_pass_reports_the_soonest_deadline_it_retained() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -1113,6 +1157,56 @@ async fn content_gc_reclaims_completed_content_nothing_references() {
         store.head(&content_key).await.expect("head").is_none(),
         "completed content nothing published is reclaimable"
     );
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn completed_content_delete_failure_keeps_the_session_for_retry() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::content_blob(),
+        OperationClass::Delete,
+        InjectedError::Transport("content delete timed out".to_owned()),
+    );
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (upload_id, content_ref, content_store_id, _prepared) =
+        complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
+    let content_key =
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
+    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+
+    store.fail_next(1);
+    let report = gc_namespace(&store, &namespace_id, &config(), &past)
+        .await
+        .expect("retain after failed content delete");
+    assert_eq!(report.deleted.upload_sessions, 0);
+    assert_eq!(report.deleted.content_objects, 0);
+    assert!(store
+        .head(&content_key)
+        .await
+        .expect("head content")
+        .is_some());
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_some());
+
+    let report = gc_namespace(&store, &namespace_id, &config(), &past)
+        .await
+        .expect("retry content delete");
+    assert_eq!(report.deleted.upload_sessions, 1);
+    assert_eq!(report.deleted.content_objects, 1);
+    assert!(store
+        .head(&content_key)
+        .await
+        .expect("head content")
+        .is_none());
     assert!(read_upload_session(&store, &namespace_id, &upload_id)
         .await
         .is_none());

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -102,9 +102,12 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
             }
             // Repeat provider cleanup so a later pass completes work left by a crash
             // after the abort CAS.
-            AbandonedUpload::of(&state)
+            if !AbandonedUpload::of(&state)
                 .release(store, content_store_id)
-                .await;
+                .await
+            {
+                return Ok(retain_undated());
+            }
             // Do not count this as reclaimed content. Abort cleanup runs even when no
             // object was written. Only a completed session with an `Absent` reference
             // result proves that a content object was eligible for reclamation.
@@ -133,12 +136,15 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
                     reclaimed_content: false,
                 }),
                 ContentReference::Absent => {
-                    delete_unpublished_content_object(
+                    if !delete_unpublished_content_object(
                         store,
                         content_store_id,
                         &content_ref.content_id,
                     )
-                    .await;
+                    .await
+                    {
+                        return Ok(retain_undated());
+                    }
                     Ok(UploadSessionSweep::Delete {
                         reclaimed_content: true,
                     })
@@ -201,7 +207,7 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
     match aborted {
         // Keep the newly aborted record until its post-abort grace period expires.
         Ok(CasAttempt::Settled(Some(abandoned))) => {
-            abandoned.release(store, content_store_id).await;
+            let _ = abandoned.release(store, content_store_id).await;
             Ok(retain_until(context.now_ms.saturating_add(grace_window_ms)))
         }
         Ok(CasAttempt::Settled(None)) => Ok(retain_undated()),

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -198,7 +198,7 @@ pub(crate) async fn begin_direct_multipart_upload_target<S: ObjectStore + ?Sized
     let upload_id = match create_upload_session(store, namespace_id, session, context).await {
         Ok(upload_id) => upload_id,
         Err(error) => {
-            abort_unpublished_multipart_upload(
+            let _ = abort_unpublished_multipart_upload(
                 store,
                 &content_store_id,
                 &content_id,
@@ -1094,7 +1094,7 @@ pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
         })
         .await?;
 
-    abandoned.release(store, content_store_id).await;
+    let _ = abandoned.release(store, content_store_id).await;
     Ok(response)
 }
 
@@ -1124,21 +1124,29 @@ impl AbandonedUpload {
 
     /// Releases everything the session left behind, provider upload first so
     /// the object it might still assemble cannot outlive the deletion.
+    ///
+    /// `true` confirms both cleanup steps. A failed provider abort stops
+    /// before object deletion so an in-flight assembly cannot resurrect the
+    /// object after it was deleted.
+    #[must_use]
     pub(crate) async fn release<S: ObjectStore + ?Sized>(
         &self,
         store: &S,
         content_store_id: &ContentStoreId,
-    ) {
+    ) -> bool {
         if let Some(provider_upload_id) = &self.provider_multipart_upload_id {
-            abort_unpublished_multipart_upload(
+            if !abort_unpublished_multipart_upload(
                 store,
                 content_store_id,
                 &self.content_id,
                 provider_upload_id,
             )
-            .await;
+            .await
+            {
+                return false;
+            }
         }
-        delete_unpublished_content_object(store, content_store_id, &self.content_id).await;
+        delete_unpublished_content_object(store, content_store_id, &self.content_id).await
     }
 }
 
@@ -1733,6 +1741,46 @@ mod tests {
         .await
         .expect("replay direct-put completion");
         assert_eq!(replay, first);
+    }
+
+    #[tokio::test]
+    async fn provider_abort_failure_stops_before_object_delete() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        bootstrap_namespace(&store, &namespace_id, &context(1_000), false)
+            .await
+            .expect("bootstrap");
+        let content_store_id = load_namespace_content_store_id(&store, &namespace_id)
+            .await
+            .expect("content store id");
+        let content_id = ContentId::generate();
+        let content_key = content_blob(&content_store_id, &content_id);
+        store
+            .put(
+                &content_key,
+                Bytes::from_static(BYTES),
+                PutMode::CreateIfAbsent,
+            )
+            .await
+            .expect("write unpublished content");
+        let abandoned = AbandonedUpload {
+            content_id,
+            provider_multipart_upload_id: Some("unsupported-provider-upload".to_owned()),
+        };
+
+        assert!(
+            !abandoned.release(&store, &content_store_id).await,
+            "an unsupported provider abort is incomplete cleanup"
+        );
+        assert!(
+            store
+                .head(&content_key)
+                .await
+                .expect("head content")
+                .is_some(),
+            "object deletion waits until provider abort succeeds"
+        );
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -272,21 +272,26 @@ pub(crate) async fn verify_durable_content_checksum<S: ObjectStore + ?Sized>(
 /// object and no metadata can reference it. Deleting is therefore safe and
 /// keeping it would leak bytes nobody can name again. This runs strictly
 /// after the durable transition that made the session terminal, and it is
-/// idempotent, so a cleanup lost to a crash is simply repeated by the next
-/// garbage-collection pass — which is why a failure here is logged rather
-/// than propagated.
+/// idempotent, so a cleanup lost to a crash is repeated by the next
+/// garbage-collection pass. The returned flag tells that pass whether it may
+/// remove the durable session record that makes the retry possible.
+#[must_use]
 pub(crate) async fn delete_unpublished_content_object<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
     content_id: &ContentId,
-) {
+) -> bool {
     let object_key = content_blob(content_store_id, content_id);
-    if let Err(error) = store.delete(&object_key).await {
-        tracing::warn!(
-            content_id = %content_id,
-            error_class = ?error.class(),
-            "failed to remove the content object of a terminated upload session"
-        );
+    match store.delete(&object_key).await {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(
+                content_id = %content_id,
+                error_class = ?error.class(),
+                "failed to remove the content object of a terminated upload session"
+            );
+            false
+        }
     }
 }
 
@@ -295,25 +300,30 @@ pub(crate) async fn delete_unpublished_content_object<S: ObjectStore + ?Sized>(
 /// Aborting is safe whatever the upload's real state: an upload that already
 /// assembled its object survives the abort untouched, and one the provider
 /// has never heard of succeeds anyway. So this runs strictly after the
-/// durable transition without first proving what it is cleaning up, and a
-/// failure is logged rather than propagated — the next garbage-collection
-/// pass repeats it from the terminal record.
+/// durable transition without first proving what it is cleaning up. The
+/// returned flag tells garbage collection whether the provider is quiescent
+/// enough to proceed to object deletion and eventual session-record removal.
+#[must_use]
 pub(crate) async fn abort_unpublished_multipart_upload<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
     content_id: &ContentId,
     provider_upload_id: &str,
-) {
+) -> bool {
     let object_key = content_blob(content_store_id, content_id);
-    if let Err(error) = store
+    match store
         .abort_multipart_upload(&object_key, provider_upload_id)
         .await
     {
-        tracing::warn!(
-            content_id = %content_id,
-            error_class = ?error.class(),
-            "failed to abandon the multipart upload of a terminated upload session"
-        );
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(
+                content_id = %content_id,
+                error_class = ?error.class(),
+                "failed to abandon the multipart upload of a terminated upload session"
+            );
+            false
+        }
     }
 }
 


### PR DESCRIPTION
Keep terminal upload-session records when provider abort or content deletion fails. Retry cleanup in a later garbage-collection pass, and do not delete the object until multipart provider abort succeeds.

This preserves the durable record needed to finish cleanup and prevents an unfinished provider assembly from recreating an object after deletion.