### PR TITLE
fix(grep): rebuild after undelete

### DIFF
--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -24,9 +24,10 @@ pub struct GrepRequest {
     /// bound to that page's request; each page is evaluated against the
     /// namespace head at page time.
     pub cursor: Option<String>,
-    /// When the unindexed tail exceeds the scan budget, return
-    /// indexed-only results (reported via `tail_scanned: false`) instead
-    /// of failing with `index_lagging`.
+    /// When the unindexed tail exceeds the scan budget or crosses an
+    /// undelete that requires an index rebuild, return indexed-only results
+    /// (reported via `tail_scanned: false`) instead of failing with
+    /// `index_lagging`.
     pub allow_stale: bool,
     /// Permit a capped exhaustive scan when the pattern yields no required
     /// grams. Refused beyond the server's scan budget.

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -18,6 +18,7 @@ use crate::root::{
 use crate::{GrepError, Result};
 use futures::future::{join_all, try_join_all};
 use loonfs::{CoreError, CurrentFileState, MetadataViewError};
+use loonfs_api::v0::FilesystemChange;
 use loonfs_api::wire::hex::hex_decode_bytes;
 use loonfs_api::wire::sst_blocks::{
     decode_filter_block, index_blocks_for_key_range, string_prefix_upper_bound, BlockHandle,
@@ -467,6 +468,9 @@ async fn tail_revisions(reads: &NamespaceReads<'_>, resume: ChangeFeedResume) ->
                 });
             }
             for event in change.events.iter().skip(start_event_index) {
+                if matches!(event, FilesystemChange::Undeleted { .. }) {
+                    return Ok(TailScan::RebuildRequired);
+                }
                 if let Some(revision) = published_revision(event) {
                     inodes.insert(revision.inode_id);
                 }
@@ -486,6 +490,10 @@ async fn tail_revisions(reads: &NamespaceReads<'_>, resume: ChangeFeedResume) ->
 enum TailScan {
     /// Every file whose content changed after the index watermark.
     Within(BTreeSet<InodeId>),
+    /// An undelete may expose files absent from the checkpoint index. The
+    /// event names only the restored root, so an exact query must wait for
+    /// the worker to rebuild the projection from the now-visible tree.
+    RebuildRequired,
     /// More files changed after the watermark than the tail budget allows;
     /// enumeration stopped there, so no set is carried.
     OverBudget,
@@ -740,7 +748,7 @@ impl GrepService {
         if let Some(tail_resume) = tail_resume {
             match tail_revisions(reads, tail_resume).await? {
                 TailScan::Within(inodes) => candidates.unfiltered.extend(inodes),
-                TailScan::OverBudget if request.allow_stale => {
+                TailScan::OverBudget | TailScan::RebuildRequired if request.allow_stale => {
                     // Serve the index's cut and nothing newer. A candidate
                     // whose current revision is past the watermark carries no
                     // posting for that revision, so `admits` already refuses
@@ -748,7 +756,7 @@ impl GrepService {
                     // at an unindexed revision.
                     tail_scanned = false;
                 }
-                TailScan::OverBudget => {
+                TailScan::OverBudget | TailScan::RebuildRequired => {
                     return Err(CoreError::IndexLagging {
                         behind_commits: head_seq.0.saturating_sub(snapshot.built_through_seq.0),
                     }

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -27,7 +27,7 @@ use loonfs::{
     FsReader, PassBudget, RuntimeError, StoreFailureClass, DEFAULT_GC_MAX_OBJECTS,
     GC_MIN_GRACE_WINDOW_MS, METADATA_PUBLICATION_BUDGET_MS,
 };
-use loonfs_api::v0::{GrepIndex, GrepIndexLifecycle};
+use loonfs_api::v0::{FilesystemChange, GrepIndex, GrepIndexLifecycle};
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::sst_blocks::{
     index_blocks_for_key_range, DecodedDataBlock, SegmentBlocksBuilder, SegmentIndexEntry,
@@ -405,6 +405,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             } => {
                 collect_backfill_unit(&reads, checkpoint_id, *target_seq, *cursor_inode_id, policy)
                     .await
+                    .map(CollectedIndexWork::Unit)
             }
             GrepIndexStatus::Active {
                 built_through_seq,
@@ -419,10 +420,8 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         };
 
         let unit = match collected {
-            Ok(Some(unit)) => unit,
-            // `None` is valid only during active indexing. A backfill must
-            // always return its next page.
-            Ok(None) => {
+            Ok(CollectedIndexWork::Unit(unit)) => unit,
+            Ok(CollectedIndexWork::UpToDate) => {
                 let built_through_seq = current
                     .manifest_state()
                     .status()
@@ -436,6 +435,14 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     namespace_id,
                     GrepBuildOutcome::UpToDate { built_through_seq },
                 ));
+            }
+            // An undelete may expose a whole subtree that was hidden from
+            // the checkpoint backfill. The event names only its root and
+            // carries no descendant revisions, so no incremental unit can
+            // prove the projection complete. Rebuild from a checkpoint that
+            // sees the restored tree before advancing the watermark.
+            Ok(CollectedIndexWork::Restart) => {
+                return self.restart_backfill(namespace_id, &current).await;
             }
             // The projection's basis is gone. Either the change feed no
             // longer retains history back to the watermark, or the pinned
@@ -747,6 +754,12 @@ struct CollectedIndexUnit {
     progress: CollectedProgress,
 }
 
+enum CollectedIndexWork {
+    Unit(CollectedIndexUnit),
+    UpToDate,
+    Restart,
+}
+
 #[derive(Default)]
 struct IndexingStats {
     indexed_revisions: u64,
@@ -793,7 +806,7 @@ async fn collect_backfill_unit(
     target_seq: ChangeSeq,
     cursor: Option<InodeId>,
     policy: GramIndexBuildPolicy,
-) -> Result<Option<CollectedIndexUnit>> {
+) -> Result<CollectedIndexUnit> {
     let mut postings = BTreeMap::new();
     let mut stats = IndexingStats::default();
     let mut next_cursor = cursor;
@@ -850,7 +863,7 @@ async fn collect_backfill_unit(
         }
     }
     load_and_fold_revision_contents(reads, &pending, &mut postings, &mut stats).await?;
-    Ok(Some(CollectedIndexUnit {
+    Ok(CollectedIndexUnit {
         postings,
         stats,
         progress: CollectedProgress::Backfill {
@@ -858,7 +871,7 @@ async fn collect_backfill_unit(
             target_seq,
             next_cursor,
         },
-    }))
+    })
 }
 
 /// Collects one incremental step from the semantic change feed.
@@ -869,13 +882,13 @@ async fn collect_incremental_unit(
     built_through_seq: ChangeSeq,
     next_event_index: u32,
     policy: GramIndexBuildPolicy,
-) -> Result<Option<CollectedIndexUnit>> {
+) -> Result<CollectedIndexWork> {
     let resume = ChangeFeedResume::new(built_through_seq, next_event_index);
     let feed = reads
         .list_changes_after(resume.after_seq(), policy.max_files_per_step.get())
         .await?;
     if feed.changes.is_empty() {
-        return Ok(None);
+        return Ok(CollectedIndexWork::UpToDate);
     }
     let mut postings = BTreeMap::new();
     let mut stats = IndexingStats::default();
@@ -902,6 +915,9 @@ async fn collect_incremental_unit(
             });
         }
         for (event_index, event) in change.events.iter().enumerate().skip(start_event_index) {
+            if matches!(event, FilesystemChange::Undeleted { .. }) {
+                return Ok(CollectedIndexWork::Restart);
+            }
             let Some(revision) = published_revision(event) else {
                 continue;
             };
@@ -953,10 +969,10 @@ async fn collect_incremental_unit(
     }
     if collected_through_seq == built_through_seq && collected_next_event_index == next_event_index
     {
-        return Ok(None);
+        return Ok(CollectedIndexWork::UpToDate);
     }
     load_and_fold_revision_contents(reads, &pending, &mut postings, &mut stats).await?;
-    Ok(Some(CollectedIndexUnit {
+    Ok(CollectedIndexWork::Unit(CollectedIndexUnit {
         postings,
         stats,
         progress: CollectedProgress::Incremental {

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -1121,7 +1121,7 @@ async fn a_move_reindexes_nothing_and_answers_the_new_path() {
 }
 
 #[tokio::test]
-async fn a_recursive_delete_hides_matches_and_an_undelete_restores_them() {
+async fn a_recursive_delete_hides_matches_and_an_undelete_rebuild_restores_them() {
     let temp_dir = tempdir().expect("tempdir");
     let store: SharedObjectStore =
         Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
@@ -1203,6 +1203,14 @@ async fn a_recursive_delete_hides_matches_and_an_undelete_restores_them() {
         )
         .await
         .expect("undelete the subtree");
+    let restart = worker
+        .build_step(&namespace_id, GramIndexBuildPolicy::default())
+        .await
+        .expect("restart after undelete");
+    assert!(matches!(
+        restart.outcome,
+        GrepBuildOutcome::BackfillRestarted { .. }
+    ));
     drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
 
     let restored = new_query(&store, &namespace_id, &request("subtree needle"))
@@ -1211,13 +1219,110 @@ async fn a_recursive_delete_hides_matches_and_an_undelete_restores_them() {
     assert_eq!(
         matched_paths(&restored),
         vec!["/docs/a.txt", "/docs/b.txt"],
-        "an undelete makes the same postings eligible again"
+        "the fresh checkpoint must index the restored subtree"
     );
-    assert_eq!(
+    assert_ne!(
         grep_segment_ids(&store, &namespace_id).await,
         segments_before,
-        "an undelete must write no new postings"
+        "an undelete must replace the old projection"
     );
+    writer.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn undeleting_a_subtree_hidden_from_backfill_restarts_the_projection() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("undelete-after-backfill").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("undelete-backfill-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    let reader = writer.reader();
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for name in ["a", "b"] {
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/docs/{name}.txt"),
+                format!("restored needle {name}\n").as_bytes(),
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("write file before delete");
+    }
+    let docs_inode_id = reader
+        .get_path_entry(&namespace_id, "/docs", Default::default())
+        .await
+        .expect("stat docs before delete")
+        .inode_id;
+    let deleted = writer
+        .delete_path(
+            &namespace_id,
+            "/docs",
+            loonfs::DeleteOptions {
+                behavior: loonfs::DeleteDirectoryBehavior::Recursive,
+                ..loonfs::DeleteOptions::new(loonfs_test_support::test_actor())
+            },
+        )
+        .await
+        .expect("delete subtree before backfill");
+
+    let worker = worker(&store).await;
+    worker.enable(&namespace_id).await.expect("enable");
+    drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
+    assert!(
+        new_query(&store, &namespace_id, &request("restored needle"))
+            .await
+            .expect("query hidden tree")
+            .matches
+            .is_empty()
+    );
+
+    writer
+        .undelete(
+            &namespace_id,
+            docs_inode_id,
+            deleted.committed_seq,
+            Some("/docs"),
+            loonfs::UndeleteOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("undelete subtree after backfill");
+
+    let exact_error = new_query(&store, &namespace_id, &request("restored needle"))
+        .await
+        .expect_err("an exact query cannot project an unseen restored subtree");
+    assert_eq!(exact_error.code(), ErrorCode::IndexLagging);
+
+    let mut stale_request = request("restored needle");
+    stale_request.allow_stale = true;
+    let stale = new_query(&store, &namespace_id, &stale_request)
+        .await
+        .expect("indexed-only query across undelete");
+    assert!(!stale.tail_scanned);
+    assert!(stale.matches.is_empty());
+
+    let restart = worker
+        .build_step(&namespace_id, GramIndexBuildPolicy::default())
+        .await
+        .expect("restart after undelete");
+    assert!(matches!(
+        restart.outcome,
+        GrepBuildOutcome::BackfillRestarted { .. }
+    ));
+    drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
+
+    let restored = new_query(&store, &namespace_id, &request("restored needle"))
+        .await
+        .expect("query rebuilt restored tree");
+    assert_eq!(matched_paths(&restored), vec!["/docs/a.txt", "/docs/b.txt"]);
     writer.shutdown().await.expect("shutdown");
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2461,10 +2461,20 @@ opts into a capped exhaustive scan. A tail past the scan budget is
 rejected with `index_lagging` unless `allow_stale` accepts indexed-only
 results (reported via `tail_scanned: false`); stale results are a
 consistent cut at the index watermark — files whose newest revision
-postdates it are omitted entirely rather than mixed in. The `path_prefix`
-value is a complete absolute path, not a partial textual segment prefix. The
-server resolves it using the name-key folding rule (format spec, section
-2.3.1), then limits results to descendants of that inode. It must therefore
+postdates it are omitted entirely rather than mixed in.
+
+An undelete after the index watermark also returns `index_lagging` for an
+exact query: the restored entry may be a directory whose descendants were
+hidden from the checkpoint backfill, and the change event names only that
+root. With `allow_stale`, the query serves indexed-only results and reports
+`tail_scanned: false`. The worker starts a fresh checkpoint backfill
+before advancing its watermark past the undelete, so a later exact query
+includes the restored subtree.
+
+The `path_prefix` value is a complete absolute path, not a partial textual
+segment prefix. The server resolves it using the name-key folding rule
+(format spec, section 2.3.1), then limits results to descendants of that
+inode. It must therefore
 use the same canonical spelling as any other path. A scope that does not exist
 answers `path_not_found`; an
 empty existing scope answers successfully with no matches. A missing data half answers `not_supported` with the


### PR DESCRIPTION
When an undelete restores files that were hidden from the grep checkpoint, return index_lagging for exact queries and rebuild from a fresh checkpoint. Allow stale queries to keep serving indexed-only results.

This prevents the worker from advancing past an undelete without postings for the restored subtree.