### PR TITLE
feat(sdk): expose file transfers on the client

### DIFF
--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -109,6 +109,18 @@ server_module = package_root / "server.py"
     '"""Explicit server and proxy entry points for the LoonFS SDK."""\n'
 )
 
+source = server_module.read_text()
+generated_import = "    from .client import AsyncLoonFS, LoonFS\n"
+assert source.count(generated_import) == 1, "generated server.py client import not found"
+source = source.replace(
+    generated_import,
+    "    from .client import AsyncLoonFS\n    from .transfers import LoonFS\n",
+)
+generated_mapping = '    "LoonFS": ".client",\n'
+assert source.count(generated_mapping) == 1, "generated server.py client mapping not found"
+source = source.replace(generated_mapping, '    "LoonFS": ".transfers",\n')
+server_module.write_text(source)
+
 for example_path in [*package_root.rglob("*.py"), package_root / "reference.md"]:
     source = example_path.read_text()
     example_path.write_text(
@@ -163,6 +175,22 @@ source = source.replace("                headers: response.headers,\n", "")
 fetcher_path.write_text(source)
 
 (package_root / "core/fetcher/createRequestUrl.ts").unlink()
+
+index_path = package_root / "index.ts"
+source = index_path.read_text()
+generated_export = 'export { LoonFSClient } from "./Client.js";\n'
+assert source.count(generated_export) == 1, "generated index.ts client export not found"
+source = source.replace(
+    generated_export,
+    'export { LoonFSClient } from "./transfers.js";\n'
+    'export type {\n'
+    '    FileDownloadInput,\n'
+    '    FileDownloadResult,\n'
+    '    FileUploadInput,\n'
+    '    FileUploadResult,\n'
+    '} from "./transfers.js";\n',
+)
+index_path.write_text(source)
 PY
         ;;
     esac

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 
 	loonfs "github.com/loonfs/loonfs-sdk-go"
+	"github.com/loonfs/loonfs-sdk-go/files"
 	"github.com/loonfs/loonfs-sdk-go/option"
 	loonfsproxy "github.com/loonfs/loonfs-sdk-go/proxy"
 	"github.com/loonfs/loonfs-sdk-go/server"
-	"github.com/loonfs/loonfs-sdk-go/transfers"
 )
 
 type conformanceCase struct {
@@ -378,7 +378,7 @@ func runDirectPut(t *testing.T, h *harness, testCase conformanceCase) {
 	stat := statPath(t, h.client, request.NamespaceID, request.Path)
 	file := requireFileProjection(t, stat)
 	assertContentRefEqual(t, file.ContentRef, completedStatus.ContentRef)
-	readback := getFile(t, h.client, request.NamespaceID, request.Path)
+	readback := downloadFile(t, h.client, request.NamespaceID, request.Path)
 	if !bytes.Equal(readback.Bytes, payload) {
 		t.Error("direct PUT readback did not match payload")
 	}
@@ -523,15 +523,15 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 	if int64(committed.CommittedSeq) != expected.CommittedSeq {
 		t.Errorf("committed_seq = %d, want %d", committed.CommittedSeq, expected.CommittedSeq)
 	}
-	readback := getFile(t, h.client, request.NamespaceID, request.Path)
+	readback := downloadFile(t, h.client, request.NamespaceID, request.Path)
 	if !bytes.Equal(readback.Bytes, payload) {
 		t.Error("multipart readback did not match payload")
 	}
 
 	// The same content through the high-level helper: the payload exceeds the
-	// part size, so this exercises PutFile's multipart branch.
+	// part size, so this exercises Files.Upload's multipart branch.
 	helperPath := request.Path + "-helper"
-	helperCommit, err := transfers.PutFile(context.Background(), h.client, transfers.PutFileInput{
+	helperCommit, err := h.client.Files.Upload(context.Background(), files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(helperPath),
 		Bytes:       payload,
@@ -544,7 +544,7 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 	if helperCommit.CommittedSeq == 0 {
 		t.Error("helper multipart put reported no committed_seq")
 	}
-	helperReadback := getFile(t, h.client, request.NamespaceID, helperPath)
+	helperReadback := downloadFile(t, h.client, request.NamespaceID, helperPath)
 	if !bytes.Equal(helperReadback.Bytes, payload) {
 		t.Error("helper multipart readback did not match payload")
 	}
@@ -628,7 +628,7 @@ func runDownload(t *testing.T, h *harness, testCase conformanceCase) {
 	createNamespace(t, h.client, request.NamespaceID)
 	payload := []byte(request.ContentUTF8)
 	commitID := loonfs.CommitID(request.CommitID)
-	committed, err := transfers.PutFile(context.Background(), h.client, transfers.PutFileInput{
+	committed, err := h.client.Files.Upload(context.Background(), files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(request.Path),
 		Bytes:       payload,
@@ -713,7 +713,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	uploadCommitID := loonfs.CommitID(request.CommitIDs.Upload)
-	upload, err := transfers.PutFile(context.Background(), h.client, transfers.PutFileInput{
+	upload, err := h.client.Files.Upload(context.Background(), files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(request.UploadPath),
 		Bytes:       []byte(request.ContentUTF8),
@@ -737,7 +737,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 	if !listingContainsPath(initialListing, request.UploadPath) {
 		t.Errorf("initial listing does not contain %q", request.UploadPath)
 	}
-	downloaded := getFile(t, h.client, request.NamespaceID, request.UploadPath)
+	downloaded := downloadFile(t, h.client, request.NamespaceID, request.UploadPath)
 	if !bytes.Equal(downloaded.Bytes, []byte(request.ContentUTF8)) {
 		t.Error("end-to-end download did not match payload")
 	}
@@ -1080,7 +1080,7 @@ func runInodeMutations(t *testing.T, h *harness, testCase conformanceCase) {
 		&request.Actor,
 		childPath(request.PathDirectoryName),
 	)
-	if _, err := transfers.PutFile(context.Background(), h.client, transfers.PutFileInput{
+	if _, err := h.client.Files.Upload(context.Background(), files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.PathFileName)),
 		Bytes:       []byte(request.ContentUTF8),
@@ -1183,7 +1183,7 @@ func runInodeMutations(t *testing.T, h *harness, testCase conformanceCase) {
 	if revised.RevisionNo != expected.RevisedRevisionNo {
 		t.Errorf("revised revision_no = %d, want %d", revised.RevisionNo, expected.RevisedRevisionNo)
 	}
-	readback := getFile(t, h.client, request.NamespaceID, childPath(request.InodeFileName))
+	readback := downloadFile(t, h.client, request.NamespaceID, childPath(request.InodeFileName))
 	if !bytes.Equal(readback.Bytes, []byte(request.RevisedContentUTF8)) {
 		t.Error("inode-addressed revision readback did not match the revised payload")
 	}
@@ -1413,7 +1413,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 			nil,
 		),
 	)
-	_, err := transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+	_, err := h.client.Files.Upload(ctx, files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.ReplacedFileName)),
 		Bytes:       []byte(request.CapturedContentUTF8),
@@ -1423,7 +1423,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	if err != nil {
 		t.Fatalf("create replaced snapshot file: %v", err)
 	}
-	_, err = transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+	_, err = h.client.Files.Upload(ctx, files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.DeletedFileName)),
 		Bytes:       []byte(request.DeletedContentUTF8),
@@ -1456,7 +1456,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	}
 
 	replace := loonfs.DestinationBehaviorReplace
-	_, err = transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+	_, err = h.client.Files.Upload(ctx, files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.ReplacedFileName)),
 		Bytes:       []byte(request.CurrentContentUTF8),
@@ -1467,7 +1467,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	if err != nil {
 		t.Fatalf("replace snapshot file: %v", err)
 	}
-	_, err = transfers.PutFile(ctx, h.client, transfers.PutFileInput{
+	_, err = h.client.Files.Upload(ctx, files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.AddedFileName)),
 		Bytes:       []byte(request.AddedContentUTF8),
@@ -2587,9 +2587,9 @@ func statPath(t *testing.T, sdk *server.Client, namespaceID, path string) *loonf
 	return entry
 }
 
-func getFile(t *testing.T, sdk *server.Client, namespaceID, path string) *transfers.GetFileResult {
+func downloadFile(t *testing.T, sdk *server.Client, namespaceID, path string) *files.DownloadResult {
 	t.Helper()
-	result, err := transfers.GetFile(context.Background(), sdk, transfers.GetFileInput{
+	result, err := sdk.Files.Download(context.Background(), files.DownloadInput{
 		NamespaceID: loonfs.NamespaceID(namespaceID),
 		Path:        loonfs.AbsolutePath(path),
 	})

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -58,7 +58,6 @@ from loonfs.server import (
     UploadSession_Completed,
 )
 from loonfs.proxy import LoonFSProxy
-from loonfs.transfers import get_file, put_file
 
 
 RUNNER_SKIP = "run scripts/run-sdk-conformance.sh python"
@@ -916,9 +915,8 @@ def test_inode_mutations(cases: dict[str, ConformanceCase], harness: Harness) ->
             path=child_path(request.path_directory_name), parents=False
         ),
     )
-    put_file(
-        client,
-        namespace_id=namespace_id,
+    client.files.upload(
+        namespace_id,
         path=child_path(request.path_file_name),
         content=request.content_utf8.encode(),
         actor=request.actor,
@@ -1087,17 +1085,15 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
         request.actor,
         FilesystemOperation_CreateDirectory(path=request.directory, parents=False),
     )
-    put_file(
-        client,
-        namespace_id=namespace_id,
+    client.files.upload(
+        namespace_id,
         path=child_path(request.replaced_file_name),
         content=request.captured_content_utf8.encode(),
         actor=request.actor,
         commit_id="conf-snapshots-create-replaced",
     )
-    put_file(
-        client,
-        namespace_id=namespace_id,
+    client.files.upload(
+        namespace_id,
         path=child_path(request.deleted_file_name),
         content=request.deleted_content_utf8.encode(),
         actor=request.actor,
@@ -1114,18 +1110,16 @@ def test_snapshots(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert snapshot.head_seq == expected.snapshot_head_seq
     assert snapshot.expires_at_ms > snapshot.created_at_ms
 
-    put_file(
-        client,
-        namespace_id=namespace_id,
+    client.files.upload(
+        namespace_id,
         path=child_path(request.replaced_file_name),
         content=request.current_content_utf8.encode(),
         actor=request.actor,
         commit_id="conf-snapshots-replace-file",
         behavior="replace",
     )
-    put_file(
-        client,
-        namespace_id=namespace_id,
+    client.files.upload(
+        namespace_id,
         path=child_path(request.added_file_name),
         content=request.added_content_utf8.encode(),
         actor=request.actor,
@@ -1610,20 +1604,18 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
     assert _read_proxied(harness.client, request.namespace_id, request.path) == payload
 
     # The same content through the high-level helper: the payload exceeds the
-    # part size, so this exercises put_file's multipart branch.
+    # part size, so this exercises files.upload's multipart branch.
     helper_path = request.path + "-helper"
-    helper_commit = put_file(
-        harness.client,
-        namespace_id=request.namespace_id,
+    helper_commit = harness.client.files.upload(
+        request.namespace_id,
         path=helper_path,
         content=payload,
         actor=request.actor,
         commit_id=request.commit_id + "-helper",
     )
     assert helper_commit.committed_seq > 0
-    helper_read = get_file(
-        harness.client,
-        namespace_id=request.namespace_id,
+    helper_read = harness.client.files.download(
+        request.namespace_id,
         path=helper_path,
     )
     assert helper_read.content == payload
@@ -1658,9 +1650,8 @@ def test_download(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     )
     harness.client.namespaces.create(namespace_id=request.namespace_id)
     payload = request.content_utf8.encode()
-    committed = put_file(
-        harness.client,
-        namespace_id=request.namespace_id,
+    committed = harness.client.files.upload(
+        request.namespace_id,
         path=request.path,
         content=payload,
         actor=request.actor,
@@ -1671,9 +1662,8 @@ def test_download(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     stat = _file_entry(
         harness.client.files.retrieve(request.namespace_id, path=request.path)
     )
-    downloaded = get_file(
-        harness.client,
-        namespace_id=request.namespace_id,
+    downloaded = harness.client.files.download(
+        request.namespace_id,
         path=request.path,
     )
     assert stat.content_ref == downloaded.content_ref
@@ -1702,9 +1692,8 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
     assert mkdir.committed_seq == expected.mkdir_committed_seq
 
     payload = request.content_utf8.encode()
-    upload = put_file(
-        harness.client,
-        namespace_id=request.namespace_id,
+    upload = harness.client.files.upload(
+        request.namespace_id,
         path=request.upload_path,
         content=payload,
         actor=request.actor,
@@ -1723,9 +1712,8 @@ def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None
     )
     assert any(entry.path == request.upload_path for entry in initial_listing.entries)
 
-    downloaded = get_file(
-        harness.client,
-        namespace_id=request.namespace_id,
+    downloaded = harness.client.files.download(
+        request.namespace_id,
         path=request.upload_path,
     )
     assert downloaded.content == payload

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -8,15 +8,10 @@ import { pipeline } from "node:stream/promises";
 import { test } from "node:test";
 
 import { LoonFS, LoonFSClient } from "../../../generated/typescript/index.js";
-import { getFile, putFile } from "../../../generated/typescript/transfers.js";
 import {
     LoonFS as BrowserLoonFS,
     LoonFSClient as BrowserLoonFSClient,
 } from "../../../generated/typescript-client/index.js";
-import {
-    getFile as getBrowserFile,
-    putFile as putBrowserFile,
-} from "../../../generated/typescript-client/transfers.js";
 import { createProxyHandler } from "../../../proxy/typescript/proxy.js";
 
 
@@ -872,7 +867,7 @@ async function assertBrowserTransfer(
     commitId: string,
     label: string,
 ): Promise<void> {
-    const committed = await putBrowserFile(client, {
+    const committed = await client.files.upload({
         namespace_alias: namespaceAlias,
         path,
         bytes,
@@ -881,7 +876,7 @@ async function assertBrowserTransfer(
     });
     assert.ok(committed.committed_seq > 0, `${label} commit sequence is not positive`);
 
-    const readback = await getBrowserFile(client, {
+    const readback = await client.files.download({
         namespace_alias: namespaceAlias,
         path,
     });
@@ -1405,7 +1400,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
             childPath(request.path_directory_name),
         ),
     );
-    await putFile(client, {
+    await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.path_file_name),
         bytes: new TextEncoder().encode(request.content_utf8),
@@ -1620,14 +1615,14 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
             request.directory,
         ),
     );
-    await putFile(client, {
+    await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.replaced_file_name),
         bytes: capturedBytes,
         actor: request.actor,
         commit_id: "conf-snapshots-create-replaced",
     });
-    await putFile(client, {
+    await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.deleted_file_name),
         bytes: new TextEncoder().encode(request.deleted_content_utf8),
@@ -1645,7 +1640,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     assert.equal(snapshot.head_seq, expected.snapshot_head_seq);
     assert.ok(snapshot.expires_at_ms > snapshot.created_at_ms);
 
-    await putFile(client, {
+    await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.replaced_file_name),
         bytes: currentBytes,
@@ -1653,7 +1648,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
         commit_id: "conf-snapshots-replace-file",
         behavior: "replace",
     });
-    await putFile(client, {
+    await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.added_file_name),
         bytes: new TextEncoder().encode(request.added_content_utf8),
@@ -2044,7 +2039,7 @@ test("proxy", { skip: environmentSkip }, async (context) => {
 
     // The rig fails only at begin. No session exists then, so mid-flow cleanup is not covered.
     await assert.rejects(
-        putBrowserFile(browserClient, {
+        browserClient.files.upload({
             namespace_alias: request.unknown_namespace_alias,
             path: `${request.proxied_path}-browser-failure`,
             bytes: payload,
@@ -2235,9 +2230,9 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     );
 
     // The same content through the high-level helper: the payload exceeds the
-    // part size, so this exercises putFile's multipart branch.
+    // part size, so this exercises files.upload's multipart branch.
     const helperPath = `${request.path}-helper`;
-    const helperCommit = await putFile(activeHarness.client, {
+    const helperCommit = await activeHarness.client.files.upload({
         namespace_id: request.namespace_id,
         path: helperPath,
         bytes: payload,
@@ -2245,7 +2240,7 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
         commit_id: `${request.commit_id}-helper`,
     });
     assert.ok(helperCommit.committed_seq > 0, "helper multipart put reported no committed_seq");
-    const helperRead = await getFile(activeHarness.client, {
+    const helperRead = await activeHarness.client.files.download({
         namespace_id: request.namespace_id,
         path: helperPath,
     });
@@ -2284,7 +2279,7 @@ conformanceTest("download", async (activeHarness, testCase) => {
     const [request, expected] = decodeDownload(testCase);
     await activeHarness.client.namespaces.create({ namespace_id: request.namespace_id });
     const payload = new TextEncoder().encode(request.content_utf8);
-    const committed = await putFile(activeHarness.client, {
+    const committed = await activeHarness.client.files.upload({
         namespace_id: request.namespace_id,
         path: request.path,
         bytes: payload,
@@ -2298,7 +2293,7 @@ conformanceTest("download", async (activeHarness, testCase) => {
             path: request.path,
         }),
     );
-    const download = await getFile(activeHarness.client, {
+    const download = await activeHarness.client.files.download({
         namespace_id: request.namespace_id,
         path: request.path,
     });
@@ -2327,7 +2322,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
     assert.equal(mkdir.committed_seq, expected.mkdir_committed_seq);
 
     const payload = new TextEncoder().encode(request.content_utf8);
-    const upload = await putFile(activeHarness.client, {
+    const upload = await activeHarness.client.files.upload({
         namespace_id: request.namespace_id,
         path: request.upload_path,
         bytes: payload,
@@ -2350,7 +2345,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
     });
     assert.ok(initialListing.data.some((entry) => entry.path === request.upload_path));
 
-    const downloaded = await getFile(activeHarness.client, {
+    const downloaded = await activeHarness.client.files.download({
         namespace_id: request.namespace_id,
         path: request.upload_path,
     });

--- a/sdk/overlays/go/README.md
+++ b/sdk/overlays/go/README.md
@@ -39,7 +39,7 @@ func main() {
 }
 ```
 
-Upload and download helpers are available from the `transfers` package. See
+`client.Files.Upload` and `client.Files.Download` transfer whole files in memory. See
 [reference.md](./reference.md) for the generated API reference.
 
 ## Proxy

--- a/sdk/overlays/python/README.md
+++ b/sdk/overlays/python/README.md
@@ -26,8 +26,7 @@ client = LoonFS(
 capabilities = client.capabilities.retrieve()
 ```
 
-`AsyncLoonFS` provides the same API for async applications. Upload and download
-helpers are available from `loonfs.transfers`.
+`client.files.upload` and `client.files.download` transfer whole files in memory. `AsyncLoonFS` provides the same generated API for async applications; it does not have the transfer methods yet.
 
 ## Proxy
 

--- a/sdk/transfers/go/files/transfers.go
+++ b/sdk/transfers/go/files/transfers.go
@@ -1,5 +1,4 @@
-// Package transfers provides in-memory file transfer orchestration for the Go SDK.
-package transfers
+package files
 
 import (
 	"bytes"
@@ -14,8 +13,10 @@ import (
 	"strings"
 
 	loonfs "github.com/loonfs/loonfs-sdk-go"
+	"github.com/loonfs/loonfs-sdk-go/capabilities"
+	"github.com/loonfs/loonfs-sdk-go/commits"
 	"github.com/loonfs/loonfs-sdk-go/option"
-	"github.com/loonfs/loonfs-sdk-go/server"
+	"github.com/loonfs/loonfs-sdk-go/uploads"
 )
 
 const (
@@ -41,8 +42,8 @@ var (
 	}
 )
 
-// PutFileInput describes one in-memory file write.
-type PutFileInput struct {
+// UploadInput describes one in-memory file write.
+type UploadInput struct {
 	NamespaceID        loonfs.NamespaceID
 	Path               loonfs.AbsolutePath
 	Bytes              []byte
@@ -54,22 +55,22 @@ type PutFileInput struct {
 	ExpectedRevisionNo *loonfs.RevisionNo
 }
 
-// PutFileResult identifies the commit that made the new revision visible.
-type PutFileResult struct {
+// UploadResult identifies the commit that made the new revision visible.
+type UploadResult struct {
 	NamespaceID  loonfs.NamespaceID
 	CommitID     loonfs.CommitID
 	CommittedSeq loonfs.ChangeSeq
 }
 
-// GetFileInput describes one current or retained file revision to read.
-type GetFileInput struct {
+// DownloadInput describes one current or retained file revision to read.
+type DownloadInput struct {
 	NamespaceID loonfs.NamespaceID
 	Path        loonfs.AbsolutePath
 	RevisionNo  *loonfs.RevisionNo
 }
 
-// GetFileResult contains file bytes and the resolved revision facts.
-type GetFileResult struct {
+// DownloadResult contains file bytes and the resolved revision facts.
+type DownloadResult struct {
 	Bytes       []byte
 	NamespaceID loonfs.NamespaceID
 	Path        loonfs.AbsolutePath
@@ -77,9 +78,9 @@ type GetFileResult struct {
 	ContentRef  *loonfs.ContentRef
 }
 
-// PutFile uploads bytes, completes the upload, and commits the content to a path.
+// Upload uploads bytes, completes the upload, and commits the content to a path.
 // Streaming and resume are follow-ups.
-func PutFile(ctx context.Context, c *server.Client, in PutFileInput) (*PutFileResult, error) {
+func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, error) {
 	if c == nil {
 		return nil, fmt.Errorf("transfers: client is nil")
 	}
@@ -87,7 +88,10 @@ func PutFile(ctx context.Context, c *server.Client, in PutFileInput) (*PutFileRe
 		return nil, fmt.Errorf("transfers: actor is required")
 	}
 
-	capabilities, err := c.Capabilities.Retrieve(ctx)
+	capabilitiesClient := capabilities.NewClient(c.options)
+	uploadsClient := uploads.NewClient(c.options)
+	commitsClient := commits.NewClient(c.options)
+	capabilities, err := capabilitiesClient.Retrieve(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
 	}
@@ -95,12 +99,12 @@ func PutFile(ctx context.Context, c *server.Client, in PutFileInput) (*PutFileRe
 	if err != nil {
 		return nil, err
 	}
-	begin, err := c.Uploads.Create(ctx, createRequest)
+	begin, err := uploadsClient.Create(ctx, createRequest)
 	if err != nil {
 		return nil, fmt.Errorf("transfers: begin upload: %w", err)
 	}
 
-	completed, err := transferAndComplete(ctx, c, in.NamespaceID, in.Bytes, begin)
+	completed, err := transferAndComplete(ctx, uploadsClient, in.NamespaceID, in.Bytes, begin)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +124,7 @@ func PutFile(ctx context.Context, c *server.Client, in PutFileInput) (*PutFileRe
 	if status.ContentToken != nil {
 		contentTokens = []*loonfs.ContentToken{status.ContentToken}
 	}
-	committed, err := c.Commits.Create(ctx, &loonfs.CommitRequest{
+	committed, err := commitsClient.Create(ctx, &loonfs.CommitRequest{
 		NamespaceID:   string(in.NamespaceID),
 		Actor:         in.Actor,
 		CommitID:      in.CommitID,
@@ -141,27 +145,28 @@ func PutFile(ctx context.Context, c *server.Client, in PutFileInput) (*PutFileRe
 	if err != nil {
 		return nil, fmt.Errorf("transfers: commit file: %w", err)
 	}
-	return &PutFileResult{
+	return &UploadResult{
 		NamespaceID:  committed.NamespaceID,
 		CommitID:     committed.CommitID,
 		CommittedSeq: committed.CommittedSeq,
 	}, nil
 }
 
-// GetFile downloads one file revision into memory and verifies its content reference.
+// Download reads one revision into memory and verifies its content claim.
 // Streaming and resume are follow-ups.
-func GetFile(ctx context.Context, c *server.Client, in GetFileInput) (*GetFileResult, error) {
+func (c *Client) Download(ctx context.Context, in DownloadInput) (*DownloadResult, error) {
 	if c == nil {
 		return nil, fmt.Errorf("transfers: client is nil")
 	}
-	capabilities, err := c.Capabilities.Retrieve(ctx)
+	capabilitiesClient := capabilities.NewClient(c.options)
+	capabilities, err := capabilitiesClient.Retrieve(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
 	}
 	if capabilities == nil || !capabilities.Features[featureDirectGet] {
-		return getFileProxied(ctx, c, in)
+		return downloadProxied(ctx, c, in)
 	}
-	grant, err := c.Files.CreateDownload(ctx, &loonfs.BeginDownloadRequest{
+	grant, err := c.CreateDownload(ctx, &loonfs.BeginDownloadRequest{
 		NamespaceID: string(in.NamespaceID),
 		Path:        in.Path,
 		RevisionNo:  in.RevisionNo,
@@ -188,7 +193,7 @@ func GetFile(ctx context.Context, c *server.Client, in GetFileInput) (*GetFileRe
 		return nil, fmt.Errorf("transfers: verify download: %w", err)
 	}
 
-	return &GetFileResult{
+	return &DownloadResult{
 		Bytes:       payload,
 		NamespaceID: grant.NamespaceID,
 		Path:        grant.Path,
@@ -197,14 +202,14 @@ func GetFile(ctx context.Context, c *server.Client, in GetFileInput) (*GetFileRe
 	}, nil
 }
 
-// getFileProxied reads through LoonFS when direct reads are unavailable.
+// downloadProxied reads through LoonFS when direct reads are unavailable.
 // It loads the content reference first, then requests the exact revision so
 // the reference and returned bytes describe the same file version.
-func getFileProxied(ctx context.Context, c *server.Client, in GetFileInput) (*GetFileResult, error) {
+func downloadProxied(ctx context.Context, c *Client, in DownloadInput) (*DownloadResult, error) {
 	revisionNo := in.RevisionNo
 	var claim *loonfs.ContentRef
 	if revisionNo == nil {
-		entry, err := c.Files.Retrieve(ctx, &loonfs.GetPathEntryRequest{
+		entry, err := c.Retrieve(ctx, &loonfs.GetPathEntryRequest{
 			NamespaceID: string(in.NamespaceID),
 			Path:        string(in.Path),
 		})
@@ -219,7 +224,7 @@ func getFileProxied(ctx context.Context, c *server.Client, in GetFileInput) (*Ge
 		revisionNo = &headRevision
 		claim = file.ContentRef
 	} else {
-		page, err := c.Files.ListRevisions(ctx, &loonfs.ListFileRevisionsRequest{
+		page, err := c.ListRevisions(ctx, &loonfs.ListFileRevisionsRequest{
 			NamespaceID: string(in.NamespaceID),
 			Path:        string(in.Path),
 		})
@@ -242,7 +247,7 @@ func getFileProxied(ctx context.Context, c *server.Client, in GetFileInput) (*Ge
 		return nil, fmt.Errorf("transfers: revision has no content reference")
 	}
 
-	reader, err := c.Files.Content(ctx, &loonfs.GetFileBytesRequest{
+	reader, err := c.Content(ctx, &loonfs.GetFileBytesRequest{
 		NamespaceID: string(in.NamespaceID),
 		Path:        string(in.Path),
 		RevisionNo:  revisionNo,
@@ -265,7 +270,7 @@ func getFileProxied(ctx context.Context, c *server.Client, in GetFileInput) (*Ge
 		return nil, fmt.Errorf("transfers: verify proxied read: %w", err)
 	}
 
-	return &GetFileResult{
+	return &DownloadResult{
 		Bytes:       payload,
 		NamespaceID: in.NamespaceID,
 		Path:        in.Path,
@@ -324,7 +329,7 @@ func createUploadRequest(
 
 func transferAndComplete(
 	ctx context.Context,
-	c *server.Client,
+	uploadsClient *uploads.Client,
 	namespaceID loonfs.NamespaceID,
 	payload []byte,
 	begin *loonfs.BeginUploadResponse,
@@ -334,11 +339,11 @@ func transferAndComplete(
 	}
 	switch {
 	case begin.DirectPut != nil:
-		return transferDirectPut(ctx, c, namespaceID, payload, begin.DirectPut)
+		return transferDirectPut(ctx, uploadsClient, namespaceID, payload, begin.DirectPut)
 	case begin.DirectMultipart != nil:
-		return transferDirectMultipart(ctx, c, namespaceID, payload, begin.DirectMultipart)
+		return transferDirectMultipart(ctx, uploadsClient, namespaceID, payload, begin.DirectMultipart)
 	case begin.ServiceProxied != nil:
-		return transferServiceProxied(ctx, c, namespaceID, payload, begin.ServiceProxied)
+		return transferServiceProxied(ctx, uploadsClient, namespaceID, payload, begin.ServiceProxied)
 	default:
 		return nil, fmt.Errorf("transfers: unsupported begin upload mode %q", begin.Mode)
 	}
@@ -346,25 +351,25 @@ func transferAndComplete(
 
 func transferDirectPut(
 	ctx context.Context,
-	c *server.Client,
+	uploadsClient *uploads.Client,
 	namespaceID loonfs.NamespaceID,
 	payload []byte,
 	begin *loonfs.BeginUploadResponseDirectPut,
 ) (*loonfs.UploadSession, error) {
 	checksum, err := computeChecksum(begin.ChecksumAlgorithm, payload)
 	if err != nil {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
+		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: direct PUT: %w", err)
 	}
 	if _, err := putPresigned(ctx, begin.Access, payload); err != nil {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
+		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: direct PUT: %w", err)
 	}
 	content := &loonfs.UploadContentClaim{
 		Checksum:  checksum,
 		SizeBytes: int64(len(payload)),
 	}
-	completed, err := c.Uploads.Complete(ctx, &loonfs.CompleteUploadBody{
+	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadBody{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
 		Body: &loonfs.CompleteUploadRequest{
@@ -379,7 +384,7 @@ func transferDirectPut(
 
 func transferDirectMultipart(
 	ctx context.Context,
-	c *server.Client,
+	uploadsClient *uploads.Client,
 	namespaceID loonfs.NamespaceID,
 	payload []byte,
 	begin *loonfs.BeginUploadResponseDirectMultipart,
@@ -391,14 +396,14 @@ func transferDirectMultipart(
 	}
 	parts := splitParts(payload, partSize)
 	if len(parts) == 0 {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
+		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: multipart response selected for an empty payload")
 	}
 	claims := make([]*loonfs.UploadPartChecksumClaim, len(parts))
 	for index, part := range parts {
 		checksum, checksumErr := computeChecksum(begin.ChecksumAlgorithm, part)
 		if checksumErr != nil {
-			abortUpload(ctx, c, namespaceID, begin.UploadID)
+			abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 			return nil, fmt.Errorf("transfers: checksum part %d: %w", index+1, checksumErr)
 		}
 		claims[index] = &loonfs.UploadPartChecksumClaim{
@@ -406,17 +411,17 @@ func transferDirectMultipart(
 			PartNumber: index + 1,
 		}
 	}
-	signed, err := c.Uploads.SignParts(ctx, &loonfs.SignUploadPartsRequest{
+	signed, err := uploadsClient.SignParts(ctx, &loonfs.SignUploadPartsRequest{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
 		Parts:       claims,
 	})
 	if err != nil {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
+		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: sign multipart parts: %w", err)
 	}
 	if signed == nil {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
+		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: sign multipart parts returned no response")
 	}
 	accessByPart := make(map[int]*loonfs.SignedUploadPart, len(signed.Parts))
@@ -429,16 +434,16 @@ func transferDirectMultipart(
 		partNumber := index + 1
 		signedPart := accessByPart[partNumber]
 		if signedPart == nil {
-			abortUpload(ctx, c, namespaceID, begin.UploadID)
+			abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 			return nil, fmt.Errorf("transfers: server did not sign multipart part %d", partNumber)
 		}
 		etag, putErr := putPresigned(ctx, signedPart.Access, part)
 		if putErr != nil {
-			abortUpload(ctx, c, namespaceID, begin.UploadID)
+			abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 			return nil, fmt.Errorf("transfers: upload part %d: %w", partNumber, putErr)
 		}
 		if etag == "" {
-			abortUpload(ctx, c, namespaceID, begin.UploadID)
+			abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 			return nil, fmt.Errorf("transfers: upload part %d: presigned PUT response has no ETag", partNumber)
 		}
 		completedParts = append(completedParts, &loonfs.CompletedUploadPart{
@@ -449,10 +454,10 @@ func transferDirectMultipart(
 	}
 	wholeChecksum, err := computeChecksum(begin.ChecksumAlgorithm, payload)
 	if err != nil {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
+		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: checksum multipart payload: %w", err)
 	}
-	completed, err := c.Uploads.Complete(ctx, &loonfs.CompleteUploadBody{
+	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadBody{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
 		Body: &loonfs.CompleteUploadRequest{
@@ -473,22 +478,22 @@ func transferDirectMultipart(
 
 func transferServiceProxied(
 	ctx context.Context,
-	c *server.Client,
+	uploadsClient *uploads.Client,
 	namespaceID loonfs.NamespaceID,
 	payload []byte,
 	begin *loonfs.BeginUploadResponseServiceProxied,
 ) (*loonfs.UploadSession, error) {
-	if _, err := c.Uploads.PutContent(
+	if _, err := uploadsClient.PutContent(
 		ctx,
 		string(namespaceID),
 		string(begin.UploadID),
 		bytes.NewReader(payload),
 		option.WithHTTPHeader(http.Header{"Content-Type": []string{"application/octet-stream"}}),
 	); err != nil {
-		abortUpload(ctx, c, namespaceID, begin.UploadID)
+		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: upload proxied content: %w", err)
 	}
-	completed, err := c.Uploads.Complete(ctx, &loonfs.CompleteUploadBody{
+	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadBody{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
 		Body: &loonfs.CompleteUploadRequest{
@@ -501,8 +506,8 @@ func transferServiceProxied(
 	return completed, nil
 }
 
-func abortUpload(ctx context.Context, c *server.Client, namespaceID loonfs.NamespaceID, uploadID loonfs.UploadID) {
-	_, _ = c.Uploads.Abort(ctx, &loonfs.AbortUploadRequest{
+func abortUpload(ctx context.Context, uploadsClient *uploads.Client, namespaceID loonfs.NamespaceID, uploadID loonfs.UploadID) {
+	_, _ = uploadsClient.Abort(ctx, &loonfs.AbortUploadRequest{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(uploadID),
 	})

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -1,16 +1,19 @@
 """Synchronous, in-memory file transfer orchestration.
 
-Streaming and resume are follow-ups. AsyncLoonFS support is a follow-up.
+Streaming and resume are follow-ups. The async client does not have these
+methods yet.
 """
 
 from __future__ import annotations
 
 import hashlib
+import typing
 from dataclasses import dataclass
 
 import httpx
 
-from .client import LoonFS
+from .client import LoonFS as _GeneratedLoonFS
+from .files.client import FilesClient as _GeneratedFilesClient
 from .types import (
     ActorRef,
     BeginUploadRequest_DirectMultipart,
@@ -30,9 +33,6 @@ from .types import (
     UploadPartChecksumClaim,
     UploadSession,
 )
-
-__all__ = ["GetFileResult", "PutFileResult", "get_file", "put_file"]
-
 
 _MULTIPART_MIN_BYTES = 8 * 1024 * 1024
 _DIRECT_GET_FEATURE = "core.downloads.direct_get"
@@ -59,7 +59,7 @@ _CRC32C_TABLE = _crc_table(0x82F63B78, _CRC32C_MASK)
 
 
 @dataclass(frozen=True)
-class PutFileResult:
+class FileUploadResult:
     """The identity and sequence of the commit that stored the file."""
 
     namespace_id: str
@@ -68,7 +68,7 @@ class PutFileResult:
 
 
 @dataclass(frozen=True)
-class GetFileResult:
+class FileDownloadResult:
     """Downloaded bytes and the immutable revision facts from its grant."""
 
     content: bytes
@@ -84,111 +84,139 @@ class _StagedContent:
     content_token: str | None
 
 
-def put_file(
-    client: LoonFS,
-    *,
-    namespace_id: str,
-    path: str,
-    content: bytes,
-    actor: ActorRef,
-    commit_id: str,
-    message: str | None = None,
-    behavior: DestinationBehavior | None = None,
-    expected_inode_id: str | None = None,
-    expected_revision_no: RevisionNo | None = None,
-    http_client: httpx.Client | None = None,
-) -> PutFileResult:
-    """Upload in-memory bytes, complete the upload, and commit the file."""
+class FilesClient(_GeneratedFilesClient):
+    """The files group plus whole-file transfers."""
 
-    begin = _create_upload(client, namespace_id, content)
-    if http_client is None:
-        with httpx.Client() as transfer_client:
+    def __init__(self, *, client_wrapper, root: "LoonFS") -> None:
+        super().__init__(client_wrapper=client_wrapper)
+        self._root = root
+
+    def upload(
+        self,
+        namespace_id: str,
+        *,
+        path: str,
+        content: bytes,
+        actor: ActorRef,
+        commit_id: str,
+        message: str | None = None,
+        behavior: DestinationBehavior | None = None,
+        expected_inode_id: str | None = None,
+        expected_revision_no: RevisionNo | None = None,
+        http_client: httpx.Client | None = None,
+    ) -> FileUploadResult:
+        """Upload in-memory bytes, complete the upload, and commit the file."""
+
+        begin = _create_upload(self._root, namespace_id, content)
+        if http_client is None:
+            with httpx.Client() as transfer_client:
+                staged = _stage_upload(
+                    self._root, transfer_client, namespace_id, begin, content
+                )
+        else:
             staged = _stage_upload(
-                client, transfer_client, namespace_id, begin, content
+                self._root, http_client, namespace_id, begin, content
             )
-    else:
-        staged = _stage_upload(client, http_client, namespace_id, begin, content)
 
-    operation_arguments = {"path": path, "content_ref": staged.content_ref}
-    if behavior is not None:
-        operation_arguments["behavior"] = behavior
-    if expected_inode_id is not None:
-        operation_arguments["expected_inode_id"] = expected_inode_id
-    if expected_revision_no is not None:
-        operation_arguments["expected_revision_no"] = expected_revision_no
-    operation = FilesystemOperation_PutFile(**operation_arguments)
-    commit_arguments = {
-        "actor": actor,
-        "commit_id": commit_id,
-        "operations": [operation],
-        "content_tokens": [staged.content_token]
-        if staged.content_token is not None
-        else [],
-    }
-    if message is not None:
-        commit_arguments["message"] = message
-    committed = client.commits.create(namespace_id, **commit_arguments)
-    return PutFileResult(
-        namespace_id=committed.namespace_id,
-        commit_id=committed.commit_id,
-        committed_seq=committed.committed_seq,
-    )
-
-
-def get_file(
-    client: LoonFS,
-    *,
-    namespace_id: str,
-    path: str,
-    revision_no: RevisionNo | None = None,
-    http_client: httpx.Client | None = None,
-) -> GetFileResult:
-    """Download one file revision into memory and verify its checksum."""
-
-    capabilities = client.capabilities.retrieve()
-    if not capabilities.features.get(_DIRECT_GET_FEATURE, False):
-        return _get_file_proxied(
-            client, namespace_id=namespace_id, path=path, revision_no=revision_no
+        operation_arguments = {"path": path, "content_ref": staged.content_ref}
+        if behavior is not None:
+            operation_arguments["behavior"] = behavior
+        if expected_inode_id is not None:
+            operation_arguments["expected_inode_id"] = expected_inode_id
+        if expected_revision_no is not None:
+            operation_arguments["expected_revision_no"] = expected_revision_no
+        operation = FilesystemOperation_PutFile(**operation_arguments)
+        commit_arguments = {
+            "actor": actor,
+            "commit_id": commit_id,
+            "operations": [operation],
+            "content_tokens": [staged.content_token]
+            if staged.content_token is not None
+            else [],
+        }
+        if message is not None:
+            commit_arguments["message"] = message
+        committed = self._root.commits.create(namespace_id, **commit_arguments)
+        return FileUploadResult(
+            namespace_id=committed.namespace_id,
+            commit_id=committed.commit_id,
+            committed_seq=committed.committed_seq,
         )
-    if revision_no is None:
-        grant = client.files.create_download(namespace_id, path=path)
-    else:
-        grant = client.files.create_download(
-            namespace_id,
-            path=path,
-            revision_no=revision_no,
+
+    def download(
+        self,
+        namespace_id: str,
+        *,
+        path: str,
+        revision_no: RevisionNo | None = None,
+        http_client: httpx.Client | None = None,
+    ) -> FileDownloadResult:
+        """Download one file revision into memory and verify its checksum."""
+
+        capabilities = self._root.capabilities.retrieve()
+        if not capabilities.features.get(_DIRECT_GET_FEATURE, False):
+            return _get_file_proxied(
+                self._root,
+                namespace_id=namespace_id,
+                path=path,
+                revision_no=revision_no,
+            )
+        if revision_no is None:
+            grant = self.create_download(namespace_id, path=path)
+        else:
+            grant = self.create_download(
+                namespace_id,
+                path=path,
+                revision_no=revision_no,
+            )
+        if http_client is None:
+            with httpx.Client() as transfer_client:
+                response = _send_presigned(transfer_client, grant.access, "GET")
+        else:
+            response = _send_presigned(http_client, grant.access, "GET")
+        content = response.content
+        if len(content) != grant.content_ref.size_bytes:
+            raise RuntimeError(
+                f"download returned {len(content)} bytes, expected {grant.content_ref.size_bytes}"
+            )
+        if (
+            _checksum(grant.content_ref.checksum.algorithm, content)
+            != grant.content_ref.checksum
+        ):
+            raise RuntimeError("download checksum did not match its content reference")
+        return FileDownloadResult(
+            content=content,
+            namespace_id=grant.namespace_id,
+            path=grant.path,
+            revision_no=grant.revision_no,
+            content_ref=grant.content_ref,
         )
-    if http_client is None:
-        with httpx.Client() as transfer_client:
-            response = _send_presigned(transfer_client, grant.access, "GET")
-    else:
-        response = _send_presigned(http_client, grant.access, "GET")
-    content = response.content
-    if len(content) != grant.content_ref.size_bytes:
-        raise RuntimeError(
-            f"download returned {len(content)} bytes, expected {grant.content_ref.size_bytes}"
-        )
-    if (
-        _checksum(grant.content_ref.checksum.algorithm, content)
-        != grant.content_ref.checksum
-    ):
-        raise RuntimeError("download checksum did not match its content reference")
-    return GetFileResult(
-        content=content,
-        namespace_id=grant.namespace_id,
-        path=grant.path,
-        revision_no=grant.revision_no,
-        content_ref=grant.content_ref,
-    )
+
+
+class LoonFS(_GeneratedLoonFS):
+    """The generated client with ``files.upload`` and ``files.download``."""
+
+    _transfer_files: typing.Optional[FilesClient] = None
+
+    @property
+    def files(self) -> FilesClient:
+        if self._transfer_files is None:
+            self._transfer_files = FilesClient(
+                client_wrapper=self._client_wrapper, root=self
+            )
+        return self._transfer_files
+
+
+__all__ = ["FileDownloadResult", "FileUploadResult", "FilesClient", "LoonFS"]
 
 
 def _get_file_proxied(
-    client: LoonFS,
+    client: _GeneratedLoonFS,
     *,
     namespace_id: str,
     path: str,
     revision_no: RevisionNo | None,
-) -> GetFileResult:
+) -> FileDownloadResult:
     """Read through LoonFS when direct reads are unavailable.
 
     Load the content reference first, then request the exact revision so the
@@ -225,7 +253,7 @@ def _get_file_proxied(
         )
     if _checksum(claim.checksum.algorithm, content) != claim.checksum:
         raise RuntimeError("proxied read checksum did not match its content reference")
-    return GetFileResult(
+    return FileDownloadResult(
         content=content,
         namespace_id=namespace_id,
         path=path,
@@ -234,7 +262,7 @@ def _get_file_proxied(
     )
 
 
-def _create_upload(client: LoonFS, namespace_id: str, content: bytes):
+def _create_upload(client: _GeneratedLoonFS, namespace_id: str, content: bytes):
     capabilities = client.capabilities.retrieve()
     features = capabilities.features or {}
     limits = capabilities.limits or {}
@@ -265,7 +293,7 @@ def _create_upload(client: LoonFS, namespace_id: str, content: bytes):
 
 
 def _stage_upload(
-    client: LoonFS,
+    client: _GeneratedLoonFS,
     transfer_client: httpx.Client,
     namespace_id: str,
     begin,
@@ -319,7 +347,7 @@ def _stage_upload(
 
 
 def _stage_multipart(
-    client: LoonFS,
+    client: _GeneratedLoonFS,
     transfer_client: httpx.Client,
     namespace_id: str,
     upload_id: str,
@@ -423,7 +451,9 @@ def _completed_content(response: UploadSession) -> _StagedContent:
     )
 
 
-def _abort_quietly(client: LoonFS, namespace_id: str, upload_id: str) -> None:
+def _abort_quietly(
+    client: _GeneratedLoonFS, namespace_id: str, upload_id: str
+) -> None:
     try:
         client.uploads.abort(namespace_id, upload_id)
     except Exception:

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -1,4 +1,5 @@
-import { LoonFSClient } from "./Client.js";
+import { LoonFSClient as GeneratedLoonFSClient } from "./Client.js";
+import { FilesClient as GeneratedFilesClient } from "./api/resources/files/client/Client.js";
 import type * as LoonFS from "./api/index.js";
 
 const DIRECT_GET_FEATURE = "core.downloads.direct_get";
@@ -17,7 +18,7 @@ const CRC64_MASK = 0xffffffffffffffffn;
 const CRC32C_TABLE = makeCrc32cTable();
 const CRC64_NVME_TABLE = makeCrc64NvmeTable();
 
-export interface PutFileInput {
+export interface FileUploadInput {
     namespace_alias: string;
     path: LoonFS.AbsolutePath;
     bytes: Uint8Array;
@@ -28,19 +29,19 @@ export interface PutFileInput {
     expected_revision_no?: LoonFS.RevisionNo;
 }
 
-export interface PutFileResult {
+export interface FileUploadResult {
     namespace_id: LoonFS.NamespaceId;
     commit_id: LoonFS.CommitId;
     committed_seq: LoonFS.ChangeSeq;
 }
 
-export interface GetFileInput {
+export interface FileDownloadInput {
     namespace_alias: string;
     path: LoonFS.AbsolutePath;
     revision_no?: LoonFS.RevisionNo;
 }
 
-export interface GetFileResult {
+export interface FileDownloadResult {
     namespace_alias: string;
     path: LoonFS.AbsolutePath;
     revision_no: LoonFS.RevisionNo;
@@ -58,73 +59,89 @@ interface DirectPutBody {
     content: LoonFS.UploadContentClaim;
 }
 
-/**
- * Uploads in-memory bytes and commits them at one namespace alias path.
- * Streaming and resume are follow-ups.
- */
-export async function putFile(client: LoonFSClient, input: PutFileInput): Promise<PutFileResult> {
-    const staged = await stageBytes(client, input.namespace_alias, input.bytes);
-    const request: LoonFS.CommitRequest = {
-        namespace_alias: input.namespace_alias,
-        actor: input.actor,
-        commit_id: input.commit_id,
-        content_tokens: staged.contentToken === undefined ? [] : [staged.contentToken],
-        operations: [
-            {
-                kind: "put_file",
-                path: input.path,
-                content_ref: staged.contentRef,
-                behavior: input.behavior ?? "no_replace",
-                expected_revision_no: input.expected_revision_no,
-            },
-        ],
-    };
-    if (input.message !== undefined) {
-        request.message = input.message;
+/** The files group plus whole-file transfers. */
+export class FilesClient extends GeneratedFilesClient {
+    constructor(
+        options: GeneratedFilesClient.Options,
+        private readonly root: LoonFSClient,
+    ) {
+        super(options);
     }
-    return client.commits.create(request);
+
+    /** Uploads in-memory bytes and commits them at one path. Streaming and resume are follow-ups. */
+    public async upload(input: FileUploadInput): Promise<FileUploadResult> {
+        const staged = await stageBytes(this.root, input.namespace_alias, input.bytes);
+        const request: LoonFS.CommitRequest = {
+            namespace_alias: input.namespace_alias,
+            actor: input.actor,
+            commit_id: input.commit_id,
+            content_tokens: staged.contentToken === undefined ? [] : [staged.contentToken],
+            operations: [
+                {
+                    kind: "put_file",
+                    path: input.path,
+                    content_ref: staged.contentRef,
+                    behavior: input.behavior ?? "no_replace",
+                    expected_revision_no: input.expected_revision_no,
+                },
+            ],
+        };
+        if (input.message !== undefined) {
+            request.message = input.message;
+        }
+        return this.root.commits.create(request);
+    }
+
+    /** Downloads one revision into memory and verifies its content claim. Streaming and resume are follow-ups. */
+    public async download(input: FileDownloadInput): Promise<FileDownloadResult> {
+        const capabilities = await this.root.capabilities.retrieve();
+        if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
+            return downloadProxied(this.root, input);
+        }
+        const grant = await this.createDownload(input);
+        requirePresignedMethod(grant.access, "GET", "download");
+        const response = await fetch(grant.access.url, {
+            redirect: "error",
+            method: grant.access.method,
+            headers: grant.access.headers,
+        });
+        requireSuccessfulResponse(response, "download");
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        if (bytes.byteLength !== grant.content_ref.size_bytes) {
+            throw new Error(
+                `download returned ${bytes.byteLength} bytes, expected ${grant.content_ref.size_bytes}`,
+            );
+        }
+        const actual = await checksum(grant.content_ref.checksum.algorithm, bytes);
+        if (actual.value !== grant.content_ref.checksum.value) {
+            throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
+        }
+        return {
+            namespace_alias: input.namespace_alias,
+            path: grant.path,
+            revision_no: grant.revision_no,
+            content_ref: grant.content_ref,
+            bytes,
+        };
+    }
 }
 
-/**
- * Downloads one revision into memory and verifies its content claim.
- * Streaming and resume are follow-ups.
- */
-export async function getFile(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
-    const capabilities = await client.capabilities.retrieve();
-    if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
-        return getFileProxied(client, input);
+/** The generated client with `files.upload` and `files.download`. */
+export class LoonFSClient extends GeneratedLoonFSClient {
+    private _transferFiles: FilesClient | undefined;
+
+    public override get files(): FilesClient {
+        return (this._transferFiles ??= new FilesClient(this._options, this));
     }
-    const grant = await client.files.createDownload(input);
-    requirePresignedMethod(grant.access, "GET", "download");
-    const response = await fetch(grant.access.url, {
-        redirect: "error",
-        method: grant.access.method,
-        headers: grant.access.headers,
-    });
-    requireSuccessfulResponse(response, "download");
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.byteLength !== grant.content_ref.size_bytes) {
-        throw new Error(
-            `download returned ${bytes.byteLength} bytes, expected ${grant.content_ref.size_bytes}`,
-        );
-    }
-    const actual = await checksum(grant.content_ref.checksum.algorithm, bytes);
-    if (actual.value !== grant.content_ref.checksum.value) {
-        throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
-    }
-    return {
-        namespace_alias: input.namespace_alias,
-        path: grant.path,
-        revision_no: grant.revision_no,
-        content_ref: grant.content_ref,
-        bytes,
-    };
 }
 
 // Reads through LoonFS when direct reads are unavailable. It loads the content
 // reference first, then requests the exact revision so the reference and
 // returned bytes describe the same file version.
-async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
+async function downloadProxied(
+    client: GeneratedLoonFSClient,
+    input: FileDownloadInput,
+): Promise<FileDownloadResult> {
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;
     if (revisionNo === undefined) {
@@ -169,7 +186,7 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
 }
 
 async function stageBytes(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceAlias: string,
     bytes: Uint8Array,
 ): Promise<StagedContent> {
@@ -223,7 +240,7 @@ function selectBeginRequest(
 }
 
 async function stageServiceProxied(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceAlias: string,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.ServiceProxied,
@@ -244,7 +261,7 @@ async function stageServiceProxied(
 }
 
 async function stageDirectPut(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceAlias: string,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectPut,
@@ -274,7 +291,7 @@ async function stageDirectPut(
 }
 
 async function stageMultipart(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceAlias: string,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectMultipart,
@@ -366,7 +383,7 @@ function stagedContent(response: LoonFS.UploadSession): StagedContent {
 }
 
 async function abortQuietly(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceAlias: string,
     uploadId: LoonFS.UploadId,
 ): Promise<void> {

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -1,4 +1,5 @@
-import { LoonFSClient } from "./Client.js";
+import { LoonFSClient as GeneratedLoonFSClient } from "./Client.js";
+import { FilesClient as GeneratedFilesClient } from "./api/resources/files/client/Client.js";
 import type * as LoonFS from "./api/index.js";
 
 const DIRECT_GET_FEATURE = "core.downloads.direct_get";
@@ -14,7 +15,7 @@ const CRC64_MASK = 0xffffffffffffffffn;
 const CRC32C_TABLE = makeCrc32cTable();
 const CRC64_NVME_TABLE = makeCrc64NvmeTable();
 
-export interface PutFileInput {
+export interface FileUploadInput {
     namespace_id: LoonFS.NamespaceId;
     path: LoonFS.AbsolutePath;
     bytes: Uint8Array;
@@ -26,19 +27,19 @@ export interface PutFileInput {
     expected_revision_no?: LoonFS.RevisionNo;
 }
 
-export interface PutFileResult {
+export interface FileUploadResult {
     namespace_id: LoonFS.NamespaceId;
     commit_id: LoonFS.CommitId;
     committed_seq: LoonFS.ChangeSeq;
 }
 
-export interface GetFileInput {
+export interface FileDownloadInput {
     namespace_id: LoonFS.NamespaceId;
     path: LoonFS.AbsolutePath;
     revision_no?: LoonFS.RevisionNo;
 }
 
-export interface GetFileResult {
+export interface FileDownloadResult {
     namespace_id: LoonFS.NamespaceId;
     path: LoonFS.AbsolutePath;
     revision_no: LoonFS.RevisionNo;
@@ -56,74 +57,90 @@ interface DirectPutBody {
     content: LoonFS.UploadContentClaim;
 }
 
-/**
- * Uploads in-memory bytes and commits them at one path.
- * Streaming and resume are follow-ups.
- */
-export async function putFile(client: LoonFSClient, input: PutFileInput): Promise<PutFileResult> {
-    const staged = await stageBytes(client, input.namespace_id, input.bytes);
-    const request: LoonFS.CommitRequest = {
-        namespace_id: input.namespace_id,
-        actor: input.actor,
-        commit_id: input.commit_id,
-        content_tokens: staged.contentToken === undefined ? [] : [staged.contentToken],
-        operations: [
-            {
-                kind: "put_file",
-                path: input.path,
-                content_ref: staged.contentRef,
-                behavior: input.behavior ?? "no_replace",
-                expected_inode_id: input.expected_inode_id,
-                expected_revision_no: input.expected_revision_no,
-            },
-        ],
-    };
-    if (input.message !== undefined) {
-        request.message = input.message;
+/** The files group plus whole-file transfers. */
+export class FilesClient extends GeneratedFilesClient {
+    constructor(
+        options: GeneratedFilesClient.Options,
+        private readonly root: LoonFSClient,
+    ) {
+        super(options);
     }
-    return client.commits.create(request);
+
+    /** Uploads in-memory bytes and commits them at one path. Streaming and resume are follow-ups. */
+    public async upload(input: FileUploadInput): Promise<FileUploadResult> {
+        const staged = await stageBytes(this.root, input.namespace_id, input.bytes);
+        const request: LoonFS.CommitRequest = {
+            namespace_id: input.namespace_id,
+            actor: input.actor,
+            commit_id: input.commit_id,
+            content_tokens: staged.contentToken === undefined ? [] : [staged.contentToken],
+            operations: [
+                {
+                    kind: "put_file",
+                    path: input.path,
+                    content_ref: staged.contentRef,
+                    behavior: input.behavior ?? "no_replace",
+                    expected_inode_id: input.expected_inode_id,
+                    expected_revision_no: input.expected_revision_no,
+                },
+            ],
+        };
+        if (input.message !== undefined) {
+            request.message = input.message;
+        }
+        return this.root.commits.create(request);
+    }
+
+    /** Downloads one revision into memory and verifies its content claim. Streaming and resume are follow-ups. */
+    public async download(input: FileDownloadInput): Promise<FileDownloadResult> {
+        const capabilities = await this.root.capabilities.retrieve();
+        if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
+            return downloadProxied(this.root, input);
+        }
+        const grant = await this.createDownload(input);
+        requirePresignedMethod(grant.access, "GET", "download");
+        const response = await fetch(grant.access.url, {
+            redirect: "error",
+            method: grant.access.method,
+            headers: grant.access.headers,
+        });
+        requireSuccessfulResponse(response, "download");
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        if (bytes.byteLength !== grant.content_ref.size_bytes) {
+            throw new Error(
+                `download returned ${bytes.byteLength} bytes, expected ${grant.content_ref.size_bytes}`,
+            );
+        }
+        const actual = await checksum(grant.content_ref.checksum.algorithm, bytes);
+        if (actual.value !== grant.content_ref.checksum.value) {
+            throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
+        }
+        return {
+            namespace_id: input.namespace_id,
+            path: grant.path,
+            revision_no: grant.revision_no,
+            content_ref: grant.content_ref,
+            bytes,
+        };
+    }
 }
 
-/**
- * Downloads one revision into memory and verifies its content claim.
- * Streaming and resume are follow-ups.
- */
-export async function getFile(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
-    const capabilities = await client.capabilities.retrieve();
-    if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
-        return getFileProxied(client, input);
+/** The generated client with `files.upload` and `files.download`. */
+export class LoonFSClient extends GeneratedLoonFSClient {
+    private _transferFiles: FilesClient | undefined;
+
+    public override get files(): FilesClient {
+        return (this._transferFiles ??= new FilesClient(this._options, this));
     }
-    const grant = await client.files.createDownload(input);
-    requirePresignedMethod(grant.access, "GET", "download");
-    const response = await fetch(grant.access.url, {
-        redirect: "error",
-        method: grant.access.method,
-        headers: grant.access.headers,
-    });
-    requireSuccessfulResponse(response, "download");
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.byteLength !== grant.content_ref.size_bytes) {
-        throw new Error(
-            `download returned ${bytes.byteLength} bytes, expected ${grant.content_ref.size_bytes}`,
-        );
-    }
-    const actual = await checksum(grant.content_ref.checksum.algorithm, bytes);
-    if (actual.value !== grant.content_ref.checksum.value) {
-        throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
-    }
-    return {
-        namespace_id: input.namespace_id,
-        path: grant.path,
-        revision_no: grant.revision_no,
-        content_ref: grant.content_ref,
-        bytes,
-    };
 }
 
 // Reads through LoonFS when direct reads are unavailable. It loads the content
 // reference first, then requests the exact revision so the reference and
 // returned bytes describe the same file version.
-async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promise<GetFileResult> {
+async function downloadProxied(
+    client: GeneratedLoonFSClient,
+    input: FileDownloadInput,
+): Promise<FileDownloadResult> {
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;
     if (revisionNo === undefined) {
@@ -168,7 +185,7 @@ async function getFileProxied(client: LoonFSClient, input: GetFileInput): Promis
 }
 
 async function stageBytes(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
 ): Promise<StagedContent> {
@@ -222,7 +239,7 @@ function selectBeginRequest(
 }
 
 async function stageServiceProxied(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.ServiceProxied,
@@ -243,7 +260,7 @@ async function stageServiceProxied(
 }
 
 async function stageDirectPut(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectPut,
@@ -273,7 +290,7 @@ async function stageDirectPut(
 }
 
 async function stageMultipart(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectMultipart,
@@ -365,7 +382,7 @@ function stagedContent(response: LoonFS.UploadSession): StagedContent {
 }
 
 async function abortQuietly(
-    client: LoonFSClient,
+    client: GeneratedLoonFSClient,
     namespaceId: LoonFS.NamespaceId,
     uploadId: LoonFS.UploadId,
 ): Promise<void> {


### PR DESCRIPTION
Stacked on `conor/sdk-surface` (#807). The whole-file transfer helpers were the only calls that did not hang off the client: `putFile(client, ...)`, `put_file(client, ...)`, `transfers.PutFile(ctx, client, ...)`. They now read `client.files.upload(...)` and `client.files.download(...)` in TypeScript (server and browser clients) and Python, and `client.Files.Upload` / `client.Files.Download` in Go. The transfer bodies move unchanged; each language gets a thin wrapper around the generated files group that reaches the other groups through the root client, and the generation script points the package entry points at that wrapper. The free functions are removed. The async Python client does not get the transfer methods yet, and the README says so.