### PR TITLE
test(core): cover ordered binding guards

### DIFF
--- a/crates/loonfs-core/tests/it/inode_mutations.rs
+++ b/crates/loonfs-core/tests/it/inode_mutations.rs
@@ -337,6 +337,123 @@ async fn delete_requires_the_current_binding_generation() {
 }
 
 #[tokio::test]
+async fn earlier_move_makes_a_later_guard_stale_and_rolls_back_the_commit() {
+    let (_temp_dir, store, namespace_id, context) = namespace_with_docs().await;
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/report.txt",
+        b"body",
+        &context,
+        Some("put-report"),
+    )
+    .await
+    .expect("put file");
+    let (report_inode_id, binding_generation) =
+        read_entry(&store, &namespace_id, "/docs/report.txt").await;
+
+    let error = submit_commit(
+        &store,
+        &namespace_id,
+        CommitRequest {
+            commit_id: test_commit_id(Some("move-then-delete-with-old-generation")),
+            actor: loonfs_test_support::test_actor(),
+            message: None,
+            operations: vec![
+                FilesystemOperation::MoveByInode {
+                    inode_id: report_inode_id,
+                    expected_binding_generation: binding_generation.clone(),
+                    to_parent_inode_id: ROOT_INODE_ID,
+                    to_display_name: display_name("moved.txt"),
+                    behavior: DestinationBehavior::NoReplace,
+                },
+                FilesystemOperation::DeleteByInode {
+                    inode_id: report_inode_id,
+                    expected_binding_generation: binding_generation,
+                    behavior: DeleteDirectoryBehavior::NonRecursive,
+                },
+            ],
+        },
+        &context,
+    )
+    .await
+    .expect_err("the move must make the old generation stale");
+
+    assert_eq!(error.code(), ErrorCode::BindingGenerationMismatch);
+    assert_eq!(
+        read_entry(&store, &namespace_id, "/docs/report.txt")
+            .await
+            .0,
+        report_inode_id
+    );
+    assert_eq!(
+        resolve_path(&store, &namespace_id, "/moved.txt")
+            .await
+            .expect_err("the rejected commit must not publish its first operation")
+            .code(),
+        ErrorCode::PathNotFound
+    );
+}
+
+#[tokio::test]
+async fn content_write_preserves_the_guard_for_a_later_move() {
+    let (_temp_dir, store, namespace_id, context) = namespace_with_docs().await;
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/report.txt",
+        b"first",
+        &context,
+        Some("put-report"),
+    )
+    .await
+    .expect("put file");
+    let (report_inode_id, binding_generation) =
+        read_entry(&store, &namespace_id, "/docs/report.txt").await;
+
+    submit_commit(
+        &store,
+        &namespace_id,
+        CommitRequest {
+            commit_id: test_commit_id(Some("write-then-move-with-same-generation")),
+            actor: loonfs_test_support::test_actor(),
+            message: None,
+            operations: vec![
+                put_revision_by_inode(
+                    &store,
+                    &namespace_id,
+                    report_inode_id,
+                    b"second",
+                    RevisionNo(1),
+                )
+                .await,
+                FilesystemOperation::MoveByInode {
+                    inode_id: report_inode_id,
+                    expected_binding_generation: binding_generation.clone(),
+                    to_parent_inode_id: ROOT_INODE_ID,
+                    to_display_name: display_name("moved.txt"),
+                    behavior: DestinationBehavior::NoReplace,
+                },
+            ],
+        },
+        &context,
+    )
+    .await
+    .expect("content-only writes must preserve the binding guard");
+
+    assert_eq!(
+        read_file_bytes(&store, &namespace_id, "/moved.txt")
+            .await
+            .expect("read moved file")
+            .bytes,
+        b"second"
+    );
+    let (moved_inode_id, moved_generation) = read_entry(&store, &namespace_id, "/moved.txt").await;
+    assert_eq!(moved_inode_id, report_inode_id);
+    assert_ne!(moved_generation, binding_generation);
+}
+
+#[tokio::test]
 async fn malformed_foreign_and_root_binding_guards_are_invalid() {
     let (_temp_dir, store, namespace_id, context) = namespace_with_docs().await;
     let (docs_inode_id, local_generation) = read_entry(&store, &namespace_id, "/docs").await;


### PR DESCRIPTION
Cover ordered inode binding-generation guards within one commit. A move makes the old generation stale and rejects the whole request, while a content-only write preserves the generation for a later move.

This protects the request overlay and rollback behavior that binding-generation safety depends on.