### PR TITLE
docs(specs): correct namespace and metadata descriptions

### DIFF
--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -12,7 +12,7 @@ use super::cache::{
 };
 use super::error::ManifestLoadError;
 use super::runs::{
-    runs_in_materialization_order, runs_in_scan_order, MetadataRunManifest,
+    runs_in_materialization_order, runs_in_reorganization_order, MetadataRunManifest,
     CHECKPOINT_DELTA_RUN_LEVEL, REORGANIZE_FAMILY_GROUPS,
 };
 use super::scan::{ordered_manifest_segments, VerifiedMetadataSegments};
@@ -278,7 +278,7 @@ pub(crate) async fn load_verified_manifest_segments_with_cache<'a, S: ObjectStor
         validate_manifest_run_identity(&manifest_key, &manifest.payload)?;
         validate_manifest_materialization_ranges(&manifest_key, &manifest.payload)?;
         validate_manifest_segment_descriptors(&manifest_key, &manifest)?;
-        let scan_runs = Arc::new(runs_in_scan_order(&manifest.payload));
+        let scan_runs = Arc::new(runs_in_reorganization_order(&manifest.payload));
         Ok(DecodedMetadataSegmentBlock::Manifest {
             manifest: Arc::new(manifest),
             scan_runs,

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -150,15 +150,16 @@ pub(super) fn delta_run_count(payload: &NamespaceManifestPayload) -> usize {
         .count()
 }
 
-/// Newest run first: delta runs before base runs, later sequences before
-/// earlier ones. A read takes the first row it finds for a key, so this
-/// order is what makes the newest write win.
+/// Orders runs for reorganization planning: delta runs before base runs,
+/// later sequences before earlier ones, and later run numbers first.
 ///
 /// Two runs may carry the same sequence and level, because a reorganization
 /// writes its output beside the runs it did not consume. They hold different
-/// families in that case, so no read compares them, and the later-allocated
-/// run number breaks the tie to keep the order total.
-pub(super) fn runs_in_scan_order(payload: &NamespaceManifestPayload) -> Vec<MetadataRunManifest> {
+/// families in that case, and the later-allocated run number keeps the order
+/// total.
+pub(super) fn runs_in_reorganization_order(
+    payload: &NamespaceManifestPayload,
+) -> Vec<MetadataRunManifest> {
     let mut runs = runs_from_segments(payload);
     runs.sort_by(|left, right| {
         left.level
@@ -170,7 +171,7 @@ pub(super) fn runs_in_scan_order(payload: &NamespaceManifestPayload) -> Vec<Meta
 }
 
 /// Oldest run first, which is the order a materialization applies rows in.
-/// It is the reverse of the scan order, down to the same tiebreak.
+/// It is the reverse of the reorganization order, down to the same tiebreak.
 pub(super) fn runs_in_materialization_order(
     payload: &NamespaceManifestPayload,
 ) -> Vec<MetadataRunManifest> {

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -41,9 +41,9 @@ pub(crate) struct VerifiedMetadataSegments<'a, S: ObjectStore + ?Sized> {
     pub(super) segment_cache: Option<&'a MetadataSegmentCache>,
     pub(super) manifest_object_key: String,
     pub(super) manifest: Arc<NamespaceManifestEnvelope>,
-    /// The manifest's runs in scan order, derived once at load validation
-    /// and shared through the manifest cache entry. A run list is immutable
-    /// per manifest object; scans must not regroup it per page.
+    /// The manifest's runs, grouped once during load validation and shared
+    /// through the manifest cache entry. Scans merge globally unique row keys
+    /// and do not depend on this order.
     pub(super) scan_runs: Arc<Vec<MetadataRunManifest>>,
     /// Per-view memo of decoded blocks: one operation never re-fetches a
     /// block it already saw, with or without a shared cache attached.

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -267,8 +267,8 @@ async fn cached_manifest_carries_its_scan_order_runs() {
     );
     assert_eq!(
         *first.scan_runs,
-        runs_in_scan_order(&first.manifest().payload),
-        "the cached run list must equal the manifest's scan-order grouping"
+        runs_in_reorganization_order(&first.manifest().payload),
+        "the cached run list must equal the manifest's reorganization-order grouping"
     );
     assert!(
         Arc::ptr_eq(&first.scan_runs, &second.scan_runs),

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -33,10 +33,10 @@ use super::record::load_checkpoint_record;
 use super::retention::advance_retention_floor;
 use super::row::{manifest_rows_for_family, metadata_states_equivalent};
 use super::runs::{
-    flatten_manifest_segments, runs_from_segments, runs_in_scan_order, MetadataFamilyGroup,
-    MetadataFamilySegments, MetadataLsmPolicy, MetadataRunManifest, CHECKPOINT_BASE_RUN_LEVEL,
-    CHECKPOINT_DELTA_RUN_LEVEL, CHECKPOINT_ROW_FAMILIES, DEFAULT_MAX_CHECKPOINT_DELTA_RUNS,
-    REORGANIZE_FAMILY_GROUPS,
+    flatten_manifest_segments, runs_from_segments, runs_in_reorganization_order,
+    MetadataFamilyGroup, MetadataFamilySegments, MetadataLsmPolicy, MetadataRunManifest,
+    CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_DELTA_RUN_LEVEL, CHECKPOINT_ROW_FAMILIES,
+    DEFAULT_MAX_CHECKPOINT_DELTA_RUNS, REORGANIZE_FAMILY_GROUPS,
 };
 use super::stored_block_cache::{
     StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind,

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -518,7 +518,7 @@ async fn policy_that_starves_the_group<S: ObjectStore + ?Sized>(
     group: MetadataFamilyGroup,
 ) -> MetadataLsmPolicy {
     let segments = load_current_manifest_segments(store, namespace_id).await;
-    let base_rows: u64 = runs_in_scan_order(&segments.manifest().payload)
+    let base_rows: u64 = runs_in_reorganization_order(&segments.manifest().payload)
         .iter()
         .filter(|run| run.level == CHECKPOINT_BASE_RUN_LEVEL)
         .flat_map(|run| run.segments.iter())
@@ -567,7 +567,7 @@ fn snapshot_runs_for_group(
     manifest: &NamespaceManifestEnvelope,
     group: MetadataFamilyGroup,
 ) -> Vec<MetadataRunManifest> {
-    runs_in_scan_order(&manifest.payload)
+    runs_in_reorganization_order(&manifest.payload)
         .into_iter()
         .filter(|run| {
             run.segments.iter().any(|family_segments| {

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -145,20 +145,17 @@ pub(super) enum NamespaceHeadInstall {
     Deleted,
 }
 
-/// Publishes a complete namespace head as the namespace's one and only
-/// installation write.
+/// Installs a complete namespace head with one conditional create.
 ///
-/// Conditional creation is the whole protocol: exactly one attempt can win,
-/// and the loser reads the head back to say what it lost to — an existing
-/// namespace or a deletion tombstone. There is no third answer, because
-/// there is no state between absent and complete.
+/// A confirmed precondition failure is a plain conflict. The stored head is
+/// read only to distinguish an active namespace from a deleted id.
 ///
-/// The loser is not told whether the winner was its own earlier attempt.
-/// Nothing durable can say: the head's writer block is one writer session,
-/// and a server holds one session across every caller it serves, so
-/// "written by my session" does not mean "written by this attempt". A
-/// caller that wants a retry to succeed asks for that with
-/// `allow_existing`.
+/// A transport failure may leave the write unacknowledged. In that case, the
+/// stored head's immutable `namespace_id`, `content_store_id`, `created_at_ms`,
+/// and `fork_basis` fields decide whether this attempt's write landed. A create
+/// mints a fresh `content_store_id`, so the comparison distinguishes its head
+/// from one installed by a concurrent create even when both use the same writer
+/// session.
 pub(super) async fn install_namespace_head<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/docs/design/metadata-block-storage.md
+++ b/docs/design/metadata-block-storage.md
@@ -65,15 +65,15 @@ a filter fetch pulls the adjacent index block in the same ranged GET,
 and a segment whose whole object costs less to transfer than a second
 round trip is fetched once and decoded section by section.
 
-## Checkpoints and reorganization
+## Flushes and reorganization
 
 The mutation log (WAL) is absorbed into the tree by two separate
 operations, each with its own cost bound.
 
-**Checkpoints append.** A checkpoint folds the WAL tail into one new
+**Flushes append.** A flush folds the WAL tail into one new
 delta run and publishes a manifest referencing every prior run
 unchanged. Its cost is proportional to what changed since the last
-checkpoint, never to namespace size.
+flush, never to namespace size.
 
 **Reorganization folds.** As delta runs accumulate, maintenance merges an
 oldest-first subset of complete runs for one family group, each fold ending
@@ -90,7 +90,7 @@ rows they would need — and the step says so in a warning naming the group,
 the base run's size, and the budget it crossed.
 
 ```
-checkpoints append:          reorganization folds, one group per step:
+flushes append:              reorganization folds, one group per step:
 
   delta run 3 (newest)         bindings:  oldest bounded subset -> base
   delta run 2                  revisions: oldest bounded subset -> base

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -4,7 +4,7 @@ Status: accepted
 
 ## Summary
 
-LoonFS stores namespace metadata in immutable runs. The oldest data is stored in a base run, and checkpoints add newer delta runs. Routine maintenance merges complete runs within a fixed per-step budget, but a family group can eventually become larger than that budget. Once this happens, ordinary maintenance can reduce the number of delta runs but cannot rebuild the base run or apply retention across the complete group.
+LoonFS stores namespace metadata in immutable runs. The oldest data is stored in a base run, and flushes add newer delta runs. Routine maintenance merges complete runs within a fixed per-step budget, but a family group can eventually become larger than that budget. Once this happens, ordinary maintenance can reduce the number of delta runs but cannot rebuild the base run or apply retention across the complete group.
 
 This design adds a background streaming compaction for oversized metadata family groups. The job reads a fixed snapshot of the selected runs and captures a retention floor, which is the sequence number below which obsolete history may be removed. It applies that floor throughout the job, writes output segments under a job-specific prefix, and publishes the result with one manifest update. Readers continue using the existing manifest until that final update succeeds.
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2211,6 +2211,9 @@ Representative complete-upload response:
 {
   "namespace_id": "demo",
   "upload_id": "upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c",
+  "mode": "service_proxied",
+  "status": "completed",
+  "completed_at_ms": 1730000001000,
   "content_ref": {
     "kind": "blob_v1",
     "content_id": "con_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41",

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1164,10 +1164,10 @@ while the session is open, so the session's lease bounds it and a request
 cancelled while holding it costs that session the rest of its lease.
 
 **Direct upload** hands the transfer to the client instead of proxying it. The
-client declares the size and SHA-256 of bytes it already holds; the server
-mints the identity, signs both the digest and a create-only precondition into
-a short-lived write capability, and returns the resulting `content_ref`. A
-client can never name the object it writes to.
+client declares the size and the checksum in the algorithm the begin response
+named; the server mints the identity, signs both the digest and a create-only
+precondition into a short-lived write capability, and returns the resulting
+`content_ref`. A client can never name the object it writes to.
 
 Completion **verifies rather than trusts**. The server issues one
 `HeadObject` with checksum mode enabled and compares the provider's stored
@@ -1480,10 +1480,10 @@ writers.
 A commit request contains an ordered list of operations. Eight use paths:
 
 - `create_directory(path, parents)`
-- `put_file(path, content_ref, behavior, expected_revision_no?)`
+- `put_file(path, content_ref, behavior, expected_inode_id?, expected_revision_no?)`
 - `delete_path(path, behavior, expected_inode_id?)`
-- `move_path(from_path, to_path, behavior)`
-- `copy_path(from_path, to_path, behavior)`
+- `move_path(from_path, to_path, behavior, expected_destination_inode_id?, expected_destination_revision_no?)`
+- `copy_path(from_path, to_path, behavior, expected_destination_inode_id?, expected_destination_revision_no?)`
 - `undelete(inode_id, deletion_seq, path?)`
 - `restore_revision(path, source_revision_no)`
 - `update_attributes(path, set, remove, expected_inode_id?, expected_attributes_revision_no?)`
@@ -1493,12 +1493,12 @@ Five use inode IDs:
 - `create_directory_by_inode(parent_inode_id, display_name)`
 - `put_file_by_inode(parent_inode_id, display_name, content_ref)`
 - `put_file_revision_by_inode(inode_id, content_ref, expected_revision_no)`
-- `move_by_inode(inode_id, expected_binding_generation, to_parent_inode_id, to_display_name, behavior)`
+- `move_by_inode(inode_id, expected_binding_generation, to_parent_inode_id, to_display_name, behavior, expected_destination_inode_id?, expected_destination_revision_no?)`
 - `delete_by_inode(inode_id, expected_binding_generation, behavior)`
 
 Every `path`, `from_path`, and `to_path` is a canonical absolute path (section 2.3). Every `display_name` and `to_display_name` is one path component under the same grammar.
 
-Parameters marked `?` are optional and have no default. The optional `expected_*` parameters prevent races; omitting one disables that check. Inode revision writes require `expected_revision_no`, while inode moves and deletes require `expected_binding_generation`. `undelete.path` overrides the original parent and name and is required when the deletion did not record a binding.
+Parameters marked `?` are optional and have no default. The optional `expected_*` parameters prevent races; omitting one disables that check. A revision guard requires its matching inode guard. Inode revision writes require `expected_revision_no`, while inode moves and deletes require `expected_binding_generation`. `undelete.path` overrides the original parent and name and is required when the deletion did not record a binding.
 
 `parents`, `behavior`, `set`, and `remove` have defaults. `parents` defaults to false. `behavior` defaults to `no_replace` for puts, moves, and copies, and to `non_recursive` for deletes. `set` and `remove` default to empty collections.
 
@@ -1545,9 +1545,8 @@ commit's sequence and its `delta_index`, like every other delta's.
 
 ### 3.6 Preconditions
 
-A commit may include explicit preconditions. Preconditions are how clients
-say, "apply this only if the namespace still looks like the state I planned
-against."
+The server derives each commit precondition from its operation. Callers state
+additional guards through the `expected_*` parameters in section 3.5.
 
 The core kinds of precondition are:
 
@@ -1559,9 +1558,6 @@ The core kinds of precondition are:
 | **Attribute-revision based** | "Write these attributes only if the inode is still at the attribute revision I saw." |
 | **Ancestor-visibility based** | "Apply this only if no ancestor was tombstoned." |
 | **Directory-contents based** | "Delete this directory non-recursively only if it is still empty." |
-
-The exact wire shape of preconditions may vary by transport binding, but the
-semantics must match these checks.
 
 The exact binding precondition is
 `binding_is(parent_inode_id, name_key, child_inode_id, bind_seq, bind_delta_index)`.
@@ -1580,10 +1576,9 @@ consumers.
 The change feed is ordered by logical commit, not by physical WAL segment. A
 segment containing N logical commits produces N ordered change events.
 
-Each change event exposes the commit identity, optional message, and
-materialized WAL deltas keyed by `semantic_op_index` and `delta_index`. These
-deltas are the authoritative metadata facts that replay/projectors should
-apply.
+The feed exposes semantic filesystem events in request order; one request
+operation can produce several events, and their kinds appear in the event
+table in [API spec section 6.11](api.md#611-get-changes).
 
 ### 3.8 Retention floor
 
@@ -1718,15 +1713,13 @@ write the same object under the same conditions.
 The loser reads the head back. An active head means the id is taken and the
 answer is `namespace_exists`; a deleted head answers `namespace_deleted`; a
 head that cannot be decoded is corruption and is reported as such — never
-overwritten, and never taken as an empty slot. There is no fourth answer,
-because there is no state between absent and complete.
+overwritten, and never taken as an empty slot. A confirmed precondition failure
+remains a plain conflict.
 
 The loser is not told whether the winner was its own earlier attempt.
-Nothing durable can say so: the head's writer block names a writer label,
-not an attempt, and a server publishes every caller's work under one label,
-so "written by my writer" does not mean "written by this attempt" — two
-callers of one server would otherwise both be told they created the same
-namespace. An embedded caller that wants a retry after a lost
+Only an unacknowledged write compares the head's immutable `namespace_id`,
+`content_store_id`, `created_at_ms`, and `fork_basis`; matching fields mean this
+attempt's write landed. An embedded caller that wants a retry after a lost
 acknowledgment to succeed asks for that explicitly, with its
 create-if-not-exists option.
 
@@ -1935,10 +1928,7 @@ above the manifest's `next_run_no`, one `run_no` carrying two sequences or two
 levels, a family's `segment_index` values inside one run that are not
 zero-based and dense, and key ranges that descend or overlap.
 
-A read consults the runs holding the family it wants, newest first: delta runs
-before base runs, and within one level, the higher `run_seq` first. The higher
-`run_no` breaks a tie, which keeps the order total. The first row a read finds
-for a key is the answer.
+Every metadata row key identifies exactly one row, so a read merges runs by key and never has to choose between two rows for one key.
 
 ##### Row-key grammar
 
@@ -1996,7 +1986,7 @@ starts without grep state until grep is enabled for the target.
   `manifest_payload_checksum`, which must equal the named manifest envelope's
   own `payload_checksum`.
 
-This is not the namespace manifest reference from section 1.7. A grep manifest has no logical position or head sequence, so the pointer contains only the two fields above.
+This is not the namespace manifest reference from section 1.7. A grep manifest has no logical position or head sequence, so the pointer names its manifest without them.
 
 Each immutable manifest has the same envelope grammar with
 `kind = "grep_manifest"` and `format_version = 1`. Its payload is the full


### PR DESCRIPTION
Corrects specification and design text that no longer matched the implementation. The docs now describe namespace installation conflicts, metadata run ordering, write guards, checksums, change events, and upload responses accurately.

The code change only renames the run-order helper to describe how it is used. Runtime behavior is unchanged.