### PR TITLE
fix(snapshot): enforce quota across concurrent creates

### DIFF
--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -796,22 +796,16 @@ impl EmbeddedBackend {
     ) -> Result<SnapshotSummary, BackendError> {
         let now_ms = validate_embedded_snapshot_ttl(namespace_id, ttl_ms)?;
         let expires_at_ms = now_ms.saturating_add(ttl_ms);
-        self.admin
-            .ensure_snapshot_quota(
-                namespace_id,
-                now_ms,
-                EMBEDDED_SNAPSHOT_MAX_LIVE_PER_NAMESPACE,
-            )
-            .await
-            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?;
         let checkpoint = self
             .admin
-            .create_snapshot(
+            .create_snapshot_with_quota(
                 namespace_id,
                 CreateSnapshotOptions {
                     name: name.to_owned(),
                     expires_at_ms,
                 },
+                now_ms,
+                EMBEDDED_SNAPSHOT_MAX_LIVE_PER_NAMESPACE,
             )
             .await
             .map_err(|error| {

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -417,23 +417,16 @@ pub(super) async fn create_snapshot(
     query.into_params()?;
     let now_ms = super::handlers_uploads::current_unix_ms()?;
     let expires_at_ms = snapshot_expiry_from_ttl(&state, now_ms, request.ttl_ms)?;
-    state
-        .admin
-        .ensure_snapshot_quota(
-            &namespace_id,
-            now_ms,
-            state.config.snapshot_max_live_per_namespace,
-        )
-        .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     let checkpoint = state
         .admin
-        .create_snapshot(
+        .create_snapshot_with_quota(
             &namespace_id,
             CreateSnapshotOptions {
                 name: request.name,
                 expires_at_ms,
             },
+            now_ms,
+            state.config.snapshot_max_live_per_namespace,
         )
         .await
         .map_err(|error| {

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -738,6 +738,32 @@ impl FsAdmin {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
+    /// Creates a snapshot only when the namespace has quota for it.
+    ///
+    /// The second quota check closes the race between concurrent callers that
+    /// both observe the same free slot. A caller that loses that race releases
+    /// its tentative snapshot before returning the quota error.
+    pub async fn create_snapshot_with_quota(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateSnapshotOptions,
+        now_ms: u64,
+        max_live: usize,
+    ) -> Result<Checkpoint> {
+        self.ensure_snapshot_quota(namespace_id, now_ms, max_live)
+            .await?;
+        let checkpoint = self.create_snapshot(namespace_id, options).await?;
+        if let Err(error) = self
+            .ensure_live_snapshot_limit(namespace_id, now_ms, max_live, 0)
+            .await
+        {
+            self.release_snapshot(namespace_id, &checkpoint.checkpoint_id)
+                .await?;
+            return Err(error);
+        }
+        Ok(checkpoint)
+    }
+
     /// Checks whether the namespace has room for another live snapshot.
     pub async fn ensure_snapshot_quota(
         &self,
@@ -745,9 +771,29 @@ impl FsAdmin {
         now_ms: u64,
         max_live: usize,
     ) -> Result<()> {
+        self.ensure_live_snapshot_limit(namespace_id, now_ms, max_live, 1)
+            .await
+    }
+
+    async fn ensure_live_snapshot_limit(
+        &self,
+        namespace_id: &NamespaceId,
+        now_ms: u64,
+        max_live: usize,
+        additional_live: usize,
+    ) -> Result<()> {
         let page_limit = loonfs_api::PaginationPolicy::default().max_limit();
         let mut cursor = None;
-        let mut live_after_create = 1usize;
+        let mut live_with_additional = additional_live;
+        let quota_error = || {
+            RuntimeError::Core(loonfs_core::Error::SnapshotQuotaExceeded {
+                namespace_id: namespace_id.clone(),
+                max_live,
+            })
+        };
+        if live_with_additional > max_live {
+            return Err(quota_error());
+        }
         loop {
             let page = self
                 .engine(namespace_id)
@@ -763,14 +809,9 @@ impl FsAdmin {
                     loonfs_api::CheckpointOwnerSummary::Snapshot { expires_at_ms, .. }
                         if expires_at_ms > now_ms
                 ) {
-                    live_after_create = live_after_create.saturating_add(1);
-                    if live_after_create > max_live {
-                        return Err(RuntimeError::Core(
-                            loonfs_core::Error::SnapshotQuotaExceeded {
-                                namespace_id: namespace_id.clone(),
-                                max_live,
-                            },
-                        ));
+                    live_with_additional = live_with_additional.saturating_add(1);
+                    if live_with_additional > max_live {
+                        return Err(quota_error());
                     }
                 }
             }

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -16,13 +16,19 @@ use loonfs_api::wire::control::{
     HeadState, HeadStateEnvelope,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
-use loonfs_objectstore::keys::{metadata_manifest_object, wal_head, wal_segment_prefix};
+use loonfs_objectstore::keys::{
+    checkpoint_prefix, metadata_manifest_object, wal_head, wal_segment_prefix,
+};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
-use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
+use loonfs_test_support::stores::{
+    BlockingStore, CountingStore, KeyPredicate, OperationClass, OperationKind,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tempfile::tempdir;
 
 #[test]
@@ -786,6 +792,108 @@ fn a_created_snapshot_is_listed_with_its_snapshot_owner() {
     assert_eq!(listed_snapshot.owner, snapshot.owner);
     assert_eq!(listed_snapshot.expires_at_ms, Some(expires_at_ms));
     assert_eq!(listed_snapshot.checkpoint_seq, snapshot.checkpoint_seq);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_snapshot_creates_cannot_both_claim_the_last_quota_slot() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("snapshot-quota-race");
+    let checkpoint_key_prefix = checkpoint_prefix(&namespace_id);
+    let checkpoint_writes = Arc::new(AtomicUsize::new(0));
+    let checkpoint_writes_seen = checkpoint_writes.clone();
+    let checkpoint_write_gate = Arc::new(BlockingStore::matching(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        move |operation| {
+            let matches = operation.key().starts_with(&checkpoint_key_prefix)
+                && matches!(
+                    operation.kind(),
+                    OperationKind::Put { .. } | OperationKind::PutStreamed { .. }
+                );
+            if matches {
+                checkpoint_writes_seen.fetch_add(1, Ordering::SeqCst);
+            }
+            matches
+        },
+    ));
+    let checkpoint_list_prefix = checkpoint_prefix(&namespace_id);
+    let checkpoint_lists = Arc::new(AtomicUsize::new(0));
+    let checkpoint_lists_seen = checkpoint_lists.clone();
+    let checkpoint_list_gate = Arc::new(BlockingStore::matching(
+        checkpoint_write_gate.clone(),
+        move |operation| {
+            let matches = operation.key() == checkpoint_list_prefix
+                && matches!(operation.kind(), OperationKind::List);
+            if matches {
+                checkpoint_lists_seen.fetch_add(1, Ordering::SeqCst);
+            }
+            matches
+        },
+    ));
+    let object_store: SharedObjectStore = checkpoint_list_gate.clone();
+    let fs = open_runtime_async(object_store, "snapshot-quota-race").await;
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    checkpoint_list_gate.arm();
+    checkpoint_write_gate.arm();
+    let first_admin = fs.admin.clone();
+    let first_namespace = namespace_id.clone();
+    let first = tokio::spawn(async move {
+        first_admin
+            .create_snapshot_with_quota(
+                &first_namespace,
+                CreateSnapshotOptions {
+                    name: "first".to_owned(),
+                    expires_at_ms: u64::MAX,
+                },
+                0,
+                1,
+            )
+            .await
+    });
+    let second_admin = fs.admin.clone();
+    let second_namespace = namespace_id.clone();
+    let second = tokio::spawn(async move {
+        second_admin
+            .create_snapshot_with_quota(
+                &second_namespace,
+                CreateSnapshotOptions {
+                    name: "second".to_owned(),
+                    expires_at_ms: u64::MAX,
+                },
+                0,
+                1,
+            )
+            .await
+    });
+
+    wait_for_operations(&checkpoint_lists, 2).await;
+    checkpoint_list_gate.release();
+    wait_for_operations(&checkpoint_writes, 2).await;
+    checkpoint_list_gate.arm();
+    checkpoint_write_gate.release();
+    wait_for_operations(&checkpoint_lists, 4).await;
+    checkpoint_list_gate.release();
+
+    let first = first.await.expect("first create task");
+    let second = second.await.expect("second create task");
+    assert_core_error_kind(first, ErrorCode::SnapshotQuotaExceeded);
+    assert_core_error_kind(second, ErrorCode::SnapshotQuotaExceeded);
+    let listed = collect_checkpoints(&fs.admin, &namespace_id)
+        .await
+        .expect("list checkpoints after raced creates");
+    assert!(listed.checkpoints.is_empty());
+}
+
+async fn wait_for_operations(counter: &AtomicUsize, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while counter.load(Ordering::SeqCst) < expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {expected} operations"));
 }
 
 #[test]


### PR DESCRIPTION
When snapshot creations race for the last quota slot, recount after publishing each snapshot record. Release a new snapshot before returning a quota error if the recount is over the limit.

This prevents concurrent requests from both succeeding after observing the same free slot.