### PR TITLE
fix(core): wait for commit ID evidence

### DIFF
--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -536,6 +536,16 @@ struct InFlightRequest {
     waiters: Vec<oneshot::Sender<CommitResult>>,
 }
 
+enum SubmissionAdmission {
+    /// This submission owns the published outcome, either as the primary or
+    /// as an exact duplicate of it.
+    OwnOutcome,
+    /// A different claim currently owns the commit ID. Its successful outcome
+    /// supplies the receipt evidence this submission needs for a useful
+    /// conflict; if it fails, this submission gets another turn at admission.
+    Contended { primary_identity: CommitFingerprint },
+}
+
 impl NamespacePublisher {
     fn new(
         namespace_id: NamespaceId,
@@ -629,8 +639,9 @@ impl NamespacePublisher {
 
     /// Admits the request before awaiting its result.
     ///
-    /// The first poll either admits the candidate or returns an error. After
-    /// admission, cancelling the caller only drops result delivery; the worker
+    /// The first poll either admits the candidate, waits behind an in-flight
+    /// claim on its commit ID, or returns an error. Once the candidate enters
+    /// the queue, cancelling the caller only drops result delivery; the worker
     /// still owns and publishes the request.
     #[allow(clippy::disallowed_methods)]
     // Monotonic time is used only to record queue latency.
@@ -638,16 +649,35 @@ impl NamespacePublisher {
         let commit_id = candidate.commit_id().clone();
         let enqueued_at = Instant::now();
         let semantic_identity = candidate.semantic_identity(&self.namespace_id)?;
-        let (sender, receiver) = oneshot::channel();
-        self.admit(commit_id, candidate, semantic_identity, sender, enqueued_at)?;
-        receiver.await.unwrap_or_else(|_| {
-            Err(
+        loop {
+            let (sender, receiver) = oneshot::channel();
+            let admission = self.admit(
+                commit_id.clone(),
+                candidate.clone(),
+                semantic_identity.clone(),
+                sender,
+                enqueued_at,
+            )?;
+            let result = receiver.await.map_err(|_| {
                 CoreError::HeadPublish(CommitHeadPublishError::OutcomeUnknown(
                     "publisher task stopped before reporting an outcome".to_owned(),
                 ))
-                .into(),
-            )
-        })
+            })?;
+            match admission {
+                SubmissionAdmission::OwnOutcome => return result,
+                SubmissionAdmission::Contended { primary_identity } => match result {
+                    Ok(response) => {
+                        return Err(CoreError::CommitIdReuseConflict {
+                            commit_id: commit_id.to_string(),
+                            committed_seq: Some(response.committed_seq),
+                            committed_fingerprint: Some(primary_identity.as_str().to_owned()),
+                        }
+                        .into())
+                    }
+                    Err(_) => continue,
+                },
+            }
+        }
     }
 
     fn admit(
@@ -657,22 +687,19 @@ impl NamespacePublisher {
         semantic_identity: CommitFingerprint,
         waiter: oneshot::Sender<CommitResult>,
         enqueued_at: Instant,
-    ) -> Result<(), CoreError> {
+    ) -> Result<SubmissionAdmission, CoreError> {
         let mut state = self.lock_state();
         self.check_admission(&state)?;
         if let Some(existing) = state.in_flight.get_mut(&commit_id) {
             if existing.semantic_identity != semantic_identity {
-                // Both claims are still in flight, so nothing has landed
-                // under this id for the caller to read back.
-                return Err(CoreError::CommitIdReuseConflict {
-                    commit_id: commit_id.to_string(),
-                    committed_seq: None,
-                    committed_fingerprint: None,
-                });
+                let primary_identity = existing.semantic_identity.clone();
+                existing.waiters.push(waiter);
+                self.trace_enqueue(queued_candidates(&state), "contended");
+                return Ok(SubmissionAdmission::Contended { primary_identity });
             }
             existing.waiters.push(waiter);
             self.trace_enqueue(queued_candidates(&state), "duplicate");
-            return Ok(());
+            return Ok(SubmissionAdmission::OwnOutcome);
         }
 
         let queued = queued_candidates(&state);
@@ -703,7 +730,7 @@ impl NamespacePublisher {
             },
         );
         self.ensure_worker(&mut state);
-        Ok(())
+        Ok(SubmissionAdmission::OwnOutcome)
     }
 
     /// Enqueues the delete as a barrier: requests admitted before it

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -365,6 +365,24 @@ async fn wait_for_queued_candidates(publisher: &NamespacePublisher, expected: us
     }
 }
 
+/// Yields until all expected callers are waiting on one in-flight commit ID.
+async fn wait_for_commit_waiters(
+    publisher: &NamespacePublisher,
+    commit_id: &CommitId,
+    expected: usize,
+) {
+    loop {
+        let ready = publisher_state(publisher)
+            .in_flight
+            .get(commit_id)
+            .is_some_and(|request| request.waiters.len() >= expected);
+        if ready {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
 /// Yields until a delete sits at the tail of the publisher's queue.
 async fn wait_for_queued_delete(publisher: &NamespacePublisher) {
     loop {
@@ -481,13 +499,14 @@ fn try_admit_candidate(
     let commit_id = candidate.commit_id().clone();
     let semantic_identity = candidate.semantic_identity(namespace_id)?;
     let (sender, receiver) = oneshot::channel();
-    publisher.admit(
+    let admission = publisher.admit(
         commit_id,
         candidate,
         semantic_identity,
         sender,
         Instant::now(),
     )?;
+    assert!(matches!(admission, SubmissionAdmission::OwnOutcome));
     Ok(receiver)
 }
 
@@ -682,7 +701,7 @@ async fn publisher_admits_pending_batch_while_active_publish_blocks() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
+async fn publisher_contender_waits_for_active_request_receipt() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
@@ -692,11 +711,11 @@ async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
     let publisher = standalone_publisher(&namespace_id, &runtime);
 
     store.block_next();
-    let active = admit_commit(
-        &publisher,
-        &namespace_id,
-        create_directory_request("active", "active"),
-    );
+    let active_request = create_directory_request("active", "active");
+    let active_identity = CommitCandidate::new(active_request.clone())
+        .semantic_identity(&namespace_id)
+        .expect("active identity");
+    let active = admit_commit(&publisher, &namespace_id, active_request);
     store.wait_until_blocked().await;
 
     let duplicate = admit_commit(
@@ -704,26 +723,79 @@ async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
         &namespace_id,
         create_directory_request("active", "active"),
     );
-    let conflict = try_admit_commit(
-        &publisher,
-        &namespace_id,
-        create_directory_request("active", "different-active"),
-    );
-    // Both claims are still in flight, so there is no receipt to name.
-    assert!(matches!(
-        conflict,
-        Err(CoreError::CommitIdReuseConflict {
-            commit_id,
-            committed_seq: None,
-            committed_fingerprint: None,
-        }) if commit_id == "active"
-    ));
+    let conflict = {
+        let publisher = publisher.clone();
+        let request = create_directory_request("active", "different-active");
+        tokio::spawn(async move { publisher.submit(CommitCandidate::new(request)).await })
+    };
+    let active_commit_id = CommitId::parse("active").expect("valid commit id");
+    wait_for_commit_waiters(&publisher, &active_commit_id, 3).await;
 
     store.release();
     let active_response = recv_commit(active, "active").await;
     let duplicate_response = recv_commit(duplicate, "duplicate").await;
+    let conflict = conflict
+        .await
+        .expect("conflict task")
+        .expect_err("different request conflicts after the primary lands");
     assert_eq!(active_response.committed_seq, ChangeSeq(1));
     assert_eq!(duplicate_response.committed_seq, ChangeSeq(1));
+    assert!(matches!(
+        conflict,
+        RuntimeError::Core(CoreError::CommitIdReuseConflict {
+            commit_id,
+            committed_seq: Some(ChangeSeq(1)),
+            committed_fingerprint: Some(fingerprint),
+        }) if commit_id == "active" && fingerprint == active_identity.as_str()
+    ));
+}
+
+#[tokio::test]
+async fn publisher_contender_retries_after_active_request_fails() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let runtime = test_runtime(store);
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
+    let commit_id = CommitId::parse("handoff").expect("valid commit id");
+    let primary_identity = CommitCandidate::new(create_directory_request("handoff", "first"))
+        .semantic_identity(&namespace_id)
+        .expect("primary identity");
+    publisher_state(&publisher).in_flight.insert(
+        commit_id.clone(),
+        InFlightRequest {
+            semantic_identity: primary_identity,
+            waiters: Vec::new(),
+        },
+    );
+
+    let contender = {
+        let publisher = publisher.clone();
+        tokio::spawn(async move {
+            publisher
+                .submit(CommitCandidate::new(create_directory_request(
+                    "handoff", "second",
+                )))
+                .await
+        })
+    };
+    wait_for_commit_waiters(&publisher, &commit_id, 1).await;
+
+    let failed_primary = publisher_state(&publisher)
+        .in_flight
+        .remove(&commit_id)
+        .expect("in-flight primary");
+    for waiter in failed_primary.waiters {
+        let _ = waiter.send(Err(CoreError::Internal("primary failed".to_owned()).into()));
+    }
+
+    let response = contender
+        .await
+        .expect("contender task")
+        .expect("contender publishes after the failed primary");
+    assert_eq!(response.commit_id, commit_id);
+    assert_eq!(response.committed_seq, ChangeSeq(1));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -758,19 +830,13 @@ async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
         &namespace_id,
         create_directory_request("pending-0", "pending-0"),
     );
-    let conflict = try_admit_commit(
-        &publisher,
-        &namespace_id,
-        create_directory_request("pending-0", "different-pending"),
-    );
-    assert!(matches!(
-        conflict,
-        Err(CoreError::CommitIdReuseConflict {
-            commit_id,
-            committed_seq: None,
-            committed_fingerprint: None,
-        }) if commit_id == "pending-0"
-    ));
+    let conflict = {
+        let publisher = publisher.clone();
+        let request = create_directory_request("pending-0", "different-pending");
+        tokio::spawn(async move { publisher.submit(CommitCandidate::new(request)).await })
+    };
+    let pending_commit_id = CommitId::parse("pending-0").expect("valid commit id");
+    wait_for_commit_waiters(&publisher, &pending_commit_id, 3).await;
 
     let overflow = try_admit_commit(
         &publisher,
@@ -794,6 +860,18 @@ async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
         recv_commit(duplicate, "duplicate").await.committed_seq,
         ChangeSeq(2)
     );
+    let conflict = conflict
+        .await
+        .expect("conflict task")
+        .expect_err("different request conflicts after the primary lands");
+    assert!(matches!(
+        conflict,
+        RuntimeError::Core(CoreError::CommitIdReuseConflict {
+            commit_id,
+            committed_seq: Some(ChangeSeq(2)),
+            committed_fingerprint: Some(_),
+        }) if commit_id == "pending-0"
+    ));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -79,6 +79,76 @@ async fn namespace(runtime: &TestRuntime) -> NamespaceId {
     namespace_id
 }
 
+/// Advances retention and rebuilds the metadata runs that held a commit receipt.
+async fn compact_receipt_past_horizon(
+    runtime: &TestRuntime,
+    namespace_id: &NamespaceId,
+    committed_seq: ChangeSeq,
+) -> ChangeSeq {
+    // Nine rounds: the first flush builds the base run, and the next eight
+    // accumulate the delta runs that reach the fold trigger
+    // (`DEFAULT_MAX_CHECKPOINT_DELTA_RUNS`).
+    let mut last_seq = committed_seq;
+    for round in 0..9 {
+        let filler = runtime
+            .put_file_bytes(
+                namespace_id,
+                &format!("/docs/filler-{round}.txt"),
+                b"filler\n",
+                options(&CommitId::parse(format!("filler-{round}")).expect("valid commit id")),
+            )
+            .await
+            .expect("filler put");
+        last_seq = filler.committed_seq;
+        runtime
+            .create_checkpoint(namespace_id)
+            .await
+            .expect("create checkpoint");
+    }
+    let advanced = runtime
+        .admin
+        .run_maintenance(
+            namespace_id,
+            MaintenancePlan {
+                advance_retention: true,
+                ..MaintenancePlan::default()
+            },
+        )
+        .await
+        .expect("advance retention floor")
+        .retention
+        .expect("retention selected");
+    assert!(
+        advanced.retention_floor_seq > committed_seq,
+        "the floor must pass the commit for this to test anything: floor {:?}, commit {:?}",
+        advanced.retention_floor_seq,
+        committed_seq
+    );
+
+    // The floor alone leaves the receipt answering. Drain reorganization so
+    // the run families holding the receipt are rebuilt above the floor.
+    let mut folded = false;
+    for _ in 0..32 {
+        let step = runtime
+            .admin
+            .run_maintenance(namespace_id, MaintenancePlan::metadata())
+            .await
+            .expect("upkeep step")
+            .metadata_maintenance
+            .expect("metadata selected");
+        if matches!(step.reorganize, ReorganizeStepOutcome::NotNeeded) {
+            break;
+        }
+        folded = true;
+    }
+    assert!(
+        folded,
+        "reorganization must actually rebuild runs for this to test anything"
+    );
+
+    last_seq
+}
+
 #[tokio::test]
 async fn restart_replays_the_commit_actor_from_the_wal() {
     let temp_dir = tempdir().expect("tempdir");
@@ -609,72 +679,7 @@ async fn a_retry_past_the_receipt_horizon_commits_again() {
         .await
         .expect("first put");
 
-    // Move the floor strictly past the pinned commit, and pile up enough
-    // flushed runs that reorganization has real folding to do — receipts
-    // are dropped when the runs holding them are rebuilt, and rebuilding
-    // waits for enough delta runs to accumulate.
-    // Nine rounds: the first flush builds the base run, and the next eight
-    // accumulate the delta runs that reach the fold trigger
-    // (`DEFAULT_MAX_CHECKPOINT_DELTA_RUNS`).
-    let mut last_seq = first.committed_seq;
-    for round in 0..9 {
-        let filler = runtime
-            .put_file_bytes(
-                &namespace_id,
-                &format!("/docs/filler-{round}.txt"),
-                b"filler\n",
-                options(&CommitId::parse(format!("filler-{round}")).expect("valid commit id")),
-            )
-            .await
-            .expect("filler put");
-        last_seq = filler.committed_seq;
-        runtime
-            .create_checkpoint(&namespace_id)
-            .await
-            .expect("create checkpoint");
-    }
-    let advanced = runtime
-        .admin
-        .run_maintenance(
-            &namespace_id,
-            MaintenancePlan {
-                advance_retention: true,
-                ..MaintenancePlan::default()
-            },
-        )
-        .await
-        .expect("advance retention floor")
-        .retention
-        .expect("retention selected");
-    assert!(
-        advanced.retention_floor_seq > first.committed_seq,
-        "the floor must pass the commit for this to test anything: floor {:?}, commit {:?}",
-        advanced.retention_floor_seq,
-        first.committed_seq
-    );
-
-    // The floor alone leaves the receipt answering (the conflict test above
-    // proves it). Drain reorganization until it reports nothing left, so
-    // the run families holding the receipt have been rebuilt above the
-    // floor.
-    let mut folded = false;
-    for _ in 0..32 {
-        let step = runtime
-            .admin
-            .run_maintenance(&namespace_id, MaintenancePlan::metadata())
-            .await
-            .expect("upkeep step")
-            .metadata_maintenance
-            .expect("metadata selected");
-        if matches!(step.reorganize, ReorganizeStepOutcome::NotNeeded) {
-            break;
-        }
-        folded = true;
-    }
-    assert!(
-        folded,
-        "reorganization must actually rebuild runs for this to test anything"
-    );
+    let last_seq = compact_receipt_past_horizon(&runtime, &namespace_id, first.committed_seq).await;
 
     // The live session's caches still answer the receipt (a conservative,
     // longer in-process window — a rerun in the same process still replays
@@ -708,6 +713,49 @@ async fn a_retry_past_the_receipt_horizon_commits_again() {
             .expect("read file")
             .bytes,
         b"stable bytes\n",
+    );
+}
+
+#[tokio::test]
+async fn concurrent_retries_past_the_receipt_horizon_commit_once() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("concurrent-horizon-put").expect("valid commit id");
+
+    let first = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
+        .await
+        .expect("first put");
+    let last_seq = compact_receipt_past_horizon(&runtime, &namespace_id, first.committed_seq).await;
+
+    // Reopen so both retries observe the durable receipt horizon rather than
+    // the conservative in-process cache.
+    drop(runtime);
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-b").await;
+
+    let (left, right) = tokio::join!(
+        runtime.put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id)),
+        runtime.put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id)),
+    );
+    let left = left.expect("first late retry");
+    let right = right.expect("second late retry");
+
+    assert_eq!(left, right, "both retries resolve to the same commit");
+    assert_eq!(
+        left.committed_seq,
+        ChangeSeq(last_seq.0 + 1),
+        "only one retry advances the namespace head"
+    );
+    assert_eq!(
+        runtime
+            .admin
+            .get_namespace_diagnostics(&namespace_id)
+            .await
+            .expect("namespace diagnostics")
+            .head_seq,
+        left.committed_seq,
+        "the losing retry does not publish another commit"
     );
 }
 


### PR DESCRIPTION
When two different request fingerprints race under one commit ID, wait for the first request to finish. If it commits, return its sequence and fingerprint to the waiting request. If it fails, let the waiting request try to publish.

This lets identical file retries with different staged content objects reconcile to one commit after the old receipt has passed the retention horizon.