### PR TITLE
fix(grep): pin query reads

### DIFF
--- a/crates/loonfs-grep/src/reads.rs
+++ b/crates/loonfs-grep/src/reads.rs
@@ -5,8 +5,8 @@
 
 use crate::{GrepError, Result};
 use loonfs::{
-    CheckpointFilesPage, CheckpointFilesPageCursor, CoreError, CurrentFileState, FsReader,
-    ListChangesOptions, StatPathOptions, MAX_RESOLVE_CURRENT_FILES,
+    CheckpointFilesPage, CheckpointFilesPageCursor, CoreError, CurrentFileState, FsReadSnapshot,
+    FsReader, ListChangesOptions, StatPathOptions, MAX_RESOLVE_CURRENT_FILES,
 };
 use loonfs_api::v0::{FilesystemChange, ListChangesResponse};
 use loonfs_api::{
@@ -18,8 +18,8 @@ use loonfs_api::{
 /// Filesystem reads for one namespace.
 ///
 /// Each call uses an internally consistent snapshot, but consecutive calls
-/// may observe different heads. Query candidates are reverified against
-/// current state, so a snapshot does not need to span calls.
+/// may observe different heads. Query execution pins one view so every
+/// metadata phase in one response uses the same head.
 pub struct NamespaceReads<'a> {
     reader: &'a FsReader,
     namespace_id: &'a NamespaceId,
@@ -37,6 +37,14 @@ impl<'a> NamespaceReads<'a> {
     /// Returns the namespace used by this reader.
     pub fn namespace_id(&self) -> &NamespaceId {
         self.namespace_id
+    }
+
+    /// Pins one metadata view for a query.
+    pub(crate) async fn pin(&self) -> Result<PinnedNamespaceReads<'a>> {
+        Ok(PinnedNamespaceReads {
+            reader: self.reader,
+            snapshot: self.reader.pin_namespace(self.namespace_id).await?,
+        })
     }
 
     /// Returns the namespace's current head sequence.
@@ -169,6 +177,137 @@ impl<'a> NamespaceReads<'a> {
         Ok(self
             .reader
             .read_content_ref(self.namespace_id, content_ref, max_bytes)
+            .await?)
+    }
+}
+
+/// Filesystem reads held to one namespace head for a single grep query.
+pub(crate) struct PinnedNamespaceReads<'a> {
+    reader: &'a FsReader,
+    snapshot: FsReadSnapshot,
+}
+
+impl PinnedNamespaceReads<'_> {
+    /// Returns the namespace used by this reader.
+    pub(crate) fn namespace_id(&self) -> &NamespaceId {
+        self.snapshot.namespace_id()
+    }
+
+    /// Returns the head sequence shared by every metadata read.
+    pub(crate) fn head_seq(&self) -> ChangeSeq {
+        self.snapshot.head_seq()
+    }
+
+    /// Reads committed changes after `after_seq`, capped at the pinned head.
+    ///
+    /// The feed itself may observe a later durable head. Its immutable commit
+    /// prefix is truncated here so later commits cannot affect this query.
+    pub(crate) async fn list_changes_after(
+        &self,
+        after_seq: ChangeSeq,
+        limit: usize,
+    ) -> Result<ListChangesResponse> {
+        let head_seq = self.head_seq();
+        if after_seq > head_seq {
+            return Err(CoreError::InvalidCursor(format!(
+                "change feed sequence `{after_seq}` is ahead of pinned head `{head_seq}`"
+            ))
+            .into());
+        }
+        if after_seq == head_seq {
+            return Ok(ListChangesResponse {
+                namespace_id: self.namespace_id().clone(),
+                after_seq,
+                through_seq: head_seq,
+                next_after_seq: None,
+                changes: Vec::new(),
+            });
+        }
+        let mut page = self
+            .reader
+            .list_changes(
+                self.namespace_id(),
+                after_seq,
+                ListChangesOptions {
+                    limit: Some(page_limit(limit).map_err(invalid_page_limit)?),
+                },
+            )
+            .await?;
+        page.changes
+            .retain(|change| change.committed_seq <= head_seq);
+        page.through_seq = head_seq;
+        page.next_after_seq = page
+            .changes
+            .last()
+            .map(|change| change.committed_seq)
+            .filter(|last_seq| *last_seq < head_seq);
+        Ok(page)
+    }
+
+    /// Resolves visibility, revision, and path in input order.
+    pub(crate) async fn resolve_current_files(
+        &self,
+        inode_ids: &[InodeId],
+    ) -> Result<Vec<CurrentFileState>> {
+        Ok(self.snapshot.resolve_current_files(inode_ids).await?)
+    }
+
+    /// Resolves one path against the pinned metadata view.
+    pub(crate) async fn resolve_path(&self, absolute_path: &AbsolutePath) -> Result<PathEntry> {
+        Ok(self
+            .snapshot
+            .get_path_entry(
+                absolute_path.as_str(),
+                StatPathOptions {
+                    include_attributes: false,
+                },
+            )
+            .await?)
+    }
+
+    /// Lists one directory page against the pinned metadata view.
+    pub(crate) async fn list_path_page(
+        &self,
+        absolute_path: &AbsolutePath,
+        cursor: Option<DirectoryPageCursor>,
+        limit: usize,
+    ) -> Result<Page<PathEntry, DirectoryPageCursor>> {
+        let page = self
+            .snapshot
+            .list_path_entries_page(
+                absolute_path.as_str(),
+                PageRequest {
+                    limit: page_limit(limit).map_err(invalid_page_limit)?,
+                    cursor,
+                },
+                loonfs::ListPathEntriesOptions::default(),
+            )
+            .await?;
+        let next_cursor = page
+            .next_cursor
+            .as_deref()
+            .map(decode_cursor)
+            .transpose()
+            .map_err(|error| {
+                GrepError::from(CoreError::InvalidCursor(format!(
+                    "the directory listing cursor did not decode: {error}"
+                )))
+            })?;
+        Ok(Page {
+            items: page.entries,
+            next_cursor,
+        })
+    }
+
+    /// Reads one immutable content object selected from the pinned view.
+    pub(crate) async fn read_content_ref(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> Result<Vec<u8>> {
+        Ok(self
+            .snapshot
+            .read_content_ref(content_ref, max_bytes)
             .await?)
     }
 }

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -10,7 +10,7 @@ use crate::index_read::{
 };
 use crate::keyspace::{manifest_key, segment_key};
 use crate::query::{plan_pattern, GramPlanOutcome, GramQueryPlan};
-use crate::reads::{published_revision, resolve_batch_size, NamespaceReads};
+use crate::reads::{published_revision, resolve_batch_size, NamespaceReads, PinnedNamespaceReads};
 use crate::root::{
     load_grep_manifest, load_grep_root_pointer, ChangeFeedResume, GrepIndexStatus,
     GrepManifestState,
@@ -443,7 +443,10 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
 /// Paging stops as soon as the tail exceeds the query's tail budget: past
 /// that the query either fails as lagging or serves the index's cut, and
 /// neither needs the rest of the feed enumerated.
-async fn tail_revisions(reads: &NamespaceReads<'_>, resume: ChangeFeedResume) -> Result<TailScan> {
+async fn tail_revisions(
+    reads: &PinnedNamespaceReads<'_>,
+    resume: ChangeFeedResume,
+) -> Result<TailScan> {
     let mut inodes = BTreeSet::new();
     let mut after_seq = resume.after_seq();
     loop {
@@ -616,7 +619,7 @@ enum CandidateContent {
 /// reaches the same inode. It also supplies the content reference, so the
 /// oversized skip stays a decision on declared size, before any fetch.
 async fn candidate_content(
-    reads: &NamespaceReads<'_>,
+    reads: &PinnedNamespaceReads<'_>,
     candidate: &GrepContentCandidate,
 ) -> CandidateContent {
     let entry = match reads.resolve_path(&candidate.path).await {
@@ -666,7 +669,8 @@ impl GrepService {
         reads: &NamespaceReads<'_>,
         store: &S,
     ) -> Result<GrepResponse> {
-        let head_seq = reads.head_seq().await?;
+        let reads = reads.pin().await?;
+        let head_seq = reads.head_seq();
         let limit = limit.as_usize();
         let fingerprint = request.fingerprint();
         let resume = match &request.cursor {
@@ -739,14 +743,14 @@ impl GrepService {
                 }
                 // A full scan includes all files at the current head, so it
                 // does not need a separate scan of recent unindexed changes.
-                candidates.unfiltered = scan_candidate_inodes(reads, scope.as_ref()).await?;
+                candidates.unfiltered = scan_candidate_inodes(&reads, scope.as_ref()).await?;
                 None
             }
         };
 
         let mut tail_scanned = true;
         if let Some(tail_resume) = tail_resume {
-            match tail_revisions(reads, tail_resume).await? {
+            match tail_revisions(&reads, tail_resume).await? {
                 TailScan::Within(inodes) => candidates.unfiltered.extend(inodes),
                 TailScan::OverBudget | TailScan::RebuildRequired if request.allow_stale => {
                     // Serve the index's cut and nothing newer. A candidate
@@ -883,7 +887,7 @@ impl GrepService {
             let contents = join_all(
                 batch
                     .iter()
-                    .map(|candidate| candidate_content(reads, candidate)),
+                    .map(|candidate| candidate_content(&reads, candidate)),
             )
             .await;
             // Emission stays strictly in candidate (inode) order: the batch
@@ -978,7 +982,7 @@ impl GrepService {
 /// when no path is given. The directory limit bounds the work and prevents a
 /// binding cycle from running forever.
 async fn scan_candidate_inodes(
-    reads: &NamespaceReads<'_>,
+    reads: &PinnedNamespaceReads<'_>,
     scope: Option<&PathEntry>,
 ) -> Result<BTreeSet<InodeId>> {
     let mut inodes = BTreeSet::new();

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -147,6 +147,65 @@ fn normalize_namespace(mut response: GrepResponse, namespace_id: &NamespaceId) -
 }
 
 #[tokio::test]
+async fn grep_query_keeps_its_pinned_head_when_a_matching_file_commits_mid_query() {
+    let temp_dir = tempdir().expect("tempdir");
+    let base = Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let base_store: SharedObjectStore = base.clone();
+    let namespace_id = NamespaceId::parse("query-pin").expect("namespace id");
+    let writer = FsWriter::builder_with_store(base_store.clone())
+        .writer_id("query-pin-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    GrepHost::new(&base_store, "query-pin-index")
+        .await
+        .enable_grep_index(&namespace_id)
+        .await
+        .expect("enable empty index");
+
+    let blocking = Arc::new(BlockingStore::new(
+        base.clone(),
+        KeyPredicate::exact(root_key(&namespace_id)),
+        OperationClass::GetWithMetadata,
+    ));
+    let query_store: SharedObjectStore = blocking.clone();
+    blocking.block_next();
+    let grep_request = request("mid-query needle");
+    let query = new_query(&query_store, &namespace_id, &grep_request);
+    let publish = async {
+        blocking.wait_until_blocked().await;
+        let committed = writer
+            .put_file_bytes(
+                &namespace_id,
+                "/later.txt",
+                b"mid-query needle\n",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await;
+        blocking.release();
+        committed
+    };
+    let (pinned_response, committed) = tokio::join!(query, publish);
+    let committed = committed.expect("publish matching file while query is paused");
+    let pinned_response = pinned_response.expect("pinned query completes");
+
+    assert!(pinned_response.matches.is_empty());
+    assert!(pinned_response.head_seq < committed.committed_seq);
+
+    let latest = new_query(&query_store, &namespace_id, &grep_request)
+        .await
+        .expect("later query sees committed file");
+    assert_eq!(latest.head_seq, committed.committed_seq);
+    assert_eq!(latest.matches.len(), 1);
+    assert_eq!(latest.matches[0].path, "/later.txt");
+}
+
+#[tokio::test]
 async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
     let temp_dir = tempdir().expect("tempdir");
     let store: SharedObjectStore =

--- a/crates/loonfs/src/fs/mod.rs
+++ b/crates/loonfs/src/fs/mod.rs
@@ -9,7 +9,8 @@ mod writes;
 
 pub use maintenance::{CheckpointsPager, MetadataCompactionOutcome};
 pub use reads::{
-    ChangesPager, FileRevisionsPager, InodeChildrenPager, PathEntriesPager, TrashPager,
+    ChangesPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager, PathEntriesPager,
+    TrashPager,
 };
 
 pub(crate) use core::{should_invalidate_after_result, ReadCore, WriterBits, WriterIdentity};

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -16,6 +16,87 @@ use loonfs_api::{
     AbsolutePath, DirectoryPageCursor, FileRevisionsPageCursor, PageCursor, PageRequest,
     PaginationPolicy, TrashPageCursor,
 };
+use loonfs_core::{NamespaceReaderEngine, RuntimeReadContext};
+
+/// A namespace metadata view pinned to one head sequence.
+///
+/// Create one with [`FsReader::pin_namespace`] when several related reads
+/// must describe the same filesystem state. Immutable content selected by
+/// this view remains safe to read through [`Self::read_content_ref`].
+#[must_use]
+pub struct FsReadSnapshot {
+    engine: NamespaceReaderEngine<SharedObjectStore>,
+    context: RuntimeReadContext,
+}
+
+impl FsReadSnapshot {
+    /// Returns the namespace this snapshot reads.
+    pub fn namespace_id(&self) -> &NamespaceId {
+        self.engine.namespace_id()
+    }
+
+    /// Returns the head sequence this snapshot is pinned to.
+    pub fn head_seq(&self) -> ChangeSeq {
+        self.context.head.seq
+    }
+
+    /// Resolves an absolute path against this snapshot.
+    pub async fn get_path_entry(
+        &self,
+        absolute_path: &str,
+        options: StatPathOptions,
+    ) -> Result<PathEntry> {
+        Ok(self
+            .engine
+            .resolve_path(absolute_path, options, &self.context)
+            .await?)
+    }
+
+    /// Lists one directory page against this snapshot.
+    pub async fn list_path_entries_page(
+        &self,
+        absolute_path: &str,
+        request: PageRequest<DirectoryPageCursor>,
+        options: ListPathEntriesOptions,
+    ) -> Result<ListPathEntriesResponse> {
+        let listed_path = AbsolutePath::parse(absolute_path)
+            .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
+        let page = self
+            .engine
+            .list_path_page(listed_path.as_str(), request, options, &self.context)
+            .await?;
+        Ok(ListPathEntriesResponse {
+            namespace_id: self.namespace_id().clone(),
+            path: listed_path,
+            head_seq: self.head_seq(),
+            entries: page.items,
+            next_cursor: encode_next_cursor(page.next_cursor.as_ref())?,
+        })
+    }
+
+    /// Resolves current visibility, revision, and path against this snapshot.
+    pub async fn resolve_current_files(
+        &self,
+        inode_ids: &[InodeId],
+    ) -> Result<Vec<CurrentFileState>> {
+        Ok(self
+            .engine
+            .resolve_current_files(inode_ids, &self.context)
+            .await?)
+    }
+
+    /// Reads and verifies immutable content selected from this snapshot.
+    pub async fn read_content_ref(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> Result<Vec<u8>> {
+        Ok(self
+            .engine
+            .read_content_ref(content_ref, max_bytes, &self.context)
+            .await?)
+    }
+}
 
 /// Fetches directory pages as needed.
 ///
@@ -345,6 +426,18 @@ fn advance_typed_cursor<C: PageCursor>(
 }
 
 impl FsReader {
+    /// Pins one namespace metadata view for a sequence of related reads.
+    ///
+    /// The returned snapshot keeps path lookup, directory listing, inode
+    /// resolution, and content selection on the same head even if commits
+    /// publish concurrently. It is intended to be short-lived for one
+    /// request or unit of work.
+    pub async fn pin_namespace(&self, namespace_id: &NamespaceId) -> Result<FsReadSnapshot> {
+        self.core.record_trace_context(&tracing::Span::current());
+        let (engine, context) = self.core.pinned_metadata_read(namespace_id).await?;
+        Ok(FsReadSnapshot { engine, context })
+    }
+
     /// Returns a namespace's current state.
     #[tracing::instrument(
         level = "debug",

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -181,7 +181,7 @@ pub use loonfs_objectstore::{
 pub use cache::RuntimeCacheStats;
 pub use config::{RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE};
 pub use fs::{
-    ChangesPager, CheckpointsPager, FileRevisionsPager, InodeChildrenPager,
+    ChangesPager, CheckpointsPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager,
     MetadataCompactionOutcome, PathEntriesPager, TrashPager,
 };
 pub use handle::{FsAdmin, FsAdminBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder};

--- a/crates/loonfs/tests/it/main.rs
+++ b/crates/loonfs/tests/it/main.rs
@@ -25,6 +25,7 @@ mod metrics_instruments;
 mod namespace_advance_observer;
 mod pagination;
 mod publication;
+mod read_snapshot;
 mod request_accounting;
 mod runtime_config;
 mod staged_content_reclamation;

--- a/crates/loonfs/tests/it/read_snapshot.rs
+++ b/crates/loonfs/tests/it/read_snapshot.rs
@@ -1,0 +1,121 @@
+//! Multi-call namespace read snapshots.
+
+use crate::common::{open_runtime_async, store};
+use loonfs::{
+    CreateNamespaceOptions, DestinationBehavior, ErrorCode, NamespaceId, PageRequest,
+    PaginationPolicy, PutFileOptions,
+};
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn pinned_namespace_reads_keep_one_head_across_later_commits() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "snapshot-reader-test").await;
+    let namespace_id = NamespaceId::parse("snapshot-reads").expect("namespace id");
+    runtime
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let created = runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/before.txt",
+            b"before",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create initial file");
+
+    let snapshot = runtime
+        .reader
+        .pin_namespace(&namespace_id)
+        .await
+        .expect("pin namespace");
+    assert_eq!(snapshot.head_seq(), created.committed_seq);
+    let before = snapshot
+        .get_path_entry("/before.txt", Default::default())
+        .await
+        .expect("resolve initial file");
+
+    runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/before.txt",
+            b"after",
+            PutFileOptions {
+                behavior: DestinationBehavior::Replace,
+                ..PutFileOptions::new(loonfs_test_support::test_actor())
+            },
+        )
+        .await
+        .expect("replace file after pin");
+    runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/later.txt",
+            b"later",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create file after pin");
+
+    let pinned_before = snapshot
+        .get_path_entry("/before.txt", Default::default())
+        .await
+        .expect("resolve pinned file");
+    assert_eq!(pinned_before.revision_no(), before.revision_no());
+    assert_eq!(
+        snapshot
+            .read_content_ref(
+                pinned_before.content_ref().expect("file content reference"),
+                64,
+            )
+            .await
+            .expect("read pinned content"),
+        b"before"
+    );
+    let later_error = snapshot
+        .get_path_entry("/later.txt", Default::default())
+        .await
+        .expect_err("later file is absent from the pinned view");
+    assert_eq!(later_error.code(), ErrorCode::PathNotFound);
+
+    let page = snapshot
+        .list_path_entries_page(
+            "/",
+            PageRequest {
+                limit: PaginationPolicy::default()
+                    .resolve_limit(None)
+                    .expect("default page limit"),
+                cursor: None,
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list pinned root");
+    assert_eq!(page.head_seq, snapshot.head_seq());
+    assert_eq!(
+        page.entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>(),
+        ["/before.txt"]
+    );
+    let states = snapshot
+        .resolve_current_files(&[before.inode_id])
+        .await
+        .expect("resolve pinned inode");
+    assert_eq!(states[0].current_revision_no, before.revision_no());
+
+    let latest = runtime
+        .reader
+        .get_file_bytes(&namespace_id, "/before.txt")
+        .await
+        .expect("read latest replacement");
+    assert_eq!(latest.bytes, b"after");
+    runtime
+        .reader
+        .get_path_entry(&namespace_id, "/later.txt", Default::default())
+        .await
+        .expect("latest view sees later file");
+}


### PR DESCRIPTION
Pin one namespace metadata view for each grep page and use it for scope resolution, candidate enumeration, candidate verification, and content selection. Limit the change-feed tail to that pinned head and report the same sequence.

This prevents concurrent commits from mixing filesystem states inside one response.