### PR TITLE
feat(sdk): group generated clients by resource

### DIFF
--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -79,6 +79,10 @@ pub(crate) enum OpenapiPostprocessError {
     Json(#[from] serde_json::Error),
     #[error("OpenAPI operation `{operation_id}` has no retry classification")]
     MissingRetryClassification { operation_id: String },
+    #[error("OpenAPI operation `{operation_id}` has no SDK name")]
+    MissingSdkName { operation_id: String },
+    #[error("OpenAPI SDK-named operation `{operation_id}` does not appear in the document")]
+    MissingSdkNameOperation { operation_id: String },
     #[error("OpenAPI pagination operation `{operation_id}` does not appear in the document")]
     MissingPaginationOperation { operation_id: String },
     #[error("OpenAPI pagination operation `{operation_id}` has no `cursor` query parameter")]
@@ -178,6 +182,335 @@ pub(crate) const OPERATION_RETRY_CLASSES: &[(&str, RetryClass)] = &[
     ("sign_upload_parts", RetryClass::Idempotent),
 ];
 
+/// Names each operation takes in generated SDKs: the Fern group path, the
+/// method name, and the synthesized request type name for operations whose
+/// request is not a component schema. Keep this table sorted by operation ID.
+pub(crate) const OPERATION_SDK_NAMES: &[(&str, SdkName)] = &[
+    (
+        "abort_upload",
+        SdkName {
+            group: &["uploads"],
+            method: "abort",
+            request: Some("AbortUploadRequest"),
+        },
+    ),
+    (
+        "complete_upload",
+        SdkName {
+            group: &["uploads"],
+            method: "complete",
+            request: Some("CompleteUploadBody"),
+        },
+    ),
+    (
+        "create_checkpoint",
+        SdkName {
+            group: &["admin", "checkpoints"],
+            method: "create",
+            request: None,
+        },
+    ),
+    (
+        "create_commit",
+        SdkName {
+            group: &["commits"],
+            method: "create",
+            request: None,
+        },
+    ),
+    (
+        "create_download",
+        SdkName {
+            group: &["files"],
+            method: "createDownload",
+            request: None,
+        },
+    ),
+    (
+        "create_download_by_inode",
+        SdkName {
+            group: &["inodes"],
+            method: "createDownload",
+            request: Some("CreateDownloadByInodeRequest"),
+        },
+    ),
+    (
+        "create_namespace",
+        SdkName {
+            group: &["namespaces"],
+            method: "create",
+            request: None,
+        },
+    ),
+    (
+        "create_snapshot",
+        SdkName {
+            group: &["snapshots"],
+            method: "create",
+            request: None,
+        },
+    ),
+    (
+        "create_upload",
+        SdkName {
+            group: &["uploads"],
+            method: "create",
+            request: Some("CreateUploadRequest"),
+        },
+    ),
+    (
+        "delete_namespace",
+        SdkName {
+            group: &["namespaces"],
+            method: "delete",
+            request: Some("DeleteNamespaceRequest"),
+        },
+    ),
+    (
+        "disable_grep_index",
+        SdkName {
+            group: &["admin", "grepIndex"],
+            method: "disable",
+            request: Some("DisableGrepIndexRequest"),
+        },
+    ),
+    (
+        "enable_grep_index",
+        SdkName {
+            group: &["admin", "grepIndex"],
+            method: "enable",
+            request: Some("EnableGrepIndexRequest"),
+        },
+    ),
+    (
+        "extend_snapshot",
+        SdkName {
+            group: &["snapshots"],
+            method: "extend",
+            request: None,
+        },
+    ),
+    (
+        "fork_namespace",
+        SdkName {
+            group: &["namespaces"],
+            method: "fork",
+            request: None,
+        },
+    ),
+    (
+        "gc_grep_index",
+        SdkName {
+            group: &["admin", "grepIndex"],
+            method: "gc",
+            request: None,
+        },
+    ),
+    (
+        "get_capabilities",
+        SdkName {
+            group: &["capabilities"],
+            method: "retrieve",
+            request: None,
+        },
+    ),
+    (
+        "get_file_bytes",
+        SdkName {
+            group: &["files"],
+            method: "content",
+            request: Some("GetFileBytesRequest"),
+        },
+    ),
+    (
+        "get_file_revision_bytes_by_inode",
+        SdkName {
+            group: &["inodes"],
+            method: "content",
+            request: Some("GetFileRevisionBytesByInodeRequest"),
+        },
+    ),
+    (
+        "get_grep_index",
+        SdkName {
+            group: &["admin", "grepIndex"],
+            method: "retrieve",
+            request: Some("GetGrepIndexRequest"),
+        },
+    ),
+    (
+        "get_inode",
+        SdkName {
+            group: &["inodes"],
+            method: "retrieve",
+            request: Some("GetInodeRequest"),
+        },
+    ),
+    (
+        "get_namespace",
+        SdkName {
+            group: &["namespaces"],
+            method: "retrieve",
+            request: Some("GetNamespaceRequest"),
+        },
+    ),
+    (
+        "get_namespace_diagnostics",
+        SdkName {
+            group: &["admin", "diagnostics"],
+            method: "retrieve",
+            request: Some("GetNamespaceDiagnosticsRequest"),
+        },
+    ),
+    (
+        "get_path_entry",
+        SdkName {
+            group: &["files"],
+            method: "retrieve",
+            request: Some("GetPathEntryRequest"),
+        },
+    ),
+    (
+        "get_upload",
+        SdkName {
+            group: &["uploads"],
+            method: "retrieve",
+            request: Some("GetUploadRequest"),
+        },
+    ),
+    (
+        "grep",
+        SdkName {
+            group: &["files"],
+            method: "grep",
+            request: Some("GrepRequest"),
+        },
+    ),
+    (
+        "list_changes",
+        SdkName {
+            group: &["changes"],
+            method: "list",
+            request: Some("ListChangesRequest"),
+        },
+    ),
+    (
+        "list_checkpoints",
+        SdkName {
+            group: &["admin", "checkpoints"],
+            method: "list",
+            request: Some("ListCheckpointsRequest"),
+        },
+    ),
+    (
+        "list_file_revisions",
+        SdkName {
+            group: &["files"],
+            method: "listRevisions",
+            request: Some("ListFileRevisionsRequest"),
+        },
+    ),
+    (
+        "list_file_revisions_by_inode",
+        SdkName {
+            group: &["inodes"],
+            method: "listRevisions",
+            request: Some("ListFileRevisionsByInodeRequest"),
+        },
+    ),
+    (
+        "list_inode_children",
+        SdkName {
+            group: &["inodes"],
+            method: "listChildren",
+            request: Some("ListInodeChildrenRequest"),
+        },
+    ),
+    (
+        "list_path_entries",
+        SdkName {
+            group: &["files"],
+            method: "list",
+            request: Some("ListPathEntriesRequest"),
+        },
+    ),
+    (
+        "list_snapshots",
+        SdkName {
+            group: &["snapshots"],
+            method: "list",
+            request: Some("ListSnapshotsRequest"),
+        },
+    ),
+    (
+        "list_trash",
+        SdkName {
+            group: &["trash"],
+            method: "list",
+            request: Some("ListTrashRequest"),
+        },
+    ),
+    (
+        "probe_store",
+        SdkName {
+            group: &["admin", "store"],
+            method: "probe",
+            request: None,
+        },
+    ),
+    (
+        "put_upload_content",
+        SdkName {
+            group: &["uploads"],
+            method: "putContent",
+            request: None,
+        },
+    ),
+    (
+        "release_checkpoint",
+        SdkName {
+            group: &["admin", "checkpoints"],
+            method: "release",
+            request: Some("ReleaseCheckpointRequest"),
+        },
+    ),
+    (
+        "release_snapshot",
+        SdkName {
+            group: &["snapshots"],
+            method: "release",
+            request: Some("ReleaseSnapshotRequest"),
+        },
+    ),
+    (
+        "run_maintenance",
+        SdkName {
+            group: &["admin", "maintenance"],
+            method: "run",
+            request: None,
+        },
+    ),
+    (
+        "sign_upload_parts",
+        SdkName {
+            group: &["uploads"],
+            method: "signParts",
+            request: None,
+        },
+    ),
+];
+
+/// Operations served over HTTP but left out of generated SDKs. Keep this table sorted.
+pub(crate) const SDK_EXCLUDED_OPERATIONS: &[&str] = &["get_health", "get_metrics", "get_readiness"];
+
+/// The SDK surface of one operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SdkName {
+    pub(crate) group: &'static [&'static str],
+    pub(crate) method: &'static str,
+    pub(crate) request: Option<&'static str>,
+}
+
 impl Value {
     fn get(&self, name: &str) -> Option<&Self> {
         self.as_object()?.get(name)
@@ -231,6 +564,7 @@ pub(crate) fn openapi_json_pretty(
     extract_union_variants(&mut document)?;
     merge_union_composites(&mut document)?;
     add_operation_retry_classes(&mut document)?;
+    add_sdk_names(&mut document)?;
     add_pagination_metadata(&mut document)?;
     Ok(serde_json::to_string_pretty(&document)?)
 }
@@ -564,6 +898,85 @@ fn add_operation_retry_classes(document: &mut Value) -> Result<(), OpenapiPostpr
             }
         }
     }
+    Ok(())
+}
+
+/// Adds the Fern naming extensions to every operation and hides the excluded ones.
+fn add_sdk_names(document: &mut Value) -> Result<(), OpenapiPostprocessError> {
+    let paths = document
+        .as_object_mut()
+        .and_then(|document| document.get_mut("paths"))
+        .and_then(Value::as_object_mut)
+        .expect("OpenAPI document has no paths object");
+    let mut seen_operations = BTreeSet::new();
+
+    for path_item in paths.values_mut() {
+        let path_item = path_item
+            .as_object_mut()
+            .expect("OpenAPI path item is not an object");
+        for &method in HTTP_METHODS {
+            let Some(operation) = path_item.get_mut(method) else {
+                continue;
+            };
+            let operation = operation
+                .as_object_mut()
+                .expect("OpenAPI operation is not an object");
+            let operation_id = operation
+                .get("operationId")
+                .and_then(Value::as_str)
+                .expect("OpenAPI operation has no operationId")
+                .to_owned();
+            seen_operations.insert(operation_id.clone());
+
+            if SDK_EXCLUDED_OPERATIONS.contains(&operation_id.as_str()) {
+                operation.insert("x-fern-ignore".to_owned(), Value::Bool(true));
+                continue;
+            }
+
+            let sdk_name = OPERATION_SDK_NAMES
+                .iter()
+                .find_map(|(candidate, sdk_name)| (*candidate == operation_id).then_some(*sdk_name))
+                .ok_or_else(|| OpenapiPostprocessError::MissingSdkName {
+                    operation_id: operation_id.clone(),
+                })?;
+            operation.insert(
+                "x-fern-sdk-group-name".to_owned(),
+                Value::Array(
+                    sdk_name
+                        .group
+                        .iter()
+                        .map(|segment| Value::String((*segment).to_owned()))
+                        .collect(),
+                ),
+            );
+            operation.insert(
+                "x-fern-sdk-method-name".to_owned(),
+                Value::String(sdk_name.method.to_owned()),
+            );
+            if let Some(request) = sdk_name.request {
+                operation.insert(
+                    "x-fern-request-name".to_owned(),
+                    Value::String(request.to_owned()),
+                );
+            }
+        }
+    }
+
+    for &(operation_id, _) in OPERATION_SDK_NAMES {
+        if !seen_operations.contains(operation_id) {
+            return Err(OpenapiPostprocessError::MissingSdkNameOperation {
+                operation_id: operation_id.to_owned(),
+            });
+        }
+    }
+    for &operation_id in SDK_EXCLUDED_OPERATIONS {
+        if !seen_operations.contains(operation_id) {
+            return Err(OpenapiPostprocessError::MissingSdkNameOperation {
+                operation_id: operation_id.to_owned(),
+            });
+        }
+    }
+
     Ok(())
 }
 
@@ -1928,6 +2341,68 @@ mod tests {
             OpenapiPostprocessError::MissingRetryClassification { operation_id }
                 if operation_id == "future_operation"
         ));
+    }
+
+    #[test]
+    fn missing_sdk_name_returns_a_named_error() {
+        let mut document = ordered(serde_json::json!({
+            "paths": {
+                "/future": {
+                    "post": {"operationId": "future_operation"}
+                }
+            }
+        }));
+
+        let error =
+            add_sdk_names(&mut document).expect_err("unknown operation should fail generation");
+        assert!(matches!(
+            error,
+            OpenapiPostprocessError::MissingSdkName { operation_id }
+                if operation_id == "future_operation"
+        ));
+    }
+
+    #[test]
+    fn sdk_name_tables_partition_the_retry_registry() {
+        let named = OPERATION_SDK_NAMES
+            .iter()
+            .map(|(operation_id, _)| *operation_id)
+            .collect::<Vec<_>>();
+        let excluded = SDK_EXCLUDED_OPERATIONS.to_vec();
+
+        let mut sorted_named = named.clone();
+        sorted_named.sort_unstable();
+        assert_eq!(named, sorted_named, "SDK name table must stay sorted");
+
+        let mut sorted_excluded = excluded.clone();
+        sorted_excluded.sort_unstable();
+        assert_eq!(
+            excluded, sorted_excluded,
+            "SDK exclusion table must stay sorted"
+        );
+
+        let named_set = named.iter().copied().collect::<BTreeSet<_>>();
+        let excluded_set = excluded.iter().copied().collect::<BTreeSet<_>>();
+        assert!(named_set.is_disjoint(&excluded_set));
+
+        let mut sdk_operations = named;
+        sdk_operations.extend(excluded);
+        sdk_operations.sort_unstable();
+        let mut retry_operations = OPERATION_RETRY_CLASSES
+            .iter()
+            .map(|(operation_id, _)| *operation_id)
+            .collect::<Vec<_>>();
+        retry_operations.sort_unstable();
+        assert_eq!(sdk_operations, retry_operations);
+    }
+
+    #[test]
+    fn sdk_method_names_are_unique_within_each_group() {
+        let methods = OPERATION_SDK_NAMES
+            .iter()
+            .map(|(_, sdk_name)| (sdk_name.group, sdk_name.method))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(methods.len(), OPERATION_SDK_NAMES.len());
     }
 
     #[test]

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::panic)]
 
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
 #[path = "../../src/bin/loonfs-openapi/openapi_postprocess.rs"]
@@ -460,7 +460,7 @@ fn openapi_documents_current_server_paths() {
 
 #[test]
 fn openapi_operation_ids_match_the_public_registry() {
-    const REGISTRY_MESSAGE: &str = "operation IDs define generated SDK method names; update OPERATION_RETRY_CLASSES only when renaming a public method";
+    const REGISTRY_MESSAGE: &str = "operation IDs are the wire registry; add or rename an operation in OPERATION_RETRY_CLASSES and OPERATION_SDK_NAMES together";
 
     let spec: Value = serde_json::from_str(
         &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
@@ -728,6 +728,89 @@ fn every_registered_operation_publishes_its_retry_class() {
         .map(|(operation_id, retry_class)| (*operation_id, retry_class.as_str()))
         .collect::<BTreeMap<_, _>>();
     assert_eq!(published, expected);
+}
+
+#[test]
+fn every_registered_operation_publishes_its_sdk_name() {
+    let generated = openapi_postprocess::openapi_json_pretty(&loonfs_server::openapi_document())
+        .expect("generate openapi json");
+    let spec: Value = serde_json::from_str(&generated).expect("parse generated openapi json");
+
+    for (operation_id, operation) in operations_by_id(&spec) {
+        if openapi_postprocess::SDK_EXCLUDED_OPERATIONS.contains(&operation_id) {
+            assert_eq!(operation.get("x-fern-ignore"), Some(&json!(true)));
+            for extension in [
+                "x-fern-sdk-group-name",
+                "x-fern-sdk-method-name",
+                "x-fern-request-name",
+            ] {
+                assert!(
+                    operation.get(extension).is_none(),
+                    "excluded operation `{operation_id}` has `{extension}`"
+                );
+            }
+            continue;
+        }
+
+        let sdk_name = openapi_postprocess::OPERATION_SDK_NAMES
+            .iter()
+            .find_map(|(candidate, sdk_name)| (*candidate == operation_id).then_some(sdk_name))
+            .unwrap_or_else(|| panic!("operation `{operation_id}` has no SDK name"));
+        assert_eq!(
+            operation.get("x-fern-sdk-group-name"),
+            Some(&json!(sdk_name.group)),
+            "unexpected SDK group for `{operation_id}`"
+        );
+        assert_eq!(
+            operation.get("x-fern-sdk-method-name"),
+            Some(&json!(sdk_name.method)),
+            "unexpected SDK method for `{operation_id}`"
+        );
+        let expected_request = sdk_name.request.map(|request| json!(request));
+        assert_eq!(
+            operation.get("x-fern-request-name"),
+            expected_request.as_ref(),
+            "unexpected SDK request name for `{operation_id}`"
+        );
+        assert!(
+            operation.get("x-fern-ignore").is_none(),
+            "named operation `{operation_id}` is ignored"
+        );
+    }
+}
+
+#[test]
+fn proxy_operations_keep_their_sdk_names() {
+    let proxy: Value = serde_json::from_str(
+        &std::fs::read_to_string(PROXY_OPENAPI_JSON_PATH).expect("read static proxy openapi json"),
+    )
+    .expect("parse proxy openapi json");
+    let full: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let full_operations = operations_by_id(&full);
+
+    for (operation_id, proxy_operation) in operations_by_id(&proxy) {
+        let full_operation = full_operations.get(operation_id).unwrap_or_else(|| {
+            panic!("proxy operation `{operation_id}` is missing from full spec")
+        });
+        for extension in [
+            "x-fern-sdk-group-name",
+            "x-fern-sdk-method-name",
+            "x-fern-request-name",
+        ] {
+            assert_eq!(
+                proxy_operation.get(extension),
+                full_operation.get(extension),
+                "proxy operation `{operation_id}` changed `{extension}`"
+            );
+        }
+        assert!(
+            proxy_operation.get("x-fern-ignore").is_none(),
+            "proxy operation `{operation_id}` is ignored"
+        );
+    }
 }
 
 #[test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -364,9 +364,16 @@ opaque value and MUST NOT create IDs or infer ordering from the numeric suffix.
   `not_supported` error with its `feature` name, so gating logic — check the
   capability document, fall back on `not_supported` — is identical against
   either backend.
-- As optional planes gain ops, SDKs should group them the way the planes are
-  grouped (`core`, `admin`, and later), so the surface a deployment does not
-  support is visibly absent instead of failing call by call.
+- Generated SDKs group operations by resource, not by plane. `capabilities`,
+  `namespaces`, `snapshots`, `commits`, `changes`, `files`, `inodes`, `trash`,
+  and `uploads` sit at the client root. The `admin` plane keeps its prefix as
+  a nested group, as in `admin.checkpoints.create`, because a hosted
+  deployment may hide the whole plane. A method on a group's own resource is
+  a bare verb: `create`, `retrieve`, `list`, `delete`, or the action, as in
+  `fork` and `grep`. A sub-resource of one file or inode is verb plus noun on
+  the parent, as in `files.listRevisions` and `inodes.listChildren`. The
+  `/health`, `/readiness`, and `/metrics` probes are HTTP-only and have no
+  SDK method.
 
 ### 4.2 Checksums
 
@@ -676,7 +683,7 @@ underlying semantics.
 
 GET routes name resources, so they use nouns such as `entry`, `entries`, `content`, `revisions`, and `trash`. A POST route ends in a verb when it invokes an action rather than creating a resource, as in `run`, `release`, `enable`, `disable`, `gc`, `abort`, `complete`, and `probe`. `/v0/admin/` is the only plane prefix. Other routes are grouped by resource, including `GET /v0/namespaces/{ns}/grep`.
 
-Operation IDs start with a verb. `get` reads one resource, `list` reads a page, and `create` posts a new resource to a collection. Other verbs describe the operation directly, as in `grep`, `run_maintenance`, and `release_checkpoint`. Generated SDK method names come from these IDs, so changing an ID also changes the generated method name.
+Operation IDs start with a verb. `get` reads one resource, `list` reads a page, and `create` posts a new resource to a collection. Other verbs describe the operation directly, as in `grep`, `run_maintenance`, and `release_checkpoint`. Operation IDs are the wire registry only. Generated SDK group and method names come from the SDK naming table in the OpenAPI postprocessor, which every operation must appear in or be explicitly excluded from.
 
 ### Authentication and transport
 

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -53,7 +53,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "capabilities"
+        ],
+        "x-fern-sdk-method-name": "retrieve"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/changes": {
@@ -171,7 +175,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "changes"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListChangesRequest"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/commits": {
@@ -268,7 +277,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "replayable"
+        "x-loonfs-retry": "replayable",
+        "x-fern-sdk-group-name": [
+          "commits"
+        ],
+        "x-fern-sdk-method-name": "create"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/filesystem/content": {
@@ -387,7 +400,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "content",
+        "x-fern-request-name": "GetFileBytesRequest"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/filesystem/downloads": {
@@ -493,7 +511,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "createDownload"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/filesystem/entries": {
@@ -621,6 +643,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListPathEntriesRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -730,7 +757,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "retrieve",
+        "x-fern-request-name": "GetPathEntryRequest"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/filesystem/revisions": {
@@ -839,6 +871,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "listRevisions",
+        "x-fern-request-name": "ListFileRevisionsRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -943,6 +980,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "trash"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListTrashRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -1115,6 +1157,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "grep",
+        "x-fern-request-name": "GrepRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -1209,6 +1256,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "snapshots"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListSnapshotsRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -1311,7 +1363,11 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "snapshots"
+        ],
+        "x-fern-sdk-method-name": "create"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/snapshots/{snapshot_id}/extend": {
@@ -1407,7 +1463,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "snapshots"
+        ],
+        "x-fern-sdk-method-name": "extend"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/snapshots/{snapshot_id}/release": {
@@ -1473,7 +1533,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "snapshots"
+        ],
+        "x-fern-sdk-method-name": "release",
+        "x-fern-request-name": "ReleaseSnapshotRequest"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/uploads": {
@@ -1583,7 +1648,12 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "create",
+        "x-fern-request-name": "CreateUploadRequest"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/uploads/{upload_id}": {
@@ -1669,7 +1739,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "retrieve",
+        "x-fern-request-name": "GetUploadRequest"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/uploads/{upload_id}/abort": {
@@ -1765,7 +1840,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "abort",
+        "x-fern-request-name": "AbortUploadRequest"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/uploads/{upload_id}/complete": {
@@ -1882,7 +1962,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "replayable"
+        "x-loonfs-retry": "replayable",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "complete",
+        "x-fern-request-name": "CompleteUploadBody"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/uploads/{upload_id}/content": {
@@ -2003,7 +2088,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "putContent"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/uploads/{upload_id}/parts": {
@@ -2129,7 +2218,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "signParts"
       }
     }
   },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -36,7 +36,8 @@
         "security": [
           {}
         ],
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-ignore": true
       }
     },
     "/metrics": {
@@ -72,7 +73,8 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-ignore": true
       }
     },
     "/readiness": {
@@ -101,7 +103,8 @@
         "security": [
           {}
         ],
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-ignore": true
       }
     },
     "/v0/admin/namespaces/{namespace_id}/checkpoints": {
@@ -191,6 +194,12 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "admin",
+          "checkpoints"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListCheckpointsRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -284,7 +293,12 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "admin",
+          "checkpoints"
+        ],
+        "x-fern-sdk-method-name": "create"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release": {
@@ -360,7 +374,13 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "admin",
+          "checkpoints"
+        ],
+        "x-fern-sdk-method-name": "release",
+        "x-fern-request-name": "ReleaseCheckpointRequest"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/diagnostics": {
@@ -437,7 +457,13 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "admin",
+          "diagnostics"
+        ],
+        "x-fern-sdk-method-name": "retrieve",
+        "x-fern-request-name": "GetNamespaceDiagnosticsRequest"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/grep/index": {
@@ -514,7 +540,13 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "admin",
+          "grepIndex"
+        ],
+        "x-fern-sdk-method-name": "retrieve",
+        "x-fern-request-name": "GetGrepIndexRequest"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/grep/index/disable": {
@@ -611,7 +643,13 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "admin",
+          "grepIndex"
+        ],
+        "x-fern-sdk-method-name": "disable",
+        "x-fern-request-name": "DisableGrepIndexRequest"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/grep/index/enable": {
@@ -708,7 +746,13 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "admin",
+          "grepIndex"
+        ],
+        "x-fern-sdk-method-name": "enable",
+        "x-fern-request-name": "EnableGrepIndexRequest"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/grep/index/gc": {
@@ -797,7 +841,12 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "admin",
+          "grepIndex"
+        ],
+        "x-fern-sdk-method-name": "gc"
       }
     },
     "/v0/admin/namespaces/{namespace_id}/maintenance/run": {
@@ -888,7 +937,12 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "admin",
+          "maintenance"
+        ],
+        "x-fern-sdk-method-name": "run"
       }
     },
     "/v0/admin/store/probe": {
@@ -948,7 +1002,12 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "admin",
+          "store"
+        ],
+        "x-fern-sdk-method-name": "probe"
       }
     },
     "/v0/capabilities": {
@@ -994,7 +1053,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "capabilities"
+        ],
+        "x-fern-sdk-method-name": "retrieve"
       }
     },
     "/v0/namespaces": {
@@ -1073,7 +1136,11 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "namespaces"
+        ],
+        "x-fern-sdk-method-name": "create"
       }
     },
     "/v0/namespaces/{namespace_id}": {
@@ -1150,7 +1217,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "namespaces"
+        ],
+        "x-fern-sdk-method-name": "retrieve",
+        "x-fern-request-name": "GetNamespaceRequest"
       },
       "delete": {
         "tags": [
@@ -1247,7 +1319,12 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "namespaces"
+        ],
+        "x-fern-sdk-method-name": "delete",
+        "x-fern-request-name": "DeleteNamespaceRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/changes": {
@@ -1365,7 +1442,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "changes"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListChangesRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/commits": {
@@ -1462,7 +1544,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "replayable"
+        "x-loonfs-retry": "replayable",
+        "x-fern-sdk-group-name": [
+          "commits"
+        ],
+        "x-fern-sdk-method-name": "create"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/content": {
@@ -1581,7 +1667,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "content",
+        "x-fern-request-name": "GetFileBytesRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/downloads": {
@@ -1687,7 +1778,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "createDownload"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/entries": {
@@ -1815,6 +1910,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListPathEntriesRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -1924,7 +2024,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "retrieve",
+        "x-fern-request-name": "GetPathEntryRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/filesystem/revisions": {
@@ -2033,6 +2138,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "listRevisions",
+        "x-fern-request-name": "ListFileRevisionsRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -2137,6 +2247,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "trash"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListTrashRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -2241,7 +2356,11 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "namespaces"
+        ],
+        "x-fern-sdk-method-name": "fork"
       }
     },
     "/v0/namespaces/{namespace_id}/grep": {
@@ -2409,6 +2528,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "files"
+        ],
+        "x-fern-sdk-method-name": "grep",
+        "x-fern-request-name": "GrepRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -2511,7 +2635,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "inodes"
+        ],
+        "x-fern-sdk-method-name": "retrieve",
+        "x-fern-request-name": "GetInodeRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/inodes/{inode_id}/children": {
@@ -2642,6 +2771,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "inodes"
+        ],
+        "x-fern-sdk-method-name": "listChildren",
+        "x-fern-request-name": "ListInodeChildrenRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -2767,6 +2901,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "inodes"
+        ],
+        "x-fern-sdk-method-name": "listRevisions",
+        "x-fern-request-name": "ListFileRevisionsByInodeRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -2893,7 +3032,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "inodes"
+        ],
+        "x-fern-sdk-method-name": "content",
+        "x-fern-request-name": "GetFileRevisionBytesByInodeRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads": {
@@ -3020,7 +3164,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "inodes"
+        ],
+        "x-fern-sdk-method-name": "createDownload",
+        "x-fern-request-name": "CreateDownloadByInodeRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/snapshots": {
@@ -3110,6 +3259,11 @@
           }
         },
         "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "snapshots"
+        ],
+        "x-fern-sdk-method-name": "list",
+        "x-fern-request-name": "ListSnapshotsRequest",
         "x-fern-pagination": {
           "cursor": "$request.cursor",
           "next_cursor": "$response.next_cursor",
@@ -3212,7 +3366,11 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "snapshots"
+        ],
+        "x-fern-sdk-method-name": "create"
       }
     },
     "/v0/namespaces/{namespace_id}/snapshots/{snapshot_id}/extend": {
@@ -3308,7 +3466,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "snapshots"
+        ],
+        "x-fern-sdk-method-name": "extend"
       }
     },
     "/v0/namespaces/{namespace_id}/snapshots/{snapshot_id}/release": {
@@ -3374,7 +3536,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "snapshots"
+        ],
+        "x-fern-sdk-method-name": "release",
+        "x-fern-request-name": "ReleaseSnapshotRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads": {
@@ -3484,7 +3651,12 @@
         "x-loonfs-retry": "not_idempotent",
         "x-fern-retries": {
           "disabled": true
-        }
+        },
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "create",
+        "x-fern-request-name": "CreateUploadRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}": {
@@ -3570,7 +3742,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "retrieve",
+        "x-fern-request-name": "GetUploadRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/abort": {
@@ -3666,7 +3843,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "abort",
+        "x-fern-request-name": "AbortUploadRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete": {
@@ -3783,7 +3965,12 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "replayable"
+        "x-loonfs-retry": "replayable",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "complete",
+        "x-fern-request-name": "CompleteUploadBody"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content": {
@@ -3904,7 +4091,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "putContent"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/parts": {
@@ -4030,7 +4221,11 @@
             "$ref": "#/components/responses/UnavailableResponse"
           }
         },
-        "x-loonfs-retry": "idempotent"
+        "x-loonfs-retry": "idempotent",
+        "x-fern-sdk-group-name": [
+          "uploads"
+        ],
+        "x-fern-sdk-method-name": "signParts"
       }
     }
   },

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -34,7 +34,8 @@ prune_generated() {
     case "$1" in
     go)
         # Fern cannot omit these generator-level model tests.
-        for name in admin filesystem inodes namespaces query system types uploads; do
+        for name in capabilities changes commits files inodes namespaces snapshots trash types uploads \
+            admin/checkpoints admin/diagnostics admin/grep_index admin/maintenance; do
             rm "generated/go/${name}_test.go"
         done
         python3 - <<'PY'
@@ -54,7 +55,10 @@ for source_path in [*module_root.rglob("*.go"), *module_root.rglob("*.md")]:
         'client "github.com/loonfs/loonfs-sdk-go/server"',
         'server "github.com/loonfs/loonfs-sdk-go/server"',
     )
-    source = source.replace("client.NewClient", "server.NewClient")
+    # Only files that import the root server package construct the root client;
+    # server/client.go builds the nested admin client through its own `client` alias.
+    if '"github.com/loonfs/loonfs-sdk-go/server"' in source:
+        source = source.replace("client.NewClient", "server.NewClient")
     if source_path.parent == server_package:
         source = source.replace("package client", "package server")
     source_path.write_text(source)

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -226,7 +226,7 @@ type errorStatusExpected struct {
 func runErrorContract(t *testing.T, h *harness, testCase conformanceCase) {
 	t.Helper()
 	request, expected := decodeCaseValues[errorContractRequest, errorContractExpected](t, testCase)
-	_, err := h.unauthenticated.Namespaces.GetNamespace(
+	_, err := h.unauthenticated.Namespaces.Retrieve(
 		context.Background(),
 		&loonfs.GetNamespaceRequest{NamespaceID: request.NamespaceID},
 	)
@@ -271,11 +271,11 @@ func runCommitReplay(t *testing.T, h *harness, testCase conformanceCase) {
 		request.Path,
 		&request.Message,
 	)
-	first, err := h.client.Filesystem.CreateCommit(context.Background(), commit)
+	first, err := h.client.Commits.Create(context.Background(), commit)
 	if err != nil {
 		t.Fatalf("first commit: %v", err)
 	}
-	replayed, err := h.client.Filesystem.CreateCommit(context.Background(), commit)
+	replayed, err := h.client.Commits.Create(context.Background(), commit)
 	if err != nil {
 		t.Fatalf("replayed commit: %v", err)
 	}
@@ -317,7 +317,7 @@ func runDirectPut(t *testing.T, h *harness, testCase conformanceCase) {
 	createNamespace(t, h.client, request.NamespaceID)
 	payload := []byte(request.ContentUTF8)
 	sizeBytes := int64(len(payload))
-	begin, err := h.client.Uploads.CreateUpload(context.Background(), &loonfs.CreateUploadRequest{
+	begin, err := h.client.Uploads.Create(context.Background(), &loonfs.CreateUploadRequest{
 		NamespaceID: request.NamespaceID,
 		Body: &loonfs.BeginUploadRequest{
 			DirectPut: &loonfs.BeginUploadDirectPut{SizeBytes: &sizeBytes},
@@ -342,7 +342,7 @@ func runDirectPut(t *testing.T, h *harness, testCase conformanceCase) {
 		Checksum:  mustChecksum(t, directPut.ChecksumAlgorithm, payload),
 		SizeBytes: int64(len(payload)),
 	}
-	completed, err := h.client.Uploads.CompleteUpload(context.Background(), &loonfs.CompleteUploadBody{
+	completed, err := h.client.Uploads.Complete(context.Background(), &loonfs.CompleteUploadBody{
 		NamespaceID: request.NamespaceID,
 		UploadID:    string(begin.DirectPut.UploadID),
 		Body: &loonfs.CompleteUploadRequest{
@@ -411,7 +411,7 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 	request, expected := decodeCaseValues[multipartRequest, multipartExpected](t, testCase)
 	createNamespace(t, h.client, request.NamespaceID)
 	payload := makeBytePattern(t, request.ContentPattern)
-	begin, err := h.client.Uploads.CreateUpload(context.Background(), &loonfs.CreateUploadRequest{
+	begin, err := h.client.Uploads.Create(context.Background(), &loonfs.CreateUploadRequest{
 		NamespaceID: request.NamespaceID,
 		Body: &loonfs.BeginUploadRequest{
 			DirectMultipart: &loonfs.BeginUploadDirectMultipart{
@@ -446,7 +446,7 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 			PartNumber: index + 1,
 		}
 	}
-	signed, err := h.client.Uploads.SignUploadParts(context.Background(), &loonfs.SignUploadPartsRequest{
+	signed, err := h.client.Uploads.SignParts(context.Background(), &loonfs.SignUploadPartsRequest{
 		NamespaceID: request.NamespaceID,
 		UploadID:    string(begin.DirectMultipart.UploadID),
 		Parts:       claims,
@@ -487,12 +487,12 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 			},
 		},
 	}
-	first, err := h.client.Uploads.CompleteUpload(context.Background(), completionRequest)
+	first, err := h.client.Uploads.Complete(context.Background(), completionRequest)
 	if err != nil {
 		t.Fatalf("complete multipart upload: %v", err)
 	}
 	firstStatus := requireCompletedStatus(t, first)
-	replayed, err := h.client.Uploads.CompleteUpload(context.Background(), completionRequest)
+	replayed, err := h.client.Uploads.Complete(context.Background(), completionRequest)
 	if err != nil {
 		t.Fatalf("replay multipart completion: %v", err)
 	}
@@ -568,7 +568,7 @@ func runAbort(t *testing.T, h *harness, testCase conformanceCase) {
 	t.Helper()
 	request, expected := decodeCaseValues[abortRequest, abortExpected](t, testCase)
 	createNamespace(t, h.client, request.NamespaceID)
-	begin, err := h.client.Uploads.CreateUpload(context.Background(), &loonfs.CreateUploadRequest{
+	begin, err := h.client.Uploads.Create(context.Background(), &loonfs.CreateUploadRequest{
 		NamespaceID: request.NamespaceID,
 		Body: &loonfs.BeginUploadRequest{
 			ServiceProxied: &loonfs.BeginUploadServiceProxied{},
@@ -587,11 +587,11 @@ func runAbort(t *testing.T, h *harness, testCase conformanceCase) {
 		NamespaceID: request.NamespaceID,
 		UploadID:    string(begin.ServiceProxied.UploadID),
 	}
-	first, err := h.client.Uploads.AbortUpload(context.Background(), abort)
+	first, err := h.client.Uploads.Abort(context.Background(), abort)
 	if err != nil {
 		t.Fatalf("abort upload: %v", err)
 	}
-	replayed, err := h.client.Uploads.AbortUpload(context.Background(), abort)
+	replayed, err := h.client.Uploads.Abort(context.Background(), abort)
 	if err != nil {
 		t.Fatalf("replay abort: %v", err)
 	}
@@ -643,7 +643,7 @@ func runDownload(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 	stat := statPath(t, h.client, request.NamespaceID, request.Path)
 	file := requireFileProjection(t, stat)
-	grant, err := h.client.Filesystem.CreateDownload(context.Background(), &loonfs.BeginDownloadRequest{
+	grant, err := h.client.Files.CreateDownload(context.Background(), &loonfs.BeginDownloadRequest{
 		NamespaceID: request.NamespaceID,
 		Path:        loonfs.AbsolutePath(request.Path),
 	})
@@ -765,7 +765,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Errorf("moved listing does not contain %q", request.MovedPath)
 	}
 
-	revisions, err := h.client.Filesystem.ListFileRevisions(context.Background(), &loonfs.ListFileRevisionsRequest{
+	revisions, err := h.client.Files.ListRevisions(context.Background(), &loonfs.ListFileRevisionsRequest{
 		NamespaceID: request.NamespaceID,
 		Path:        request.MovedPath,
 	})
@@ -820,7 +820,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 		}
 	}
 
-	trash, err := h.client.Filesystem.ListTrash(context.Background(), &loonfs.ListTrashRequest{
+	trash, err := h.client.Trash.List(context.Background(), &loonfs.ListTrashRequest{
 		NamespaceID: request.NamespaceID,
 	})
 	if err != nil {
@@ -908,7 +908,7 @@ func runChildrenByInode(t *testing.T, h *harness, testCase conformanceCase) {
 	var savedCursor *string
 	resumeOffset := -1
 	ctx := context.Background()
-	page, err := h.client.Inodes.ListInodeChildren(
+	page, err := h.client.Inodes.ListChildren(
 		ctx,
 		&loonfs.ListInodeChildrenRequest{
 			NamespaceID: request.NamespaceID,
@@ -996,7 +996,7 @@ func runChildrenByInode(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	resumed := make([]string, 0, len(request.EntryNames)-resumeOffset)
-	page, err = h.client.Inodes.ListInodeChildren(
+	page, err = h.client.Inodes.ListChildren(
 		ctx,
 		&loonfs.ListInodeChildrenRequest{
 			NamespaceID: request.NamespaceID,
@@ -1223,7 +1223,7 @@ func runInodeMutations(t *testing.T, h *harness, testCase conformanceCase) {
 		}
 	}
 
-	_, err := h.client.Filesystem.CreateCommit(
+	_, err := h.client.Commits.Create(
 		context.Background(),
 		moveByInode("conf-inode-mutations-stale-move", staleGeneration),
 	)
@@ -1237,7 +1237,7 @@ func runInodeMutations(t *testing.T, h *harness, testCase conformanceCase) {
 	if conflict.Body == nil || conflict.Body.Code != expected.StaleBindingGeneration.Code {
 		t.Errorf("stale move body = %#v, want code %q", conflict.Body, expected.StaleBindingGeneration.Code)
 	}
-	_, err = h.client.Filesystem.CreateCommit(
+	_, err = h.client.Commits.Create(
 		context.Background(),
 		moveByInode("conf-inode-mutations-malformed-move", request.MalformedBindingGeneration),
 	)
@@ -1276,7 +1276,7 @@ func runInodeMutations(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	limit := 1
-	feed, err := h.client.Filesystem.ListChanges(context.Background(), &loonfs.ListChangesRequest{
+	feed, err := h.client.Changes.List(context.Background(), &loonfs.ListChangesRequest{
 		NamespaceID: request.NamespaceID,
 		AfterSeq:    loonfs.ChangeSeq(expected.MovedCommittedSeq - 1),
 		Limit:       &limit,
@@ -1323,7 +1323,7 @@ func stageContent(
 	payload []byte,
 ) (*loonfs.ContentRef, *loonfs.ContentToken) {
 	t.Helper()
-	begin, err := sdk.Uploads.CreateUpload(context.Background(), &loonfs.CreateUploadRequest{
+	begin, err := sdk.Uploads.Create(context.Background(), &loonfs.CreateUploadRequest{
 		NamespaceID: namespaceID,
 		Body: &loonfs.BeginUploadRequest{
 			ServiceProxied: &loonfs.BeginUploadServiceProxied{},
@@ -1336,7 +1336,7 @@ func stageContent(
 		t.Fatalf("begin upload mode = %q, want service_proxied", begin.Mode)
 	}
 	uploadID := string(begin.ServiceProxied.UploadID)
-	if _, err := sdk.Uploads.PutUploadContent(
+	if _, err := sdk.Uploads.PutContent(
 		context.Background(),
 		namespaceID,
 		uploadID,
@@ -1344,7 +1344,7 @@ func stageContent(
 	); err != nil {
 		t.Fatalf("stage upload content: %v", err)
 	}
-	completed, err := sdk.Uploads.CompleteUpload(context.Background(), &loonfs.CompleteUploadBody{
+	completed, err := sdk.Uploads.Complete(context.Background(), &loonfs.CompleteUploadBody{
 		NamespaceID: namespaceID,
 		UploadID:    uploadID,
 		Body: &loonfs.CompleteUploadRequest{
@@ -1434,7 +1434,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Fatalf("create deleted snapshot file: %v", err)
 	}
 
-	snapshot, err := h.client.Namespaces.CreateSnapshot(ctx, &loonfs.CreateSnapshotRequest{
+	snapshot, err := h.client.Snapshots.Create(ctx, &loonfs.CreateSnapshotRequest{
 		NamespaceID: request.NamespaceID,
 		Name:        request.SnapshotName,
 		TTLMs:       request.CreateTTLMs,
@@ -1493,7 +1493,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	})
 
 	snapshotID := snapshot.SnapshotID
-	capturedEntry, err := h.client.Filesystem.GetPathEntry(ctx, &loonfs.GetPathEntryRequest{
+	capturedEntry, err := h.client.Files.Retrieve(ctx, &loonfs.GetPathEntryRequest{
 		NamespaceID: request.NamespaceID,
 		Path:        childPath(request.ReplacedFileName),
 		SnapshotID:  &snapshotID,
@@ -1509,7 +1509,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Errorf("current revision_no = %d, want %d", revision, expected.CurrentRevisionNo)
 	}
 
-	capturedListing, err := h.client.Filesystem.ListPathEntries(ctx, &loonfs.ListPathEntriesRequest{
+	capturedListing, err := h.client.Files.List(ctx, &loonfs.ListPathEntriesRequest{
 		NamespaceID: request.NamespaceID,
 		Path:        request.Directory,
 		SnapshotID:  &snapshotID,
@@ -1548,7 +1548,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	limit := 100
-	feed, err := h.client.Filesystem.ListChanges(ctx, &loonfs.ListChangesRequest{
+	feed, err := h.client.Changes.List(ctx, &loonfs.ListChangesRequest{
 		NamespaceID: request.NamespaceID,
 		AfterSeq:    loonfs.ChangeSeq(0),
 		Limit:       &limit,
@@ -1571,7 +1571,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Errorf("snapshot change seqs = %v, want %v", changeSeqs, expected.SnapshotChangeSeqs)
 	}
 
-	extended, err := h.client.Namespaces.ExtendSnapshot(ctx, &loonfs.ExtendSnapshotRequest{
+	extended, err := h.client.Snapshots.Extend(ctx, &loonfs.ExtendSnapshotRequest{
 		NamespaceID: request.NamespaceID,
 		SnapshotID:  snapshotID,
 		TTLMs:       request.ExtendTTLMs,
@@ -1586,7 +1586,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Errorf("extended expires_at_ms = %d, want greater than %d", extended.ExpiresAtMs, snapshot.ExpiresAtMs)
 	}
 
-	listed, err := h.client.Namespaces.ListSnapshots(ctx, &loonfs.ListSnapshotsRequest{
+	listed, err := h.client.Snapshots.List(ctx, &loonfs.ListSnapshotsRequest{
 		NamespaceID: request.NamespaceID,
 	})
 	if err != nil {
@@ -1607,7 +1607,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 		SnapshotID:  snapshotID,
 	}
 	for _, label := range []string{"release snapshot", "release snapshot again"} {
-		released, releaseErr := h.client.Namespaces.ReleaseSnapshot(ctx, releaseRequest)
+		released, releaseErr := h.client.Snapshots.Release(ctx, releaseRequest)
 		if releaseErr != nil {
 			t.Fatalf("%s: %v", label, releaseErr)
 		}
@@ -1616,13 +1616,13 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 		}
 	}
 
-	_, err = h.client.Filesystem.GetPathEntry(ctx, &loonfs.GetPathEntryRequest{
+	_, err = h.client.Files.Retrieve(ctx, &loonfs.GetPathEntryRequest{
 		NamespaceID: request.NamespaceID,
 		Path:        childPath(request.ReplacedFileName),
 		SnapshotID:  &snapshotID,
 	})
 	assertGoneError(t, err, expected.SnapshotGone)
-	_, err = h.client.Namespaces.ExtendSnapshot(ctx, &loonfs.ExtendSnapshotRequest{
+	_, err = h.client.Snapshots.Extend(ctx, &loonfs.ExtendSnapshotRequest{
 		NamespaceID: request.NamespaceID,
 		SnapshotID:  snapshotID,
 		TTLMs:       request.ExtendTTLMs,
@@ -1630,7 +1630,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	assertGoneError(t, err, expected.SnapshotGone)
 
 	unknownSnapshotID := loonfs.CheckpointID(request.UnknownSnapshotID)
-	_, err = h.client.Filesystem.GetPathEntry(ctx, &loonfs.GetPathEntryRequest{
+	_, err = h.client.Files.Retrieve(ctx, &loonfs.GetPathEntryRequest{
 		NamespaceID: request.NamespaceID,
 		Path:        childPath(request.ReplacedFileName),
 		SnapshotID:  &unknownSnapshotID,
@@ -1644,14 +1644,14 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	revision := loonfs.RevisionNo(expected.CapturedRevisionNo)
-	_, err = h.client.Filesystem.GetFileBytes(ctx, &loonfs.GetFileBytesRequest{
+	_, err = h.client.Files.Content(ctx, &loonfs.GetFileBytesRequest{
 		NamespaceID: request.NamespaceID,
 		Path:        childPath(request.ReplacedFileName),
 		RevisionNo:  &revision,
 		SnapshotID:  &snapshotID,
 	})
 	assertBadRequestError(t, err, expected.RevisionWithSnapshot)
-	_, err = h.client.Namespaces.CreateSnapshot(ctx, &loonfs.CreateSnapshotRequest{
+	_, err = h.client.Snapshots.Create(ctx, &loonfs.CreateSnapshotRequest{
 		NamespaceID: request.NamespaceID,
 		Name:        request.SnapshotName,
 		TTLMs:       0,
@@ -1666,7 +1666,7 @@ func readSDKFileBytes(
 	label string,
 ) []byte {
 	t.Helper()
-	reader, err := sdk.Filesystem.GetFileBytes(context.Background(), request)
+	reader, err := sdk.Files.Content(context.Background(), request)
 	if err != nil {
 		t.Fatalf("%s: %v", label, err)
 	}
@@ -1739,7 +1739,7 @@ func runPagination(t *testing.T, h *harness, testCase conformanceCase) {
 	var savedCursor *string
 	resumeOffset := -1
 	ctx := context.Background()
-	page, err := h.client.Filesystem.ListPathEntries(
+	page, err := h.client.Files.List(
 		ctx,
 		&loonfs.ListPathEntriesRequest{
 			NamespaceID: request.NamespaceID,
@@ -1793,7 +1793,7 @@ func runPagination(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	resumed := make([]string, 0, len(request.EntryNames)-resumeOffset)
-	page, err = h.client.Filesystem.ListPathEntries(
+	page, err = h.client.Files.List(
 		ctx,
 		&loonfs.ListPathEntriesRequest{
 			NamespaceID: request.NamespaceID,
@@ -2251,14 +2251,14 @@ func runChanges(t *testing.T, h *harness, testCase conformanceCase) {
 		request.Path,
 		nil,
 	)
-	committed, err := h.client.Filesystem.CreateCommit(context.Background(), commit)
+	committed, err := h.client.Commits.Create(context.Background(), commit)
 	if err != nil {
 		t.Fatalf("commit change: %v", err)
 	}
 	if int64(committed.CommittedSeq) != expected.CommittedSeq {
 		t.Errorf("committed_seq = %d, want %d", committed.CommittedSeq, expected.CommittedSeq)
 	}
-	feed, err := h.client.Filesystem.ListChanges(
+	feed, err := h.client.Changes.List(
 		context.Background(),
 		&loonfs.ListChangesRequest{
 			NamespaceID: request.NamespaceID,
@@ -2568,7 +2568,7 @@ func commitCompletedFile(
 
 func applyCommit(t *testing.T, sdk *server.Client, request *loonfs.CommitRequest) *loonfs.CommitResponse {
 	t.Helper()
-	response, err := sdk.Filesystem.CreateCommit(context.Background(), request)
+	response, err := sdk.Commits.Create(context.Background(), request)
 	if err != nil {
 		t.Fatalf("apply commit %q: %v", request.CommitID, err)
 	}
@@ -2577,7 +2577,7 @@ func applyCommit(t *testing.T, sdk *server.Client, request *loonfs.CommitRequest
 
 func statPath(t *testing.T, sdk *server.Client, namespaceID, path string) *loonfs.PathEntry {
 	t.Helper()
-	entry, err := sdk.Filesystem.GetPathEntry(context.Background(), &loonfs.GetPathEntryRequest{
+	entry, err := sdk.Files.Retrieve(context.Background(), &loonfs.GetPathEntryRequest{
 		NamespaceID: namespaceID,
 		Path:        path,
 	})
@@ -2606,7 +2606,7 @@ func listPathEntries(
 	path string,
 ) []*loonfs.PathEntry {
 	t.Helper()
-	page, err := sdk.Filesystem.ListPathEntries(context.Background(), &loonfs.ListPathEntriesRequest{
+	page, err := sdk.Files.List(context.Background(), &loonfs.ListPathEntriesRequest{
 		NamespaceID: namespaceID,
 		Path:        path,
 	})
@@ -2627,7 +2627,7 @@ func listingContainsPath(entries []*loonfs.PathEntry, path string) bool {
 
 func listChanges(t *testing.T, sdk *server.Client, namespaceID string) *loonfs.ListChangesResponse {
 	t.Helper()
-	changes, err := sdk.Filesystem.ListChanges(context.Background(), &loonfs.ListChangesRequest{
+	changes, err := sdk.Changes.List(context.Background(), &loonfs.ListChangesRequest{
 		NamespaceID: namespaceID,
 		AfterSeq:    loonfs.ChangeSeq(0),
 	})
@@ -2646,7 +2646,7 @@ func actorsEqual(left, right *loonfs.ActorRef) bool {
 
 func createNamespace(t *testing.T, sdk *server.Client, namespaceID string) {
 	t.Helper()
-	_, err := sdk.Namespaces.CreateNamespace(
+	_, err := sdk.Namespaces.Create(
 		context.Background(),
 		&loonfs.CreateNamespaceRequest{NamespaceID: loonfs.NamespaceID(namespaceID)},
 	)
@@ -2664,7 +2664,7 @@ func applyCreateDirectory(
 	path string,
 ) {
 	t.Helper()
-	_, err := sdk.Filesystem.CreateCommit(
+	_, err := sdk.Commits.Create(
 		context.Background(),
 		createDirectoryCommit(namespaceID, commitID, actor, path, nil),
 	)

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -519,7 +519,7 @@ def _apply(
         extra["message"] = message
     if content_tokens is not None:
         extra["content_tokens"] = content_tokens
-    return client.filesystem.create_commit(
+    return client.commits.create(
         namespace_id,
         actor=actor,
         commit_id=commit_id,
@@ -572,13 +572,13 @@ def _completed_upload(response: UploadSession) -> UploadSession_Completed:
 def _stage_content(
     client: LoonFS, namespace_id: str, payload: bytes
 ) -> UploadSession_Completed:
-    begin = client.uploads.create_upload(
+    begin = client.uploads.create(
         namespace_id, request=BeginUploadRequest_ServiceProxied()
     )
     assert isinstance(begin, BeginUploadResponse_ServiceProxied)
-    client.uploads.put_upload_content(namespace_id, begin.upload_id, request=payload)
+    client.uploads.put_content(namespace_id, begin.upload_id, request=payload)
     return _completed_upload(
-        client.uploads.complete_upload(
+        client.uploads.complete(
             namespace_id,
             begin.upload_id,
             request=CompleteUploadRequest_ServiceProxied(),
@@ -606,7 +606,7 @@ def _wire(model: pydantic.BaseModel) -> JsonObject:
 
 
 def _read_proxied(client: LoonFS, namespace_id: str, path: str) -> bytes:
-    return b"".join(client.filesystem.get_file_bytes(namespace_id, path=path))
+    return b"".join(client.files.content(namespace_id, path=path))
 
 
 def _proxy_response_json(response: httpx.Response, label: str) -> JsonObject:
@@ -654,12 +654,12 @@ def _list_path_entries(
     cursor: str | None,
 ) -> Any:
     if cursor is None:
-        return client.filesystem.list_path_entries(
+        return client.files.list(
             request.namespace_id,
             path=request.directory,
             limit=request.page_size,
         )
-    return client.filesystem.list_path_entries(
+    return client.files.list(
         request.namespace_id,
         path=request.directory,
         limit=request.page_size,
@@ -674,12 +674,12 @@ def _list_inode_children(
     cursor: str | None,
 ) -> Any:
     if cursor is None:
-        return client.inodes.list_inode_children(
+        return client.inodes.list_children(
             request.namespace_id,
             parent_inode_id,
             limit=request.page_size,
         )
-    return client.inodes.list_inode_children(
+    return client.inodes.list_children(
         request.namespace_id,
         parent_inode_id,
         limit=request.page_size,
@@ -692,7 +692,7 @@ def test_error_contract(cases: dict[str, ConformanceCase], harness: Harness) -> 
         cases["error_contract"], ErrorContractRequest, ErrorContractExpected
     )
     with pytest.raises(UnauthorizedError) as captured:
-        harness.unauthenticated.namespaces.get_namespace(request.namespace_id)
+        harness.unauthenticated.namespaces.retrieve(request.namespace_id)
 
     error = captured.value
     assert error.status_code == expected.unauthenticated.status
@@ -704,7 +704,7 @@ def test_commit_replay(cases: dict[str, ConformanceCase], harness: Harness) -> N
     request, expected = _decode(
         cases["commit_replay"], CommitReplayRequest, CommitReplayExpected
     )
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     first = _apply(
         harness.client,
         request.namespace_id,
@@ -733,7 +733,7 @@ def test_pagination(cases: dict[str, ConformanceCase], harness: Harness) -> None
     request, expected = _decode(
         cases["pagination"], PaginationRequest, PaginationExpected
     )
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     _apply(
         harness.client,
         request.namespace_id,
@@ -798,7 +798,7 @@ def test_children_by_inode(
     request, expected = _decode(
         cases["children_by_inode"], ChildrenByInodeRequest, ChildrenByInodeExpected
     )
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     _apply(
         harness.client,
         request.namespace_id,
@@ -817,7 +817,7 @@ def test_children_by_inode(
             ),
         )
 
-    parent_inode_id = harness.client.filesystem.get_path_entry(
+    parent_inode_id = harness.client.files.retrieve(
         request.namespace_id, path=request.directory
     ).inode_id
     observed: list[str] = []
@@ -855,7 +855,7 @@ def test_children_by_inode(
                 ),
             )
             assert renamed.committed_seq == expected.renamed_head_seq
-            renamed_inode_id = harness.client.filesystem.get_path_entry(
+            renamed_inode_id = harness.client.files.retrieve(
                 request.namespace_id, path=request.renamed_directory
             ).inode_id
             assert renamed_inode_id == parent_inode_id
@@ -899,7 +899,7 @@ def test_inode_mutations(cases: dict[str, ConformanceCase], harness: Harness) ->
     def child_path(name: str) -> str:
         return f"{request.directory}/{name}"
 
-    client.namespaces.create_namespace(namespace_id=namespace_id)
+    client.namespaces.create(namespace_id=namespace_id)
     _apply(
         client,
         namespace_id,
@@ -925,7 +925,7 @@ def test_inode_mutations(cases: dict[str, ConformanceCase], harness: Harness) ->
         commit_id="conf-inode-mutations-path-file",
     )
 
-    parent_inode_id = client.filesystem.get_path_entry(
+    parent_inode_id = client.files.retrieve(
         namespace_id, path=request.directory
     ).inode_id
     _apply(
@@ -952,7 +952,7 @@ def test_inode_mutations(cases: dict[str, ConformanceCase], harness: Harness) ->
         content_tokens=[staged.content_token] if staged.content_token else None,
     )
 
-    entries = client.filesystem.list_path_entries(
+    entries = client.files.list(
         namespace_id, path=request.directory
     ).entries
     assert _listed_names(entries) == expected.entry_names
@@ -987,7 +987,7 @@ def test_inode_mutations(cases: dict[str, ConformanceCase], harness: Harness) ->
         content_tokens=[staged.content_token] if staged.content_token else None,
     )
     revised = _file_entry(
-        client.filesystem.get_path_entry(
+        client.files.retrieve(
             namespace_id, path=child_path(request.inode_file_name)
         )
     )
@@ -1035,19 +1035,19 @@ def test_inode_mutations(cases: dict[str, ConformanceCase], harness: Harness) ->
     assert malformed.value.status_code == expected.malformed_binding_generation.status
     assert malformed.value.body.code == expected.malformed_binding_generation.code
 
-    fresh_generation = client.filesystem.get_path_entry(
+    fresh_generation = client.files.retrieve(
         namespace_id, path=child_path(request.renamed_file_name)
     ).binding_generation
     moved = move_by_inode("conf-inode-mutations-move", fresh_generation)
     assert moved.committed_seq == expected.moved_committed_seq
-    moved_entry = client.filesystem.get_path_entry(
+    moved_entry = client.files.retrieve(
         namespace_id,
         path=f"{child_path(request.inode_directory_name)}/{request.moved_file_name}",
     )
     assert moved_entry.inode_id == inode_file.inode_id
     assert moved_entry.binding_generation != fresh_generation
 
-    feed = client.filesystem.list_changes(
+    feed = client.changes.list(
         namespace_id, after_seq=expected.moved_committed_seq - 1, limit=1
     )
     assert len(feed.changes) == 1
@@ -1079,7 +1079,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     def child_path(name: str) -> str:
         return f"{request.directory}/{name}"
 
-    client.namespaces.create_namespace(namespace_id=namespace_id)
+    client.namespaces.create(namespace_id=namespace_id)
     _apply(
         client,
         namespace_id,
@@ -1104,7 +1104,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         commit_id="conf-snapshots-create-deleted",
     )
 
-    snapshot = client.namespaces.create_snapshot(
+    snapshot = client.snapshots.create(
         namespace_id,
         name=request.snapshot_name,
         ttl_ms=request.create_ttl_ms,
@@ -1140,7 +1140,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     )
 
     captured_entry = _file_entry(
-        client.filesystem.get_path_entry(
+        client.files.retrieve(
             namespace_id,
             path=child_path(request.replaced_file_name),
             snapshot_id=snapshot.snapshot_id,
@@ -1148,28 +1148,28 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     )
     assert captured_entry.revision_no == expected.captured_revision_no
     current_entry = _file_entry(
-        client.filesystem.get_path_entry(
+        client.files.retrieve(
             namespace_id,
             path=child_path(request.replaced_file_name),
         )
     )
     assert current_entry.revision_no == expected.current_revision_no
 
-    captured_listing = client.filesystem.list_path_entries(
+    captured_listing = client.files.list(
         namespace_id,
         path=request.directory,
         snapshot_id=snapshot.snapshot_id,
     )
     assert captured_listing.head_seq == expected.snapshot_head_seq
     assert _listed_names(captured_listing.entries) == expected.captured_entry_names
-    current_listing = client.filesystem.list_path_entries(
+    current_listing = client.files.list(
         namespace_id,
         path=request.directory,
     )
     assert _listed_names(current_listing.entries) == expected.current_entry_names
 
     captured_content = b"".join(
-        client.filesystem.get_file_bytes(
+        client.files.content(
             namespace_id,
             path=child_path(request.replaced_file_name),
             snapshot_id=snapshot.snapshot_id,
@@ -1177,14 +1177,14 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     )
     assert captured_content == request.captured_content_utf8.encode()
     current_content = b"".join(
-        client.filesystem.get_file_bytes(
+        client.files.content(
             namespace_id,
             path=child_path(request.replaced_file_name),
         )
     )
     assert current_content == request.current_content_utf8.encode()
 
-    feed = client.filesystem.list_changes(
+    feed = client.changes.list(
         namespace_id,
         after_seq=0,
         limit=100,
@@ -1196,7 +1196,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         expected.snapshot_change_seqs
     )
 
-    extended = client.namespaces.extend_snapshot(
+    extended = client.snapshots.extend(
         namespace_id,
         snapshot.snapshot_id,
         ttl_ms=request.extend_ttl_ms,
@@ -1206,25 +1206,25 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert extended.name == request.snapshot_name
     assert extended.expires_at_ms > snapshot.expires_at_ms
 
-    listed = client.namespaces.list_snapshots(namespace_id)
+    listed = client.snapshots.list(namespace_id)
     assert listed.namespace_id == namespace_id
     assert listed.next_cursor is None
     assert len(listed.snapshots) == 1
     assert listed.snapshots[0].snapshot_id == snapshot.snapshot_id
 
-    first_release = client.namespaces.release_snapshot(
+    first_release = client.snapshots.release(
         namespace_id, snapshot.snapshot_id
     )
     assert first_release.namespace_id == namespace_id
     assert first_release.snapshot_id == snapshot.snapshot_id
-    second_release = client.namespaces.release_snapshot(
+    second_release = client.snapshots.release(
         namespace_id, snapshot.snapshot_id
     )
     assert second_release.namespace_id == namespace_id
     assert second_release.snapshot_id == snapshot.snapshot_id
 
     with pytest.raises(GoneError) as released_read:
-        client.filesystem.get_path_entry(
+        client.files.retrieve(
             namespace_id,
             path=child_path(request.replaced_file_name),
             snapshot_id=snapshot.snapshot_id,
@@ -1232,7 +1232,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert released_read.value.status_code == expected.snapshot_gone.status
     assert released_read.value.body.code == expected.snapshot_gone.code
     with pytest.raises(GoneError) as released_extend:
-        client.namespaces.extend_snapshot(
+        client.snapshots.extend(
             namespace_id,
             snapshot.snapshot_id,
             ttl_ms=request.extend_ttl_ms,
@@ -1241,7 +1241,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert released_extend.value.body.code == expected.snapshot_gone.code
 
     with pytest.raises(NotFoundError) as unknown_read:
-        client.filesystem.get_path_entry(
+        client.files.retrieve(
             namespace_id,
             path=child_path(request.replaced_file_name),
             snapshot_id=request.unknown_snapshot_id,
@@ -1250,7 +1250,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert unknown_read.value.body.code == expected.snapshot_not_found.code
     with pytest.raises(BadRequestError) as revision_with_snapshot:
         b"".join(
-            client.filesystem.get_file_bytes(
+            client.files.content(
                 namespace_id,
                 path=child_path(request.replaced_file_name),
                 revision_no=expected.captured_revision_no,
@@ -1265,7 +1265,7 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         revision_with_snapshot.value.body.code == expected.revision_with_snapshot.code
     )
     with pytest.raises(BadRequestError) as zero_ttl:
-        client.namespaces.create_snapshot(
+        client.snapshots.create(
             namespace_id,
             name=request.snapshot_name,
             ttl_ms=0,
@@ -1280,7 +1280,7 @@ def test_proxy(
     proxy_harness: str,
 ) -> None:
     request, expected = _decode(cases["proxy"], ProxyRequest, ProxyExpected)
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     payload = request.content_utf8.encode()
     namespace_alias_base = f"/v0/namespace-aliases/{request.namespace_alias}"
 
@@ -1435,7 +1435,7 @@ def test_proxy(
 
 def test_changes(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     request, expected = _decode(cases["changes"], ChangesRequest, ChangesExpected)
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     committed = _apply(
         harness.client,
         request.namespace_id,
@@ -1445,7 +1445,7 @@ def test_changes(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     )
     assert committed.committed_seq == expected.committed_seq
 
-    feed = harness.client.filesystem.list_changes(
+    feed = harness.client.changes.list(
         request.namespace_id,
         after_seq=request.after_seq,
     )
@@ -1463,9 +1463,9 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
     request, expected = _decode(
         cases["upload_direct_put"], DirectPutRequest, DirectPutExpected
     )
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     payload = request.content_utf8.encode()
-    begin = harness.client.uploads.create_upload(
+    begin = harness.client.uploads.create(
         request.namespace_id,
         request=BeginUploadRequest_DirectPut(size_bytes=len(payload)),
     )
@@ -1478,7 +1478,7 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
         size_bytes=len(payload),
         checksum=_checksum(begin.checksum_algorithm, payload),
     )
-    completed = harness.client.uploads.complete_upload(
+    completed = harness.client.uploads.complete(
         request.namespace_id,
         begin.upload_id,
         request=CompleteUploadRequest_DirectPut(content=claim),
@@ -1501,7 +1501,7 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
     )
     assert committed.committed_seq == expected.committed_seq
     stat = _file_entry(
-        harness.client.filesystem.get_path_entry(request.namespace_id, path=request.path)
+        harness.client.files.retrieve(request.namespace_id, path=request.path)
     )
     assert stat.content_ref == content_ref
     assert _read_proxied(harness.client, request.namespace_id, request.path) == payload
@@ -1511,9 +1511,9 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
     request, expected = _decode(
         cases["upload_multipart"], MultipartRequest, MultipartExpected
     )
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     payload = _byte_pattern(request.content_pattern)
-    begin = harness.client.uploads.create_upload(
+    begin = harness.client.uploads.create(
         request.namespace_id,
         request=BeginUploadRequest_DirectMultipart(
             part_size_bytes=request.part_size_bytes,
@@ -1537,7 +1537,7 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
         )
         for index, chunk in enumerate(chunks, start=1)
     ]
-    signed = harness.client.uploads.sign_upload_parts(
+    signed = harness.client.uploads.sign_parts(
         request.namespace_id,
         begin.upload_id,
         parts=claims,
@@ -1568,14 +1568,14 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
         ),
         parts=completed_parts,
     )
-    first = harness.client.uploads.complete_upload(
+    first = harness.client.uploads.complete(
         request.namespace_id,
         begin.upload_id,
         request=completion_request,
     )
     first_completed = _completed_upload(first)
     first_content_ref = first_completed.content_ref
-    replayed = harness.client.uploads.complete_upload(
+    replayed = harness.client.uploads.complete(
         request.namespace_id,
         begin.upload_id,
         request=completion_request,
@@ -1634,16 +1634,16 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
 
 def test_upload_abort(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     request, expected = _decode(cases["upload_abort"], AbortRequest, AbortExpected)
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
-    begin = harness.client.uploads.create_upload(
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
+    begin = harness.client.uploads.create(
         request.namespace_id,
         request=BeginUploadRequest_ServiceProxied(),
     )
     first = _aborted_upload(
-        harness.client.uploads.abort_upload(request.namespace_id, begin.upload_id)
+        harness.client.uploads.abort(request.namespace_id, begin.upload_id)
     )
     replayed = _aborted_upload(
-        harness.client.uploads.abort_upload(request.namespace_id, begin.upload_id)
+        harness.client.uploads.abort(request.namespace_id, begin.upload_id)
     )
 
     assert first.mode == expected.mode
@@ -1656,7 +1656,7 @@ def test_download(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     request, expected = _decode(
         cases["download"], DownloadRequest, DownloadExpected
     )
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     payload = request.content_utf8.encode()
     committed = put_file(
         harness.client,
@@ -1669,7 +1669,7 @@ def test_download(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert committed.committed_seq == expected.committed_seq
 
     stat = _file_entry(
-        harness.client.filesystem.get_path_entry(request.namespace_id, path=request.path)
+        harness.client.files.retrieve(request.namespace_id, path=request.path)
     )
     downloaded = get_file(
         harness.client,
@@ -1691,7 +1691,7 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
     request, expected = _decode(
         cases["end_to_end"], EndToEndRequest, EndToEndExpected
     )
-    harness.client.namespaces.create_namespace(namespace_id=request.namespace_id)
+    harness.client.namespaces.create(namespace_id=request.namespace_id)
     mkdir = _apply(
         harness.client,
         request.namespace_id,
@@ -1711,13 +1711,13 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
         commit_id=request.commit_ids.upload,
     )
     assert upload.committed_seq == expected.upload_committed_seq
-    stat = harness.client.filesystem.get_path_entry(
+    stat = harness.client.files.retrieve(
         request.namespace_id, path=request.upload_path
     )
     assert stat.size_bytes == expected.size_bytes
     uploaded_inode = stat.inode_id
 
-    initial_listing = harness.client.filesystem.list_path_entries(
+    initial_listing = harness.client.files.list(
         request.namespace_id,
         path=request.directory,
     )
@@ -1741,20 +1741,20 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
         ),
     )
     assert moved.committed_seq == expected.move_committed_seq
-    moved_listing = harness.client.filesystem.list_path_entries(
+    moved_listing = harness.client.files.list(
         request.namespace_id,
         path=request.directory,
     )
     assert any(entry.path == request.moved_path for entry in moved_listing.entries)
 
-    revisions = harness.client.filesystem.list_file_revisions(
+    revisions = harness.client.files.list_revisions(
         request.namespace_id,
         path=request.moved_path,
     )
     assert len(revisions.revisions) == expected.revision_count
     assert revisions.revisions[0].commit_id == request.commit_ids.upload
 
-    changes_before_remove = harness.client.filesystem.list_changes(
+    changes_before_remove = harness.client.changes.list(
         request.namespace_id,
         after_seq=0,
     )
@@ -1769,7 +1769,7 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
     )
     assert removed.committed_seq == expected.remove_committed_seq
 
-    changes = harness.client.filesystem.list_changes(
+    changes = harness.client.changes.list(
         request.namespace_id,
         after_seq=0,
     )
@@ -1786,7 +1786,7 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
         for change in changes.changes
     )
 
-    trash = harness.client.filesystem.list_trash(request.namespace_id)
+    trash = harness.client.trash.list(request.namespace_id)
     removed_entry = next(
         entry for entry in trash.entries if entry.inode_id == uploaded_inode
     )

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -854,7 +854,7 @@ async function readProxied(
     snapshotId?: string,
     revisionNo?: number,
 ): Promise<Uint8Array> {
-    const response = await client.filesystem.getFileBytes({
+    const response = await client.files.content({
         namespace_id: namespaceId,
         path,
         snapshot_id: snapshotId,
@@ -898,13 +898,13 @@ async function stageContent(
     namespaceId: string,
     bytes: Uint8Array,
 ): Promise<CompletedUpload> {
-    const begin = await client.uploads.createUpload({
+    const begin = await client.uploads.create({
         namespace_id: namespaceId,
         body: { mode: "service_proxied" },
     });
-    await client.uploads.putUploadContent(arrayBuffer(bytes), namespaceId, begin.upload_id);
+    await client.uploads.putContent(arrayBuffer(bytes), namespaceId, begin.upload_id);
     return completedUpload(
-        await client.uploads.completeUpload({
+        await client.uploads.complete({
             namespace_id: namespaceId,
             upload_id: begin.upload_id,
             body: { mode: "service_proxied" },
@@ -1169,7 +1169,7 @@ conformanceTest("error_contract", async (activeHarness, testCase) => {
     const [request, expected] = decodeErrorContract(testCase);
     let caught: unknown;
     try {
-        await activeHarness.unauthenticated.namespaces.getNamespace({ namespace_id: request.namespace_id });
+        await activeHarness.unauthenticated.namespaces.retrieve({ namespace_id: request.namespace_id });
     } catch (error) {
         caught = error;
     }
@@ -1182,7 +1182,7 @@ conformanceTest("error_contract", async (activeHarness, testCase) => {
 
 conformanceTest("commit_replay", async (activeHarness, testCase) => {
     const [request, expected] = decodeCommitReplay(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
     const commit = directoryCommit(
         request.namespace_id,
         request.commit_id,
@@ -1190,8 +1190,8 @@ conformanceTest("commit_replay", async (activeHarness, testCase) => {
         request.path,
         request.message,
     );
-    const first = await activeHarness.client.filesystem.createCommit(commit);
-    const replayed = await activeHarness.client.filesystem.createCommit(commit);
+    const first = await activeHarness.client.commits.create(commit);
+    const replayed = await activeHarness.client.commits.create(commit);
 
     assert.equal(first.committed_seq, expected.committed_seq);
     assert.equal(first.commit_id, request.commit_id);
@@ -1201,8 +1201,8 @@ conformanceTest("commit_replay", async (activeHarness, testCase) => {
 
 conformanceTest("pagination", async (activeHarness, testCase) => {
     const [request, expected] = decodePagination(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
-    await activeHarness.client.filesystem.createCommit(
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
+    await activeHarness.client.commits.create(
         directoryCommit(
             request.namespace_id,
             "conf-pagination-directory",
@@ -1211,7 +1211,7 @@ conformanceTest("pagination", async (activeHarness, testCase) => {
         ),
     );
     for (const [index, name] of request.entry_names.entries()) {
-        await activeHarness.client.filesystem.createCommit(
+        await activeHarness.client.commits.create(
             directoryCommit(
                 request.namespace_id,
                 `conf-pagination-entry-${index.toString().padStart(2, "0")}`,
@@ -1225,7 +1225,7 @@ conformanceTest("pagination", async (activeHarness, testCase) => {
     let pageCount = 0;
     let savedCursor: string | undefined;
     let resumeOffset: number | undefined;
-    let page = await activeHarness.client.filesystem.listPathEntries({
+    let page = await activeHarness.client.files.list({
         namespace_id: request.namespace_id,
         path: request.directory,
         limit: request.page_size,
@@ -1253,7 +1253,7 @@ conformanceTest("pagination", async (activeHarness, testCase) => {
     assert.ok(resumeOffset !== undefined, "resume position was not recorded");
 
     const resumed: string[] = [];
-    page = await activeHarness.client.filesystem.listPathEntries({
+    page = await activeHarness.client.files.list({
         namespace_id: request.namespace_id,
         path: request.directory,
         limit: request.page_size,
@@ -1276,8 +1276,8 @@ conformanceTest("pagination", async (activeHarness, testCase) => {
 
 conformanceTest("children_by_inode", async (activeHarness, testCase) => {
     const [request, expected] = decodeChildrenByInode(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
-    await activeHarness.client.filesystem.createCommit(
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
+    await activeHarness.client.commits.create(
         directoryCommit(
             request.namespace_id,
             "conf-children-by-inode-directory",
@@ -1286,7 +1286,7 @@ conformanceTest("children_by_inode", async (activeHarness, testCase) => {
         ),
     );
     for (const [index, name] of [...request.entry_names].reverse().entries()) {
-        await activeHarness.client.filesystem.createCommit(
+        await activeHarness.client.commits.create(
             directoryCommit(
                 request.namespace_id,
                 `conf-children-by-inode-entry-${index.toString().padStart(2, "0")}`,
@@ -1296,7 +1296,7 @@ conformanceTest("children_by_inode", async (activeHarness, testCase) => {
         );
     }
 
-    const parent = await activeHarness.client.filesystem.getPathEntry({
+    const parent = await activeHarness.client.files.retrieve({
         namespace_id: request.namespace_id,
         path: request.directory,
     });
@@ -1305,7 +1305,7 @@ conformanceTest("children_by_inode", async (activeHarness, testCase) => {
     let pageCount = 0;
     let savedCursor: string | undefined;
     let resumeOffset: number | undefined;
-    let page = await activeHarness.client.inodes.listInodeChildren({
+    let page = await activeHarness.client.inodes.listChildren({
         namespace_id: request.namespace_id,
         inode_id: parentInodeId,
         limit: request.page_size,
@@ -1327,7 +1327,7 @@ conformanceTest("children_by_inode", async (activeHarness, testCase) => {
             resumeOffset = observed.length;
         }
         if (pageCount === request.rename_after_page) {
-            const renamed = await activeHarness.client.filesystem.createCommit(
+            const renamed = await activeHarness.client.commits.create(
                 moveCommit(
                     request.namespace_id,
                     request.rename_commit_id,
@@ -1337,7 +1337,7 @@ conformanceTest("children_by_inode", async (activeHarness, testCase) => {
                 ),
             );
             assert.equal(renamed.committed_seq, expected.renamed_head_seq);
-            const renamedParent = await activeHarness.client.filesystem.getPathEntry({
+            const renamedParent = await activeHarness.client.files.retrieve({
                 namespace_id: request.namespace_id,
                 path: request.renamed_directory,
             });
@@ -1355,7 +1355,7 @@ conformanceTest("children_by_inode", async (activeHarness, testCase) => {
     assert.ok(resumeOffset !== undefined, "resume position was not recorded");
 
     const resumed: string[] = [];
-    page = await activeHarness.client.inodes.listInodeChildren({
+    page = await activeHarness.client.inodes.listChildren({
         namespace_id: request.namespace_id,
         inode_id: parentInodeId,
         limit: request.page_size,
@@ -1388,8 +1388,8 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
     const client = activeHarness.client;
     const namespaceId = request.namespace_id;
     const childPath = (name: string): string => `${request.directory}/${name}`;
-    await client.namespaces.createNamespace({ namespace_id: namespaceId });
-    await client.filesystem.createCommit(
+    await client.namespaces.create({ namespace_id: namespaceId });
+    await client.commits.create(
         directoryCommit(
             namespaceId,
             "conf-inode-mutations-directory",
@@ -1397,7 +1397,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
             request.directory,
         ),
     );
-    await client.filesystem.createCommit(
+    await client.commits.create(
         directoryCommit(
             namespaceId,
             "conf-inode-mutations-path-directory",
@@ -1413,11 +1413,11 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         commit_id: "conf-inode-mutations-path-file",
     });
 
-    const parent = await client.filesystem.getPathEntry({
+    const parent = await client.files.retrieve({
         namespace_id: namespaceId,
         path: request.directory,
     });
-    await client.filesystem.createCommit({
+    await client.commits.create({
         namespace_id: namespaceId,
         actor: request.actor,
         commit_id: "conf-inode-mutations-inode-directory",
@@ -1434,7 +1434,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         namespaceId,
         new TextEncoder().encode(request.content_utf8),
     );
-    await client.filesystem.createCommit(
+    await client.commits.create(
         stagedCommit(
             namespaceId,
             "conf-inode-mutations-inode-file",
@@ -1449,7 +1449,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         ),
     );
 
-    const listing = await client.filesystem.listPathEntries({
+    const listing = await client.files.list({
         namespace_id: namespaceId,
         path: request.directory,
     });
@@ -1480,7 +1480,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         namespaceId,
         new TextEncoder().encode(request.revised_content_utf8),
     );
-    await client.filesystem.createCommit(
+    await client.commits.create(
         stagedCommit(
             namespaceId,
             "conf-inode-mutations-revision",
@@ -1495,7 +1495,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         ),
     );
     const revised = fileEntry(
-        await client.filesystem.getPathEntry({
+        await client.files.retrieve({
             namespace_id: namespaceId,
             path: childPath(request.inode_file_name),
         }),
@@ -1506,7 +1506,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         new TextEncoder().encode(request.revised_content_utf8),
     );
 
-    await client.filesystem.createCommit(
+    await client.commits.create(
         moveCommit(
             namespaceId,
             "conf-inode-mutations-rename",
@@ -1533,7 +1533,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
 
     assert.ok(revised.binding_generation != null, "revised entry has no binding_generation");
     await assert.rejects(
-        client.filesystem.createCommit(
+        client.commits.create(
             moveByInode("conf-inode-mutations-stale-move", revised.binding_generation),
         ),
         (error: unknown) => {
@@ -1544,7 +1544,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         },
     );
     await assert.rejects(
-        client.filesystem.createCommit(
+        client.commits.create(
             moveByInode(
                 "conf-inode-mutations-malformed-move",
                 request.malformed_binding_generation,
@@ -1558,16 +1558,16 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
         },
     );
 
-    const renamed = await client.filesystem.getPathEntry({
+    const renamed = await client.files.retrieve({
         namespace_id: namespaceId,
         path: childPath(request.renamed_file_name),
     });
     assert.ok(renamed.binding_generation != null, "renamed entry has no binding_generation");
-    const moved = await client.filesystem.createCommit(
+    const moved = await client.commits.create(
         moveByInode("conf-inode-mutations-move", renamed.binding_generation),
     );
     assert.equal(moved.committed_seq, expected.moved_committed_seq);
-    const movedEntry = await client.filesystem.getPathEntry({
+    const movedEntry = await client.files.retrieve({
         namespace_id: namespaceId,
         path: `${childPath(request.inode_directory_name)}/${request.moved_file_name}`,
     });
@@ -1575,7 +1575,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
     assert.ok(movedEntry.binding_generation != null, "moved entry has no binding_generation");
     assert.notEqual(movedEntry.binding_generation, renamed.binding_generation);
 
-    const feed = await client.filesystem.listChanges({
+    const feed = await client.changes.list({
         namespace_id: namespaceId,
         after_seq: expected.moved_committed_seq - 1,
         limit: 1,
@@ -1587,7 +1587,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
     assert.ok(movedEvent?.kind === "moved");
     assert.equal(movedEvent.binding_generation, movedEntry.binding_generation);
 
-    const deleted = await client.filesystem.createCommit({
+    const deleted = await client.commits.create({
         namespace_id: namespaceId,
         actor: request.actor,
         commit_id: "conf-inode-mutations-delete",
@@ -1611,8 +1611,8 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     const capturedBytes = new TextEncoder().encode(request.captured_content_utf8);
     const currentBytes = new TextEncoder().encode(request.current_content_utf8);
 
-    await client.namespaces.createNamespace({ namespace_id: namespaceId });
-    await client.filesystem.createCommit(
+    await client.namespaces.create({ namespace_id: namespaceId });
+    await client.commits.create(
         directoryCommit(
             namespaceId,
             "conf-snapshots-create-directory",
@@ -1635,7 +1635,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         commit_id: "conf-snapshots-create-deleted",
     });
 
-    const snapshot = await client.namespaces.createSnapshot({
+    const snapshot = await client.snapshots.create({
         namespace_id: namespaceId,
         name: request.snapshot_name,
         ttl_ms: request.create_ttl_ms,
@@ -1660,7 +1660,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         actor: request.actor,
         commit_id: "conf-snapshots-add-file",
     });
-    await client.filesystem.createCommit(
+    await client.commits.create(
         deleteCommit(
             namespaceId,
             "conf-snapshots-delete-file",
@@ -1670,7 +1670,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     );
 
     const capturedEntry = fileEntry(
-        await client.filesystem.getPathEntry({
+        await client.files.retrieve({
             namespace_id: namespaceId,
             path: childPath(request.replaced_file_name),
             snapshot_id: snapshot.snapshot_id,
@@ -1678,21 +1678,21 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     );
     assert.equal(capturedEntry.revision_no, expected.captured_revision_no);
     const currentEntry = fileEntry(
-        await client.filesystem.getPathEntry({
+        await client.files.retrieve({
             namespace_id: namespaceId,
             path: childPath(request.replaced_file_name),
         }),
     );
     assert.equal(currentEntry.revision_no, expected.current_revision_no);
 
-    const capturedListing = await client.filesystem.listPathEntries({
+    const capturedListing = await client.files.list({
         namespace_id: namespaceId,
         path: request.directory,
         snapshot_id: snapshot.snapshot_id,
     });
     assert.equal(capturedListing.response.head_seq, expected.snapshot_head_seq);
     assert.deepEqual(listedNames(capturedListing.data), expected.captured_entry_names);
-    const currentListing = await client.filesystem.listPathEntries({
+    const currentListing = await client.files.list({
         namespace_id: namespaceId,
         path: request.directory,
     });
@@ -1712,7 +1712,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         currentBytes,
     );
 
-    const feed = await client.filesystem.listChanges({
+    const feed = await client.changes.list({
         namespace_id: namespaceId,
         after_seq: 0,
         limit: 100,
@@ -1725,7 +1725,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         expected.snapshot_change_seqs,
     );
 
-    const extended = await client.namespaces.extendSnapshot({
+    const extended = await client.snapshots.extend({
         namespace_id: namespaceId,
         snapshot_id: snapshot.snapshot_id,
         ttl_ms: request.extend_ttl_ms,
@@ -1735,7 +1735,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     assert.equal(extended.name, request.snapshot_name);
     assert.ok(extended.expires_at_ms > snapshot.expires_at_ms);
 
-    const listed = await client.namespaces.listSnapshots({ namespace_id: namespaceId });
+    const listed = await client.snapshots.list({ namespace_id: namespaceId });
     assert.equal(listed.response.namespace_id, namespaceId);
     assert.equal(listed.response.next_cursor, undefined);
     assert.equal(listed.data.length, 1);
@@ -1745,15 +1745,15 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         namespace_id: namespaceId,
         snapshot_id: snapshot.snapshot_id,
     };
-    const firstRelease = await client.namespaces.releaseSnapshot(releaseRequest);
+    const firstRelease = await client.snapshots.release(releaseRequest);
     assert.equal(firstRelease.namespace_id, namespaceId);
     assert.equal(firstRelease.snapshot_id, snapshot.snapshot_id);
-    const secondRelease = await client.namespaces.releaseSnapshot(releaseRequest);
+    const secondRelease = await client.snapshots.release(releaseRequest);
     assert.equal(secondRelease.namespace_id, namespaceId);
     assert.equal(secondRelease.snapshot_id, snapshot.snapshot_id);
 
     await assert.rejects(
-        client.filesystem.getPathEntry({
+        client.files.retrieve({
             namespace_id: namespaceId,
             path: childPath(request.replaced_file_name),
             snapshot_id: snapshot.snapshot_id,
@@ -1766,7 +1766,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         },
     );
     await assert.rejects(
-        client.namespaces.extendSnapshot({
+        client.snapshots.extend({
             namespace_id: namespaceId,
             snapshot_id: snapshot.snapshot_id,
             ttl_ms: request.extend_ttl_ms,
@@ -1779,7 +1779,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         },
     );
     await assert.rejects(
-        client.filesystem.getPathEntry({
+        client.files.retrieve({
             namespace_id: namespaceId,
             path: childPath(request.replaced_file_name),
             snapshot_id: request.unknown_snapshot_id,
@@ -1807,7 +1807,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         },
     );
     await assert.rejects(
-        client.namespaces.createSnapshot({
+        client.snapshots.create({
             namespace_id: namespaceId,
             name: request.snapshot_name,
             ttl_ms: 0,
@@ -1845,7 +1845,7 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     const proxy = await startProxyServer(handler);
     context.after(() => proxy.close());
 
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
     const namespaceAliasBase =
         `${proxy.baseUrl}/v0/namespace-aliases/` +
         encodeURIComponent(request.namespace_alias);
@@ -2009,7 +2009,7 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     );
     assert.deepEqual(beginModes, ["service_proxied"]);
 
-    const capabilities = await browserClient.system.getCapabilities();
+    const capabilities = await browserClient.capabilities.retrieve();
     const proxyUploadMaxBytes = capabilities.limits?.[PROXY_UPLOAD_MAX_BYTES];
     assert.ok(proxyUploadMaxBytes !== undefined, "browser proxy upload limit is not advertised");
     assert.ok(Number.isSafeInteger(proxyUploadMaxBytes) && proxyUploadMaxBytes >= 0);
@@ -2061,13 +2061,13 @@ test("proxy", { skip: environmentSkip }, async (context) => {
 
 conformanceTest("changes", async (activeHarness, testCase) => {
     const [request, expected] = decodeChanges(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
-    const committed = await activeHarness.client.filesystem.createCommit(
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
+    const committed = await activeHarness.client.commits.create(
         directoryCommit(request.namespace_id, request.commit_id, request.actor, request.path),
     );
     assert.equal(committed.committed_seq, expected.committed_seq);
 
-    const feed = await activeHarness.client.filesystem.listChanges({
+    const feed = await activeHarness.client.changes.list({
         namespace_id: request.namespace_id,
         after_seq: request.after_seq,
     });
@@ -2082,9 +2082,9 @@ conformanceTest("changes", async (activeHarness, testCase) => {
 
 conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
     const [request, expected] = decodeDirectPut(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
     const payload = new TextEncoder().encode(request.content_utf8);
-    const begin = await activeHarness.client.uploads.createUpload({
+    const begin = await activeHarness.client.uploads.create({
         namespace_id: request.namespace_id,
         body: { mode: "direct_put", size_bytes: payload.byteLength },
     });
@@ -2098,7 +2098,7 @@ conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
         checksum: checksum(directPut.checksum_algorithm, payload),
     };
     const completed = completedUpload(
-        await activeHarness.client.uploads.completeUpload({
+        await activeHarness.client.uploads.complete({
             namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
             body: { mode: "direct_put", content: claim },
@@ -2112,7 +2112,7 @@ conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
         checksum(completed.content_ref.checksum.algorithm, payload),
     );
 
-    const committed = await activeHarness.client.filesystem.createCommit(
+    const committed = await activeHarness.client.commits.create(
         fileCommit(
             request.namespace_id,
             request.commit_id,
@@ -2124,7 +2124,7 @@ conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
     );
     assert.equal(committed.committed_seq, expected.committed_seq);
     const stat = fileEntry(
-        await activeHarness.client.filesystem.getPathEntry({
+        await activeHarness.client.files.retrieve({
             namespace_id: request.namespace_id,
             path: request.path,
         }),
@@ -2138,9 +2138,9 @@ conformanceTest("upload_direct_put", async (activeHarness, testCase) => {
 
 conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     const [request, expected] = decodeMultipart(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
     const payload = bytePattern(request.content_pattern);
-    const begin = await activeHarness.client.uploads.createUpload({
+    const begin = await activeHarness.client.uploads.create({
         namespace_id: request.namespace_id,
         body: {
             mode: "direct_multipart",
@@ -2158,7 +2158,7 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
         part_number: index + 1,
         checksum: checksum(multipart.checksum_algorithm, chunk),
     }));
-    const signed = await activeHarness.client.uploads.signUploadParts({
+    const signed = await activeHarness.client.uploads.signParts({
         namespace_id: request.namespace_id,
         upload_id: begin.upload_id,
         parts: claims,
@@ -2196,14 +2196,14 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
         parts: completedParts,
     };
     const first = completedUpload(
-        await activeHarness.client.uploads.completeUpload({
+        await activeHarness.client.uploads.complete({
             namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
             body: completion,
         }),
     );
     const replayed = completedUpload(
-        await activeHarness.client.uploads.completeUpload({
+        await activeHarness.client.uploads.complete({
             namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
             body: completion,
@@ -2218,7 +2218,7 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     assert.deepEqual(first.content_ref.checksum, wholeChecksum);
     assert.deepEqual(checksum(first.content_ref.checksum.algorithm, payload), wholeChecksum);
 
-    const committed = await activeHarness.client.filesystem.createCommit(
+    const committed = await activeHarness.client.commits.create(
         fileCommit(
             request.namespace_id,
             request.commit_id,
@@ -2257,19 +2257,19 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
 
 conformanceTest("upload_abort", async (activeHarness, testCase) => {
     const [request, expected] = decodeAbort(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
-    const begin = await activeHarness.client.uploads.createUpload({
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
+    const begin = await activeHarness.client.uploads.create({
         namespace_id: request.namespace_id,
         body: { mode: "service_proxied" },
     });
     const first = abortedUpload(
-        await activeHarness.client.uploads.abortUpload({
+        await activeHarness.client.uploads.abort({
             namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
         }),
     );
     const replayed = abortedUpload(
-        await activeHarness.client.uploads.abortUpload({
+        await activeHarness.client.uploads.abort({
             namespace_id: request.namespace_id,
             upload_id: begin.upload_id,
         }),
@@ -2282,7 +2282,7 @@ conformanceTest("upload_abort", async (activeHarness, testCase) => {
 
 conformanceTest("download", async (activeHarness, testCase) => {
     const [request, expected] = decodeDownload(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
     const payload = new TextEncoder().encode(request.content_utf8);
     const committed = await putFile(activeHarness.client, {
         namespace_id: request.namespace_id,
@@ -2293,7 +2293,7 @@ conformanceTest("download", async (activeHarness, testCase) => {
     });
     assert.equal(committed.committed_seq, expected.committed_seq);
     const stat = fileEntry(
-        await activeHarness.client.filesystem.getPathEntry({
+        await activeHarness.client.files.retrieve({
             namespace_id: request.namespace_id,
             path: request.path,
         }),
@@ -2315,8 +2315,8 @@ conformanceTest("download", async (activeHarness, testCase) => {
 
 conformanceTest("end_to_end", async (activeHarness, testCase) => {
     const [request, expected] = decodeEndToEnd(testCase);
-    await activeHarness.client.namespaces.createNamespace({ namespace_id: request.namespace_id });
-    const mkdir = await activeHarness.client.filesystem.createCommit(
+    await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
+    const mkdir = await activeHarness.client.commits.create(
         directoryCommit(
             request.namespace_id,
             request.commit_ids.mkdir,
@@ -2336,7 +2336,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
     });
     assert.equal(upload.committed_seq, expected.upload_committed_seq);
     const stat = fileEntry(
-        await activeHarness.client.filesystem.getPathEntry({
+        await activeHarness.client.files.retrieve({
             namespace_id: request.namespace_id,
             path: request.upload_path,
         }),
@@ -2344,7 +2344,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
     assert.equal(stat.size_bytes, expected.size_bytes);
     const uploadedInode = stat.inode_id;
 
-    const initialListing = await activeHarness.client.filesystem.listPathEntries({
+    const initialListing = await activeHarness.client.files.list({
         namespace_id: request.namespace_id,
         path: request.directory,
     });
@@ -2356,7 +2356,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
     });
     assert.deepEqual(downloaded.bytes, payload);
 
-    const moved = await activeHarness.client.filesystem.createCommit(
+    const moved = await activeHarness.client.commits.create(
         moveCommit(
             request.namespace_id,
             request.commit_ids.move,
@@ -2366,25 +2366,25 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
         ),
     );
     assert.equal(moved.committed_seq, expected.move_committed_seq);
-    const movedListing = await activeHarness.client.filesystem.listPathEntries({
+    const movedListing = await activeHarness.client.files.list({
         namespace_id: request.namespace_id,
         path: request.directory,
     });
     assert.ok(movedListing.data.some((entry) => entry.path === request.moved_path));
 
-    const revisions = await activeHarness.client.filesystem.listFileRevisions({
+    const revisions = await activeHarness.client.files.listRevisions({
         namespace_id: request.namespace_id,
         path: request.moved_path,
     });
     assert.equal(revisions.data.length, expected.revision_count);
     assert.equal(revisions.data[0]?.commit_id, request.commit_ids.upload);
 
-    let changes = await activeHarness.client.filesystem.listChanges({
+    let changes = await activeHarness.client.changes.list({
         namespace_id: request.namespace_id,
         after_seq: 0,
     });
     assert.equal(changes.changes.length, expected.change_count - 1);
-    const removed = await activeHarness.client.filesystem.createCommit(
+    const removed = await activeHarness.client.commits.create(
         deleteCommit(
             request.namespace_id,
             request.commit_ids.remove,
@@ -2394,7 +2394,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
     );
     assert.equal(removed.committed_seq, expected.remove_committed_seq);
 
-    changes = await activeHarness.client.filesystem.listChanges({
+    changes = await activeHarness.client.changes.list({
         namespace_id: request.namespace_id,
         after_seq: 0,
     });
@@ -2412,7 +2412,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
         assert.deepEqual(change.committed_by, request.actor);
     }
 
-    const trash = await activeHarness.client.filesystem.listTrash({
+    const trash = await activeHarness.client.trash.list({
         namespace_id: request.namespace_id,
     });
     const removedEntry = trash.data.find((entry) => entry.inode_id === uploadedInode);

--- a/sdk/overlays/go/README.md
+++ b/sdk/overlays/go/README.md
@@ -31,7 +31,7 @@ func main() {
 		option.WithToken(os.Getenv("LOONFS_AUTH_TOKEN")),
 	)
 
-	capabilities, err := loon.System.GetCapabilities(context.Background())
+	capabilities, err := loon.Capabilities.Retrieve(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/sdk/overlays/python/README.md
+++ b/sdk/overlays/python/README.md
@@ -23,7 +23,7 @@ client = LoonFS(
     token=os.environ["LOONFS_AUTH_TOKEN"],
 )
 
-capabilities = client.system.get_capabilities()
+capabilities = client.capabilities.retrieve()
 ```
 
 `AsyncLoonFS` provides the same API for async applications. Upload and download

--- a/sdk/transfers/go/transfers/transfers.go
+++ b/sdk/transfers/go/transfers/transfers.go
@@ -87,7 +87,7 @@ func PutFile(ctx context.Context, c *server.Client, in PutFileInput) (*PutFileRe
 		return nil, fmt.Errorf("transfers: actor is required")
 	}
 
-	capabilities, err := c.System.GetCapabilities(ctx)
+	capabilities, err := c.Capabilities.Retrieve(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
 	}
@@ -95,7 +95,7 @@ func PutFile(ctx context.Context, c *server.Client, in PutFileInput) (*PutFileRe
 	if err != nil {
 		return nil, err
 	}
-	begin, err := c.Uploads.CreateUpload(ctx, createRequest)
+	begin, err := c.Uploads.Create(ctx, createRequest)
 	if err != nil {
 		return nil, fmt.Errorf("transfers: begin upload: %w", err)
 	}
@@ -120,7 +120,7 @@ func PutFile(ctx context.Context, c *server.Client, in PutFileInput) (*PutFileRe
 	if status.ContentToken != nil {
 		contentTokens = []*loonfs.ContentToken{status.ContentToken}
 	}
-	committed, err := c.Filesystem.CreateCommit(ctx, &loonfs.CommitRequest{
+	committed, err := c.Commits.Create(ctx, &loonfs.CommitRequest{
 		NamespaceID:   string(in.NamespaceID),
 		Actor:         in.Actor,
 		CommitID:      in.CommitID,
@@ -154,14 +154,14 @@ func GetFile(ctx context.Context, c *server.Client, in GetFileInput) (*GetFileRe
 	if c == nil {
 		return nil, fmt.Errorf("transfers: client is nil")
 	}
-	capabilities, err := c.System.GetCapabilities(ctx)
+	capabilities, err := c.Capabilities.Retrieve(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
 	}
 	if capabilities == nil || !capabilities.Features[featureDirectGet] {
 		return getFileProxied(ctx, c, in)
 	}
-	grant, err := c.Filesystem.CreateDownload(ctx, &loonfs.BeginDownloadRequest{
+	grant, err := c.Files.CreateDownload(ctx, &loonfs.BeginDownloadRequest{
 		NamespaceID: string(in.NamespaceID),
 		Path:        in.Path,
 		RevisionNo:  in.RevisionNo,
@@ -204,7 +204,7 @@ func getFileProxied(ctx context.Context, c *server.Client, in GetFileInput) (*Ge
 	revisionNo := in.RevisionNo
 	var claim *loonfs.ContentRef
 	if revisionNo == nil {
-		entry, err := c.Filesystem.GetPathEntry(ctx, &loonfs.GetPathEntryRequest{
+		entry, err := c.Files.Retrieve(ctx, &loonfs.GetPathEntryRequest{
 			NamespaceID: string(in.NamespaceID),
 			Path:        string(in.Path),
 		})
@@ -219,7 +219,7 @@ func getFileProxied(ctx context.Context, c *server.Client, in GetFileInput) (*Ge
 		revisionNo = &headRevision
 		claim = file.ContentRef
 	} else {
-		page, err := c.Filesystem.ListFileRevisions(ctx, &loonfs.ListFileRevisionsRequest{
+		page, err := c.Files.ListRevisions(ctx, &loonfs.ListFileRevisionsRequest{
 			NamespaceID: string(in.NamespaceID),
 			Path:        string(in.Path),
 		})
@@ -242,7 +242,7 @@ func getFileProxied(ctx context.Context, c *server.Client, in GetFileInput) (*Ge
 		return nil, fmt.Errorf("transfers: revision has no content reference")
 	}
 
-	reader, err := c.Filesystem.GetFileBytes(ctx, &loonfs.GetFileBytesRequest{
+	reader, err := c.Files.Content(ctx, &loonfs.GetFileBytesRequest{
 		NamespaceID: string(in.NamespaceID),
 		Path:        string(in.Path),
 		RevisionNo:  revisionNo,
@@ -364,7 +364,7 @@ func transferDirectPut(
 		Checksum:  checksum,
 		SizeBytes: int64(len(payload)),
 	}
-	completed, err := c.Uploads.CompleteUpload(ctx, &loonfs.CompleteUploadBody{
+	completed, err := c.Uploads.Complete(ctx, &loonfs.CompleteUploadBody{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
 		Body: &loonfs.CompleteUploadRequest{
@@ -406,7 +406,7 @@ func transferDirectMultipart(
 			PartNumber: index + 1,
 		}
 	}
-	signed, err := c.Uploads.SignUploadParts(ctx, &loonfs.SignUploadPartsRequest{
+	signed, err := c.Uploads.SignParts(ctx, &loonfs.SignUploadPartsRequest{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
 		Parts:       claims,
@@ -452,7 +452,7 @@ func transferDirectMultipart(
 		abortUpload(ctx, c, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: checksum multipart payload: %w", err)
 	}
-	completed, err := c.Uploads.CompleteUpload(ctx, &loonfs.CompleteUploadBody{
+	completed, err := c.Uploads.Complete(ctx, &loonfs.CompleteUploadBody{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
 		Body: &loonfs.CompleteUploadRequest{
@@ -478,7 +478,7 @@ func transferServiceProxied(
 	payload []byte,
 	begin *loonfs.BeginUploadResponseServiceProxied,
 ) (*loonfs.UploadSession, error) {
-	if _, err := c.Uploads.PutUploadContent(
+	if _, err := c.Uploads.PutContent(
 		ctx,
 		string(namespaceID),
 		string(begin.UploadID),
@@ -488,7 +488,7 @@ func transferServiceProxied(
 		abortUpload(ctx, c, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: upload proxied content: %w", err)
 	}
-	completed, err := c.Uploads.CompleteUpload(ctx, &loonfs.CompleteUploadBody{
+	completed, err := c.Uploads.Complete(ctx, &loonfs.CompleteUploadBody{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
 		Body: &loonfs.CompleteUploadRequest{
@@ -502,7 +502,7 @@ func transferServiceProxied(
 }
 
 func abortUpload(ctx context.Context, c *server.Client, namespaceID loonfs.NamespaceID, uploadID loonfs.UploadID) {
-	_, _ = c.Uploads.AbortUpload(ctx, &loonfs.AbortUploadRequest{
+	_, _ = c.Uploads.Abort(ctx, &loonfs.AbortUploadRequest{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(uploadID),
 	})

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -127,7 +127,7 @@ def put_file(
     }
     if message is not None:
         commit_arguments["message"] = message
-    committed = client.filesystem.create_commit(namespace_id, **commit_arguments)
+    committed = client.commits.create(namespace_id, **commit_arguments)
     return PutFileResult(
         namespace_id=committed.namespace_id,
         commit_id=committed.commit_id,
@@ -145,15 +145,15 @@ def get_file(
 ) -> GetFileResult:
     """Download one file revision into memory and verify its checksum."""
 
-    capabilities = client.system.get_capabilities()
+    capabilities = client.capabilities.retrieve()
     if not capabilities.features.get(_DIRECT_GET_FEATURE, False):
         return _get_file_proxied(
             client, namespace_id=namespace_id, path=path, revision_no=revision_no
         )
     if revision_no is None:
-        grant = client.filesystem.create_download(namespace_id, path=path)
+        grant = client.files.create_download(namespace_id, path=path)
     else:
-        grant = client.filesystem.create_download(
+        grant = client.files.create_download(
             namespace_id,
             path=path,
             revision_no=revision_no,
@@ -195,7 +195,7 @@ def _get_file_proxied(
     reference and returned bytes describe the same file version.
     """
     if revision_no is None:
-        entry = client.filesystem.get_path_entry(namespace_id, path=path)
+        entry = client.files.retrieve(namespace_id, path=path)
         if entry.inode_kind != "file":
             raise RuntimeError(f"path {path!r} is a {entry.inode_kind}, not a file")
         claim = entry.content_ref
@@ -204,7 +204,7 @@ def _get_file_proxied(
         claim = None
         cursor = None
         while True:
-            page = client.filesystem.list_file_revisions(
+            page = client.files.list_revisions(
                 namespace_id, path=path, cursor=cursor
             )
             for revision in page.revisions:
@@ -217,7 +217,7 @@ def _get_file_proxied(
         if claim is None:
             raise RuntimeError(f"revision {revision_no} not found for {path!r}")
     content = b"".join(
-        client.filesystem.get_file_bytes(namespace_id, path=path, revision_no=revision_no)
+        client.files.content(namespace_id, path=path, revision_no=revision_no)
     )
     if len(content) != claim.size_bytes:
         raise RuntimeError(
@@ -235,7 +235,7 @@ def _get_file_proxied(
 
 
 def _create_upload(client: LoonFS, namespace_id: str, content: bytes):
-    capabilities = client.system.get_capabilities()
+    capabilities = client.capabilities.retrieve()
     features = capabilities.features or {}
     limits = capabilities.limits or {}
     size_bytes = len(content)
@@ -261,7 +261,7 @@ def _create_upload(client: LoonFS, namespace_id: str, content: bytes):
                 f"{size_bytes} bytes exceed the advertised proxy and direct PUT limits, "
                 "and direct multipart is unavailable"
             )
-    return client.uploads.create_upload(namespace_id, request=request)
+    return client.uploads.create(namespace_id, request=request)
 
 
 def _stage_upload(
@@ -273,8 +273,8 @@ def _stage_upload(
 ) -> _StagedContent:
     if begin.mode == "service_proxied":
         try:
-            client.uploads.put_upload_content(namespace_id, begin.upload_id, request=content)
-            completion = client.uploads.complete_upload(
+            client.uploads.put_content(namespace_id, begin.upload_id, request=content)
+            completion = client.uploads.complete(
                 namespace_id,
                 begin.upload_id,
                 request=CompleteUploadRequest_ServiceProxied(),
@@ -294,7 +294,7 @@ def _stage_upload(
         except Exception:
             _abort_quietly(client, namespace_id, begin.upload_id)
             raise
-        completion = client.uploads.complete_upload(
+        completion = client.uploads.complete(
             namespace_id,
             begin.upload_id,
             request=CompleteUploadRequest_DirectPut(
@@ -341,7 +341,7 @@ def _stage_multipart(
         for index, part in enumerate(parts, start=1)
     ]
     try:
-        signed = client.uploads.sign_upload_parts(
+        signed = client.uploads.sign_parts(
             namespace_id,
             upload_id,
             parts=claims,
@@ -375,7 +375,7 @@ def _stage_multipart(
     except Exception:
         _abort_quietly(client, namespace_id, upload_id)
         raise
-    completion = client.uploads.complete_upload(
+    completion = client.uploads.complete(
         namespace_id,
         upload_id,
         request=CompleteUploadRequest_DirectMultipart(
@@ -425,7 +425,7 @@ def _completed_content(response: UploadSession) -> _StagedContent:
 
 def _abort_quietly(client: LoonFS, namespace_id: str, upload_id: str) -> None:
     try:
-        client.uploads.abort_upload(namespace_id, upload_id)
+        client.uploads.abort(namespace_id, upload_id)
     except Exception:
         pass
 

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -82,7 +82,7 @@ export async function putFile(client: LoonFSClient, input: PutFileInput): Promis
     if (input.message !== undefined) {
         request.message = input.message;
     }
-    return client.filesystem.createCommit(request);
+    return client.commits.create(request);
 }
 
 /**
@@ -90,11 +90,11 @@ export async function putFile(client: LoonFSClient, input: PutFileInput): Promis
  * Streaming and resume are follow-ups.
  */
 export async function getFile(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
-    const capabilities = await client.system.getCapabilities();
+    const capabilities = await client.capabilities.retrieve();
     if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
         return getFileProxied(client, input);
     }
-    const grant = await client.filesystem.createDownload(input);
+    const grant = await client.files.createDownload(input);
     requirePresignedMethod(grant.access, "GET", "download");
     const response = await fetch(grant.access.url, {
         redirect: "error",
@@ -128,7 +128,7 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;
     if (revisionNo === undefined) {
-        const entry = await client.filesystem.getPathEntry({
+        const entry = await client.files.retrieve({
             namespace_alias: input.namespace_alias,
             path: input.path,
         });
@@ -138,7 +138,7 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
         claim = entry.content_ref;
         revisionNo = entry.revision_no;
     } else {
-        const page = await client.filesystem.listFileRevisions({
+        const page = await client.files.listRevisions({
             namespace_alias: input.namespace_alias,
             path: input.path,
         });
@@ -152,7 +152,7 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
             throw new Error(`revision ${revisionNo} not found for ${input.path}`);
         }
     }
-    const body = await client.filesystem.getFileBytes({
+    const body = await client.files.content({
         namespace_alias: input.namespace_alias,
         path: input.path,
         revision_no: revisionNo,
@@ -173,9 +173,9 @@ async function stageBytes(
     namespaceAlias: string,
     bytes: Uint8Array,
 ): Promise<StagedContent> {
-    const capabilities = await client.system.getCapabilities();
+    const capabilities = await client.capabilities.retrieve();
     const beginRequest = selectBeginRequest(capabilities, bytes);
-    const begin = await client.uploads.createUpload({
+    const begin = await client.uploads.create({
         namespace_alias: namespaceAlias,
         body: beginRequest,
     });
@@ -229,9 +229,9 @@ async function stageServiceProxied(
     begin: LoonFS.BeginUploadResponse.ServiceProxied,
 ): Promise<StagedContent> {
     try {
-        await client.uploads.putUploadContent(arrayBuffer(bytes), namespaceAlias, begin.upload_id);
+        await client.uploads.putContent(arrayBuffer(bytes), namespaceAlias, begin.upload_id);
         return stagedContent(
-            await client.uploads.completeUpload({
+            await client.uploads.complete({
                 namespace_alias: namespaceAlias,
                 upload_id: begin.upload_id,
                 body: { mode: "service_proxied" },
@@ -265,7 +265,7 @@ async function stageDirectPut(
         throw error;
     }
     return stagedContent(
-        await client.uploads.completeUpload({
+        await client.uploads.complete({
             namespace_alias: namespaceAlias,
             upload_id: begin.upload_id,
             body: { mode: "direct_put", content: upload.content },
@@ -297,7 +297,7 @@ async function stageMultipart(
     }
     const completedParts: LoonFS.CompletedUploadPart[] = [];
     try {
-        const signed = await client.uploads.signUploadParts({
+        const signed = await client.uploads.signParts({
             namespace_alias: namespaceAlias,
             upload_id: begin.upload_id,
             parts: claims,
@@ -332,7 +332,7 @@ async function stageMultipart(
     }
 
     return stagedContent(
-        await client.uploads.completeUpload({
+        await client.uploads.complete({
             namespace_alias: namespaceAlias,
             upload_id: begin.upload_id,
             body: {
@@ -371,7 +371,7 @@ async function abortQuietly(
     uploadId: LoonFS.UploadId,
 ): Promise<void> {
     try {
-        await client.uploads.abortUpload({
+        await client.uploads.abort({
             namespace_alias: namespaceAlias,
             upload_id: uploadId,
         });

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -81,7 +81,7 @@ export async function putFile(client: LoonFSClient, input: PutFileInput): Promis
     if (input.message !== undefined) {
         request.message = input.message;
     }
-    return client.filesystem.createCommit(request);
+    return client.commits.create(request);
 }
 
 /**
@@ -89,11 +89,11 @@ export async function putFile(client: LoonFSClient, input: PutFileInput): Promis
  * Streaming and resume are follow-ups.
  */
 export async function getFile(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
-    const capabilities = await client.system.getCapabilities();
+    const capabilities = await client.capabilities.retrieve();
     if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
         return getFileProxied(client, input);
     }
-    const grant = await client.filesystem.createDownload(input);
+    const grant = await client.files.createDownload(input);
     requirePresignedMethod(grant.access, "GET", "download");
     const response = await fetch(grant.access.url, {
         redirect: "error",
@@ -127,7 +127,7 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;
     if (revisionNo === undefined) {
-        const entry = await client.filesystem.getPathEntry({
+        const entry = await client.files.retrieve({
             namespace_id: input.namespace_id,
             path: input.path,
         });
@@ -137,7 +137,7 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
         claim = entry.content_ref;
         revisionNo = entry.revision_no;
     } else {
-        const page = await client.filesystem.listFileRevisions({
+        const page = await client.files.listRevisions({
             namespace_id: input.namespace_id,
             path: input.path,
         });
@@ -151,7 +151,7 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
             throw new Error(`revision ${revisionNo} not found for ${input.path}`);
         }
     }
-    const body = await client.filesystem.getFileBytes({
+    const body = await client.files.content({
         namespace_id: input.namespace_id,
         path: input.path,
         revision_no: revisionNo,
@@ -172,9 +172,9 @@ async function stageBytes(
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
 ): Promise<StagedContent> {
-    const capabilities = await client.system.getCapabilities();
+    const capabilities = await client.capabilities.retrieve();
     const beginRequest = selectBeginRequest(capabilities, bytes);
-    const begin = await client.uploads.createUpload({
+    const begin = await client.uploads.create({
         namespace_id: namespaceId,
         body: beginRequest,
     });
@@ -228,9 +228,9 @@ async function stageServiceProxied(
     begin: LoonFS.BeginUploadResponse.ServiceProxied,
 ): Promise<StagedContent> {
     try {
-        await client.uploads.putUploadContent(arrayBuffer(bytes), namespaceId, begin.upload_id);
+        await client.uploads.putContent(arrayBuffer(bytes), namespaceId, begin.upload_id);
         return stagedContent(
-            await client.uploads.completeUpload({
+            await client.uploads.complete({
                 namespace_id: namespaceId,
                 upload_id: begin.upload_id,
                 body: { mode: "service_proxied" },
@@ -264,7 +264,7 @@ async function stageDirectPut(
         throw error;
     }
     return stagedContent(
-        await client.uploads.completeUpload({
+        await client.uploads.complete({
             namespace_id: namespaceId,
             upload_id: begin.upload_id,
             body: { mode: "direct_put", content: upload.content },
@@ -296,7 +296,7 @@ async function stageMultipart(
     }
     const completedParts: LoonFS.CompletedUploadPart[] = [];
     try {
-        const signed = await client.uploads.signUploadParts({
+        const signed = await client.uploads.signParts({
             namespace_id: namespaceId,
             upload_id: begin.upload_id,
             parts: claims,
@@ -331,7 +331,7 @@ async function stageMultipart(
     }
 
     return stagedContent(
-        await client.uploads.completeUpload({
+        await client.uploads.complete({
             namespace_id: namespaceId,
             upload_id: begin.upload_id,
             body: {
@@ -370,7 +370,7 @@ async function abortQuietly(
     uploadId: LoonFS.UploadId,
 ): Promise<void> {
     try {
-        await client.uploads.abortUpload({ namespace_id: namespaceId, upload_id: uploadId });
+        await client.uploads.abort({ namespace_id: namespaceId, upload_id: uploadId });
     } catch {
         // Preserve the transfer error.
     }


### PR DESCRIPTION
Fern named SDK groups after the OpenAPI tags and methods after the operation IDs, so the generated clients read `client.filesystem.createCommit` next to `client.query.grep` and `client.namespaces.createNamespace`. The postprocessor now stamps an explicit SDK name on every operation: a resource group, a bare verb, and the request wrapper name so that no generated type moves. The result is `client.commits.create`, `client.files.grep`, `client.namespaces.create`, and `client.admin.checkpoints.create` in all three SDKs, and the health, readiness, and metrics probes leave the SDKs. Nothing on the wire changes. The OpenAPI documents are regenerated, the transfer helpers and conformance suites use the new names, and generation fails if an operation is ever added without a name. Folding the transfer helpers into the client as `files.upload` and `files.download` follows in a second PR stacked on this one.