### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loonfs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-api"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ciborium",
  "crc32c",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "clap",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-client"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "bytes",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-conformance"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-grep"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-model"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "loonfs-api",
  "serde",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-objectstore"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-server"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-sim"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-test-support"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.2.1"
+version = "0.3.0"
 license = "Apache-2.0"
 rust-version = "1.85"
 description = "Spec-locked object-store-backed file service"
@@ -80,12 +80,12 @@ loonfs-test-support = { path = "crates/loonfs-test-support" }
 # Cargo requires published dependencies to include a registry version even
 # when they also have a local path. These versions must match
 # `workspace.package.version`.
-loonfs = { path = "crates/loonfs", version = "0.2.1" }
-loonfs-api = { path = "crates/loonfs-api", version = "0.2.1" }
-loonfs-client = { path = "crates/loonfs-client", version = "0.2.1" }
-loonfs-core = { path = "crates/loonfs-core", version = "0.2.1" }
-loonfs-grep = { path = "crates/loonfs-grep", version = "0.2.1" }
-loonfs-objectstore = { path = "crates/loonfs-objectstore", version = "0.2.1" }
+loonfs = { path = "crates/loonfs", version = "0.3.0" }
+loonfs-api = { path = "crates/loonfs-api", version = "0.3.0" }
+loonfs-client = { path = "crates/loonfs-client", version = "0.3.0" }
+loonfs-core = { path = "crates/loonfs-core", version = "0.3.0" }
+loonfs-grep = { path = "crates/loonfs-grep", version = "0.3.0" }
+loonfs-objectstore = { path = "crates/loonfs-objectstore", version = "0.3.0" }
 # foyer reports its internal counters through this registry trait and does not
 # re-export it, so a host that wants to read them names the crate itself. The
 # version must stay the one foyer resolves, or the trait this workspace

--- a/crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml
@@ -4,5 +4,5 @@ description: The LoonFS server, one active process behind the v0 HTTP API.
 type: application
 # Keep both values equal to `workspace.package.version`. `version` identifies
 # the chart package, and `appVersion` identifies the LoonFS server version.
-version: 0.2.1
-appVersion: "0.2.1"
+version: 0.3.0
+appVersion: "0.3.0"

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "identifier": "Apache-2.0"
     },
-    "version": "0.2.1"
+    "version": "0.3.0"
   },
   "paths": {
     "/v0/capabilities": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "identifier": "Apache-2.0"
     },
-    "version": "0.2.1"
+    "version": "0.3.0"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
Prepare LoonFS 0.3.0 by updating `workspace.package.version` and the registry versions declared for each published workspace crate. Refresh `Cargo.lock` so all workspace packages record the new version.

Update the Helm chart `version` and `appVersion` fields and the version reported by the generated OpenAPI document. This is a release metadata change only; it does not change runtime behavior or API shapes.

Validate the updated metadata with locked Cargo metadata resolution and the server's OpenAPI tests.