### PR TITLE
fix(objectstore): bound retries and reduce local storage work

### DIFF
--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -445,9 +445,18 @@ impl LocalFsStore {
             }
         }
 
-        Self::metadata_for_path(key, &path)
-            .await?
-            .ok_or_else(|| ObjectStoreError::transport(key, "object disappeared after write"))
+        let content_digest = sha256_digest(bytes);
+        let metadata = match fs::metadata(&path).await {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(ObjectStoreError::transport(
+                    key,
+                    "object disappeared after write",
+                ));
+            }
+            Err(err) => return Err(io_error(key, err)),
+        };
+        Self::metadata_from_fs_metadata(key, &metadata, &content_digest, &path)
     }
 
     async fn delete_object(&self, key: &str) -> Result<()> {
@@ -588,10 +597,7 @@ async fn list_prefix_for_root(
         return Ok(Vec::new());
     }
 
-    let mut keys = collect_keys(&prefix, root).await?;
-    keys.retain(|key| {
-        key.starts_with(&prefix) && start_after.is_none_or(|start_after| key.as_str() > start_after)
-    });
+    let mut keys = collect_keys(&prefix, start_after, root).await?;
     keys.sort();
     Ok(keys)
 }
@@ -660,7 +666,11 @@ async fn sync_dir_chain(key: &str, path: &Path, root: &Path) -> Result<()> {
     Ok(())
 }
 
-async fn collect_keys(prefix: &str, root: PathBuf) -> Result<Vec<String>> {
+async fn collect_keys(
+    prefix: &str,
+    start_after: Option<&str>,
+    root: PathBuf,
+) -> Result<Vec<String>> {
     let mut keys = Vec::new();
     let mut dirs = vec![root.clone()];
 
@@ -703,12 +713,21 @@ async fn collect_keys(prefix: &str, root: PathBuf) -> Result<Vec<String>> {
                 Err(err) => return Err(io_error(prefix, err)),
             };
             if metadata.is_dir() {
-                dirs.push(path);
+                let mut directory_prefix = relative_key(prefix, &root, &path)?;
+                directory_prefix.push('/');
+                if directory_prefix.starts_with(prefix) || prefix.starts_with(&directory_prefix) {
+                    dirs.push(path);
+                }
                 continue;
             }
 
             if metadata.is_file() {
-                keys.push(relative_key(prefix, &root, &path)?);
+                let key = relative_key(prefix, &root, &path)?;
+                if key.starts_with(prefix)
+                    && start_after.is_none_or(|start_after| key.as_str() > start_after)
+                {
+                    keys.push(key);
+                }
             }
         }
     }

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -499,13 +499,11 @@ pub trait ObjectStore: Send + Sync + Debug {
         start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String>>;
 
-    /// Collects and sorts every key under `prefix`.
+    /// Collects every key under `prefix` in the order returned by the provider.
     ///
     /// The operation fails if prefix validation or any streamed provider page fails.
     async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>> {
-        let mut keys: Vec<String> = self.list_prefix_stream(prefix).try_collect().await?;
-        keys.sort();
-        Ok(keys)
+        self.list_prefix_stream(prefix).try_collect().await
     }
 
     /// Writes bytes unconditionally, replacing any existing object at `key`.

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -524,15 +524,12 @@ async fn sorted_listing(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult 
         )?;
     }
 
-    // The streamed keys are the provider's own answer; `list_prefix` sorts
-    // client-side, so it is the documented convenience rather than evidence
-    // about the provider.
+    // Both listing methods preserve the provider's order.
     let mut streamed = Vec::new();
     let mut stream = store.list_prefix_stream(&prefix);
     while let Some(item) = stream.next().await {
         streamed.push(ok("list", item)?);
     }
-    streamed.sort();
     let listed = ok("list", store.list_prefix(&prefix).await)?;
     if streamed != keys {
         return Err(wrong(format!(

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -48,9 +48,10 @@ pub const PROVIDER_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// Reads apply it through the provider client. Verified immutable writes and
 /// deletes apply it through `TransportRetryPolicy`. A new outer attempt may
-/// start only while time remains. Multipart uploads are excluded because
-/// each part has its own timeout and retry limit. The garbage-collection
-/// grace period is longer than the maximum publication operation.
+/// start only while time remains. Multipart uploads apply it to each control
+/// call and to each part, so one part's outer retries cannot outlast it. The
+/// garbage-collection grace period is longer than the maximum publication
+/// operation.
 pub const PROVIDER_OPERATION_DEADLINE: Duration = Duration::from_secs(120);
 
 /// Minimum payload size for native multipart overwrite uploads.
@@ -274,7 +275,7 @@ impl ProviderObjectStore {
     /// ambiguous transport error, immutable writes verify the stored bytes before
     /// deciding whether the write succeeded.
     ///
-    /// Multipart uploads have per-part limits rather than one total deadline.
+    /// Each control call and each part is bounded by the operation deadline.
     /// Conditional write modes do not use this path.
     async fn put_large_multipart(
         &self,
@@ -443,6 +444,10 @@ struct MultipartWrite<'op> {
 
 impl MultipartWrite<'_> {
     async fn create(&self, payload_bytes: u64) -> Result<AbortUploadOnDrop> {
+        let deadline = OperationDeadline::start(
+            self.store.timer.as_ref(),
+            self.store.transport_retry.operation_deadline,
+        );
         let mut retries: u32 = 0;
         loop {
             let err = match self.multipart.create_multipart(self.path).await {
@@ -464,7 +469,7 @@ impl MultipartWrite<'_> {
                 "create_multipart",
                 payload_bytes,
                 &mut retries,
-                None,
+                Some(&deadline),
             ) else {
                 return Err(map_provider_error(self.key, err));
             };
@@ -590,6 +595,10 @@ impl MultipartWrite<'_> {
         payload: Bytes,
     ) -> Result<PartId> {
         let payload_bytes = payload.len() as u64;
+        let deadline = OperationDeadline::start(
+            self.store.timer.as_ref(),
+            self.store.transport_retry.operation_deadline,
+        );
         let mut retries: u32 = 0;
         loop {
             let err = match self
@@ -614,7 +623,7 @@ impl MultipartWrite<'_> {
                 "put_part",
                 payload_bytes,
                 &mut retries,
-                None,
+                Some(&deadline),
             ) else {
                 return Err(map_provider_error(self.key, err));
             };
@@ -2761,7 +2770,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn multipart_part_retries_are_count_bounded_not_clock_bounded() {
+    async fn multipart_part_retries_stop_once_the_operation_deadline_is_spent() {
         let flaky = Arc::new(FlakyStore::default());
         let store = multipart_test_store(Arc::clone(&flaky))
             .monotonic_timer(Arc::new(SteppingTimer::new(45_000)));
@@ -2770,13 +2779,13 @@ mod tests {
         let error = store
             .put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
             .await
-            .expect_err("persistent part failure surfaces after the retry budget");
+            .expect_err("persistent part failure surfaces after the operation deadline");
 
         assert!(matches!(error, ObjectStoreError::Transport { .. }));
-        assert_eq!(
-            part_attempts(&flaky, 0),
-            5,
-            "1 attempt + max_retries, unaffected by elapsed time"
+        let attempts = part_attempts(&flaky, 0);
+        assert!(
+            attempts < 5,
+            "deadline must stop the loop before the count budget ({attempts} attempts)"
         );
         assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
     }

--- a/crates/loonfs-test-support/src/stores/blocking_store.rs
+++ b/crates/loonfs-test-support/src/stores/blocking_store.rs
@@ -6,9 +6,10 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
+use loonfs_api::Checksum;
 use loonfs_objectstore::{
-    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-    StoredObjectChecksum,
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
+    ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
 };
 use std::fmt;
 use std::pin::pin;
@@ -196,6 +197,32 @@ impl<S: ObjectStore> ObjectStore for BlockingStore<S> {
         let result = self.inner.head(key).await;
         self.mark_completed(blocked);
         result
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
+        self.inner.create_multipart_upload(key).await
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion, ObjectStoreError> {
+        self.inner
+            .complete_multipart_upload(key, provider_upload_id, parts, checksum)
+            .await
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+    ) -> Result<(), ObjectStoreError> {
+        self.inner
+            .abort_multipart_upload(key, provider_upload_id)
+            .await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-test-support/src/stores/buffer_watch_store.rs
+++ b/crates/loonfs-test-support/src/stores/buffer_watch_store.rs
@@ -8,9 +8,10 @@ use super::KeyPredicate;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{BoxStream, StreamExt};
+use loonfs_api::Checksum;
 use loonfs_objectstore::{
-    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-    StoredObjectChecksum,
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
+    ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
 };
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -142,6 +143,32 @@ impl<S: ObjectStore> ObjectStore for BufferWatchStore<S> {
         key: &str,
     ) -> Result<Option<StoredObjectChecksum>, ObjectStoreError> {
         self.inner.head_stored_checksum(key).await
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
+        self.inner.create_multipart_upload(key).await
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion, ObjectStoreError> {
+        self.inner
+            .complete_multipart_upload(key, provider_upload_id, parts, checksum)
+            .await
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+    ) -> Result<(), ObjectStoreError> {
+        self.inner
+            .abort_multipart_upload(key, provider_upload_id)
+            .await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-test-support/src/stores/concurrency_watch_store.rs
+++ b/crates/loonfs-test-support/src/stores/concurrency_watch_store.rs
@@ -16,9 +16,10 @@ use super::KeyPredicate;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use loonfs_api::Checksum;
 use loonfs_objectstore::{
-    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-    StoredObjectChecksum,
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
+    ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -105,6 +106,32 @@ impl<S: ObjectStore> ObjectStore for ConcurrencyWatchStore<S> {
     ) -> Result<Option<StoredObjectChecksum>, ObjectStoreError> {
         let _in_flight = self.enter(key).await;
         self.inner.head_stored_checksum(key).await
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
+        self.inner.create_multipart_upload(key).await
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion, ObjectStoreError> {
+        self.inner
+            .complete_multipart_upload(key, provider_upload_id, parts, checksum)
+            .await
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+    ) -> Result<(), ObjectStoreError> {
+        self.inner
+            .abort_multipart_upload(key, provider_upload_id)
+            .await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-test-support/src/stores/counting_store.rs
+++ b/crates/loonfs-test-support/src/stores/counting_store.rs
@@ -4,9 +4,10 @@ use super::{KeyPredicate, OperationClass};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use loonfs_api::Checksum;
 use loonfs_objectstore::{
-    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-    StoredObjectChecksum,
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
+    ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
 };
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
@@ -191,6 +192,32 @@ impl<S: ObjectStore> ObjectStore for CountingStore<S> {
             self.counters.heads.fetch_add(1, Ordering::SeqCst);
         }
         self.inner.head_stored_checksum(key).await
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
+        self.inner.create_multipart_upload(key).await
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion, ObjectStoreError> {
+        self.inner
+            .complete_multipart_upload(key, provider_upload_id, parts, checksum)
+            .await
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+    ) -> Result<(), ObjectStoreError> {
+        self.inner
+            .abort_multipart_upload(key, provider_upload_id)
+            .await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-test-support/src/stores/fail_store.rs
+++ b/crates/loonfs-test-support/src/stores/fail_store.rs
@@ -4,9 +4,10 @@ use super::{KeyPredicate, OperationClass, OperationContext, OperationKind};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream};
+use loonfs_api::Checksum;
 use loonfs_objectstore::{
-    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-    StoredObjectChecksum,
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
+    ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
 };
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -194,6 +195,32 @@ impl<S: ObjectStore> ObjectStore for FailStore<S> {
         } else {
             result
         }
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
+        self.inner.create_multipart_upload(key).await
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion, ObjectStoreError> {
+        self.inner
+            .complete_multipart_upload(key, provider_upload_id, parts, checksum)
+            .await
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+    ) -> Result<(), ObjectStoreError> {
+        self.inner
+            .abort_multipart_upload(key, provider_upload_id)
+            .await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-test-support/src/stores/metadata_map_store.rs
+++ b/crates/loonfs-test-support/src/stores/metadata_map_store.rs
@@ -4,9 +4,10 @@ use super::KeyPredicate;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use loonfs_api::Checksum;
 use loonfs_objectstore::{
-    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-    StoredObjectChecksum,
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
+    ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
 };
 use std::fmt;
 use std::sync::Arc;
@@ -100,6 +101,32 @@ impl<S: ObjectStore> ObjectStore for MetadataMapStore<S> {
         key: &str,
     ) -> Result<Option<StoredObjectChecksum>, ObjectStoreError> {
         self.inner.head_stored_checksum(key).await
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
+        self.inner.create_multipart_upload(key).await
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion, ObjectStoreError> {
+        self.inner
+            .complete_multipart_upload(key, provider_upload_id, parts, checksum)
+            .await
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+    ) -> Result<(), ObjectStoreError> {
+        self.inner
+            .abort_multipart_upload(key, provider_upload_id)
+            .await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-test-support/src/stores/mod.rs
+++ b/crates/loonfs-test-support/src/stores/mod.rs
@@ -27,8 +27,9 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use futures::TryStreamExt;
+    use loonfs_api::Checksum;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
-    use loonfs_objectstore::ObjectStore;
+    use loonfs_objectstore::{MultipartCompletion, ObjectStore};
 
     #[tokio::test]
     async fn wrappers_preserve_the_start_after_contract() {
@@ -83,5 +84,17 @@ mod tests {
             .await
             .expect("list after end");
         assert!(complete.is_empty());
+
+        let multipart_key = "contract/multipart";
+        let provider_upload_id = store
+            .create_multipart_upload(multipart_key)
+            .await
+            .expect("create multipart upload");
+        let checksum = Checksum::crc64nvme(&[]);
+        let completion = store
+            .complete_multipart_upload(multipart_key, &provider_upload_id, &[], &checksum)
+            .await
+            .expect("complete multipart upload");
+        assert_eq!(completion, MultipartCompletion::Assembled);
     }
 }

--- a/crates/loonfs-test-support/src/stores/recording_store.rs
+++ b/crates/loonfs-test-support/src/stores/recording_store.rs
@@ -4,9 +4,10 @@ use super::KeyPredicate;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use loonfs_api::Checksum;
 use loonfs_objectstore::{
-    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-    StoredObjectChecksum,
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
+    ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
 };
 use std::sync::Mutex;
 
@@ -155,6 +156,32 @@ impl<S: ObjectStore> ObjectStore for RecordingStore<S> {
             key: key.to_owned(),
         });
         self.inner.head_stored_checksum(key).await
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String, ObjectStoreError> {
+        self.inner.create_multipart_upload(key).await
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion, ObjectStoreError> {
+        self.inner
+            .complete_multipart_upload(key, provider_upload_id, parts, checksum)
+            .await
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+    ) -> Result<(), ObjectStoreError> {
+        self.inner
+            .abort_multipart_upload(key, provider_upload_id)
+            .await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {


### PR DESCRIPTION
Bounds outer retries for multipart setup and part uploads with the same operation deadline used elsewhere. Local filesystem writes now hash the supplied bytes directly, and prefix listings avoid walking unrelated directories.

Object listings now preserve provider order so the conformance probe can detect an unsorted provider. Test store wrappers also forward multipart operations instead of reporting them as unsupported. No wire or durable formats change.