### PR TITLE
feat(observability): polish snapshot diagnostics and read metrics

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -196,6 +196,10 @@ pub struct NamespaceDiagnostics {
     pub current_manifest_no: Option<ManifestNo>,
     /// Number of visible WAL segments after the current manifest.
     pub wal_tail_segments: u64,
+    /// Number of active snapshot-owned records unexpired when diagnostics were read.
+    pub live_snapshots: u64,
+    /// Number of active user-owned records, expired or not.
+    pub live_checkpoints: u64,
 }
 
 /// Result of deleting a namespace.
@@ -1422,6 +1426,8 @@ mod tests {
             retention_floor_seq: ChangeSeq(4),
             current_manifest_no: Some(ManifestNo(8)),
             wal_tail_segments: 3,
+            live_snapshots: 2,
+            live_checkpoints: 5,
         };
         assert_eq!(
             serde_json::to_value(diagnostics).expect("serialize namespace diagnostics"),
@@ -1430,7 +1436,9 @@ mod tests {
                 "head_seq": 11,
                 "retention_floor_seq": 4,
                 "current_manifest_no": 8,
-                "wal_tail_segments": 3
+                "wal_tail_segments": 3,
+                "live_snapshots": 2,
+                "live_checkpoints": 5
             })
         );
     }

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -196,9 +196,9 @@ pub struct NamespaceDiagnostics {
     pub current_manifest_no: Option<ManifestNo>,
     /// Number of visible WAL segments after the current manifest.
     pub wal_tail_segments: u64,
-    /// Number of active snapshot-owned records unexpired when diagnostics were read.
+    /// Number of snapshots that had not expired when diagnostics began.
     pub live_snapshots: u64,
-    /// Number of active user-owned records, expired or not.
+    /// Number of active user checkpoints, including expired records awaiting collection.
     pub live_checkpoints: u64,
 }
 

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -671,6 +671,8 @@ mod tests {
             retention_floor_seq: ChangeSeq(1),
             current_manifest_no: None,
             wal_tail_segments: 2,
+            live_snapshots: 3,
+            live_checkpoints: 4,
         };
         let transport = crate::transport::test_transport::failure_then_success(
             serde_json::to_vec(&response).expect("serialize response"),

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -116,6 +116,8 @@ pub async fn load_namespace_diagnostics<S: ObjectStore + ?Sized>(
         retention_floor_seq: loaded.retention_floor_seq,
         current_manifest_no: loaded.current_manifest_no,
         wal_tail_segments,
+        live_snapshots: 0,
+        live_checkpoints: 0,
     })
 }
 
@@ -158,5 +160,7 @@ pub async fn load_deleted_namespace_diagnostics<S: ObjectStore + ?Sized>(
         retention_floor_seq,
         current_manifest_no: None,
         wal_tail_segments: 0,
+        live_snapshots: 0,
+        live_checkpoints: 0,
     })
 }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -745,6 +745,8 @@ async fn admin_namespace_diagnostics_route_answers_storage_fields() {
     assert_eq!(diagnostics.retention_floor_seq, ChangeSeq(0));
     assert_eq!(diagnostics.current_manifest_no, None);
     assert_eq!(diagnostics.wal_tail_segments, 1);
+    assert_eq!(diagnostics.live_snapshots, 0);
+    assert_eq!(diagnostics.live_checkpoints, 0);
 
     state.writer.shutdown().await.expect("shutdown writer");
 }
@@ -895,6 +897,7 @@ async fn runtime_and_grep_cache_metrics_render_from_the_recorder() {
 
     for name in [
         "loonfs_runtime_cache_latest_metadata_view_reads_total",
+        "loonfs_runtime_cache_snapshot_view_reads_total",
         "loonfs_metadata_segment_cache_gets_total",
         "loonfs_metadata_segment_cache_inserts_total",
         "loonfs_metadata_segment_cache_evictions_total",

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -387,6 +387,13 @@ fn assert_api_spec_error_codes_are_registered(spec: &str) {
                 .filter_map(|operation| operation.get("operationId")?.as_str())
         })
         .collect();
+    let schema_properties: std::collections::BTreeSet<_> = openapi["components"]["schemas"]
+        .as_object()
+        .expect("OpenAPI schemas object")
+        .values()
+        .filter_map(|schema| schema.get("properties")?.as_object())
+        .flat_map(|properties| properties.keys().map(String::as_str))
+        .collect();
 
     for token in spec
         .split('`')
@@ -394,7 +401,10 @@ fn assert_api_spec_error_codes_are_registered(spec: &str) {
         .step_by(2)
         .filter(|token| is_snake_case_token(token))
     {
-        if API_SPEC_NON_ERROR_CODE_TOKENS.contains(&token) || operation_ids.contains(token) {
+        if API_SPEC_NON_ERROR_CODE_TOKENS.contains(&token)
+            || operation_ids.contains(token)
+            || schema_properties.contains(token)
+        {
             continue;
         }
         // Valid inode IDs are examples, not error codes.

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -210,6 +210,16 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
     assert_eq!(repeated.manifest_no, first.manifest_no);
     assert_eq!(repeated.expires_at_ms, first.expires_at_ms);
     assert!(repeated.created_at_ms >= first.created_at_ms);
+    client
+        .fork_namespace(&namespace, &namespace_id("fork"))
+        .await
+        .expect("fork namespace");
+    let diagnostics = client
+        .get_namespace_diagnostics(&namespace)
+        .await
+        .expect("read checkpoint diagnostics");
+    assert_eq!(diagnostics.live_snapshots, 0);
+    assert_eq!(diagnostics.live_checkpoints, 2);
 
     // Releasing a checkpoint twice returns the same result.
     let released = post_checkpoint_release(
@@ -232,6 +242,11 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
     )
     .expect("repeat release");
     assert_eq!(released_again, released);
+    let diagnostics = client
+        .get_namespace_diagnostics(&namespace)
+        .await
+        .expect("read diagnostics after release");
+    assert_eq!(diagnostics.live_checkpoints, 1);
     let bogus_release =
         post_checkpoint_release(&server_url, namespace.as_str(), "not-a-checkpoint-id")
             .expect_err("malformed checkpoint id");

--- a/crates/loonfs-server/tests/it/http_metrics.rs
+++ b/crates/loonfs-server/tests/it/http_metrics.rs
@@ -106,6 +106,7 @@ async fn a_scrape_reports_requests_object_store_calls_and_cache_metrics() {
     );
     assert!(first.contains_key("loonfs_metadata_segment_cache_gets_total{result=\"hit\"}"));
     assert!(first.contains_key("loonfs_runtime_cache_latest_metadata_view_reads_total"));
+    assert!(first.contains_key("loonfs_runtime_cache_snapshot_view_reads_total"));
     assert!(first.contains_key("loonfs_grep_block_cache_gets_total{result=\"hit\"}"));
     assert!(first.contains_key("loonfs_wal_tail_projection_cache_retained_rows"));
     assert_eq!(

--- a/crates/loonfs-server/tests/it/http_snapshots.rs
+++ b/crates/loonfs-server/tests/it/http_snapshots.rs
@@ -140,6 +140,13 @@ async fn http_snapshots_lifecycle_is_live_extendable_and_releasable() {
     assert!(created.created_at_ms <= after_create);
     assert!(created.expires_at_ms >= before_create + 5_000);
     assert!(created.expires_at_ms <= after_create + 5_000);
+    let diagnostics = harness
+        .client
+        .get_namespace_diagnostics(&namespace)
+        .await
+        .expect("read snapshot diagnostics");
+    assert_eq!(diagnostics.live_snapshots, 1);
+    assert_eq!(diagnostics.live_checkpoints, 0);
 
     let listed = list_snapshots(&harness.server_url, namespace.as_str()).expect("list snapshot");
     assert_eq!(listed.snapshots, vec![created.clone()]);
@@ -182,6 +189,12 @@ async fn http_snapshots_lifecycle_is_live_extendable_and_releasable() {
         .expect("list after release")
         .snapshots
         .is_empty());
+    let diagnostics = harness
+        .client
+        .get_namespace_diagnostics(&namespace)
+        .await
+        .expect("read diagnostics after release");
+    assert_eq!(diagnostics.live_snapshots, 0);
     assert_eq!(
         release_snapshot(
             &harness.server_url,

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -842,6 +842,18 @@ fn openapi_publishes_namespace_diagnostics_in_the_admin_plane() {
         operation["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
         "#/components/schemas/NamespaceDiagnostics"
     );
+    let diagnostics = &spec["components"]["schemas"]["NamespaceDiagnostics"];
+    assert_eq!(
+        required_fields(diagnostics),
+        BTreeSet::from([
+            "head_seq",
+            "live_checkpoints",
+            "live_snapshots",
+            "namespace_id",
+            "retention_floor_seq",
+            "wal_tail_segments",
+        ])
+    );
 }
 
 #[test]

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -60,7 +60,7 @@ pub(crate) struct CachedNamespaceAnchor {
 pub struct RuntimeCacheStats {
     /// Latest metadata reads served through the metadata-view path.
     pub latest_metadata_view_reads: usize,
-    /// Metadata reads served through a snapshot-pinned view.
+    /// Snapshot-backed metadata views created by the runtime.
     pub snapshot_view_reads: usize,
     /// WAL-tail projection cache hits.
     pub wal_tail_projection_cache_hits: usize,

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -60,6 +60,8 @@ pub(crate) struct CachedNamespaceAnchor {
 pub struct RuntimeCacheStats {
     /// Latest metadata reads served through the metadata-view path.
     pub latest_metadata_view_reads: usize,
+    /// Metadata reads served through a snapshot-pinned view.
+    pub snapshot_view_reads: usize,
     /// WAL-tail projection cache hits.
     pub wal_tail_projection_cache_hits: usize,
     /// WAL-tail projection cache misses.
@@ -98,6 +100,7 @@ pub struct RuntimeCacheStats {
 
 pub(crate) struct RuntimeCacheStatsInner {
     latest_metadata_view_reads: AtomicUsize,
+    snapshot_view_reads: AtomicUsize,
     instruments: Arc<RuntimeInstruments>,
 }
 
@@ -105,6 +108,7 @@ impl RuntimeCacheStatsInner {
     pub(crate) fn new(instruments: Arc<RuntimeInstruments>) -> Self {
         Self {
             latest_metadata_view_reads: AtomicUsize::new(0),
+            snapshot_view_reads: AtomicUsize::new(0),
             instruments,
         }
     }
@@ -116,6 +120,7 @@ impl RuntimeCacheStatsInner {
     ) -> RuntimeCacheStats {
         RuntimeCacheStats {
             latest_metadata_view_reads: self.latest_metadata_view_reads.load(Ordering::SeqCst),
+            snapshot_view_reads: self.snapshot_view_reads.load(Ordering::SeqCst),
             wal_tail_projection_cache_hits: wal_tail_projection_cache.hits,
             wal_tail_projection_cache_misses: wal_tail_projection_cache.misses,
             wal_tail_projection_cache_inserts: wal_tail_projection_cache.inserts,
@@ -145,6 +150,11 @@ impl RuntimeCacheStatsInner {
         self.latest_metadata_view_reads
             .fetch_add(1, Ordering::SeqCst);
         self.instruments.latest_metadata_view_read();
+    }
+
+    pub(crate) fn record_snapshot_view_read(&self) {
+        self.snapshot_view_reads.fetch_add(1, Ordering::SeqCst);
+        self.instruments.snapshot_view_read();
     }
 }
 

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -168,7 +168,40 @@ impl FsAdmin {
         namespace_id: &NamespaceId,
     ) -> Result<NamespaceDiagnostics> {
         self.core.record_trace_context(&tracing::Span::current());
-        Ok(loonfs_core::cache::load_namespace_diagnostics(self.core.store(), namespace_id).await?)
+        let mut diagnostics =
+            loonfs_core::cache::load_namespace_diagnostics(self.core.store(), namespace_id).await?;
+        let now_ms = self.actor.mutation_context()?.now_ms;
+        let page_limit = loonfs_api::PaginationPolicy::default().max_limit();
+        let mut cursor = None;
+        loop {
+            let page = self
+                .engine(namespace_id)
+                .list_checkpoints_page(PageRequest {
+                    limit: loonfs_api::EffectiveLimit::new(page_limit),
+                    cursor,
+                })
+                .await
+                .map_err(RuntimeError::from)?;
+            for checkpoint in page.items {
+                match checkpoint.owner {
+                    loonfs_api::CheckpointOwnerSummary::User { .. } => {
+                        diagnostics.live_checkpoints =
+                            diagnostics.live_checkpoints.saturating_add(1);
+                    }
+                    loonfs_api::CheckpointOwnerSummary::Snapshot { expires_at_ms, .. }
+                        if expires_at_ms > now_ms =>
+                    {
+                        diagnostics.live_snapshots = diagnostics.live_snapshots.saturating_add(1);
+                    }
+                    loonfs_api::CheckpointOwnerSummary::Fork { .. }
+                    | loonfs_api::CheckpointOwnerSummary::Snapshot { .. } => {}
+                }
+            }
+            let Some(next_cursor) = page.next_cursor else {
+                return Ok(diagnostics);
+            };
+            cursor = Some(next_cursor);
+        }
     }
 
     /// Runs one bounded maintenance step against a namespace.

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -490,6 +490,7 @@ impl FsReader {
             .core
             .pinned_read_at_snapshot(namespace_id, snapshot_id, now_ms)
             .await?;
+        self.core.inner.cache_stats.record_snapshot_view_read();
         Ok(FsReadSnapshot {
             engine,
             context,

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -126,6 +126,13 @@ impl RuntimeInstruments {
         }
     }
 
+    /// Records one read handled through a snapshot-pinned view.
+    pub(crate) fn snapshot_view_read(&self) {
+        if let Some(installed) = &self.installed {
+            installed.cache.snapshot_view_reads.increment(1);
+        }
+    }
+
     /// Returns the metadata-segment cache metrics observer, if metrics are enabled.
     pub(crate) fn metadata_segment_cache_observer(
         &self,
@@ -567,6 +574,7 @@ impl MaintenanceJobInstruments {
 /// Metrics for caches owned by the runtime. All instruments are registered together.
 struct RuntimeCacheInstruments {
     latest_metadata_view_reads: Arc<dyn CounterHandle>,
+    snapshot_view_reads: Arc<dyn CounterHandle>,
     metadata_segment: Arc<MetadataSegmentCacheInstruments>,
     wal_tail_projection: Arc<WalTailProjectionCacheInstruments>,
 }
@@ -600,6 +608,11 @@ impl RuntimeCacheInstruments {
             latest_metadata_view_reads: recorder.register_counter(
                 "loonfs.runtime_cache.latest_metadata_view_reads",
                 "Latest metadata reads served through the metadata-view path",
+                &[],
+            ),
+            snapshot_view_reads: recorder.register_counter(
+                "loonfs.runtime_cache.snapshot_view_reads",
+                "Metadata reads served through a snapshot-pinned view",
                 &[],
             ),
             metadata_segment: Arc::new(MetadataSegmentCacheInstruments::register(recorder)),
@@ -1022,6 +1035,7 @@ mod tests {
         let recorder = Arc::new(DefaultMetricsRecorder::new());
         let instruments = RuntimeInstruments::new(Some(recorder.clone()));
         instruments.latest_metadata_view_read();
+        instruments.snapshot_view_read();
 
         let metadata = instruments
             .metadata_segment_cache_observer()
@@ -1050,6 +1064,7 @@ mod tests {
                 &[][..],
                 1,
             ),
+            ("loonfs.runtime_cache.snapshot_view_reads", &[][..], 1),
             (
                 "loonfs.metadata_segment_cache.gets",
                 &[("result", "hit")][..],

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -126,7 +126,7 @@ impl RuntimeInstruments {
         }
     }
 
-    /// Records one read handled through a snapshot-pinned view.
+    /// Records one snapshot-backed metadata view.
     pub(crate) fn snapshot_view_read(&self) {
         if let Some(installed) = &self.installed {
             installed.cache.snapshot_view_reads.increment(1);
@@ -612,7 +612,7 @@ impl RuntimeCacheInstruments {
             ),
             snapshot_view_reads: recorder.register_counter(
                 "loonfs.runtime_cache.snapshot_view_reads",
-                "Metadata reads served through a snapshot-pinned view",
+                "Snapshot-backed metadata views created by the runtime",
                 &[],
             ),
             metadata_segment: Arc::new(MetadataSegmentCacheInstruments::register(recorder)),

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -64,7 +64,7 @@ fn namespace_diagnostics_reports_wal_tail_segments() {
     assert_eq!(status.current_manifest_no, None);
     assert_eq!(status.wal_tail_segments, 1);
     assert_eq!(status.retention_floor_seq, ChangeSeq(0));
-    assert_eq!(store.count(OperationClass::List), 0);
+    assert_eq!(store.count(OperationClass::List), 1);
 }
 
 #[test]
@@ -97,6 +97,57 @@ fn namespace_diagnostics_counts_wal_tail_without_reading_segments() {
         .expect("status with populated tail");
     assert_eq!(status.wal_tail_segments, 3);
     assert_eq!(store.count(OperationClass::Read), 0);
+}
+
+#[test]
+fn namespace_diagnostics_counts_user_and_live_snapshot_records_only() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "diagnostic-checkpoint-count-test");
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+
+    fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    block_on(fs.admin.create_checkpoint(
+        &source,
+        CreateCheckpointOptions {
+            name: "durable".to_owned(),
+            ttl_ms: None,
+        },
+    ))
+    .expect("create durable checkpoint");
+    block_on(fs.admin.create_checkpoint(
+        &source,
+        CreateCheckpointOptions {
+            name: "expired".to_owned(),
+            ttl_ms: Some(0),
+        },
+    ))
+    .expect("create expired checkpoint");
+    block_on(fs.admin.create_snapshot(
+        &source,
+        CreateSnapshotOptions {
+            name: "expired".to_owned(),
+            expires_at_ms: 1,
+        },
+    ))
+    .expect("create expired snapshot record");
+    block_on(fs.admin.create_snapshot(
+        &source,
+        CreateSnapshotOptions {
+            name: "live".to_owned(),
+            expires_at_ms: u64::MAX,
+        },
+    ))
+    .expect("create live snapshot");
+    fs.fork_namespace_blocking(&source, &target)
+        .expect("fork namespace");
+
+    let diagnostics = fs
+        .namespace_diagnostics_blocking(&source)
+        .expect("read diagnostics");
+    assert_eq!(diagnostics.live_snapshots, 1);
+    assert_eq!(diagnostics.live_checkpoints, 2);
 }
 
 /// Pointers a head published before the accelerator was sized to cover the

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -8,8 +8,8 @@
 use crate::common::*;
 use loonfs::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};
 use loonfs::{
-    CreateNamespaceOptions, FsBackgroundWork, MaintenanceJobId, MaintenanceStepConclusion,
-    MetadataMaintenanceOptions, PutFileOptions,
+    CreateCheckpointOptions, CreateNamespaceOptions, CreateSnapshotOptions, FsBackgroundWork,
+    MaintenanceJobId, MaintenanceStepConclusion, MetadataMaintenanceOptions, PutFileOptions,
 };
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
@@ -173,6 +173,63 @@ fn a_collection_step_reports_what_the_pass_retained() {
         ),
         0,
         "a fresh namespace has nothing to reclaim yet"
+    );
+}
+
+#[test]
+fn snapshot_pins_report_the_snapshot_view_counter() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let namespace_id = namespace_id("snapshot-metrics");
+    let (stats, snapshot) = block_on(async {
+        let fs = open_runtime_with_async(store(temp_dir.path()), "snapshot-metrics", |builder| {
+            builder.metrics_recorder(recorder.clone())
+        })
+        .await;
+        fs.writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        let checkpoint = fs
+            .admin
+            .create_checkpoint(
+                &namespace_id,
+                CreateCheckpointOptions {
+                    name: "operator".to_owned(),
+                    ttl_ms: None,
+                },
+            )
+            .await
+            .expect("create checkpoint");
+        let _checkpoint_view = fs
+            .reader
+            .pin_namespace_at_checkpoint(&namespace_id, &checkpoint.checkpoint_id)
+            .await
+            .expect("pin checkpoint");
+        let read_snapshot = fs
+            .admin
+            .create_snapshot(
+                &namespace_id,
+                CreateSnapshotOptions {
+                    name: "reader".to_owned(),
+                    expires_at_ms: u64::MAX,
+                },
+            )
+            .await
+            .expect("create snapshot");
+        let _snapshot_view = fs
+            .reader
+            .pin_namespace_at_snapshot(&namespace_id, &read_snapshot.checkpoint_id)
+            .await
+            .expect("pin snapshot");
+        (fs.reader.runtime_cache_stats(), recorder.snapshot())
+    });
+
+    assert_eq!(stats.latest_metadata_view_reads, 0);
+    assert_eq!(stats.snapshot_view_reads, 1);
+    assert_eq!(
+        counter(&snapshot, "loonfs.runtime_cache.snapshot_view_reads", &[],),
+        1
     );
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1427,6 +1427,8 @@ namespace state plus storage details used by maintenance:
 | `retention_floor_seq` | Oldest sequence still promised for incremental replay. |
 | `current_manifest_no` | Current manifest number; omitted until the namespace has a manifest. |
 | `wal_tail_segments` | Number of visible WAL segments after the current manifest. |
+| `live_snapshots` | Number of active snapshot records whose expiry was still in the future when diagnostics were read. |
+| `live_checkpoints` | Number of active user-owned checkpoint records, including expired records awaiting collection. |
 
 ```json
 {
@@ -1434,7 +1436,9 @@ namespace state plus storage details used by maintenance:
   "head_seq": 418,
   "retention_floor_seq": 120,
   "current_manifest_no": 410,
-  "wal_tail_segments": 3
+  "wal_tail_segments": 3,
+  "live_snapshots": 2,
+  "live_checkpoints": 4
 }
 ```
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1427,8 +1427,8 @@ namespace state plus storage details used by maintenance:
 | `retention_floor_seq` | Oldest sequence still promised for incremental replay. |
 | `current_manifest_no` | Current manifest number; omitted until the namespace has a manifest. |
 | `wal_tail_segments` | Number of visible WAL segments after the current manifest. |
-| `live_snapshots` | Number of active snapshot records whose expiry was still in the future when diagnostics were read. |
-| `live_checkpoints` | Number of active user-owned checkpoint records, including expired records awaiting collection. |
+| `live_snapshots` | Number of snapshots that had not expired when diagnostics began. |
+| `live_checkpoints` | Number of active user checkpoints, including expired records awaiting collection. |
 
 ```json
 {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -5720,7 +5720,9 @@
           "namespace_id",
           "head_seq",
           "retention_floor_seq",
-          "wal_tail_segments"
+          "wal_tail_segments",
+          "live_snapshots",
+          "live_checkpoints"
         ],
         "properties": {
           "current_manifest_no": {
@@ -5730,6 +5732,18 @@
           "head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Current visible namespace sequence."
+          },
+          "live_checkpoints": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of active user-owned records, expired or not.",
+            "minimum": 0
+          },
+          "live_snapshots": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of active snapshot-owned records unexpired when diagnostics were read.",
+            "minimum": 0
           },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -5736,13 +5736,13 @@
           "live_checkpoints": {
             "type": "integer",
             "format": "int64",
-            "description": "Number of active user-owned records, expired or not.",
+            "description": "Number of active user checkpoints, including expired records awaiting collection.",
             "minimum": 0
           },
           "live_snapshots": {
             "type": "integer",
             "format": "int64",
-            "description": "Number of active snapshot-owned records unexpired when diagnostics were read.",
+            "description": "Number of snapshots that had not expired when diagnostics began.",
             "minimum": 0
           },
           "namespace_id": {


### PR DESCRIPTION
Finishes the snapshot design's observability step. Namespace diagnostics report live_snapshots, counting active snapshot records whose leases are still ahead, and live_checkpoints, counting active user-owned records the way the admin listing shows them; both come from one bounded walk of the checkpoint listing and fork-owned records land in neither. Reads served through a snapshot-pinned view count into a new snapshot_view_reads cache statistic and its metrics instrument, the sibling of the latest-view counter that the checkpoint pin deliberately left untouched.