### PR TITLE
perf(core): reduce metadata read and flush overhead

### DIFF
--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -212,6 +212,17 @@ impl SegmentBlocksBuilder {
         filter_key: &str,
         row: &R,
     ) -> Result<(), SstBlockCodecError> {
+        self.push_with_encoded_row(row_key, filter_key, row)
+            .map(drop)
+    }
+
+    /// Appends one row and returns its CBOR encoding.
+    pub fn push_with_encoded_row<R: Serialize>(
+        &mut self,
+        row_key: &str,
+        filter_key: &str,
+        row: &R,
+    ) -> Result<Vec<u8>, SstBlockCodecError> {
         if self.row_count > 0 && row_key < self.previous_key.as_str() {
             return Err(SstBlockCodecError::RowKeysOutOfOrder {
                 previous: self.previous_key.clone(),
@@ -249,7 +260,7 @@ impl SegmentBlocksBuilder {
         if self.entries.len() >= self.target_block_bytes {
             self.finish_data_block();
         }
-        Ok(())
+        Ok(row_bytes)
     }
 
     fn finish_data_block(&mut self) {

--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -318,7 +318,7 @@ async fn load_and_publish_segment_sections<S: ObjectStore + ?Sized>(
                 );
                 let decoded = decode_data_block(stored, &entry.block)
                     .map_err(|err| segment_codec_error(&object_key, err))?;
-                let block = decoded_data_cache_block(descriptor.family, decoded);
+                let block = decoded_data_cache_block(decoded);
                 publish_segment_block(
                     segment_cache,
                     memo,

--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -37,9 +37,7 @@ pub(super) async fn build_manifest_segments<S: ObjectStore + ?Sized>(
         run_seq,
         level,
         |family| manifest_rows_for_family(metadata_state, family),
-        MetadataSegmentation::Base {
-            max_rows_per_segment,
-        },
+        max_rows_per_segment,
     )
     .await
 }
@@ -74,6 +72,7 @@ pub(super) async fn build_manifest_delta_run_segments<S: ObjectStore + ?Sized>(
     run_seq: ChangeSeq,
     after_seq: ChangeSeq,
     metadata_state: &MetadataState,
+    max_rows_per_segment: NonZeroUsize,
 ) -> Result<Vec<MetadataFamilySegments>> {
     build_manifest_segments_from_rows(
         store,
@@ -82,15 +81,9 @@ pub(super) async fn build_manifest_delta_run_segments<S: ObjectStore + ?Sized>(
         run_seq,
         CHECKPOINT_DELTA_RUN_LEVEL,
         |family| manifest_rows_for_family_after_seq(metadata_state, family, after_seq),
-        MetadataSegmentation::Full,
+        max_rows_per_segment,
     )
     .await
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(super) enum MetadataSegmentation {
-    Base { max_rows_per_segment: NonZeroUsize },
-    Full,
 }
 
 pub(super) struct MetadataSegmentRows {
@@ -111,7 +104,7 @@ pub(super) async fn build_manifest_segments_from_rows<S, RowsForFamily>(
     run_seq: ChangeSeq,
     level: u32,
     mut rows_for_family: RowsForFamily,
-    segmentation: MetadataSegmentation,
+    max_rows_per_segment: NonZeroUsize,
 ) -> Result<Vec<MetadataFamilySegments>>
 where
     S: ObjectStore + ?Sized,
@@ -129,7 +122,7 @@ where
             continue;
         }
 
-        let segments = segment_manifest_rows(rows, segmentation);
+        let segments = segment_rows_by_row_key_range(rows, max_rows_per_segment);
         let mut requests = Vec::with_capacity(segments.len());
         for (segment_index, segment_rows) in segments.into_iter().enumerate() {
             let segment_index = u32::try_from(segment_index)
@@ -238,16 +231,30 @@ pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
     store: &S,
     request: MetadataSegmentWriteRequest<'_>,
 ) -> Result<MetadataSegmentRef> {
+    write_manifest_segment_with_encoded_rows(store, request, |_| {}).await
+}
+
+pub(super) async fn write_manifest_segment_with_encoded_rows<
+    S: ObjectStore + ?Sized,
+    FoldEncodedRow: FnMut(&[u8]),
+>(
+    store: &S,
+    request: MetadataSegmentWriteRequest<'_>,
+    mut fold_encoded_row: FoldEncodedRow,
+) -> Result<MetadataSegmentRef> {
     let segment_id = request.segment_id;
     let mut builder = SegmentBlocksBuilder::default();
     for row in &request.rows {
         let row_key = row.row_key_for_family(request.family);
         let filter_key = row.filter_key_for_family(request.family);
-        builder.push(&row_key, &filter_key, row).map_err(|err| {
-            CoreError::Internal(format!(
-                "failed to build metadata segment `{segment_id}`: {err}"
-            ))
-        })?;
+        let encoded_row = builder
+            .push_with_encoded_row(&row_key, &filter_key, row)
+            .map_err(|err| {
+                CoreError::Internal(format!(
+                    "failed to build metadata segment `{segment_id}`: {err}"
+                ))
+            })?;
+        fold_encoded_row(&encoded_row);
     }
     let built = builder.finish().map_err(|err| {
         CoreError::Internal(format!(
@@ -282,18 +289,6 @@ pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
         )
         .await?;
     Ok(descriptor)
-}
-
-pub(super) fn segment_manifest_rows(
-    rows: Vec<MetadataRow>,
-    segmentation: MetadataSegmentation,
-) -> Vec<MetadataSegmentRows> {
-    match segmentation {
-        MetadataSegmentation::Full => vec![MetadataSegmentRows { rows }],
-        MetadataSegmentation::Base {
-            max_rows_per_segment,
-        } => segment_rows_by_row_key_range(rows, max_rows_per_segment),
-    }
 }
 
 pub(super) fn segment_rows_by_row_key_range(

--- a/crates/loonfs-core/src/checkpoint/compaction_output.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_output.rs
@@ -9,7 +9,7 @@
 //! publishing them. A merge completed within one maintenance step writes to
 //! `metadata/segments/` because it publishes those segments in the same step.
 
-use super::build::{write_manifest_segment, MetadataSegmentDestination};
+use super::build::{write_manifest_segment_with_encoded_rows, MetadataSegmentDestination};
 use super::reorganize::MergePlacement;
 use super::runs::MetadataLsmPolicy;
 use crate::error::Result;
@@ -51,37 +51,43 @@ impl<'a> MergeSegmentWriter<'a> {
         self.rows.push(row);
     }
 
-    pub(super) async fn roll_full_segments<S: ObjectStore + ?Sized>(
+    pub(super) async fn roll_full_segments<
+        S: ObjectStore + ?Sized,
+        FoldEncodedRow: FnMut(&[u8]),
+    >(
         &mut self,
         store: &S,
         policy: MetadataLsmPolicy,
+        fold_encoded_row: &mut FoldEncodedRow,
     ) -> Result<()> {
         let max_rows = policy.max_rows_per_segment.get();
         while self.rows.len() >= max_rows {
             let rest = self.rows.split_off(max_rows);
             let full = std::mem::replace(&mut self.rows, rest);
-            self.write_segment(store, full).await?;
+            self.write_segment(store, full, fold_encoded_row).await?;
         }
         Ok(())
     }
 
-    pub(super) async fn finish<S: ObjectStore + ?Sized>(
+    pub(super) async fn finish<S: ObjectStore + ?Sized, FoldEncodedRow: FnMut(&[u8])>(
         mut self,
         store: &S,
+        fold_encoded_row: &mut FoldEncodedRow,
     ) -> Result<Vec<MetadataSegmentRef>> {
         let rest = std::mem::take(&mut self.rows);
         if !rest.is_empty() {
-            self.write_segment(store, rest).await?;
+            self.write_segment(store, rest, fold_encoded_row).await?;
         }
         Ok(self.segments)
     }
 
-    async fn write_segment<S: ObjectStore + ?Sized>(
+    async fn write_segment<S: ObjectStore + ?Sized, FoldEncodedRow: FnMut(&[u8])>(
         &mut self,
         store: &S,
         rows: Vec<MetadataRow>,
+        fold_encoded_row: &mut FoldEncodedRow,
     ) -> Result<()> {
-        let descriptor = write_manifest_segment(
+        let descriptor = write_manifest_segment_with_encoded_rows(
             store,
             self.destination.write_request(
                 self.run_no,
@@ -91,6 +97,7 @@ impl<'a> MergeSegmentWriter<'a> {
                 self.next_segment_index,
                 rows,
             ),
+            fold_encoded_row,
         )
         .await?;
         self.next_segment_index += 1;

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -15,9 +15,7 @@ use super::cache::{DecodedMetadataSegmentBlock, MetadataSegmentBlockKind, Metada
 use super::error::ManifestLoadError;
 use super::stored_block_cache::StoredMetadataBlockKind;
 use crate::metadata::content_ref_evidence_bytes;
-use loonfs_api::wire::manifest::{
-    ActiveDeletionRowAction, MetadataRow, MetadataRowFamily, MetadataSegmentRef,
-};
+use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow, MetadataSegmentRef};
 use loonfs_api::wire::sst_blocks::{decode_data_block, DecodedDataBlock, SegmentIndexEntry};
 use loonfs_objectstore::keys::metadata_segment_object_key;
 use loonfs_objectstore::ObjectStore;
@@ -52,7 +50,7 @@ pub(super) async fn load_segment_data_block<S: ObjectStore + ?Sized>(
         )
         .await
         {
-            return Ok(decoded_data_cache_block(descriptor.family, decoded));
+            return Ok(decoded_data_cache_block(decoded));
         }
         let object_key = metadata_segment_object_key(descriptor);
         let bytes =
@@ -65,7 +63,6 @@ pub(super) async fn load_segment_data_block<S: ObjectStore + ?Sized>(
             &bytes,
         );
         Ok(decoded_data_cache_block(
-            descriptor.family,
             decode_data_block(&bytes, &handle)
                 .map_err(|err| segment_codec_error(&object_key, err))?,
         ))
@@ -86,12 +83,9 @@ pub(super) async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     }
 }
 
-pub(super) fn decoded_data_cache_block(
-    family: MetadataRowFamily,
-    block: DecodedDataBlock,
-) -> DecodedMetadataSegmentBlock {
+pub(super) fn decoded_data_cache_block(block: DecodedDataBlock) -> DecodedMetadataSegmentBlock {
     DecodedMetadataSegmentBlock::Data {
-        decoded_bytes: decoded_manifest_block_weight(family, &block.rows),
+        decoded_bytes: decoded_manifest_block_weight(&block),
         block: Arc::new(block),
     }
 }
@@ -248,7 +242,7 @@ async fn load_and_publish_span<S: ObjectStore + ?Sized>(
         let cache_key =
             segment_block_cache_key(descriptor, MetadataSegmentBlockKind::Data, handle.offset);
         let cache_block = DecodedMetadataSegmentBlock::Data {
-            decoded_bytes: decoded_manifest_block_weight(descriptor.family, &decoded.rows),
+            decoded_bytes: decoded_manifest_block_weight(&decoded),
             block: Arc::clone(&decoded),
         };
         memo.record(&cache_key, &cache_block);
@@ -266,19 +260,16 @@ async fn load_and_publish_span<S: ObjectStore + ?Sized>(
     Ok(first_block.expect("a span should always hold at least one block"))
 }
 
-pub(super) fn decoded_manifest_block_weight(
-    family: MetadataRowFamily,
-    rows: &[MetadataRow],
-) -> usize {
+pub(super) fn decoded_manifest_block_weight(block: &DecodedDataBlock) -> usize {
     // Approximate decoded map/vector bookkeeping beyond owned row payloads.
     const BLOCK_ENTRY_OVERHEAD: usize = 64;
     const BLOCK_ALLOCATION_OVERHEAD: usize = 128;
-    let row_weight = rows
+    let row_weight = block
+        .rows
         .iter()
-        .map(|row| {
-            BLOCK_ENTRY_OVERHEAD
-                + row.row_key_for_family(family).len()
-                + decoded_manifest_row_weight(row)
+        .zip(&block.row_keys)
+        .map(|(row, row_key)| {
+            BLOCK_ENTRY_OVERHEAD + row_key.len() + decoded_manifest_row_weight(row)
         })
         .sum::<usize>();
     row_weight.saturating_add(BLOCK_ALLOCATION_OVERHEAD)

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -104,15 +104,13 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
                 ))),
             })
             .collect::<Result<Vec<_>>>()?;
-        let inode_ids = inode_rows
+        let file_inode_ids = inode_rows
             .iter()
+            .filter(|(_, inode_kind)| *inode_kind == InodeKind::File)
             .map(|(inode_id, _)| *inode_id)
             .collect::<Vec<_>>();
-        session.preload_visibility(&inode_ids).await?;
-        for (inode_id, inode_kind) in inode_rows {
-            if inode_kind != InodeKind::File {
-                continue;
-            }
+        session.preload_visibility(&file_inode_ids).await?;
+        for inode_id in file_inode_ids {
             if session.visible_inode(inode_id).await?.is_none() {
                 continue;
             }

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -91,17 +91,25 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
             Some((row_key, _)) => lower_bound = format!("{row_key}\0"),
             None => break,
         }
-        for (row_key, row) in rows {
-            let MetadataRow::Inode {
-                inode_id,
-                inode_kind,
-                ..
-            } = row
-            else {
-                return Err(CoreError::NamespaceCorrupt(format!(
+        let inode_rows = rows
+            .into_iter()
+            .map(|(row_key, row)| match row {
+                MetadataRow::Inode {
+                    inode_id,
+                    inode_kind,
+                    ..
+                } => Ok((inode_id, inode_kind)),
+                _ => Err(CoreError::NamespaceCorrupt(format!(
                     "inodes family returned a non-inode row at `{row_key}`"
-                )));
-            };
+                ))),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let inode_ids = inode_rows
+            .iter()
+            .map(|(inode_id, _)| *inode_id)
+            .collect::<Vec<_>>();
+        session.preload_visibility(&inode_ids).await?;
+        for (inode_id, inode_kind) in inode_rows {
             if inode_kind != InodeKind::File {
                 continue;
             }

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -374,6 +374,7 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
                     head_seq,
                     previous_manifest.payload.head_seq,
                     &projection.tail_state,
+                    MetadataLsmPolicy::default().max_rows_per_segment,
                 )
                 .await?,
             ));

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -67,12 +67,10 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
                 message: source.public_message().into_owned(),
             }),
         ),
-        Err(_) => Err(MetadataProjectionLoadError::ManifestLoad(
+        Err(error) => Err(MetadataProjectionLoadError::ManifestLoad(
             ManifestLoadError::ReadManifest {
                 object_key: manifest_key,
-                message: loonfs_objectstore::ObjectStoreErrorClass::Other
-                    .public_message()
-                    .into_owned(),
+                message: error.to_string(),
             },
         )),
     }
@@ -160,7 +158,7 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
             .await
         }
         // Re-read the root to resolve an unknown write outcome.
-        Err(error) => {
+        Err(error @ ObjectStoreError::Transport { .. }) => {
             match classify_current_root(
                 store,
                 namespace_id,
@@ -175,6 +173,7 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
                 outcome => Ok(outcome),
             }
         }
+        Err(error) => Err(CoreError::store(&loaded.object_key, &error)),
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -1138,8 +1138,24 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             self.write_row(kept, &mut writers).await?;
         }
 
-        for writer in writers.into_values() {
-            let segments = writer.finish(self.store).await?;
+        for (family, writer) in writers {
+            let segments = match index_pair(self.group) {
+                Some((canonical, _)) if family == canonical => {
+                    writer
+                        .finish(self.store, &mut |encoded_row| {
+                            self.canonical_digest.fold(encoded_row);
+                        })
+                        .await?
+                }
+                Some((_, index)) if family == index => {
+                    writer
+                        .finish(self.store, &mut |encoded_row| {
+                            self.index_digest.fold(encoded_row);
+                        })
+                        .await?
+                }
+                _ => writer.finish(self.store, &mut |_| {}).await?,
+            };
             self.result.output_bytes = self
                 .result
                 .output_bytes
@@ -1192,7 +1208,6 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         (family, row): KeptRow,
         writers: &mut BTreeMap<MetadataRowFamily, MergeSegmentWriter<'_>>,
     ) -> Result<()> {
-        self.fold_into_index_digests(family, &row)?;
         *self
             .result
             .rows_written_by_family
@@ -1203,7 +1218,27 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             .get_mut(&family)
             .expect("a cluster writes only the families it merges");
         writer.push(row);
-        writer.roll_full_segments(self.store, self.policy).await
+        match index_pair(self.group) {
+            Some((canonical, _)) if family == canonical => {
+                writer
+                    .roll_full_segments(self.store, self.policy, &mut |encoded_row| {
+                        self.canonical_digest.fold(encoded_row);
+                    })
+                    .await
+            }
+            Some((_, index)) if family == index => {
+                writer
+                    .roll_full_segments(self.store, self.policy, &mut |encoded_row| {
+                        self.index_digest.fold(encoded_row);
+                    })
+                    .await
+            }
+            _ => {
+                writer
+                    .roll_full_segments(self.store, self.policy, &mut |_| {})
+                    .await
+            }
+        }
     }
 
     /// Remembers a below-floor unbind for the reverse pass, when the merge is
@@ -1334,24 +1369,6 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         Ok(rows)
     }
 
-    /// Folds a written row into the digest of its side of the group's index
-    /// pair, when the group has one.
-    fn fold_into_index_digests(
-        &mut self,
-        family: MetadataRowFamily,
-        row: &MetadataRow,
-    ) -> Result<()> {
-        let Some((canonical, index)) = index_pair(self.group) else {
-            return Ok(());
-        };
-        if family == canonical {
-            self.canonical_digest.fold(row)?;
-        } else if family == index {
-            self.index_digest.fold(row)?;
-        }
-        Ok(())
-    }
-
     /// Refuses to hand back a run whose secondary index does not hold the same
     /// rows as its canonical family.
     ///
@@ -1395,8 +1412,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
 /// and, for the bind pair, in different passes. This is corruption detection,
 /// not a signature: what it has to catch is a merge that wrote a secondary
 /// index rows its canonical family does not hold, including a row differing in one
-/// field. Nothing durable carries it, so the input is the row's serde
-/// encoding.
+/// field. Nothing durable carries it.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct RowDigest {
     value: u128,
@@ -1404,18 +1420,12 @@ struct RowDigest {
 }
 
 impl RowDigest {
-    fn fold(&mut self, row: &MetadataRow) -> Result<()> {
-        let encoded = serde_json::to_vec(row).map_err(|err| {
-            CoreError::Internal(format!(
-                "failed to encode a metadata row for digesting: {err}"
-            ))
-        })?;
-        let digest = Sha256::digest(&encoded);
+    fn fold(&mut self, encoded_row: &[u8]) {
+        let digest = Sha256::digest(encoded_row);
         let mut head = [0u8; 16];
         head.copy_from_slice(&digest[..16]);
         self.value = self.value.wrapping_add(u128::from_be_bytes(head));
         self.rows += 1;
-        Ok(())
     }
 
     fn spell(&self) -> String {
@@ -1497,6 +1507,10 @@ mod tests {
         }
     }
 
+    fn fold_row(digest: &mut RowDigest, row: &MetadataRow) {
+        digest.fold(&serde_json::to_vec(row).expect("encode row"));
+    }
+
     #[test]
     fn the_row_digest_ignores_order_and_notices_one_changed_field() {
         let rows = [
@@ -1507,10 +1521,10 @@ mod tests {
         let mut forward = RowDigest::default();
         let mut backward = RowDigest::default();
         for row in &rows {
-            forward.fold(row).expect("digest");
+            fold_row(&mut forward, row);
         }
         for row in rows.iter().rev() {
-            backward.fold(row).expect("digest");
+            fold_row(&mut backward, row);
         }
         assert_eq!(forward, backward);
 
@@ -1522,12 +1536,12 @@ mod tests {
         ]
         .iter()
         {
-            changed.fold(row).expect("digest");
+            fold_row(&mut changed, row);
         }
         assert_ne!(forward, changed);
 
         let mut short = RowDigest::default();
-        short.fold(&rows[0]).expect("digest");
+        fold_row(&mut short, &rows[0]);
         assert_ne!(forward, short);
     }
 }

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -1124,7 +1124,7 @@ fn seed_decoded_blocks(
                 MetadataSegmentBlockKind::Data,
                 handle.offset,
             ),
-            data_block_load::decoded_data_cache_block(descriptor.family, decoded),
+            data_block_load::decoded_data_cache_block(decoded),
         );
     }
 }

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -1026,6 +1026,113 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
 }
 
 #[tokio::test]
+async fn root_cas_permission_error_surfaces_when_a_newer_root_was_published() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let raw_store = LocalFsStore::new(temp_dir.path()).expect("raw store");
+    bootstrap_namespace(&raw_store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &raw_store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let materialization = load_current_projection(&raw_store, &namespace_id)
+        .await
+        .expect("materialization");
+    let candidate_manifest_no = ManifestNo(materialization.root.manifest.manifest_no.0 + 1);
+    let candidate_manifest = build_manifest_from_projection(
+        &raw_store,
+        &namespace_id,
+        &materialization,
+        candidate_manifest_no,
+    )
+    .await;
+    let competing_manifest = build_manifest_from_projection(
+        &raw_store,
+        &namespace_id,
+        &materialization,
+        ManifestNo(candidate_manifest_no.0 + 1),
+    )
+    .await;
+    write_namespace_manifest(&raw_store, &candidate_manifest)
+        .await
+        .expect("write candidate manifest");
+    write_namespace_manifest(&raw_store, &competing_manifest)
+        .await
+        .expect("write competing manifest");
+    let competing_root = MetadataRootState {
+        namespace_id: namespace_id.clone(),
+        manifest: ManifestRef {
+            owner_namespace_id: namespace_id.clone(),
+            manifest_no: competing_manifest.payload.manifest_no,
+            manifest_object_id: competing_manifest.payload.manifest_object_id.clone(),
+            manifest_head_seq: competing_manifest.payload.head_seq,
+            manifest_payload_checksum: competing_manifest.payload_checksum.clone(),
+        },
+        updated_at_ms: context.now_ms + 1,
+    };
+    let root_key = metadata_root(&namespace_id);
+    let failing = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::exact(root_key.clone()),
+        OperationClass::CompareAndSwap,
+        InjectedError::PermissionDenied("root write forbidden".to_owned()),
+    );
+    failing.fail_all();
+    let store = BlockingStore::new(
+        failing,
+        KeyPredicate::exact(root_key.clone()),
+        OperationClass::CompareAndSwap,
+    );
+    store.block_next();
+
+    let (publication, ()) = tokio::join!(
+        publish_metadata_root(
+            &store,
+            &namespace_id,
+            &candidate_manifest,
+            Some(materialization.root.manifest.manifest_object_id.clone()),
+            context.now_ms,
+        ),
+        async {
+            store.wait_until_blocked().await;
+            let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+                loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
+                competing_root,
+            )
+            .expect("metadata root envelope");
+            let bytes = loonfs_api::wire::control::encode_control_object(&envelope)
+                .expect("encode metadata root");
+            raw_store
+                .put(&root_key, Bytes::from(bytes), PutMode::Overwrite)
+                .await
+                .expect("install competing root");
+            store.release();
+        }
+    );
+
+    let error = publication.expect_err("permission-denied root CAS must fail");
+    assert_eq!(error.code(), ErrorCode::StoragePermissionDenied);
+    assert!(matches!(
+        error,
+        CoreError::Store {
+            class: loonfs_objectstore::ObjectStoreErrorClass::PermissionDenied,
+            ..
+        }
+    ));
+    assert_eq!(store.inner().attempts(), 1);
+}
+
+#[tokio::test]
 async fn first_root_create_recovers_when_the_write_lands_ambiguously() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -749,7 +749,7 @@ async fn manifest_run_rejects_rows_after_run_seq() {
         first,
         CHECKPOINT_BASE_RUN_LEVEL,
         |family| manifest_rows_for_family(&materialization.metadata_state, family),
-        MetadataSegmentation::Full,
+        NonZeroUsize::MAX,
     )
     .await
     .expect("write malformed run segments");
@@ -766,7 +766,7 @@ async fn manifest_run_rejects_rows_after_run_seq() {
                 first,
             )
         },
-        MetadataSegmentation::Full,
+        NonZeroUsize::MAX,
     )
     .await
     .expect("write empty metadata run segments");

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -14,9 +14,7 @@ mod manifest_round_trips;
 mod retention;
 mod streaming_compaction;
 
-use super::build::{
-    build_manifest_segments, build_manifest_segments_from_rows, MetadataSegmentation,
-};
+use super::build::{build_manifest_segments, build_manifest_segments_from_rows};
 use super::cache::{MetadataSegmentBlockKind, MetadataSegmentCache, MetadataSegmentCacheConfig};
 use super::compaction_merge::locality_of;
 use super::compaction_retention::RetentionRule;
@@ -94,7 +92,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use loonfs_test_support::stores::{
-    CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+    BlockingStore, CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::{NonZeroU32, NonZeroUsize};
@@ -863,6 +861,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
                         head_seq,
                         previous.manifest.payload.head_seq,
                         metadata_state,
+                        policy.max_rows_per_segment,
                     )
                     .await?,
                 ));

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -1814,9 +1814,7 @@ async fn install_synthetic_bindings_base(
             rows.sort_by_key(|row| row.row_key_for_family(family));
             rows
         },
-        MetadataSegmentation::Base {
-            max_rows_per_segment: rows_per_segment,
-        },
+        rows_per_segment,
     )
     .await
     .expect("build the synthetic bindings run");

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -5,6 +5,7 @@ use super::durable_cache::{
     BindingCacheKey, DurableVisibilityCache, ParentNameCacheKey, SharedRows,
 };
 use super::manifest_index;
+use super::view_session::LeafRevisionPrefetch;
 use super::visibility::{self, MetadataVisibilityReads};
 use crate::checkpoint::VerifiedMetadataSegments;
 use crate::error::CoreError;
@@ -240,7 +241,9 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         &self,
         absolute_path: &AbsolutePath,
     ) -> Result<ResolvedVisiblePath, CoreError> {
-        visibility::resolve_visible_path(&mut self.reads(), absolute_path).await
+        self.session()
+            .resolve_visible_path(absolute_path, LeafRevisionPrefetch::Skip)
+            .await
     }
 
     pub(crate) async fn visible_child(

--- a/crates/loonfs-core/src/metadata/view_session.rs
+++ b/crates/loonfs-core/src/metadata/view_session.rs
@@ -379,44 +379,17 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         let mut pending_child_ids: Vec<InodeId> = latest_binds
             .iter()
             .map(|direntry| direntry.child_inode_id)
-            .filter(|child_inode_id| {
-                !(self.inode_at_seq_cache.contains_key(child_inode_id)
-                    && self
-                        .latest_parent_binding_cache
-                        .contains_key(child_inode_id)
-                    && self.active_tombstone_cache.contains_key(child_inode_id))
-            })
             .collect();
         pending_child_ids.sort_unstable();
         pending_child_ids.dedup();
-        if pending_child_ids.is_empty() {
-            return Ok(());
-        }
-        self.counters.list_preload_child_lookups = self
-            .counters
-            .list_preload_child_lookups
-            .saturating_add(pending_child_ids.len() as u64);
+        self.preload_visibility(&pending_child_ids).await?;
 
-        let base = &self.base;
-        let lookups = futures::future::try_join_all(pending_child_ids.iter().map(
-            |&child_inode_id| async move {
-                let (inode, bindings, tombstones) = futures::try_join!(
-                    base.inode_at_seq(child_inode_id),
-                    base.direntry_binds_for_child(child_inode_id),
-                    base.tombstones_for_root(child_inode_id),
-                )?;
-                Ok::<_, CoreError>((child_inode_id, inode, bindings, tombstones))
-            },
-        ))
-        .await?;
-
-        for (child_inode_id, inode, bindings, tombstones) in lookups {
-            self.inode_at_seq_cache.insert(child_inode_id, inode);
-            let latest_binding = bindings
-                .iter()
-                .filter(|direntry| direntry.bind_seq <= visible_seq)
-                .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-                .cloned();
+        for child_inode_id in pending_child_ids {
+            let latest_binding = self
+                .latest_parent_binding_cache
+                .get(&child_inode_id)
+                .cloned()
+                .flatten();
             if let Some(latest_binding) = &latest_binding {
                 // A child bound in this directory within the preloaded name
                 // range gets its unbind fact from the range scan; bindings
@@ -430,12 +403,59 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                     self.unbind_cache.entry(cache_key).or_insert(unbound);
                 }
             }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn preload_visibility(
+        &mut self,
+        inode_ids: &[InodeId],
+    ) -> Result<(), CoreError> {
+        let mut pending: Vec<InodeId> = inode_ids
+            .iter()
+            .copied()
+            .filter(|inode_id| {
+                !(self.inode_at_seq_cache.contains_key(inode_id)
+                    && self.latest_parent_binding_cache.contains_key(inode_id)
+                    && self.active_tombstone_cache.contains_key(inode_id))
+            })
+            .collect();
+        pending.sort_unstable();
+        pending.dedup();
+        if pending.is_empty() {
+            return Ok(());
+        }
+        self.counters.list_preload_child_lookups = self
+            .counters
+            .list_preload_child_lookups
+            .saturating_add(pending.len() as u64);
+
+        let visible_seq = self.base.visible_seq();
+        let base = &self.base;
+        let lookups =
+            futures::future::try_join_all(pending.into_iter().map(|inode_id| async move {
+                let (inode, bindings, tombstones) = futures::try_join!(
+                    base.inode_at_seq(inode_id),
+                    base.direntry_binds_for_child(inode_id),
+                    base.tombstones_for_root(inode_id),
+                )?;
+                Ok::<_, CoreError>((inode_id, inode, bindings, tombstones))
+            }))
+            .await?;
+
+        for (inode_id, inode, bindings, tombstones) in lookups {
+            self.inode_at_seq_cache.insert(inode_id, inode);
+            let latest_binding = bindings
+                .iter()
+                .filter(|direntry| direntry.bind_seq <= visible_seq)
+                .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
+                .cloned();
             self.latest_parent_binding_cache
-                .insert(child_inode_id, latest_binding);
+                .insert(inode_id, latest_binding);
             let active_tombstone =
                 super::rows::active_tombstone_from_records(tombstones.iter().cloned(), visible_seq);
             self.active_tombstone_cache
-                .insert(child_inode_id, active_tombstone);
+                .insert(inode_id, active_tombstone);
         }
         Ok(())
     }


### PR DESCRIPTION
Reduces metadata work on flush and read paths. Delta runs now use the normal segment row limit, checkpoint file listings batch visibility lookups, and path resolution uses the existing preloading session.

Compaction hashes the CBOR bytes it already produces, decoded-block accounting reuses stored row keys, and metadata root publication only reconciles ambiguous transport failures. No wire or durable formats change.