### PR TITLE
fix(snapshot): bind directory cursors to snapshots

### DIFF
--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -160,21 +160,27 @@ pub struct Page<T, C> {
 /// Cursor for one directory listing position.
 ///
 /// Directory pagination advances in canonical `name_key` order. The cursor
-/// is an ordering resume, not a snapshot pin: any head at or past `head_seq`
-/// serves the next page, resuming strictly after `last_name_key` — the same
-/// forward-only drift grep cursors tolerate.
+/// is an ordering resume for live reads: any head at or past `head_seq` serves
+/// the next page, resuming strictly after `last_name_key` — the same
+/// forward-only drift grep cursors tolerate. A cursor minted by a snapshot
+/// read also carries `snapshot_id` and can resume only against that snapshot.
 ///
-/// The cursor intentionally contains only the minting head (`head_seq`),
-/// listed directory identity (`directory_inode_id`), and resume position
-/// (`last_name_key`). HTTP clients must pass the URL namespace and the
-/// directory target — the `path` parameter, or the inode ID in the route for
-/// inode-addressed listing — on every page. Runtime/server code resolves
-/// that target at the current head and rejects the cursor unless it names
-/// `directory_inode_id`.
+/// HTTP clients must pass the URL namespace and the directory target — the
+/// `path` parameter, or the inode ID in the route for inode-addressed listing
+/// — on every page. Snapshot clients must also repeat `snapshot_id`. Runtime
+/// and server code resolve that target at the selected view and reject a
+/// cursor with a different directory or snapshot identity.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirectoryPageCursor {
     /// Head sequence the issuing page was evaluated at.
     pub head_seq: ChangeSeq,
+    /// Live snapshot that minted this cursor, if any.
+    ///
+    /// The omitted form preserves version-1 live cursors. A snapshot read may
+    /// accept an omitted value only when `head_seq` exactly matches its pinned
+    /// head, then stamps the snapshot id into the next cursor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<crate::CheckpointId>,
     /// Directory inode resolved at `head_seq`.
     // The wire field is frozen as `dir_inode_id` in page cursor version 1.
     #[serde(rename = "dir_inode_id")]
@@ -446,6 +452,10 @@ mod tests {
     fn directory_cursor_round_trips() {
         let cursor = DirectoryPageCursor {
             head_seq: ChangeSeq(11),
+            snapshot_id: Some(
+                crate::CheckpointId::parse("chk_00000000000000000000000000000001")
+                    .expect("snapshot id"),
+            ),
             directory_inode_id: InodeId(7),
             last_name_key: NameKey::parse("plan.md").expect("name key"),
         };
@@ -454,6 +464,26 @@ mod tests {
         let decoded: DirectoryPageCursor = decode_cursor(&encoded).expect("decode cursor");
 
         assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn live_directory_cursor_omits_the_additive_snapshot_field() {
+        let cursor = DirectoryPageCursor {
+            head_seq: ChangeSeq(11),
+            snapshot_id: None,
+            directory_inode_id: InodeId(7),
+            last_name_key: NameKey::parse("plan.md").expect("name key"),
+        };
+
+        let encoded = encode_cursor(&cursor).expect("encode cursor");
+        let bytes = crate::hex::hex_decode_bytes(&encoded).expect("decode hex");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("decode JSON");
+
+        assert!(json.get("snapshot_id").is_none());
+        assert_eq!(
+            decode_cursor::<DirectoryPageCursor>(&encoded).expect("decode cursor"),
+            cursor
+        );
     }
 
     #[test]
@@ -536,6 +566,7 @@ mod tests {
             kind: DirectoryPageCursor::KIND.to_owned(),
             cursor: DirectoryPageCursor {
                 head_seq: ChangeSeq(11),
+                snapshot_id: None,
                 directory_inode_id: InodeId(7),
                 last_name_key: NameKey::parse("plan.md").expect("name key"),
             },

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -170,6 +170,7 @@ mod cursor_tests {
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
         let directory = DirectoryPageCursor {
             head_seq: loonfs_api::ChangeSeq(1),
+            snapshot_id: None,
             directory_inode_id: loonfs_api::InodeId(1),
             last_name_key: NameKey::parse("entry").expect("name key"),
         };

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -607,6 +607,7 @@ async fn trash_pages_resume_after_the_generation_the_cursor_names() {
 
     let wrong_kind = loonfs_api::encode_cursor(&loonfs_api::DirectoryPageCursor {
         head_seq: ChangeSeq(1),
+        snapshot_id: None,
         directory_inode_id: InodeId(1),
         last_name_key: NameKey::parse("x").expect("name key"),
     })

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -738,6 +738,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .limit
             .finish_page(&mut children, |last| DirectoryPageCursor {
                 head_seq: self.head.seq,
+                snapshot_id: None,
                 directory_inode_id: resolved.inode_id,
                 last_name_key: last.binding.name_key.clone(),
             });

--- a/crates/loonfs-server/tests/it/http_snapshot_reads.rs
+++ b/crates/loonfs-server/tests/it/http_snapshot_reads.rs
@@ -599,6 +599,35 @@ async fn snapshot_page_cursors_resume_one_pinned_directory() {
             .expect("add current file");
     }
 
+    let current_resume: ApiResult<ListPathEntriesResponse> = get_json(&listing_url(
+        &harness.server_url,
+        namespace.as_str(),
+        None,
+        Some("2"),
+        Some(&cursor),
+    ));
+    let (status, error) = current_resume.expect_err("snapshot cursor must not resume live");
+    assert_eq!(status, 400);
+    assert_eq!(error.code, "invalid_request");
+
+    let later_snapshot = create_snapshot(
+        &harness.server_url,
+        namespace.as_str(),
+        "later-pagination",
+        10_000,
+    );
+    let other_snapshot_resume: ApiResult<ListPathEntriesResponse> = get_json(&listing_url(
+        &harness.server_url,
+        namespace.as_str(),
+        Some(later_snapshot.snapshot_id.as_str()),
+        Some("2"),
+        Some(&cursor),
+    ));
+    let (status, error) =
+        other_snapshot_resume.expect_err("snapshot cursor must not resume another snapshot");
+    assert_eq!(status, 400);
+    assert_eq!(error.code, "invalid_request");
+
     loop {
         let page: ListPathEntriesResponse = get_json(&listing_url(
             &harness.server_url,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -29,6 +29,48 @@ fn reject_snapshot_option(snapshot_id: &Option<CheckpointId>, reader: &str) -> R
     Ok(())
 }
 
+fn validate_pinned_directory_cursor(
+    cursor: Option<&DirectoryPageCursor>,
+    pinned_head_seq: ChangeSeq,
+    snapshot_id: Option<&CheckpointId>,
+) -> Result<()> {
+    let Some(cursor) = cursor else {
+        return Ok(());
+    };
+    if cursor.head_seq != pinned_head_seq {
+        return Err(CoreError::InvalidCursor(format!(
+            "directory cursor head `{}` does not match pinned head `{pinned_head_seq}`",
+            cursor.head_seq
+        ))
+        .into());
+    }
+    match (&cursor.snapshot_id, snapshot_id) {
+        (Some(actual), Some(expected)) if actual == expected => Ok(()),
+        (Some(actual), Some(expected)) => Err(CoreError::InvalidCursor(format!(
+            "directory cursor snapshot `{actual}` does not match requested snapshot `{expected}`"
+        ))
+        .into()),
+        (Some(actual), None) => Err(CoreError::InvalidCursor(format!(
+            "directory cursor is bound to snapshot `{actual}`"
+        ))
+        .into()),
+        // A cursor minted before snapshot binding has no snapshot field.
+        // Matching the immutable head makes its resume safe; the next cursor
+        // is stamped below.
+        (None, _) => Ok(()),
+    }
+}
+
+fn reject_snapshot_bound_directory_cursor(cursor: Option<&DirectoryPageCursor>) -> Result<()> {
+    let Some(snapshot_id) = cursor.and_then(|cursor| cursor.snapshot_id.as_ref()) else {
+        return Ok(());
+    };
+    Err(CoreError::InvalidCursor(format!(
+        "directory cursor is bound to snapshot `{snapshot_id}`; repeat snapshot_id on every page"
+    ))
+    .into())
+}
+
 /// A namespace metadata view pinned to one head sequence.
 ///
 /// Create one from the current state, a checkpoint, or a live snapshot. All
@@ -37,6 +79,7 @@ fn reject_snapshot_option(snapshot_id: &Option<CheckpointId>, reader: &str) -> R
 pub struct FsReadSnapshot {
     engine: NamespaceReaderEngine<SharedObjectStore>,
     context: RuntimeReadContext,
+    snapshot_id: Option<CheckpointId>,
     max_read_content_bytes: Option<u64>,
 }
 
@@ -75,12 +118,22 @@ impl FsReadSnapshot {
         options: ListPathEntriesOptions,
     ) -> Result<ListPathEntriesResponse> {
         reject_snapshot_option(&options.snapshot_id, "here; this view is already pinned")?;
+        validate_pinned_directory_cursor(
+            request.cursor.as_ref(),
+            self.head_seq(),
+            self.snapshot_id.as_ref(),
+        )?;
         let listed_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
-        let page = self
+        let mut page = self
             .engine
             .list_path_page(listed_path.as_str(), request, options, &self.context)
             .await?;
+        if let (Some(cursor), Some(snapshot_id)) =
+            (page.next_cursor.as_mut(), self.snapshot_id.as_ref())
+        {
+            cursor.snapshot_id = Some(snapshot_id.clone());
+        }
         Ok(ListPathEntriesResponse {
             namespace_id: self.namespace_id().clone(),
             path: listed_path,
@@ -470,6 +523,7 @@ impl FsReader {
         Ok(FsReadSnapshot {
             engine,
             context,
+            snapshot_id: None,
             max_read_content_bytes: self.core.inner.config.max_read_content_bytes,
         })
     }
@@ -490,6 +544,7 @@ impl FsReader {
         Ok(FsReadSnapshot {
             engine,
             context,
+            snapshot_id: None,
             max_read_content_bytes: self.core.inner.config.max_read_content_bytes,
         })
     }
@@ -510,6 +565,7 @@ impl FsReader {
         Ok(FsReadSnapshot {
             engine,
             context,
+            snapshot_id: Some(snapshot_id.clone()),
             max_read_content_bytes: self.core.inner.config.max_read_content_bytes,
         })
     }
@@ -643,6 +699,7 @@ impl FsReader {
             &options.snapshot_id,
             "FsReader; call pin_namespace_at_snapshot first",
         )?;
+        reject_snapshot_bound_directory_cursor(request.cursor.as_ref())?;
         self.core.record_trace_context(&tracing::Span::current());
         let (mut response, next_cursor) = self
             .list_path_entries_page_typed(namespace_id, absolute_path, request, options)
@@ -722,6 +779,7 @@ impl FsReader {
         request: PageRequest<DirectoryPageCursor>,
         options: ListInodeChildrenOptions,
     ) -> Result<ListInodeChildrenResponse> {
+        reject_snapshot_bound_directory_cursor(request.cursor.as_ref())?;
         self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let page = engine

--- a/crates/loonfs/tests/it/read_snapshot.rs
+++ b/crates/loonfs/tests/it/read_snapshot.rs
@@ -8,6 +8,188 @@ use loonfs::{
 use tempfile::tempdir;
 
 #[tokio::test]
+async fn snapshot_directory_cursor_resumes_only_at_its_snapshot() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "snapshot-cursor-test").await;
+    let namespace_id = NamespaceId::parse("snapshot-cursor").expect("namespace id");
+    runtime
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for name in ["a", "c", "e", "g"] {
+        runtime
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/{name}.txt"),
+                name.as_bytes(),
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("seed file");
+    }
+
+    let now_ms = loonfs::current_time_ms().expect("current time");
+    let first_snapshot = runtime
+        .admin
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "first".to_owned(),
+                expires_at_ms: now_ms + 60_000,
+            },
+        )
+        .await
+        .expect("create first snapshot");
+    let first_view = runtime
+        .reader
+        .pin_namespace_at_snapshot(&namespace_id, &first_snapshot.checkpoint_id)
+        .await
+        .expect("pin first snapshot");
+    let limit = PaginationPolicy::default()
+        .resolve_limit(Some(2))
+        .expect("page limit");
+    let first_page = first_view
+        .list_path_entries_page(
+            "/",
+            PageRequest {
+                limit,
+                cursor: None,
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list first snapshot page");
+    let cursor = loonfs_api::decode_cursor::<loonfs::DirectoryPageCursor>(
+        first_page.next_cursor.as_deref().expect("next cursor"),
+    )
+    .expect("decode cursor");
+    assert_eq!(
+        cursor.snapshot_id.as_ref(),
+        Some(&first_snapshot.checkpoint_id)
+    );
+
+    runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/d.txt",
+            b"d",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("change current directory");
+    let second_snapshot = runtime
+        .admin
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "second".to_owned(),
+                expires_at_ms: now_ms + 60_000,
+            },
+        )
+        .await
+        .expect("create second snapshot");
+    let second_view = runtime
+        .reader
+        .pin_namespace_at_snapshot(&namespace_id, &second_snapshot.checkpoint_id)
+        .await
+        .expect("pin second snapshot");
+
+    assert_core_error_kind(
+        second_view
+            .list_path_entries_page(
+                "/",
+                PageRequest {
+                    limit,
+                    cursor: Some(cursor.clone()),
+                },
+                Default::default(),
+            )
+            .await,
+        ErrorCode::InvalidRequest,
+    );
+    let mut legacy_cursor = cursor.clone();
+    legacy_cursor.snapshot_id = None;
+    assert_core_error_kind(
+        second_view
+            .list_path_entries_page(
+                "/",
+                PageRequest {
+                    limit,
+                    cursor: Some(legacy_cursor.clone()),
+                },
+                Default::default(),
+            )
+            .await,
+        ErrorCode::InvalidRequest,
+    );
+    assert_core_error_kind(
+        runtime
+            .reader
+            .list_path_entries_page(
+                &namespace_id,
+                "/",
+                PageRequest {
+                    limit,
+                    cursor: Some(cursor.clone()),
+                },
+                Default::default(),
+            )
+            .await,
+        ErrorCode::InvalidRequest,
+    );
+    let root_inode_id = first_page.entries[0]
+        .parent_inode_id
+        .expect("listed entry has root parent");
+    assert_core_error_kind(
+        runtime
+            .reader
+            .list_inode_children_page(
+                &namespace_id,
+                root_inode_id,
+                PageRequest {
+                    limit,
+                    cursor: Some(cursor.clone()),
+                },
+                Default::default(),
+            )
+            .await,
+        ErrorCode::InvalidRequest,
+    );
+
+    first_view
+        .list_path_entries_page(
+            "/",
+            PageRequest {
+                limit,
+                cursor: Some(legacy_cursor),
+            },
+            Default::default(),
+        )
+        .await
+        .expect("resume a legacy cursor at its exact pinned head");
+
+    let second_page = first_view
+        .list_path_entries_page(
+            "/",
+            PageRequest {
+                limit,
+                cursor: Some(cursor),
+            },
+            Default::default(),
+        )
+        .await
+        .expect("resume the original snapshot");
+    assert_eq!(
+        second_page
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>(),
+        ["/e.txt", "/g.txt"]
+    );
+}
+
+#[tokio::test]
 async fn pinned_namespace_reads_keep_one_head_across_later_commits() {
     let temp_dir = tempdir().expect("tempdir");
     let runtime = open_runtime_async(store(temp_dir.path()), "snapshot-reader-test").await;

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1568,19 +1568,23 @@ listing on this route. A directory deleted mid-listing answers
 
 `include_attributes` works exactly as it does on the entry route and obeys the same required-siblings-together projection rule, but it defaults to `false`. This keeps the default response bounded because a page may contain up to `pagination.max_limit` entries and each attribute map may be 64 KiB. Clients that request attributes should choose a suitable page size.
 
-A cursor is an opaque ordering resume, not a snapshot pin. Every cursor in the API
-— directory listing, revision listing, grep, and the change feed alike —
-tolerates forward head drift: commits landing mid-listing never retire it,
-and the resumed page evaluates at the then-current head, continuing strictly
-after the last returned position. Each page is internally consistent at its
-own head, but a multi-page listing spans whatever heads its pages ran at: an
-entry created behind the resume position is missed, an entry deleted behind
-it was already returned, and a rename can surface as a duplicate or a miss.
-A client that needs one consistent cut re-issues the listing when `head_seq`
-changes between pages. Only a cursor minted ahead of the serving head
-answers `rebootstrap_required` — drift tolerance runs forward, never
-backward. (A malformed cursor, or one replayed against a different target,
-stays `invalid_request`.)
+A cursor is normally an opaque ordering resume, not a snapshot pin. Directory
+listing, revision listing, grep, and change-feed cursors tolerate forward head
+drift: commits landing mid-listing never retire them, and the resumed page
+evaluates at the then-current head, continuing strictly after the last returned
+position. Each page is internally consistent at its own head, but a multi-page
+listing spans whatever heads its pages ran at: an entry created behind the
+resume position is missed, an entry deleted behind it was already returned,
+and a rename can surface as a duplicate or a miss. A client that needs one
+consistent cut re-issues the listing when `head_seq` changes between pages.
+Only a cursor minted ahead of the serving head answers `rebootstrap_required`
+— drift tolerance runs forward, never backward. (A malformed cursor, or one
+replayed against a different target, stays `invalid_request`.)
+
+A directory cursor minted with `snapshot_id` is the exception: it binds to
+that snapshot's immutable view. The client must repeat the same `snapshot_id`
+on every page. Omitting it or supplying another snapshot returns
+`invalid_request` instead of combining rows from different views.
 The CLI reports the last page's head as `head_seq` and, for multi-page and
 recursive reads, reports the first and last observed heads as `head_drift`
 when they differ; a caller that needs a settled tree re-lists until the


### PR DESCRIPTION
When a directory page is read from a snapshot, bind its next cursor to that snapshot. Reject the cursor if a later request omits the snapshot or selects another one.

This prevents one listing from combining entries from different namespace views.