### PR TITLE
feat(cli): manage and read snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,10 +1864,12 @@ dependencies = [
 name = "loonfs-client"
 version = "0.2.1"
 dependencies = [
+ "axum",
  "bytes",
  "futures",
  "http 1.4.0",
  "loonfs-api",
+ "loonfs-server",
  "loonfs-test-support",
  "reqwest",
  "serde",

--- a/crates/loonfs-api/src/options.rs
+++ b/crates/loonfs-api/src/options.rs
@@ -10,8 +10,8 @@
 //! options reach the wire as query parameters the surface builds from them.
 
 use crate::{
-    ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue, CommitId, DeleteDirectoryBehavior,
-    DestinationBehavior, InodeId, RevisionNo,
+    ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue, CheckpointId, CommitId,
+    DeleteDirectoryBehavior, DestinationBehavior, InodeId, RevisionNo,
 };
 use std::collections::BTreeMap;
 
@@ -46,12 +46,18 @@ pub struct StatPathOptions {
     /// capped at 64 KiB, so the cost of including it is bounded by the
     /// request.
     pub include_attributes: bool,
+    /// Read the path state captured by this live snapshot.
+    ///
+    /// This applies to path stat operations. Inode stat operations do not
+    /// accept snapshot selection.
+    pub snapshot_id: Option<CheckpointId>,
 }
 
 impl Default for StatPathOptions {
     fn default() -> Self {
         Self {
             include_attributes: true,
+            snapshot_id: None,
         }
     }
 }
@@ -67,6 +73,8 @@ pub struct ListPathEntriesOptions {
     /// declares no byte budget anywhere. A caller that wants attributes for a
     /// whole directory asks for them, and pages accordingly.
     pub include_attributes: bool,
+    /// Read the directory state captured by this live snapshot.
+    pub snapshot_id: Option<CheckpointId>,
 }
 
 /// Options for listing a directory's children by parent inode.

--- a/crates/loonfs-api/src/options.rs
+++ b/crates/loonfs-api/src/options.rs
@@ -46,10 +46,7 @@ pub struct StatPathOptions {
     /// capped at 64 KiB, so the cost of including it is bounded by the
     /// request.
     pub include_attributes: bool,
-    /// Read the path state captured by this live snapshot.
-    ///
-    /// This applies to path stat operations. Inode stat operations do not
-    /// accept snapshot selection.
+    /// Read a path from this snapshot. Inode lookups do not support snapshots.
     pub snapshot_id: Option<CheckpointId>,
 }
 
@@ -73,7 +70,7 @@ pub struct ListPathEntriesOptions {
     /// declares no byte budget anywhere. A caller that wants attributes for a
     /// whole directory asks for them, and pages accordingly.
     pub include_attributes: bool,
-    /// Read the directory state captured by this live snapshot.
+    /// Read the directory from this snapshot.
     pub snapshot_id: Option<CheckpointId>,
 }
 

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -168,14 +168,14 @@ Namespace management
 
 Snapshot management
   loonfs snapshot create <namespace> --name <label> --ttl-ms <ms>
-    Capture the namespace's current state for the requested lifetime
+    Save the namespace's current state for the requested time
 
   loonfs snapshot list <namespace> [--limit <n>] [--page-size <n>]
                                    [--cursor <cursor>] [--all] [--jsonl]
-    List live snapshots in ID order
+    List snapshots that are still available
 
   loonfs snapshot extend <namespace> <snapshot-id> --ttl-ms <ms>
-    Extend a live snapshot's lease from now, within its lifetime limit
+    Keep a snapshot available for longer
 
   loonfs snapshot release <namespace> <snapshot-id>
     Release a snapshot. Repeating the command succeeds.

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -166,29 +166,44 @@ Namespace management
   loonfs current
     Show the selected profile and namespace
 
+Snapshot management
+  loonfs snapshot create <namespace> --name <label> --ttl-ms <ms>
+    Capture the namespace's current state for the requested lifetime
+
+  loonfs snapshot list <namespace> [--limit <n>] [--page-size <n>]
+                                   [--cursor <cursor>] [--all] [--jsonl]
+    List live snapshots in ID order
+
+  loonfs snapshot extend <namespace> <snapshot-id> --ttl-ms <ms>
+    Extend a live snapshot's lease from now, within its lifetime limit
+
+  loonfs snapshot release <namespace> <snapshot-id>
+    Release a snapshot. Repeating the command succeeds.
+
 Pagination
-  ls, grep, revisions, trash, changes, and admin checkpoint list return one
-  page by default. --limit sets the total maximum across pages, --page-size
-  controls each request, and --cursor resumes a previous result. --all fetches
-  every page for human output. --json returns a bounded document and cannot be
-  combined with --all. Use --jsonl to stream every result. changes uses
-  --after instead of --cursor.
+  ls, grep, revisions, trash, changes, snapshot list, and admin checkpoint
+  list return one page by default. --limit sets the total maximum across
+  pages, --page-size controls each request, and --cursor resumes a previous
+  result. --all fetches every page for human output. --json returns a bounded
+  document and cannot be combined with --all. Use --jsonl to stream every
+  result. changes uses --after instead of --cursor.
 
 Reading
   loonfs ls [path] [--limit <n>] [--page-size <n>] [--cursor <cursor>]
-                   [--all] [--jsonl]
+                   [--all] [--jsonl] [--snapshot-id <id>]
     List the entries of a directory, or `/` when the path is omitted
 
-  loonfs stat <path>
+  loonfs stat <path> [--snapshot-id <id>]
   loonfs stat --inode <inode-id>
     Describe a path or visible inode. The output includes its kind, size,
     revision, content digest, and attributes
 
-  loonfs cat <path> [--revision <n>]
+  loonfs cat <path> [--revision <n>] [--snapshot-id <id>]
     Print a file's bytes to stdout; --revision prints that revision instead
     of the current content
 
-  loonfs get <remote-path> [local-destination] [-r] [--revision <n>] [--force]
+  loonfs get <remote-path> [local-destination] [-r] [--revision <n>]
+             [--snapshot-id <id>] [--force]
     Download one file, or use -r to download a directory. For recursive
     downloads, the local destination is the root of the downloaded contents.
     Existing files are not overwritten unless --force is set. --revision
@@ -278,9 +293,10 @@ History and recovery
     somewhere else, or when the deletion did not record a binding
 
   loonfs changes [--after <seq>] [--limit <n>] [--page-size <n>]
-                 [--all] [--jsonl]
+                 [--all] [--jsonl] [--snapshot-id <id>]
     List committed changes after a sequence number. When --after is omitted,
-    start at the beginning of retained history
+    start at the beginning of retained history. --snapshot-id ends the feed
+    at the snapshot's captured sequence.
 
 Inspection and diagnostics
   loonfs capabilities [--profile <name>]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -32,6 +32,7 @@ Context and configuration:
   init        Interactively create a config and first profile
   profile     Manage connection profiles
   namespace   Manage namespaces
+  snapshot    Manage point-in-time snapshots
   use         Set a profile's default namespace
   current     Show the selected profile and namespace
   config      Inspect the CLI config file
@@ -151,6 +152,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: NamespaceCommand,
     },
+    /// Create, list, extend, or release point-in-time snapshots.
+    Snapshot {
+        #[command(subcommand)]
+        command: SnapshotCommand,
+    },
     /// Set the default namespace for a profile.
     /// This sets the interactive default; concurrent automation should pass
     /// `--namespace` or set `LOONFS_NAMESPACE`.
@@ -264,6 +270,9 @@ impl Command {
             Self::Revisions(args) => Some(&args.pagination),
             Self::Trash(args) => Some(&args.pagination),
             Self::Changes(args) => Some(&args.pagination),
+            Self::Snapshot {
+                command: SnapshotCommand::List(args),
+            } => Some(&args.pagination),
             Self::Admin {
                 command:
                     AdminCommand::Checkpoint {
@@ -706,6 +715,9 @@ pub(crate) struct FilesystemLsArgs {
     /// Resume from a cursor returned by a previous listing.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
+    /// Read the point-in-time state captured by this snapshot.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub snapshot_id: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -727,6 +739,14 @@ pub(crate) struct FilesystemStatArgs {
     /// Visible inode to describe instead of a path.
     #[arg(long, value_name = "INODE_ID", value_parser = parse_public_inode_id)]
     pub inode: Option<InodeId>,
+    /// Read the point-in-time state captured by this snapshot.
+    #[arg(
+        long,
+        value_hint = ValueHint::Other,
+        requires = "path",
+        conflicts_with = "inode"
+    )]
+    pub snapshot_id: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -836,6 +856,9 @@ pub(crate) struct FilesystemCatArgs {
     /// Print this revision instead of the current content.
     #[arg(long)]
     pub revision: Option<u64>,
+    /// Read the point-in-time state captured by this snapshot.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub snapshot_id: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -886,6 +909,9 @@ pub(crate) struct FilesystemGetArgs {
     /// Download this revision instead of the current content.
     #[arg(long)]
     pub revision: Option<u64>,
+    /// Read the point-in-time state captured by this snapshot.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub snapshot_id: Option<String>,
     /// Overwrite existing local files.
     #[arg(long)]
     pub force: bool,
@@ -1031,6 +1057,76 @@ pub(crate) struct ChangesArgs {
     pub after: Option<u64>,
     #[command(flatten)]
     pub pagination: PaginationArgs,
+    /// Read the point-in-time state captured by this snapshot.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub snapshot_id: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum SnapshotCommand {
+    /// Capture the namespace's current state for a bounded time.
+    Create(SnapshotCreateArgs),
+    /// List live snapshots in snapshot-id order.
+    List(SnapshotListArgs),
+    /// Extend a live snapshot's lease.
+    Extend(SnapshotExtendArgs),
+    /// Release a snapshot.
+    Release(SnapshotReleaseArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SnapshotTargetArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+    #[command(flatten)]
+    pub request: RequestBehaviorArgs,
+    /// Namespace whose snapshots to manage.
+    #[arg(value_hint = ValueHint::Other)]
+    pub namespace_id: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SnapshotCreateArgs {
+    #[command(flatten)]
+    pub target: SnapshotTargetArgs,
+    /// Snapshot label. Labels do not need to be unique.
+    #[arg(long)]
+    pub name: String,
+    /// Snapshot lifetime from now, in milliseconds.
+    #[arg(long)]
+    pub ttl_ms: u64,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SnapshotListArgs {
+    #[command(flatten)]
+    pub target: SnapshotTargetArgs,
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
+    /// Resume from a cursor returned by a previous listing.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SnapshotExtendArgs {
+    #[command(flatten)]
+    pub target: SnapshotTargetArgs,
+    /// Snapshot id to extend.
+    #[arg(value_hint = ValueHint::Other)]
+    pub snapshot_id: String,
+    /// Snapshot lifetime from now, in milliseconds.
+    #[arg(long)]
+    pub ttl_ms: u64,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SnapshotReleaseArgs {
+    #[command(flatten)]
+    pub target: SnapshotTargetArgs,
+    /// Snapshot id to release.
+    #[arg(value_hint = ValueHint::Other)]
+    pub snapshot_id: String,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1327,6 +1423,10 @@ pub(crate) enum CommandKind {
     NamespaceDelete,
     NamespaceFork,
     NamespaceUse,
+    SnapshotCreate,
+    SnapshotList,
+    SnapshotExtend,
+    SnapshotRelease,
     Current,
     FilesystemLs,
     FilesystemStat,
@@ -1380,6 +1480,10 @@ impl CommandKind {
             CommandKind::NamespaceDelete => "namespace_delete",
             CommandKind::NamespaceFork => "namespace_fork",
             CommandKind::NamespaceUse => "namespace_use",
+            CommandKind::SnapshotCreate => "snapshot_create",
+            CommandKind::SnapshotList => "snapshot_list",
+            CommandKind::SnapshotExtend => "snapshot_extend",
+            CommandKind::SnapshotRelease => "snapshot_release",
             CommandKind::Current => "current",
             CommandKind::FilesystemLs => "filesystem_ls",
             CommandKind::FilesystemStat => "filesystem_stat",
@@ -1441,6 +1545,12 @@ impl Cli {
                 NamespaceCommand::Show(_) => CommandKind::NamespaceShow,
                 NamespaceCommand::Delete(_) => CommandKind::NamespaceDelete,
                 NamespaceCommand::Fork(_) => CommandKind::NamespaceFork,
+            },
+            Command::Snapshot { command } => match command {
+                SnapshotCommand::Create(_) => CommandKind::SnapshotCreate,
+                SnapshotCommand::List(_) => CommandKind::SnapshotList,
+                SnapshotCommand::Extend(_) => CommandKind::SnapshotExtend,
+                SnapshotCommand::Release(_) => CommandKind::SnapshotRelease,
             },
             Command::Use(_) => CommandKind::NamespaceUse,
             Command::Current(_) => CommandKind::Current,
@@ -1662,6 +1772,20 @@ mod tests {
                 "--cursor",
                 "c",
             ],
+            &[
+                "loonfs",
+                "snapshot",
+                "list",
+                "demo",
+                "--limit",
+                "5",
+                "--page-size",
+                "2",
+                "--all",
+                "--jsonl",
+                "--cursor",
+                "c",
+            ],
         ];
         for arguments in cases {
             let cli = Cli::try_parse_from(*arguments).expect("pagination arguments parse");
@@ -1685,6 +1809,9 @@ mod tests {
                 "--all",
                 "--limit",
                 "5",
+            ],
+            &[
+                "loonfs", "--json", "snapshot", "list", "demo", "--all", "--limit", "5",
             ],
             &["loonfs", "--json", "trash", "--all", "--limit", "5"],
             &["loonfs", "--json", "changes", "--all", "--limit", "5"],
@@ -1764,6 +1891,10 @@ mod tests {
             (CommandKind::NamespaceDelete, "namespace_delete"),
             (CommandKind::NamespaceFork, "namespace_fork"),
             (CommandKind::NamespaceUse, "namespace_use"),
+            (CommandKind::SnapshotCreate, "snapshot_create"),
+            (CommandKind::SnapshotList, "snapshot_list"),
+            (CommandKind::SnapshotExtend, "snapshot_extend"),
+            (CommandKind::SnapshotRelease, "snapshot_release"),
             (CommandKind::Current, "current"),
             (CommandKind::FilesystemLs, "filesystem_ls"),
             (CommandKind::FilesystemStat, "filesystem_stat"),
@@ -1830,6 +1961,9 @@ mod tests {
         let namespace = subcommand(&command, "namespace");
         assert_subcommands(namespace, &["create", "show", "delete", "fork"]);
 
+        let snapshot = subcommand(&command, "snapshot");
+        assert_subcommands(snapshot, &["create", "list", "extend", "release"]);
+
         let admin = subcommand(&command, "admin");
         assert_subcommands(
             admin,
@@ -1853,6 +1987,55 @@ mod tests {
         assert_subcommands(subcommand(admin, "maintenance"), &["run", "step", "flush"]);
         assert_subcommands(subcommand(admin, "retention"), &["advance"]);
         assert_subcommands(subcommand(admin, "store"), &["probe"]);
+    }
+
+    #[test]
+    fn snapshot_commands_and_read_flags_follow_the_public_grammar() {
+        Cli::try_parse_from([
+            "loonfs", "snapshot", "create", "demo", "--name", "report", "--ttl-ms", "5000",
+        ])
+        .expect("snapshot create grammar");
+        Cli::try_parse_from([
+            "loonfs",
+            "snapshot",
+            "extend",
+            "demo",
+            "chk_00000000000000000000000000000001",
+            "--ttl-ms",
+            "5000",
+        ])
+        .expect("snapshot extend grammar");
+        for arguments in [
+            vec!["loonfs", "ls", "/", "--snapshot-id", "snapshot"],
+            vec!["loonfs", "stat", "/doc", "--snapshot-id", "snapshot"],
+            vec!["loonfs", "cat", "/doc", "--snapshot-id", "snapshot"],
+            vec!["loonfs", "get", "/doc", "--snapshot-id", "snapshot"],
+            vec!["loonfs", "changes", "--snapshot-id", "snapshot"],
+        ] {
+            Cli::try_parse_from(arguments).expect("snapshot read flag");
+        }
+        assert!(Cli::try_parse_from([
+            "loonfs",
+            "stat",
+            "--inode",
+            "ino_2",
+            "--snapshot-id",
+            "snapshot",
+        ])
+        .is_err());
+
+        let mut command = Cli::command();
+        for name in ["ls", "stat", "cat", "get", "changes"] {
+            let help = command
+                .find_subcommand_mut(name)
+                .expect("read command")
+                .render_long_help()
+                .to_string();
+            assert!(
+                help.contains("Read the point-in-time state captured by this snapshot"),
+                "{name} help:\n{help}"
+            );
+        }
     }
 
     #[test]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -715,7 +715,7 @@ pub(crate) struct FilesystemLsArgs {
     /// Resume from a cursor returned by a previous listing.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
-    /// Read the point-in-time state captured by this snapshot.
+    /// Read from this snapshot instead of the current state.
     #[arg(long, value_hint = ValueHint::Other)]
     pub snapshot_id: Option<String>,
 }
@@ -739,7 +739,7 @@ pub(crate) struct FilesystemStatArgs {
     /// Visible inode to describe instead of a path.
     #[arg(long, value_name = "INODE_ID", value_parser = parse_public_inode_id)]
     pub inode: Option<InodeId>,
-    /// Read the point-in-time state captured by this snapshot.
+    /// Read from this snapshot instead of the current state.
     #[arg(
         long,
         value_hint = ValueHint::Other,
@@ -856,8 +856,8 @@ pub(crate) struct FilesystemCatArgs {
     /// Print this revision instead of the current content.
     #[arg(long)]
     pub revision: Option<u64>,
-    /// Read the point-in-time state captured by this snapshot.
-    #[arg(long, value_hint = ValueHint::Other)]
+    /// Read from this snapshot instead of the current state.
+    #[arg(long, value_hint = ValueHint::Other, conflicts_with = "revision")]
     pub snapshot_id: Option<String>,
 }
 
@@ -909,8 +909,8 @@ pub(crate) struct FilesystemGetArgs {
     /// Download this revision instead of the current content.
     #[arg(long)]
     pub revision: Option<u64>,
-    /// Read the point-in-time state captured by this snapshot.
-    #[arg(long, value_hint = ValueHint::Other)]
+    /// Read from this snapshot instead of the current state.
+    #[arg(long, value_hint = ValueHint::Other, conflicts_with = "revision")]
     pub snapshot_id: Option<String>,
     /// Overwrite existing local files.
     #[arg(long)]
@@ -1057,18 +1057,18 @@ pub(crate) struct ChangesArgs {
     pub after: Option<u64>,
     #[command(flatten)]
     pub pagination: PaginationArgs,
-    /// Read the point-in-time state captured by this snapshot.
+    /// End the change feed at this snapshot.
     #[arg(long, value_hint = ValueHint::Other)]
     pub snapshot_id: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum SnapshotCommand {
-    /// Capture the namespace's current state for a bounded time.
+    /// Save the namespace's current state for a limited time.
     Create(SnapshotCreateArgs),
-    /// List live snapshots in snapshot-id order.
+    /// List snapshots that are still available.
     List(SnapshotListArgs),
-    /// Extend a live snapshot's lease.
+    /// Keep a snapshot available for longer.
     Extend(SnapshotExtendArgs),
     /// Release a snapshot.
     Release(SnapshotReleaseArgs),
@@ -1092,7 +1092,7 @@ pub(crate) struct SnapshotCreateArgs {
     /// Snapshot label. Labels do not need to be unique.
     #[arg(long)]
     pub name: String,
-    /// Snapshot lifetime from now, in milliseconds.
+    /// How long the snapshot remains available, in milliseconds.
     #[arg(long)]
     pub ttl_ms: u64,
 }
@@ -1115,7 +1115,7 @@ pub(crate) struct SnapshotExtendArgs {
     /// Snapshot id to extend.
     #[arg(value_hint = ValueHint::Other)]
     pub snapshot_id: String,
-    /// Snapshot lifetime from now, in milliseconds.
+    /// New lifetime from now, in milliseconds.
     #[arg(long)]
     pub ttl_ms: u64,
 }
@@ -1987,55 +1987,6 @@ mod tests {
         assert_subcommands(subcommand(admin, "maintenance"), &["run", "step", "flush"]);
         assert_subcommands(subcommand(admin, "retention"), &["advance"]);
         assert_subcommands(subcommand(admin, "store"), &["probe"]);
-    }
-
-    #[test]
-    fn snapshot_commands_and_read_flags_follow_the_public_grammar() {
-        Cli::try_parse_from([
-            "loonfs", "snapshot", "create", "demo", "--name", "report", "--ttl-ms", "5000",
-        ])
-        .expect("snapshot create grammar");
-        Cli::try_parse_from([
-            "loonfs",
-            "snapshot",
-            "extend",
-            "demo",
-            "chk_00000000000000000000000000000001",
-            "--ttl-ms",
-            "5000",
-        ])
-        .expect("snapshot extend grammar");
-        for arguments in [
-            vec!["loonfs", "ls", "/", "--snapshot-id", "snapshot"],
-            vec!["loonfs", "stat", "/doc", "--snapshot-id", "snapshot"],
-            vec!["loonfs", "cat", "/doc", "--snapshot-id", "snapshot"],
-            vec!["loonfs", "get", "/doc", "--snapshot-id", "snapshot"],
-            vec!["loonfs", "changes", "--snapshot-id", "snapshot"],
-        ] {
-            Cli::try_parse_from(arguments).expect("snapshot read flag");
-        }
-        assert!(Cli::try_parse_from([
-            "loonfs",
-            "stat",
-            "--inode",
-            "ino_2",
-            "--snapshot-id",
-            "snapshot",
-        ])
-        .is_err());
-
-        let mut command = Cli::command();
-        for name in ["ls", "stat", "cat", "get", "changes"] {
-            let help = command
-                .find_subcommand_mut(name)
-                .expect("read command")
-                .render_long_help()
-                .to_string();
-            assert!(
-                help.contains("Read the point-in-time state captured by this snapshot"),
-                "{name} help:\n{help}"
-            );
-        }
     }
 
     #[test]

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -178,7 +178,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Describes a path at the current head or one live snapshot.
+    /// Describes a path from the current state or a snapshot.
     pub(crate) async fn get_path_entry_at_snapshot(
         &self,
         spec: &NamespacePath,
@@ -249,7 +249,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Reads path-based file content using the requested revision or snapshot.
+    /// Reads file content from a revision or snapshot.
     pub(crate) async fn get_file_bytes_with_options(
         &self,
         spec: &NamespacePath,
@@ -651,9 +651,7 @@ impl ResolvedTarget {
         }
     }
 
-    // --- snapshot lifecycle (`core/v0`) ---
-
-    /// Creates a time-bounded snapshot of the namespace's current state.
+    /// Saves the namespace's current state for a limited time.
     pub(crate) async fn create_snapshot(
         &self,
         namespace_id: &NamespaceId,
@@ -674,7 +672,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Lists one page of live snapshots.
+    /// Lists one page of available snapshots.
     pub(crate) async fn list_snapshots_page(
         &self,
         namespace_id: &NamespaceId,
@@ -695,7 +693,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Extends one live snapshot lease.
+    /// Extends a snapshot's lifetime.
     pub(crate) async fn extend_snapshot(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -2,7 +2,7 @@
 
 use super::progress::{rest_between_status_checks, wait_for_grep_index, GrepWaitStep};
 use super::{FileDownload, GrepWaitProgress, MaintenanceDrainProgress, StepBudget};
-use crate::backend_error::{map_namespace_scoped_runtime_error, BackendError};
+use crate::backend_error::BackendError;
 use crate::payload::LocalPayload;
 use crate::progress::ProgressReporter;
 use crate::resolve::ResolvedTarget;
@@ -10,8 +10,9 @@ use crate::uploads::UploadJournal;
 use loonfs::MaintenanceJobId;
 use loonfs_api::{
     v0::{
-        GrepGcRequest, GrepGcResponse, GrepIndex, ListChangesResponse, StoreProbeRequest,
-        StoreProbeResponse, UploadSession,
+        GrepGcRequest, GrepGcResponse, GrepIndex, ListChangesResponse, ListSnapshotsResponse,
+        ReleaseSnapshotResponse, SnapshotSummary, StoreProbeRequest, StoreProbeResponse,
+        UploadSession,
     },
     AbsolutePath, CapabilityDocument, ChangeSeq, Checkpoint, CheckpointId, CommitResponse,
     ContentRef, CreateCheckpointRequest, DeleteNamespaceResponse, GrepRequest, GrepResponse,
@@ -20,9 +21,10 @@ use loonfs_api::{
     PathEntry, ReleaseCheckpointResponse, RevisionNo, UploadId,
 };
 use loonfs_client::{
-    ClientError, CopyOptions, CreateDirectoryOptions, DeleteOptions, ListPathEntriesOptions,
-    MoveOptions, NamespacePath, PutFileOptions, RestoreRevisionOptions, StatPathOptions,
-    UndeleteOptions, UpdateAttributesOptions,
+    ClientError, CopyOptions, CreateDirectoryOptions, DeleteOptions, DownloadOptions,
+    ListChangesOptions, ListPathEntriesOptions, MoveOptions, NamespacePath, PutFileOptions,
+    ReadFileOptions, RestoreRevisionOptions, StatPathOptions, UndeleteOptions,
+    UpdateAttributesOptions,
 };
 use std::sync::Arc;
 
@@ -45,30 +47,6 @@ fn maintenance_host_needs_an_embedded_profile() -> BackendError {
          own maintenance; use `loonfs admin maintenance step` for one pass or `loonfs admin \
          index status` to inspect the index",
     )
-}
-
-/// Directory pager for embedded and remote profiles.
-pub(crate) enum PathEntriesPager {
-    Embedded {
-        pager: loonfs::PathEntriesPager,
-        namespace_id: NamespaceId,
-    },
-    Remote(loonfs_client::PathEntriesPager),
-}
-
-impl PathEntriesPager {
-    /// Returns the next page with its metadata.
-    pub(crate) async fn next(&mut self) -> Option<Result<ListPathEntriesResponse, BackendError>> {
-        match self {
-            Self::Embedded {
-                pager,
-                namespace_id,
-            } => pager.next().await.map(|result| {
-                result.map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
-            }),
-            Self::Remote(pager) => pager.next().await.map(|result| result.map_err(Into::into)),
-        }
-    }
 }
 
 /// Implements CLI operations for embedded and remote targets.
@@ -170,59 +148,50 @@ impl ResolvedTarget {
         }
     }
 
-    /// Creates a directory pager that fetches pages as needed.
-    pub(crate) fn list_path_entries_pager(
-        &self,
-        spec: &NamespacePath,
-        page_size: Option<u32>,
-        cursor: Option<&str>,
-    ) -> Result<PathEntriesPager, BackendError> {
-        match self {
-            Self::Embedded(target) => Ok(PathEntriesPager::Embedded {
-                pager: target
-                    .backend
-                    .list_path_entries_pager(spec, page_size, cursor)?,
-                namespace_id: spec.namespace().clone(),
-            }),
-            Self::Remote(target) => Ok(PathEntriesPager::Remote(
-                target.client.list_path_entries_pager(
-                    spec,
-                    page_size,
-                    cursor.map(ToOwned::to_owned),
-                    &ListPathEntriesOptions::default(),
-                ),
-            )),
-        }
-    }
-
     /// Lists one page of a directory, for callers that bound their output.
     pub(crate) async fn list_path_entries_page(
         &self,
         spec: &NamespacePath,
         limit: Option<u32>,
         cursor: Option<&str>,
+        snapshot_id: Option<&CheckpointId>,
     ) -> Result<ListPathEntriesResponse, BackendError> {
         match self {
             Self::Embedded(target) => {
                 target
                     .backend
-                    .list_path_entries_page(spec, limit, cursor)
+                    .list_path_entries_page(spec, limit, cursor, snapshot_id)
                     .await
             }
             Self::Remote(target) => Ok(target
                 .client
-                .list_path_entries_page(spec, limit, cursor, &ListPathEntriesOptions::default())
+                .list_path_entries_page(
+                    spec,
+                    limit,
+                    cursor,
+                    &ListPathEntriesOptions {
+                        snapshot_id: snapshot_id.cloned(),
+                        ..ListPathEntriesOptions::default()
+                    },
+                )
                 .await?),
         }
     }
 
-    /// Describes a single path entry, attributes included.
-    pub(crate) async fn get_path_entry(
+    /// Describes a path at the current head or one live snapshot.
+    pub(crate) async fn get_path_entry_at_snapshot(
         &self,
         spec: &NamespacePath,
+        snapshot_id: Option<&CheckpointId>,
     ) -> Result<PathEntry, BackendError> {
-        self.get_path_entry_projected(spec, &StatPathOptions::default())
-            .await
+        self.get_path_entry_projected(
+            spec,
+            &StatPathOptions {
+                snapshot_id: snapshot_id.cloned(),
+                ..StatPathOptions::default()
+            },
+        )
+        .await
     }
 
     /// Describes one visible inode, including its attributes.
@@ -250,10 +219,20 @@ impl ResolvedTarget {
         &self,
         spec: &NamespacePath,
     ) -> Result<PathEntry, BackendError> {
+        self.get_path_entry_without_attributes_at_snapshot(spec, None)
+            .await
+    }
+
+    pub(crate) async fn get_path_entry_without_attributes_at_snapshot(
+        &self,
+        spec: &NamespacePath,
+        snapshot_id: Option<&CheckpointId>,
+    ) -> Result<PathEntry, BackendError> {
         self.get_path_entry_projected(
             spec,
             &StatPathOptions {
                 include_attributes: false,
+                snapshot_id: snapshot_id.cloned(),
             },
         )
         .await
@@ -270,14 +249,23 @@ impl ResolvedTarget {
         }
     }
 
-    /// Reads a file's current content.
-    pub(crate) async fn get_file_bytes(
+    /// Reads path-based file content using the requested revision or snapshot.
+    pub(crate) async fn get_file_bytes_with_options(
         &self,
         spec: &NamespacePath,
+        options: &ReadFileOptions,
     ) -> Result<Vec<u8>, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.get_file_bytes(spec).await,
-            Self::Remote(target) => Ok(target.client.get_file_bytes(spec).await?),
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .get_file_bytes_with_options(spec, options)
+                    .await
+            }
+            Self::Remote(target) => Ok(target
+                .client
+                .get_file_bytes_with_options(spec, options)
+                .await?),
         }
     }
 
@@ -294,12 +282,22 @@ impl ResolvedTarget {
         &self,
         spec: &NamespacePath,
         revision_no: Option<RevisionNo>,
+        snapshot_id: Option<&CheckpointId>,
         size_bytes: Option<u64>,
         start_offset: u64,
     ) -> Result<FileDownload, BackendError> {
         if let (Self::Remote(target), Some(size_bytes)) = (self, size_bytes) {
             if target.client.offers_direct_download(size_bytes).await? {
-                let grant = target.client.create_download(spec, revision_no).await?;
+                let grant = target
+                    .client
+                    .create_download_with_options(
+                        spec,
+                        &DownloadOptions {
+                            revision_no,
+                            snapshot_id: snapshot_id.cloned(),
+                        },
+                    )
+                    .await?;
                 return Ok(FileDownload::Direct {
                     stream: Box::new(
                         target
@@ -311,9 +309,16 @@ impl ResolvedTarget {
                 });
             }
         }
-        if let Some(revision_no) = revision_no {
+        if revision_no.is_some() || snapshot_id.is_some() {
             return Ok(FileDownload::Whole(
-                self.get_file_revision_bytes(spec, revision_no).await?,
+                self.get_file_bytes_with_options(
+                    spec,
+                    &ReadFileOptions {
+                        revision_no,
+                        snapshot_id: snapshot_id.cloned(),
+                    },
+                )
+                .await?,
             ));
         }
         match self {
@@ -420,26 +425,6 @@ impl ResolvedTarget {
                 )
                 .await
             }
-        }
-    }
-
-    /// Reads a retained file revision's content.
-    pub(crate) async fn get_file_revision_bytes(
-        &self,
-        spec: &NamespacePath,
-        revision_no: RevisionNo,
-    ) -> Result<Vec<u8>, BackendError> {
-        match self {
-            Self::Embedded(target) => {
-                target
-                    .backend
-                    .get_file_revision_bytes(spec, revision_no)
-                    .await
-            }
-            Self::Remote(target) => Ok(target
-                .client
-                .get_file_revision_bytes(spec, revision_no)
-                .await?),
         }
     }
 
@@ -666,6 +651,91 @@ impl ResolvedTarget {
         }
     }
 
+    // --- snapshot lifecycle (`core/v0`) ---
+
+    /// Creates a time-bounded snapshot of the namespace's current state.
+    pub(crate) async fn create_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        name: &str,
+        ttl_ms: u64,
+    ) -> Result<SnapshotSummary, BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .create_snapshot(namespace_id, name, ttl_ms)
+                    .await
+            }
+            Self::Remote(target) => Ok(target
+                .client
+                .create_snapshot(namespace_id, name, ttl_ms)
+                .await?),
+        }
+    }
+
+    /// Lists one page of live snapshots.
+    pub(crate) async fn list_snapshots_page(
+        &self,
+        namespace_id: &NamespaceId,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListSnapshotsResponse, BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .list_snapshots_page(namespace_id, limit, cursor)
+                    .await
+            }
+            Self::Remote(target) => Ok(target
+                .client
+                .list_snapshots_page(namespace_id, limit, cursor)
+                .await?),
+        }
+    }
+
+    /// Extends one live snapshot lease.
+    pub(crate) async fn extend_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        snapshot_id: &CheckpointId,
+        ttl_ms: u64,
+    ) -> Result<SnapshotSummary, BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .extend_snapshot(namespace_id, snapshot_id, ttl_ms)
+                    .await
+            }
+            Self::Remote(target) => Ok(target
+                .client
+                .extend_snapshot(namespace_id, snapshot_id, ttl_ms)
+                .await?),
+        }
+    }
+
+    /// Releases one snapshot. Repeated releases succeed.
+    pub(crate) async fn release_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        snapshot_id: &CheckpointId,
+    ) -> Result<ReleaseSnapshotResponse, BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .release_snapshot(namespace_id, snapshot_id)
+                    .await
+            }
+            Self::Remote(target) => Ok(target
+                .client
+                .release_snapshot(namespace_id, snapshot_id)
+                .await?),
+        }
+    }
+
     // --- maintenance/admin plane (`admin/v0`) ---
 
     /// Creates or reuses a named, user-owned checkpoint pinning the
@@ -809,17 +879,25 @@ impl ResolvedTarget {
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
         limit: Option<u32>,
+        snapshot_id: Option<&CheckpointId>,
     ) -> Result<ListChangesResponse, BackendError> {
         match self {
             Self::Embedded(target) => {
                 target
                     .backend
-                    .list_changes(namespace_id, after_seq, limit)
+                    .list_changes(namespace_id, after_seq, limit, snapshot_id)
                     .await
             }
             Self::Remote(target) => Ok(target
                 .client
-                .list_changes(namespace_id, after_seq, limit)
+                .list_changes_with_options(
+                    namespace_id,
+                    after_seq,
+                    &ListChangesOptions {
+                        limit,
+                        snapshot_id: snapshot_id.cloned(),
+                    },
+                )
                 .await?),
         }
     }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -9,17 +9,19 @@ use crate::backend_error::{
 use crate::render::write_stderr_warning;
 use loonfs::{
     ByteStream, CheckpointPageCursor, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
-    CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    FileContentStream, FsAdmin, FsReader, FsWriter, ListChangesOptions, ListChangesResponse,
-    ListPathEntriesOptions, MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenancePlan,
+    CreateNamespaceOptions, CreateSnapshotOptions, DeleteNamespaceOptions, DeleteNamespaceResponse,
+    DeleteOptions, FileContentStream, FsAdmin, FsReader, FsWriter,
+    ListChangesOptions as RuntimeListChangesOptions, ListChangesResponse, ListPathEntriesOptions,
+    MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenancePlan,
     MaintenanceStepConclusion, MoveOptions, PutFileOptions, ReadFileStreamOptions,
     RestoreRevisionOptions, RuntimeError, SharedObjectStore, StatPathOptions, UndeleteOptions,
     UpdateAttributesOptions,
 };
 use loonfs_api::{
     v0::{
-        GrepGcRequest, GrepGcResponse, GrepIndex, GrepIndexLifecycle, StoreProbeCheckOutcome,
-        StoreProbeCheckResult, StoreProbeResponse,
+        GrepGcRequest, GrepGcResponse, GrepIndex, GrepIndexLifecycle, ListSnapshotsResponse,
+        ReleaseSnapshotResponse, SnapshotSummary, StoreProbeCheckOutcome, StoreProbeCheckResult,
+        StoreProbeResponse,
     },
     AbsolutePath, ChangeSeq, Checkpoint, CheckpointId, CommitResponse, CreateCheckpointRequest,
     EffectiveLimit, ErrorCode, GrepRequest, GrepResponse, InodeId, ListCheckpointsResponse,
@@ -27,7 +29,7 @@ use loonfs_api::{
     MaintenanceStepResponse, Namespace, NamespaceId, PaginationPolicy, PathEntry,
     ReleaseCheckpointResponse, RevisionNo,
 };
-use loonfs_client::NamespacePath;
+use loonfs_client::{NamespacePath, ReadFileOptions};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBlockCache, GrepDisableOutcome, GrepEnableOutcome, GrepError,
     GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads, GREP_GC_JOB,
@@ -66,6 +68,10 @@ pub(crate) struct EmbeddedBackend {
 /// step it scheduled. One recovery is the normal case; the second covers a
 /// step that raced another writer's debt. Past that the error surfaces.
 const MAX_MAINTENANCE_RECOVERIES: usize = 2;
+
+const EMBEDDED_SNAPSHOT_MAX_TTL_MS: u64 = 86_400_000;
+const EMBEDDED_SNAPSHOT_MAX_LIFETIME_MS: u64 = 604_800_000;
+const EMBEDDED_SNAPSHOT_MAX_LIVE_PER_NAMESPACE: usize = 16;
 
 /// A selected maintenance job and its executor.
 type HostedJob = (MaintenanceJobId, Arc<dyn MaintenanceJob>);
@@ -187,28 +193,29 @@ impl EmbeddedBackend {
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
-    pub(super) fn list_path_entries_pager(
-        &self,
-        spec: &NamespacePath,
-        page_size: Option<u32>,
-        cursor: Option<&str>,
-    ) -> Result<loonfs::PathEntriesPager, BackendError> {
-        let request = cli_page_request(page_size, cursor)?;
-        Ok(self.reader.list_path_entries_pager(
-            spec.namespace(),
-            spec.absolute_path().as_str(),
-            request,
-            ListPathEntriesOptions::default(),
-        ))
-    }
-
     pub(super) async fn list_path_entries_page(
         &self,
         spec: &NamespacePath,
         limit: Option<u32>,
         cursor: Option<&str>,
+        snapshot_id: Option<&CheckpointId>,
     ) -> Result<ListPathEntriesResponse, BackendError> {
         let request = cli_page_request(limit, cursor)?;
+        if let Some(snapshot_id) = snapshot_id {
+            let snapshot = self
+                .reader
+                .pin_namespace_at_snapshot(spec.namespace(), snapshot_id)
+                .await
+                .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?;
+            return snapshot
+                .list_path_entries_page(
+                    spec.absolute_path().as_str(),
+                    request,
+                    ListPathEntriesOptions::default(),
+                )
+                .await
+                .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error));
+        }
         self.reader
             .list_path_entries_page(
                 spec.namespace(),
@@ -225,6 +232,19 @@ impl EmbeddedBackend {
         spec: &NamespacePath,
         options: &StatPathOptions,
     ) -> Result<PathEntry, BackendError> {
+        if let Some(snapshot_id) = &options.snapshot_id {
+            let snapshot = self
+                .reader
+                .pin_namespace_at_snapshot(spec.namespace(), snapshot_id)
+                .await
+                .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?;
+            let mut options = options.clone();
+            options.snapshot_id = None;
+            return snapshot
+                .get_path_entry(spec.absolute_path().as_str(), options)
+                .await
+                .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error));
+        }
         self.reader
             .get_path_entry(
                 spec.namespace(),
@@ -257,6 +277,35 @@ impl EmbeddedBackend {
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?;
         Ok(result.bytes)
+    }
+
+    pub(super) async fn get_file_bytes_with_options(
+        &self,
+        spec: &NamespacePath,
+        options: &ReadFileOptions,
+    ) -> Result<Vec<u8>, BackendError> {
+        if options.revision_no.is_some() && options.snapshot_id.is_some() {
+            return Err(BackendError::invalid_request(
+                "revision_no cannot be combined with snapshot_id",
+            )
+            .with_param("revision_no"));
+        }
+        if let Some(snapshot_id) = &options.snapshot_id {
+            let snapshot = self
+                .reader
+                .pin_namespace_at_snapshot(spec.namespace(), snapshot_id)
+                .await
+                .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?;
+            return snapshot
+                .get_file_bytes(spec.absolute_path().as_str())
+                .await
+                .map(|file| file.bytes)
+                .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error));
+        }
+        match options.revision_no {
+            Some(revision_no) => self.get_file_revision_bytes(spec, revision_no).await,
+            None => self.get_file_bytes(spec).await,
+        }
     }
 
     /// Opens a file's content as bounded chunks, at the runtime's own chunk
@@ -739,6 +788,96 @@ impl EmbeddedBackend {
         .await
     }
 
+    pub(super) async fn create_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        name: &str,
+        ttl_ms: u64,
+    ) -> Result<SnapshotSummary, BackendError> {
+        let now_ms = validate_embedded_snapshot_ttl(namespace_id, ttl_ms)?;
+        let expires_at_ms = now_ms.saturating_add(ttl_ms);
+        self.admin
+            .ensure_snapshot_quota(
+                namespace_id,
+                now_ms,
+                EMBEDDED_SNAPSHOT_MAX_LIVE_PER_NAMESPACE,
+            )
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?;
+        let checkpoint = self
+            .admin
+            .create_snapshot(
+                namespace_id,
+                CreateSnapshotOptions {
+                    name: name.to_owned(),
+                    expires_at_ms,
+                },
+            )
+            .await
+            .map_err(|error| {
+                map_namespace_scoped_runtime_error(namespace_id, error)
+                    .with_invalid_request_param("/name")
+            })?;
+        SnapshotSummary::from_checkpoint(checkpoint).ok_or_else(|| {
+            BackendError::runtime_error("snapshot creation returned a non-snapshot checkpoint")
+        })
+    }
+
+    pub(super) async fn list_snapshots_page(
+        &self,
+        namespace_id: &NamespaceId,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListSnapshotsResponse, BackendError> {
+        let request = loonfs_api::PageRequest {
+            limit: resolve_cli_page_limit(limit)?,
+            cursor: cursor
+                .map(|cursor| {
+                    loonfs_api::decode_namespace_cursor::<CheckpointPageCursor>(
+                        cursor,
+                        namespace_id,
+                    )
+                })
+                .transpose()
+                .map_err(|error| {
+                    BackendError::invalid_request(error.to_string()).with_param("cursor")
+                })?,
+        };
+        self.admin
+            .list_snapshots_page(namespace_id, request)
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+    }
+
+    pub(super) async fn extend_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        snapshot_id: &CheckpointId,
+        ttl_ms: u64,
+    ) -> Result<SnapshotSummary, BackendError> {
+        let now_ms = validate_embedded_snapshot_ttl(namespace_id, ttl_ms)?;
+        self.admin
+            .extend_snapshot(
+                namespace_id,
+                snapshot_id,
+                now_ms.saturating_add(ttl_ms),
+                EMBEDDED_SNAPSHOT_MAX_LIFETIME_MS,
+            )
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+    }
+
+    pub(super) async fn release_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        snapshot_id: &CheckpointId,
+    ) -> Result<ReleaseSnapshotResponse, BackendError> {
+        self.admin
+            .release_snapshot(namespace_id, snapshot_id)
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+    }
+
     // The admin methods mirror the server handlers' error scoping exactly:
     // every operation addressing an existing namespace names it when the
     // runtime reports namespace_not_found. Parity keeps embedded and remote
@@ -824,17 +963,80 @@ impl EmbeddedBackend {
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
         limit: Option<u32>,
+        snapshot_id: Option<&CheckpointId>,
     ) -> Result<ListChangesResponse, BackendError> {
         let limit = resolve_cli_page_limit(limit)?;
-        self.reader
+        let captured_seq = match snapshot_id {
+            Some(snapshot_id) => Some(
+                self.reader
+                    .pin_namespace_at_snapshot(namespace_id, snapshot_id)
+                    .await
+                    .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?
+                    .head_seq(),
+            ),
+            None => None,
+        };
+        if let Some(captured_seq) = captured_seq {
+            if after_seq > captured_seq {
+                return Err(BackendError::invalid_request(format!(
+                    "after_seq `{after_seq}` is above snapshot sequence `{captured_seq}`"
+                ))
+                .with_param("after_seq"));
+            }
+            if after_seq == captured_seq {
+                return Ok(ListChangesResponse {
+                    namespace_id: namespace_id.clone(),
+                    after_seq,
+                    through_seq: captured_seq,
+                    next_after_seq: None,
+                    changes: Vec::new(),
+                });
+            }
+        }
+        let mut page = self
+            .reader
             .list_changes(
                 namespace_id,
                 after_seq,
-                ListChangesOptions { limit: Some(limit) },
+                RuntimeListChangesOptions { limit: Some(limit) },
             )
             .await
-            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?;
+        if let Some(captured_seq) = captured_seq {
+            page.changes
+                .retain(|change| change.committed_seq <= captured_seq);
+            page.through_seq = captured_seq;
+            page.next_after_seq = page
+                .changes
+                .last()
+                .map(|change| change.committed_seq)
+                .filter(|last_seq| *last_seq < captured_seq);
+        }
+        Ok(page)
     }
+}
+
+fn validate_embedded_snapshot_ttl(
+    namespace_id: &NamespaceId,
+    ttl_ms: u64,
+) -> Result<u64, BackendError> {
+    if ttl_ms == 0 || ttl_ms > EMBEDDED_SNAPSHOT_MAX_TTL_MS {
+        return Err(BackendError::invalid_request(format!(
+            "ttl_ms must be greater than zero and may not exceed the `snapshot.max_ttl_ms` limit \
+             of {EMBEDDED_SNAPSHOT_MAX_TTL_MS} milliseconds"
+        ))
+        .with_param("/ttl_ms"));
+    }
+    if ttl_ms > EMBEDDED_SNAPSHOT_MAX_LIFETIME_MS {
+        return Err(BackendError::invalid_request(format!(
+            "ttl_ms may not exceed the `snapshot.max_lifetime_ms` limit of \
+             {EMBEDDED_SNAPSHOT_MAX_LIFETIME_MS} milliseconds"
+        ))
+        .with_param("/ttl_ms"));
+    }
+    loonfs::current_time_ms().map_err(|error| {
+        map_namespace_scoped_runtime_error(namespace_id, RuntimeError::Core(error))
+    })
 }
 
 /// How long an assignment rests before it is asserted again, unless
@@ -1327,7 +1529,7 @@ mod tests {
 
         let changes = target
             .backend
-            .list_changes(&namespace_id("demo"), ChangeSeq(0), None)
+            .list_changes(&namespace_id("demo"), ChangeSeq(0), None, None)
             .await
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);
@@ -1360,7 +1562,7 @@ mod tests {
 
         let changes = target
             .backend
-            .list_changes(&namespace_id("missing"), ChangeSeq(0), None)
+            .list_changes(&namespace_id("missing"), ChangeSeq(0), None, None)
             .await
             .expect_err("changes on missing namespace");
         assert_eq!(changes.code, ErrorCode::NamespaceNotFound.as_str());

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -541,6 +541,21 @@ pub(crate) async fn run_admin_changes(
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let after_seq = parse_public_ordinal_arg("--after", args.after.unwrap_or(0), ChangeSeq::parse)
         .map_err(|error| context.fail(kind, error))?;
+    let snapshot_id = args
+        .snapshot_id
+        .as_deref()
+        .map(CheckpointId::parse)
+        .transpose()
+        .map_err(|error| {
+            context.fail(
+                kind,
+                crate::error::CliError::new(
+                    ErrorCode::InvalidRequest.as_str(),
+                    format!("invalid --snapshot-id: {error}"),
+                )
+                .with_param("--snapshot-id"),
+            )
+        })?;
     let mut plan = PagePlan::new(&args.pagination);
     let mut cursor = after_seq;
     let mut response: Option<loonfs_api::v0::ListChangesResponse> = None;
@@ -549,7 +564,12 @@ pub(crate) async fn run_admin_changes(
     loop {
         let page = context
             .target
-            .list_changes(&context.namespace, cursor, plan.request_size())
+            .list_changes(
+                &context.namespace,
+                cursor,
+                plan.request_size(),
+                snapshot_id.as_ref(),
+            )
             .await
             .map_err(|error| context.fail(kind, error))?;
         plan.record(page.changes.len());

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -27,13 +27,13 @@ use crate::progress::{ProgressOp, ProgressReporter};
 use crate::uploads::{SourceIdentity, UploadJournal};
 use loonfs_api::v0::UploadSessionStatus;
 use loonfs_api::{
-    AbsolutePath, ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue, ChangeSeq, CommitId,
-    CommitResponse, ContentRef, DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeKind,
-    ListPathEntriesResponse, NamespaceId, RevisionNo,
+    AbsolutePath, ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue, ChangeSeq,
+    CheckpointId, CommitId, CommitResponse, ContentRef, DeleteDirectoryBehavior,
+    DestinationBehavior, ErrorCode, InodeKind, ListPathEntriesResponse, NamespaceId, RevisionNo,
 };
 use loonfs_client::{
     CommitOptions, CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions,
-    UpdateAttributesOptions,
+    ReadFileOptions, UpdateAttributesOptions,
 };
 use std::collections::BTreeMap;
 use std::fs;
@@ -49,6 +49,17 @@ fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliE
             CommitId::parse(value).map_err(|error| {
                 CliError::invalid_request(format!("invalid --commit-id: {error}"))
                     .with_param("--commit-id")
+            })
+        })
+        .transpose()
+}
+
+fn parse_snapshot_id_arg(snapshot_id: Option<&str>) -> Result<Option<CheckpointId>, CliError> {
+    snapshot_id
+        .map(|value| {
+            CheckpointId::parse(value).map_err(|error| {
+                CliError::invalid_request(format!("invalid --snapshot-id: {error}"))
+                    .with_param("--snapshot-id")
             })
         })
         .transpose()
@@ -80,6 +91,7 @@ async fn follow_path_entry_pages(
     spec: &NamespacePath,
     pagination: &PaginationArgs,
     cursor: Option<&str>,
+    snapshot_id: Option<&CheckpointId>,
     mut visit: impl FnMut(Vec<loonfs_api::PathEntry>) -> Result<(), CliError>,
 ) -> Result<FollowedPathEntryPages, CommandFailure> {
     let mut plan = PagePlan::new(pagination);
@@ -88,7 +100,7 @@ async fn follow_path_entry_pages(
     loop {
         let page = context
             .target
-            .list_path_entries_page(spec, plan.request_size(), cursor.as_deref())
+            .list_path_entries_page(spec, plan.request_size(), cursor.as_deref(), snapshot_id)
             .await
             .map_err(|error| context.fail(kind, error))?;
         let ListPathEntriesResponse {
@@ -132,6 +144,8 @@ pub(crate) async fn run_filesystem_ls(
         allow_root,
     )
     .map_err(|error| context.fail(kind, error))?;
+    let snapshot_id = parse_snapshot_id_arg(args.snapshot_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     let streams_pages = args.pagination.jsonl || (args.pagination.all && !runtime.json);
     if streams_pages {
         let stdout = io::stdout();
@@ -142,6 +156,7 @@ pub(crate) async fn run_filesystem_ls(
             &spec,
             &args.pagination,
             args.cursor.as_deref(),
+            snapshot_id.as_ref(),
             |entries| {
                 write_path_entries_page(&mut stdout, &entries, args.pagination.jsonl)
                     .map_err(CliError::io)
@@ -168,6 +183,7 @@ pub(crate) async fn run_filesystem_ls(
         &spec,
         &args.pagination,
         args.cursor.as_deref(),
+        snapshot_id.as_ref(),
         |page| {
             entries.extend(page);
             Ok(())
@@ -200,6 +216,8 @@ pub(crate) async fn run_filesystem_stat(
     args: FilesystemStatArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
+    let snapshot_id = parse_snapshot_id_arg(args.snapshot_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     let entry = match args.inode {
         Some(inode_id) => context.target.get_inode(&context.namespace, inode_id).await,
         None => {
@@ -210,7 +228,10 @@ pub(crate) async fn run_filesystem_stat(
             let allow_root = true;
             let spec = namespace_path(&context.namespace, "path", path, allow_root)
                 .map_err(|error| context.fail(kind, error))?;
-            context.target.get_path_entry(&spec).await
+            context
+                .target
+                .get_path_entry_at_snapshot(&spec, snapshot_id.as_ref())
+                .await
         }
     }
     .map_err(|error| context.fail(kind, error))?;
@@ -423,16 +444,19 @@ pub(crate) async fn run_filesystem_cat(
         .map(|value| parse_public_ordinal_arg("--revision", value, RevisionNo::parse))
         .transpose()
         .map_err(|error| context.fail(kind, error))?;
-    let bytes = match revision_no {
-        Some(revision_no) => {
-            context
-                .target
-                .get_file_revision_bytes(&spec, revision_no)
-                .await
-        }
-        None => context.target.get_file_bytes(&spec).await,
-    }
-    .map_err(|error| context.fail(kind, error))?;
+    let snapshot_id = parse_snapshot_id_arg(args.snapshot_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
+    let bytes = context
+        .target
+        .get_file_bytes_with_options(
+            &spec,
+            &ReadFileOptions {
+                revision_no,
+                snapshot_id,
+            },
+        )
+        .await
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -471,9 +495,11 @@ pub(crate) async fn run_filesystem_get(
         .map(|value| parse_public_ordinal_arg("--revision", value, RevisionNo::parse))
         .transpose()
         .map_err(|error| context.fail(kind, error))?;
+    let snapshot_id = parse_snapshot_id_arg(args.snapshot_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     let entry = context
         .target
-        .get_path_entry_without_attributes(&spec)
+        .get_path_entry_without_attributes_at_snapshot(&spec, snapshot_id.as_ref())
         .await
         .map_err(|error| context.fail(kind, error))?;
     if args.recursive {
@@ -513,6 +539,7 @@ pub(crate) async fn run_filesystem_get(
             &local_root,
             args.force,
             runtime,
+            snapshot_id.as_ref(),
         )
         .await;
     }
@@ -532,7 +559,13 @@ pub(crate) async fn run_filesystem_get(
         // and bytes already piped onward are somewhere this CLI cannot see.
         let mut download = context
             .target
-            .open_file_download(&spec, revision_no, entry.size_bytes(), 0)
+            .open_file_download(
+                &spec,
+                revision_no,
+                snapshot_id.as_ref(),
+                entry.size_bytes(),
+                0,
+            )
             .await
             .map_err(|error| context.fail(kind, error))?;
         stream_download_to_stdout(&mut download)
@@ -556,6 +589,7 @@ pub(crate) async fn run_filesystem_get(
         &context,
         &spec,
         revision_no,
+        snapshot_id.as_ref(),
         entry.size_bytes(),
         &destination,
         entry.content_ref(),
@@ -607,6 +641,7 @@ pub(super) async fn open_resumable_download(
     context: &CommandContext,
     spec: &NamespacePath,
     revision_no: Option<RevisionNo>,
+    snapshot_id: Option<&CheckpointId>,
     size_bytes: Option<u64>,
     destination: &Path,
     content_ref: Option<&ContentRef>,
@@ -617,7 +652,7 @@ pub(super) async fn open_resumable_download(
         .map_or(0, |meta| partial::resumable_bytes(destination, meta));
     let download = context
         .target
-        .open_file_download(spec, revision_no, size_bytes, start_offset)
+        .open_file_download(spec, revision_no, snapshot_id, size_bytes, start_offset)
         .await?;
     Ok((download, meta))
 }

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ mod partial;
 mod profile;
 mod profile_config;
 mod recursive;
+mod snapshot;
 
 pub(crate) use self::output::{
     CommandData, CommandFailure, CommandOutput, DoctorCheck, DoctorStatus, ListingHeadDrift,
@@ -77,6 +78,9 @@ pub(crate) async fn run(
         }
         Command::Namespace { command } => {
             namespace::run_namespace_command(kind, config_path, command, runtime).await
+        }
+        Command::Snapshot { command } => {
+            snapshot::run_snapshot_command(kind, config_path, command).await
         }
         Command::Use(args) => namespace::run_namespace_use(kind, config_path, args).await,
         Command::Current(args) => namespace::run_namespace_current(kind, config_path, args).await,

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -5,7 +5,10 @@ use crate::config::{CliConfig, ConfigSource, ProfileConfig};
 use crate::error::CliError;
 use crate::profiles::ProfileSummary;
 use crate::render::{store_probe_verdict, StoreProbeVerdict};
-use loonfs_api::v0::{GrepGcResponse, GrepIndex, ListChangesResponse, StoreProbeResponse};
+use loonfs_api::v0::{
+    GrepGcResponse, GrepIndex, ListChangesResponse, ListSnapshotsResponse, ReleaseSnapshotResponse,
+    SnapshotSummary, StoreProbeResponse,
+};
 use loonfs_api::{
     AbsolutePath, CapabilityDocument, ChangeSeq, Checkpoint, CommitId, DeleteNamespaceResponse,
     FileRevision, GcResponse, GrepMatch, InodeId, ListCheckpointsResponse, MaintenanceStepResponse,
@@ -162,6 +165,10 @@ pub(crate) enum CommandData {
     },
     NamespaceStatus(Namespace),
     NamespaceDeleted(DeleteNamespaceResponse),
+    SnapshotCreated(SnapshotSummary),
+    SnapshotsListed(ListSnapshotsResponse),
+    SnapshotExtended(SnapshotSummary),
+    SnapshotReleased(ReleaseSnapshotResponse),
     CheckpointCreated(Checkpoint),
     CheckpointsListed(ListCheckpointsResponse),
     CheckpointReleased(ReleaseCheckpointResponse),

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -1,7 +1,7 @@
 //! Client-side recursive transfers: `put -r`, `get -r`, and `cp -r`.
 //!
-//! Traversal is unpinned and tolerates directory changes between pages. Each
-//! file uses the corresponding single-file operation and commits independently.
+//! Traversal follows current state unless a snapshot is selected. Each file
+//! uses the corresponding single-file operation and commits independently.
 //! Transfers use bounded concurrency and report failures per file.
 
 use super::context::CommandContext;
@@ -15,7 +15,7 @@ use crate::payload::LocalPayload;
 use crate::progress::{ProgressOp, ProgressReporter};
 use crate::render::write_stderr_progress;
 use futures::StreamExt;
-use loonfs_api::{DestinationBehavior, ErrorCode, InodeKind, PathEntryKind};
+use loonfs_api::{CheckpointId, DestinationBehavior, ErrorCode, InodeKind, PathEntryKind};
 use loonfs_client::{CommitOptions, CreateDirectoryOptions, NamespacePath, PutFileOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -297,13 +297,14 @@ pub(crate) async fn run_get_tree(
     local_root: &Path,
     force: bool,
     runtime: RuntimeBehavior,
+    snapshot_id: Option<&CheckpointId>,
 ) -> Result<CommandOutput, CommandFailure> {
     let mut tally = TreeTally::new();
     // Fail early if the destination cannot be created.
     let root_outcome = create_local_directory(local_root)
         .map_err(|error| context.fail(kind, CliError::io_for_path(local_root, error)))?;
     tally.record_directory(root_outcome);
-    let listing = walk_remote_tree(context, kind, "remote_path", remote_root).await?;
+    let listing = walk_remote_tree(context, kind, "remote_path", remote_root, snapshot_id).await?;
     if !runtime.json {
         if let Some(drift) = listing.head_drift.as_ref() {
             crate::render::write_listing_drift_warning(drift);
@@ -340,6 +341,7 @@ pub(crate) async fn run_get_tree(
                 context,
                 &spec,
                 None,
+                snapshot_id,
                 job.size_bytes,
                 &local,
                 job.content_ref.as_ref(),
@@ -402,7 +404,7 @@ pub(crate) async fn run_copy_tree(
     message: Option<String>,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let listing = walk_remote_tree(context, kind, "source_path", source_root).await?;
+    let listing = walk_remote_tree(context, kind, "source_path", source_root, None).await?;
     if !runtime.json {
         if let Some(drift) = listing.head_drift.as_ref() {
             crate::render::write_listing_drift_warning(drift);
@@ -626,6 +628,7 @@ async fn walk_remote_tree(
     kind: CommandKind,
     remote_param: &str,
     root: &str,
+    snapshot_id: Option<&CheckpointId>,
 ) -> Result<RemoteTree, CommandFailure> {
     let mut tree = RemoteTree {
         directories: Vec::new(),
@@ -643,13 +646,15 @@ async fn walk_remote_tree(
         };
         let spec = parse_remote(context, listed, remote_param)
             .map_err(|error| context.fail(kind, error))?;
-        let mut pager = context
-            .target
-            .list_path_entries_pager(&spec, None, None)
-            .map_err(|error| context.fail(kind, error))?;
-        while let Some(response) = pager.next().await {
-            let response = response.map_err(|error| context.fail(kind, error))?;
+        let mut cursor = None;
+        loop {
+            let response = context
+                .target
+                .list_path_entries_page(&spec, None, cursor.as_deref(), snapshot_id)
+                .await
+                .map_err(|error| context.fail(kind, error))?;
             heads.observe(response.head_seq);
+            cursor = response.next_cursor;
             for entry in response.entries {
                 let Some(name) = entry.display_name.as_ref() else {
                     continue;
@@ -675,6 +680,9 @@ async fn walk_remote_tree(
                         content_ref: Some(content_ref),
                     }),
                 }
+            }
+            if cursor.is_none() {
+                break;
             }
         }
     }
@@ -802,7 +810,7 @@ mod tests {
         assert_eq!(
             context
                 .target
-                .get_file_bytes(&spec)
+                .get_file_bytes_with_options(&spec, &loonfs_client::ReadFileOptions::default())
                 .await
                 .expect("read the uploaded file back"),
             large,

--- a/crates/loonfs-cli/src/commands/snapshot.rs
+++ b/crates/loonfs-cli/src/commands/snapshot.rs
@@ -1,5 +1,3 @@
-//! Point-in-time snapshot lifecycle commands.
-
 use super::context::{fail, fail_for};
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use super::pagination::{write_jsonl_page, PagePlan};

--- a/crates/loonfs-cli/src/commands/snapshot.rs
+++ b/crates/loonfs-cli/src/commands/snapshot.rs
@@ -1,0 +1,171 @@
+//! Point-in-time snapshot lifecycle commands.
+
+use super::context::{fail, fail_for};
+use super::output::{CommandData, CommandFailure, CommandOutput};
+use super::pagination::{write_jsonl_page, PagePlan};
+use crate::args::{
+    CommandKind, SnapshotCommand, SnapshotCreateArgs, SnapshotExtendArgs, SnapshotListArgs,
+    SnapshotReleaseArgs, SnapshotTargetArgs,
+};
+use crate::backend_error::BackendError;
+use crate::resolve::{parse_namespace_id, resolve_target_profile, ResolvedTarget};
+use loonfs_api::{CheckpointId, ErrorCode, NamespaceId};
+use std::io::{self, BufWriter};
+use std::path::Path;
+
+struct SnapshotContext {
+    profile_name: String,
+    mode: String,
+    namespace_id: NamespaceId,
+    target: ResolvedTarget,
+}
+
+impl SnapshotContext {
+    fn fail(&self, kind: CommandKind, error: impl Into<crate::error::CliError>) -> CommandFailure {
+        fail_for(kind, &self.profile_name, &self.mode, error)
+    }
+
+    fn output(&self, kind: CommandKind, data: CommandData) -> CommandOutput {
+        CommandOutput {
+            kind,
+            profile: Some(self.profile_name.clone()),
+            mode: Some(self.mode.clone()),
+            data,
+        }
+    }
+}
+
+async fn resolve_snapshot_context(
+    kind: CommandKind,
+    config_path: &Path,
+    target: &SnapshotTargetArgs,
+) -> Result<SnapshotContext, CommandFailure> {
+    let explicit_profile = target.profile.profile.as_deref();
+    let resolved = resolve_target_profile(config_path, explicit_profile, target.request.no_retry)
+        .await
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    let namespace_id = parse_namespace_id(&target.namespace_id)
+        .map_err(|error| error.with_param("namespace_id"))
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+    Ok(SnapshotContext {
+        profile_name: resolved.profile_name,
+        mode,
+        namespace_id,
+        target: resolved.target,
+    })
+}
+
+fn parse_snapshot_id(value: &str) -> Result<CheckpointId, BackendError> {
+    CheckpointId::parse(value).map_err(|error| {
+        BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
+            .with_param("snapshot_id")
+    })
+}
+
+pub(crate) async fn run_snapshot_command(
+    kind: CommandKind,
+    config_path: &Path,
+    command: SnapshotCommand,
+) -> Result<CommandOutput, CommandFailure> {
+    match command {
+        SnapshotCommand::Create(args) => run_snapshot_create(kind, config_path, args).await,
+        SnapshotCommand::List(args) => run_snapshot_list(kind, config_path, args).await,
+        SnapshotCommand::Extend(args) => run_snapshot_extend(kind, config_path, args).await,
+        SnapshotCommand::Release(args) => run_snapshot_release(kind, config_path, args).await,
+    }
+}
+
+async fn run_snapshot_create(
+    kind: CommandKind,
+    config_path: &Path,
+    args: SnapshotCreateArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_snapshot_context(kind, config_path, &args.target).await?;
+    let response = context
+        .target
+        .create_snapshot(&context.namespace_id, &args.name, args.ttl_ms)
+        .await
+        .map_err(|error| context.fail(kind, error))?;
+    Ok(context.output(kind, CommandData::SnapshotCreated(response)))
+}
+
+async fn run_snapshot_list(
+    kind: CommandKind,
+    config_path: &Path,
+    args: SnapshotListArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_snapshot_context(kind, config_path, &args.target).await?;
+    let mut plan = PagePlan::new(&args.pagination);
+    let mut cursor = args.cursor;
+    let mut response: Option<loonfs_api::v0::ListSnapshotsResponse> = None;
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
+    loop {
+        let page = context
+            .target
+            .list_snapshots_page(
+                &context.namespace_id,
+                plan.request_size(),
+                cursor.as_deref(),
+            )
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        plan.record(page.snapshots.len());
+        cursor = page.next_cursor.clone();
+        if args.pagination.jsonl {
+            write_jsonl_page(&mut stdout, &page.snapshots)
+                .map_err(crate::error::CliError::io)
+                .map_err(|error| context.fail(kind, error))?;
+        } else if let Some(response) = response.as_mut() {
+            response.snapshots.extend(page.snapshots);
+            response.next_cursor = page.next_cursor;
+        } else {
+            response = Some(page);
+        }
+        if !plan.should_continue(cursor.is_some()) {
+            break;
+        }
+    }
+    if args.pagination.jsonl {
+        return Ok(context.output(kind, CommandData::StreamedToStdout));
+    }
+    Ok(context.output(
+        kind,
+        CommandData::SnapshotsListed(
+            response.expect("snapshot loop should fetch at least one page"),
+        ),
+    ))
+}
+
+async fn run_snapshot_extend(
+    kind: CommandKind,
+    config_path: &Path,
+    args: SnapshotExtendArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_snapshot_context(kind, config_path, &args.target).await?;
+    let snapshot_id =
+        parse_snapshot_id(&args.snapshot_id).map_err(|error| context.fail(kind, error))?;
+    let response = context
+        .target
+        .extend_snapshot(&context.namespace_id, &snapshot_id, args.ttl_ms)
+        .await
+        .map_err(|error| context.fail(kind, error))?;
+    Ok(context.output(kind, CommandData::SnapshotExtended(response)))
+}
+
+async fn run_snapshot_release(
+    kind: CommandKind,
+    config_path: &Path,
+    args: SnapshotReleaseArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_snapshot_context(kind, config_path, &args.target).await?;
+    let snapshot_id =
+        parse_snapshot_id(&args.snapshot_id).map_err(|error| context.fail(kind, error))?;
+    let response = context
+        .target
+        .release_snapshot(&context.namespace_id, &snapshot_id)
+        .await
+        .map_err(|error| context.fail(kind, error))?;
+    Ok(context.output(kind, CommandData::SnapshotReleased(response)))
+}

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -64,7 +64,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             response.namespace_id, response.head_seq.0
         ),
         CommandData::SnapshotCreated(snapshot) => format!(
-            "snapshot {} created for {} @ seq {} (name {}, expires at {})",
+            "snapshot {} created for {} at sequence {} (name: {}, expires: {})",
             snapshot.snapshot_id,
             snapshot.namespace_id,
             snapshot.head_seq.0,
@@ -101,7 +101,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             format_utc_ms(snapshot.expires_at_ms)
         ),
         CommandData::SnapshotReleased(response) => format!(
-            "snapshot {} in {} released or already gone",
+            "snapshot {} in {} released",
             response.snapshot_id, response.namespace_id
         ),
         CommandData::CheckpointCreated(checkpoint) => {

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -63,6 +63,47 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             "deleted {} (head_seq {})",
             response.namespace_id, response.head_seq.0
         ),
+        CommandData::SnapshotCreated(snapshot) => format!(
+            "snapshot {} created for {} @ seq {} (name {}, expires at {})",
+            snapshot.snapshot_id,
+            snapshot.namespace_id,
+            snapshot.head_seq.0,
+            snapshot.name,
+            format_utc_ms(snapshot.expires_at_ms)
+        ),
+        CommandData::SnapshotsListed(response) => {
+            let mut lines = vec![
+                format!("live snapshots for {}", response.namespace_id),
+                "SNAPSHOT\tNAME\tSEQ\tCREATED\tEXPIRES".to_owned(),
+            ];
+            for snapshot in &response.snapshots {
+                lines.push(format!(
+                    "{}\t{}\t{}\t{}\t{}",
+                    snapshot.snapshot_id,
+                    snapshot.name,
+                    snapshot.head_seq.0,
+                    format_utc_ms(snapshot.created_at_ms),
+                    format_utc_ms(snapshot.expires_at_ms),
+                ));
+            }
+            if response.snapshots.is_empty() {
+                lines.push("(none)".to_owned());
+            }
+            if let Some(cursor) = &response.next_cursor {
+                lines.push(format!("next_cursor: {cursor}"));
+            }
+            lines.join("\n")
+        }
+        CommandData::SnapshotExtended(snapshot) => format!(
+            "snapshot {} in {} extended to {}",
+            snapshot.snapshot_id,
+            snapshot.namespace_id,
+            format_utc_ms(snapshot.expires_at_ms)
+        ),
+        CommandData::SnapshotReleased(response) => format!(
+            "snapshot {} in {} released or already gone",
+            response.snapshot_id, response.namespace_id
+        ),
         CommandData::CheckpointCreated(checkpoint) => {
             let expiry = match checkpoint.expires_at_ms {
                 Some(expires_at_ms) => format!(", expires at {}", format_utc_ms(expires_at_ms)),

--- a/crates/loonfs-cli/tests/it/main.rs
+++ b/crates/loonfs-cli/tests/it/main.rs
@@ -8,3 +8,4 @@ mod inspection;
 mod output;
 mod profile;
 mod recursive;
+mod snapshots;

--- a/crates/loonfs-cli/tests/it/snapshots.rs
+++ b/crates/loonfs-cli/tests/it/snapshots.rs
@@ -1,5 +1,3 @@
-//! Snapshot lifecycle and point-in-time CLI reads.
-
 use super::common::*;
 
 #[test]
@@ -35,12 +33,6 @@ fn snapshot_family_and_captured_read_work_end_to_end() {
     let listed_data = json_data(&listed);
     assert_eq!(listed_data["kind"], "snapshots_listed");
     assert_eq!(listed_data["snapshots"][0]["snapshot_id"], snapshot_id);
-
-    let listed_human = harness.run(&["snapshot", "list", "demo"]);
-    assert_success(&listed_human);
-    let listed_text = stdout_string(&listed_human);
-    assert!(listed_text.contains("SNAPSHOT\tNAME\tSEQ\tCREATED\tEXPIRES"));
-    assert!(listed_text.contains(&snapshot_id));
 
     let extended = harness.run(&[
         "--json",

--- a/crates/loonfs-cli/tests/it/snapshots.rs
+++ b/crates/loonfs-cli/tests/it/snapshots.rs
@@ -1,0 +1,100 @@
+//! Snapshot lifecycle and point-in-time CLI reads.
+
+use super::common::*;
+
+#[test]
+fn snapshot_family_and_captured_read_work_end_to_end() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("report.txt");
+    fs::write(&payload, b"captured\n").expect("write captured payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/report.txt"]));
+
+    let created = harness.run(&[
+        "--json", "snapshot", "create", "demo", "--name", "report", "--ttl-ms", "5000",
+    ]);
+    assert_success(&created);
+    let created_data = json_data(&created);
+    assert_eq!(created_data["kind"], "snapshot_created");
+    assert_eq!(created_data["namespace_id"], "demo");
+    assert_eq!(created_data["name"], "report");
+    assert_eq!(created_data["head_seq"], 1);
+    let snapshot_id = created_data["snapshot_id"]
+        .as_str()
+        .expect("snapshot id")
+        .to_owned();
+    let original_expiry = created_data["expires_at_ms"]
+        .as_u64()
+        .expect("snapshot expiry");
+
+    let listed = harness.run(&["--json", "snapshot", "list", "demo"]);
+    assert_success(&listed);
+    let listed_data = json_data(&listed);
+    assert_eq!(listed_data["kind"], "snapshots_listed");
+    assert_eq!(listed_data["snapshots"][0]["snapshot_id"], snapshot_id);
+
+    let listed_human = harness.run(&["snapshot", "list", "demo"]);
+    assert_success(&listed_human);
+    let listed_text = stdout_string(&listed_human);
+    assert!(listed_text.contains("SNAPSHOT\tNAME\tSEQ\tCREATED\tEXPIRES"));
+    assert!(listed_text.contains(&snapshot_id));
+
+    let extended = harness.run(&[
+        "--json",
+        "snapshot",
+        "extend",
+        "demo",
+        &snapshot_id,
+        "--ttl-ms",
+        "60000",
+    ]);
+    assert_success(&extended);
+    let extended_data = json_data(&extended);
+    assert_eq!(extended_data["kind"], "snapshot_extended");
+    assert!(
+        extended_data["expires_at_ms"]
+            .as_u64()
+            .expect("extended expiry")
+            > original_expiry
+    );
+
+    fs::write(&payload, b"current\n").expect("write current payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/report.txt",
+        "--force",
+    ]));
+    let captured = harness.run(&["cat", "/report.txt", "--snapshot-id", &snapshot_id]);
+    assert_success(&captured);
+    assert_eq!(captured.stdout, b"captured\n");
+
+    let released = harness.run(&["--json", "snapshot", "release", "demo", &snapshot_id]);
+    assert_success(&released);
+    assert_eq!(json_data(&released)["kind"], "snapshot_released");
+
+    let empty = harness.run(&["--json", "snapshot", "list", "demo"]);
+    assert_success(&empty);
+    assert!(json_data(&empty)["snapshots"]
+        .as_array()
+        .expect("snapshot array")
+        .is_empty());
+
+    let gone = harness.run(&[
+        "--json",
+        "stat",
+        "/report.txt",
+        "--snapshot-id",
+        &snapshot_id,
+    ]);
+    assert_failure(&gone);
+    let error = json_error(&gone);
+    assert_eq!(error["code"], "snapshot_gone");
+    assert!(error["message"]
+        .as_str()
+        .expect("snapshot error message")
+        .contains("released"));
+}

--- a/crates/loonfs-client/Cargo.toml
+++ b/crates/loonfs-client/Cargo.toml
@@ -22,6 +22,8 @@ tracing.workspace = true
 urlencoding.workspace = true
 
 [dev-dependencies]
+axum.workspace = true
+loonfs-server = { path = "../loonfs-server" }
 loonfs-test-support.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -1,4 +1,4 @@
-//! Checkpoints, maintenance, store probes, and grep administration.
+//! Snapshots, checkpoints, maintenance, store probes, and grep administration.
 
 use super::*;
 use crate::transport::{append_optional_pagination_query, append_query_param};
@@ -57,7 +57,140 @@ impl CheckpointsPager {
     }
 }
 
+/// Fetches live-snapshot pages as needed.
+#[must_use]
+pub struct SnapshotsPager {
+    client: Client,
+    namespace_id: NamespaceId,
+    page_size: Option<u32>,
+    cursor: Option<String>,
+    pending: Option<ListSnapshotsResponse>,
+    exhausted: bool,
+}
+
+impl SnapshotsPager {
+    /// Returns the next snapshot page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ListSnapshotsResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .client
+            .list_snapshots_page(&self.namespace_id, self.page_size, self.cursor.as_deref())
+            .await;
+        Some(page.inspect(|page| {
+            self.cursor = page.next_cursor.clone();
+            self.exhausted = self.cursor.is_none();
+        }))
+    }
+
+    /// Returns at most `max_items` snapshots.
+    ///
+    /// Unused snapshots from the last page remain available to later calls.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<SnapshotSummary>> {
+        let mut snapshots = Vec::new();
+        while snapshots.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - snapshots.len()).min(page.snapshots.len());
+            if take < page.snapshots.len() {
+                let remaining = page.snapshots.split_off(take);
+                snapshots.extend(page.snapshots);
+                page.snapshots = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            snapshots.extend(page.snapshots);
+        }
+        Ok(snapshots)
+    }
+}
+
 impl Client {
+    /// Creates a time-bounded view of the namespace's current state.
+    /// Retrying this request starts a distinct attempt.
+    pub async fn create_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        name: &str,
+        ttl_ms: u64,
+    ) -> Result<SnapshotSummary> {
+        let url = format!("{}/v0/namespaces/{namespace_id}/snapshots", self.base_url);
+        self.request_json_once(
+            self.post(&url),
+            Some(&CreateSnapshotRequest {
+                name: name.to_owned(),
+                ttl_ms,
+            }),
+        )
+        .await
+    }
+
+    /// Creates a snapshot pager beginning at `cursor`.
+    pub fn list_snapshots_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        page_size: Option<u32>,
+        cursor: Option<String>,
+    ) -> SnapshotsPager {
+        SnapshotsPager {
+            client: self.clone(),
+            namespace_id: namespace_id.clone(),
+            page_size,
+            cursor,
+            pending: None,
+            exhausted: false,
+        }
+    }
+
+    /// Lists one bounded page of live snapshots.
+    pub async fn list_snapshots_page(
+        &self,
+        namespace_id: &NamespaceId,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListSnapshotsResponse> {
+        let mut url = format!("{}/v0/namespaces/{namespace_id}/snapshots", self.base_url);
+        let mut has_query = false;
+        append_optional_pagination_query(&mut url, &mut has_query, limit, cursor);
+        self.request_json::<(), ListSnapshotsResponse>(self.get(&url), None)
+            .await
+    }
+
+    /// Extends a live snapshot's lease. Repeating the same request is safe.
+    pub async fn extend_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        snapshot_id: &CheckpointId,
+        ttl_ms: u64,
+    ) -> Result<SnapshotSummary> {
+        let url = format!(
+            "{}/v0/namespaces/{namespace_id}/snapshots/{snapshot_id}/extend",
+            self.base_url
+        );
+        self.request_json(self.post(&url), Some(&ExtendSnapshotRequest { ttl_ms }))
+            .await
+    }
+
+    /// Releases a snapshot. Releasing it again succeeds.
+    pub async fn release_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        snapshot_id: &CheckpointId,
+    ) -> Result<ReleaseSnapshotResponse> {
+        let url = format!(
+            "{}/v0/namespaces/{namespace_id}/snapshots/{snapshot_id}/release",
+            self.base_url
+        );
+        self.request_json::<(), ReleaseSnapshotResponse>(self.post(&url), None)
+            .await
+    }
+
     /// Returns namespace state and storage details used by maintenance.
     pub async fn get_namespace_diagnostics(
         &self,

--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -112,7 +112,7 @@ impl SnapshotsPager {
 }
 
 impl Client {
-    /// Creates a time-bounded view of the namespace's current state.
+    /// Saves the namespace's current state for a limited time.
     /// Retrying this request starts a distinct attempt.
     pub async fn create_snapshot(
         &self,
@@ -148,7 +148,7 @@ impl Client {
         }
     }
 
-    /// Lists one bounded page of live snapshots.
+    /// Lists one bounded page of available snapshots.
     pub async fn list_snapshots_page(
         &self,
         namespace_id: &NamespaceId,
@@ -162,7 +162,7 @@ impl Client {
             .await
     }
 
-    /// Extends a live snapshot's lease. Repeating the same request is safe.
+    /// Extends a snapshot's lifetime. Repeating the same request is safe.
     pub async fn extend_snapshot(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-client/src/downloads.rs
+++ b/crates/loonfs-client/src/downloads.rs
@@ -2,14 +2,12 @@
 
 use super::*;
 
-/// Optional selectors for a path-based download grant.
+/// Selects a retained revision or snapshot for a download. Set at most one.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DownloadOptions {
     /// Download one retained revision instead of the current file.
     pub revision_no: Option<RevisionNo>,
-    /// Download the file revision captured by this live snapshot.
-    ///
-    /// The server rejects a request that supplies both selectors.
+    /// Download the file revision captured by this snapshot.
     pub snapshot_id: Option<CheckpointId>,
 }
 
@@ -140,10 +138,7 @@ impl Client {
         .await
     }
 
-    /// Requests short-lived direct access using the requested revision or snapshot.
-    ///
-    /// Both selectors are sent when both are present so the server remains
-    /// authoritative for their mutual-exclusion error.
+    /// Requests short-lived direct access to a revision or snapshot.
     pub async fn create_download_with_options(
         &self,
         spec: &NamespacePath,

--- a/crates/loonfs-client/src/downloads.rs
+++ b/crates/loonfs-client/src/downloads.rs
@@ -2,6 +2,17 @@
 
 use super::*;
 
+/// Optional selectors for a path-based download grant.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DownloadOptions {
+    /// Download one retained revision instead of the current file.
+    pub revision_no: Option<RevisionNo>,
+    /// Download the file revision captured by this live snapshot.
+    ///
+    /// The server rejects a request that supplies both selectors.
+    pub snapshot_id: Option<CheckpointId>,
+}
+
 /// A direct download returned in verified, bounded chunks.
 ///
 /// Verification completes only when [`Self::next_chunk`] returns `None`.
@@ -119,12 +130,35 @@ impl Client {
         spec: &NamespacePath,
         revision_no: Option<RevisionNo>,
     ) -> Result<BeginDownloadResponse> {
-        let url = format!(
+        self.create_download_with_options(
+            spec,
+            &DownloadOptions {
+                revision_no,
+                snapshot_id: None,
+            },
+        )
+        .await
+    }
+
+    /// Requests short-lived direct access using the requested revision or snapshot.
+    ///
+    /// Both selectors are sent when both are present so the server remains
+    /// authoritative for their mutual-exclusion error.
+    pub async fn create_download_with_options(
+        &self,
+        spec: &NamespacePath,
+        options: &DownloadOptions,
+    ) -> Result<BeginDownloadResponse> {
+        let mut url = format!(
             "{}/v0/namespaces/{}/filesystem/downloads",
             self.base_url,
             spec.namespace().as_str()
         );
-        let request = match revision_no {
+        if let Some(snapshot_id) = &options.snapshot_id {
+            url.push_str("?snapshot_id=");
+            url.push_str(snapshot_id.as_str());
+        }
+        let request = match options.revision_no {
             Some(revision_no) => {
                 BeginDownloadRequest::for_revision(spec.absolute_path().clone(), revision_no)
             }

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -29,11 +29,12 @@ use loonfs_api::{
         BeginDownloadByInodeRequest, BeginDownloadByInodeResponse, BeginDownloadRequest,
         BeginDownloadResponse, BeginUploadRequest, BeginUploadResponse,
         CommitResponse as ApiCommitResponse, CommittedChange, CompleteMultipartUploadRequest,
-        CompleteUploadRequest, CompletedUploadPart, ContentToken, GrepGcRequest, GrepGcResponse,
-        GrepIndex, ListChangesResponse, ObjectTransferAccess, SignUploadPartsRequest,
-        SignUploadPartsResponse, SignedUploadPart, StoreProbeRequest, StoreProbeResponse,
-        UploadContentClaim, UploadContentResponse, UploadPartChecksumClaim, UploadSession,
-        UploadSessionStatus,
+        CompleteUploadRequest, CompletedUploadPart, ContentToken, CreateSnapshotRequest,
+        ExtendSnapshotRequest, GrepGcRequest, GrepGcResponse, GrepIndex, ListChangesResponse,
+        ListSnapshotsResponse, ObjectTransferAccess, ReleaseSnapshotResponse,
+        SignUploadPartsRequest, SignUploadPartsResponse, SignedUploadPart, SnapshotSummary,
+        StoreProbeRequest, StoreProbeResponse, UploadContentClaim, UploadContentResponse,
+        UploadPartChecksumClaim, UploadSession, UploadSessionStatus,
     },
     AbsolutePath, CapabilityDocument, ChangeSeq, Checkpoint, CheckpointId, Checksum,
     ChecksumAlgorithm, CommitId, CommitRequest, ContentEvidence, ContentRef,
@@ -51,12 +52,13 @@ use payload::PartReader;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-pub use admin::CheckpointsPager;
+pub use admin::{CheckpointsPager, SnapshotsPager};
 pub use config::ClientConfig;
 pub use error::ClientError;
 pub use payload::{PayloadSource, PayloadStream};
 pub use reads::{
-    ChangesPager, FileRevisionsPager, InodeChildrenPager, PathEntriesPager, TrashPager,
+    ChangesPager, FileRevisionsPager, InodeChildrenPager, ListChangesOptions, PathEntriesPager,
+    ReadFileOptions, TrashPager,
 };
 use transport::{StdMonotonicTimer, TransportRetryPolicy, WireRequest, IO_INACTIVITY_TIMEOUT};
 pub use ClientError as Error;
@@ -73,7 +75,7 @@ pub use loonfs_api::options::{
 /// Result type returned by the client.
 pub type Result<T> = std::result::Result<T, ClientError>;
 
-pub use downloads::DirectDownloadStream;
+pub use downloads::{DirectDownloadStream, DownloadOptions};
 pub use namespace_path::NamespacePath;
 pub use uploads::staging::{
     MultipartUploadJournal, MultipartUploadResume, STREAMING_PUT_MIN_BYTES,

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -647,8 +647,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retry_policy_matches_admin_operation_classes() {
+    async fn retry_policy_matches_snapshot_and_admin_operation_classes() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        let (transport, client) = single_attempt_probe();
+        assert_single_attempt(
+            client
+                .create_snapshot(&namespace_id, "backup", 10_000)
+                .await,
+            &transport,
+        );
+        drop(transport);
 
         let (transport, client) = single_attempt_probe();
         assert_single_attempt(

--- a/crates/loonfs-client/src/reads.rs
+++ b/crates/loonfs-client/src/reads.rs
@@ -3,6 +3,26 @@
 use super::*;
 use crate::transport::{append_optional_pagination_query, append_query_param};
 
+/// Optional selectors for a path-based file-content read.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReadFileOptions {
+    /// Read one retained revision instead of the current file.
+    pub revision_no: Option<RevisionNo>,
+    /// Read the file revision captured by this live snapshot.
+    ///
+    /// The server rejects a request that supplies both selectors.
+    pub snapshot_id: Option<CheckpointId>,
+}
+
+/// Optional selectors for one change-feed page.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ListChangesOptions {
+    /// Maximum number of changes in the page.
+    pub limit: Option<u32>,
+    /// End the feed at this live snapshot's captured sequence.
+    pub snapshot_id: Option<CheckpointId>,
+}
+
 /// Fetches directory pages as needed.
 ///
 /// [`Self::next`] returns one page with its metadata. [`Self::collect_up_to`]
@@ -272,6 +292,7 @@ pub struct ChangesPager {
     namespace_id: NamespaceId,
     after_seq: ChangeSeq,
     page_size: Option<u32>,
+    snapshot_id: Option<CheckpointId>,
     pending: Option<ListChangesResponse>,
     exhausted: bool,
 }
@@ -287,7 +308,14 @@ impl ChangesPager {
         }
         let page = self
             .client
-            .list_changes(&self.namespace_id, self.after_seq, self.page_size)
+            .list_changes_with_options(
+                &self.namespace_id,
+                self.after_seq,
+                &ListChangesOptions {
+                    limit: self.page_size,
+                    snapshot_id: self.snapshot_id.clone(),
+                },
+            )
             .await;
         Some(page.inspect(|page| {
             self.exhausted = page.next_after_seq.is_none();
@@ -425,6 +453,14 @@ impl Client {
             "include_attributes",
             &options.include_attributes.to_string(),
         );
+        if let Some(snapshot_id) = &options.snapshot_id {
+            append_query_param(
+                &mut url,
+                &mut has_query,
+                "snapshot_id",
+                snapshot_id.as_str(),
+            );
+        }
         self.request_json::<(), _>(self.get(&url), None).await
     }
 
@@ -447,6 +483,14 @@ impl Client {
             "include_attributes",
             &options.include_attributes.to_string(),
         );
+        if let Some(snapshot_id) = &options.snapshot_id {
+            append_query_param(
+                &mut url,
+                &mut has_query,
+                "snapshot_id",
+                snapshot_id.as_str(),
+            );
+        }
         self.request_json::<(), _>(self.get(&url), None).await
     }
 
@@ -521,13 +565,8 @@ impl Client {
 
     /// Reads the file's current contents into memory.
     pub async fn get_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>> {
-        let url = format!(
-            "{}/v0/namespaces/{}/filesystem/content?path={}",
-            self.base_url,
-            spec.namespace().as_str(),
-            urlencoding::encode(spec.absolute_path().as_str())
-        );
-        self.request_bytes(&url).await
+        self.get_file_bytes_with_options(spec, &ReadFileOptions::default())
+            .await
     }
 
     /// Reads the requested file revision into memory.
@@ -536,13 +575,48 @@ impl Client {
         spec: &NamespacePath,
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>> {
-        let url = format!(
-            "{}/v0/namespaces/{}/filesystem/content?path={}&revision_no={}",
+        self.get_file_bytes_with_options(
+            spec,
+            &ReadFileOptions {
+                revision_no: Some(revision_no),
+                snapshot_id: None,
+            },
+        )
+        .await
+    }
+
+    /// Reads path-based file content using the requested revision or snapshot.
+    ///
+    /// Both selectors are sent when both are present so the server remains
+    /// authoritative for their mutual-exclusion error.
+    pub async fn get_file_bytes_with_options(
+        &self,
+        spec: &NamespacePath,
+        options: &ReadFileOptions,
+    ) -> Result<Vec<u8>> {
+        let mut url = format!(
+            "{}/v0/namespaces/{}/filesystem/content?path={}",
             self.base_url,
             spec.namespace().as_str(),
-            urlencoding::encode(spec.absolute_path().as_str()),
-            revision_no.0
+            urlencoding::encode(spec.absolute_path().as_str())
         );
+        let mut has_query = true;
+        if let Some(revision_no) = options.revision_no {
+            append_query_param(
+                &mut url,
+                &mut has_query,
+                "revision_no",
+                &revision_no.0.to_string(),
+            );
+        }
+        if let Some(snapshot_id) = &options.snapshot_id {
+            append_query_param(
+                &mut url,
+                &mut has_query,
+                "snapshot_id",
+                snapshot_id.as_str(),
+            );
+        }
         self.request_bytes(&url).await
     }
 
@@ -679,12 +753,34 @@ impl Client {
         after_seq: ChangeSeq,
         limit: Option<u32>,
     ) -> Result<ListChangesResponse> {
+        self.list_changes_with_options(
+            namespace_id,
+            after_seq,
+            &ListChangesOptions {
+                limit,
+                snapshot_id: None,
+            },
+        )
+        .await
+    }
+
+    /// Returns committed changes using the requested page and snapshot bounds.
+    pub async fn list_changes_with_options(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+        options: &ListChangesOptions,
+    ) -> Result<ListChangesResponse> {
         let mut url = format!(
             "{}/v0/namespaces/{namespace_id}/changes?after_seq={}",
             self.base_url, after_seq.0
         );
-        if let Some(limit) = limit {
+        if let Some(limit) = options.limit {
             url.push_str(&format!("&limit={limit}"));
+        }
+        if let Some(snapshot_id) = &options.snapshot_id {
+            url.push_str("&snapshot_id=");
+            url.push_str(snapshot_id.as_str());
         }
         self.request_json::<(), ListChangesResponse>(self.get(&url), None)
             .await
@@ -702,6 +798,26 @@ impl Client {
             namespace_id: namespace_id.clone(),
             after_seq,
             page_size,
+            snapshot_id: None,
+            pending: None,
+            exhausted: false,
+        }
+    }
+
+    /// Creates a snapshot-bounded change-feed pager beginning after `after_seq`.
+    pub fn list_changes_pager_at_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+        page_size: Option<u32>,
+        snapshot_id: &CheckpointId,
+    ) -> ChangesPager {
+        ChangesPager {
+            client: self.clone(),
+            namespace_id: namespace_id.clone(),
+            after_seq,
+            page_size,
+            snapshot_id: Some(snapshot_id.clone()),
             pending: None,
             exhausted: false,
         }

--- a/crates/loonfs-client/src/reads.rs
+++ b/crates/loonfs-client/src/reads.rs
@@ -3,14 +3,12 @@
 use super::*;
 use crate::transport::{append_optional_pagination_query, append_query_param};
 
-/// Optional selectors for a path-based file-content read.
+/// Selects a retained revision or snapshot for a file read. Set at most one.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ReadFileOptions {
     /// Read one retained revision instead of the current file.
     pub revision_no: Option<RevisionNo>,
-    /// Read the file revision captured by this live snapshot.
-    ///
-    /// The server rejects a request that supplies both selectors.
+    /// Read the file revision captured by this snapshot.
     pub snapshot_id: Option<CheckpointId>,
 }
 
@@ -19,7 +17,7 @@ pub struct ReadFileOptions {
 pub struct ListChangesOptions {
     /// Maximum number of changes in the page.
     pub limit: Option<u32>,
-    /// End the feed at this live snapshot's captured sequence.
+    /// End the feed at this snapshot's captured sequence.
     pub snapshot_id: Option<CheckpointId>,
 }
 
@@ -585,10 +583,7 @@ impl Client {
         .await
     }
 
-    /// Reads path-based file content using the requested revision or snapshot.
-    ///
-    /// Both selectors are sent when both are present so the server remains
-    /// authoritative for their mutual-exclusion error.
+    /// Reads file content from a retained revision or snapshot.
     pub async fn get_file_bytes_with_options(
         &self,
         spec: &NamespacePath,

--- a/crates/loonfs-client/tests/snapshots.rs
+++ b/crates/loonfs-client/tests/snapshots.rs
@@ -1,0 +1,190 @@
+#![allow(clippy::panic)]
+
+use loonfs_api::{ChangeSeq, DestinationBehavior, NamespaceId};
+use loonfs_client::{
+    Client, ClientConfig, NamespacePath, PutFileOptions, ReadFileOptions, StatPathOptions,
+};
+use loonfs_server::{
+    app, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
+};
+use tempfile::TempDir;
+
+struct TestServer {
+    client: Client,
+    server: tokio::task::JoinHandle<()>,
+    _temp_dir: TempDir,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+async fn start_server(name: &str) -> TestServer {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let config = ServerConfig {
+        bind: "127.0.0.1:0".to_owned(),
+        auth_token: Some("test-token".into()),
+        content_token_secret: "test-content-token-secret".into(),
+        writer_id: name.to_owned(),
+        runtime_cache: RuntimeCacheConfigOverrides::default(),
+        local_cache: None,
+        grep: GrepConfig::default(),
+        maintenance: MaintenanceMode::Automatic,
+        min_publish_interval_ms: 0,
+        request_deadline_ms: 60_000,
+        shutdown_deadline_ms: 60_000,
+        max_upload_bytes: 16 * 1024 * 1024,
+        max_download_bytes: 16 * 1024 * 1024,
+        snapshot_max_ttl_ms: 60_000,
+        snapshot_max_lifetime_ms: 60_000,
+        snapshot_max_live_per_namespace: 16,
+        max_concurrent_uploads: 4,
+        max_concurrent_downloads: 4,
+        max_concurrent_maintenance: 2,
+        allow_unauthenticated_remote: false,
+        allow_remote_without_tls: false,
+        tls: None,
+        store: StoreConfig::LocalFs {
+            root: temp_dir.path().join("store").display().to_string(),
+            key_prefix: Some(name.to_owned()),
+        },
+    };
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let address = listener.local_addr().expect("listener address");
+    let (router, _writer, _cache) = app(config).await.expect("build server");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve app");
+    });
+    let client = Client::new(ClientConfig {
+        server_url: format!("http://{address}"),
+        auth_token: Some("test-token".into()),
+        request_timeout_ms: None,
+        disable_transient_retry: false,
+        ca_cert_path: None,
+    })
+    .expect("client config");
+    TestServer {
+        client,
+        server,
+        _temp_dir: temp_dir,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snapshot_lifecycle_round_trips_through_the_client() {
+    let harness = start_server("client-snapshot-lifecycle").await;
+    let namespace = NamespaceId::parse("demo").expect("namespace id");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+
+    let created = harness
+        .client
+        .create_snapshot(&namespace, "first", 5_000)
+        .await
+        .expect("create snapshot");
+    assert_eq!(created.namespace_id, namespace);
+    assert_eq!(created.name, "first");
+    assert_eq!(created.head_seq, ChangeSeq(0));
+
+    let mut pager = harness
+        .client
+        .list_snapshots_pager(&namespace, Some(1), None);
+    assert_eq!(
+        pager.collect_up_to(10).await.expect("list snapshots"),
+        vec![created.clone()]
+    );
+
+    let extended = harness
+        .client
+        .extend_snapshot(&namespace, &created.snapshot_id, 10_000)
+        .await
+        .expect("extend snapshot");
+    assert!(extended.expires_at_ms > created.expires_at_ms);
+
+    harness
+        .client
+        .release_snapshot(&namespace, &created.snapshot_id)
+        .await
+        .expect("release snapshot");
+    assert!(harness
+        .client
+        .list_snapshots_page(&namespace, None, None)
+        .await
+        .expect("list released snapshots")
+        .snapshots
+        .is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snapshot_file_read_returns_the_captured_state() {
+    let harness = start_server("client-snapshot-read").await;
+    let namespace = NamespaceId::parse("demo").expect("namespace id");
+    let path = NamespacePath::parse("demo", "/report.txt").expect("namespace path");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    harness
+        .client
+        .put_file_bytes(
+            &path,
+            b"captured",
+            &PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("write captured content");
+    let snapshot = harness
+        .client
+        .create_snapshot(&namespace, "captured", 10_000)
+        .await
+        .expect("create snapshot");
+
+    let mut replace = PutFileOptions::new(loonfs_test_support::test_actor());
+    replace.behavior = DestinationBehavior::Replace;
+    harness
+        .client
+        .put_file_bytes(&path, b"current", &replace)
+        .await
+        .expect("replace content");
+
+    let entry = harness
+        .client
+        .get_path_entry(
+            &path,
+            &StatPathOptions {
+                snapshot_id: Some(snapshot.snapshot_id.clone()),
+                ..StatPathOptions::default()
+            },
+        )
+        .await
+        .expect("snapshot stat");
+    assert_eq!(entry.head_seq, snapshot.head_seq);
+    let bytes = harness
+        .client
+        .get_file_bytes_with_options(
+            &path,
+            &ReadFileOptions {
+                revision_no: None,
+                snapshot_id: Some(snapshot.snapshot_id),
+            },
+        )
+        .await
+        .expect("snapshot content");
+    assert_eq!(bytes, b"captured");
+    assert_eq!(
+        harness
+            .client
+            .get_file_bytes(&path)
+            .await
+            .expect("current content"),
+        b"current"
+    );
+}

--- a/crates/loonfs-grep/src/reads.rs
+++ b/crates/loonfs-grep/src/reads.rs
@@ -125,6 +125,7 @@ impl<'a> NamespaceReads<'a> {
                 absolute_path.as_str(),
                 StatPathOptions {
                     include_attributes: false,
+                    snapshot_id: None,
                 },
             )
             .await?)
@@ -260,6 +261,7 @@ impl PinnedNamespaceReads<'_> {
                 absolute_path.as_str(),
                 StatPathOptions {
                     include_attributes: false,
+                    snapshot_id: None,
                 },
             )
             .await?)

--- a/crates/loonfs-server/tests/it/http_attributes.rs
+++ b/crates/loonfs-server/tests/it/http_attributes.rs
@@ -240,6 +240,7 @@ async fn the_client_round_trips_the_read_options() {
             &path("/docs/report.txt"),
             &StatPathOptions {
                 include_attributes: false,
+                snapshot_id: None,
             },
         )
         .await
@@ -259,6 +260,7 @@ async fn the_client_round_trips_the_read_options() {
         &path("/docs"),
         &ListPathEntriesOptions {
             include_attributes: true,
+            snapshot_id: None,
         },
     )
     .await

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -18,6 +18,19 @@ use loonfs_api::{
 };
 use loonfs_core::{NamespaceReaderEngine, RuntimeReadContext};
 
+/// The options carry `snapshot_id` for the wire and the CLI backends; the
+/// embedded readers pin explicitly instead, and refuse the option rather
+/// than silently reading a different state than the caller named.
+fn reject_snapshot_option(snapshot_id: &Option<CheckpointId>, place: &str) -> Result<()> {
+    if snapshot_id.is_some() {
+        return Err(loonfs_core::Error::InvalidCheckpointRequest(format!(
+            "the snapshot_id option is not accepted {place}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
 /// A namespace metadata view pinned to one head sequence.
 ///
 /// Create one from the current state, a checkpoint, or a live snapshot. All
@@ -46,6 +59,7 @@ impl FsReadSnapshot {
         absolute_path: &str,
         options: StatPathOptions,
     ) -> Result<PathEntry> {
+        reject_snapshot_option(&options.snapshot_id, "here; this view is already pinned")?;
         Ok(self
             .engine
             .resolve_path(absolute_path, options, &self.context)
@@ -59,6 +73,7 @@ impl FsReadSnapshot {
         request: PageRequest<DirectoryPageCursor>,
         options: ListPathEntriesOptions,
     ) -> Result<ListPathEntriesResponse> {
+        reject_snapshot_option(&options.snapshot_id, "here; this view is already pinned")?;
         let listed_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
         let page = self
@@ -536,6 +551,10 @@ impl FsReader {
         absolute_path: &str,
         options: StatPathOptions,
     ) -> Result<PathEntry> {
+        reject_snapshot_option(
+            &options.snapshot_id,
+            "here; pin the view with FsReader::pin_namespace_at_snapshot",
+        )?;
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
@@ -618,6 +637,10 @@ impl FsReader {
         request: PageRequest<DirectoryPageCursor>,
         options: ListPathEntriesOptions,
     ) -> Result<ListPathEntriesResponse> {
+        reject_snapshot_option(
+            &options.snapshot_id,
+            "here; pin the view with FsReader::pin_namespace_at_snapshot",
+        )?;
         self.core.record_trace_context(&tracing::Span::current());
         let (mut response, next_cursor) = self
             .list_path_entries_page_typed(namespace_id, absolute_path, request, options)

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -18,13 +18,11 @@ use loonfs_api::{
 };
 use loonfs_core::{NamespaceReaderEngine, RuntimeReadContext};
 
-/// The options carry `snapshot_id` for the wire and the CLI backends; the
-/// embedded readers pin explicitly instead, and refuse the option rather
-/// than silently reading a different state than the caller named.
-fn reject_snapshot_option(snapshot_id: &Option<CheckpointId>, place: &str) -> Result<()> {
+/// Runtime readers require callers to pin snapshots explicitly.
+fn reject_snapshot_option(snapshot_id: &Option<CheckpointId>, reader: &str) -> Result<()> {
     if snapshot_id.is_some() {
         return Err(loonfs_core::Error::InvalidCheckpointRequest(format!(
-            "the snapshot_id option is not accepted {place}"
+            "snapshot_id is not supported by {reader}"
         ))
         .into());
     }
@@ -59,7 +57,10 @@ impl FsReadSnapshot {
         absolute_path: &str,
         options: StatPathOptions,
     ) -> Result<PathEntry> {
-        reject_snapshot_option(&options.snapshot_id, "here; this view is already pinned")?;
+        reject_snapshot_option(
+            &options.snapshot_id,
+            "FsReadSnapshot because it is already pinned",
+        )?;
         Ok(self
             .engine
             .resolve_path(absolute_path, options, &self.context)
@@ -553,7 +554,7 @@ impl FsReader {
     ) -> Result<PathEntry> {
         reject_snapshot_option(
             &options.snapshot_id,
-            "here; pin the view with FsReader::pin_namespace_at_snapshot",
+            "FsReader; call pin_namespace_at_snapshot first",
         )?;
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
@@ -639,7 +640,7 @@ impl FsReader {
     ) -> Result<ListPathEntriesResponse> {
         reject_snapshot_option(
             &options.snapshot_id,
-            "here; pin the view with FsReader::pin_namespace_at_snapshot",
+            "FsReader; call pin_namespace_at_snapshot first",
         )?;
         self.core.record_trace_context(&tracing::Span::current());
         let (mut response, next_cursor) = self

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -207,6 +207,7 @@ fn read_options_project_grouped_attributes_or_none() {
         "/docs/report.txt",
         StatPathOptions {
             include_attributes: false,
+            snapshot_id: None,
         },
     ))
     .expect("stat without attributes");
@@ -228,6 +229,7 @@ fn read_options_project_grouped_attributes_or_none() {
         },
         ListPathEntriesOptions {
             include_attributes: true,
+            snapshot_id: None,
         },
     ))
     .expect("list with attributes");

--- a/crates/loonfs/tests/it/read_snapshot.rs
+++ b/crates/loonfs/tests/it/read_snapshot.rs
@@ -325,3 +325,55 @@ async fn snapshot_pins_serve_captured_state_and_enforce_release() {
         ErrorCode::SnapshotGone,
     );
 }
+
+#[tokio::test]
+async fn embedded_readers_refuse_the_snapshot_id_option() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "snapshot-option-test").await;
+    let namespace_id = NamespaceId::parse("snapshot-option-refusal").expect("namespace id");
+    runtime
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let created = runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/pinned.txt",
+            b"pinned",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create file");
+    let snapshot = runtime
+        .admin
+        .create_snapshot(
+            &namespace_id,
+            loonfs::CreateSnapshotOptions {
+                name: "option-refusal".to_owned(),
+                expires_at_ms: u64::MAX,
+            },
+        )
+        .await
+        .expect("create snapshot");
+    let with_option = loonfs::StatPathOptions {
+        snapshot_id: Some(snapshot.checkpoint_id.clone()),
+        ..Default::default()
+    };
+    assert_core_error_kind(
+        runtime
+            .reader
+            .get_path_entry(&namespace_id, "/pinned.txt", with_option.clone())
+            .await,
+        ErrorCode::InvalidRequest,
+    );
+    let pinned = runtime
+        .reader
+        .pin_namespace_at_checkpoint(&namespace_id, &snapshot.checkpoint_id)
+        .await
+        .expect("pin at snapshot record");
+    assert_core_error_kind(
+        pinned.get_path_entry("/pinned.txt", with_option).await,
+        ErrorCode::InvalidRequest,
+    );
+    assert_eq!(pinned.head_seq(), created.committed_seq);
+}

--- a/crates/loonfs/tests/it/read_snapshot.rs
+++ b/crates/loonfs/tests/it/read_snapshot.rs
@@ -272,6 +272,17 @@ async fn snapshot_pins_serve_captured_state_and_enforce_release() {
         )
         .await
         .expect("create snapshot");
+    let snapshot_options = loonfs::StatPathOptions {
+        snapshot_id: Some(snapshot.checkpoint_id.clone()),
+        ..Default::default()
+    };
+    assert_core_error_kind(
+        runtime
+            .reader
+            .get_path_entry(&namespace_id, "/pinned.txt", snapshot_options.clone())
+            .await,
+        ErrorCode::InvalidRequest,
+    );
 
     runtime
         .put_file_bytes(
@@ -290,6 +301,10 @@ async fn snapshot_pins_serve_captured_state_and_enforce_release() {
         .pin_namespace_at_snapshot(&namespace_id, &snapshot.checkpoint_id)
         .await
         .expect("pin live snapshot");
+    assert_core_error_kind(
+        pinned.get_path_entry("/pinned.txt", snapshot_options).await,
+        ErrorCode::InvalidRequest,
+    );
     assert_eq!(pinned.head_seq(), snapshot.checkpoint_seq);
     assert_eq!(
         pinned
@@ -324,56 +339,4 @@ async fn snapshot_pins_serve_captured_state_and_enforce_release() {
             .await,
         ErrorCode::SnapshotGone,
     );
-}
-
-#[tokio::test]
-async fn embedded_readers_refuse_the_snapshot_id_option() {
-    let temp_dir = tempdir().expect("tempdir");
-    let runtime = open_runtime_async(store(temp_dir.path()), "snapshot-option-test").await;
-    let namespace_id = NamespaceId::parse("snapshot-option-refusal").expect("namespace id");
-    runtime
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
-        .await
-        .expect("create namespace");
-    let created = runtime
-        .put_file_bytes(
-            &namespace_id,
-            "/pinned.txt",
-            b"pinned",
-            PutFileOptions::new(loonfs_test_support::test_actor()),
-        )
-        .await
-        .expect("create file");
-    let snapshot = runtime
-        .admin
-        .create_snapshot(
-            &namespace_id,
-            loonfs::CreateSnapshotOptions {
-                name: "option-refusal".to_owned(),
-                expires_at_ms: u64::MAX,
-            },
-        )
-        .await
-        .expect("create snapshot");
-    let with_option = loonfs::StatPathOptions {
-        snapshot_id: Some(snapshot.checkpoint_id.clone()),
-        ..Default::default()
-    };
-    assert_core_error_kind(
-        runtime
-            .reader
-            .get_path_entry(&namespace_id, "/pinned.txt", with_option.clone())
-            .await,
-        ErrorCode::InvalidRequest,
-    );
-    let pinned = runtime
-        .reader
-        .pin_namespace_at_checkpoint(&namespace_id, &snapshot.checkpoint_id)
-        .await
-        .expect("pin at snapshot record");
-    assert_core_error_kind(
-        pinned.get_path_entry("/pinned.txt", with_option).await,
-        ErrorCode::InvalidRequest,
-    );
-    assert_eq!(pinned.head_seq(), created.committed_seq);
 }


### PR DESCRIPTION
Adds snapshot support to the Rust client and CLI. Users can create, list, extend, and release snapshots, then pass `--snapshot-id` to `ls`, `stat`, `cat`, `get`, and `changes` to read the saved state.

Remote profiles send the snapshot ID to the server. Embedded profiles pin the snapshot locally before reading. Existing read methods continue to use current state when no snapshot is selected. Tests cover the snapshot lifecycle, pagination, captured reads, and error handling.