### PR TITLE
perf(core): reduce commit-path copying

### DIFF
--- a/crates/loonfs-core/src/commit/metadata_overlay.rs
+++ b/crates/loonfs-core/src/commit/metadata_overlay.rs
@@ -11,15 +11,10 @@ pub(super) struct CommitOverlayRows {
 }
 
 impl CommitOverlayRows {
-    #[cfg(test)]
     pub(super) fn new() -> Self {
         Self {
             rows: MetadataState::default(),
         }
-    }
-
-    pub(super) fn from_rows(rows: &MetadataState) -> Self {
-        Self { rows: rows.clone() }
     }
 
     pub(super) fn rows(&self) -> &MetadataState {

--- a/crates/loonfs-core/src/commit/validate/view.rs
+++ b/crates/loonfs-core/src/commit/validate/view.rs
@@ -7,11 +7,10 @@ use loonfs_api::{ActorRef, ChangeSeq, CommitId};
 use loonfs_objectstore::ObjectStore;
 
 /// The publish view: it holds the loaded [`MetadataView`] plus the
-/// accumulating commit overlay (seeded from the rows already accepted earlier
-/// in the batch), rebuilding an overlaid view for each lookup so object-store
-/// failures surface as [`CoreError`].
+/// accumulating commit overlay, rebuilding an overlaid view for each lookup.
 pub(crate) struct PublishValidationView<'a, S: ObjectStore + ?Sized> {
     base_view: MetadataView<'a, 'a, S>,
+    batch_accepted: &'a MetadataState,
     committed_seq: ChangeSeq,
     overlay: CommitOverlayRows,
 }
@@ -19,13 +18,14 @@ pub(crate) struct PublishValidationView<'a, S: ObjectStore + ?Sized> {
 impl<'a, S: ObjectStore + ?Sized> PublishValidationView<'a, S> {
     pub(crate) fn new(
         base_view: MetadataView<'a, 'a, S>,
-        accepted_rows: &MetadataState,
+        accepted_rows: &'a MetadataState,
         committed_seq: ChangeSeq,
     ) -> Self {
         Self {
             base_view,
+            batch_accepted: accepted_rows,
             committed_seq,
-            overlay: CommitOverlayRows::from_rows(accepted_rows),
+            overlay: CommitOverlayRows::new(),
         }
     }
 
@@ -35,7 +35,7 @@ impl<'a, S: ObjectStore + ?Sized> PublishValidationView<'a, S> {
     /// what its predecessors did.
     pub(crate) fn view(&self) -> MetadataView<'_, 'a, S> {
         self.base_view
-            .with_overlay(self.overlay.rows(), self.committed_seq)
+            .with_overlay(self.overlay.rows(), self.batch_accepted, self.committed_seq)
     }
 }
 

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -115,6 +115,7 @@ impl CommitCandidate {
     pub(crate) fn validate_request_limits(&self) -> Result<()> {
         // Apply limits to the complete request because the serialized publisher
         // processes every operation before releasing the write path.
+        self.validate_request_has_operations()?;
         if self.request.operations.len() > crate::limits::MAX_COMMIT_OPERATIONS {
             return Err(CoreError::InvalidCommitRequest(format!(
                 "mutation has {} operations; maximum is {}",
@@ -153,6 +154,15 @@ impl CommitCandidate {
                 "mutation references {distinct_content_refs} distinct external content refs; maximum is {}",
                 crate::limits::MAX_COMMIT_EXTERNAL_CONTENT_REFS
             )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_request_has_operations(&self) -> Result<()> {
+        if self.request.operations.is_empty() {
+            return Err(CoreError::InvalidCommitRequest(
+                "mutation request carries no operations".to_owned(),
+            ));
         }
         Ok(())
     }
@@ -462,7 +472,7 @@ impl NamespaceCommitEngine {
                     head_etag: projection.head_etag().to_owned(),
                     basis: projection.basis().clone(),
                     manifest_head_seq: projection.manifest_head_seq(),
-                    tail_rows: Arc::new(projection.tail_state.clone()),
+                    tail_rows: Arc::clone(&projection.tail_state),
                 })
             }
             _ => None,
@@ -514,8 +524,9 @@ impl NamespaceCommitEngine {
                     self.invalidate_projection();
                     return wal_tail_segments;
                 };
+                let tail_state = Arc::make_mut(&mut projection.tail_state);
                 for record in &records {
-                    projection.tail_state.apply_committed_wal_record_mut(record);
+                    tail_state.apply_committed_wal_record_mut(record);
                 }
                 projection.reanchor(head.seq, head_etag);
                 if projection.within_limits(tail_options) {

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -70,6 +70,7 @@ pub(crate) struct MetadataSnapshot {
 
 pub(crate) struct MetadataSourceStack<'a, 'store, S: ObjectStore + ?Sized> {
     overlay: Option<&'a MetadataState>,
+    batch_accepted: Option<&'a MetadataState>,
     wal_tail: Option<&'a MetadataState>,
     manifest: Option<&'a VerifiedMetadataSegments<'store, S>>,
     durable_cache: Option<&'a DurableVisibilityCache>,
@@ -110,6 +111,7 @@ impl<'a> InMemoryMetadataView<'a> {
             snapshot: MetadataSnapshot { visible_seq },
             sources: MetadataSourceStack {
                 overlay,
+                batch_accepted: None,
                 wal_tail: Some(base),
                 manifest: None,
                 durable_cache: None,
@@ -130,6 +132,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             },
             sources: MetadataSourceStack {
                 overlay: None,
+                batch_accepted: None,
                 wal_tail: Some(wal_tail_rows),
                 manifest: Some(segments),
                 durable_cache: None,
@@ -152,6 +155,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             },
             sources: MetadataSourceStack {
                 overlay: None,
+                batch_accepted: None,
                 wal_tail: None,
                 manifest: Some(segments),
                 durable_cache: None,
@@ -162,12 +166,14 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     pub(crate) fn with_overlay<'view>(
         &'view self,
         overlay: &'view MetadataState,
+        batch_accepted: &'view MetadataState,
         visible_seq: ChangeSeq,
     ) -> MetadataView<'view, 'store, S> {
         MetadataView {
             snapshot: MetadataSnapshot { visible_seq },
             sources: MetadataSourceStack {
                 overlay: Some(overlay),
+                batch_accepted: Some(batch_accepted),
                 wal_tail: self.sources.wal_tail,
                 manifest: self.sources.manifest,
                 durable_cache: self.sources.durable_cache,
@@ -193,13 +199,19 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     }
 
     pub(super) fn row_states(&self) -> impl Iterator<Item = &'a MetadataState> + '_ {
-        [self.sources.overlay, self.sources.wal_tail]
-            .into_iter()
-            .flatten()
+        [
+            self.sources.overlay,
+            self.sources.batch_accepted,
+            self.sources.wal_tail,
+        ]
+        .into_iter()
+        .flatten()
     }
 
-    fn overlay_state(&self) -> Option<&'a MetadataState> {
-        self.sources.overlay
+    fn overlay_states(&self) -> impl Iterator<Item = &'a MetadataState> + '_ {
+        [self.sources.overlay, self.sources.batch_accepted]
+            .into_iter()
+            .flatten()
     }
 
     fn durable_row_states(&self) -> impl Iterator<Item = &'a MetadataState> + '_ {
@@ -263,8 +275,8 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         inode_id: InodeId,
     ) -> Result<Option<InodeRecord>, CoreError> {
         if let Some(inode) = self
-            .overlay_state()
-            .and_then(|state| state.inode_at_seq(inode_id, self.visible_seq()))
+            .overlay_states()
+            .find_map(|state| state.inode_at_seq(inode_id, self.visible_seq()))
         {
             return Ok(Some(inode));
         }
@@ -600,8 +612,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             durable
         };
         let overlay = self
-            .overlay_state()
-            .into_iter()
+            .overlay_states()
             .flat_map(|state| {
                 state
                     .direntry_binds()
@@ -650,8 +661,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             durable
         };
         let overlay = self
-            .overlay_state()
-            .into_iter()
+            .overlay_states()
             .flat_map(|state| {
                 state
                     .direntry_binds()
@@ -698,8 +708,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             durable
         };
         let overlay = self
-            .overlay_state()
-            .into_iter()
+            .overlay_states()
             .flat_map(|state| {
                 state
                     .direntry_unbinds()
@@ -906,8 +915,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             durable
         };
         let overlay = self
-            .overlay_state()
-            .into_iter()
+            .overlay_states()
             .flat_map(|state| {
                 state
                     .subtree_tombstones()

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -66,11 +66,6 @@ pub(crate) async fn prepare_commit_against_publish_view<S: ObjectStore + ?Sized>
     committed_at_ms: u64,
     allocation: &mut CandidateAllocation,
 ) -> Result<ValidatedCommitPlan> {
-    if request.operations.is_empty() {
-        return Err(CoreError::InvalidCommitRequest(
-            "mutation request carries no operations".to_owned(),
-        ));
-    }
     let committed_seq = next_public_ordinal(head.seq.0)
         .map(ChangeSeq)
         .ok_or_else(|| {
@@ -710,24 +705,5 @@ mod tests {
                 .operation_index,
             Some(1)
         );
-    }
-
-    #[tokio::test]
-    async fn an_empty_request_is_rejected() {
-        let (_temp_dir, store, namespace_id, _context) = setup_namespace().await;
-        let error = try_plan_against_current_state(
-            &store,
-            &namespace_id,
-            &CommitRequest {
-                commit_id: CommitId::parse("empty-request").expect("valid commit id"),
-                actor: loonfs_test_support::test_actor(),
-                message: None,
-                operations: Vec::new(),
-            },
-        )
-        .await
-        .expect_err("an empty request has nothing to commit");
-
-        assert_eq!(error.code(), crate::error::ErrorCode::InvalidRequest);
     }
 }

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -2,9 +2,7 @@
 //! plus one head compare-and-swap, with outcomes fanned back to every
 //! candidate slot.
 
-use super::candidates::{
-    prepare_candidate_request, validate_commit_content_references, BatchDedup, CandidateAdmission,
-};
+use super::candidates::{prepare_candidate_request, BatchDedup, CandidateAdmission};
 use super::changes::committed_change_from_wal_record;
 use super::publish_view::PublishMetadataView;
 use crate::commit::{
@@ -143,18 +141,6 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             };
             let validated = candidate_request.validated;
             let allocation = candidate_request.allocation;
-            // Validation first, uniformly: coverage is checked once the
-            // whole request has planned and validated.
-            if let Err(error) = validate_commit_content_references(
-                candidate,
-                namespace_id,
-                view.content_store_id(),
-                context.now_ms,
-            ) {
-                session.discard_candidate(allocation);
-                slots[index] = BatchOutcomeSlot::SettledIndependent(Err(error));
-                continue;
-            }
             let resulting_next_inode_id = match session.commit_candidate(allocation) {
                 Ok(resulting_next_inode_id) => resulting_next_inode_id,
                 Err(error) => {

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -8,10 +8,10 @@ use crate::commit::{CandidateAllocation, CommitFingerprint, ValidatedCommitPlan}
 use crate::commit_engine::{CommitCandidate, ContentPreparation, ContentPreparationError};
 use crate::error::{CoreError, Result};
 use crate::metadata::CommitReceiptRecord;
-use crate::path::write::{FilesystemOperation, PublishPlanningSession};
+use crate::path::write::{CommitRequest, FilesystemOperation, PublishPlanningSession};
 use crate::storage::content_admission::ContentAdmission;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
-use loonfs_api::{CommitId, ContentRef, ContentStoreId, NamespaceId};
+use loonfs_api::{CommitId, ContentStoreId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
 
@@ -90,6 +90,9 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     committed_at_ms: u64,
     dedup: &mut BatchDedup,
 ) -> CandidateAdmission {
+    if let Err(error) = candidate.validate_request_has_operations() {
+        return CandidateAdmission::independent(Err(error));
+    }
     let mutation = candidate.request();
     let semantic_identity = match candidate.semantic_identity(namespace_id) {
         Ok(semantic_identity) => semantic_identity,
@@ -109,7 +112,17 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         Ok(None) => {}
         Err(error) => return CandidateAdmission::independent(Err(error)),
     }
-    if let Err(error) = validate_new_primary(candidate) {
+    let admissions = match validate_new_primary(candidate) {
+        Ok(admissions) => admissions,
+        Err(error) => return CandidateAdmission::independent(Err(error)),
+    };
+    if let Err(error) = validate_commit_content_references(
+        mutation,
+        admissions,
+        namespace_id,
+        view.content_store_id(),
+        committed_at_ms,
+    ) {
         return CandidateAdmission::independent(Err(error));
     }
     let mut allocation = session.begin_candidate();
@@ -134,11 +147,11 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     }
 }
 
-fn validate_new_primary(candidate: &CommitCandidate) -> Result<()> {
+fn validate_new_primary(candidate: &CommitCandidate) -> Result<&[ContentAdmission]> {
     // Check request limits before content preparation errors.
     candidate.validate_request_limits()?;
     match candidate.content_preparation() {
-        ContentPreparation::Ready(_) => Ok(()),
+        ContentPreparation::Ready(admissions) => Ok(admissions),
         ContentPreparation::Rejected(error) => Err(error.clone().into()),
     }
 }
@@ -209,67 +222,37 @@ async fn commit_response_from_commit_receipt<S: ObjectStore + ?Sized>(
     ))
 }
 
-struct CommitContentAdmissions<'a> {
-    namespace_id: &'a NamespaceId,
-    content_store_id: &'a ContentStoreId,
-    admissions: &'a [ContentAdmission],
-    now_ms: u64,
-}
-
-impl CommitContentAdmissions<'_> {
-    fn admits(&self, content_ref: &ContentRef) -> bool {
-        self.admissions.iter().any(|admission| {
-            admission.admits(
-                self.namespace_id,
-                self.content_store_id,
-                content_ref,
-                self.now_ms,
-            )
-        })
-    }
-}
-
 /// Checks that each put has a matching content preparation proof.
-pub(super) fn validate_commit_content_references(
-    candidate: &CommitCandidate,
+fn validate_commit_content_references(
+    request: &CommitRequest,
+    admissions: &[ContentAdmission],
     namespace_id: &NamespaceId,
     content_store_id: &ContentStoreId,
     now_ms: u64,
 ) -> Result<()> {
-    let admissions = CommitContentAdmissions {
-        namespace_id,
-        content_store_id,
-        now_ms,
-        admissions: match candidate.content_preparation() {
-            ContentPreparation::Ready(admissions) => admissions,
-            ContentPreparation::Rejected(_) => {
-                return Err(CoreError::Internal(
-                    "rejected content preparation reached coverage validation".to_owned(),
-                ));
-            }
-        },
-    };
-    for content_ref in candidate
-        .request()
+    let mut admissions_by_content_id = HashMap::with_capacity(admissions.len());
+    for admission in admissions {
+        admissions_by_content_id
+            .entry(admission.content_id())
+            .or_insert(admission);
+    }
+    for content_ref in request
         .operations
         .iter()
         .filter_map(FilesystemOperation::content_ref)
     {
-        require_content_admission(&admissions, content_ref)?;
+        let admitted = admissions_by_content_id
+            .get(&content_ref.content_id)
+            .is_some_and(|admission| {
+                admission.admits(namespace_id, content_store_id, content_ref, now_ms)
+            });
+        if !admitted {
+            return Err(ContentPreparationError::ContentNotPrepared {
+                content_id: content_ref.content_id.clone(),
+            }
+            .into());
+        }
     }
 
     Ok(())
-}
-
-fn require_content_admission(
-    admissions: &CommitContentAdmissions<'_>,
-    content_ref: &ContentRef,
-) -> Result<()> {
-    if admissions.admits(content_ref) {
-        return Ok(());
-    }
-    Err(ContentPreparationError::ContentNotPrepared {
-        content_id: content_ref.content_id.clone(),
-    }
-    .into())
 }

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -11,7 +11,7 @@ use crate::metadata::CommitReceiptRecord;
 use crate::path::write::{CommitRequest, FilesystemOperation, PublishPlanningSession};
 use crate::storage::content_admission::ContentAdmission;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
-use loonfs_api::{CommitId, ContentStoreId, NamespaceId};
+use loonfs_api::{CommitId, ContentId, ContentStoreId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
 
@@ -230,11 +230,13 @@ fn validate_commit_content_references(
     content_store_id: &ContentStoreId,
     now_ms: u64,
 ) -> Result<()> {
-    let mut admissions_by_content_id = HashMap::with_capacity(admissions.len());
+    let mut admissions_by_content_id: HashMap<&ContentId, Vec<&ContentAdmission>> =
+        HashMap::with_capacity(admissions.len());
     for admission in admissions {
         admissions_by_content_id
             .entry(admission.content_id())
-            .or_insert(admission);
+            .or_default()
+            .push(admission);
     }
     for content_ref in request
         .operations
@@ -243,8 +245,10 @@ fn validate_commit_content_references(
     {
         let admitted = admissions_by_content_id
             .get(&content_ref.content_id)
-            .is_some_and(|admission| {
-                admission.admits(namespace_id, content_store_id, content_ref, now_ms)
+            .is_some_and(|candidates| {
+                candidates.iter().any(|admission| {
+                    admission.admits(namespace_id, content_store_id, content_ref, now_ms)
+                })
             });
         if !admitted {
             return Err(ContentPreparationError::ContentNotPrepared {

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -24,6 +24,7 @@ use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceStatus};
 use loonfs_api::{ChangeSeq, CommitId, ContentStoreId, NamespaceId};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::ObjectStore;
+use std::sync::Arc;
 
 pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     content_store_id: ContentStoreId,
@@ -31,7 +32,7 @@ pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     pub(super) head_etag: String,
     pub(super) acquired_writer: AcquiredWriter,
     manifest_segments: VerifiedMetadataSegments<'a, S>,
-    tail_state: MetadataState,
+    tail_state: Arc<MetadataState>,
 }
 
 impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
@@ -108,7 +109,7 @@ struct PublishProjectionKey {
 pub(crate) struct PublishTailProjection {
     key: PublishProjectionKey,
     pub(crate) wal_tail_segments: u64,
-    pub(crate) tail_state: MetadataState,
+    pub(crate) tail_state: Arc<MetadataState>,
 }
 
 impl PublishTailProjection {
@@ -197,7 +198,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     };
 
     let manifest_segments = loaded_basis.segments;
-    let tail_state = projection.tail_state.clone();
+    let tail_state = Arc::clone(&projection.tail_state);
     ensure_publish_head_etag_still_current(store, namespace_id, &head_etag, &acquired_writer)
         .await?;
 
@@ -250,7 +251,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     let projection = PublishTailProjection {
         key,
         wal_tail_segments,
-        tail_state: replayed.resulting_metadata_state,
+        tail_state: Arc::new(replayed.resulting_metadata_state),
     };
     Ok(projection)
 }
@@ -353,7 +354,7 @@ mod tests {
         PublishTailProjection {
             key,
             wal_tail_segments: 3,
-            tail_state: bootstrap_metadata_state(1_000),
+            tail_state: Arc::new(bootstrap_metadata_state(1_000)),
         }
     }
 

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -10,7 +10,7 @@ use crate::limits::CONTENT_RECEIPT_TTL_MS;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use base64::Engine as _;
 use loonfs_api::v0::ContentToken;
-use loonfs_api::{ContentRef, ContentStoreId, NamespaceId};
+use loonfs_api::{ContentId, ContentRef, ContentStoreId, NamespaceId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -56,6 +56,10 @@ pub(crate) struct ContentAdmission {
 }
 
 impl ContentAdmission {
+    pub(crate) fn content_id(&self) -> &ContentId {
+        &self.content_ref.content_id
+    }
+
     /// Unbounded admission for a ref the caller keeps externally rooted;
     /// no deadline is derivable from the reference alone.
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -1243,6 +1243,48 @@ async fn oversized_prepared_proof_candidate_replays_receipt_but_new_request_is_r
 }
 
 #[tokio::test]
+async fn empty_request_is_rejected_before_commit_id_reuse() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    submit_commit(
+        &store,
+        &namespace_id,
+        commit_request(
+            "empty-reuse",
+            FilesystemOperation::CreateDirectory {
+                path: AbsolutePath::parse("/docs").expect("path"),
+                parents: false,
+            },
+        ),
+        &context,
+    )
+    .await
+    .expect("initial commit");
+
+    let error = submit_commit(
+        &store,
+        &namespace_id,
+        CommitRequest {
+            commit_id: CommitId::parse("empty-reuse").expect("valid commit id"),
+            actor: loonfs_test_support::test_actor(),
+            message: None,
+            operations: Vec::new(),
+        },
+        &context,
+    )
+    .await
+    .expect_err("empty request must fail before commit id reuse");
+
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
+}
+
+#[tokio::test]
 async fn same_batch_over_limit_proof_duplicate_joins_its_primary() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -672,7 +672,7 @@ async fn a_guarded_put_reports_missing_content_before_the_stale_revision_without
     assert!(matches!(
         error,
         CoreError::ContentPreparation(
-            loonfs_core::ContentPreparationError::ContentNotPrepared { ref content_id }
+            loonfs_core::publish::ContentPreparationError::ContentNotPrepared { ref content_id }
         ) if *content_id == missing_content.content_id
     ));
     assert_eq!(guarded_store.content_store_access_count(), 0);

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -623,7 +623,7 @@ async fn metadata_only_mutation_does_not_validate_content_store_refs() {
 }
 
 #[tokio::test]
-async fn a_guarded_put_reports_the_stale_revision_before_missing_content_without_content_reads() {
+async fn a_guarded_put_reports_missing_content_before_the_stale_revision_without_content_reads() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
@@ -667,17 +667,13 @@ async fn a_guarded_put_reports_the_stale_revision_before_missing_content_without
     .into_iter()
     .next()
     .expect("one result")
-    .expect_err("the stale revision guard should win before unprepared content");
-    assert_eq!(error.code(), ErrorCode::StaleRevision);
+    .expect_err("unprepared content should be reported before the stale revision guard");
+    assert_eq!(error.code(), ErrorCode::ContentNotPrepared);
     assert!(matches!(
         error,
-        CoreError::CommitValidation(
-            loonfs_core::commit::CommitValidationError::ReplaceFileBaseRevisionMismatch {
-                expected: RevisionNo(99),
-                actual: Some(RevisionNo(1)),
-                ..
-            }
-        )
+        CoreError::ContentPreparation(
+            loonfs_core::ContentPreparationError::ContentNotPrepared { ref content_id }
+        ) if *content_id == missing_content.content_id
     ));
     assert_eq!(guarded_store.content_store_access_count(), 0);
 }


### PR DESCRIPTION
Reduces copying and repeated scans during commit publication. Batch validation borrows rows accepted earlier in the batch, the WAL tail projection is shared, and content proofs are indexed by content ID.

Content validation now runs before metadata planning, so missing content is reported first. Empty operation lists are rejected before commit ID replay. No wire or durable formats change.