### PR TITLE
perf(grep): reduce query and garbage collection overhead

### DIFF
--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -2,6 +2,7 @@
 
 use crate::cache::{DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind};
 use crate::codec::IndexRow;
+use crate::root::GrepSegmentRef;
 use crate::{GrepError, Result};
 use loonfs::StoreFailureClass;
 use loonfs_api::wire::sst_blocks::{
@@ -10,6 +11,8 @@ use loonfs_api::wire::sst_blocks::{
 };
 use loonfs_objectstore::{ByteRange, ObjectStore};
 use std::sync::Arc;
+
+const WHOLE_SEGMENT_LOAD_MAX_BYTES: u64 = 128 * 1024;
 
 pub(crate) fn index_segment_corrupt(
     object_key: &str,
@@ -77,16 +80,112 @@ async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
     Ok(bytes.to_vec())
 }
 
+struct WholeSegment {
+    filter: Arc<SegmentFilter>,
+    entries: Arc<Vec<SegmentIndexEntry>>,
+}
+
+fn segment_object_len(object_key: &str, descriptor: &GrepSegmentRef) -> Result<u64> {
+    descriptor
+        .index_block
+        .offset
+        .checked_add(u64::from(descriptor.index_block.stored_len))
+        .ok_or_else(|| GrepError::CorruptIndex {
+            message: format!(
+                "index segment `{object_key}` descriptor names bytes past the address space"
+            ),
+        })
+}
+
+async fn load_and_publish_segment_sections<S: ObjectStore + ?Sized>(
+    store: &S,
+    cache: &GrepBlockCache,
+    object_key: &str,
+    descriptor: &GrepSegmentRef,
+    object_len: u64,
+) -> Result<WholeSegment> {
+    let whole_handle = BlockHandle {
+        offset: 0,
+        stored_len: object_len as u32,
+        decoded_len: 0,
+        crc32c: 0,
+    };
+    let bytes = load_index_section_bytes(store, object_key, &whole_handle).await?;
+    let section = |handle: &BlockHandle| -> Option<&[u8]> {
+        let start = usize::try_from(handle.offset).ok()?;
+        let end = start.checked_add(handle.stored_len as usize)?;
+        bytes.get(start..end)
+    };
+    let index_bytes = section(&descriptor.index_block).ok_or_else(|| GrepError::CorruptIndex {
+        message: format!("index segment `{object_key}` index block exceeds the object bounds"),
+    })?;
+    let entries = Arc::new(
+        decode_index_block(index_bytes, &descriptor.index_block)
+            .map_err(|error| index_segment_corrupt(object_key, "index block", &error))?,
+    );
+    let filter_bytes =
+        section(&descriptor.filter_block).ok_or_else(|| GrepError::CorruptIndex {
+            message: format!("index segment `{object_key}` filter block exceeds the object bounds"),
+        })?;
+    let filter = Arc::new(
+        decode_filter_block(filter_bytes, &descriptor.filter_block)
+            .map_err(|error| index_segment_corrupt(object_key, "filter block", &error))?,
+    );
+    for entry in entries.iter() {
+        let stored = section(&entry.block).ok_or_else(|| GrepError::CorruptIndex {
+            message: format!("index segment `{object_key}` data block exceeds the object bounds"),
+        })?;
+        let block = Arc::new(
+            decode_data_block_rows::<IndexRow>(stored, &entry.block)
+                .map_err(|error| index_segment_corrupt(object_key, "data block", &error))?,
+        );
+        cache.insert(
+            cache_key(
+                &descriptor.object_checksum,
+                GrepBlockKind::Data,
+                &entry.block,
+            ),
+            DecodedGrepBlock::Data {
+                block,
+                decoded_bytes: entry.block.decoded_len as usize,
+            },
+        );
+    }
+    Ok(WholeSegment { filter, entries })
+}
+
 pub(crate) async fn load_filter_block<S: ObjectStore + ?Sized>(
     store: &S,
     cache: &GrepBlockCache,
     object_key: &str,
-    object_checksum: &str,
-    handle: &BlockHandle,
+    descriptor: &GrepSegmentRef,
 ) -> Result<Arc<SegmentFilter>> {
-    let key = cache_key(object_checksum, GrepBlockKind::Filter, handle);
+    let handle = &descriptor.filter_block;
+    let key = cache_key(&descriptor.object_checksum, GrepBlockKind::Filter, handle);
     let decoded = cache
         .get_or_load(&key, || async {
+            let object_len = segment_object_len(object_key, descriptor)?;
+            if object_len <= WHOLE_SEGMENT_LOAD_MAX_BYTES {
+                let whole = load_and_publish_segment_sections(
+                    store, cache, object_key, descriptor, object_len,
+                )
+                .await?;
+                cache.insert(
+                    cache_key(
+                        &descriptor.object_checksum,
+                        GrepBlockKind::Index,
+                        &descriptor.index_block,
+                    ),
+                    DecodedGrepBlock::Index {
+                        entries: whole.entries,
+                        decoded_bytes: descriptor.index_block.decoded_len as usize,
+                    },
+                );
+                return Ok(DecodedGrepBlock::Filter {
+                    filter: whole.filter,
+                    decoded_bytes: handle.decoded_len as usize,
+                });
+            }
             let bytes = load_index_section_bytes(store, object_key, handle).await?;
             let filter = Arc::new(
                 decode_filter_block(&bytes, handle)
@@ -108,12 +207,34 @@ pub(crate) async fn load_index_block<S: ObjectStore + ?Sized>(
     store: &S,
     cache: &GrepBlockCache,
     object_key: &str,
-    object_checksum: &str,
-    handle: &BlockHandle,
+    descriptor: &GrepSegmentRef,
 ) -> Result<Arc<Vec<SegmentIndexEntry>>> {
-    let key = cache_key(object_checksum, GrepBlockKind::Index, handle);
+    let handle = &descriptor.index_block;
+    let key = cache_key(&descriptor.object_checksum, GrepBlockKind::Index, handle);
     let decoded = cache
         .get_or_load(&key, || async {
+            let object_len = segment_object_len(object_key, descriptor)?;
+            if object_len <= WHOLE_SEGMENT_LOAD_MAX_BYTES {
+                let whole = load_and_publish_segment_sections(
+                    store, cache, object_key, descriptor, object_len,
+                )
+                .await?;
+                cache.insert(
+                    cache_key(
+                        &descriptor.object_checksum,
+                        GrepBlockKind::Filter,
+                        &descriptor.filter_block,
+                    ),
+                    DecodedGrepBlock::Filter {
+                        filter: whole.filter,
+                        decoded_bytes: descriptor.filter_block.decoded_len as usize,
+                    },
+                );
+                return Ok(DecodedGrepBlock::Index {
+                    entries: whole.entries,
+                    decoded_bytes: handle.decoded_len as usize,
+                });
+            }
             let bytes = load_index_section_bytes(store, object_key, handle).await?;
             let entries = Arc::new(
                 decode_index_block(&bytes, handle)

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -13,7 +13,7 @@ use crate::query::{plan_pattern, GramPlanOutcome, GramQueryPlan};
 use crate::reads::{published_revision, resolve_batch_size, NamespaceReads, PinnedNamespaceReads};
 use crate::root::{
     load_grep_manifest, load_grep_root_pointer, ChangeFeedResume, GrepIndexStatus,
-    GrepManifestState,
+    GrepManifestState, GrepSegmentRef,
 };
 use crate::{GrepError, Result};
 use futures::future::{join_all, try_join_all};
@@ -21,7 +21,7 @@ use loonfs::{CoreError, CurrentFileState, MetadataViewError};
 use loonfs_api::v0::FilesystemChange;
 use loonfs_api::wire::hex::hex_decode_bytes;
 use loonfs_api::wire::sst_blocks::{
-    decode_filter_block, index_blocks_for_key_range, string_prefix_upper_bound, BlockHandle,
+    decode_filter_block, index_blocks_for_key_range, string_prefix_upper_bound,
 };
 use loonfs_api::{
     decode_cursor, encode_cursor, AbsolutePath, ChangeSeq, EffectiveLimit, ErrorCode, GrepMatch,
@@ -73,18 +73,7 @@ pub(crate) const MAX_GREP_CONTENT_IO: usize = 32;
 struct MaterializedGrepIndexSnapshot {
     built_through_seq: ChangeSeq,
     next_event_index: u32,
-    segments: Vec<GrepQuerySegment>,
-}
-
-#[derive(Debug, Clone)]
-struct GrepQuerySegment {
-    object_key: String,
-    min_row_key: String,
-    max_row_key: String,
-    index_block: BlockHandle,
-    filter_block: BlockHandle,
-    filter_inline: Option<String>,
-    object_checksum: String,
+    state: Arc<GrepManifestState>,
 }
 
 impl GrepService {
@@ -160,16 +149,16 @@ impl GrepService {
                 ),
             });
         }
-        materialized_snapshot_from_state(&state)
+        materialized_snapshot_from_state(state)
     }
 }
 
 fn materialized_snapshot_from_state(
-    root: &GrepManifestState,
+    state: Arc<GrepManifestState>,
 ) -> Result<MaterializedGrepIndexSnapshot> {
     // Queries require an active index and its watermark. Disabled and
     // backfilling indexes return their corresponding errors.
-    let (built_through_seq, next_event_index) = match root.status() {
+    let (built_through_seq, next_event_index) = match state.status() {
         GrepIndexStatus::Disabled {} => return Err(GrepError::NotEnabled),
         GrepIndexStatus::Backfilling { .. } => return Err(GrepError::Backfilling),
         GrepIndexStatus::Active {
@@ -177,23 +166,10 @@ fn materialized_snapshot_from_state(
             next_event_index,
         } => (*built_through_seq, *next_event_index),
     };
-    let segments = root
-        .segments()
-        .iter()
-        .map(|segment| GrepQuerySegment {
-            object_key: segment_key(root.namespace_id(), &segment.segment_id),
-            min_row_key: segment.min_row_key.clone(),
-            max_row_key: segment.max_row_key.clone(),
-            index_block: segment.index_block,
-            filter_block: segment.filter_block,
-            filter_inline: segment.filter_inline.clone(),
-            object_checksum: segment.object_checksum.clone(),
-        })
-        .collect();
     Ok(MaterializedGrepIndexSnapshot {
         built_through_seq,
         next_event_index,
-        segments,
+        state,
     })
 }
 
@@ -264,7 +240,8 @@ impl GrepCandidates {
 async fn indexed_candidates<S: ObjectStore + ?Sized>(
     store: &S,
     block_cache: &GrepBlockCache,
-    segments: &[GrepQuerySegment],
+    namespace_id: &NamespaceId,
+    segments: &[GrepSegmentRef],
     plan: &GramQueryPlan,
 ) -> Result<BTreeMap<InodeId, BTreeSet<RevisionNo>>> {
     let mut intersection: Option<BTreeSet<(InodeId, RevisionNo)>> = None;
@@ -272,7 +249,7 @@ async fn indexed_candidates<S: ObjectStore + ?Sized>(
         // Lookup keys derive once per gram; the key-range prune is free
         // (already in the descriptor), so only surviving probes fan out.
         let lookups: Vec<GramLookup> = or_set.iter().map(|gram| GramLookup::new(*gram)).collect();
-        let mut probes: Vec<(&GramLookup, &GrepQuerySegment)> = Vec::new();
+        let mut probes: Vec<(&GramLookup, &GrepSegmentRef)> = Vec::new();
         for gram_lookup in &lookups {
             for descriptor in segments {
                 if descriptor.max_row_key.as_str() < gram_lookup.probe.as_str()
@@ -293,7 +270,7 @@ async fn indexed_candidates<S: ObjectStore + ?Sized>(
         let mut set_postings = BTreeSet::new();
         for chunk in probes.chunks(MAX_GREP_READ_IO) {
             let batches = try_join_all(chunk.iter().map(|(gram_lookup, descriptor)| {
-                segment_postings_for_gram(store, block_cache, descriptor, gram_lookup)
+                segment_postings_for_gram(store, block_cache, namespace_id, descriptor, gram_lookup)
             }))
             .await?;
             for batch in batches {
@@ -357,9 +334,11 @@ impl GramLookup {
 async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
     store: &S,
     block_cache: &GrepBlockCache,
-    descriptor: &GrepQuerySegment,
+    namespace_id: &NamespaceId,
+    descriptor: &GrepSegmentRef,
     gram_lookup: &GramLookup,
 ) -> Result<BTreeSet<(InodeId, RevisionNo)>> {
+    let object_key = segment_key(namespace_id, &descriptor.segment_id);
     let mut postings = BTreeSet::new();
     let admitted = match &descriptor.filter_inline {
         Some(inline) => {
@@ -367,38 +346,22 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
                 hex_decode_bytes(inline).map_err(|error| GrepError::CorruptIndex {
                     message: format!(
                         "index segment `{}` carries undecodable inline filter hex: {error}",
-                        descriptor.object_key
+                        object_key
                     ),
                 })?;
-            let filter =
-                decode_filter_block(&filter_bytes, &descriptor.filter_block).map_err(|error| {
-                    index_segment_corrupt(&descriptor.object_key, "filter block", &error)
-                })?;
+            let filter = decode_filter_block(&filter_bytes, &descriptor.filter_block)
+                .map_err(|error| index_segment_corrupt(&object_key, "filter block", &error))?;
             filter.may_contain(&gram_lookup.probe)
         }
         None => {
-            let filter = load_filter_block(
-                store,
-                block_cache,
-                &descriptor.object_key,
-                &descriptor.object_checksum,
-                &descriptor.filter_block,
-            )
-            .await?;
+            let filter = load_filter_block(store, block_cache, &object_key, descriptor).await?;
             filter.may_contain(&gram_lookup.probe)
         }
     };
     if !admitted {
         return Ok(postings);
     }
-    let entries = load_index_block(
-        store,
-        block_cache,
-        &descriptor.object_key,
-        &descriptor.object_checksum,
-        &descriptor.index_block,
-    )
-    .await?;
+    let entries = load_index_block(store, block_cache, &object_key, descriptor).await?;
     let range =
         index_blocks_for_key_range(&entries, &gram_lookup.prefix, gram_lookup.upper.as_deref());
     // The range's blocks are independent ranged GETs, so they fan out
@@ -410,7 +373,7 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
             load_data_block(
                 store,
                 block_cache,
-                &descriptor.object_key,
+                &object_key,
                 &descriptor.object_checksum,
                 &entry.block,
             )
@@ -422,9 +385,9 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
                 if *row_gram != gram_lookup.gram {
                     continue;
                 }
-                let batch = row.postings().map_err(|error| {
-                    index_segment_corrupt(&descriptor.object_key, "posting batch", &error)
-                })?;
+                let batch = row
+                    .postings()
+                    .map_err(|error| index_segment_corrupt(&object_key, "posting batch", &error))?;
                 postings.extend(
                     batch
                         .into_iter()
@@ -725,8 +688,14 @@ impl GrepService {
             .map_err(CoreError::InvalidQuery)?
         {
             GramPlanOutcome::Indexable(plan) => {
-                candidates.indexed =
-                    indexed_candidates(store, &self.block_cache, &snapshot.segments, &plan).await?;
+                candidates.indexed = indexed_candidates(
+                    store,
+                    &self.block_cache,
+                    reads.namespace_id(),
+                    snapshot.state.segments(),
+                    &plan,
+                )
+                .await?;
                 Some(ChangeFeedResume::new(
                     snapshot.built_through_seq,
                     snapshot.next_event_index,
@@ -1012,7 +981,9 @@ async fn scan_candidate_inodes(
                     }
                 }
             }
-            if inodes.len() > MAX_GREP_SCAN_FILES || walked_directories > MAX_GREP_SCAN_FILES {
+            if inodes.len() + directories.len() > MAX_GREP_SCAN_FILES
+                || walked_directories > MAX_GREP_SCAN_FILES
+            {
                 return Err(CoreError::QueryUnindexable(format!(
                     "the namespace exceeds the {MAX_GREP_SCAN_FILES}-file scan budget; \
                      give the pattern a run of at least 3 literal bytes so the \

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -60,6 +60,8 @@ pub const GREP_BACKFILL_CHECKPOINT_TTL_MS: u64 = 24 * 60 * 60 * 1000;
 /// root update cannot lose an object it has written but not yet referenced.
 pub const GREP_GC_GRACE_WINDOW_MS: u64 = 60 * 60 * 1000;
 
+const GREP_REVERIFY_CHUNK: usize = 1024;
+
 // The floor is derived from publication budgets and provider bounds rather
 // than chosen, so a window that stopped clearing it is a compile error here
 // instead of an unreproducible delete of an object a publication was about
@@ -278,6 +280,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     /// Enables grep by pinning a checkpoint and CAS-publishing a fresh
     /// backfilling root. Enabling an active root is idempotent.
     pub async fn enable(&self, namespace_id: &NamespaceId) -> Result<GrepEnableOutcome> {
+        ensure_live_namespace(&self.reads(namespace_id)).await?;
         if let Some(current) = load_grep_root(&self.store, namespace_id).await? {
             if !matches!(
                 current.manifest_state().status(),
@@ -1309,8 +1312,9 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     /// `max_objects` reads are spent, answering the position it stopped at
     /// so the next call resumes there. Like core garbage collection, that
     /// cursor is an enumeration shortcut and nothing else: every resumed
-    /// pass re-reads liveness and the grep root before it deletes anything,
-    /// so losing the cursor costs a repeated walk and never a wrong delete.
+    /// pass re-reads the required liveness or grep root state before it
+    /// deletes anything, so losing the cursor costs a repeated walk and
+    /// never a wrong delete.
     ///
     /// A pass always examines at least one key, whatever the budget. The
     /// budget bounds how much work one call does; it may not stop a caller
@@ -1333,9 +1337,8 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let mut budget =
             PassBudget::new(Some(request.max_objects.unwrap_or(DEFAULT_GC_MAX_OBJECTS)));
         let reads = self.reads(namespace_id);
-        // Liveness is decided once per pass — and re-decided per candidate
-        // below, which is what authorizes a delete. This first read is
-        // charged like any other.
+        // Liveness is decided once per pass and refreshed in bounded chunks
+        // below. This first read is charged like any other.
         budget.charge();
         let liveness = namespace_liveness(&reads).await;
         if liveness == NamespaceLiveness::Unknown {
@@ -1343,15 +1346,15 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         }
 
         let prefix = grep_prefix(namespace_id);
-        let mut keys = self.store.list_prefix_stream(&prefix);
+        let mut keys = self
+            .store
+            .list_prefix_from_stream(&prefix, resume.last_key());
         let mut position = resume.clone();
+        let mut live_set = GrepLiveSet::new();
         let mut deleted_any = false;
         let mut examined = 0_u64;
         while let Some(key) = keys.next().await {
             let key = key.map_err(|error| core_store_error(&prefix, &error))?;
-            if resume.covers(&key) {
-                continue;
-            }
             // The first key of a pass is examined whatever the budget: the
             // cursor must advance, or a caller looping it never finishes.
             if examined > 0 && budget.exhausted() {
@@ -1367,6 +1370,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     namespace_id,
                     &reads,
                     liveness,
+                    &mut live_set,
                     &key,
                     now_ms,
                     &mut budget,
@@ -1380,14 +1384,15 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         if deleted_any && liveness == NamespaceLiveness::Gone {
             report.namespace_reaped = true;
         }
+        report.namespace_degraded |= live_set.degraded;
         Ok(report)
     }
 
-    /// Decides one candidate key against freshly re-read state.
+    /// Decides one candidate key against chunk-refreshed state.
     ///
-    /// Answers whether the key was deleted. Selection may be stale — the
-    /// listing is a snapshot — but every decision here re-reads what
-    /// authorizes it, which is what makes resuming from a cursor safe.
+    /// Answers whether the key was deleted. Selection may be stale because
+    /// the listing is a snapshot. The grace window covers the bounded state
+    /// refresh interval.
     #[allow(
         clippy::too_many_arguments,
         reason = "one collection decision needs liveness, budget, and report state together"
@@ -1397,22 +1402,25 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         reads: &NamespaceReads<'_>,
         liveness: NamespaceLiveness,
+        live_set: &mut GrepLiveSet,
         key: &str,
         now_ms: u64,
         budget: &mut PassBudget,
         report: &mut GrepGcReport,
     ) -> Result<bool> {
+        if !live_set
+            .refresh_if_due(&self.store, namespace_id, reads, liveness, budget)
+            .await
+        {
+            report.retained_candidates += 1;
+            return Ok(false);
+        }
         match liveness {
             // A verified deleted namespace head is already the absorbing
             // gate for this pointer: `enable` refuses that tombstone, so no
             // legal writer can re-reference grep state after this liveness
             // check. Pointer deletion needs no second state.
             NamespaceLiveness::Gone => {
-                budget.charge();
-                if namespace_liveness(reads).await != NamespaceLiveness::Gone {
-                    report.retained_candidates += 1;
-                    return Ok(false);
-                }
                 budget.charge();
                 Ok(self.delete_if_unreferenced(key, now_ms, report).await?)
             }
@@ -1424,20 +1432,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             // aged unreachable objects need no condemned state before
             // deletion.
             NamespaceLiveness::Live => {
-                budget.charge();
-                let root = match load_grep_root(&self.store, namespace_id).await {
-                    Ok(root) => root,
-                    Err(_) => {
-                        report.namespace_degraded = true;
-                        report.retained_candidates += 1;
-                        return Ok(false);
-                    }
-                };
-                let live = root
-                    .as_ref()
-                    .map(live_grep_keys)
-                    .unwrap_or_else(|| BTreeSet::from([root_key(namespace_id)]));
-                if live.contains(key) {
+                if live_set.live.contains(key) {
                     return Ok(false);
                 }
                 budget.charge();
@@ -1514,13 +1509,6 @@ impl GrepGcCursor {
             namespace_id: namespace_id.clone(),
             last_key: Some(key),
         }
-    }
-
-    /// Whether an earlier pass already examined this key.
-    fn covers(&self, key: &str) -> bool {
-        self.last_key
-            .as_deref()
-            .is_some_and(|last_key| key <= last_key)
     }
 
     fn decode(token: &str, namespace_id: &NamespaceId) -> Result<Self> {
@@ -1685,14 +1673,7 @@ impl SegmentRangeReader {
         cursor: &str,
     ) -> Result<Self> {
         let object_key = segment_key(namespace_id, &segment.segment_id);
-        let entries = load_index_block(
-            store,
-            block_cache,
-            &object_key,
-            &segment.object_checksum,
-            &segment.index_block,
-        )
-        .await?;
+        let entries = load_index_block(store, block_cache, &object_key, segment).await?;
         let start = if cursor.is_empty() {
             GRAM_ROW_PREFIX
         } else {
@@ -1754,6 +1735,64 @@ impl SegmentRangeReader {
             }
         }
         Ok(())
+    }
+}
+
+struct GrepLiveSet {
+    live: BTreeSet<String>,
+    decided_since_load: usize,
+    verified: bool,
+    degraded: bool,
+}
+
+impl GrepLiveSet {
+    fn new() -> Self {
+        Self {
+            live: BTreeSet::new(),
+            decided_since_load: GREP_REVERIFY_CHUNK,
+            verified: false,
+            degraded: false,
+        }
+    }
+
+    async fn refresh_if_due<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        reads: &NamespaceReads<'_>,
+        liveness: NamespaceLiveness,
+        budget: &mut PassBudget,
+    ) -> bool {
+        if self.decided_since_load >= GREP_REVERIFY_CHUNK {
+            self.live.clear();
+            self.verified = match liveness {
+                NamespaceLiveness::Gone => {
+                    budget.charge();
+                    namespace_liveness(reads).await == NamespaceLiveness::Gone
+                }
+                NamespaceLiveness::Live => {
+                    budget.charge();
+                    match load_grep_root(store, namespace_id).await {
+                        Ok(Some(root)) => {
+                            self.live = live_grep_keys(&root);
+                            true
+                        }
+                        Ok(None) => {
+                            self.live.insert(root_key(namespace_id));
+                            true
+                        }
+                        Err(_) => {
+                            self.degraded = true;
+                            false
+                        }
+                    }
+                }
+                NamespaceLiveness::Unknown => false,
+            };
+            self.decided_since_load = 0;
+        }
+        self.decided_since_load += 1;
+        self.verified
     }
 }
 

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -688,9 +688,10 @@ async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
         .expect("first grep");
     assert_eq!(first.matches.len(), 1);
     let after_first = raw_store.count(OperationClass::Read);
-    assert!(
-        after_first > before_first,
-        "the first grep must read posting blocks from the store"
+    assert_eq!(
+        after_first - before_first,
+        1,
+        "the first grep must load the small segment in one read"
     );
 
     let second = host

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -2248,6 +2248,11 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .delete_namespace(&deleted_namespace, DeleteNamespaceOptions::default())
         .await
         .expect("delete namespace");
+    let enable_error = worker
+        .enable(&deleted_namespace)
+        .await
+        .expect_err("a deleted namespace cannot enable grep");
+    assert_eq!(enable_error.code(), ErrorCode::NamespaceDeleted);
     let live_report = worker
         .garbage_collect_namespace(
             &live_namespace,
@@ -2545,7 +2550,7 @@ async fn a_budgeted_grep_collection_walks_everything_an_unbudgeted_one_does() {
 }
 
 #[tokio::test]
-async fn the_collection_budget_charges_each_key_the_reads_it_costs() {
+async fn the_collection_budget_shares_reverification_across_a_candidate_chunk() {
     let namespace_id = NamespaceId::parse("gc-charge").expect("namespace id");
     let temp_dir = tempdir().expect("tempdir");
     let store = seed_collectable_namespace(temp_dir.path(), &namespace_id).await;
@@ -2582,8 +2587,8 @@ async fn the_collection_budget_charges_each_key_the_reads_it_costs() {
         .expect("collect under a seven-read budget");
     let reclaimed = pass.deleted_segments + pass.deleted_other_objects;
     assert!(
-        reclaimed > 0 && reclaimed * 2 <= BUDGET,
-        "the budget must pay for each key's own reads, not just its listing: {pass:?}"
+        reclaimed > BUDGET / 3,
+        "one liveness read must authorize a chunk of candidate decisions: {pass:?}"
     );
     assert!(pass.next_cursor.is_some(), "{pass:?}");
     assert_eq!(


### PR DESCRIPTION
Reduces repeated work in grep queries and garbage collection. Garbage collection resumes provider listings at its cursor and refreshes the live object set in chunks instead of reloading the root for every key.

Queries reuse cached manifest state, count pending directories against the scan budget, and read small index segments in one request. Enabling grep now rejects deleted namespaces consistently. No wire or durable formats change.