### PR TITLE
fix(core): reconcile ambiguous control record writes

### DIFF
--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -13,7 +13,7 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::{NamespaceId, UploadId};
 use loonfs_objectstore::keys::{upload_session, wal_head};
-use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
+use loonfs_objectstore::{ImmutableWriteError, ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::future::Future;
 use thiserror::Error;
 
@@ -42,16 +42,40 @@ where
 }
 
 /// Creates a control object and reports a generated-ID collision as an internal error.
+///
+/// A transport failure from the first conditional write has an unknown
+/// outcome. Retry it through the immutable-write path, which accepts success
+/// only when the generated key contains the exact intended bytes. An immediate
+/// precondition failure remains a collision rather than adopting a record from
+/// another generated-ID owner.
 pub(crate) async fn create_control_object_under_generated_id<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
     encoded: Bytes,
 ) -> crate::error::Result<ObjectMetadata> {
-    match store.put_if_absent(object_key, encoded).await {
-        Ok(metadata) => Ok(metadata),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => Err(CoreError::Internal(format!(
+    let collision = || {
+        CoreError::Internal(format!(
             "a generated id collided with the existing control object `{object_key}`"
-        ))),
+        ))
+    };
+    match store.put_if_absent(object_key, encoded.clone()).await {
+        Ok(metadata) => Ok(metadata),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => Err(collision()),
+        Err(ObjectStoreError::Transport { .. }) => {
+            match store
+                .put_immutable_verified_with_metadata(object_key, encoded)
+                .await
+            {
+                Ok(metadata) => Ok(metadata),
+                Err(ImmutableWriteError::DifferentObject { .. }) => Err(collision()),
+                Err(ImmutableWriteError::Transport { source, .. }) => {
+                    Err(CoreError::store(object_key, &source))
+                }
+                Err(error) => Err(CoreError::Internal(format!(
+                    "generated-id write reconciliation failed for `{object_key}`: {error}"
+                ))),
+            }
+        }
         Err(error) => Err(CoreError::store(object_key, &error)),
     }
 }
@@ -260,6 +284,55 @@ mod tests {
             .put_if_absent(&wal_head(namespace_id), Bytes::from(bytes))
             .await
             .expect("write head");
+    }
+
+    #[tokio::test]
+    async fn generated_id_create_recovers_when_the_first_write_lands_ambiguously() {
+        let temp_dir = tempdir().expect("tempdir");
+        let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+        let object_key = "namespaces/demo/checkpoints/chk_00000000000000000000000000000001.json";
+        let payload = Bytes::from_static(b"generated control record");
+        let store = FailStore::new(
+            inner,
+            KeyPredicate::exact(object_key),
+            OperationClass::PutCreateIfAbsent,
+            InjectedError::Transport("lost write acknowledgement".to_owned()),
+        )
+        .apply_then_fail();
+        store.fail_next(1);
+
+        let metadata =
+            create_control_object_under_generated_id(&store, object_key, payload.clone())
+                .await
+                .expect("exact read-back reconciles the landed write");
+
+        assert_eq!(store.attempts(), 2);
+        assert!(metadata.etag.is_some());
+        assert_eq!(
+            store.get(object_key, None).await.expect("read record"),
+            Some(payload)
+        );
+    }
+
+    #[tokio::test]
+    async fn generated_id_create_does_not_adopt_an_existing_identical_record() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let object_key = "namespaces/demo/checkpoints/chk_00000000000000000000000000000001.json";
+        let payload = Bytes::from_static(b"generated control record");
+        store
+            .put_if_absent(object_key, payload.clone())
+            .await
+            .expect("seed colliding record");
+
+        let error = create_control_object_under_generated_id(&store, object_key, payload)
+            .await
+            .expect_err("an immediate precondition failure remains a collision");
+
+        assert!(matches!(
+            error,
+            CoreError::Internal(message) if message.contains("generated id collided")
+        ));
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/tests/it/common/mod.rs
+++ b/crates/loonfs-core/tests/it/common/mod.rs
@@ -363,6 +363,9 @@ pub(crate) mod commit_split_support {
         Transport {
             message: &'static str,
         },
+        PermissionDenied {
+            message: &'static str,
+        },
         PreconditionFailed {
             write_attempted_object: bool,
             additional_writes: Vec<(String, Vec<u8>)>,
@@ -377,7 +380,7 @@ pub(crate) mod commit_split_support {
             attempted_bytes: Bytes,
         ) -> Result<(), ObjectStoreError> {
             match self {
-                Self::Transport { .. } => Ok(()),
+                Self::Transport { .. } | Self::PermissionDenied { .. } => Ok(()),
                 Self::PreconditionFailed {
                     write_attempted_object,
                     additional_writes,
@@ -402,6 +405,10 @@ pub(crate) mod commit_split_support {
                 Self::Transport { message } => {
                     ObjectStoreError::transport(attempted_key, (*message).to_owned())
                 }
+                Self::PermissionDenied { message } => ObjectStoreError::PermissionDenied {
+                    object_key: attempted_key.to_owned(),
+                    message: (*message).to_owned(),
+                },
                 Self::PreconditionFailed { .. } => ObjectStoreError::PreconditionFailed {
                     object_key: attempted_key.to_owned(),
                 },

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -783,7 +783,7 @@ async fn fork_source_checkpoint_failure_leaves_target_namespace_absent() {
             "namespaces/{}/checkpoints/",
             source_namespace_id.as_str()
         )),
-        InjectedCreateFailure::Transport {
+        InjectedCreateFailure::PermissionDenied {
             message: "injected source checkpoint failure",
         },
     );
@@ -792,7 +792,7 @@ async fn fork_source_checkpoint_failure_leaves_target_namespace_absent() {
     let error = fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
         .await
         .expect_err("source checkpoint failure should abort fork before target publication");
-    assert_eq!(error.code(), ErrorCode::ServerError);
+    assert_eq!(error.code(), ErrorCode::StoragePermissionDenied);
     assert!(
         namespace_keys(&store, &clone_namespace_id).await.is_empty(),
         "the target must not be installed before the source basis is pinned"

--- a/crates/loonfs-objectstore/src/immutable_write.rs
+++ b/crates/loonfs-objectstore/src/immutable_write.rs
@@ -47,7 +47,7 @@ pub(crate) async fn put<S: ObjectStore + ?Sized>(
     store: &S,
     key: &str,
     bytes: Bytes,
-) -> std::result::Result<(), ImmutableWriteError> {
+) -> std::result::Result<ObjectMetadata, ImmutableWriteError> {
     let timer = StdMonotonicTimer::default();
     let retry_policy = TransportRetryPolicy::DEFAULT;
     let mode = if bytes.len() as u64 >= PROVIDER_MULTIPART_THRESHOLD_BYTES {
@@ -61,7 +61,7 @@ pub(crate) async fn put<S: ObjectStore + ?Sized>(
 
     loop {
         match store.put(key, bytes.clone(), mode.clone()).await {
-            Ok(_) => return Ok(()),
+            Ok(metadata) => return Ok(metadata),
             Err(error @ ObjectStoreError::PreconditionFailed { .. }) => {
                 return resolve_readback(store, key, &bytes, ambiguous_transport.unwrap_or(error))
                     .await;
@@ -93,9 +93,9 @@ async fn resolve_readback<S: ObjectStore + ?Sized>(
     key: &str,
     expected: &Bytes,
     original: ObjectStoreError,
-) -> std::result::Result<(), ImmutableWriteError> {
+) -> std::result::Result<ObjectMetadata, ImmutableWriteError> {
     match readback(store, key, expected).await {
-        Ok(ImmutableReadback::Identical(_)) => Ok(()),
+        Ok(ImmutableReadback::Identical(metadata)) => Ok(metadata),
         Ok(ImmutableReadback::Different) => Err(ImmutableWriteError::DifferentObject {
             object_key: key.to_owned(),
         }),

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -537,6 +537,18 @@ pub trait ObjectStore: Send + Sync + Debug {
         key: &str,
         bytes: Bytes,
     ) -> std::result::Result<(), crate::ImmutableWriteError> {
+        self.put_immutable_verified_with_metadata(key, bytes)
+            .await
+            .map(|_| ())
+    }
+
+    /// Performs [`Self::put_immutable_verified`] and returns metadata from the
+    /// confirmed write or exact read-back.
+    async fn put_immutable_verified_with_metadata(
+        &self,
+        key: &str,
+        bytes: Bytes,
+    ) -> std::result::Result<ObjectMetadata, crate::ImmutableWriteError> {
         crate::immutable_write::put(self, key, bytes).await
     }
 
@@ -646,6 +658,16 @@ impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
         self.as_ref().put_immutable_verified(key, bytes).await
     }
 
+    async fn put_immutable_verified_with_metadata(
+        &self,
+        key: &str,
+        bytes: Bytes,
+    ) -> std::result::Result<ObjectMetadata, crate::ImmutableWriteError> {
+        self.as_ref()
+            .put_immutable_verified_with_metadata(key, bytes)
+            .await
+    }
+
     async fn compare_and_swap(
         &self,
         key: &str,
@@ -740,6 +762,16 @@ impl<T: ObjectStore + ?Sized> ObjectStore for &T {
         bytes: Bytes,
     ) -> std::result::Result<(), crate::ImmutableWriteError> {
         (*self).put_immutable_verified(key, bytes).await
+    }
+
+    async fn put_immutable_verified_with_metadata(
+        &self,
+        key: &str,
+        bytes: Bytes,
+    ) -> std::result::Result<ObjectMetadata, crate::ImmutableWriteError> {
+        (*self)
+            .put_immutable_verified_with_metadata(key, bytes)
+            .await
     }
 
     async fn compare_and_swap(

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -24,7 +24,8 @@ use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{
-    BlockingStore, CountingStore, KeyPredicate, OperationClass, OperationKind,
+    BlockingStore, CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+    OperationKind,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -792,6 +793,46 @@ fn a_created_snapshot_is_listed_with_its_snapshot_owner() {
     assert_eq!(listed_snapshot.owner, snapshot.owner);
     assert_eq!(listed_snapshot.expires_at_ms, Some(expires_at_ms));
     assert_eq!(listed_snapshot.checkpoint_seq, snapshot.checkpoint_seq);
+}
+
+#[tokio::test]
+async fn snapshot_create_recovers_an_ambiguously_landed_record_write() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("snapshot-ambiguous-write");
+    let store = Arc::new(
+        FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::prefix(checkpoint_prefix(&namespace_id)),
+            OperationClass::PutCreateIfAbsent,
+            InjectedError::Transport("lost checkpoint write acknowledgement".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    let object_store: SharedObjectStore = store.clone();
+    let fs = open_runtime_async(object_store, "snapshot-ambiguous-write").await;
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    store.fail_next(1);
+
+    let snapshot = fs
+        .admin
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "report-run".to_owned(),
+                expires_at_ms: u64::MAX,
+            },
+        )
+        .await
+        .expect("reconcile the durable snapshot record");
+
+    assert_eq!(store.attempts(), 2);
+    let listed = collect_checkpoints(&fs.admin, &namespace_id)
+        .await
+        .expect("list checkpoints");
+    assert_eq!(listed.checkpoints.len(), 1);
+    assert_eq!(listed.checkpoints[0].checkpoint_id, snapshot.checkpoint_id);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
When a generated-ID control record write returns a transport error, retry it through exact-byte verification at the same key. Preserve immediate precondition failures as ID collisions.

This prevents a snapshot, checkpoint, upload session, or compaction lease from being left behind a failed call when the first write actually landed.