### PR TITLE
fix(core): reconcile control publications

### DIFF
--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -119,20 +119,14 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
         .await
         .map_err(CoreError::ControlObjectLoad)?
     else {
-        return match create_first_metadata_root(store, namespace_id, &candidate, updated_at_ms)
-            .await?
-        {
-            Some(root) => Ok(ManifestPublicationOutcome::Published(root)),
-            None => {
-                classify_current_root(
-                    store,
-                    namespace_id,
-                    &candidate,
-                    expected_predecessor.as_ref(),
-                )
-                .await
-            }
-        };
+        return create_first_metadata_root(
+            store,
+            namespace_id,
+            &candidate,
+            expected_predecessor.as_ref(),
+            updated_at_ms,
+        )
+        .await;
     };
     match root_transition(&loaded.state, &candidate, expected_predecessor.as_ref()) {
         RootTransition::InstallAgainstCurrent => {}
@@ -258,13 +252,16 @@ fn ensure_legal_successor(
 
 /// Publishes the namespace's first `metadata/root.json`.
 ///
-/// Returns `None` when another publisher wins the conditional create.
+/// A confirmed conflict and an ambiguous transport result are both resolved
+/// by reading the authoritative root and applying the same classification as
+/// the later CAS path.
 async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     candidate: &ManifestRef,
+    expected_predecessor: Option<&ManifestObjectId>,
     updated_at_ms: u64,
-) -> Result<Option<MetadataRootState>> {
+) -> Result<ManifestPublicationOutcome> {
     let object_key = metadata_root(namespace_id);
     let next = MetadataRootState {
         namespace_id: namespace_id.clone(),
@@ -279,8 +276,20 @@ async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
             }
         })?;
     match store.put_if_absent(&object_key, Bytes::from(encoded)).await {
-        Ok(_) => Ok(Some(next)),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(None),
+        Ok(_) => Ok(ManifestPublicationOutcome::Published(next)),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => {
+            classify_current_root(store, namespace_id, candidate, expected_predecessor).await
+        }
+        Err(error @ ObjectStoreError::Transport { .. }) => {
+            match classify_current_root(store, namespace_id, candidate, expected_predecessor)
+                .await?
+            {
+                ManifestPublicationOutcome::RootCasRaceLost => {
+                    Err(CoreError::store(&object_key, &error))
+                }
+                outcome => Ok(outcome),
+            }
+        }
         Err(error) => Err(CoreError::store(&object_key, &error)),
     }
 }

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -15,7 +15,7 @@ use crate::namespace::control_snapshot::resolve_retention_floor_seq;
 use bytes::Bytes;
 use loonfs_api::wire::control::{encode_control_state, ControlObjectKind, WalFloorState};
 use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
-use loonfs_api::{AdvanceRetentionResponse, NamespaceId};
+use loonfs_api::{AdvanceRetentionResponse, ChangeSeq, NamespaceId};
 use loonfs_objectstore::keys::metadata_segment_object_key;
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 use std::collections::BTreeSet;
@@ -51,6 +51,22 @@ async fn verify_manifest_segments_exist<S: ObjectStore + ?Sized>(
         .await?;
     }
     Ok(())
+}
+
+/// Reads back a monotonic floor after a write whose outcome is unknown.
+///
+/// Any value at or above the requested target proves that the operation is
+/// already settled, whether this writer or a concurrent writer published it.
+async fn load_floor_at_or_above<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    target_floor: ChangeSeq,
+) -> Result<Option<ChangeSeq>> {
+    match load_wal_floor_object(store, namespace_id).await {
+        Ok(loaded) if loaded.state.floor_seq >= target_floor => Ok(Some(loaded.state.floor_seq)),
+        Ok(_) | Err(ControlObjectLoadError::MissingObject { .. }) => Ok(None),
+        Err(error) => Err(CoreError::ControlObjectLoad(error)),
+    }
 }
 
 pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
@@ -147,6 +163,12 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         match published {
             Ok(_) => Ok(CasAttempt::Settled(target_floor)),
             Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
+            Err(error @ ObjectStoreError::Transport { .. }) => {
+                match load_floor_at_or_above(store, namespace_id, target_floor).await? {
+                    Some(floor_seq) => Ok(CasAttempt::Settled(floor_seq)),
+                    None => Err(CoreError::store(object_key, &error)),
+                }
+            }
             Err(error) => Err(CoreError::store(object_key, &error)),
         }
     })

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -1026,6 +1026,147 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
 }
 
 #[tokio::test]
+async fn first_root_create_recovers_when_the_write_lands_ambiguously() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::exact(metadata_root(&namespace_id)),
+        OperationClass::PutCreateIfAbsent,
+        InjectedError::Transport("lost first-root acknowledgment".to_owned()),
+    )
+    .apply_then_fail();
+    crate::namespace::bootstrap::bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap without a root");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    store.fail_next(1);
+
+    let response = flush::flush_wal(&store, &namespace_id, &context)
+        .await
+        .expect("root read-back reconciles the landed create");
+
+    assert_eq!(response.manifest_head_seq, ChangeSeq(1));
+    assert_eq!(store.attempts(), 1);
+    assert_eq!(
+        load_metadata_root_object(&store, &namespace_id)
+            .await
+            .expect("load reconciled root")
+            .state
+            .manifest
+            .manifest_head_seq,
+        ChangeSeq(1)
+    );
+}
+
+#[tokio::test]
+async fn first_floor_create_recovers_when_the_write_lands_ambiguously() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::exact(wal_floor(&namespace_id)),
+        OperationClass::PutCreateIfAbsent,
+        InjectedError::Transport("lost first-floor acknowledgment".to_owned()),
+    )
+    .apply_then_fail();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    flush::flush_wal(&store, &namespace_id, &context)
+        .await
+        .expect("publish root at sequence one");
+    store.fail_next(1);
+
+    let response = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("floor read-back reconciles the landed create");
+
+    assert_eq!(response.retention_floor_seq, ChangeSeq(1));
+    assert_eq!(store.attempts(), 1);
+    assert_eq!(read_floor_seq(&store, &namespace_id).await, ChangeSeq(1));
+}
+
+#[tokio::test]
+async fn floor_cas_recovers_when_the_write_lands_ambiguously() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::exact(wal_floor(&namespace_id)),
+        OperationClass::CompareAndSwap,
+        InjectedError::Transport("lost floor-CAS acknowledgment".to_owned()),
+    )
+    .apply_then_fail();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/one.txt",
+        b"one\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write first file");
+    flush::flush_wal(&store, &namespace_id, &context)
+        .await
+        .expect("publish root at sequence one");
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("create the initial floor");
+
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/two.txt",
+        b"two\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write second file");
+    flush::flush_wal(&store, &namespace_id, &context)
+        .await
+        .expect("publish root at sequence two");
+    assert_eq!(read_floor_seq(&store, &namespace_id).await, ChangeSeq(1));
+    store.fail_next(1);
+
+    let response = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("floor read-back reconciles the landed CAS");
+
+    assert_eq!(response.retention_floor_seq, ChangeSeq(2));
+    assert_eq!(store.attempts(), 1);
+    assert_eq!(read_floor_seq(&store, &namespace_id).await, ChangeSeq(2));
+}
+
+#[tokio::test]
 async fn floor_cas_never_regresses_under_a_competing_advancement() {
     // A competing GC actor lands a higher floor between our verification and
     // CAS. The retry observes it and yields: floors are monotonic.

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -187,7 +187,41 @@ pub(super) async fn install_namespace_head<S: ObjectStore + ?Sized>(
             }
             Ok(NamespaceHeadInstall::Exists)
         }
+        // The create may have reached the provider before its acknowledgment
+        // was lost. The immutable identity fields distinguish this attempt's
+        // installed head from a concurrent winner even after later head
+        // updates. An immediate precondition failure above remains a plain
+        // conflict because it carries no evidence that this attempt wrote.
+        Err(error @ ObjectStoreError::Transport { .. }) => {
+            let existing = match load_head_object(store, namespace_id).await {
+                Ok(loaded) => loaded.state,
+                Err(ControlObjectLoadError::MissingObject { .. }) => {
+                    return Err(CoreError::store(&object_key, &error))
+                }
+                Err(load_error) => return Err(CoreError::ControlObjectLoad(load_error)),
+            };
+            Ok(classify_ambiguous_namespace_install(head, &existing))
+        }
         Err(error) => Err(CoreError::store(&object_key, &error)),
+    }
+}
+
+/// Classifies the authoritative head after an ambiguous conditional create.
+///
+/// Deleted namespace ids stay retired. Otherwise the proposed head owns the
+/// result only when all immutable identity fields survived in the loaded
+/// head. Mutable fields may already have advanced after the create landed.
+fn classify_ambiguous_namespace_install(
+    proposed: &HeadState,
+    existing: &HeadState,
+) -> NamespaceHeadInstall {
+    if existing.status == (NamespaceStatus::Deleted {}) {
+        return NamespaceHeadInstall::Deleted;
+    }
+    if proposed.ensure_successor_identity(existing).is_ok() {
+        NamespaceHeadInstall::Landed
+    } else {
+        NamespaceHeadInstall::Exists
     }
 }
 
@@ -213,4 +247,63 @@ pub(crate) fn bootstrap_metadata_state(created_at_ms: u64) -> MetadataState {
         Vec::new(),
         Vec::new(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loonfs_api::{CommitId, WriterEpoch};
+
+    fn namespace(value: &str) -> NamespaceId {
+        NamespaceId::parse(value).expect("valid namespace id")
+    }
+
+    fn proposed_head() -> HeadState {
+        HeadState::initial(
+            namespace("demo"),
+            ContentStoreId::parse("cs_0123456789abcdef0123456789abcdef")
+                .expect("valid content store id"),
+            1_000,
+        )
+    }
+
+    #[test]
+    fn ambiguous_install_recognizes_its_identity_after_mutable_head_fields_advance() {
+        let proposed = proposed_head();
+        let mut advanced = proposed.clone();
+        advanced.seq = ChangeSeq(1);
+        advanced.head_commit_id =
+            CommitId::parse("c_00000000000000000000000000000001").expect("valid commit id");
+        advanced.writer_epoch = WriterEpoch(1);
+
+        assert_eq!(
+            classify_ambiguous_namespace_install(&proposed, &advanced),
+            NamespaceHeadInstall::Landed
+        );
+    }
+
+    #[test]
+    fn ambiguous_install_does_not_adopt_a_foreign_namespace_identity() {
+        let proposed = proposed_head();
+        let mut foreign = proposed.clone();
+        foreign.content_store_id = ContentStoreId::parse("cs_fedcba9876543210fedcba9876543210")
+            .expect("valid content store id");
+
+        assert_eq!(
+            classify_ambiguous_namespace_install(&proposed, &foreign),
+            NamespaceHeadInstall::Exists
+        );
+    }
+
+    #[test]
+    fn ambiguous_install_never_revives_a_deleted_namespace_id() {
+        let proposed = proposed_head();
+        let mut deleted = proposed.clone();
+        deleted.status = NamespaceStatus::Deleted {};
+
+        assert_eq!(
+            classify_ambiguous_namespace_install(&proposed, &deleted),
+            NamespaceHeadInstall::Deleted
+        );
+    }
 }

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -29,7 +29,9 @@ use loonfs_objectstore::keys::{metadata_manifest_object, metadata_root, wal_floo
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::ids::namespace_id;
-use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
+use loonfs_test_support::stores::{
+    CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+};
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -185,6 +187,31 @@ async fn a_created_namespace_is_one_object_until_its_first_flush() {
 }
 
 #[tokio::test]
+async fn namespace_create_recovers_when_the_head_write_lands_ambiguously() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::exact(wal_head(&namespace_id)),
+        OperationClass::PutCreateIfAbsent,
+        InjectedError::Transport("lost namespace-head acknowledgment".to_owned()),
+    )
+    .apply_then_fail();
+    store.fail_next(1);
+
+    let created = bootstrap_namespace(&store, &namespace_id, &mutation_context(), false)
+        .await
+        .expect("head identity reconciles the landed create");
+
+    assert_eq!(created.namespace_id, namespace_id);
+    assert_eq!(store.attempts(), 1);
+    assert_eq!(
+        head_state(&store, &namespace_id).await.status,
+        loonfs_api::wire::control::NamespaceStatus::Active {}
+    );
+}
+
+#[tokio::test]
 async fn concurrent_creates_of_one_id_leave_exactly_one_winner() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
@@ -302,6 +329,33 @@ async fn concurrent_installs_of_one_target_leave_exactly_one_winner() {
     } else {
         assert!(head.fork_basis.is_some(), "the fork won");
     }
+}
+
+#[tokio::test]
+async fn fork_install_recovers_when_the_target_head_lands_ambiguously() {
+    let temp_dir = tempdir().expect("tempdir");
+    let context = mutation_context();
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::exact(wal_head(&target)),
+        OperationClass::PutCreateIfAbsent,
+        InjectedError::Transport("lost fork-head acknowledgment".to_owned()),
+    )
+    .apply_then_fail();
+    seed_source_namespace_for_fork(&store, &source, &context).await;
+    store.fail_next(1);
+
+    let forked = fork_namespace(&store, &source, &target, &context)
+        .await
+        .expect("fork basis identity reconciles the landed target");
+
+    assert_eq!(forked.namespace_id, target);
+    assert_eq!(store.attempts(), 1);
+    let target_head = head_state(&store, &target).await;
+    let basis = target_head.fork_basis.expect("fork target basis");
+    assert_eq!(basis.manifest.owner_namespace_id, source);
 }
 
 #[tokio::test]


### PR DESCRIPTION
When a namespace head, first metadata root, or retention floor write returns a transport error, read the authoritative control object and return success only when it proves the intended state landed. Preserve namespace identity, deleted namespace, root coverage, and floor monotonicity checks.

This prevents a lost object-store acknowledgment from hiding a completed namespace installation, metadata publication, or retention advance.