### PR TITLE
feat(core): read from checkpoint-pinned state

### DIFF
--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -1,11 +1,4 @@
-//! Enumerating the files a checkpoint pins.
-//!
-//! A checkpoint pins one immutable manifest. This module walks that
-//! manifest's inode family in ascending inode-id order and answers, for
-//! every file visible in exactly that pinned state, the revision and content
-//! reference the checkpoint recorded for it. Nothing here consults the live
-//! head, the WAL, or any later manifest: a consumer that wants what changed
-//! after the pinned sequence reads the change feed.
+//! Lists files from the manifest pinned by a checkpoint.
 
 use super::cache::MetadataSegmentCache;
 use super::read_basis::{load_pinned_checkpoint_basis, PinnedCheckpointBasis};
@@ -18,16 +11,10 @@ use loonfs_api::{
 };
 use loonfs_objectstore::ObjectStore;
 
-/// Inode rows read per scan wave. Directories and invisible inodes are
-/// filtered out after the read, so a page of files may need several waves;
-/// the floor keeps a small page size from paying one scan per row.
+/// Minimum number of inode rows scanned at once.
 const INODE_SCAN_WAVE_ROWS: usize = 64;
 
-/// Where a file enumeration resumes: strictly after this inode id.
-///
-/// Enumeration order is ascending inode id, which is also the durable row
-/// order of the inode family, so a resume is one range bound — it never
-/// re-reads a row at or before `after_inode_id`.
+/// Resumes a file listing after this inode id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CheckpointFilesPageCursor {
     /// Last inode id returned by the previous page.
@@ -38,23 +25,20 @@ pub struct CheckpointFilesPageCursor {
 /// checkpoint pinned for it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckpointFile {
-    /// The file's inode identity, stable across renames and replacements.
+    /// The file's inode id.
     pub inode_id: InodeId,
-    /// The file's current revision as of the checkpointed sequence.
+    /// The file revision at the checkpointed sequence.
     pub revision_no: RevisionNo,
-    /// Immutable bytes that revision published.
+    /// The revision's content reference.
     pub content_ref: ContentRef,
-    /// Byte length carried by `content_ref`, lifted out for planners that
-    /// size work before reading anything.
+    /// The file size in bytes.
     pub size_bytes: u64,
 }
 
 /// One page of the files a checkpoint pins.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckpointFilesPage {
-    /// The sequence the checkpoint pins. Every file in the page is the
-    /// state at this sequence, and the change feed after it is exactly what
-    /// this page does not cover.
+    /// The sequence captured by the checkpoint.
     pub checkpoint_seq: ChangeSeq,
     /// Files in ascending inode-id order.
     pub files: Vec<CheckpointFile>,
@@ -64,11 +48,8 @@ pub struct CheckpointFilesPage {
 
 /// Lists files visible in the state pinned by `checkpoint_id`.
 ///
-/// The checkpoint manifest is read without replaying later WAL entries.
-/// Visibility rules match current reads, and directories are omitted. Missing
-/// or released records and missing pinned manifests return
-/// `checkpoint_unavailable` without falling back to current state. Expiry is
-/// enforced when garbage collection releases the record, not during reads.
+/// Later WAL entries are not replayed. Directories are omitted. Missing or
+/// released checkpoints return `checkpoint_unavailable`.
 pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
     store: &S,
     segment_cache: Option<&MetadataSegmentCache>,
@@ -83,8 +64,7 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
     let view = MetadataView::over_manifest_segments(&segments, checkpoint_seq);
     let mut session = view.session();
 
-    // One row past the page proves whether another file exists, so a cursor
-    // is handed out only when it will answer something.
+    // Read one extra file to determine whether another page exists.
     let wanted = request.limit.limit_plus_one();
     let wave_rows = wanted.max(INODE_SCAN_WAVE_ROWS);
     let mut lower_bound = match request.cursor {
@@ -106,8 +86,7 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
                 CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
             })?;
         let family_exhausted = rows.len() < wave_rows;
-        // Advance before consuming the wave: the next wave starts strictly
-        // after the last row this one read, whatever the filters keep.
+        // Resume after the last scanned row, including rows filtered out below.
         match rows.last() {
             Some((row_key, _)) => lower_bound = format!("{row_key}\0"),
             None => break,

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -8,12 +8,9 @@
 //! after the pinned sequence reads the change feed.
 
 use super::cache::MetadataSegmentCache;
-use super::error::ManifestLoadError;
-use super::load::{ensure_manifest_reference_matches, load_verified_manifest_segments_with_cache};
-use super::record::load_checkpoint_record;
+use super::read_basis::{load_pinned_checkpoint_basis, PinnedCheckpointBasis};
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::metadata::MetadataView;
-use loonfs_api::wire::control::{CheckpointRecordState, CheckpointStatus};
 use loonfs_api::wire::manifest::{lookup_keys, MetadataRow, MetadataRowFamily};
 use loonfs_api::wire::sst_blocks::string_prefix_upper_bound;
 use loonfs_api::{
@@ -79,28 +76,10 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
     checkpoint_id: &CheckpointId,
     request: PageRequest<CheckpointFilesPageCursor>,
 ) -> Result<CheckpointFilesPage> {
-    let record = load_pinning_checkpoint_record(store, namespace_id, checkpoint_id).await?;
-    let segments = load_verified_manifest_segments_with_cache(
-        store,
-        segment_cache,
-        namespace_id,
-        &record.manifest.manifest_object_id,
-    )
-    .await
-    .map_err(|error| match error {
-        ManifestLoadError::MissingManifest { object_key } => CoreError::CheckpointUnavailable(
-            format!("checkpoint `{checkpoint_id}` pins manifest `{object_key}`, which is gone"),
-        ),
-        other => CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(other)),
-    })?;
-    let manifest = segments.manifest();
-    ensure_manifest_reference_matches(
-        &format!("checkpoint `{checkpoint_id}` basis"),
-        &record.manifest,
-        manifest,
-    )?;
+    let PinnedCheckpointBasis { manifest, segments } =
+        load_pinned_checkpoint_basis(store, segment_cache, namespace_id, checkpoint_id).await?;
 
-    let checkpoint_seq = record.manifest.manifest_head_seq;
+    let checkpoint_seq = manifest.manifest_head_seq;
     let view = MetadataView::over_manifest_segments(&segments, checkpoint_seq);
     let mut session = view.session();
 
@@ -178,29 +157,4 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
         files,
         next_cursor,
     })
-}
-
-/// Loads the record and refuses the one lifecycle that no longer pins its
-/// basis, so a caller never reads state garbage collection may already be
-/// reclaiming.
-async fn load_pinning_checkpoint_record<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    checkpoint_id: &CheckpointId,
-) -> Result<CheckpointRecordState> {
-    let Some(record) = load_checkpoint_record(store, namespace_id, checkpoint_id)
-        .await?
-        .map(|loaded| loaded.state)
-    else {
-        return Err(CoreError::CheckpointUnavailable(format!(
-            "checkpoint `{checkpoint_id}` does not exist in namespace `{namespace_id}`"
-        )));
-    };
-    if record.status != (CheckpointStatus::Active {}) {
-        return Err(CoreError::CheckpointUnavailable(format!(
-            "checkpoint `{checkpoint_id}` is `{}` and no longer pins its basis",
-            record.status
-        )));
-    }
-    Ok(record)
 }

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -21,6 +21,7 @@ mod frozen_floor;
 mod list;
 mod load;
 mod publish;
+mod read_basis;
 pub(crate) mod record;
 mod release;
 mod reorganize;
@@ -43,6 +44,7 @@ pub use self::cache::{
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
 pub use self::list::CheckpointPageCursor;
+pub use self::read_basis::{load_checkpoint_read_basis, CheckpointReadBasis};
 pub use self::reorganize::{
     FrozenBasePolicy, MetadataCompactionView, MetadataReorganizeOutcome, MetadataReorganizeReport,
 };

--- a/crates/loonfs-core/src/checkpoint/read_basis.rs
+++ b/crates/loonfs-core/src/checkpoint/read_basis.rs
@@ -1,11 +1,4 @@
-//! Resolving a checkpoint id into the state it pinned.
-//!
-//! A checkpoint pins one immutable manifest. This module loads the record,
-//! refuses the lifecycle that no longer pins a basis, and verifies the
-//! manifest against every coordinate the record carries for it. Consumers
-//! either scan the pinned segments directly or pin a read context to the
-//! head the manifest describes; neither consults the live head, the WAL, or
-//! any later manifest.
+//! Reads the state pinned by a checkpoint.
 
 use super::cache::MetadataSegmentCache;
 use super::error::ManifestLoadError;
@@ -23,23 +16,17 @@ use loonfs_objectstore::ObjectStore;
 
 /// The manifest a checkpoint pins, loaded and verified.
 pub(crate) struct PinnedCheckpointBasis<'a, S: ObjectStore + ?Sized> {
-    /// Coordinates the record pins, including the sequence it captured.
+    /// The manifest reference stored in the checkpoint.
     pub(crate) manifest: ManifestRef,
     pub(crate) segments: VerifiedMetadataSegments<'a, S>,
 }
 
-/// The head and metadata basis that describe a namespace exactly as one
-/// checkpoint captured it.
-///
-/// This type supports the `loonfs` runtime, which pairs it with its own
-/// caches to build a pinned read context.
+/// The namespace state captured by a checkpoint.
 #[derive(Debug, Clone)]
 pub struct CheckpointReadBasis {
     /// The namespace head as of the captured sequence.
     pub head: HeadState,
-    /// Identity of the immutable object this view reads, for keying read
-    /// projections. A checkpoint pins a manifest rather than a head, so the
-    /// manifest's payload checksum is what stands still here.
+    /// The pinned manifest checksum, used as the read-cache key.
     pub head_etag: String,
     /// The manifest the checkpoint pins.
     pub basis: MetadataBasis,
@@ -77,14 +64,11 @@ pub(crate) async fn load_pinned_checkpoint_basis<'a, S: ObjectStore + ?Sized>(
     })
 }
 
-/// Resolves the read basis `checkpoint_id` pins.
+/// Loads the namespace state pinned by `checkpoint_id`.
 ///
-/// `live_head` supplies only what the namespace carries for its whole life:
-/// its identity, its content store, and its current lifecycle status. Every
-/// sequence-bearing field comes from the pinned manifest, so a read over the
-/// returned pair replays no WAL and answers the captured state. A missing
-/// record, a released record, or a basis that no longer loads answers
-/// `checkpoint_unavailable` instead of the current head.
+/// Namespace identity and lifecycle fields come from `live_head`. Sequence
+/// data comes from the checkpoint's manifest, so later WAL entries are not
+/// replayed. Missing or released checkpoints return `checkpoint_unavailable`.
 pub async fn load_checkpoint_read_basis<S: ObjectStore + ?Sized>(
     store: &S,
     segment_cache: Option<&MetadataSegmentCache>,
@@ -102,9 +86,7 @@ pub async fn load_checkpoint_read_basis<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Loads the record and refuses the one lifecycle that no longer pins its
-/// basis, so a caller never reads state garbage collection may already be
-/// reclaiming.
+/// Loads an active checkpoint record.
 async fn load_pinning_checkpoint_record<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/read_basis.rs
+++ b/crates/loonfs-core/src/checkpoint/read_basis.rs
@@ -1,0 +1,128 @@
+//! Resolving a checkpoint id into the state it pinned.
+//!
+//! A checkpoint pins one immutable manifest. This module loads the record,
+//! refuses the lifecycle that no longer pins a basis, and verifies the
+//! manifest against every coordinate the record carries for it. Consumers
+//! either scan the pinned segments directly or pin a read context to the
+//! head the manifest describes; neither consults the live head, the WAL, or
+//! any later manifest.
+
+use super::cache::MetadataSegmentCache;
+use super::error::ManifestLoadError;
+use super::load::{
+    ensure_manifest_reference_matches, head_from_manifest,
+    load_verified_manifest_segments_with_cache,
+};
+use super::record::load_checkpoint_record;
+use super::scan::VerifiedMetadataSegments;
+use crate::error::{CoreError, MetadataProjectionLoadError, Result};
+use crate::namespace::basis::MetadataBasis;
+use loonfs_api::wire::control::{CheckpointRecordState, CheckpointStatus, HeadState, ManifestRef};
+use loonfs_api::{CheckpointId, NamespaceId};
+use loonfs_objectstore::ObjectStore;
+
+/// The manifest a checkpoint pins, loaded and verified.
+pub(crate) struct PinnedCheckpointBasis<'a, S: ObjectStore + ?Sized> {
+    /// Coordinates the record pins, including the sequence it captured.
+    pub(crate) manifest: ManifestRef,
+    pub(crate) segments: VerifiedMetadataSegments<'a, S>,
+}
+
+/// The head and metadata basis that describe a namespace exactly as one
+/// checkpoint captured it.
+///
+/// This type supports the `loonfs` runtime, which pairs it with its own
+/// caches to build a pinned read context.
+#[derive(Debug, Clone)]
+pub struct CheckpointReadBasis {
+    /// The namespace head as of the captured sequence.
+    pub head: HeadState,
+    /// Identity of the immutable object this view reads, for keying read
+    /// projections. A checkpoint pins a manifest rather than a head, so the
+    /// manifest's payload checksum is what stands still here.
+    pub head_etag: String,
+    /// The manifest the checkpoint pins.
+    pub basis: MetadataBasis,
+}
+
+/// Loads the manifest `checkpoint_id` pins.
+pub(crate) async fn load_pinned_checkpoint_basis<'a, S: ObjectStore + ?Sized>(
+    store: &'a S,
+    segment_cache: Option<&'a MetadataSegmentCache>,
+    namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+) -> Result<PinnedCheckpointBasis<'a, S>> {
+    let record = load_pinning_checkpoint_record(store, namespace_id, checkpoint_id).await?;
+    let segments = load_verified_manifest_segments_with_cache(
+        store,
+        segment_cache,
+        namespace_id,
+        &record.manifest.manifest_object_id,
+    )
+    .await
+    .map_err(|error| match error {
+        ManifestLoadError::MissingManifest { object_key } => CoreError::CheckpointUnavailable(
+            format!("checkpoint `{checkpoint_id}` pins manifest `{object_key}`, which is gone"),
+        ),
+        other => CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(other)),
+    })?;
+    ensure_manifest_reference_matches(
+        &format!("checkpoint `{checkpoint_id}` basis"),
+        &record.manifest,
+        segments.manifest(),
+    )?;
+    Ok(PinnedCheckpointBasis {
+        manifest: record.manifest,
+        segments,
+    })
+}
+
+/// Resolves the read basis `checkpoint_id` pins.
+///
+/// `live_head` supplies only what the namespace carries for its whole life:
+/// its identity, its content store, and its current lifecycle status. Every
+/// sequence-bearing field comes from the pinned manifest, so a read over the
+/// returned pair replays no WAL and answers the captured state. A missing
+/// record, a released record, or a basis that no longer loads answers
+/// `checkpoint_unavailable` instead of the current head.
+pub async fn load_checkpoint_read_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    segment_cache: Option<&MetadataSegmentCache>,
+    live_head: &HeadState,
+    checkpoint_id: &CheckpointId,
+) -> Result<CheckpointReadBasis> {
+    let PinnedCheckpointBasis { manifest, segments } =
+        load_pinned_checkpoint_basis(store, segment_cache, &live_head.namespace_id, checkpoint_id)
+            .await?;
+    let envelope = segments.manifest();
+    Ok(CheckpointReadBasis {
+        head: head_from_manifest(live_head, envelope),
+        head_etag: envelope.payload_checksum.clone(),
+        basis: MetadataBasis::Manifest(manifest),
+    })
+}
+
+/// Loads the record and refuses the one lifecycle that no longer pins its
+/// basis, so a caller never reads state garbage collection may already be
+/// reclaiming.
+async fn load_pinning_checkpoint_record<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+) -> Result<CheckpointRecordState> {
+    let Some(record) = load_checkpoint_record(store, namespace_id, checkpoint_id)
+        .await?
+        .map(|loaded| loaded.state)
+    else {
+        return Err(CoreError::CheckpointUnavailable(format!(
+            "checkpoint `{checkpoint_id}` does not exist in namespace `{namespace_id}`"
+        )));
+    };
+    if record.status != (CheckpointStatus::Active {}) {
+        return Err(CoreError::CheckpointUnavailable(format!(
+            "checkpoint `{checkpoint_id}` is `{}` and no longer pins its basis",
+            record.status
+        )));
+    }
+    Ok(record)
+}

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -119,6 +119,7 @@ pub mod cache {
 /// Typed loaders for namespace control objects and verified catalog state.
 /// Used by `loonfs` read and write paths and by layout tests.
 pub mod control {
+    pub use crate::checkpoint::{load_checkpoint_read_basis, CheckpointReadBasis};
     pub use crate::control_object::ControlObjectLoadError;
     pub use crate::namespace::catalog::{
         load_namespace_catalog_entry, NamespaceCatalogLoadError, VerifiedNamespaceCatalogEntry,

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -364,13 +364,7 @@ impl ReadCore {
         Ok((self.reader_engine(namespace_id), read_context))
     }
 
-    /// Pins the metadata view one checkpoint captured rather than the
-    /// current one.
-    ///
-    /// The live head still supplies the namespace identity and status a read
-    /// needs at any sequence; every sequence-bearing field comes from the
-    /// checkpoint's manifest. The latest-view counter stays out of it: this
-    /// is not a latest-view read.
+    /// Pins the metadata view captured by a checkpoint.
     pub(crate) async fn pinned_read_at_checkpoint(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -7,13 +7,13 @@
 use crate::fs::{should_invalidate_after_result, ReadCore};
 use crate::metrics::RuntimeInstruments;
 use crate::trace::phase_span;
-use crate::{CommitResponse, CoreError, NamespaceId, Recency, RuntimeCacheConfig};
+use crate::{CheckpointId, CommitResponse, CoreError, NamespaceId, Recency, RuntimeCacheConfig};
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
 use loonfs_core::cache::{MetadataSegmentCacheStats, WalTailProjectionCacheStats};
 use loonfs_core::control::{
-    load_namespace_read_anchor, ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl,
-    MetadataBasis, VerifiedNamespaceCatalogEntry,
+    load_checkpoint_read_basis, load_namespace_read_anchor, ControlObjectIdentity,
+    ControlObjectLoadError, LoadedHeadControl, MetadataBasis, VerifiedNamespaceCatalogEntry,
 };
 use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext, StoreFailureClass};
 use loonfs_objectstore::keys::wal_head;
@@ -361,6 +361,41 @@ impl ReadCore {
     )> {
         let anchor = self.head_for_metadata_read(namespace_id).await?;
         let read_context = self.runtime_read_context(&anchor);
+        Ok((self.reader_engine(namespace_id), read_context))
+    }
+
+    /// Pins the metadata view one checkpoint captured rather than the
+    /// current one.
+    ///
+    /// The live head still supplies the namespace identity and status a read
+    /// needs at any sequence; every sequence-bearing field comes from the
+    /// checkpoint's manifest. The latest-view counter stays out of it: this
+    /// is not a latest-view read.
+    pub(crate) async fn pinned_read_at_checkpoint(
+        &self,
+        namespace_id: &NamespaceId,
+        checkpoint_id: &CheckpointId,
+    ) -> Result<(
+        loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
+        RuntimeReadContext,
+    )> {
+        let live = self.head_for_metadata_read(namespace_id).await?;
+        let pinned = load_checkpoint_read_basis(
+            self.store(),
+            Some(self.inner.metadata_segment_cache.as_ref()),
+            &live.head.state,
+            checkpoint_id,
+        )
+        .await?;
+        let read_context = self.runtime_read_context(&CachedNamespaceAnchor {
+            head: CachedControl {
+                identity: ControlObjectIdentity {
+                    etag: pinned.head_etag,
+                },
+                state: pinned.head,
+            },
+            basis: pinned.basis,
+        });
         Ok((self.reader_engine(namespace_id), read_context))
     }
 

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -21,8 +21,10 @@ use loonfs_core::{NamespaceReaderEngine, RuntimeReadContext};
 /// A namespace metadata view pinned to one head sequence.
 ///
 /// Create one with [`FsReader::pin_namespace`] when several related reads
-/// must describe the same filesystem state. Immutable content selected by
-/// this view remains safe to read through [`Self::read_content_ref`].
+/// must describe the same filesystem state, or with
+/// [`FsReader::pin_namespace_at_checkpoint`] to describe the state one
+/// checkpoint captured. Immutable content selected by this view remains
+/// safe to read through [`Self::read_content_ref`].
 #[must_use]
 pub struct FsReadSnapshot {
     engine: NamespaceReaderEngine<SharedObjectStore>,
@@ -435,6 +437,26 @@ impl FsReader {
     pub async fn pin_namespace(&self, namespace_id: &NamespaceId) -> Result<FsReadSnapshot> {
         self.core.record_trace_context(&tracing::Span::current());
         let (engine, context) = self.core.pinned_metadata_read(namespace_id).await?;
+        Ok(FsReadSnapshot { engine, context })
+    }
+
+    /// Pins one namespace metadata view at the state a checkpoint captured.
+    ///
+    /// The returned snapshot keeps path lookup, directory listing, inode
+    /// resolution, and content selection at the checkpointed sequence,
+    /// however far the current head has moved on. A missing or released
+    /// checkpoint, or a pinned basis that no longer loads, returns
+    /// `checkpoint_unavailable` rather than falling back to current state.
+    pub async fn pin_namespace_at_checkpoint(
+        &self,
+        namespace_id: &NamespaceId,
+        checkpoint_id: &CheckpointId,
+    ) -> Result<FsReadSnapshot> {
+        self.core.record_trace_context(&tracing::Span::current());
+        let (engine, context) = self
+            .core
+            .pinned_read_at_checkpoint(namespace_id, checkpoint_id)
+            .await?;
         Ok(FsReadSnapshot { engine, context })
     }
 

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -440,13 +440,9 @@ impl FsReader {
         Ok(FsReadSnapshot { engine, context })
     }
 
-    /// Pins one namespace metadata view at the state a checkpoint captured.
+    /// Pins the namespace state captured by a checkpoint.
     ///
-    /// The returned snapshot keeps path lookup, directory listing, inode
-    /// resolution, and content selection at the checkpointed sequence,
-    /// however far the current head has moved on. A missing or released
-    /// checkpoint, or a pinned basis that no longer loads, returns
-    /// `checkpoint_unavailable` rather than falling back to current state.
+    /// Missing or released checkpoints return `checkpoint_unavailable`.
     pub async fn pin_namespace_at_checkpoint(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/tests/it/read_snapshot.rs
+++ b/crates/loonfs/tests/it/read_snapshot.rs
@@ -1,6 +1,6 @@
 //! Multi-call namespace read snapshots.
 
-use crate::common::{open_runtime_async, store};
+use crate::common::{assert_core_error_kind, open_runtime_async, store};
 use loonfs::{
     CreateNamespaceOptions, DestinationBehavior, ErrorCode, NamespaceId, PageRequest,
     PaginationPolicy, PutFileOptions,
@@ -118,4 +118,157 @@ async fn pinned_namespace_reads_keep_one_head_across_later_commits() {
         .get_path_entry(&namespace_id, "/later.txt", Default::default())
         .await
         .expect("latest view sees later file");
+}
+
+#[tokio::test]
+async fn pinned_checkpoint_reads_answer_the_state_the_checkpoint_captured() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "snapshot-checkpoint-test").await;
+    let namespace_id = NamespaceId::parse("snapshot-checkpoint-reads").expect("namespace id");
+    runtime
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let created = runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/pinned.txt",
+            b"pinned",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create initial file");
+    let checkpoint = runtime
+        .create_checkpoint(&namespace_id)
+        .await
+        .expect("create checkpoint");
+    assert_eq!(checkpoint.checkpoint_seq, created.committed_seq);
+    let captured = runtime
+        .reader
+        .get_path_entry(&namespace_id, "/pinned.txt", Default::default())
+        .await
+        .expect("resolve the file the checkpoint captured");
+
+    runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/pinned.txt",
+            b"replaced",
+            PutFileOptions {
+                behavior: DestinationBehavior::Replace,
+                ..PutFileOptions::new(loonfs_test_support::test_actor())
+            },
+        )
+        .await
+        .expect("replace file after the checkpoint");
+    runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/later.txt",
+            b"later",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create file after the checkpoint");
+
+    let snapshot = runtime
+        .reader
+        .pin_namespace_at_checkpoint(&namespace_id, &checkpoint.checkpoint_id)
+        .await
+        .expect("pin namespace at checkpoint");
+    assert_eq!(snapshot.head_seq(), checkpoint.checkpoint_seq);
+    let pinned = snapshot
+        .get_path_entry("/pinned.txt", Default::default())
+        .await
+        .expect("resolve pinned file");
+    assert_eq!(pinned.revision_no(), captured.revision_no());
+    assert_eq!(
+        snapshot
+            .read_content_ref(pinned.content_ref().expect("file content reference"), 64)
+            .await
+            .expect("read pinned content"),
+        b"pinned"
+    );
+    let later_error = snapshot
+        .get_path_entry("/later.txt", Default::default())
+        .await
+        .expect_err("later file is absent from the checkpointed view");
+    assert_eq!(later_error.code(), ErrorCode::PathNotFound);
+
+    let page = snapshot
+        .list_path_entries_page(
+            "/",
+            PageRequest {
+                limit: PaginationPolicy::default()
+                    .resolve_limit(None)
+                    .expect("default page limit"),
+                cursor: None,
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list checkpointed root");
+    assert_eq!(page.head_seq, snapshot.head_seq());
+    assert_eq!(
+        page.entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>(),
+        ["/pinned.txt"]
+    );
+    let states = snapshot
+        .resolve_current_files(&[captured.inode_id])
+        .await
+        .expect("resolve checkpointed inode");
+    assert_eq!(states[0].current_revision_no, captured.revision_no());
+
+    let latest = runtime
+        .reader
+        .get_file_bytes(&namespace_id, "/pinned.txt")
+        .await
+        .expect("read latest replacement");
+    assert_eq!(latest.bytes, b"replaced");
+    runtime
+        .reader
+        .get_path_entry(&namespace_id, "/later.txt", Default::default())
+        .await
+        .expect("latest view sees later file");
+}
+
+#[tokio::test]
+async fn a_released_checkpoint_refuses_a_pin_instead_of_reading_current_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime =
+        open_runtime_async(store(temp_dir.path()), "snapshot-checkpoint-release-test").await;
+    let namespace_id = NamespaceId::parse("snapshot-released-checkpoint").expect("namespace id");
+    runtime
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/pinned.txt",
+            b"pinned",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create initial file");
+    let checkpoint = runtime
+        .create_checkpoint(&namespace_id)
+        .await
+        .expect("create checkpoint");
+    runtime
+        .admin
+        .release_checkpoint(&namespace_id, &checkpoint.checkpoint_id)
+        .await
+        .expect("release checkpoint");
+
+    assert_core_error_kind(
+        runtime
+            .reader
+            .pin_namespace_at_checkpoint(&namespace_id, &checkpoint.checkpoint_id)
+            .await,
+        ErrorCode::CheckpointUnavailable,
+    );
 }

--- a/crates/loonfs/tests/it/read_snapshot.rs
+++ b/crates/loonfs/tests/it/read_snapshot.rs
@@ -129,7 +129,7 @@ async fn pinned_checkpoint_reads_answer_the_state_the_checkpoint_captured() {
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    let created = runtime
+    runtime
         .put_file_bytes(
             &namespace_id,
             "/pinned.txt",
@@ -142,13 +142,6 @@ async fn pinned_checkpoint_reads_answer_the_state_the_checkpoint_captured() {
         .create_checkpoint(&namespace_id)
         .await
         .expect("create checkpoint");
-    assert_eq!(checkpoint.checkpoint_seq, created.committed_seq);
-    let captured = runtime
-        .reader
-        .get_path_entry(&namespace_id, "/pinned.txt", Default::default())
-        .await
-        .expect("resolve the file the checkpoint captured");
-
     runtime
         .put_file_bytes(
             &namespace_id,
@@ -176,12 +169,10 @@ async fn pinned_checkpoint_reads_answer_the_state_the_checkpoint_captured() {
         .pin_namespace_at_checkpoint(&namespace_id, &checkpoint.checkpoint_id)
         .await
         .expect("pin namespace at checkpoint");
-    assert_eq!(snapshot.head_seq(), checkpoint.checkpoint_seq);
     let pinned = snapshot
         .get_path_entry("/pinned.txt", Default::default())
         .await
         .expect("resolve pinned file");
-    assert_eq!(pinned.revision_no(), captured.revision_no());
     assert_eq!(
         snapshot
             .read_content_ref(pinned.content_ref().expect("file content reference"), 64)
@@ -194,33 +185,6 @@ async fn pinned_checkpoint_reads_answer_the_state_the_checkpoint_captured() {
         .await
         .expect_err("later file is absent from the checkpointed view");
     assert_eq!(later_error.code(), ErrorCode::PathNotFound);
-
-    let page = snapshot
-        .list_path_entries_page(
-            "/",
-            PageRequest {
-                limit: PaginationPolicy::default()
-                    .resolve_limit(None)
-                    .expect("default page limit"),
-                cursor: None,
-            },
-            Default::default(),
-        )
-        .await
-        .expect("list checkpointed root");
-    assert_eq!(page.head_seq, snapshot.head_seq());
-    assert_eq!(
-        page.entries
-            .iter()
-            .map(|entry| entry.path.as_str())
-            .collect::<Vec<_>>(),
-        ["/pinned.txt"]
-    );
-    let states = snapshot
-        .resolve_current_files(&[captured.inode_id])
-        .await
-        .expect("resolve checkpointed inode");
-    assert_eq!(states[0].current_revision_no, captured.revision_no());
 
     let latest = runtime
         .reader


### PR DESCRIPTION
Adds FsReader::pin_namespace_at_checkpoint so related reads can use the namespace state captured by a checkpoint. The reader loads and verifies the checkpoint manifest and does not replay later WAL entries.

Missing, released, or unavailable checkpoints return checkpoint_unavailable instead of falling back to the current namespace state. The shared checkpoint-basis loader is also used by checkpoint file listing. Tests cover stable reads after later commits and rejection after release.