### PR TITLE
fix(core): preserve nested fork ancestry

### DIFF
--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -21,7 +21,7 @@ use crate::namespace::control_snapshot::resolve_retention_floor_seq;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_state, CheckpointOwner, CheckpointRecordState, CheckpointStatus,
-    ControlObjectKind,
+    ControlObjectKind, NamespaceStatus,
 };
 use loonfs_api::{CheckpointId, NamespaceId};
 use loonfs_objectstore::keys::checkpoint_record;
@@ -279,6 +279,13 @@ pub(crate) async fn verify_checkpoint_basis<S: ObjectStore + ?Sized>(
         .await
         .map_err(CoreError::ControlObjectLoad)?
         .state;
+    // A checkpoint that verifies after the namespace tombstone could create
+    // a new durable dependency after an ancestor collector had already
+    // proved this namespace had none. The tombstone is terminal, so such a
+    // record cannot become a readable checkpoint and must not verify.
+    if head.status == (NamespaceStatus::Deleted {}) {
+        return Ok(CheckpointBasisVerification::Invalid);
+    }
     let floor_seq = resolve_retention_floor_seq(store, &head)
         .await
         .map_err(CoreError::ControlObjectLoad)?;

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -926,6 +926,63 @@ async fn checkpoint_verification_rejects_a_basis_below_the_floor() {
 }
 
 #[tokio::test]
+async fn checkpoint_verification_rejects_a_deleted_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/file.txt",
+        b"body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write");
+    let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let record = load_checkpoint_record(&store, &namespace_id, &checkpoint.checkpoint_id)
+        .await
+        .expect("load checkpoint")
+        .expect("checkpoint exists")
+        .state;
+
+    let loaded_head = load_head_object(&store, &namespace_id)
+        .await
+        .expect("load head");
+    let mut deleted_head = loaded_head.state;
+    deleted_head.status = loonfs_api::wire::control::NamespaceStatus::Deleted {};
+    let encoded = loonfs_api::wire::control::encode_control_state(
+        loonfs_api::wire::control::ControlObjectKind::WalHead,
+        &deleted_head,
+    )
+    .expect("encode deleted head");
+    store
+        .compare_and_swap(
+            &loaded_head.object_key,
+            &loaded_head.etag,
+            Bytes::from(encoded),
+        )
+        .await
+        .expect("install deleted head");
+
+    let verified = super::record::verify_checkpoint_basis(&store, &record)
+        .await
+        .expect("verification runs");
+    assert_eq!(
+        verified,
+        super::record::CheckpointBasisVerification::Invalid,
+        "a tombstoned namespace cannot acquire a new checkpoint dependency"
+    );
+}
+
+#[tokio::test]
 async fn checkpoint_basis_verification_store_failure_surfaces_and_releases_record() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -6,8 +6,8 @@
 ///
 /// * the namespace control snapshot: head, metadata root, and retention floor
 ///   read concurrently;
-/// * one checkpoint record read while marking, plus one more for the fork
-///   target head that decides whether that record's target is gone;
+/// * one checkpoint record read while marking, plus two more for the fork
+///   target head and its possible metadata-root probe;
 /// * one manifest opened, whether to mark its segments or by the content
 ///   reference scan;
 /// * one page of revision rows read out of an opened manifest;

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -7,7 +7,7 @@ use crate::checkpoint::record::{
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
-use crate::namespace::control::load_head_object;
+use crate::namespace::control::{load_head_object, load_metadata_root_object_if_present};
 use loonfs_api::wire::control::{
     CheckpointOwner, CheckpointRecordState, CheckpointStatus, NamespaceStatus,
 };
@@ -95,6 +95,7 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
     {
         ForkCheckpointReachability::Reclaimable => {}
         ForkCheckpointReachability::ReferencedByLiveTarget
+        | ForkCheckpointReachability::MayHaveLiveDescendant
         | ForkCheckpointReachability::InFlight
         | ForkCheckpointReachability::Ambiguous => return Ok(ForkCheckpointSweep::Retained),
     }
@@ -112,6 +113,7 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
 /// Whether a fork checkpoint is still needed.
 pub(super) enum ForkCheckpointReachability {
     ReferencedByLiveTarget,
+    MayHaveLiveDescendant,
     InFlight,
     Reclaimable,
     Ambiguous,
@@ -153,6 +155,19 @@ pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
         },
     };
     if head.status == (NamespaceStatus::Deleted {}) {
+        // A nested fork must materialize its immediate source's metadata root
+        // before it can publish the descendant checkpoint. That root may name
+        // metadata and content owned by earlier ancestors, and it is a direct,
+        // non-swept control object rather than listing evidence. Retain this
+        // source record conservatively whenever the deleted target ever
+        // materialized one.
+        if load_metadata_root_object_if_present(store, target_namespace_id)
+            .await
+            .map_err(CoreError::ControlObjectLoad)?
+            .is_some()
+        {
+            return Ok(ForkCheckpointReachability::MayHaveLiveDescendant);
+        }
         return Ok(ForkCheckpointReachability::Reclaimable);
     }
     let Some(basis) = head.fork_basis else {

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -398,6 +398,10 @@ async fn checkpoint_is_candidate<S: ObjectStore + ?Sized>(
             target_namespace_id,
             expires_at_ms,
         } => {
+            // Reserve the largest classification path: the target head and,
+            // for a deleted target, its metadata root. Charging both here is
+            // deliberately coarse and keeps root collection all-or-nothing.
+            charge(budget)?;
             charge(budget)?;
             Ok(matches!(
                 classify_fork_checkpoint(

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -535,6 +535,46 @@ async fn fork_clone_survives_source_delete() {
 }
 
 #[tokio::test]
+async fn nested_fork_survives_ancestor_and_parent_delete_and_collection() {
+    let temp_dir = tempdir().expect("tempdir");
+    let ancestor = NamespaceId::parse("ancestor").expect("valid namespace id");
+    let parent = NamespaceId::parse("parent").expect("valid namespace id");
+    let descendant = NamespaceId::parse("descendant").expect("valid namespace id");
+    let context = mutation_context();
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    seed_source_namespace_for_fork(&store, &ancestor, &context).await;
+    fork_namespace(&store, &ancestor, &parent, &context)
+        .await
+        .expect("fork parent");
+    fork_namespace(&store, &parent, &descendant, &context)
+        .await
+        .expect("fork descendant");
+
+    namespace_engine(&store, &parent, &context)
+        .delete_namespace(loonfs_core::DeleteNamespaceOptions::default())
+        .await
+        .expect("delete parent");
+    namespace_engine(&store, &ancestor, &context)
+        .delete_namespace(loonfs_core::DeleteNamespaceOptions::default())
+        .await
+        .expect("delete ancestor");
+
+    let mut aged = context.clone();
+    aged.now_ms = u64::MAX / 2;
+    loonfs_core::gc_namespace(&store, &ancestor, &loonfs_core::GcConfig::default(), &aged)
+        .await
+        .expect("collect ancestor");
+
+    assert_eq!(
+        read_file_bytes(&store, &descendant, "/docs/shared.txt")
+            .await
+            .expect("descendant reads through its retained ancestry")
+            .bytes,
+        b"base"
+    );
+}
+
+#[tokio::test]
 async fn a_fork_basis_checksum_mismatch_is_corruption() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -834,7 +834,9 @@ manifests, and non-protecting checkpoint records under the usual windows,
 leaving the head as the id-retiring tombstone, together with the root and
 floor objects if the namespace ever wrote them (section 6, rule 4). Objects
 protected by fork-owned checkpoint records survive, so clones of a deleted
-source stay readable.
+source stay readable. A deleted fork target that materialized its own metadata
+root also keeps its source checkpoint: that root may be the basis of a nested
+fork whose manifest still names source-owned segments and content.
 
 ### 2.6 Forks
 
@@ -845,7 +847,10 @@ verified fork-owned source checkpoint at that head, then installs the complete
 target head with one create-if-absent. The target writes no manifest, no root, and no floor: the
 head's `fork_basis` names the source manifest the target starts from, and the
 fork-owned checkpoint record is what keeps that manifest and its segments alive
-for as long as the target may still need them.
+for as long as the target or a nested descendant may still need them. A target
+must materialize its own metadata root before it can be forked again; that
+direct-read, non-swept control object conservatively keeps the source
+checkpoint after target deletion.
 
 Fork provenance lives in the target head and stays there for the namespace's
 life. Reads and recovery use the target head, its own manifests once it has
@@ -1685,8 +1690,8 @@ context. The protocol is:
    generated id. Its owner carries the target namespace id and
    `expires_at_ms = now + FORK_CHECKPOINT_LEASE_MS`. This record is the
    reachability root that keeps the source's basis manifest and segments alive
-   for as long as the target lives; nothing under the target's prefix protects
-   them. Each attempt creates a new record.
+   for as long as the target or a nested descendant may need them. Each attempt
+   creates a new record.
 3. Read the pinned manifest to get the target's next inode id. Build the active target head with the source's `content_store_id` and a `fork_basis` containing the record's `manifest` reference and checkpoint id. The reference's `manifest_head_seq` is the target's fork sequence.
 4. Renew the source checkpoint with compare-and-swap. The record must be active, fork-owned, and assigned to this target. The new expiry must be later than the stored expiry and at least `now + FORK_CHECKPOINT_LEASE_MS`. The remaining lease must cover the target-head write. If either check fails, the fork stops before creating the target.
 5. Write the target head with create-if-absent.
@@ -2423,9 +2428,9 @@ publishing CAS) — under these rules:
    a later pass. Content objects are never enumerated by listing the content
    store, which is shared by every namespace whose head names it; they are
    reached only through the upload session that owns them (rule 11).
-10. **Fork checkpoints require an exact reference.** A fork-owned record remains a root while its active target's `fork_basis` names the record's source namespace, checkpoint id, and manifest. An absent target keeps the record until its lease expires. A deleted target, a target without a fork basis, or a target that names another source or checkpoint makes the record releasable immediately. This also allows GC to release records created by failed fork attempts against an existing target.
+10. **Fork checkpoints require an exact reference.** A fork-owned record remains a root while its active target's `fork_basis` names the record's source namespace, checkpoint id, and manifest. An absent target keeps the record until its lease expires. A deleted target with no metadata root makes the record releasable immediately. A deleted target with a metadata root retains the record conservatively, because nested checkpoint creation must publish that root before installing a descendant and the descendant's manifest may still name source-owned objects. An active target without a fork basis, or one that names another source or checkpoint, makes the record releasable immediately. This also allows GC to release records created by failed fork attempts against an existing target.
 
-    If the target head cannot be read, GC retains the record. If the source namespace and checkpoint id match but the manifest differs, the namespace is corrupt and the pass fails.
+    If the target head or metadata root cannot be read, GC retains the record or fails the pass without deletion. Checkpoint basis verification rejects a deleted source, so a checkpoint attempt that publishes a late root after the target tombstone cannot install a new descendant. If the source namespace and checkpoint id match but the manifest differs, the namespace is corrupt and the pass fails.
 11. **Uploads and content, split at `completed`.** One sweep of `uploads/`
    owns both halves, because a session record is the only handle on the
    content object it created.


### PR DESCRIPTION
When a deleted fork target has materialized its own metadata root, keep its source checkpoint so nested forks can continue reading ancestor-owned metadata and content. Reject checkpoint verification after namespace deletion so a late materialization cannot create a new descendant dependency.

This prevents collecting an ancestor from breaking a live fork through a deleted intermediate namespace.