### PR TITLE
feat(sdk): revamp client SDK API 

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -15,6 +15,7 @@ use std::collections::BTreeMap;
 /// HTTP error body used by LoonFS APIs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = ErrorResponse))]
 pub struct ApiError {
     /// Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)
     /// registry.
@@ -790,6 +791,7 @@ pub struct Checkpoint {
 /// A live snapshot.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = Snapshot))]
 pub struct SnapshotSummary {
     /// Snapshot id.
     pub snapshot_id: CheckpointId,

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -280,6 +280,7 @@ pub struct UploadContentResponse {
 /// include the expected content details. Multipart also includes its parts.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = UploadCompletion))]
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CompleteUploadRequest {
     /// Complete a service-proxied upload.

--- a/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi/openapi_postprocess.rs
@@ -199,7 +199,7 @@ pub(crate) const OPERATION_SDK_NAMES: &[(&str, SdkName)] = &[
         SdkName {
             group: &["uploads"],
             method: "complete",
-            request: Some("CompleteUploadBody"),
+            request: Some("CompleteUploadRequest"),
         },
     ),
     (

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -151,7 +151,7 @@ fn no_schema_a_response_reaches_admits_null() {
         assert_no_null_property(&spec, response, &location, &mut visited, &mut properties);
     }
 
-    for schema_name in ["ApiError", "ErrorDetails", "GcResponse", "GrepMatch"] {
+    for schema_name in ["ErrorResponse", "ErrorDetails", "GcResponse", "GrepMatch"] {
         assert!(
             visited.contains(&format!("#/components/schemas/{schema_name}")),
             "the walk never reached `{schema_name}`"
@@ -1197,7 +1197,7 @@ fn openapi_names_tagged_one_of_alternatives() {
             ][..],
         ),
         (
-            "CompleteUploadRequest",
+            "UploadCompletion",
             &[
                 "CompleteUploadServiceProxied",
                 "CompleteUploadDirectPut",
@@ -1653,7 +1653,7 @@ fn openapi_reuses_the_one_checksum_and_upload_claim_shapes() {
     }
 
     let completion_variants = schemas
-        .get("CompleteUploadRequest")
+        .get("UploadCompletion")
         .and_then(|schema| schema.get("oneOf"))
         .and_then(Value::as_array)
         .expect("completion variants");

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -34,7 +34,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -44,7 +44,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -126,7 +126,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -136,7 +136,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -146,7 +146,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -156,7 +156,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -166,7 +166,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -228,7 +228,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -238,7 +238,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -248,7 +248,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -258,7 +258,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -268,7 +268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -351,7 +351,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -361,7 +361,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -371,7 +371,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -381,7 +381,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -391,7 +391,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -462,7 +462,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -472,7 +472,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -482,7 +482,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -492,7 +492,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -502,7 +502,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -603,7 +603,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -613,7 +613,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -623,7 +623,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -633,7 +633,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -718,7 +718,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -728,7 +728,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -738,7 +738,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -748,7 +748,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -831,7 +831,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -841,7 +841,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -851,7 +851,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -861,7 +861,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -940,7 +940,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -950,7 +950,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -960,7 +960,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -970,7 +970,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1097,7 +1097,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1107,7 +1107,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1117,7 +1117,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1127,7 +1127,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1137,7 +1137,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1147,7 +1147,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1226,7 +1226,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1236,7 +1236,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1246,7 +1246,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1301,7 +1301,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SnapshotSummary"
+                  "$ref": "#/components/schemas/Snapshot"
                 }
               }
             }
@@ -1311,7 +1311,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1321,7 +1321,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1331,7 +1331,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1341,7 +1341,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1351,7 +1351,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1414,7 +1414,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SnapshotSummary"
+                  "$ref": "#/components/schemas/Snapshot"
                 }
               }
             }
@@ -1424,7 +1424,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1434,7 +1434,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1444,7 +1444,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1454,7 +1454,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1514,7 +1514,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1524,7 +1524,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1586,7 +1586,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1596,7 +1596,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1606,7 +1606,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1616,7 +1616,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1626,7 +1626,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1636,7 +1636,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1700,7 +1700,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1710,7 +1710,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1720,7 +1720,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1730,7 +1730,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1791,7 +1791,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1801,7 +1801,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1811,7 +1811,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1821,7 +1821,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1831,7 +1831,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1881,7 +1881,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CompleteUploadRequest"
+                "$ref": "#/components/schemas/UploadCompletion"
               }
             }
           },
@@ -1903,7 +1903,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1913,7 +1913,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1923,7 +1923,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1933,7 +1933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1943,7 +1943,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1953,7 +1953,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1967,7 +1967,7 @@
           "uploads"
         ],
         "x-fern-sdk-method-name": "complete",
-        "x-fern-request-name": "CompleteUploadBody"
+        "x-fern-request-name": "CompleteUploadRequest"
       }
     },
     "/v0/namespace-aliases/{namespace_alias}/uploads/{upload_id}/content": {
@@ -2029,7 +2029,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2039,7 +2039,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2049,7 +2049,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2059,7 +2059,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2069,7 +2069,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2079,7 +2079,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2149,7 +2149,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2159,7 +2159,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2169,7 +2169,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2179,7 +2179,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2189,7 +2189,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2199,7 +2199,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2209,7 +2209,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2265,40 +2265,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "ApiError": {
-        "type": "object",
-        "description": "HTTP error body used by LoonFS APIs.",
-        "required": [
-          "code",
-          "message"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
-          },
-          "details": {
-            "$ref": "#/components/schemas/ErrorDetails",
-            "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
-          },
-          "feature": {
-            "type": "string",
-            "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
-          },
-          "message": {
-            "type": "string",
-            "description": "Human-readable error message."
-          },
-          "param": {
-            "type": "string",
-            "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
-          },
-          "request_id": {
-            "type": "string",
-            "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
-          }
-        }
       },
       "AttributeKey": {
         "type": "string",
@@ -2641,28 +2607,6 @@
           }
         }
       },
-      "CompleteUploadRequest": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CompleteUploadServiceProxied"
-          },
-          {
-            "$ref": "#/components/schemas/CompleteUploadDirectPut"
-          },
-          {
-            "$ref": "#/components/schemas/CompleteUploadDirectMultipart"
-          }
-        ],
-        "description": "Request to complete an upload session.\n\n`mode` must match the mode used to start the session. Direct uploads\ninclude the expected content details. Multipart also includes its parts.",
-        "discriminator": {
-          "propertyName": "mode",
-          "mapping": {
-            "service_proxied": "#/components/schemas/CompleteUploadServiceProxied",
-            "direct_put": "#/components/schemas/CompleteUploadDirectPut",
-            "direct_multipart": "#/components/schemas/CompleteUploadDirectMultipart"
-          }
-        }
-      },
       "CompletedUploadPart": {
         "type": "object",
         "description": "One uploaded part, as the client observed the provider accept it.\n\nThe server keeps no durable record of any part. Part bookkeeping is the\nclient's, exactly as it is in the provider's own multipart API, and this\nis where the client hands it back.",
@@ -2909,6 +2853,40 @@
           "retention_floor_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Oldest sequence still promised for incremental replay."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "HTTP error body used by LoonFS APIs.",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
+          },
+          "details": {
+            "$ref": "#/components/schemas/ErrorDetails",
+            "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
+          },
+          "feature": {
+            "type": "string",
+            "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "param": {
+            "type": "string",
+            "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
+          },
+          "request_id": {
+            "type": "string",
+            "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
           }
         }
       },
@@ -3290,7 +3268,7 @@
           "snapshots": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SnapshotSummary"
+              "$ref": "#/components/schemas/Snapshot"
             },
             "description": "Live snapshot records in ascending snapshot-id order."
           }
@@ -3457,7 +3435,7 @@
           }
         }
       },
-      "SnapshotSummary": {
+      "Snapshot": {
         "type": "object",
         "description": "A live snapshot.",
         "required": [
@@ -3532,6 +3510,28 @@
             "description": "Stable inode ID within a namespace",
             "example": "ino_123",
             "pattern": "^ino_[1-9][0-9]*$"
+          }
+        }
+      },
+      "UploadCompletion": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CompleteUploadServiceProxied"
+          },
+          {
+            "$ref": "#/components/schemas/CompleteUploadDirectPut"
+          },
+          {
+            "$ref": "#/components/schemas/CompleteUploadDirectMultipart"
+          }
+        ],
+        "description": "Request to complete an upload session.\n\n`mode` must match the mode used to start the session. Direct uploads\ninclude the expected content details. Multipart also includes its parts.",
+        "discriminator": {
+          "propertyName": "mode",
+          "mapping": {
+            "service_proxied": "#/components/schemas/CompleteUploadServiceProxied",
+            "direct_put": "#/components/schemas/CompleteUploadDirectPut",
+            "direct_multipart": "#/components/schemas/CompleteUploadDirectMultipart"
           }
         }
       },
@@ -3795,69 +3795,6 @@
           "upload_id": {
             "$ref": "#/components/schemas/UploadId",
             "description": "Durable session identity used by subsequent part-signing and\ncompletion calls."
-          }
-        }
-      },
-      "CompleteUploadServiceProxied": {
-        "type": "object",
-        "description": "Complete a service-proxied upload.",
-        "required": [
-          "mode"
-        ],
-        "properties": {
-          "mode": {
-            "type": "string",
-            "enum": [
-              "service_proxied"
-            ]
-          }
-        }
-      },
-      "CompleteUploadDirectPut": {
-        "type": "object",
-        "description": "Complete a direct-PUT upload.",
-        "required": [
-          "content",
-          "mode"
-        ],
-        "properties": {
-          "content": {
-            "$ref": "#/components/schemas/UploadContentClaim",
-            "description": "Expected length and checksum of the stored object."
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "direct_put"
-            ]
-          }
-        }
-      },
-      "CompleteUploadDirectMultipart": {
-        "type": "object",
-        "description": "Complete a direct multipart upload.",
-        "required": [
-          "content",
-          "parts",
-          "mode"
-        ],
-        "properties": {
-          "content": {
-            "$ref": "#/components/schemas/UploadContentClaim",
-            "description": "Expected length and checksum of the assembled object."
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "direct_multipart"
-            ]
-          },
-          "parts": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CompletedUploadPart"
-            },
-            "description": "Uploaded parts in ascending part order."
           }
         }
       },
@@ -4810,6 +4747,69 @@
           "path": {
             "$ref": "#/components/schemas/AbsolutePath",
             "description": "Absolute path as rendered from stored display names."
+          }
+        }
+      },
+      "CompleteUploadServiceProxied": {
+        "type": "object",
+        "description": "Complete a service-proxied upload.",
+        "required": [
+          "mode"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "service_proxied"
+            ]
+          }
+        }
+      },
+      "CompleteUploadDirectPut": {
+        "type": "object",
+        "description": "Complete a direct-PUT upload.",
+        "required": [
+          "content",
+          "mode"
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/UploadContentClaim",
+            "description": "Expected length and checksum of the stored object."
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_put"
+            ]
+          }
+        }
+      },
+      "CompleteUploadDirectMultipart": {
+        "type": "object",
+        "description": "Complete a direct multipart upload.",
+        "required": [
+          "content",
+          "parts",
+          "mode"
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/UploadContentClaim",
+            "description": "Expected length and checksum of the assembled object."
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_multipart"
+            ]
+          },
+          "parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompletedUploadPart"
+            },
+            "description": "Uploaded parts in ascending part order."
           }
         }
       },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -64,7 +64,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -164,7 +164,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -174,7 +174,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -184,7 +184,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -251,7 +251,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -261,7 +261,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -271,7 +271,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -281,7 +281,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -345,7 +345,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -355,7 +355,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -365,7 +365,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -418,7 +418,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -428,7 +428,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -438,7 +438,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -448,7 +448,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -501,7 +501,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -511,7 +511,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -521,7 +521,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -531,7 +531,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -584,7 +584,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -594,7 +594,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -604,7 +604,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -614,7 +614,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -624,7 +624,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -634,7 +634,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -687,7 +687,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -697,7 +697,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -707,7 +707,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -717,7 +717,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -727,7 +727,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -737,7 +737,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -799,7 +799,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -809,7 +809,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -819,7 +819,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -829,7 +829,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -895,7 +895,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -905,7 +905,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -915,7 +915,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -925,7 +925,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -980,7 +980,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -990,7 +990,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1034,7 +1034,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1044,7 +1044,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1094,7 +1094,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1104,7 +1104,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1114,7 +1114,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1124,7 +1124,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1178,7 +1178,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1188,7 +1188,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1198,7 +1198,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1208,7 +1208,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1267,7 +1267,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1277,7 +1277,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1287,7 +1287,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1297,7 +1297,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1307,7 +1307,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1393,7 +1393,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1403,7 +1403,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1413,7 +1413,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1423,7 +1423,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1433,7 +1433,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1495,7 +1495,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1505,7 +1505,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1515,7 +1515,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1525,7 +1525,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1535,7 +1535,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1618,7 +1618,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1628,7 +1628,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1638,7 +1638,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1648,7 +1648,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1658,7 +1658,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1729,7 +1729,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1739,7 +1739,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1749,7 +1749,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1759,7 +1759,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1769,7 +1769,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1870,7 +1870,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1880,7 +1880,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1890,7 +1890,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1900,7 +1900,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1985,7 +1985,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1995,7 +1995,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2005,7 +2005,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2015,7 +2015,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2098,7 +2098,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2108,7 +2108,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2118,7 +2118,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2128,7 +2128,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2207,7 +2207,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2217,7 +2217,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2227,7 +2227,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2237,7 +2237,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2304,7 +2304,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2314,7 +2314,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2324,7 +2324,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2334,7 +2334,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2344,7 +2344,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2468,7 +2468,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2478,7 +2478,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2488,7 +2488,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2498,7 +2498,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2508,7 +2508,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2518,7 +2518,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2596,7 +2596,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2606,7 +2606,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2616,7 +2616,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2626,7 +2626,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2721,7 +2721,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2731,7 +2731,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2741,7 +2741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2751,7 +2751,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2761,7 +2761,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2851,7 +2851,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2861,7 +2861,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2871,7 +2871,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2881,7 +2881,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2891,7 +2891,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2973,7 +2973,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2983,7 +2983,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2993,7 +2993,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3003,7 +3003,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3013,7 +3013,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3023,7 +3023,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3105,7 +3105,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3115,7 +3115,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3125,7 +3125,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3135,7 +3135,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3145,7 +3145,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3155,7 +3155,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3229,7 +3229,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3239,7 +3239,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3249,7 +3249,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3304,7 +3304,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SnapshotSummary"
+                  "$ref": "#/components/schemas/Snapshot"
                 }
               }
             }
@@ -3314,7 +3314,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3324,7 +3324,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3334,7 +3334,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3344,7 +3344,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3354,7 +3354,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3417,7 +3417,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SnapshotSummary"
+                  "$ref": "#/components/schemas/Snapshot"
                 }
               }
             }
@@ -3427,7 +3427,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3437,7 +3437,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3447,7 +3447,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3457,7 +3457,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3517,7 +3517,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3527,7 +3527,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3589,7 +3589,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3599,7 +3599,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3609,7 +3609,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3619,7 +3619,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3629,7 +3629,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3639,7 +3639,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3703,7 +3703,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3713,7 +3713,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3723,7 +3723,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3733,7 +3733,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3794,7 +3794,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3804,7 +3804,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3814,7 +3814,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3824,7 +3824,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3834,7 +3834,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3884,7 +3884,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CompleteUploadRequest"
+                "$ref": "#/components/schemas/UploadCompletion"
               }
             }
           },
@@ -3906,7 +3906,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3916,7 +3916,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3926,7 +3926,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3936,7 +3936,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3946,7 +3946,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3956,7 +3956,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3970,7 +3970,7 @@
           "uploads"
         ],
         "x-fern-sdk-method-name": "complete",
-        "x-fern-request-name": "CompleteUploadBody"
+        "x-fern-request-name": "CompleteUploadRequest"
       }
     },
     "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content": {
@@ -4032,7 +4032,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4042,7 +4042,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4052,7 +4052,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4062,7 +4062,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4072,7 +4072,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4082,7 +4082,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4152,7 +4152,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4162,7 +4162,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4172,7 +4172,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4182,7 +4182,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4192,7 +4192,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4202,7 +4202,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4212,7 +4212,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4284,40 +4284,6 @@
           "retention_floor_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "New minimum sequence for incremental replay."
-          }
-        }
-      },
-      "ApiError": {
-        "type": "object",
-        "description": "HTTP error body used by LoonFS APIs.",
-        "required": [
-          "code",
-          "message"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
-          },
-          "details": {
-            "$ref": "#/components/schemas/ErrorDetails",
-            "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
-          },
-          "feature": {
-            "type": "string",
-            "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
-          },
-          "message": {
-            "type": "string",
-            "description": "Human-readable error message."
-          },
-          "param": {
-            "type": "string",
-            "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
-          },
-          "request_id": {
-            "type": "string",
-            "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
           }
         }
       },
@@ -4770,28 +4736,6 @@
           }
         }
       },
-      "CompleteUploadRequest": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CompleteUploadServiceProxied"
-          },
-          {
-            "$ref": "#/components/schemas/CompleteUploadDirectPut"
-          },
-          {
-            "$ref": "#/components/schemas/CompleteUploadDirectMultipart"
-          }
-        ],
-        "description": "Request to complete an upload session.\n\n`mode` must match the mode used to start the session. Direct uploads\ninclude the expected content details. Multipart also includes its parts.",
-        "discriminator": {
-          "propertyName": "mode",
-          "mapping": {
-            "service_proxied": "#/components/schemas/CompleteUploadServiceProxied",
-            "direct_put": "#/components/schemas/CompleteUploadDirectPut",
-            "direct_multipart": "#/components/schemas/CompleteUploadDirectMultipart"
-          }
-        }
-      },
       "CompletedUploadPart": {
         "type": "object",
         "description": "One uploaded part, as the client observed the provider accept it.\n\nThe server keeps no durable record of any part. Part bookkeeping is the\nclient's, exactly as it is in the provider's own multipart API, and this\nis where the client hands it back.",
@@ -5143,6 +5087,40 @@
           "retention_floor_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Oldest sequence still promised for incremental replay."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "HTTP error body used by LoonFS APIs.",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
+          },
+          "details": {
+            "$ref": "#/components/schemas/ErrorDetails",
+            "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
+          },
+          "feature": {
+            "type": "string",
+            "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "param": {
+            "type": "string",
+            "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
+          },
+          "request_id": {
+            "type": "string",
+            "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
           }
         }
       },
@@ -5793,7 +5771,7 @@
           "snapshots": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SnapshotSummary"
+              "$ref": "#/components/schemas/Snapshot"
             },
             "description": "Live snapshot records in ascending snapshot-id order."
           }
@@ -6298,7 +6276,7 @@
           }
         }
       },
-      "SnapshotSummary": {
+      "Snapshot": {
         "type": "object",
         "description": "A live snapshot.",
         "required": [
@@ -6430,6 +6408,28 @@
             "description": "Stable inode ID within a namespace",
             "example": "ino_123",
             "pattern": "^ino_[1-9][0-9]*$"
+          }
+        }
+      },
+      "UploadCompletion": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CompleteUploadServiceProxied"
+          },
+          {
+            "$ref": "#/components/schemas/CompleteUploadDirectPut"
+          },
+          {
+            "$ref": "#/components/schemas/CompleteUploadDirectMultipart"
+          }
+        ],
+        "description": "Request to complete an upload session.\n\n`mode` must match the mode used to start the session. Direct uploads\ninclude the expected content details. Multipart also includes its parts.",
+        "discriminator": {
+          "propertyName": "mode",
+          "mapping": {
+            "service_proxied": "#/components/schemas/CompleteUploadServiceProxied",
+            "direct_put": "#/components/schemas/CompleteUploadDirectPut",
+            "direct_multipart": "#/components/schemas/CompleteUploadDirectMultipart"
           }
         }
       },
@@ -6786,69 +6786,6 @@
           "name": {
             "type": "string",
             "description": "A label that does not need to be unique."
-          }
-        }
-      },
-      "CompleteUploadServiceProxied": {
-        "type": "object",
-        "description": "Complete a service-proxied upload.",
-        "required": [
-          "mode"
-        ],
-        "properties": {
-          "mode": {
-            "type": "string",
-            "enum": [
-              "service_proxied"
-            ]
-          }
-        }
-      },
-      "CompleteUploadDirectPut": {
-        "type": "object",
-        "description": "Complete a direct-PUT upload.",
-        "required": [
-          "content",
-          "mode"
-        ],
-        "properties": {
-          "content": {
-            "$ref": "#/components/schemas/UploadContentClaim",
-            "description": "Expected length and checksum of the stored object."
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "direct_put"
-            ]
-          }
-        }
-      },
-      "CompleteUploadDirectMultipart": {
-        "type": "object",
-        "description": "Complete a direct multipart upload.",
-        "required": [
-          "content",
-          "parts",
-          "mode"
-        ],
-        "properties": {
-          "content": {
-            "$ref": "#/components/schemas/UploadContentClaim",
-            "description": "Expected length and checksum of the assembled object."
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "direct_multipart"
-            ]
-          },
-          "parts": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CompletedUploadPart"
-            },
-            "description": "Uploaded parts in ascending part order."
           }
         }
       },
@@ -8016,6 +7953,69 @@
             "enum": [
               "root_advanced"
             ]
+          }
+        }
+      },
+      "CompleteUploadServiceProxied": {
+        "type": "object",
+        "description": "Complete a service-proxied upload.",
+        "required": [
+          "mode"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "service_proxied"
+            ]
+          }
+        }
+      },
+      "CompleteUploadDirectPut": {
+        "type": "object",
+        "description": "Complete a direct-PUT upload.",
+        "required": [
+          "content",
+          "mode"
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/UploadContentClaim",
+            "description": "Expected length and checksum of the stored object."
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_put"
+            ]
+          }
+        }
+      },
+      "CompleteUploadDirectMultipart": {
+        "type": "object",
+        "description": "Complete a direct multipart upload.",
+        "required": [
+          "content",
+          "parts",
+          "mode"
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/UploadContentClaim",
+            "description": "Expected length and checksum of the assembled object."
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "direct_multipart"
+            ]
+          },
+          "parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompletedUploadPart"
+            },
+            "description": "Uploaded parts in ascending part order."
           }
         }
       },

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -45,6 +45,14 @@ module_root = pathlib.Path("generated/go")
 server_package = module_root / "server"
 (module_root / "client").replace(server_package)
 
+
+def remove_exact(source, snippet, expected_count, label):
+    actual_count = source.count(snippet)
+    assert actual_count == expected_count, (
+        f"expected {expected_count} {label}, found {actual_count}"
+    )
+    return source.replace(snippet, "")
+
 for source_path in [*module_root.rglob("*.go"), *module_root.rglob("*.md")]:
     source = source_path.read_text()
     source = source.replace(
@@ -63,6 +71,93 @@ for source_path in [*module_root.rglob("*.go"), *module_root.rglob("*.md")]:
         source = source.replace("package client", "package server")
     source_path.write_text(source)
 
+option_path = module_root / "option/request_option.go"
+source = option_path.read_text()
+source = remove_exact(
+    source,
+    "// WithMaxStreamBufSize configures the maximum buffer size for streaming responses.\n"
+    "// This controls the maximum size of a single message (in bytes) that the stream\n"
+    "// can process. By default, this is set to 1MB.\n"
+    "func WithMaxStreamBufSize(size int) *core.MaxBufSizeOption {\n"
+    "\treturn &core.MaxBufSizeOption{\n"
+    "\t\tMaxBufSize: size,\n"
+    "\t}\n"
+    "}\n\n",
+    1,
+    "WithMaxStreamBufSize option",
+)
+source = remove_exact(
+    source,
+    "// WithMaxStreamReconnectAttempts caps the number of transparent mid-stream\n"
+    "// reconnect attempts on streaming endpoints that support resumption. The\n"
+    "// reconnect loop honors Last-Event-ID and any server-sent `retry:` directives.\n"
+    "// Has no effect on endpoints that don't support resumption.\n"
+    "func WithMaxStreamReconnectAttempts(attempts uint) *core.MaxStreamReconnectAttemptsOption {\n"
+    "\treturn &core.MaxStreamReconnectAttemptsOption{\n"
+    "\t\tMaxStreamReconnectAttempts: attempts,\n"
+    "\t}\n"
+    "}\n\n",
+    1,
+    "WithMaxStreamReconnectAttempts option",
+)
+source = remove_exact(
+    source,
+    "// WithoutStreamReconnection disables transparent mid-stream reconnection on\n"
+    "// resumable SSE endpoints. Has no effect on non-resumable endpoints.\n"
+    "func WithoutStreamReconnection() *core.WithoutStreamReconnectionOption {\n"
+    "\treturn &core.WithoutStreamReconnectionOption{}\n"
+    "}\n\n",
+    1,
+    "WithoutStreamReconnection option",
+)
+option_path.write_text(source)
+
+core_option_path = module_root / "core/request_option.go"
+source = core_option_path.read_text()
+source = remove_exact(
+    source,
+    "\tMaxBufSize                 int\n"
+    "\tMaxStreamReconnectAttempts uint\n"
+    "\tDisableStreamReconnection  bool\n",
+    1,
+    "streaming RequestOptions fields",
+)
+source = remove_exact(
+    source,
+    "// MaxBufSizeOption implements the RequestOption interface.\n"
+    "type MaxBufSizeOption struct {\n"
+    "\tMaxBufSize int\n"
+    "}\n\n"
+    "func (m *MaxBufSizeOption) applyRequestOptions(opts *RequestOptions) {\n"
+    "\topts.MaxBufSize = m.MaxBufSize\n"
+    "}\n\n",
+    1,
+    "MaxBufSizeOption type",
+)
+source = remove_exact(
+    source,
+    "// MaxStreamReconnectAttemptsOption implements the RequestOption interface.\n"
+    "type MaxStreamReconnectAttemptsOption struct {\n"
+    "\tMaxStreamReconnectAttempts uint\n"
+    "}\n\n"
+    "func (m *MaxStreamReconnectAttemptsOption) applyRequestOptions(opts *RequestOptions) {\n"
+    "\topts.MaxStreamReconnectAttempts = m.MaxStreamReconnectAttempts\n"
+    "}\n\n",
+    1,
+    "MaxStreamReconnectAttemptsOption type",
+)
+source = remove_exact(
+    source,
+    "// WithoutStreamReconnectionOption implements the RequestOption interface.\n"
+    "type WithoutStreamReconnectionOption struct{}\n\n"
+    "func (w *WithoutStreamReconnectionOption) applyRequestOptions(opts *RequestOptions) {\n"
+    "\topts.DisableStreamReconnection = true\n"
+    "}\n\n",
+    1,
+    "WithoutStreamReconnectionOption type",
+)
+core_option_path.write_text(source)
+
 test_path = module_root / "internal/explicit_fields_test.go"
 source = test_path.read_text()
 start = source.index("// Test for backwards compatibility")
@@ -75,6 +170,16 @@ PY
         rm -r generated/python/core/http_sse
         python3 - <<'PY'
 import pathlib
+
+
+def remove_exact(source, snippet, expected_count, label):
+    actual_count = source.count(snippet)
+    assert actual_count == expected_count, (
+        f"expected {expected_count} {label}, found {actual_count}"
+    )
+    return source.replace(snippet, "")
+
+
 path = pathlib.Path("generated/python/core/pydantic_utilities.py")
 source = path.read_text()
 import_block = 'if TYPE_CHECKING:\n    from .http_sse._models import ServerSentEvent\n\n'
@@ -91,6 +196,18 @@ source = source.replace(
     "",
 )
 source = source.replace("    timeout_in_seconds: NotRequired[int]\n", "")
+source = remove_exact(
+    source,
+    "    stream_reconnection_enabled: NotRequired[bool]\n",
+    1,
+    "request stream_reconnection_enabled option",
+)
+source = remove_exact(
+    source,
+    "    max_stream_reconnection_attempts: NotRequired[int]\n",
+    1,
+    "request max_stream_reconnection_attempts option",
+)
 request_options_path.write_text(source)
 
 http_client_path = pathlib.Path("generated/python/core/http_client.py")
@@ -102,6 +219,102 @@ source = source.replace(
 )
 http_client_path.write_text(source)
 
+client_path = pathlib.Path("generated/python/client.py")
+source = client_path.read_text()
+source = remove_exact(
+    source,
+    "    stream_reconnection_enabled : typing.Optional[bool]\n"
+    "        Whether to automatically reconnect on stream disconnection for resumable streaming endpoints. Defaults to True. Per-request `stream_reconnection_enabled` in `request_options` takes precedence over this value.\n\n",
+    2,
+    "client stream_reconnection_enabled documentation blocks",
+)
+source = remove_exact(
+    source,
+    "    max_stream_reconnection_attempts : typing.Optional[int]\n"
+    "        The maximum number of reconnection attempts for resumable streaming endpoints. Defaults to no limit. Per-request `max_stream_reconnection_attempts` in `request_options` takes precedence over this value.\n\n",
+    2,
+    "client max_stream_reconnection_attempts documentation blocks",
+)
+source = remove_exact(
+    source,
+    "        stream_reconnection_enabled: typing.Optional[bool] = None,\n",
+    2,
+    "client stream_reconnection_enabled parameters",
+)
+source = remove_exact(
+    source,
+    "        max_stream_reconnection_attempts: typing.Optional[int] = None,\n",
+    2,
+    "client max_stream_reconnection_attempts parameters",
+)
+source = remove_exact(
+    source,
+    "            stream_reconnection_enabled=stream_reconnection_enabled,\n",
+    2,
+    "client stream_reconnection_enabled pass-throughs",
+)
+source = remove_exact(
+    source,
+    "            max_stream_reconnection_attempts=max_stream_reconnection_attempts,\n",
+    2,
+    "client max_stream_reconnection_attempts pass-throughs",
+)
+client_path.write_text(source)
+
+wrapper_path = pathlib.Path("generated/python/core/client_wrapper.py")
+source = wrapper_path.read_text()
+source = remove_exact(
+    source,
+    "        stream_reconnection_enabled: typing.Optional[bool] = None,\n",
+    3,
+    "client wrapper stream_reconnection_enabled parameters",
+)
+source = remove_exact(
+    source,
+    "        max_stream_reconnection_attempts: typing.Optional[int] = None,\n",
+    3,
+    "client wrapper max_stream_reconnection_attempts parameters",
+)
+source = remove_exact(
+    source,
+    "        self._stream_reconnection_enabled = stream_reconnection_enabled\n",
+    1,
+    "client wrapper stream_reconnection_enabled attribute",
+)
+source = remove_exact(
+    source,
+    "        self._max_stream_reconnection_attempts = max_stream_reconnection_attempts\n",
+    1,
+    "client wrapper max_stream_reconnection_attempts attribute",
+)
+source = remove_exact(
+    source,
+    "    def get_stream_reconnection_enabled(self) -> bool:\n"
+    "        return self._stream_reconnection_enabled if self._stream_reconnection_enabled is not None else True\n\n",
+    1,
+    "client wrapper stream_reconnection_enabled getter",
+)
+source = remove_exact(
+    source,
+    "    def get_max_stream_reconnection_attempts(self) -> typing.Optional[int]:\n"
+    "        return self._max_stream_reconnection_attempts\n\n",
+    1,
+    "client wrapper max_stream_reconnection_attempts getter",
+)
+source = remove_exact(
+    source,
+    "            stream_reconnection_enabled=stream_reconnection_enabled,\n",
+    2,
+    "client wrapper stream_reconnection_enabled pass-throughs",
+)
+source = remove_exact(
+    source,
+    "            max_stream_reconnection_attempts=max_stream_reconnection_attempts,\n",
+    2,
+    "client wrapper max_stream_reconnection_attempts pass-throughs",
+)
+wrapper_path.write_text(source)
+
 package_root = pathlib.Path("generated/python")
 server_module = package_root / "server.py"
 (package_root / "__init__.py").replace(server_module)
@@ -110,15 +323,32 @@ server_module = package_root / "server.py"
 )
 
 source = server_module.read_text()
+assert '"ApiError"' not in source, "generated server.py unexpectedly exports ApiError"
 generated_import = "    from .client import AsyncLoonFS, LoonFS\n"
 assert source.count(generated_import) == 1, "generated server.py client import not found"
 source = source.replace(
     generated_import,
-    "    from .client import AsyncLoonFS\n    from .transfers import LoonFS\n",
+    "    from .client import AsyncLoonFS\n"
+    "    from .core.api_error import ApiError\n"
+    "    from .transfers import FileDownloadResult, FileUploadResult, LoonFS\n",
 )
 generated_mapping = '    "LoonFS": ".client",\n'
 assert source.count(generated_mapping) == 1, "generated server.py client mapping not found"
 source = source.replace(generated_mapping, '    "LoonFS": ".transfers",\n')
+for anchor, insertion, label in (
+    ('    "AsyncLoonFS": ".client",\n', '    "ApiError": ".core.api_error",\n', "ApiError mapping"),
+    ('    "FileRevision": ".types",\n', '    "FileDownloadResult": ".transfers",\n', "FileDownloadResult mapping"),
+    ('    "FilesystemChange": ".types",\n', '    "FileUploadResult": ".transfers",\n', "FileUploadResult mapping"),
+):
+    assert source.count(anchor) == 1, f"generated server.py anchor for {label} not found exactly once"
+    source = source.replace(anchor, insertion + anchor)
+for anchor, insertion, label in (
+    ('    "AsyncLoonFS",\n', '    "ApiError",\n', "ApiError __all__ entry"),
+    ('    "FileRevision",\n', '    "FileDownloadResult",\n', "FileDownloadResult __all__ entry"),
+    ('    "FilesystemChange",\n', '    "FileUploadResult",\n', "FileUploadResult __all__ entry"),
+):
+    assert source.count(anchor) == 1, f"generated server.py anchor for {label} not found exactly once"
+    source = source.replace(anchor, insertion + anchor)
 server_module.write_text(source)
 
 for example_path in [*package_root.rglob("*.py"), package_root / "reference.md"]:
@@ -134,6 +364,22 @@ import pathlib
 import sys
 
 package_root = pathlib.Path("generated") / sys.argv[1]
+
+base_client_path = package_root / "BaseClient.ts"
+source = base_client_path.read_text()
+client_stream_options = (
+    "    /** Default options for SSE stream reconnection behavior. Has no effect on non-resumable endpoints. */\n"
+    "    stream?: { reconnectionEnabled?: boolean; maxReconnectionAttempts?: number };\n"
+)
+assert source.count(client_stream_options) == 1, "generated BaseClient.ts client stream options not found"
+source = source.replace(client_stream_options, "")
+request_stream_options = (
+    "    /** Options for SSE stream reconnection behavior. Has no effect on non-resumable endpoints. */\n"
+    "    stream?: { reconnectionEnabled?: boolean; maxReconnectionAttempts?: number };\n"
+)
+assert source.count(request_stream_options) == 1, "generated BaseClient.ts request stream options not found"
+source = source.replace(request_stream_options, "")
+base_client_path.write_text(source)
 
 response_path = package_root / "core/fetcher/APIResponse.ts"
 source = response_path.read_text()

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -342,10 +342,10 @@ func runDirectPut(t *testing.T, h *harness, testCase conformanceCase) {
 		Checksum:  mustChecksum(t, directPut.ChecksumAlgorithm, payload),
 		SizeBytes: int64(len(payload)),
 	}
-	completed, err := h.client.Uploads.Complete(context.Background(), &loonfs.CompleteUploadBody{
+	completed, err := h.client.Uploads.Complete(context.Background(), &loonfs.CompleteUploadRequest{
 		NamespaceID: request.NamespaceID,
 		UploadID:    string(begin.DirectPut.UploadID),
-		Body: &loonfs.CompleteUploadRequest{
+		Body: &loonfs.UploadCompletion{
 			DirectPut: &loonfs.CompleteUploadDirectPut{Content: claim},
 		},
 	})
@@ -379,7 +379,7 @@ func runDirectPut(t *testing.T, h *harness, testCase conformanceCase) {
 	file := requireFileProjection(t, stat)
 	assertContentRefEqual(t, file.ContentRef, completedStatus.ContentRef)
 	readback := downloadFile(t, h.client, request.NamespaceID, request.Path)
-	if !bytes.Equal(readback.Bytes, payload) {
+	if !bytes.Equal(readback.Content, payload) {
 		t.Error("direct PUT readback did not match payload")
 	}
 }
@@ -474,10 +474,10 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 		return completedParts[left].PartNumber < completedParts[right].PartNumber
 	})
 	wholeChecksum := mustChecksum(t, multipart.ChecksumAlgorithm, payload)
-	completionRequest := &loonfs.CompleteUploadBody{
+	completionRequest := &loonfs.CompleteUploadRequest{
 		NamespaceID: request.NamespaceID,
 		UploadID:    string(begin.DirectMultipart.UploadID),
-		Body: &loonfs.CompleteUploadRequest{
+		Body: &loonfs.UploadCompletion{
 			DirectMultipart: &loonfs.CompleteUploadDirectMultipart{
 				Content: &loonfs.UploadContentClaim{
 					Checksum:  wholeChecksum,
@@ -524,7 +524,7 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Errorf("committed_seq = %d, want %d", committed.CommittedSeq, expected.CommittedSeq)
 	}
 	readback := downloadFile(t, h.client, request.NamespaceID, request.Path)
-	if !bytes.Equal(readback.Bytes, payload) {
+	if !bytes.Equal(readback.Content, payload) {
 		t.Error("multipart readback did not match payload")
 	}
 
@@ -534,7 +534,7 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 	helperCommit, err := h.client.Files.Upload(context.Background(), files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(helperPath),
-		Bytes:       payload,
+		Content:     payload,
 		Actor:       &request.Actor,
 		CommitID:    loonfs.CommitID(request.CommitID + "-helper"),
 	})
@@ -545,7 +545,7 @@ func runMultipart(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Error("helper multipart put reported no committed_seq")
 	}
 	helperReadback := downloadFile(t, h.client, request.NamespaceID, helperPath)
-	if !bytes.Equal(helperReadback.Bytes, payload) {
+	if !bytes.Equal(helperReadback.Content, payload) {
 		t.Error("helper multipart readback did not match payload")
 	}
 	// Content ids are random per upload and the helper may choose a different
@@ -631,7 +631,7 @@ func runDownload(t *testing.T, h *harness, testCase conformanceCase) {
 	committed, err := h.client.Files.Upload(context.Background(), files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(request.Path),
-		Bytes:       payload,
+		Content:     payload,
 		Actor:       &request.Actor,
 		CommitID:    commitID,
 	})
@@ -716,7 +716,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 	upload, err := h.client.Files.Upload(context.Background(), files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(request.UploadPath),
-		Bytes:       []byte(request.ContentUTF8),
+		Content:     []byte(request.ContentUTF8),
 		Actor:       &request.Actor,
 		CommitID:    uploadCommitID,
 	})
@@ -738,7 +738,7 @@ func runEndToEnd(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Errorf("initial listing does not contain %q", request.UploadPath)
 	}
 	downloaded := downloadFile(t, h.client, request.NamespaceID, request.UploadPath)
-	if !bytes.Equal(downloaded.Bytes, []byte(request.ContentUTF8)) {
+	if !bytes.Equal(downloaded.Content, []byte(request.ContentUTF8)) {
 		t.Error("end-to-end download did not match payload")
 	}
 
@@ -1083,7 +1083,7 @@ func runInodeMutations(t *testing.T, h *harness, testCase conformanceCase) {
 	if _, err := h.client.Files.Upload(context.Background(), files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.PathFileName)),
-		Bytes:       []byte(request.ContentUTF8),
+		Content:     []byte(request.ContentUTF8),
 		Actor:       &request.Actor,
 		CommitID:    loonfs.CommitID("conf-inode-mutations-path-file"),
 	}); err != nil {
@@ -1184,7 +1184,7 @@ func runInodeMutations(t *testing.T, h *harness, testCase conformanceCase) {
 		t.Errorf("revised revision_no = %d, want %d", revised.RevisionNo, expected.RevisedRevisionNo)
 	}
 	readback := downloadFile(t, h.client, request.NamespaceID, childPath(request.InodeFileName))
-	if !bytes.Equal(readback.Bytes, []byte(request.RevisedContentUTF8)) {
+	if !bytes.Equal(readback.Content, []byte(request.RevisedContentUTF8)) {
 		t.Error("inode-addressed revision readback did not match the revised payload")
 	}
 	staleGeneration := optionalString(revised.BindingGeneration)
@@ -1344,10 +1344,10 @@ func stageContent(
 	); err != nil {
 		t.Fatalf("stage upload content: %v", err)
 	}
-	completed, err := sdk.Uploads.Complete(context.Background(), &loonfs.CompleteUploadBody{
+	completed, err := sdk.Uploads.Complete(context.Background(), &loonfs.CompleteUploadRequest{
 		NamespaceID: namespaceID,
 		UploadID:    uploadID,
-		Body: &loonfs.CompleteUploadRequest{
+		Body: &loonfs.UploadCompletion{
 			ServiceProxied: &loonfs.CompleteUploadServiceProxied{},
 		},
 	})
@@ -1416,7 +1416,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	_, err := h.client.Files.Upload(ctx, files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.ReplacedFileName)),
-		Bytes:       []byte(request.CapturedContentUTF8),
+		Content:     []byte(request.CapturedContentUTF8),
 		Actor:       &request.Actor,
 		CommitID:    loonfs.CommitID("conf-snapshots-create-replaced"),
 	})
@@ -1426,7 +1426,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	_, err = h.client.Files.Upload(ctx, files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.DeletedFileName)),
-		Bytes:       []byte(request.DeletedContentUTF8),
+		Content:     []byte(request.DeletedContentUTF8),
 		Actor:       &request.Actor,
 		CommitID:    loonfs.CommitID("conf-snapshots-create-deleted"),
 	})
@@ -1459,7 +1459,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	_, err = h.client.Files.Upload(ctx, files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.ReplacedFileName)),
-		Bytes:       []byte(request.CurrentContentUTF8),
+		Content:     []byte(request.CurrentContentUTF8),
 		Actor:       &request.Actor,
 		CommitID:    loonfs.CommitID("conf-snapshots-replace-file"),
 		Behavior:    replace,
@@ -1470,7 +1470,7 @@ func runSnapshots(t *testing.T, h *harness, testCase conformanceCase) {
 	_, err = h.client.Files.Upload(ctx, files.UploadInput{
 		NamespaceID: loonfs.NamespaceID(request.NamespaceID),
 		Path:        loonfs.AbsolutePath(childPath(request.AddedFileName)),
-		Bytes:       []byte(request.AddedContentUTF8),
+		Content:     []byte(request.AddedContentUTF8),
 		Actor:       &request.Actor,
 		CommitID:    loonfs.CommitID("conf-snapshots-add-file"),
 	})
@@ -1951,7 +1951,7 @@ func runProxy(t *testing.T, h *harness, testCase conformanceCase) {
 		proxyServer.Client(),
 		namespaceAliasBaseURL,
 		proxiedUploadID,
-		&loonfs.CompleteUploadRequest{
+		&loonfs.UploadCompletion{
 			ServiceProxied: &loonfs.CompleteUploadServiceProxied{},
 		},
 	)
@@ -1991,7 +1991,7 @@ func runProxy(t *testing.T, h *harness, testCase conformanceCase) {
 		proxyServer.Client(),
 		namespaceAliasBaseURL,
 		directUploadID,
-		&loonfs.CompleteUploadRequest{
+		&loonfs.UploadCompletion{
 			DirectPut: &loonfs.CompleteUploadDirectPut{Content: directClaim},
 		},
 	)
@@ -2081,7 +2081,7 @@ func proxyCompleteUpload(
 	httpClient *http.Client,
 	namespaceAliasBaseURL string,
 	uploadID string,
-	request *loonfs.CompleteUploadRequest,
+	request *loonfs.UploadCompletion,
 ) *loonfs.UploadSession {
 	t.Helper()
 	return proxyJSONRequest[loonfs.UploadSession](

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -29,9 +29,6 @@ from loonfs.server import (
     BeginUploadResponse_ServiceProxied,
     Checksum,
     CommitResponse,
-    CompleteUploadRequest_DirectMultipart,
-    CompleteUploadRequest_DirectPut,
-    CompleteUploadRequest_ServiceProxied,
     CompletedUploadPart,
     ConflictError,
     FilesystemOperation_CreateDirectory,
@@ -50,8 +47,11 @@ from loonfs.server import (
     PathEntry,
     PathEntry_File,
     UnauthorizedError,
-    UploadContentResponse,
+    UploadCompletion_DirectMultipart,
+    UploadCompletion_DirectPut,
+    UploadCompletion_ServiceProxied,
     UploadContentClaim,
+    UploadContentResponse,
     UploadPartChecksumClaim,
     UploadSession,
     UploadSession_Aborted,
@@ -580,7 +580,7 @@ def _stage_content(
         client.uploads.complete(
             namespace_id,
             begin.upload_id,
-            request=CompleteUploadRequest_ServiceProxied(),
+            request=UploadCompletion_ServiceProxied(),
         )
     )
 
@@ -1475,7 +1475,7 @@ def test_upload_direct_put(cases: dict[str, ConformanceCase], harness: Harness) 
     completed = harness.client.uploads.complete(
         request.namespace_id,
         begin.upload_id,
-        request=CompleteUploadRequest_DirectPut(content=claim),
+        request=UploadCompletion_DirectPut(content=claim),
     )
     completed = _completed_upload(completed)
     content_ref = completed.content_ref
@@ -1555,7 +1555,7 @@ def test_upload_multipart(cases: dict[str, ConformanceCase], harness: Harness) -
         )
     completed_parts.sort(key=lambda part: part.part_number)
     whole_checksum = _checksum(begin.checksum_algorithm, payload)
-    completion_request = CompleteUploadRequest_DirectMultipart(
+    completion_request = UploadCompletion_DirectMultipart(
         content=UploadContentClaim(
             size_bytes=len(payload),
             checksum=whole_checksum,

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -870,7 +870,7 @@ async function assertBrowserTransfer(
     const committed = await client.files.upload({
         namespace_alias: namespaceAlias,
         path,
-        bytes,
+        content: bytes,
         actor,
         commit_id: commitId,
     });
@@ -880,7 +880,7 @@ async function assertBrowserTransfer(
         namespace_alias: namespaceAlias,
         path,
     });
-    assert.deepEqual(readback.bytes, bytes);
+    assert.deepEqual(readback.content, bytes);
     assert.equal(readback.content_ref.size_bytes, bytes.byteLength);
     const contentChecksum = readback.content_ref.checksum;
     if (contentChecksum !== undefined) {
@@ -1141,8 +1141,8 @@ if (environmentSkip === undefined) {
     const token = requiredEnvironment("LOONFS_CONFORMANCE_TOKEN");
     cases = loadCases(requiredEnvironment("LOONFS_CONFORMANCE_CASES"));
     harness = {
-        client: new LoonFSClient({ environment: configuredBaseUrl, token }),
-        unauthenticated: new LoonFSClient({ environment: configuredBaseUrl, token, auth: false }),
+        client: new LoonFSClient({ baseUrl: configuredBaseUrl, token }),
+        unauthenticated: new LoonFSClient({ baseUrl: configuredBaseUrl, token, auth: false }),
         serverBaseUrl: configuredBaseUrl,
         token,
     };
@@ -1403,7 +1403,7 @@ conformanceTest("inode_mutations", async (activeHarness, testCase) => {
     await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.path_file_name),
-        bytes: new TextEncoder().encode(request.content_utf8),
+        content: new TextEncoder().encode(request.content_utf8),
         actor: request.actor,
         commit_id: "conf-inode-mutations-path-file",
     });
@@ -1618,14 +1618,14 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.replaced_file_name),
-        bytes: capturedBytes,
+        content: capturedBytes,
         actor: request.actor,
         commit_id: "conf-snapshots-create-replaced",
     });
     await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.deleted_file_name),
-        bytes: new TextEncoder().encode(request.deleted_content_utf8),
+        content: new TextEncoder().encode(request.deleted_content_utf8),
         actor: request.actor,
         commit_id: "conf-snapshots-create-deleted",
     });
@@ -1643,7 +1643,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.replaced_file_name),
-        bytes: currentBytes,
+        content: currentBytes,
         actor: request.actor,
         commit_id: "conf-snapshots-replace-file",
         behavior: "replace",
@@ -1651,7 +1651,7 @@ conformanceTest("snapshots", async (activeHarness, testCase) => {
     await client.files.upload({
         namespace_id: namespaceId,
         path: childPath(request.added_file_name),
-        bytes: new TextEncoder().encode(request.added_content_utf8),
+        content: new TextEncoder().encode(request.added_content_utf8),
         actor: request.actor,
         commit_id: "conf-snapshots-add-file",
     });
@@ -1991,7 +1991,7 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     assert.equal((await disallowedRoute.arrayBuffer()).byteLength, 0);
 
     beginModes.length = 0;
-    const browserClient = new BrowserLoonFSClient({ environment: proxy.baseUrl });
+    const browserClient = new BrowserLoonFSClient({ baseUrl: proxy.baseUrl });
     const browserPath = `${request.proxied_path}-browser`;
     await assertBrowserTransfer(
         browserClient,
@@ -2042,7 +2042,7 @@ test("proxy", { skip: environmentSkip }, async (context) => {
         browserClient.files.upload({
             namespace_alias: request.unknown_namespace_alias,
             path: `${request.proxied_path}-browser-failure`,
-            bytes: payload,
+            content: payload,
             actor: request.actor,
             commit_id: `${request.commit_ids.proxied}-browser-failure`,
         }),
@@ -2182,7 +2182,7 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     }
     completedParts.sort((left, right) => left.part_number - right.part_number);
     const wholeChecksum = checksum(multipart.checksum_algorithm, payload);
-    const completion: LoonFS.CompleteUploadRequest = {
+    const completion: LoonFS.UploadCompletion = {
         mode: "direct_multipart",
         content: {
             size_bytes: payload.byteLength,
@@ -2235,7 +2235,7 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
     const helperCommit = await activeHarness.client.files.upload({
         namespace_id: request.namespace_id,
         path: helperPath,
-        bytes: payload,
+        content: payload,
         actor: request.actor,
         commit_id: `${request.commit_id}-helper`,
     });
@@ -2244,7 +2244,7 @@ conformanceTest("upload_multipart", async (activeHarness, testCase) => {
         namespace_id: request.namespace_id,
         path: helperPath,
     });
-    assert.deepEqual(helperRead.bytes, payload);
+    assert.deepEqual(helperRead.content, payload);
     // Content ids are random per upload and the helper may choose a different
     // checksum algorithm; the comparable content fact is the size.
     assert.equal(helperRead.content_ref.size_bytes, first.content_ref.size_bytes);
@@ -2282,7 +2282,7 @@ conformanceTest("download", async (activeHarness, testCase) => {
     const committed = await activeHarness.client.files.upload({
         namespace_id: request.namespace_id,
         path: request.path,
-        bytes: payload,
+        content: payload,
         actor: request.actor,
         commit_id: request.commit_id,
     });
@@ -2300,12 +2300,12 @@ conformanceTest("download", async (activeHarness, testCase) => {
     assert.deepEqual(stat.content_ref, download.content_ref);
     assert.equal(download.content_ref.size_bytes, expected.size_bytes);
     assert.equal(download.content_ref.checksum.algorithm, expected.checksum_algorithm);
-    assert.equal(download.bytes.byteLength, download.content_ref.size_bytes);
+    assert.equal(download.content.byteLength, download.content_ref.size_bytes);
     assert.deepEqual(
-        checksum(download.content_ref.checksum.algorithm, download.bytes),
+        checksum(download.content_ref.checksum.algorithm, download.content),
         download.content_ref.checksum,
     );
-    assert.deepEqual(download.bytes, payload);
+    assert.deepEqual(download.content, payload);
 });
 
 conformanceTest("end_to_end", async (activeHarness, testCase) => {
@@ -2325,7 +2325,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
     const upload = await activeHarness.client.files.upload({
         namespace_id: request.namespace_id,
         path: request.upload_path,
-        bytes: payload,
+        content: payload,
         actor: request.actor,
         commit_id: request.commit_ids.upload,
     });
@@ -2349,7 +2349,7 @@ conformanceTest("end_to_end", async (activeHarness, testCase) => {
         namespace_id: request.namespace_id,
         path: request.upload_path,
     });
-    assert.deepEqual(downloaded.bytes, payload);
+    assert.deepEqual(downloaded.content, payload);
 
     const moved = await activeHarness.client.commits.create(
         moveCommit(

--- a/sdk/overlays/go/README.md
+++ b/sdk/overlays/go/README.md
@@ -1,6 +1,6 @@
 # LoonFS Go SDK
 
-One module for LoonFS server and proxy applications. SDK v0.1.x targets LoonFS
+One module for LoonFS server and proxy applications. SDK v0.2.x targets LoonFS
 API v0.3.x.
 
 ## Install

--- a/sdk/overlays/python/README.md
+++ b/sdk/overlays/python/README.md
@@ -1,6 +1,6 @@
 # LoonFS Python SDK
 
-One package for LoonFS server and proxy applications. SDK v0.1.x targets LoonFS
+One package for LoonFS server and proxy applications. SDK v0.2.x targets LoonFS
 API v0.3.x.
 
 ## Install

--- a/sdk/transfers/go/files/transfers.go
+++ b/sdk/transfers/go/files/transfers.go
@@ -46,7 +46,7 @@ var (
 type UploadInput struct {
 	NamespaceID        loonfs.NamespaceID
 	Path               loonfs.AbsolutePath
-	Bytes              []byte
+	Content            []byte
 	Actor              *loonfs.ActorRef
 	CommitID           loonfs.CommitID
 	Message            *string
@@ -71,7 +71,7 @@ type DownloadInput struct {
 
 // DownloadResult contains file bytes and the resolved revision facts.
 type DownloadResult struct {
-	Bytes       []byte
+	Content     []byte
 	NamespaceID loonfs.NamespaceID
 	Path        loonfs.AbsolutePath
 	RevisionNo  loonfs.RevisionNo
@@ -95,7 +95,7 @@ func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, err
 	if err != nil {
 		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
 	}
-	createRequest, err := createUploadRequest(capabilities, in.NamespaceID, int64(len(in.Bytes)))
+	createRequest, err := createUploadRequest(capabilities, in.NamespaceID, int64(len(in.Content)))
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, err
 		return nil, fmt.Errorf("transfers: begin upload: %w", err)
 	}
 
-	completed, err := transferAndComplete(ctx, uploadsClient, in.NamespaceID, in.Bytes, begin)
+	completed, err := transferAndComplete(ctx, uploadsClient, in.NamespaceID, in.Content, begin)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (c *Client) Download(ctx context.Context, in DownloadInput) (*DownloadResul
 	}
 
 	return &DownloadResult{
-		Bytes:       payload,
+		Content:     payload,
 		NamespaceID: grant.NamespaceID,
 		Path:        grant.Path,
 		RevisionNo:  grant.RevisionNo,
@@ -271,7 +271,7 @@ func downloadProxied(ctx context.Context, c *Client, in DownloadInput) (*Downloa
 	}
 
 	return &DownloadResult{
-		Bytes:       payload,
+		Content:     payload,
 		NamespaceID: in.NamespaceID,
 		Path:        in.Path,
 		RevisionNo:  *revisionNo,
@@ -369,10 +369,10 @@ func transferDirectPut(
 		Checksum:  checksum,
 		SizeBytes: int64(len(payload)),
 	}
-	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadBody{
+	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadRequest{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
-		Body: &loonfs.CompleteUploadRequest{
+		Body: &loonfs.UploadCompletion{
 			DirectPut: &loonfs.CompleteUploadDirectPut{Content: content},
 		},
 	})
@@ -457,10 +457,10 @@ func transferDirectMultipart(
 		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: checksum multipart payload: %w", err)
 	}
-	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadBody{
+	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadRequest{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
-		Body: &loonfs.CompleteUploadRequest{
+		Body: &loonfs.UploadCompletion{
 			DirectMultipart: &loonfs.CompleteUploadDirectMultipart{
 				Content: &loonfs.UploadContentClaim{
 					Checksum:  wholeChecksum,
@@ -493,10 +493,10 @@ func transferServiceProxied(
 		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
 		return nil, fmt.Errorf("transfers: upload proxied content: %w", err)
 	}
-	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadBody{
+	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadRequest{
 		NamespaceID: string(namespaceID),
 		UploadID:    string(begin.UploadID),
-		Body: &loonfs.CompleteUploadRequest{
+		Body: &loonfs.UploadCompletion{
 			ServiceProxied: &loonfs.CompleteUploadServiceProxied{},
 		},
 	})

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -20,15 +20,15 @@ from .types import (
     BeginUploadRequest_DirectPut,
     BeginUploadRequest_ServiceProxied,
     Checksum,
-    CompleteUploadRequest_DirectMultipart,
-    CompleteUploadRequest_DirectPut,
-    CompleteUploadRequest_ServiceProxied,
     CompletedUploadPart,
     ContentRef,
     DestinationBehavior,
     FilesystemOperation_PutFile,
     ObjectTransferAccess,
     RevisionNo,
+    UploadCompletion_DirectMultipart,
+    UploadCompletion_DirectPut,
+    UploadCompletion_ServiceProxied,
     UploadContentClaim,
     UploadPartChecksumClaim,
     UploadSession,
@@ -305,7 +305,7 @@ def _stage_upload(
             completion = client.uploads.complete(
                 namespace_id,
                 begin.upload_id,
-                request=CompleteUploadRequest_ServiceProxied(),
+                request=UploadCompletion_ServiceProxied(),
             )
         except Exception:
             _abort_quietly(client, namespace_id, begin.upload_id)
@@ -325,7 +325,7 @@ def _stage_upload(
         completion = client.uploads.complete(
             namespace_id,
             begin.upload_id,
-            request=CompleteUploadRequest_DirectPut(
+            request=UploadCompletion_DirectPut(
                 content=UploadContentClaim(
                     size_bytes=len(content),
                     checksum=_checksum(begin.checksum_algorithm, content),
@@ -406,7 +406,7 @@ def _stage_multipart(
     completion = client.uploads.complete(
         namespace_id,
         upload_id,
-        request=CompleteUploadRequest_DirectMultipart(
+        request=UploadCompletion_DirectMultipart(
             content=UploadContentClaim(
                 size_bytes=len(content),
                 checksum=_checksum(checksum_algorithm, content),

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -1,5 +1,6 @@
 import { LoonFSClient as GeneratedLoonFSClient } from "./Client.js";
 import { FilesClient as GeneratedFilesClient } from "./api/resources/files/client/Client.js";
+import * as core from "./core/index.js";
 import type * as LoonFS from "./api/index.js";
 
 const DIRECT_GET_FEATURE = "core.downloads.direct_get";
@@ -21,7 +22,7 @@ const CRC64_NVME_TABLE = makeCrc64NvmeTable();
 export interface FileUploadInput {
     namespace_alias: string;
     path: LoonFS.AbsolutePath;
-    bytes: Uint8Array;
+    content: Uint8Array;
     actor: LoonFS.ActorRef;
     commit_id: LoonFS.CommitId;
     message?: string | null;
@@ -46,7 +47,7 @@ export interface FileDownloadResult {
     path: LoonFS.AbsolutePath;
     revision_no: LoonFS.RevisionNo;
     content_ref: LoonFS.ContentRef;
-    bytes: Uint8Array;
+    content: Uint8Array;
 }
 
 interface StagedContent {
@@ -57,6 +58,20 @@ interface StagedContent {
 interface DirectPutBody {
     body: ArrayBuffer;
     content: LoonFS.UploadContentClaim;
+}
+
+export declare namespace LoonFSClient {
+    /** The generated client options with `baseUrl` in place of `environment`. */
+    export type Options = Omit<GeneratedLoonFSClient.Options, "environment"> & {
+        /** Origin of the LoonFS proxy. */
+        baseUrl: core.Supplier<string>;
+    };
+    export interface RequestOptions extends GeneratedLoonFSClient.RequestOptions {}
+}
+
+export declare namespace FilesClient {
+    export type Options = GeneratedFilesClient.Options;
+    export interface RequestOptions extends GeneratedFilesClient.RequestOptions {}
 }
 
 /** The files group plus whole-file transfers. */
@@ -70,7 +85,7 @@ export class FilesClient extends GeneratedFilesClient {
 
     /** Uploads in-memory bytes and commits them at one path. Streaming and resume are follow-ups. */
     public async upload(input: FileUploadInput): Promise<FileUploadResult> {
-        const staged = await stageBytes(this.root, input.namespace_alias, input.bytes);
+        const staged = await stageBytes(this.root, input.namespace_alias, input.content);
         const request: LoonFS.CommitRequest = {
             namespace_alias: input.namespace_alias,
             actor: input.actor,
@@ -121,7 +136,7 @@ export class FilesClient extends GeneratedFilesClient {
             path: grant.path,
             revision_no: grant.revision_no,
             content_ref: grant.content_ref,
-            bytes,
+            content: bytes,
         };
     }
 }
@@ -129,6 +144,10 @@ export class FilesClient extends GeneratedFilesClient {
 /** The generated client with `files.upload` and `files.download`. */
 export class LoonFSClient extends GeneratedLoonFSClient {
     private _transferFiles: FilesClient | undefined;
+
+    constructor(options: LoonFSClient.Options) {
+        super({ ...options, environment: options.baseUrl });
+    }
 
     public override get files(): FilesClient {
         return (this._transferFiles ??= new FilesClient(this._options, this));
@@ -182,7 +201,13 @@ async function downloadProxied(
     if (actual.value !== claim.checksum.value) {
         throw new Error(`proxied read checksum did not match ${claim.checksum.algorithm} claim`);
     }
-    return { namespace_alias: input.namespace_alias, path: input.path, revision_no: revisionNo, content_ref: claim, bytes };
+    return {
+        namespace_alias: input.namespace_alias,
+        path: input.path,
+        revision_no: revisionNo,
+        content_ref: claim,
+        content: bytes,
+    };
 }
 
 async function stageBytes(

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -1,5 +1,6 @@
 import { LoonFSClient as GeneratedLoonFSClient } from "./Client.js";
 import { FilesClient as GeneratedFilesClient } from "./api/resources/files/client/Client.js";
+import * as core from "./core/index.js";
 import type * as LoonFS from "./api/index.js";
 
 const DIRECT_GET_FEATURE = "core.downloads.direct_get";
@@ -18,7 +19,7 @@ const CRC64_NVME_TABLE = makeCrc64NvmeTable();
 export interface FileUploadInput {
     namespace_id: LoonFS.NamespaceId;
     path: LoonFS.AbsolutePath;
-    bytes: Uint8Array;
+    content: Uint8Array;
     actor: LoonFS.ActorRef;
     commit_id: LoonFS.CommitId;
     message?: string | null;
@@ -44,7 +45,7 @@ export interface FileDownloadResult {
     path: LoonFS.AbsolutePath;
     revision_no: LoonFS.RevisionNo;
     content_ref: LoonFS.ContentRef;
-    bytes: Uint8Array;
+    content: Uint8Array;
 }
 
 interface StagedContent {
@@ -55,6 +56,20 @@ interface StagedContent {
 interface DirectPutBody {
     body: ArrayBuffer;
     content: LoonFS.UploadContentClaim;
+}
+
+export declare namespace LoonFSClient {
+    /** The generated client options with `baseUrl` in place of `environment`. */
+    export type Options = Omit<GeneratedLoonFSClient.Options, "environment"> & {
+        /** Base URL of the LoonFS server. */
+        baseUrl: core.Supplier<string>;
+    };
+    export interface RequestOptions extends GeneratedLoonFSClient.RequestOptions {}
+}
+
+export declare namespace FilesClient {
+    export type Options = GeneratedFilesClient.Options;
+    export interface RequestOptions extends GeneratedFilesClient.RequestOptions {}
 }
 
 /** The files group plus whole-file transfers. */
@@ -68,7 +83,7 @@ export class FilesClient extends GeneratedFilesClient {
 
     /** Uploads in-memory bytes and commits them at one path. Streaming and resume are follow-ups. */
     public async upload(input: FileUploadInput): Promise<FileUploadResult> {
-        const staged = await stageBytes(this.root, input.namespace_id, input.bytes);
+        const staged = await stageBytes(this.root, input.namespace_id, input.content);
         const request: LoonFS.CommitRequest = {
             namespace_id: input.namespace_id,
             actor: input.actor,
@@ -120,7 +135,7 @@ export class FilesClient extends GeneratedFilesClient {
             path: grant.path,
             revision_no: grant.revision_no,
             content_ref: grant.content_ref,
-            bytes,
+            content: bytes,
         };
     }
 }
@@ -128,6 +143,10 @@ export class FilesClient extends GeneratedFilesClient {
 /** The generated client with `files.upload` and `files.download`. */
 export class LoonFSClient extends GeneratedLoonFSClient {
     private _transferFiles: FilesClient | undefined;
+
+    constructor(options: LoonFSClient.Options) {
+        super({ ...options, environment: options.baseUrl });
+    }
 
     public override get files(): FilesClient {
         return (this._transferFiles ??= new FilesClient(this._options, this));
@@ -181,7 +200,13 @@ async function downloadProxied(
     if (actual.value !== claim.checksum.value) {
         throw new Error(`proxied read checksum did not match ${claim.checksum.algorithm} claim`);
     }
-    return { namespace_id: input.namespace_id, path: input.path, revision_no: revisionNo, content_ref: claim, bytes };
+    return {
+        namespace_id: input.namespace_id,
+        path: input.path,
+        revision_no: revisionNo,
+        content_ref: claim,
+        content: bytes,
+    };
 }
 
 async function stageBytes(


### PR DESCRIPTION
Bundle of breaking changes before the SDKs go to 0.2.0. The `ApiError` schema is renamed `ErrorResponse` because it collided with the exception class in Python and Go (the Python entry point now exports the exception under that name); `SnapshotSummary` becomes `Snapshot`; the upload completion body becomes `UploadCompletion` so its request wrapper can take the `CompleteUploadRequest` name. The transfer payload field is `content` in every language instead of `bytes` in two of them; the TypeScript client takes `baseUrl` like the other two SDKs instead of Fern's `environment`,