### PR TITLE
test(conformance): verify snapshot behavior across SDKs

### DIFF
--- a/crates/loonfs-conformance/cases/snapshots.json
+++ b/crates/loonfs-conformance/cases/snapshots.json
@@ -21,19 +21,13 @@
     "unknown_snapshot_id": "chk_ffffffffffffffffffffffffffffffff"
   },
   "expected": {
-    "directory_committed_seq": 1,
-    "replaced_file_committed_seq": 2,
-    "deleted_file_committed_seq": 3,
     "snapshot_head_seq": 3,
     "captured_revision_no": 1,
     "captured_entry_names": [
       "kept.txt",
       "removed.txt"
     ],
-    "replacement_committed_seq": 4,
     "current_revision_no": 2,
-    "added_file_committed_seq": 5,
-    "deletion_committed_seq": 6,
     "current_entry_names": [
       "added.txt",
       "kept.txt"

--- a/crates/loonfs-conformance/cases/snapshots.json
+++ b/crates/loonfs-conformance/cases/snapshots.json
@@ -1,0 +1,63 @@
+{
+  "name": "snapshots",
+  "intent": "Checks snapshot lifecycle operations, captured reads, bounded change feeds, and snapshot error contracts.",
+  "request": {
+    "namespace_id": "conf-snapshots",
+    "directory": "/tree",
+    "actor": {
+      "kind": "service",
+      "id": "conformance-snapshots"
+    },
+    "snapshot_name": "captured-tree",
+    "replaced_file_name": "kept.txt",
+    "deleted_file_name": "removed.txt",
+    "added_file_name": "added.txt",
+    "captured_content_utf8": "captured snapshot content",
+    "current_content_utf8": "current snapshot content",
+    "deleted_content_utf8": "removed after snapshot",
+    "added_content_utf8": "added after snapshot",
+    "create_ttl_ms": 3600000,
+    "extend_ttl_ms": 7200000,
+    "unknown_snapshot_id": "chk_ffffffffffffffffffffffffffffffff"
+  },
+  "expected": {
+    "directory_committed_seq": 1,
+    "replaced_file_committed_seq": 2,
+    "deleted_file_committed_seq": 3,
+    "snapshot_head_seq": 3,
+    "captured_revision_no": 1,
+    "captured_entry_names": [
+      "kept.txt",
+      "removed.txt"
+    ],
+    "replacement_committed_seq": 4,
+    "current_revision_no": 2,
+    "added_file_committed_seq": 5,
+    "deletion_committed_seq": 6,
+    "current_entry_names": [
+      "added.txt",
+      "kept.txt"
+    ],
+    "snapshot_change_seqs": [
+      1,
+      2,
+      3
+    ],
+    "snapshot_gone": {
+      "status": 410,
+      "code": "snapshot_gone"
+    },
+    "snapshot_not_found": {
+      "status": 404,
+      "code": "snapshot_not_found"
+    },
+    "revision_with_snapshot": {
+      "status": 400,
+      "code": "invalid_request"
+    },
+    "zero_ttl": {
+      "status": 400,
+      "code": "invalid_request"
+    }
+  }
+}

--- a/crates/loonfs-conformance/src/lib.rs
+++ b/crates/loonfs-conformance/src/lib.rs
@@ -35,6 +35,7 @@ const EXPECTED_CASES: &[&str] = &[
     "inode_mutations",
     "pagination",
     "proxy",
+    "snapshots",
     "upload_abort",
     "upload_direct_put",
     "upload_multipart",

--- a/crates/loonfs-conformance/tests/reference.rs
+++ b/crates/loonfs-conformance/tests/reference.rs
@@ -1203,16 +1203,10 @@ struct SnapshotsRequest {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct SnapshotsExpected {
-    directory_committed_seq: u64,
-    replaced_file_committed_seq: u64,
-    deleted_file_committed_seq: u64,
     snapshot_head_seq: u64,
     captured_revision_no: u64,
     captured_entry_names: Vec<String>,
-    replacement_committed_seq: u64,
     current_revision_no: u64,
-    added_file_committed_seq: u64,
-    deletion_committed_seq: u64,
     current_entry_names: Vec<String>,
     snapshot_change_seqs: Vec<u64>,
     snapshot_gone: ErrorStatusExpected,
@@ -1239,18 +1233,14 @@ async fn run_snapshots(harness: &Harness, case: &Case) {
     let directory = namespace_path(&request.namespace_id, &request.directory);
     let mut directory_options = CreateDirectoryOptions::new(request.actor.clone());
     directory_options.commit = commit_options(&request.actor, "conf-snapshots-create-directory");
-    let created_directory = harness
+    harness
         .client
         .create_directory(&directory, &directory_options)
         .await
         .expect("create snapshots directory");
-    assert_eq!(
-        created_directory.committed_seq.0,
-        expected.directory_committed_seq
-    );
 
     let replaced_path = child_path(&request.replaced_file_name);
-    let created_replaced = harness
+    harness
         .client
         .put_file_bytes(
             &replaced_path,
@@ -1259,12 +1249,8 @@ async fn run_snapshots(harness: &Harness, case: &Case) {
         )
         .await
         .expect("create replaced snapshot file");
-    assert_eq!(
-        created_replaced.committed_seq.0,
-        expected.replaced_file_committed_seq
-    );
     let deleted_path = child_path(&request.deleted_file_name);
-    let created_deleted = harness
+    harness
         .client
         .put_file_bytes(
             &deleted_path,
@@ -1273,10 +1259,6 @@ async fn run_snapshots(harness: &Harness, case: &Case) {
         )
         .await
         .expect("create deleted snapshot file");
-    assert_eq!(
-        created_deleted.committed_seq.0,
-        expected.deleted_file_committed_seq
-    );
 
     let snapshots_url = format!(
         "{}/v0/namespaces/{}/snapshots",
@@ -1301,7 +1283,7 @@ async fn run_snapshots(harness: &Harness, case: &Case) {
 
     let mut replace_options = put_options(&request.actor, "conf-snapshots-replace-file");
     replace_options.behavior = DestinationBehavior::Replace;
-    let replaced = harness
+    harness
         .client
         .put_file_bytes(
             &replaced_path,
@@ -1310,9 +1292,8 @@ async fn run_snapshots(harness: &Harness, case: &Case) {
         )
         .await
         .expect("replace snapshot file");
-    assert_eq!(replaced.committed_seq.0, expected.replacement_committed_seq);
     let added_path = child_path(&request.added_file_name);
-    let added = harness
+    harness
         .client
         .put_file_bytes(
             &added_path,
@@ -1321,15 +1302,13 @@ async fn run_snapshots(harness: &Harness, case: &Case) {
         )
         .await
         .expect("add file after snapshot");
-    assert_eq!(added.committed_seq.0, expected.added_file_committed_seq);
     let mut delete_options = DeleteOptions::new(request.actor.clone());
     delete_options.commit = commit_options(&request.actor, "conf-snapshots-delete-file");
-    let deleted = harness
+    harness
         .client
         .delete_path(&deleted_path, &delete_options)
         .await
         .expect("delete file after snapshot");
-    assert_eq!(deleted.committed_seq.0, expected.deletion_committed_seq);
 
     let snapshot_id = snapshot.snapshot_id.as_str();
     let entry_url = format!(

--- a/crates/loonfs-conformance/tests/reference.rs
+++ b/crates/loonfs-conformance/tests/reference.rs
@@ -6,12 +6,14 @@ use bytes::Bytes;
 use loonfs_api::options::DirectMultipartUploadOptions;
 use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, CompleteMultipartUploadRequest, CompleteUploadRequest,
-    ContentToken, FilesystemChange, UploadContentClaim, UploadMode, UploadPartChecksumClaim,
-    UploadSessionStatus,
+    ContentToken, CreateSnapshotRequest, ExtendSnapshotRequest, FilesystemChange,
+    ListChangesResponse, ListSnapshotsResponse, ReleaseSnapshotResponse, SnapshotSummary,
+    UploadContentClaim, UploadMode, UploadPartChecksumClaim, UploadSessionStatus,
 };
 use loonfs_api::{
     ActorRef, ApiError, ChangeSeq, Checksum, CommitId, CommitRequest, ContentRef,
     DeleteDirectoryBehavior, DestinationBehavior, DisplayName, FilesystemOperation, NamespaceId,
+    PathEntry,
 };
 use loonfs_client::{
     Client, ClientConfig, ClientError, CommitOptions, CreateDirectoryOptions, DeleteOptions,
@@ -41,6 +43,7 @@ async fn rust_client_matches_the_reference_corpus() {
             "download" => run_download(&harness, case).await,
             "pagination" => run_pagination(&harness, case).await,
             "changes" => run_changes(&harness, case).await,
+            "snapshots" => run_snapshots(&harness, case).await,
             "end_to_end" => run_end_to_end(&harness, case).await,
             // Each SDK harness runs this case against its own proxy.
             "proxy" => {}
@@ -1176,6 +1179,453 @@ async fn run_inode_mutations(harness: &Harness, case: &Case) {
         .await
         .expect("delete by inode");
     assert_eq!(deleted.committed_seq.0, expected.deleted_committed_seq);
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotsRequest {
+    namespace_id: String,
+    directory: String,
+    actor: ActorRef,
+    snapshot_name: String,
+    replaced_file_name: String,
+    deleted_file_name: String,
+    added_file_name: String,
+    captured_content_utf8: String,
+    current_content_utf8: String,
+    deleted_content_utf8: String,
+    added_content_utf8: String,
+    create_ttl_ms: u64,
+    extend_ttl_ms: u64,
+    unknown_snapshot_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotsExpected {
+    directory_committed_seq: u64,
+    replaced_file_committed_seq: u64,
+    deleted_file_committed_seq: u64,
+    snapshot_head_seq: u64,
+    captured_revision_no: u64,
+    captured_entry_names: Vec<String>,
+    replacement_committed_seq: u64,
+    current_revision_no: u64,
+    added_file_committed_seq: u64,
+    deletion_committed_seq: u64,
+    current_entry_names: Vec<String>,
+    snapshot_change_seqs: Vec<u64>,
+    snapshot_gone: ErrorStatusExpected,
+    snapshot_not_found: ErrorStatusExpected,
+    revision_with_snapshot: ErrorStatusExpected,
+    zero_ttl: ErrorStatusExpected,
+}
+
+async fn run_snapshots(harness: &Harness, case: &Case) {
+    let (request, expected) = parse_values::<SnapshotsRequest, SnapshotsExpected>(case);
+    let namespace = namespace_id(&request.namespace_id);
+    let child_path = |name: &str| {
+        namespace_path(
+            &request.namespace_id,
+            &format!("{}/{name}", request.directory),
+        )
+    };
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create snapshots namespace");
+
+    let directory = namespace_path(&request.namespace_id, &request.directory);
+    let mut directory_options = CreateDirectoryOptions::new(request.actor.clone());
+    directory_options.commit = commit_options(&request.actor, "conf-snapshots-create-directory");
+    let created_directory = harness
+        .client
+        .create_directory(&directory, &directory_options)
+        .await
+        .expect("create snapshots directory");
+    assert_eq!(
+        created_directory.committed_seq.0,
+        expected.directory_committed_seq
+    );
+
+    let replaced_path = child_path(&request.replaced_file_name);
+    let created_replaced = harness
+        .client
+        .put_file_bytes(
+            &replaced_path,
+            request.captured_content_utf8.as_bytes(),
+            &put_options(&request.actor, "conf-snapshots-create-replaced"),
+        )
+        .await
+        .expect("create replaced snapshot file");
+    assert_eq!(
+        created_replaced.committed_seq.0,
+        expected.replaced_file_committed_seq
+    );
+    let deleted_path = child_path(&request.deleted_file_name);
+    let created_deleted = harness
+        .client
+        .put_file_bytes(
+            &deleted_path,
+            request.deleted_content_utf8.as_bytes(),
+            &put_options(&request.actor, "conf-snapshots-create-deleted"),
+        )
+        .await
+        .expect("create deleted snapshot file");
+    assert_eq!(
+        created_deleted.committed_seq.0,
+        expected.deleted_file_committed_seq
+    );
+
+    let snapshots_url = format!(
+        "{}/v0/namespaces/{}/snapshots",
+        harness.server_url, request.namespace_id
+    );
+    let snapshot: SnapshotSummary = raw_success_json(
+        harness
+            .raw_client
+            .post(&snapshots_url)
+            .bearer_auth(AUTH_TOKEN)
+            .json(&CreateSnapshotRequest {
+                name: request.snapshot_name.clone(),
+                ttl_ms: request.create_ttl_ms,
+            }),
+        "create snapshot",
+    )
+    .await;
+    assert_eq!(snapshot.namespace_id, namespace);
+    assert_eq!(snapshot.name, request.snapshot_name);
+    assert_eq!(snapshot.head_seq.0, expected.snapshot_head_seq);
+    assert!(snapshot.expires_at_ms > snapshot.created_at_ms);
+
+    let mut replace_options = put_options(&request.actor, "conf-snapshots-replace-file");
+    replace_options.behavior = DestinationBehavior::Replace;
+    let replaced = harness
+        .client
+        .put_file_bytes(
+            &replaced_path,
+            request.current_content_utf8.as_bytes(),
+            &replace_options,
+        )
+        .await
+        .expect("replace snapshot file");
+    assert_eq!(replaced.committed_seq.0, expected.replacement_committed_seq);
+    let added_path = child_path(&request.added_file_name);
+    let added = harness
+        .client
+        .put_file_bytes(
+            &added_path,
+            request.added_content_utf8.as_bytes(),
+            &put_options(&request.actor, "conf-snapshots-add-file"),
+        )
+        .await
+        .expect("add file after snapshot");
+    assert_eq!(added.committed_seq.0, expected.added_file_committed_seq);
+    let mut delete_options = DeleteOptions::new(request.actor.clone());
+    delete_options.commit = commit_options(&request.actor, "conf-snapshots-delete-file");
+    let deleted = harness
+        .client
+        .delete_path(&deleted_path, &delete_options)
+        .await
+        .expect("delete file after snapshot");
+    assert_eq!(deleted.committed_seq.0, expected.deletion_committed_seq);
+
+    let snapshot_id = snapshot.snapshot_id.as_str();
+    let entry_url = format!(
+        "{}/v0/namespaces/{}/filesystem/entry",
+        harness.server_url, request.namespace_id
+    );
+    let captured_entry: PathEntry = raw_success_json(
+        harness
+            .raw_client
+            .get(&entry_url)
+            .bearer_auth(AUTH_TOKEN)
+            .query(&[
+                ("path", replaced_path.absolute_path().as_str()),
+                ("snapshot_id", snapshot_id),
+            ]),
+        "stat snapshot file",
+    )
+    .await;
+    assert_eq!(
+        captured_entry
+            .revision_no()
+            .expect("captured file revision")
+            .0,
+        expected.captured_revision_no
+    );
+    let current_entry: PathEntry = raw_success_json(
+        harness
+            .raw_client
+            .get(&entry_url)
+            .bearer_auth(AUTH_TOKEN)
+            .query(&[("path", replaced_path.absolute_path().as_str())]),
+        "stat current file",
+    )
+    .await;
+    assert_eq!(
+        current_entry
+            .revision_no()
+            .expect("current file revision")
+            .0,
+        expected.current_revision_no
+    );
+
+    let entries_url = format!(
+        "{}/v0/namespaces/{}/filesystem/entries",
+        harness.server_url, request.namespace_id
+    );
+    let captured_listing: loonfs_api::v0::ListPathEntriesResponse = raw_success_json(
+        harness
+            .raw_client
+            .get(&entries_url)
+            .bearer_auth(AUTH_TOKEN)
+            .query(&[
+                ("path", directory.absolute_path().as_str()),
+                ("snapshot_id", snapshot_id),
+            ]),
+        "list snapshot directory",
+    )
+    .await;
+    assert_eq!(captured_listing.head_seq.0, expected.snapshot_head_seq);
+    assert_eq!(
+        listed_entry_names(&captured_listing.entries),
+        expected.captured_entry_names
+    );
+    let current_listing: loonfs_api::v0::ListPathEntriesResponse = raw_success_json(
+        harness
+            .raw_client
+            .get(&entries_url)
+            .bearer_auth(AUTH_TOKEN)
+            .query(&[("path", directory.absolute_path().as_str())]),
+        "list current directory",
+    )
+    .await;
+    assert_eq!(
+        listed_entry_names(&current_listing.entries),
+        expected.current_entry_names
+    );
+
+    let content_url = format!(
+        "{}/v0/namespaces/{}/filesystem/content",
+        harness.server_url, request.namespace_id
+    );
+    let captured_content = raw_success_bytes(
+        harness
+            .raw_client
+            .get(&content_url)
+            .bearer_auth(AUTH_TOKEN)
+            .query(&[
+                ("path", replaced_path.absolute_path().as_str()),
+                ("snapshot_id", snapshot_id),
+            ]),
+        "read snapshot content",
+    )
+    .await;
+    assert_eq!(
+        captured_content.as_ref(),
+        request.captured_content_utf8.as_bytes()
+    );
+    let current_content = raw_success_bytes(
+        harness
+            .raw_client
+            .get(&content_url)
+            .bearer_auth(AUTH_TOKEN)
+            .query(&[("path", replaced_path.absolute_path().as_str())]),
+        "read current content",
+    )
+    .await;
+    assert_eq!(
+        current_content.as_ref(),
+        request.current_content_utf8.as_bytes()
+    );
+
+    let changes_url = format!(
+        "{}/v0/namespaces/{}/changes",
+        harness.server_url, request.namespace_id
+    );
+    let feed: ListChangesResponse = raw_success_json(
+        harness
+            .raw_client
+            .get(&changes_url)
+            .bearer_auth(AUTH_TOKEN)
+            .query(&[
+                ("after_seq", "0"),
+                ("limit", "100"),
+                ("snapshot_id", snapshot_id),
+            ]),
+        "list snapshot changes",
+    )
+    .await;
+    assert_eq!(feed.through_seq.0, expected.snapshot_head_seq);
+    assert_eq!(feed.next_after_seq, None);
+    assert_eq!(
+        feed.changes
+            .iter()
+            .map(|change| change.committed_seq.0)
+            .collect::<Vec<_>>(),
+        expected.snapshot_change_seqs
+    );
+
+    let extended: SnapshotSummary = raw_success_json(
+        harness
+            .raw_client
+            .post(format!("{snapshots_url}/{snapshot_id}/extend"))
+            .bearer_auth(AUTH_TOKEN)
+            .json(&ExtendSnapshotRequest {
+                ttl_ms: request.extend_ttl_ms,
+            }),
+        "extend snapshot",
+    )
+    .await;
+    assert_eq!(extended.snapshot_id, snapshot.snapshot_id);
+    assert_eq!(extended.head_seq.0, expected.snapshot_head_seq);
+    assert_eq!(extended.name, request.snapshot_name);
+    assert!(extended.expires_at_ms > snapshot.expires_at_ms);
+
+    let listed: ListSnapshotsResponse = raw_success_json(
+        harness
+            .raw_client
+            .get(&snapshots_url)
+            .bearer_auth(AUTH_TOKEN),
+        "list snapshots",
+    )
+    .await;
+    assert_eq!(listed.namespace_id, namespace);
+    assert_eq!(listed.next_cursor, None);
+    assert_eq!(listed.snapshots.len(), 1);
+    assert_eq!(listed.snapshots[0].snapshot_id, snapshot.snapshot_id);
+
+    let release_url = format!("{snapshots_url}/{snapshot_id}/release");
+    for label in ["release snapshot", "release snapshot again"] {
+        let released: ReleaseSnapshotResponse = raw_success_json(
+            harness
+                .raw_client
+                .post(&release_url)
+                .bearer_auth(AUTH_TOKEN),
+            label,
+        )
+        .await;
+        assert_eq!(released.namespace_id, namespace);
+        assert_eq!(released.snapshot_id, snapshot.snapshot_id);
+    }
+
+    let released_read = harness
+        .raw_client
+        .get(&entry_url)
+        .bearer_auth(AUTH_TOKEN)
+        .query(&[
+            ("path", replaced_path.absolute_path().as_str()),
+            ("snapshot_id", snapshot_id),
+        ])
+        .send()
+        .await
+        .expect("send released snapshot read");
+    assert_raw_status_error(released_read, &expected.snapshot_gone).await;
+    let released_extend = harness
+        .raw_client
+        .post(format!("{snapshots_url}/{snapshot_id}/extend"))
+        .bearer_auth(AUTH_TOKEN)
+        .json(&ExtendSnapshotRequest {
+            ttl_ms: request.extend_ttl_ms,
+        })
+        .send()
+        .await
+        .expect("send released snapshot extend");
+    assert_raw_status_error(released_extend, &expected.snapshot_gone).await;
+
+    let unknown_read = harness
+        .raw_client
+        .get(&entry_url)
+        .bearer_auth(AUTH_TOKEN)
+        .query(&[
+            ("path", replaced_path.absolute_path().as_str()),
+            ("snapshot_id", request.unknown_snapshot_id.as_str()),
+        ])
+        .send()
+        .await
+        .expect("send unknown snapshot read");
+    assert_raw_status_error(unknown_read, &expected.snapshot_not_found).await;
+    let revision_with_snapshot = harness
+        .raw_client
+        .get(&content_url)
+        .bearer_auth(AUTH_TOKEN)
+        .query(&[
+            ("path", replaced_path.absolute_path().as_str()),
+            ("revision_no", "1"),
+            ("snapshot_id", snapshot_id),
+        ])
+        .send()
+        .await
+        .expect("send revision with snapshot read");
+    assert_raw_status_error(revision_with_snapshot, &expected.revision_with_snapshot).await;
+    let zero_ttl = harness
+        .raw_client
+        .post(&snapshots_url)
+        .bearer_auth(AUTH_TOKEN)
+        .json(&CreateSnapshotRequest {
+            name: request.snapshot_name,
+            ttl_ms: 0,
+        })
+        .send()
+        .await
+        .expect("send zero-ttl snapshot create");
+    assert_raw_status_error(zero_ttl, &expected.zero_ttl).await;
+}
+
+fn listed_entry_names(entries: &[PathEntry]) -> Vec<String> {
+    entries
+        .iter()
+        .map(|entry| {
+            entry
+                .display_name
+                .as_ref()
+                .expect("listed name")
+                .to_string()
+        })
+        .collect()
+}
+
+async fn raw_success_json<T>(request: reqwest::RequestBuilder, label: &str) -> T
+where
+    T: DeserializeOwned,
+{
+    let response = request
+        .send()
+        .await
+        .unwrap_or_else(|error| panic!("{label} request failed: {error}"));
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        panic!("{label} returned {status}: {body}");
+    }
+    response
+        .json()
+        .await
+        .unwrap_or_else(|error| panic!("decode {label} response: {error}"))
+}
+
+async fn raw_success_bytes(request: reqwest::RequestBuilder, label: &str) -> Bytes {
+    let response = request
+        .send()
+        .await
+        .unwrap_or_else(|error| panic!("{label} request failed: {error}"));
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        panic!("{label} returned {status}: {body}");
+    }
+    response
+        .bytes()
+        .await
+        .unwrap_or_else(|error| panic!("read {label} response: {error}"))
+}
+
+async fn assert_raw_status_error(response: reqwest::Response, expected: &ErrorStatusExpected) {
+    assert_eq!(response.status().as_u16(), expected.status);
+    let error: ApiError = response.json().await.expect("decode API error envelope");
+    assert_eq!(error.code, expected.code);
 }
 
 fn assert_api_error(error: &ClientError, expected: &ErrorStatusExpected) {

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -1383,22 +1383,16 @@ type snapshotsRequest struct {
 }
 
 type snapshotsExpected struct {
-	DirectoryCommittedSeq    int64               `json:"directory_committed_seq"`
-	ReplacedFileCommittedSeq int64               `json:"replaced_file_committed_seq"`
-	DeletedFileCommittedSeq  int64               `json:"deleted_file_committed_seq"`
-	SnapshotHeadSeq          int64               `json:"snapshot_head_seq"`
-	CapturedRevisionNo       int64               `json:"captured_revision_no"`
-	CapturedEntryNames       []string            `json:"captured_entry_names"`
-	ReplacementCommittedSeq  int64               `json:"replacement_committed_seq"`
-	CurrentRevisionNo        int64               `json:"current_revision_no"`
-	AddedFileCommittedSeq    int64               `json:"added_file_committed_seq"`
-	DeletionCommittedSeq     int64               `json:"deletion_committed_seq"`
-	CurrentEntryNames        []string            `json:"current_entry_names"`
-	SnapshotChangeSeqs       []int64             `json:"snapshot_change_seqs"`
-	SnapshotGone             errorStatusExpected `json:"snapshot_gone"`
-	SnapshotNotFound         errorStatusExpected `json:"snapshot_not_found"`
-	RevisionWithSnapshot     errorStatusExpected `json:"revision_with_snapshot"`
-	ZeroTtl                  errorStatusExpected `json:"zero_ttl"`
+	SnapshotHeadSeq      int64               `json:"snapshot_head_seq"`
+	CapturedRevisionNo   int64               `json:"captured_revision_no"`
+	CapturedEntryNames   []string            `json:"captured_entry_names"`
+	CurrentRevisionNo    int64               `json:"current_revision_no"`
+	CurrentEntryNames    []string            `json:"current_entry_names"`
+	SnapshotChangeSeqs   []int64             `json:"snapshot_change_seqs"`
+	SnapshotGone         errorStatusExpected `json:"snapshot_gone"`
+	SnapshotNotFound     errorStatusExpected `json:"snapshot_not_found"`
+	RevisionWithSnapshot errorStatusExpected `json:"revision_with_snapshot"`
+	ZeroTtl              errorStatusExpected `json:"zero_ttl"`
 }
 
 func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
@@ -1408,7 +1402,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	childPath := func(name string) string { return request.Directory + "/" + name }
 	createNamespace(t, h.client, request.NamespaceID)
 
-	directory := applyCommit(
+	applyCommit(
 		t,
 		h.client,
 		createDirectoryCommit(
@@ -1419,10 +1413,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 			nil,
 		),
 	)
-	if int64(directory.CommittedSeq) != expected.DirectoryCommittedSeq {
-		t.Errorf("directory committed_seq = %d, want %d", directory.CommittedSeq, expected.DirectoryCommittedSeq)
-	}
-	createdReplaced, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+	_, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.ReplacedFileName)),
 		Bytes:       []byte(request.CapturedContentUTF8),
@@ -1432,10 +1423,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	if err != nil {
 		t.Fatalf("create replaced snapshot file: %v", err)
 	}
-	if int64(createdReplaced.CommittedSeq) != expected.ReplacedFileCommittedSeq {
-		t.Errorf("replaced file committed_seq = %d, want %d", createdReplaced.CommittedSeq, expected.ReplacedFileCommittedSeq)
-	}
-	createdDeleted, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+	_, err = transfers.PutFile(ctx, h.client, transfers.PutFileInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.DeletedFileName)),
 		Bytes:       []byte(request.DeletedContentUTF8),
@@ -1444,9 +1432,6 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	})
 	if err != nil {
 		t.Fatalf("create deleted snapshot file: %v", err)
-	}
-	if int64(createdDeleted.CommittedSeq) != expected.DeletedFileCommittedSeq {
-		t.Errorf("deleted file committed_seq = %d, want %d", createdDeleted.CommittedSeq, expected.DeletedFileCommittedSeq)
 	}
 
 	snapshot, err := h.client.Namespaces.CreateSnapshot(ctx, &loonfs.CreateSnapshotRequest{
@@ -1471,7 +1456,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	replace := loonfs.DestinationBehaviorReplace
-	replaced, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+	_, err = transfers.PutFile(ctx, h.client, transfers.PutFileInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.ReplacedFileName)),
 		Bytes:       []byte(request.CurrentContentUTF8),
@@ -1482,10 +1467,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	if err != nil {
 		t.Fatalf("replace snapshot file: %v", err)
 	}
-	if int64(replaced.CommittedSeq) != expected.ReplacementCommittedSeq {
-		t.Errorf("replacement committed_seq = %d, want %d", replaced.CommittedSeq, expected.ReplacementCommittedSeq)
-	}
-	added, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+	_, err = transfers.PutFile(ctx, h.client, transfers.PutFileInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.AddedFileName)),
 		Bytes:       []byte(request.AddedContentUTF8),
@@ -1495,11 +1477,8 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	if err != nil {
 		t.Fatalf("add file after snapshot: %v", err)
 	}
-	if int64(added.CommittedSeq) != expected.AddedFileCommittedSeq {
-		t.Errorf("added file committed_seq = %d, want %d", added.CommittedSeq, expected.AddedFileCommittedSeq)
-	}
 	nonRecursive := loonfs.DeleteDirectoryBehaviorNonRecursive
-	deleted := applyCommit(t, h.client, &loonfs.CommitRequest{
+	applyCommit(t, h.client, &loonfs.CommitRequest{
 		NamespaceID: request.NamespaceID,
 		Actor:       &request.Actor,
 		CommitID:    loonfs.CommitID("conf-snapshots-delete-file"),
@@ -1512,9 +1491,6 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 			},
 		},
 	})
-	if int64(deleted.CommittedSeq) != expected.DeletionCommittedSeq {
-		t.Errorf("deletion committed_seq = %d, want %d", deleted.CommittedSeq, expected.DeletionCommittedSeq)
-	}
 
 	snapshotID := snapshot.SnapshotID
 	capturedEntry, err := h.client.Filesystem.GetPathEntry(ctx, &loonfs.GetPathEntryRequest{

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -44,6 +44,7 @@ var expectedCases = []string{
 	"inode_mutations",
 	"pagination",
 	"proxy",
+	"snapshots",
 	"upload_abort",
 	"upload_direct_put",
 	"upload_multipart",
@@ -91,6 +92,8 @@ func TestSDKConformance(t *testing.T) {
 				runChildrenByInode(t, h, testCase)
 			case "inode_mutations":
 				runInodeMutations(t, h, testCase)
+			case "snapshots":
+				runSnapshots(t, h, testCase)
 			case "error_contract":
 				runErrorContract(t, h, testCase)
 			case "commit_replay":
@@ -1360,6 +1363,376 @@ func contentTokens(token *loonfs.ContentToken) []*loonfs.ContentToken {
 		return nil
 	}
 	return []*loonfs.ContentToken{token}
+}
+
+type snapshotsRequest struct {
+	NamespaceID         string          `json:"namespace_id"`
+	Directory           string          `json:"directory"`
+	Actor               loonfs.ActorRef `json:"actor"`
+	SnapshotName        string          `json:"snapshot_name"`
+	ReplacedFileName    string          `json:"replaced_file_name"`
+	DeletedFileName     string          `json:"deleted_file_name"`
+	AddedFileName       string          `json:"added_file_name"`
+	CapturedContentUTF8 string          `json:"captured_content_utf8"`
+	CurrentContentUTF8  string          `json:"current_content_utf8"`
+	DeletedContentUTF8  string          `json:"deleted_content_utf8"`
+	AddedContentUTF8    string          `json:"added_content_utf8"`
+	CreateTTLMs         int64           `json:"create_ttl_ms"`
+	ExtendTTLMs         int64           `json:"extend_ttl_ms"`
+	UnknownSnapshotID   string          `json:"unknown_snapshot_id"`
+}
+
+type snapshotsExpected struct {
+	DirectoryCommittedSeq    int64               `json:"directory_committed_seq"`
+	ReplacedFileCommittedSeq int64               `json:"replaced_file_committed_seq"`
+	DeletedFileCommittedSeq  int64               `json:"deleted_file_committed_seq"`
+	SnapshotHeadSeq          int64               `json:"snapshot_head_seq"`
+	CapturedRevisionNo       int64               `json:"captured_revision_no"`
+	CapturedEntryNames       []string            `json:"captured_entry_names"`
+	ReplacementCommittedSeq  int64               `json:"replacement_committed_seq"`
+	CurrentRevisionNo        int64               `json:"current_revision_no"`
+	AddedFileCommittedSeq    int64               `json:"added_file_committed_seq"`
+	DeletionCommittedSeq     int64               `json:"deletion_committed_seq"`
+	CurrentEntryNames        []string            `json:"current_entry_names"`
+	SnapshotChangeSeqs       []int64             `json:"snapshot_change_seqs"`
+	SnapshotGone             errorStatusExpected `json:"snapshot_gone"`
+	SnapshotNotFound         errorStatusExpected `json:"snapshot_not_found"`
+	RevisionWithSnapshot     errorStatusExpected `json:"revision_with_snapshot"`
+	ZeroTtl                  errorStatusExpected `json:"zero_ttl"`
+}
+
+func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
+	t.Helper()
+	request, expected := decodeCaseValues[snapshotsRequest, snapshotsExpected](t, testCase)
+	ctx := context.Background()
+	childPath := func(name string) string { return request.Directory + "/" + name }
+	createNamespace(t, h.client, request.NamespaceID)
+
+	directory := applyCommit(
+		t,
+		h.client,
+		createDirectoryCommit(
+			request.NamespaceID,
+			"conf-snapshots-create-directory",
+			&request.Actor,
+			request.Directory,
+			nil,
+		),
+	)
+	if int64(directory.CommittedSeq) != expected.DirectoryCommittedSeq {
+		t.Errorf("directory committed_seq = %d, want %d", directory.CommittedSeq, expected.DirectoryCommittedSeq)
+	}
+	createdReplaced, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
+		Path:        loonfs.AbsolutePath(childPath(request.ReplacedFileName)),
+		Bytes:       []byte(request.CapturedContentUTF8),
+		Actor:       &request.Actor,
+		CommitID:    loonfs.CommitID("conf-snapshots-create-replaced"),
+	})
+	if err != nil {
+		t.Fatalf("create replaced snapshot file: %v", err)
+	}
+	if int64(createdReplaced.CommittedSeq) != expected.ReplacedFileCommittedSeq {
+		t.Errorf("replaced file committed_seq = %d, want %d", createdReplaced.CommittedSeq, expected.ReplacedFileCommittedSeq)
+	}
+	createdDeleted, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
+		Path:        loonfs.AbsolutePath(childPath(request.DeletedFileName)),
+		Bytes:       []byte(request.DeletedContentUTF8),
+		Actor:       &request.Actor,
+		CommitID:    loonfs.CommitID("conf-snapshots-create-deleted"),
+	})
+	if err != nil {
+		t.Fatalf("create deleted snapshot file: %v", err)
+	}
+	if int64(createdDeleted.CommittedSeq) != expected.DeletedFileCommittedSeq {
+		t.Errorf("deleted file committed_seq = %d, want %d", createdDeleted.CommittedSeq, expected.DeletedFileCommittedSeq)
+	}
+
+	snapshot, err := h.client.Namespaces.CreateSnapshot(ctx, &loonfs.CreateSnapshotRequest{
+		NamespaceID: request.NamespaceID,
+		Name:        request.SnapshotName,
+		TTLMs:       request.CreateTTLMs,
+	})
+	if err != nil {
+		t.Fatalf("create snapshot: %v", err)
+	}
+	if string(snapshot.NamespaceID) != request.NamespaceID {
+		t.Errorf("snapshot namespace_id = %q, want %q", snapshot.NamespaceID, request.NamespaceID)
+	}
+	if snapshot.Name != request.SnapshotName {
+		t.Errorf("snapshot name = %q, want %q", snapshot.Name, request.SnapshotName)
+	}
+	if int64(snapshot.HeadSeq) != expected.SnapshotHeadSeq {
+		t.Errorf("snapshot head_seq = %d, want %d", snapshot.HeadSeq, expected.SnapshotHeadSeq)
+	}
+	if snapshot.ExpiresAtMs <= snapshot.CreatedAtMs {
+		t.Errorf("snapshot expires_at_ms = %d, want greater than created_at_ms %d", snapshot.ExpiresAtMs, snapshot.CreatedAtMs)
+	}
+
+	replace := loonfs.DestinationBehaviorReplace
+	replaced, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
+		Path:        loonfs.AbsolutePath(childPath(request.ReplacedFileName)),
+		Bytes:       []byte(request.CurrentContentUTF8),
+		Actor:       &request.Actor,
+		CommitID:    loonfs.CommitID("conf-snapshots-replace-file"),
+		Behavior:    replace,
+	})
+	if err != nil {
+		t.Fatalf("replace snapshot file: %v", err)
+	}
+	if int64(replaced.CommittedSeq) != expected.ReplacementCommittedSeq {
+		t.Errorf("replacement committed_seq = %d, want %d", replaced.CommittedSeq, expected.ReplacementCommittedSeq)
+	}
+	added, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
+		Path:        loonfs.AbsolutePath(childPath(request.AddedFileName)),
+		Bytes:       []byte(request.AddedContentUTF8),
+		Actor:       &request.Actor,
+		CommitID:    loonfs.CommitID("conf-snapshots-add-file"),
+	})
+	if err != nil {
+		t.Fatalf("add file after snapshot: %v", err)
+	}
+	if int64(added.CommittedSeq) != expected.AddedFileCommittedSeq {
+		t.Errorf("added file committed_seq = %d, want %d", added.CommittedSeq, expected.AddedFileCommittedSeq)
+	}
+	nonRecursive := loonfs.DeleteDirectoryBehaviorNonRecursive
+	deleted := applyCommit(t, h.client, &loonfs.CommitRequest{
+		NamespaceID: request.NamespaceID,
+		Actor:       &request.Actor,
+		CommitID:    loonfs.CommitID("conf-snapshots-delete-file"),
+		Operations: []*loonfs.FilesystemOperation{
+			{
+				DeletePath: &loonfs.FilesystemOperationDeletePath{
+					Behavior: &nonRecursive,
+					Path:     loonfs.AbsolutePath(childPath(request.DeletedFileName)),
+				},
+			},
+		},
+	})
+	if int64(deleted.CommittedSeq) != expected.DeletionCommittedSeq {
+		t.Errorf("deletion committed_seq = %d, want %d", deleted.CommittedSeq, expected.DeletionCommittedSeq)
+	}
+
+	snapshotID := snapshot.SnapshotID
+	capturedEntry, err := h.client.Filesystem.GetPathEntry(ctx, &loonfs.GetPathEntryRequest{
+		NamespaceID: request.NamespaceID,
+		Path:        childPath(request.ReplacedFileName),
+		SnapshotID:  &snapshotID,
+	})
+	if err != nil {
+		t.Fatalf("stat snapshot file: %v", err)
+	}
+	if revision := requireFileProjection(t, capturedEntry).RevisionNo; int64(revision) != expected.CapturedRevisionNo {
+		t.Errorf("captured revision_no = %d, want %d", revision, expected.CapturedRevisionNo)
+	}
+	currentEntry := statPath(t, h.client, request.NamespaceID, childPath(request.ReplacedFileName))
+	if revision := requireFileProjection(t, currentEntry).RevisionNo; int64(revision) != expected.CurrentRevisionNo {
+		t.Errorf("current revision_no = %d, want %d", revision, expected.CurrentRevisionNo)
+	}
+
+	capturedListing, err := h.client.Filesystem.ListPathEntries(ctx, &loonfs.ListPathEntriesRequest{
+		NamespaceID: request.NamespaceID,
+		Path:        request.Directory,
+		SnapshotID:  &snapshotID,
+	})
+	if err != nil {
+		t.Fatalf("list snapshot directory: %v", err)
+	}
+	if capturedListing.Response == nil {
+		t.Fatal("snapshot directory page has no response")
+	}
+	if int64(capturedListing.Response.HeadSeq) != expected.SnapshotHeadSeq {
+		t.Errorf("snapshot listing head_seq = %d, want %d", capturedListing.Response.HeadSeq, expected.SnapshotHeadSeq)
+	}
+	if names := listedNames(t, capturedListing.Results); !equalStrings(names, expected.CapturedEntryNames) {
+		t.Errorf("snapshot listing names = %v, want %v", names, expected.CapturedEntryNames)
+	}
+	currentListing := listPathEntries(t, h.client, request.NamespaceID, request.Directory)
+	if names := listedNames(t, currentListing); !equalStrings(names, expected.CurrentEntryNames) {
+		t.Errorf("current listing names = %v, want %v", names, expected.CurrentEntryNames)
+	}
+
+	capturedBytes := readSDKFileBytes(t, h.client, &loonfs.GetFileBytesRequest{
+		NamespaceID: request.NamespaceID,
+		Path:        childPath(request.ReplacedFileName),
+		SnapshotID:  &snapshotID,
+	}, "read snapshot content")
+	if !bytes.Equal(capturedBytes, []byte(request.CapturedContentUTF8)) {
+		t.Error("snapshot content did not match the captured payload")
+	}
+	currentBytes := readSDKFileBytes(t, h.client, &loonfs.GetFileBytesRequest{
+		NamespaceID: request.NamespaceID,
+		Path:        childPath(request.ReplacedFileName),
+	}, "read current content")
+	if !bytes.Equal(currentBytes, []byte(request.CurrentContentUTF8)) {
+		t.Error("current content did not match the replacement payload")
+	}
+
+	limit := 100
+	feed, err := h.client.Filesystem.ListChanges(ctx, &loonfs.ListChangesRequest{
+		NamespaceID: request.NamespaceID,
+		AfterSeq:    loonfs.ChangeSeq(0),
+		Limit:       &limit,
+		SnapshotID:  &snapshotID,
+	})
+	if err != nil {
+		t.Fatalf("list snapshot changes: %v", err)
+	}
+	if int64(feed.ThroughSeq) != expected.SnapshotHeadSeq {
+		t.Errorf("snapshot changes through_seq = %d, want %d", feed.ThroughSeq, expected.SnapshotHeadSeq)
+	}
+	if feed.NextAfterSeq != nil {
+		t.Errorf("snapshot changes next_after_seq = %d, want nil", *feed.NextAfterSeq)
+	}
+	changeSeqs := make([]int64, 0, len(feed.Changes))
+	for _, change := range feed.Changes {
+		changeSeqs = append(changeSeqs, int64(change.CommittedSeq))
+	}
+	if !equalInt64s(changeSeqs, expected.SnapshotChangeSeqs) {
+		t.Errorf("snapshot change seqs = %v, want %v", changeSeqs, expected.SnapshotChangeSeqs)
+	}
+
+	extended, err := h.client.Namespaces.ExtendSnapshot(ctx, &loonfs.ExtendSnapshotRequest{
+		NamespaceID: request.NamespaceID,
+		SnapshotID:  snapshotID,
+		TTLMs:       request.ExtendTTLMs,
+	})
+	if err != nil {
+		t.Fatalf("extend snapshot: %v", err)
+	}
+	if extended.SnapshotID != snapshotID || int64(extended.HeadSeq) != expected.SnapshotHeadSeq || extended.Name != request.SnapshotName {
+		t.Errorf("extended snapshot = %#v, want the created snapshot", extended)
+	}
+	if extended.ExpiresAtMs <= snapshot.ExpiresAtMs {
+		t.Errorf("extended expires_at_ms = %d, want greater than %d", extended.ExpiresAtMs, snapshot.ExpiresAtMs)
+	}
+
+	listed, err := h.client.Namespaces.ListSnapshots(ctx, &loonfs.ListSnapshotsRequest{
+		NamespaceID: request.NamespaceID,
+	})
+	if err != nil {
+		t.Fatalf("list snapshots: %v", err)
+	}
+	if listed.Response == nil {
+		t.Fatal("snapshot page has no response")
+	}
+	if string(listed.Response.NamespaceID) != request.NamespaceID || listed.Response.NextCursor != nil {
+		t.Errorf("snapshot page response = %#v", listed.Response)
+	}
+	if len(listed.Results) != 1 || listed.Results[0].SnapshotID != snapshotID {
+		t.Errorf("listed snapshots = %#v, want only %q", listed.Results, snapshotID)
+	}
+
+	releaseRequest := &loonfs.ReleaseSnapshotRequest{
+		NamespaceID: request.NamespaceID,
+		SnapshotID:  snapshotID,
+	}
+	for _, label := range []string{"release snapshot", "release snapshot again"} {
+		released, releaseErr := h.client.Namespaces.ReleaseSnapshot(ctx, releaseRequest)
+		if releaseErr != nil {
+			t.Fatalf("%s: %v", label, releaseErr)
+		}
+		if string(released.NamespaceID) != request.NamespaceID || released.SnapshotID != snapshotID {
+			t.Errorf("%s response = %#v", label, released)
+		}
+	}
+
+	_, err = h.client.Filesystem.GetPathEntry(ctx, &loonfs.GetPathEntryRequest{
+		NamespaceID: request.NamespaceID,
+		Path:        childPath(request.ReplacedFileName),
+		SnapshotID:  &snapshotID,
+	})
+	assertGoneError(t, err, expected.SnapshotGone)
+	_, err = h.client.Namespaces.ExtendSnapshot(ctx, &loonfs.ExtendSnapshotRequest{
+		NamespaceID: request.NamespaceID,
+		SnapshotID:  snapshotID,
+		TTLMs:       request.ExtendTTLMs,
+	})
+	assertGoneError(t, err, expected.SnapshotGone)
+
+	unknownSnapshotID := loonfs.CheckpointID(request.UnknownSnapshotID)
+	_, err = h.client.Filesystem.GetPathEntry(ctx, &loonfs.GetPathEntryRequest{
+		NamespaceID: request.NamespaceID,
+		Path:        childPath(request.ReplacedFileName),
+		SnapshotID:  &unknownSnapshotID,
+	})
+	var notFound *loonfs.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected NotFoundError, found %T: %v", err, err)
+	}
+	if notFound.StatusCode != expected.SnapshotNotFound.Status || notFound.Body == nil || notFound.Body.Code != expected.SnapshotNotFound.Code {
+		t.Errorf("unknown snapshot error = %#v, want %#v", notFound, expected.SnapshotNotFound)
+	}
+
+	revision := loonfs.RevisionNo(expected.CapturedRevisionNo)
+	_, err = h.client.Filesystem.GetFileBytes(ctx, &loonfs.GetFileBytesRequest{
+		NamespaceID: request.NamespaceID,
+		Path:        childPath(request.ReplacedFileName),
+		RevisionNo:  &revision,
+		SnapshotID:  &snapshotID,
+	})
+	assertBadRequestError(t, err, expected.RevisionWithSnapshot)
+	_, err = h.client.Namespaces.CreateSnapshot(ctx, &loonfs.CreateSnapshotRequest{
+		NamespaceID: request.NamespaceID,
+		Name:        request.SnapshotName,
+		TTLMs:       0,
+	})
+	assertBadRequestError(t, err, expected.ZeroTtl)
+}
+
+func readSDKFileBytes(
+	t *testing.T,
+	sdk *client.Client,
+	request *loonfs.GetFileBytesRequest,
+	label string,
+) []byte {
+	t.Helper()
+	reader, err := sdk.Filesystem.GetFileBytes(context.Background(), request)
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+	return content
+}
+
+func assertGoneError(t *testing.T, err error, expected errorStatusExpected) {
+	t.Helper()
+	var gone *loonfs.GoneError
+	if !errors.As(err, &gone) {
+		t.Fatalf("expected GoneError, found %T: %v", err, err)
+	}
+	if gone.StatusCode != expected.Status || gone.Body == nil || gone.Body.Code != expected.Code {
+		t.Errorf("gone error = %#v, want %#v", gone, expected)
+	}
+}
+
+func assertBadRequestError(t *testing.T, err error, expected errorStatusExpected) {
+	t.Helper()
+	var badRequest *loonfs.BadRequestError
+	if !errors.As(err, &badRequest) {
+		t.Fatalf("expected BadRequestError, found %T: %v", err, err)
+	}
+	if badRequest.StatusCode != expected.Status || badRequest.Body == nil || badRequest.Body.Code != expected.Code {
+		t.Errorf("bad request error = %#v, want %#v", badRequest, expected)
+	}
+}
+
+func equalInt64s(left, right []int64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func runPagination(t *testing.T, h *harness, testCase conformanceCase) {

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -307,16 +307,10 @@ class SnapshotsRequest:
 
 @pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
 class SnapshotsExpected:
-    directory_committed_seq: int
-    replaced_file_committed_seq: int
-    deleted_file_committed_seq: int
     snapshot_head_seq: int
     captured_revision_no: int
     captured_entry_names: list[str]
-    replacement_committed_seq: int
     current_revision_no: int
-    added_file_committed_seq: int
-    deletion_committed_seq: int
     current_entry_names: list[str]
     snapshot_change_seqs: list[int]
     snapshot_gone: ErrorStatusExpected
@@ -1086,15 +1080,14 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         return f"{request.directory}/{name}"
 
     client.namespaces.create_namespace(namespace_id=namespace_id)
-    directory = _apply(
+    _apply(
         client,
         namespace_id,
         "conf-snapshots-create-directory",
         request.actor,
         FilesystemOperation_CreateDirectory(path=request.directory, parents=False),
     )
-    assert directory.committed_seq == expected.directory_committed_seq
-    created_replaced = put_file(
+    put_file(
         client,
         namespace_id=namespace_id,
         path=child_path(request.replaced_file_name),
@@ -1102,10 +1095,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         actor=request.actor,
         commit_id="conf-snapshots-create-replaced",
     )
-    assert (
-        created_replaced.committed_seq == expected.replaced_file_committed_seq
-    )
-    created_deleted = put_file(
+    put_file(
         client,
         namespace_id=namespace_id,
         path=child_path(request.deleted_file_name),
@@ -1113,7 +1103,6 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         actor=request.actor,
         commit_id="conf-snapshots-create-deleted",
     )
-    assert created_deleted.committed_seq == expected.deleted_file_committed_seq
 
     snapshot = client.namespaces.create_snapshot(
         namespace_id,
@@ -1125,7 +1114,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert snapshot.head_seq == expected.snapshot_head_seq
     assert snapshot.expires_at_ms > snapshot.created_at_ms
 
-    replaced = put_file(
+    put_file(
         client,
         namespace_id=namespace_id,
         path=child_path(request.replaced_file_name),
@@ -1134,8 +1123,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         commit_id="conf-snapshots-replace-file",
         behavior="replace",
     )
-    assert replaced.committed_seq == expected.replacement_committed_seq
-    added = put_file(
+    put_file(
         client,
         namespace_id=namespace_id,
         path=child_path(request.added_file_name),
@@ -1143,15 +1131,13 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         actor=request.actor,
         commit_id="conf-snapshots-add-file",
     )
-    assert added.committed_seq == expected.added_file_committed_seq
-    deleted = _apply(
+    _apply(
         client,
         namespace_id,
         "conf-snapshots-delete-file",
         request.actor,
         FilesystemOperation_DeletePath(path=child_path(request.deleted_file_name)),
     )
-    assert deleted.committed_seq == expected.deletion_committed_seq
 
     captured_entry = _file_entry(
         client.filesystem.get_path_entry(

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -43,8 +43,10 @@ from loonfs_sdk import (
     FilesystemOperation_PutFile,
     FilesystemOperation_PutFileByInode,
     FilesystemOperation_PutFileRevisionByInode,
+    GoneError,
     ListPathEntriesResponse,
     LoonFS,
+    NotFoundError,
     PathEntry,
     PathEntry_File,
     UnauthorizedError,
@@ -70,6 +72,7 @@ EXPECTED_CASES = [
     "inode_mutations",
     "pagination",
     "proxy",
+    "snapshots",
     "upload_abort",
     "upload_direct_put",
     "upload_multipart",
@@ -282,6 +285,44 @@ class InodeMutationsExpected:
     deleted_committed_seq: int
     stale_binding_generation: ErrorStatusExpected
     malformed_binding_generation: ErrorStatusExpected
+
+
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
+class SnapshotsRequest:
+    namespace_id: str
+    directory: str
+    actor: ActorRef
+    snapshot_name: str
+    replaced_file_name: str
+    deleted_file_name: str
+    added_file_name: str
+    captured_content_utf8: str
+    current_content_utf8: str
+    deleted_content_utf8: str
+    added_content_utf8: str
+    create_ttl_ms: int
+    extend_ttl_ms: int
+    unknown_snapshot_id: str
+
+
+@pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
+class SnapshotsExpected:
+    directory_committed_seq: int
+    replaced_file_committed_seq: int
+    deleted_file_committed_seq: int
+    snapshot_head_seq: int
+    captured_revision_no: int
+    captured_entry_names: list[str]
+    replacement_committed_seq: int
+    current_revision_no: int
+    added_file_committed_seq: int
+    deletion_committed_seq: int
+    current_entry_names: list[str]
+    snapshot_change_seqs: list[int]
+    snapshot_gone: ErrorStatusExpected
+    snapshot_not_found: ErrorStatusExpected
+    revision_with_snapshot: ErrorStatusExpected
+    zero_ttl: ErrorStatusExpected
 
 
 @pydantic.dataclasses.dataclass(config=pydantic.ConfigDict(extra="forbid", strict=True), frozen=True)
@@ -1032,6 +1073,219 @@ def test_inode_mutations(cases: dict[str, ConformanceCase], harness: Harness) ->
         ),
     )
     assert deleted.committed_seq == expected.deleted_committed_seq
+
+
+def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
+    request, expected = _decode(
+        cases["snapshots"], SnapshotsRequest, SnapshotsExpected
+    )
+    client = harness.client
+    namespace_id = request.namespace_id
+
+    def child_path(name: str) -> str:
+        return f"{request.directory}/{name}"
+
+    client.namespaces.create_namespace(namespace_id=namespace_id)
+    directory = _apply(
+        client,
+        namespace_id,
+        "conf-snapshots-create-directory",
+        request.actor,
+        FilesystemOperation_CreateDirectory(path=request.directory, parents=False),
+    )
+    assert directory.committed_seq == expected.directory_committed_seq
+    created_replaced = put_file(
+        client,
+        namespace_id=namespace_id,
+        path=child_path(request.replaced_file_name),
+        content=request.captured_content_utf8.encode(),
+        actor=request.actor,
+        commit_id="conf-snapshots-create-replaced",
+    )
+    assert (
+        created_replaced.committed_seq == expected.replaced_file_committed_seq
+    )
+    created_deleted = put_file(
+        client,
+        namespace_id=namespace_id,
+        path=child_path(request.deleted_file_name),
+        content=request.deleted_content_utf8.encode(),
+        actor=request.actor,
+        commit_id="conf-snapshots-create-deleted",
+    )
+    assert created_deleted.committed_seq == expected.deleted_file_committed_seq
+
+    snapshot = client.namespaces.create_snapshot(
+        namespace_id,
+        name=request.snapshot_name,
+        ttl_ms=request.create_ttl_ms,
+    )
+    assert snapshot.namespace_id == namespace_id
+    assert snapshot.name == request.snapshot_name
+    assert snapshot.head_seq == expected.snapshot_head_seq
+    assert snapshot.expires_at_ms > snapshot.created_at_ms
+
+    replaced = put_file(
+        client,
+        namespace_id=namespace_id,
+        path=child_path(request.replaced_file_name),
+        content=request.current_content_utf8.encode(),
+        actor=request.actor,
+        commit_id="conf-snapshots-replace-file",
+        behavior="replace",
+    )
+    assert replaced.committed_seq == expected.replacement_committed_seq
+    added = put_file(
+        client,
+        namespace_id=namespace_id,
+        path=child_path(request.added_file_name),
+        content=request.added_content_utf8.encode(),
+        actor=request.actor,
+        commit_id="conf-snapshots-add-file",
+    )
+    assert added.committed_seq == expected.added_file_committed_seq
+    deleted = _apply(
+        client,
+        namespace_id,
+        "conf-snapshots-delete-file",
+        request.actor,
+        FilesystemOperation_DeletePath(path=child_path(request.deleted_file_name)),
+    )
+    assert deleted.committed_seq == expected.deletion_committed_seq
+
+    captured_entry = _file_entry(
+        client.filesystem.get_path_entry(
+            namespace_id,
+            path=child_path(request.replaced_file_name),
+            snapshot_id=snapshot.snapshot_id,
+        )
+    )
+    assert captured_entry.revision_no == expected.captured_revision_no
+    current_entry = _file_entry(
+        client.filesystem.get_path_entry(
+            namespace_id,
+            path=child_path(request.replaced_file_name),
+        )
+    )
+    assert current_entry.revision_no == expected.current_revision_no
+
+    captured_listing = client.filesystem.list_path_entries(
+        namespace_id,
+        path=request.directory,
+        snapshot_id=snapshot.snapshot_id,
+    )
+    assert captured_listing.head_seq == expected.snapshot_head_seq
+    assert _listed_names(captured_listing.entries) == expected.captured_entry_names
+    current_listing = client.filesystem.list_path_entries(
+        namespace_id,
+        path=request.directory,
+    )
+    assert _listed_names(current_listing.entries) == expected.current_entry_names
+
+    captured_content = b"".join(
+        client.filesystem.get_file_bytes(
+            namespace_id,
+            path=child_path(request.replaced_file_name),
+            snapshot_id=snapshot.snapshot_id,
+        )
+    )
+    assert captured_content == request.captured_content_utf8.encode()
+    current_content = b"".join(
+        client.filesystem.get_file_bytes(
+            namespace_id,
+            path=child_path(request.replaced_file_name),
+        )
+    )
+    assert current_content == request.current_content_utf8.encode()
+
+    feed = client.filesystem.list_changes(
+        namespace_id,
+        after_seq=0,
+        limit=100,
+        snapshot_id=snapshot.snapshot_id,
+    )
+    assert feed.through_seq == expected.snapshot_head_seq
+    assert feed.next_after_seq is None
+    assert [change.committed_seq for change in feed.changes] == (
+        expected.snapshot_change_seqs
+    )
+
+    extended = client.namespaces.extend_snapshot(
+        namespace_id,
+        snapshot.snapshot_id,
+        ttl_ms=request.extend_ttl_ms,
+    )
+    assert extended.snapshot_id == snapshot.snapshot_id
+    assert extended.head_seq == expected.snapshot_head_seq
+    assert extended.name == request.snapshot_name
+    assert extended.expires_at_ms > snapshot.expires_at_ms
+
+    listed = client.namespaces.list_snapshots(namespace_id)
+    assert listed.namespace_id == namespace_id
+    assert listed.next_cursor is None
+    assert len(listed.snapshots) == 1
+    assert listed.snapshots[0].snapshot_id == snapshot.snapshot_id
+
+    first_release = client.namespaces.release_snapshot(
+        namespace_id, snapshot.snapshot_id
+    )
+    assert first_release.namespace_id == namespace_id
+    assert first_release.snapshot_id == snapshot.snapshot_id
+    second_release = client.namespaces.release_snapshot(
+        namespace_id, snapshot.snapshot_id
+    )
+    assert second_release.namespace_id == namespace_id
+    assert second_release.snapshot_id == snapshot.snapshot_id
+
+    with pytest.raises(GoneError) as released_read:
+        client.filesystem.get_path_entry(
+            namespace_id,
+            path=child_path(request.replaced_file_name),
+            snapshot_id=snapshot.snapshot_id,
+        )
+    assert released_read.value.status_code == expected.snapshot_gone.status
+    assert released_read.value.body.code == expected.snapshot_gone.code
+    with pytest.raises(GoneError) as released_extend:
+        client.namespaces.extend_snapshot(
+            namespace_id,
+            snapshot.snapshot_id,
+            ttl_ms=request.extend_ttl_ms,
+        )
+    assert released_extend.value.status_code == expected.snapshot_gone.status
+    assert released_extend.value.body.code == expected.snapshot_gone.code
+
+    with pytest.raises(NotFoundError) as unknown_read:
+        client.filesystem.get_path_entry(
+            namespace_id,
+            path=child_path(request.replaced_file_name),
+            snapshot_id=request.unknown_snapshot_id,
+        )
+    assert unknown_read.value.status_code == expected.snapshot_not_found.status
+    assert unknown_read.value.body.code == expected.snapshot_not_found.code
+    with pytest.raises(BadRequestError) as revision_with_snapshot:
+        b"".join(
+            client.filesystem.get_file_bytes(
+                namespace_id,
+                path=child_path(request.replaced_file_name),
+                revision_no=expected.captured_revision_no,
+                snapshot_id=snapshot.snapshot_id,
+            )
+        )
+    assert (
+        revision_with_snapshot.value.status_code
+        == expected.revision_with_snapshot.status
+    )
+    assert (
+        revision_with_snapshot.value.body.code == expected.revision_with_snapshot.code
+    )
+    with pytest.raises(BadRequestError) as zero_ttl:
+        client.namespaces.create_snapshot(
+            namespace_id,
+            name=request.snapshot_name,
+            ttl_ms=0,
+        )
+    assert zero_ttl.value.status_code == expected.zero_ttl.status
+    assert zero_ttl.value.body.code == expected.zero_ttl.code
 
 
 def test_proxy(

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -36,6 +36,7 @@ const EXPECTED_CASES = [
     "inode_mutations",
     "pagination",
     "proxy",
+    "snapshots",
     "upload_abort",
     "upload_direct_put",
     "upload_multipart",
@@ -136,6 +137,42 @@ interface InodeMutationsExpected {
     deleted_committed_seq: number;
     stale_binding_generation: ErrorStatusExpected;
     malformed_binding_generation: ErrorStatusExpected;
+}
+
+interface SnapshotsRequest {
+    namespace_id: string;
+    directory: string;
+    actor: ActorValue;
+    snapshot_name: string;
+    replaced_file_name: string;
+    deleted_file_name: string;
+    added_file_name: string;
+    captured_content_utf8: string;
+    current_content_utf8: string;
+    deleted_content_utf8: string;
+    added_content_utf8: string;
+    create_ttl_ms: number;
+    extend_ttl_ms: number;
+    unknown_snapshot_id: string;
+}
+
+interface SnapshotsExpected {
+    directory_committed_seq: number;
+    replaced_file_committed_seq: number;
+    deleted_file_committed_seq: number;
+    snapshot_head_seq: number;
+    captured_revision_no: number;
+    captured_entry_names: string[];
+    replacement_committed_seq: number;
+    current_revision_no: number;
+    added_file_committed_seq: number;
+    deletion_committed_seq: number;
+    current_entry_names: string[];
+    snapshot_change_seqs: number[];
+    snapshot_gone: ErrorStatusExpected;
+    snapshot_not_found: ErrorStatusExpected;
+    revision_with_snapshot: ErrorStatusExpected;
+    zero_ttl: ErrorStatusExpected;
 }
 
 interface ChangesRequest {
@@ -366,6 +403,40 @@ const INODE_MUTATIONS_EXPECTED_FIELDS = [
     "stale_binding_generation",
     "malformed_binding_generation",
 ] as const;
+const SNAPSHOTS_REQUEST_FIELDS = [
+    "namespace_id",
+    "directory",
+    "actor",
+    "snapshot_name",
+    "replaced_file_name",
+    "deleted_file_name",
+    "added_file_name",
+    "captured_content_utf8",
+    "current_content_utf8",
+    "deleted_content_utf8",
+    "added_content_utf8",
+    "create_ttl_ms",
+    "extend_ttl_ms",
+    "unknown_snapshot_id",
+] as const;
+const SNAPSHOTS_EXPECTED_FIELDS = [
+    "directory_committed_seq",
+    "replaced_file_committed_seq",
+    "deleted_file_committed_seq",
+    "snapshot_head_seq",
+    "captured_revision_no",
+    "captured_entry_names",
+    "replacement_committed_seq",
+    "current_revision_no",
+    "added_file_committed_seq",
+    "deletion_committed_seq",
+    "current_entry_names",
+    "snapshot_change_seqs",
+    "snapshot_gone",
+    "snapshot_not_found",
+    "revision_with_snapshot",
+    "zero_ttl",
+] as const;
 const CHANGES_REQUEST_FIELDS = [
     "namespace_id",
     "path",
@@ -511,6 +582,17 @@ function decodeInodeMutations(
     return [
         testCase.request as unknown as InodeMutationsRequest,
         testCase.expected as unknown as InodeMutationsExpected,
+    ];
+}
+
+function decodeSnapshots(
+    testCase: ConformanceCase,
+): [SnapshotsRequest, SnapshotsExpected] {
+    strictObject(testCase.request, SNAPSHOTS_REQUEST_FIELDS, `${testCase.name} request`);
+    strictObject(testCase.expected, SNAPSHOTS_EXPECTED_FIELDS, `${testCase.name} expected`);
+    return [
+        testCase.request as unknown as SnapshotsRequest,
+        testCase.expected as unknown as SnapshotsExpected,
     ];
 }
 
@@ -781,10 +863,14 @@ async function readProxied(
     client: LoonFSClient,
     namespaceId: string,
     path: string,
+    snapshotId?: string,
+    revisionNo?: number,
 ): Promise<Uint8Array> {
     const response = await client.filesystem.getFileBytes({
         namespace_id: namespaceId,
         path,
+        snapshot_id: snapshotId,
+        revision_no: revisionNo,
     });
     return new Uint8Array(await response.arrayBuffer());
 }
@@ -1527,6 +1613,230 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         ],
     });
     assert.equal(deleted.committed_seq, expected.deleted_committed_seq);
+});
+
+conformanceTest("snapshots", async (activeHarness, testCase) => {
+    const [request, expected] = decodeSnapshots(testCase);
+    const client = activeHarness.client;
+    const namespaceId = request.namespace_id;
+    const childPath = (name: string): string => `${request.directory}/${name}`;
+    const capturedBytes = new TextEncoder().encode(request.captured_content_utf8);
+    const currentBytes = new TextEncoder().encode(request.current_content_utf8);
+
+    await client.namespaces.createNamespace({ namespace_id: namespaceId });
+    const directory = await client.filesystem.createCommit(
+        directoryCommit(
+            namespaceId,
+            "conf-snapshots-create-directory",
+            request.actor,
+            request.directory,
+        ),
+    );
+    assert.equal(directory.committed_seq, expected.directory_committed_seq);
+    const createdReplaced = await putFile(client, {
+        namespace_id: namespaceId,
+        path: childPath(request.replaced_file_name),
+        bytes: capturedBytes,
+        actor: request.actor,
+        commit_id: "conf-snapshots-create-replaced",
+    });
+    assert.equal(createdReplaced.committed_seq, expected.replaced_file_committed_seq);
+    const createdDeleted = await putFile(client, {
+        namespace_id: namespaceId,
+        path: childPath(request.deleted_file_name),
+        bytes: new TextEncoder().encode(request.deleted_content_utf8),
+        actor: request.actor,
+        commit_id: "conf-snapshots-create-deleted",
+    });
+    assert.equal(createdDeleted.committed_seq, expected.deleted_file_committed_seq);
+
+    const snapshot = await client.namespaces.createSnapshot({
+        namespace_id: namespaceId,
+        name: request.snapshot_name,
+        ttl_ms: request.create_ttl_ms,
+    });
+    assert.equal(snapshot.namespace_id, namespaceId);
+    assert.equal(snapshot.name, request.snapshot_name);
+    assert.equal(snapshot.head_seq, expected.snapshot_head_seq);
+    assert.ok(snapshot.expires_at_ms > snapshot.created_at_ms);
+
+    const replaced = await putFile(client, {
+        namespace_id: namespaceId,
+        path: childPath(request.replaced_file_name),
+        bytes: currentBytes,
+        actor: request.actor,
+        commit_id: "conf-snapshots-replace-file",
+        behavior: "replace",
+    });
+    assert.equal(replaced.committed_seq, expected.replacement_committed_seq);
+    const added = await putFile(client, {
+        namespace_id: namespaceId,
+        path: childPath(request.added_file_name),
+        bytes: new TextEncoder().encode(request.added_content_utf8),
+        actor: request.actor,
+        commit_id: "conf-snapshots-add-file",
+    });
+    assert.equal(added.committed_seq, expected.added_file_committed_seq);
+    const deleted = await client.filesystem.createCommit(
+        deleteCommit(
+            namespaceId,
+            "conf-snapshots-delete-file",
+            request.actor,
+            childPath(request.deleted_file_name),
+        ),
+    );
+    assert.equal(deleted.committed_seq, expected.deletion_committed_seq);
+
+    const capturedEntry = fileEntry(
+        await client.filesystem.getPathEntry({
+            namespace_id: namespaceId,
+            path: childPath(request.replaced_file_name),
+            snapshot_id: snapshot.snapshot_id,
+        }),
+    );
+    assert.equal(capturedEntry.revision_no, expected.captured_revision_no);
+    const currentEntry = fileEntry(
+        await client.filesystem.getPathEntry({
+            namespace_id: namespaceId,
+            path: childPath(request.replaced_file_name),
+        }),
+    );
+    assert.equal(currentEntry.revision_no, expected.current_revision_no);
+
+    const capturedListing = await client.filesystem.listPathEntries({
+        namespace_id: namespaceId,
+        path: request.directory,
+        snapshot_id: snapshot.snapshot_id,
+    });
+    assert.equal(capturedListing.response.head_seq, expected.snapshot_head_seq);
+    assert.deepEqual(listedNames(capturedListing.data), expected.captured_entry_names);
+    const currentListing = await client.filesystem.listPathEntries({
+        namespace_id: namespaceId,
+        path: request.directory,
+    });
+    assert.deepEqual(listedNames(currentListing.data), expected.current_entry_names);
+
+    assert.deepEqual(
+        await readProxied(
+            client,
+            namespaceId,
+            childPath(request.replaced_file_name),
+            snapshot.snapshot_id,
+        ),
+        capturedBytes,
+    );
+    assert.deepEqual(
+        await readProxied(client, namespaceId, childPath(request.replaced_file_name)),
+        currentBytes,
+    );
+
+    const feed = await client.filesystem.listChanges({
+        namespace_id: namespaceId,
+        after_seq: 0,
+        limit: 100,
+        snapshot_id: snapshot.snapshot_id,
+    });
+    assert.equal(feed.through_seq, expected.snapshot_head_seq);
+    assert.equal(feed.next_after_seq, undefined);
+    assert.deepEqual(
+        feed.changes.map((change) => change.committed_seq),
+        expected.snapshot_change_seqs,
+    );
+
+    const extended = await client.namespaces.extendSnapshot({
+        namespace_id: namespaceId,
+        snapshot_id: snapshot.snapshot_id,
+        ttl_ms: request.extend_ttl_ms,
+    });
+    assert.equal(extended.snapshot_id, snapshot.snapshot_id);
+    assert.equal(extended.head_seq, expected.snapshot_head_seq);
+    assert.equal(extended.name, request.snapshot_name);
+    assert.ok(extended.expires_at_ms > snapshot.expires_at_ms);
+
+    const listed = await client.namespaces.listSnapshots({ namespace_id: namespaceId });
+    assert.equal(listed.response.namespace_id, namespaceId);
+    assert.equal(listed.response.next_cursor, undefined);
+    assert.equal(listed.data.length, 1);
+    assert.equal(listed.data[0]?.snapshot_id, snapshot.snapshot_id);
+
+    const releaseRequest = {
+        namespace_id: namespaceId,
+        snapshot_id: snapshot.snapshot_id,
+    };
+    const firstRelease = await client.namespaces.releaseSnapshot(releaseRequest);
+    assert.equal(firstRelease.namespace_id, namespaceId);
+    assert.equal(firstRelease.snapshot_id, snapshot.snapshot_id);
+    const secondRelease = await client.namespaces.releaseSnapshot(releaseRequest);
+    assert.equal(secondRelease.namespace_id, namespaceId);
+    assert.equal(secondRelease.snapshot_id, snapshot.snapshot_id);
+
+    await assert.rejects(
+        client.filesystem.getPathEntry({
+            namespace_id: namespaceId,
+            path: childPath(request.replaced_file_name),
+            snapshot_id: snapshot.snapshot_id,
+        }),
+        (error: unknown) => {
+            assert.ok(error instanceof LoonFS.GoneError);
+            assert.equal(error.statusCode, expected.snapshot_gone.status);
+            assert.equal(error.body.code, expected.snapshot_gone.code);
+            return true;
+        },
+    );
+    await assert.rejects(
+        client.namespaces.extendSnapshot({
+            namespace_id: namespaceId,
+            snapshot_id: snapshot.snapshot_id,
+            ttl_ms: request.extend_ttl_ms,
+        }),
+        (error: unknown) => {
+            assert.ok(error instanceof LoonFS.GoneError);
+            assert.equal(error.statusCode, expected.snapshot_gone.status);
+            assert.equal(error.body.code, expected.snapshot_gone.code);
+            return true;
+        },
+    );
+    await assert.rejects(
+        client.filesystem.getPathEntry({
+            namespace_id: namespaceId,
+            path: childPath(request.replaced_file_name),
+            snapshot_id: request.unknown_snapshot_id,
+        }),
+        (error: unknown) => {
+            assert.ok(error instanceof LoonFS.NotFoundError);
+            assert.equal(error.statusCode, expected.snapshot_not_found.status);
+            assert.equal(error.body.code, expected.snapshot_not_found.code);
+            return true;
+        },
+    );
+    await assert.rejects(
+        readProxied(
+            client,
+            namespaceId,
+            childPath(request.replaced_file_name),
+            snapshot.snapshot_id,
+            expected.captured_revision_no,
+        ),
+        (error: unknown) => {
+            assert.ok(error instanceof LoonFS.BadRequestError);
+            assert.equal(error.statusCode, expected.revision_with_snapshot.status);
+            assert.equal(error.body.code, expected.revision_with_snapshot.code);
+            return true;
+        },
+    );
+    await assert.rejects(
+        client.namespaces.createSnapshot({
+            namespace_id: namespaceId,
+            name: request.snapshot_name,
+            ttl_ms: 0,
+        }),
+        (error: unknown) => {
+            assert.ok(error instanceof LoonFS.BadRequestError);
+            assert.equal(error.statusCode, expected.zero_ttl.status);
+            assert.equal(error.body.code, expected.zero_ttl.code);
+            return true;
+        },
+    );
 });
 
 test("proxy", { skip: environmentSkip }, async (context) => {

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -157,16 +157,10 @@ interface SnapshotsRequest {
 }
 
 interface SnapshotsExpected {
-    directory_committed_seq: number;
-    replaced_file_committed_seq: number;
-    deleted_file_committed_seq: number;
     snapshot_head_seq: number;
     captured_revision_no: number;
     captured_entry_names: string[];
-    replacement_committed_seq: number;
     current_revision_no: number;
-    added_file_committed_seq: number;
-    deletion_committed_seq: number;
     current_entry_names: string[];
     snapshot_change_seqs: number[];
     snapshot_gone: ErrorStatusExpected;
@@ -420,16 +414,10 @@ const SNAPSHOTS_REQUEST_FIELDS = [
     "unknown_snapshot_id",
 ] as const;
 const SNAPSHOTS_EXPECTED_FIELDS = [
-    "directory_committed_seq",
-    "replaced_file_committed_seq",
-    "deleted_file_committed_seq",
     "snapshot_head_seq",
     "captured_revision_no",
     "captured_entry_names",
-    "replacement_committed_seq",
     "current_revision_no",
-    "added_file_committed_seq",
-    "deletion_committed_seq",
     "current_entry_names",
     "snapshot_change_seqs",
     "snapshot_gone",
@@ -1624,7 +1612,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     const currentBytes = new TextEncoder().encode(request.current_content_utf8);
 
     await client.namespaces.createNamespace({ namespace_id: namespaceId });
-    const directory = await client.filesystem.createCommit(
+    await client.filesystem.createCommit(
         directoryCommit(
             namespaceId,
             "conf-snapshots-create-directory",
@@ -1632,23 +1620,20 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
             request.directory,
         ),
     );
-    assert.equal(directory.committed_seq, expected.directory_committed_seq);
-    const createdReplaced = await putFile(client, {
+    await putFile(client, {
         namespace_id: namespaceId,
         path: childPath(request.replaced_file_name),
         bytes: capturedBytes,
         actor: request.actor,
         commit_id: "conf-snapshots-create-replaced",
     });
-    assert.equal(createdReplaced.committed_seq, expected.replaced_file_committed_seq);
-    const createdDeleted = await putFile(client, {
+    await putFile(client, {
         namespace_id: namespaceId,
         path: childPath(request.deleted_file_name),
         bytes: new TextEncoder().encode(request.deleted_content_utf8),
         actor: request.actor,
         commit_id: "conf-snapshots-create-deleted",
     });
-    assert.equal(createdDeleted.committed_seq, expected.deleted_file_committed_seq);
 
     const snapshot = await client.namespaces.createSnapshot({
         namespace_id: namespaceId,
@@ -1660,7 +1645,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     assert.equal(snapshot.head_seq, expected.snapshot_head_seq);
     assert.ok(snapshot.expires_at_ms > snapshot.created_at_ms);
 
-    const replaced = await putFile(client, {
+    await putFile(client, {
         namespace_id: namespaceId,
         path: childPath(request.replaced_file_name),
         bytes: currentBytes,
@@ -1668,16 +1653,14 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         commit_id: "conf-snapshots-replace-file",
         behavior: "replace",
     });
-    assert.equal(replaced.committed_seq, expected.replacement_committed_seq);
-    const added = await putFile(client, {
+    await putFile(client, {
         namespace_id: namespaceId,
         path: childPath(request.added_file_name),
         bytes: new TextEncoder().encode(request.added_content_utf8),
         actor: request.actor,
         commit_id: "conf-snapshots-add-file",
     });
-    assert.equal(added.committed_seq, expected.added_file_committed_seq);
-    const deleted = await client.filesystem.createCommit(
+    await client.filesystem.createCommit(
         deleteCommit(
             namespaceId,
             "conf-snapshots-delete-file",
@@ -1685,7 +1668,6 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
             childPath(request.deleted_file_name),
         ),
     );
-    assert.equal(deleted.committed_seq, expected.deletion_committed_seq);
 
     const capturedEntry = fileEntry(
         await client.filesystem.getPathEntry({


### PR DESCRIPTION
Adds one shared snapshot conformance case for the Rust reference implementation and the generated Go, Python, and TypeScript SDKs.

The case creates a snapshot, changes the namespace, and verifies that snapshot reads still return the saved files and content while current reads see the latest changes. It also covers bounded change feeds, listing, extension, releasing the same snapshot twice, released and unknown snapshot errors, conflicting revision selectors, and invalid lifetimes.