### PR TITLE
fix(core): reconcile checkpoint transitions

### DIFF
--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -155,15 +155,29 @@ pub(crate) async fn release_inspected_checkpoint_record<S: ObjectStore + ?Sized>
     loaded: LoadedCheckpointRecord,
     released_at_ms: u64,
 ) -> Result<CheckpointRelease> {
+    let expected_etag = loaded.etag;
     let mut next = loaded.state;
     next.status = CheckpointStatus::Released { released_at_ms };
     let encoded = encode_checkpoint_record(&next)?;
     match store
-        .compare_and_swap(object_key, &loaded.etag, encoded)
+        .compare_and_swap(object_key, &expected_etag, encoded)
         .await
     {
         Ok(_) => Ok(CheckpointRelease::Released),
         Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CheckpointRelease::LostRace),
+        Err(error @ ObjectStoreError::Transport { .. }) => {
+            match load_checkpoint_record_at_key(store, object_key).await {
+                Ok(current) if current.state.status != (CheckpointStatus::Active {}) => {
+                    Ok(CheckpointRelease::Released)
+                }
+                Ok(current) if current.etag != expected_etag => Ok(CheckpointRelease::LostRace),
+                Ok(_) => Err(CoreError::store(object_key, &error)),
+                Err(ControlObjectLoadError::MissingObject { .. }) => {
+                    Ok(CheckpointRelease::Released)
+                }
+                Err(load_error) => Err(CoreError::ControlObjectLoad(load_error)),
+            }
+        }
         Err(error) => Err(CoreError::store(object_key, &error)),
     }
 }
@@ -250,7 +264,36 @@ pub(crate) async fn renew_fork_checkpoint_for_install<S: ObjectStore + ?Sized>(
         {
             Ok(_) => Ok(CasAttempt::Settled(renewed_expiry)),
             Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            // Do not install a target unless the renewal is confirmed.
+            Err(error @ ObjectStoreError::Transport { .. }) => {
+                let Some(current) =
+                    load_checkpoint_record(store, source_namespace_id, checkpoint_id).await?
+                else {
+                    return Err(unavailable("the record is gone".to_owned()));
+                };
+                if current.state.status != (CheckpointStatus::Active {}) {
+                    return Err(unavailable(format!(
+                        "the record is `{}`",
+                        current.state.status
+                    )));
+                }
+                let CheckpointOwner::Fork {
+                    target_namespace_id,
+                    expires_at_ms,
+                } = current.state.owner
+                else {
+                    return Err(unavailable("the record is not fork-owned".to_owned()));
+                };
+                if &target_namespace_id != expected_target_namespace_id {
+                    return Err(unavailable(format!(
+                        "the record pins target `{target_namespace_id}`"
+                    )));
+                }
+                if expires_at_ms >= renewed_expiry {
+                    Ok(CasAttempt::Settled(expires_at_ms))
+                } else {
+                    Err(CoreError::store(object_key, &error))
+                }
+            }
             Err(error) => Err(CoreError::store(object_key, &error)),
         }
     })

--- a/crates/loonfs-core/src/checkpoint/snapshot.rs
+++ b/crates/loonfs-core/src/checkpoint/snapshot.rs
@@ -66,6 +66,25 @@ pub(crate) async fn extend_snapshot_expiry<S: ObjectStore + ?Sized>(
         {
             Ok(_) => Ok(CasAttempt::Settled(super::checkpoint_summary(next))),
             Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
+            Err(error @ ObjectStoreError::Transport { .. }) => {
+                let current = classify_live_snapshot(
+                    load_checkpoint_record(store, namespace_id, checkpoint_id).await?,
+                    checkpoint_id,
+                    context.now_ms,
+                )?;
+                let CheckpointOwner::Snapshot { expires_at_ms, .. } = &current.state.owner else {
+                    return Err(CoreError::Internal(
+                        "live snapshot classification returned a non-snapshot owner".to_owned(),
+                    ));
+                };
+                if *expires_at_ms >= new_expires_at_ms {
+                    Ok(CasAttempt::Settled(super::checkpoint_summary(
+                        current.state,
+                    )))
+                } else {
+                    Err(CoreError::store(&object_key, &error))
+                }
+            }
             Err(error) => Err(CoreError::store(&object_key, &error)),
         }
     })

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -835,6 +835,150 @@ async fn snapshot_create_recovers_an_ambiguously_landed_record_write() {
     assert_eq!(listed.checkpoints[0].checkpoint_id, snapshot.checkpoint_id);
 }
 
+#[tokio::test]
+async fn snapshot_extension_recovers_an_ambiguously_landed_record_write() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("snapshot-ambiguous-extension");
+    let checkpoint_key_prefix = checkpoint_prefix(&namespace_id);
+    let store = Arc::new(
+        FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::prefix(checkpoint_key_prefix),
+            OperationClass::CompareAndSwap,
+            InjectedError::Transport("lost snapshot extension acknowledgement".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    let object_store: SharedObjectStore = store.clone();
+    let fs = open_runtime_async(object_store, "snapshot-ambiguous-extension").await;
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let snapshot = fs
+        .admin
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "report-run".to_owned(),
+                expires_at_ms: u64::MAX - 1,
+            },
+        )
+        .await
+        .expect("create snapshot");
+    store.fail_next(1);
+
+    let extended = fs
+        .admin
+        .extend_snapshot(&namespace_id, &snapshot.checkpoint_id, u64::MAX, u64::MAX)
+        .await
+        .expect("reconcile the durable snapshot extension");
+
+    assert_eq!(extended.expires_at_ms, u64::MAX);
+    assert_eq!(store.attempts(), 1);
+}
+
+#[tokio::test]
+async fn snapshot_release_recovers_an_ambiguously_landed_record_write() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("snapshot-ambiguous-release");
+    let store = Arc::new(
+        FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::prefix(checkpoint_prefix(&namespace_id)),
+            OperationClass::CompareAndSwap,
+            InjectedError::Transport("lost snapshot release acknowledgement".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    let object_store: SharedObjectStore = store.clone();
+    let fs = open_runtime_async(object_store, "snapshot-ambiguous-release").await;
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let snapshot = fs
+        .admin
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "report-run".to_owned(),
+                expires_at_ms: u64::MAX,
+            },
+        )
+        .await
+        .expect("create snapshot");
+    store.fail_next(1);
+
+    fs.admin
+        .release_snapshot(&namespace_id, &snapshot.checkpoint_id)
+        .await
+        .expect("reconcile the durable snapshot release");
+
+    assert_eq!(store.attempts(), 1);
+    let listed = collect_checkpoints(&fs.admin, &namespace_id)
+        .await
+        .expect("list checkpoints");
+    assert!(listed
+        .checkpoints
+        .iter()
+        .all(|checkpoint| checkpoint.checkpoint_id != snapshot.checkpoint_id));
+}
+
+#[tokio::test]
+async fn fork_recovers_an_ambiguously_landed_checkpoint_renewal() {
+    let temp_dir = tempdir().expect("tempdir");
+    let source = namespace_id("fork-ambiguous-renewal-source");
+    let target = namespace_id("fork-ambiguous-renewal-target");
+    let store = Arc::new(
+        FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::prefix(checkpoint_prefix(&source)),
+            OperationClass::CompareAndSwap,
+            InjectedError::Transport("lost fork checkpoint renewal acknowledgement".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    let object_store: SharedObjectStore = store.clone();
+    let fs = open_runtime_async(object_store, "fork-ambiguous-renewal").await;
+    fs.create_namespace(&source, CreateNamespaceOptions::default())
+        .await
+        .expect("create source namespace");
+    fs.put_file_bytes(
+        &source,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::new(loonfs_test_support::test_actor()),
+    )
+    .await
+    .expect("write source file");
+    store.fail_next(1);
+
+    let forked = fs
+        .writer
+        .fork_namespace(&source, &target)
+        .await
+        .expect("reconcile the durable fork checkpoint renewal");
+
+    assert_eq!(store.attempts(), 1);
+    assert_eq!(forked.namespace_id, target);
+    let checkpoints = collect_checkpoints(&fs.admin, &source)
+        .await
+        .expect("list source checkpoints");
+    let fork_checkpoint = checkpoints
+        .checkpoints
+        .iter()
+        .find(|checkpoint| {
+            matches!(
+                &checkpoint.owner,
+                CheckpointOwnerSummary::Fork {
+                    target_namespace_id,
+                    ..
+                } if target_namespace_id == &target
+            )
+        })
+        .expect("fork checkpoint remains installed");
+    assert_eq!(fork_checkpoint.namespace_id, source);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn concurrent_snapshot_creates_cannot_both_claim_the_last_quota_slot() {
     let temp_dir = tempdir().expect("tempdir");


### PR DESCRIPTION
When a snapshot extension, checkpoint release, or fork-pin renewal returns a transport error, read the checkpoint record and return success only when it confirms the requested state. Keep active, owner, target, and expiry checks.

This prevents a lost object-store acknowledgment from hiding a completed checkpoint transition or allowing a fork to install without a confirmed live pin.