### PR TITLE
refactor(api): require deleted bindings in deletion records

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -306,20 +306,6 @@ pub struct DeletedDirentry {
     pub display_name: DisplayName,
 }
 
-/// Reads an optional field that must still be written.
-///
-/// Serde reads a missing `Option` field as `None`, which would make an
-/// encoding that never had the field indistinguishable from one that stated
-/// its absence. A durable optional that distinguishes those two reads
-/// through here instead.
-pub(crate) fn required_option<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
-where
-    T: Deserialize<'de>,
-    D: serde::Deserializer<'de>,
-{
-    Option::deserialize(deserializer)
-}
-
 /// Tombstone-row event vocabulary (format spec, "Tombstones and deletion").
 ///
 /// This type appears only in immutable rows, so it accepts unknown fields.
@@ -328,13 +314,8 @@ where
 pub enum TombstoneRowAction {
     /// The subtree rooted at the row's inode is deleted.
     Set {
-        /// The binding the delete removed, or `null` for a delete addressed
-        /// by inode, which had no name to record. Stated either way and
-        /// never defaulted, so bytes without the field are the pre-grouping
-        /// layout — which spelled the binding as three optional row fields —
-        /// rather than a deletion that recorded no name.
-        #[serde(deserialize_with = "required_option")]
-        deleted_direntry: Option<DeletedDirentry>,
+        /// The binding the delete removed.
+        deleted_direntry: DeletedDirentry,
     },
     /// The deletion recorded at `target` is revoked. Only a `set` carries a
     /// binding, so the revoke has no place to put one.
@@ -362,10 +343,8 @@ pub enum ActiveDeletionRowAction {
         /// Actor responsible for the deletion.
         deleted_by: crate::ActorRef,
         /// The binding the deletion removed, copied from the tombstone event
-        /// this row derives from, or `null` when it recorded none. Stated
-        /// either way, like the event's own.
-        #[serde(deserialize_with = "required_option")]
-        deleted_direntry: Option<DeletedDirentry>,
+        /// this row derives from.
+        deleted_direntry: DeletedDirentry,
     },
     /// The deletion was cancelled by an undelete at `revocation_seq`.
     Removed {
@@ -984,6 +963,14 @@ mod tests {
         CommitId::parse("c_metadata_row").expect("commit id")
     }
 
+    fn deleted_direntry() -> super::DeletedDirentry {
+        super::DeletedDirentry {
+            parent_inode_id: InodeId(9),
+            name_key: NameKey::parse("report.txt").expect("valid name key"),
+            display_name: crate::DisplayName::parse("report.txt").expect("valid display name"),
+        }
+    }
+
     #[test]
     fn inode_row_keys_sort_by_ascending_inode_id() {
         // The inode family's durable order IS ascending inode id, which is
@@ -1336,7 +1323,7 @@ mod tests {
                     },
                     commit_id: row_commit_id(),
                     action: super::TombstoneRowAction::Set {
-                        deleted_direntry: None,
+                        deleted_direntry: deleted_direntry(),
                     },
                     deleted_at_ms: 12_000,
                     deleted_by: crate::ActorRef::loonfs_system(),
@@ -1435,7 +1422,7 @@ mod tests {
                         },
                         commit_id: row_commit_id(),
                         action: super::TombstoneRowAction::Set {
-                            deleted_direntry: None,
+                            deleted_direntry: deleted_direntry(),
                         },
                         deleted_at_ms: 12_000,
                         deleted_by: actor.clone(),
@@ -1449,7 +1436,7 @@ mod tests {
                         action: super::ActiveDeletionRowAction::Listed {
                             deleted_at_ms: 12_000,
                             deleted_by: actor.clone(),
-                            deleted_direntry: None,
+                            deleted_direntry: deleted_direntry(),
                         },
                     },
                 ),

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -200,11 +200,8 @@ pub enum FilesystemChange {
             schema(schema_with = crate::public_inode_id::schema)
         )]
         inode_id: InodeId,
-        /// Directory binding removed by the deletion, when the delete
-        /// recorded one.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        #[cfg_attr(feature = "openapi", schema(nullable = false))]
-        deleted_binding: Option<DirectoryBinding>,
+        /// Directory binding removed by the deletion.
+        deleted_binding: DirectoryBinding,
     },
     /// A deleted inode was recovered and re-bound.
     #[cfg_attr(feature = "openapi", schema(title = "FilesystemChangeUndeleted"))]
@@ -465,11 +462,11 @@ mod tests {
 
         let deleted = FilesystemChange::Deleted {
             inode_id: InodeId(2),
-            deleted_binding: Some(super::DirectoryBinding {
+            deleted_binding: super::DirectoryBinding {
                 parent_inode_id: InodeId(1),
                 name_key: crate::NameKey::parse("a.txt").expect("valid name key"),
                 display_name: crate::DisplayName::parse("a.txt").expect("valid display name"),
-            }),
+            },
         };
         assert_eq!(
             serde_json::to_string(&deleted).expect("serialize deleted event"),

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -512,8 +512,7 @@ pub enum FilesystemOperation {
         ///
         /// When absent, the inode is rebound to the parent and name recorded by the
         /// deletion. Parent identity, rather than an old path string, keeps this
-        /// correct after ancestor renames. An explicit path is required when the
-        /// deletion recorded no binding.
+        /// correct after ancestor renames.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[cfg_attr(feature = "openapi", schema(nullable = false))]
         path: Option<AbsolutePath>,

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -254,8 +254,8 @@ pub struct FileBytes {
 
 /// One deletion that can still be restored.
 ///
-/// `inode_id` and `deletion_seq` are sufficient to restore it. The removed
-/// directory binding is included when available.
+/// `inode_id` and `deletion_seq` identify it. The removed directory binding
+/// determines where an in-place restore binds it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct TrashEntry {
@@ -272,10 +272,8 @@ pub struct TrashEntry {
     pub deleted_at_ms: u64,
     /// Actor responsible for the deletion.
     pub deleted_by: ActorRef,
-    /// Directory binding removed by the deletion, when available.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(nullable = false))]
-    pub deleted_binding: Option<DirectoryBinding>,
+    /// Directory binding removed by the deletion.
+    pub deleted_binding: DirectoryBinding,
 }
 
 /// One trash listing page: the namespace's recoverable deletions.
@@ -520,11 +518,11 @@ mod tests {
             deletion_seq: ChangeSeq(417),
             deleted_at_ms: 1,
             deleted_by: ActorRef::loonfs_system(),
-            deleted_binding: Some(DirectoryBinding {
+            deleted_binding: DirectoryBinding {
                 parent_inode_id: InodeId(7),
                 name_key: NameKey::parse("report.txt").expect("name key"),
                 display_name: DisplayName::parse("report.txt").expect("display name"),
-            }),
+            },
         };
         assert_eq!(
             serde_json::to_value(&trash).expect("serialize trash entry"),
@@ -540,15 +538,6 @@ mod tests {
                 }
             })
         );
-
-        // Omit the field when no binding was recorded.
-        let bindingless = TrashEntry {
-            deleted_binding: None,
-            ..trash
-        };
-        let bindingless_json =
-            serde_json::to_value(bindingless).expect("serialize bindingless entry");
-        assert!(bindingless_json.get("deleted_binding").is_none());
     }
 
     #[test]
@@ -558,11 +547,11 @@ mod tests {
             deletion_seq: ChangeSeq(417),
             deleted_at_ms: 1_752_625_000_000,
             deleted_by: ActorRef::loonfs_system(),
-            deleted_binding: Some(DirectoryBinding {
+            deleted_binding: DirectoryBinding {
                 parent_inode_id: InodeId(7),
                 name_key: NameKey::parse("report.txt").expect("name key"),
                 display_name: DisplayName::parse("Report.txt").expect("display name"),
-            }),
+            },
         };
         let trash_json = serde_json::to_value(trash).expect("serialize trash entry");
         assert_eq!(trash_json["inode_id"], serde_json::json!("ino_42"));

--- a/crates/loonfs-api/src/wal.rs
+++ b/crates/loonfs-api/src/wal.rs
@@ -4,7 +4,7 @@
 use crate::control::{validate_wal_segment_start_seq, WalSegmentPointer};
 use crate::digest::sha256_digest;
 use crate::envelope::{self, EnvelopeCodecError, EnvelopeProbe};
-use crate::manifest::{required_option, DeletedDirentry, TombstoneGeneration};
+use crate::manifest::{DeletedDirentry, TombstoneGeneration};
 use crate::{
     AttributeRevisionNo, Attributes, ChangeSeq, CommitId, ContentRef, DisplayName, InodeId,
     InodeKind, NameKey, NamespaceId, RevisionNo, WalSegmentId, WriterEpoch,
@@ -100,13 +100,9 @@ pub enum WalDelta {
         delta_index: u32,
         /// Inode at the root of the newly hidden subtree.
         root_inode_id: InodeId,
-        /// The binding a path delete removed, carried so the deleted name
-        /// survives on the immortal tombstone row after unbind rows age
-        /// out; `null` for a delete addressed by inode. Stated either way
-        /// and never defaulted, so the pre-grouping layout — which spelled
-        /// the binding as three optional delta fields — does not decode.
-        #[serde(deserialize_with = "required_option")]
-        deleted_direntry: Option<DeletedDirentry>,
+        /// The binding the delete removed, carried so the deleted name
+        /// survives on the immortal tombstone row after unbind rows age out.
+        deleted_direntry: DeletedDirentry,
     },
     /// Revokes exactly one subtree tombstone — the one recorded at `target`
     /// — making the subtree eligible for visibility again once re-bound. An

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -280,12 +280,12 @@ fn sample_wal_envelope() -> WalSegmentEnvelope {
             delta: WalDelta::TombstoneSubtree {
                 delta_index: 4,
                 root_inode_id: InodeId(9),
-                deleted_direntry: Some(DeletedDirentry {
+                deleted_direntry: DeletedDirentry {
                     parent_inode_id: InodeId(1),
                     name_key: NameKey::parse("old.txt").expect("valid name key"),
                     display_name: loonfs_api::DisplayName::parse("Old.txt")
                         .expect("valid display name"),
-                }),
+                },
             },
         },
         WalCommitDelta {
@@ -1598,12 +1598,12 @@ fn wal_decode_tolerates_additive_fields_inside_tombstone_deltas() {
             delta: WalDelta::TombstoneSubtree {
                 delta_index: 0,
                 root_inode_id: InodeId(9),
-                deleted_direntry: Some(DeletedDirentry {
+                deleted_direntry: DeletedDirentry {
                     parent_inode_id: InodeId(1),
                     name_key: name_key("old.txt"),
                     display_name: loonfs_api::DisplayName::parse("Old.txt")
                         .expect("valid display name"),
-                }),
+                },
             },
         },
         WalCommitDelta {
@@ -1790,7 +1790,11 @@ fn wal_delta_wire_tags_match_spec_names() {
             serde_json::to_value(WalDelta::TombstoneSubtree {
                 delta_index: 0,
                 root_inode_id: InodeId(2),
-                deleted_direntry: None,
+                deleted_direntry: DeletedDirentry {
+                    parent_inode_id: InodeId(1),
+                    name_key: name_key("a"),
+                    display_name: loonfs_api::DisplayName::parse("a").expect("valid display name"),
+                },
             }),
             "tombstone_subtree",
         ),
@@ -1835,12 +1839,12 @@ fn sample_tombstone_set_row() -> MetadataRow {
         },
         commit_id: commit_id(),
         action: TombstoneRowAction::Set {
-            deleted_direntry: Some(DeletedDirentry {
+            deleted_direntry: DeletedDirentry {
                 parent_inode_id: InodeId(1),
                 name_key: name_key("docs-archive"),
                 display_name: loonfs_api::DisplayName::parse("Docs-Archive")
                     .expect("valid display name"),
-            }),
+            },
         },
         deleted_at_ms: 4_000,
         deleted_by: actor(),
@@ -1877,12 +1881,12 @@ fn sample_active_deletion_listed_row() -> MetadataRow {
         action: ActiveDeletionRowAction::Listed {
             deleted_at_ms: 4_000,
             deleted_by: actor(),
-            deleted_direntry: Some(DeletedDirentry {
+            deleted_direntry: DeletedDirentry {
                 parent_inode_id: InodeId(1),
                 name_key: name_key("docs-archive"),
                 display_name: loonfs_api::DisplayName::parse("Docs-Archive")
                     .expect("valid display name"),
-            }),
+            },
         },
     }
 }
@@ -2361,11 +2365,11 @@ fn tombstone_revoke_rows_ignore_a_deleted_direntry() {
 }
 
 #[test]
-fn tombstone_rows_reject_the_pre_grouping_flat_encoding() {
+fn tombstone_rows_reject_flat_binding_fields() {
     let row = row_cbor(&sample_tombstone_set_row());
     assert_row_is_corrupt(
         &with_flat_binding(with_flat_generation(row.clone())),
-        "the pre-grouping layout is not a row this format has",
+        "flat binding fields are not a tombstone row",
     );
 
     // Each half of that encoding on its own, over a row that is otherwise

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -297,7 +297,7 @@ History and recovery
     stale command cannot cancel a later delete. Omit <path> to restore in
     place under the parent and name recorded with the deletion. This still
     works if an enclosing directory was renamed. Pass <path> to restore it
-    somewhere else, or when the deletion did not record a binding
+    somewhere else
 
   loonfs changes [--after <seq>] [--limit <n>] [--page-size <n>]
                  [--all] [--jsonl] [--snapshot-id <id>]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -1024,8 +1024,7 @@ pub(crate) struct FilesystemUndeleteArgs {
     /// Destination path for the recovered file or directory. Omit to
     /// restore in place: the entry re-binds under the parent and name its
     /// deletion recorded, which lands correctly even when the enclosing
-    /// directories were renamed since. A deletion that recorded no binding
-    /// needs the explicit path.
+    /// directories were renamed since.
     #[arg(value_hint = ValueHint::Other)]
     pub path: Option<String>,
     /// Inode ID of the deleted item, as reported by `rm` and the change

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -308,36 +308,14 @@ impl UndeleteHint {
     }
 
     /// The complete `loonfs undelete` invocation that recovers one deletion.
-    ///
-    /// A deletion that recorded its binding restores in place — the entry
-    /// re-binds under the parent and name the delete recorded — so the
-    /// pasted command names no destination at all. One that recorded no
-    /// binding needs the caller to supply where it should land.
-    pub(crate) fn command(
-        &self,
-        recorded_binding: bool,
-        inode_id: InodeId,
-        deletion_seq: ChangeSeq,
-    ) -> String {
-        // The placeholder is deliberately left unquoted: pasted unedited, a
-        // shell rejects it instead of recovering the entry to a file
-        // literally named `<path>`.
-        let destination = if recorded_binding {
-            String::new()
-        } else {
-            format!("{PATH_PLACEHOLDER} ")
-        };
+    pub(crate) fn command(&self, inode_id: InodeId, deletion_seq: ChangeSeq) -> String {
         let inode_id = loonfs_api::public_inode_id::encode(inode_id);
         format!(
-            "loonfs undelete {destination}--inode {inode_id} --deletion-seq {}{}",
+            "loonfs undelete --inode {inode_id} --deletion-seq {}{}",
             deletion_seq.0, self.context_flags
         )
     }
 }
-
-/// Stands in for the destination of a deletion that recorded no name, which
-/// the caller has to supply before the command will run.
-const PATH_PLACEHOLDER: &str = "<path>";
 
 /// Quotes an argument for a POSIX shell, leaving it alone when it needs no
 /// quoting.

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -829,19 +829,10 @@ pub(crate) async fn run_filesystem_trash(
     }
     let response = response.expect("trash loop should fetch at least one page");
     let hint = UndeleteHint::new(&context, location, args.target.profile.profile.is_some());
-    // An entry that recorded its binding restores in place with no
-    // destination in the command; only a legacy entry that recorded none
-    // still needs the caller to supply one.
     let recovery_commands = response
         .entries
         .iter()
-        .map(|entry| {
-            hint.command(
-                entry.deleted_binding.is_some(),
-                entry.inode_id,
-                entry.deletion_seq,
-            )
-        })
+        .map(|entry| hint.command(entry.inode_id, entry.deletion_seq))
         .collect();
     Ok(CommandOutput {
         kind,
@@ -1271,12 +1262,9 @@ pub(crate) async fn run_filesystem_rm(
     // printed command restores in place with no destination — and keeps
     // working even if the enclosing directories are renamed before the
     // paste.
-    let recovery_command = UndeleteHint::new(
-        &context,
-        location,
-        args.target.profile.profile.is_some(),
-    )
-    .command(true, deleted_inode, result.committed_seq);
+    let recovery_command =
+        UndeleteHint::new(&context, location, args.target.profile.profile.is_some())
+            .command(deleted_inode, result.committed_seq);
 
     Ok(CommandOutput {
         kind,

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -244,16 +244,11 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             // The commands were built one per entry, in this order.
             for (entry, recovery_command) in response.entries.iter().zip(&listing.recovery_commands)
             {
-                let name = entry
-                    .deleted_binding
-                    .as_ref()
-                    .map(|binding| binding.display_name.as_str().to_owned())
-                    .unwrap_or_else(|| "-".to_owned());
                 lines.push(format!(
                     "{}\t{}\t{}\t{}\t{}\t{recovery_command}",
                     format_utc_ms(entry.deleted_at_ms),
                     render_actor(&entry.deleted_by),
-                    name,
+                    entry.deleted_binding.display_name,
                     public_inode_id(entry.inode_id),
                     entry.deletion_seq.0,
                 ));

--- a/crates/loonfs-cli/src/render/summaries.rs
+++ b/crates/loonfs-cli/src/render/summaries.rs
@@ -334,12 +334,8 @@ pub(super) fn event_descriptor(event: &loonfs_api::v0::FilesystemChange) -> Stri
             ..
         } => format!("move '{from_display_name}' -> '{to_display_name}'"),
         FilesystemChange::Deleted {
-            inode_id,
-            deleted_binding,
-        } => match deleted_binding {
-            Some(binding) => format!("delete '{}'", binding.display_name),
-            None => format!("delete inode {}", public_inode_id(*inode_id)),
-        },
+            deleted_binding, ..
+        } => format!("delete '{}'", deleted_binding.display_name),
         FilesystemChange::Undeleted { display_name, .. } => {
             format!("undelete '{display_name}'")
         }

--- a/crates/loonfs-core/src/checkpoint/compaction_retention.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_retention.rs
@@ -442,7 +442,12 @@ mod tests {
             action: ActiveDeletionRowAction::Listed {
                 deleted_at_ms: 1_000,
                 deleted_by: loonfs_api::ActorRef::loonfs_system(),
-                deleted_direntry: None,
+                deleted_direntry: loonfs_api::wire::manifest::DeletedDirentry {
+                    parent_inode_id: InodeId(1),
+                    name_key: loonfs_api::NameKey::parse("deleted").expect("valid name key"),
+                    display_name: loonfs_api::DisplayName::parse("deleted")
+                        .expect("valid display name"),
+                },
             },
         };
         assert!(operator

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -306,9 +306,8 @@ pub(super) fn decoded_manifest_row_weight(row: &MetadataRow) -> usize {
                 deleted_direntry, ..
             } => {
                 ALLOCATED_ROW_OVERHEAD
-                    + deleted_direntry.as_ref().map_or(0, |direntry| {
-                        direntry.name_key.as_str().len() + direntry.display_name.as_str().len()
-                    })
+                    + deleted_direntry.name_key.as_str().len()
+                    + deleted_direntry.display_name.as_str().len()
             }
             ActiveDeletionRowAction::Removed { .. } => FIXED_ROW_OVERHEAD,
         },

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -30,11 +30,11 @@ fn tombstone_set(root_inode_id: InodeId, seq: u64, name: &str) -> SubtreeTombsto
         deleted_at_ms: 1_000 + seq,
         deleted_by: loonfs_api::ActorRef::loonfs_system(),
         action: SubtreeTombstoneAction::Set {
-            deleted_direntry: Some(DeletedDirentry {
+            deleted_direntry: DeletedDirentry {
                 parent_inode_id: InodeId(1),
                 name_key: NameKey::parse(name).expect("name key"),
                 display_name: DisplayName::parse(name).expect("display name"),
-            }),
+            },
         },
     }
 }
@@ -335,11 +335,11 @@ fn trash_by_walking_every_tombstone(state: &MetadataState, head_seq: ChangeSeq) 
                 deletion_seq: active.generation.seq,
                 deleted_at_ms: active.deleted_at_ms,
                 deleted_by: active.deleted_by,
-                deleted_binding: deleted_direntry.map(|direntry| DirectoryBinding {
-                    parent_inode_id: direntry.parent_inode_id,
-                    name_key: direntry.name_key,
-                    display_name: direntry.display_name,
-                }),
+                deleted_binding: DirectoryBinding {
+                    parent_inode_id: deleted_direntry.parent_inode_id,
+                    name_key: deleted_direntry.name_key,
+                    display_name: deleted_direntry.display_name,
+                },
             })
         })
         .collect()
@@ -507,14 +507,7 @@ async fn the_listing_is_ordered_oldest_deletion_first() {
     let entries = trash_entries(&store, &namespace_id, 10).await;
     let names = entries
         .iter()
-        .map(|entry| {
-            entry
-                .deleted_binding
-                .as_ref()
-                .expect("a path delete records the deleted binding")
-                .display_name
-                .to_string()
-        })
+        .map(|entry| entry.deleted_binding.display_name.to_string())
         .collect::<Vec<_>>();
     assert_eq!(
         names,

--- a/crates/loonfs-core/src/commit/materialize.rs
+++ b/crates/loonfs-core/src/commit/materialize.rs
@@ -165,7 +165,7 @@ pub(super) fn materialize_validated_op(op: &ValidatedOp) -> Vec<MaterializedComm
                 WalDelta::TombstoneSubtree {
                     delta_index: *tombstone_delta_index,
                     root_inode_id: *inode_id,
-                    deleted_direntry: Some(deleted_direntry(source_binding)),
+                    deleted_direntry: deleted_direntry(source_binding),
                 },
             );
         }
@@ -206,7 +206,7 @@ pub(super) fn materialize_validated_op(op: &ValidatedOp) -> Vec<MaterializedComm
                 WalDelta::TombstoneSubtree {
                     delta_index: *tombstone_delta_index,
                     root_inode_id: *root_inode_id,
-                    deleted_direntry: Some(deleted_direntry(source_binding)),
+                    deleted_direntry: deleted_direntry(source_binding),
                 },
             );
         }

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -14,7 +14,7 @@ use crate::commit::{
 use crate::error::{CoreError, ErrorCode};
 use crate::metadata::{InMemoryMetadataView, MetadataState};
 use loonfs_api::wire::control::{HeadState, NamespaceStatus, WriterBlock};
-use loonfs_api::wire::wal::WalDelta;
+use loonfs_api::wire::{manifest::DeletedDirentry, wal::WalDelta};
 use loonfs_api::{
     next_public_ordinal, AttributeKey, AttributeRevisionNo, AttributeValue, Attributes, ChangeSeq,
     CommitId, ContentRef, DisplayName, InodeId, InodeKind, NameKey, NamespaceId, RevisionNo,
@@ -143,7 +143,11 @@ fn wal_tombstone(delta_index: u32, root_inode_id: InodeId) -> Vec<WalDelta> {
     vec![WalDelta::TombstoneSubtree {
         delta_index,
         root_inode_id,
-        deleted_direntry: None,
+        deleted_direntry: DeletedDirentry {
+            parent_inode_id: InodeId(1),
+            name_key: NameKey::parse("docs").expect("valid name key"),
+            display_name: test_display_name("docs"),
+        },
     }]
 }
 

--- a/crates/loonfs-core/src/metadata/row_decode.rs
+++ b/crates/loonfs-core/src/metadata/row_decode.rs
@@ -271,7 +271,12 @@ mod tests {
             },
             commit_id: CommitId::parse("c_foreign_tombstone").expect("commit id"),
             action: TombstoneRowAction::Set {
-                deleted_direntry: None,
+                deleted_direntry: loonfs_api::wire::manifest::DeletedDirentry {
+                    parent_inode_id: InodeId(1),
+                    name_key: loonfs_api::NameKey::parse("foreign").expect("valid name key"),
+                    display_name: loonfs_api::DisplayName::parse("foreign")
+                        .expect("valid display name"),
+                },
             },
             deleted_at_ms: 4_000,
             deleted_by: loonfs_api::ActorRef::loonfs_system(),

--- a/crates/loonfs-core/src/metadata/rows.rs
+++ b/crates/loonfs-core/src/metadata/rows.rs
@@ -122,12 +122,9 @@ pub struct SubtreeTombstoneRecord {
 /// names the exact deletion generation it cancels.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SubtreeTombstoneAction {
-    /// The subtree rooted here is deleted, removing the binding described
-    /// here when the delete came by path. The tombstone row is immortal, so
-    /// this is where a deleted name lives after unbind rows age out.
-    Set {
-        deleted_direntry: Option<DeletedDirentry>,
-    },
+    /// The subtree rooted here is deleted. The tombstone row is immortal, so
+    /// this is where the removed binding lives after unbind rows age out.
+    Set { deleted_direntry: DeletedDirentry },
     /// The deletion recorded at `target` is revoked. Validation guarantees
     /// the target was the active generation when the revoke committed.
     Revoke { target: TombstoneGeneration },
@@ -179,7 +176,7 @@ pub(crate) enum ActiveDeletionAction {
     Listed {
         deleted_at_ms: u64,
         deleted_by: ActorRef,
-        deleted_direntry: Option<DeletedDirentry>,
+        deleted_direntry: DeletedDirentry,
     },
     /// An undelete cancelled the deletion, so the listing skips the key.
     Removed { revocation_seq: ChangeSeq },
@@ -258,9 +255,8 @@ pub(crate) struct RecoverableDeletion {
     pub(crate) deletion_seq: ChangeSeq,
     pub(crate) deleted_at_ms: u64,
     pub(crate) deleted_by: ActorRef,
-    /// The binding the delete removed, and so the one undelete restores in
-    /// place; `None` when the deletion recorded no binding.
-    pub(crate) deleted_direntry: Option<DeletedDirentry>,
+    /// The binding the delete removed and an in-place undelete restores.
+    pub(crate) deleted_direntry: DeletedDirentry,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -2,6 +2,7 @@
 //! index maintenance, and seq-gated queries.
 
 use super::*;
+use loonfs_api::wire::manifest::DeletedDirentry;
 use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalDelta};
 use loonfs_api::ContentId;
 use loonfs_api::{
@@ -19,6 +20,14 @@ fn commit_id(seq: u64) -> CommitId {
 
 fn name_key(value: &str) -> NameKey {
     NameKey::parse(value).expect("valid name key")
+}
+
+fn deleted_direntry(parent_inode_id: InodeId, display_name: &str) -> DeletedDirentry {
+    DeletedDirentry {
+        parent_inode_id,
+        name_key: name_key(display_name),
+        display_name: loonfs_api::DisplayName::parse(display_name).expect("valid display name"),
+    }
 }
 
 #[test]
@@ -39,7 +48,7 @@ fn every_provenance_row_copies_the_wal_payload_commit_id() {
         WalDelta::TombstoneSubtree {
             delta_index: 2,
             root_inode_id: InodeId(7),
-            deleted_direntry: None,
+            deleted_direntry: deleted_direntry(InodeId(1), "deleted"),
         },
         WalDelta::AppendAttributesRevision {
             delta_index: 3,
@@ -267,7 +276,7 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
         &[WalDelta::TombstoneSubtree {
             delta_index: 0,
             root_inode_id: InodeId(2),
-            deleted_direntry: None,
+            deleted_direntry: deleted_direntry(InodeId(1), "renamed"),
         }],
     );
     assert!(metadata_state

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -502,11 +502,11 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 deletion_seq: deletion.deletion_seq,
                 deleted_at_ms: deletion.deleted_at_ms,
                 deleted_by: deletion.deleted_by,
-                deleted_binding: deletion.deleted_direntry.map(|direntry| DirectoryBinding {
-                    parent_inode_id: direntry.parent_inode_id,
-                    name_key: direntry.name_key,
-                    display_name: direntry.display_name,
-                }),
+                deleted_binding: DirectoryBinding {
+                    parent_inode_id: deletion.deleted_direntry.parent_inode_id,
+                    name_key: deletion.deleted_direntry.name_key,
+                    display_name: deletion.deleted_direntry.display_name,
+                },
             })
             .collect();
         Ok(Page {

--- a/crates/loonfs-core/src/path/write/plan_create.rs
+++ b/crates/loonfs-core/src/path/write/plan_create.rs
@@ -121,18 +121,8 @@ pub(super) async fn plan_publish_undelete<S: ObjectStore + ?Sized>(
             else {
                 return Err(CommitValidationError::UndeleteTargetNotDeleted { inode_id }.into());
             };
-            // The name key is re-derived at validation from the spelling,
-            // so only the parent and the spelling are read here.
-            match deletion.deleted_direntry {
-                Some(direntry) => (direntry.parent_inode_id, direntry.display_name),
-                None => {
-                    return Err(CoreError::InvalidCommitRequest(
-                        "the deletion recorded no binding to restore into; \
-                         pass a destination path"
-                            .to_owned(),
-                    ));
-                }
-            }
+            let direntry = deletion.deleted_direntry;
+            (direntry.parent_inode_id, direntry.display_name)
         }
     };
     Ok(CompiledFilesystemOperation::new(

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -257,13 +257,11 @@ fn event_from_op_deltas(
             ..
         }] if child_inode_id == root_inode_id => FilesystemChange::Deleted {
             inode_id: *root_inode_id,
-            deleted_binding: deleted_direntry.as_ref().map(|direntry| {
-                loonfs_api::v0::DirectoryBinding {
-                    parent_inode_id: direntry.parent_inode_id,
-                    name_key: direntry.name_key.clone(),
-                    display_name: direntry.display_name.clone(),
-                }
-            }),
+            deleted_binding: loonfs_api::v0::DirectoryBinding {
+                parent_inode_id: deleted_direntry.parent_inode_id,
+                name_key: deleted_direntry.name_key.clone(),
+                display_name: deleted_direntry.display_name.clone(),
+            },
         },
         // Undelete: revoke the exact deletion generation, re-bind the root.
         [WalDelta::RevokeSubtreeTombstone { root_inode_id, .. }, WalDelta::BindDirentry {

--- a/crates/loonfs-core/tests/it/differential.rs
+++ b/crates/loonfs-core/tests/it/differential.rs
@@ -61,7 +61,7 @@ struct NormalizedTombstone {
 #[derive(Debug, PartialEq, Eq)]
 enum NormalizedTombstoneAction {
     Set {
-        deleted_binding: Option<NormalizedBinding>,
+        deleted_binding: NormalizedBinding,
     },
     Revoke {
         target_seq: u64,
@@ -173,21 +173,12 @@ fn tombstone(
     vec![WalDelta::TombstoneSubtree {
         delta_index,
         root_inode_id,
-        deleted_direntry: Some(DeletedDirentry {
+        deleted_direntry: DeletedDirentry {
             parent_inode_id,
             name_key: NameKey::parse(loonfs_api::name_key_for_display_name(display_name))
                 .expect("derived name key"),
             display_name: DisplayName::parse(display_name).expect("valid display name"),
-        }),
-    }]
-}
-
-/// A delete addressed by inode, which had no name to record.
-fn tombstone_without_binding(delta_index: u32, root_inode_id: InodeId) -> Vec<WalDelta> {
-    vec![WalDelta::TombstoneSubtree {
-        delta_index,
-        root_inode_id,
-        deleted_direntry: None,
+        },
     }]
 }
 
@@ -328,21 +319,6 @@ fn metadata_apply_matches_model_for_delete_subtree() {
         create_directory(0, InodeId(2), InodeId(1), "Docs"),
         create_directory(0, InodeId(3), InodeId(2), "nested"),
         tombstone(0, InodeId(2), InodeId(1), "Docs"),
-    ]);
-}
-
-#[test]
-fn metadata_apply_matches_model_for_delete_addressed_by_inode() {
-    assert_states_match(&[
-        create_directory(0, InodeId(2), InodeId(1), "docs"),
-        create_file(
-            0,
-            InodeId(3),
-            InodeId(2),
-            "readme.txt",
-            content_ref("content-1"),
-        ),
-        tombstone_without_binding(0, InodeId(3)),
     ]);
 }
 
@@ -579,13 +555,11 @@ fn normalize_core(state: &CoreMetadataState) -> NormalizedMetadata {
                 action: match &tombstone.action {
                     CoreTombstoneAction::Set { deleted_direntry } => {
                         NormalizedTombstoneAction::Set {
-                            deleted_binding: deleted_direntry.as_ref().map(|direntry| {
-                                NormalizedBinding {
-                                    parent_inode_id: direntry.parent_inode_id.0,
-                                    name_key: direntry.name_key.as_str().to_owned(),
-                                    display_name: direntry.display_name.as_str().to_owned(),
-                                }
-                            }),
+                            deleted_binding: NormalizedBinding {
+                                parent_inode_id: deleted_direntry.parent_inode_id.0,
+                                name_key: deleted_direntry.name_key.as_str().to_owned(),
+                                display_name: deleted_direntry.display_name.as_str().to_owned(),
+                            },
                         }
                     }
                     CoreTombstoneAction::Revoke { target } => NormalizedTombstoneAction::Revoke {
@@ -678,13 +652,11 @@ fn normalize_model(state: &ModelMetadataState) -> NormalizedMetadata {
                 action: match &tombstone.action {
                     ModelTombstoneAction::Set { deleted_binding } => {
                         NormalizedTombstoneAction::Set {
-                            deleted_binding: deleted_binding.as_ref().map(|binding| {
-                                NormalizedBinding {
-                                    parent_inode_id: binding.parent_inode_id.0,
-                                    name_key: binding.name_key.clone(),
-                                    display_name: binding.display_name.clone(),
-                                }
-                            }),
+                            deleted_binding: NormalizedBinding {
+                                parent_inode_id: deleted_binding.parent_inode_id.0,
+                                name_key: deleted_binding.name_key.clone(),
+                                display_name: deleted_binding.display_name.clone(),
+                            },
                         }
                     }
                     ModelTombstoneAction::Revoke { target } => NormalizedTombstoneAction::Revoke {

--- a/crates/loonfs-model/src/metadata.rs
+++ b/crates/loonfs-model/src/metadata.rs
@@ -132,12 +132,9 @@ pub struct DeletedBinding {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SubtreeTombstoneAction {
-    /// Deletes the subtree rooted at the record's inode. Only a delete has
-    /// a binding to remove, so this is the one action that can carry one —
-    /// absent when the delete was addressed by inode.
-    Set {
-        deleted_binding: Option<DeletedBinding>,
-    },
+    /// Deletes the subtree rooted at the record's inode and records its
+    /// removed binding.
+    Set { deleted_binding: DeletedBinding },
     /// Cancels exactly the deletion recorded at `target`.
     Revoke { target: DeletionGeneration },
 }
@@ -237,13 +234,11 @@ impl MetadataState {
                             deleted_at_ms: committed_at_ms,
                             deleted_by: actor.clone(),
                             action: SubtreeTombstoneAction::Set {
-                                deleted_binding: deleted_direntry.as_ref().map(|direntry| {
-                                    DeletedBinding {
-                                        parent_inode_id: direntry.parent_inode_id,
-                                        name_key: direntry.name_key.as_str().to_owned(),
-                                        display_name: direntry.display_name.as_str().to_owned(),
-                                    }
-                                }),
+                                deleted_binding: DeletedBinding {
+                                    parent_inode_id: deleted_direntry.parent_inode_id,
+                                    name_key: deleted_direntry.name_key.as_str().to_owned(),
+                                    display_name: deleted_direntry.display_name.as_str().to_owned(),
+                                },
                             },
                         });
                 }
@@ -343,12 +338,12 @@ mod tests {
                 WalDelta::TombstoneSubtree {
                     delta_index: 1,
                     root_inode_id: InodeId(2),
-                    deleted_direntry: Some(DeletedDirentry {
+                    deleted_direntry: DeletedDirentry {
                         parent_inode_id: InodeId(1),
                         name_key: NameKey::parse("report.txt").expect("valid name key"),
                         display_name: loonfs_api::DisplayName::parse("Report.TXT")
                             .expect("valid display name"),
-                    }),
+                    },
                 },
                 WalDelta::RevokeSubtreeTombstone {
                     delta_index: 2,
@@ -369,11 +364,11 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 SubtreeTombstoneAction::Set {
-                    deleted_binding: Some(DeletedBinding {
+                    deleted_binding: DeletedBinding {
                         parent_inode_id: InodeId(1),
                         name_key: "report.txt".to_owned(),
                         display_name: "Report.TXT".to_owned(),
-                    }),
+                    },
                 },
                 SubtreeTombstoneAction::Revoke {
                     target: DeletionGeneration {

--- a/crates/loonfs/tests/it/undelete.rs
+++ b/crates/loonfs/tests/it/undelete.rs
@@ -564,9 +564,8 @@ fn the_feed_names_deleted_entries_and_their_writer() {
         .flat_map(|change| &change.events)
         .find_map(|event| match event {
             loonfs::FilesystemChange::Deleted {
-                deleted_binding: Some(binding),
-                ..
-            } => Some(binding.display_name.as_str().to_owned()),
+                deleted_binding, ..
+            } => Some(deleted_binding.display_name.as_str().to_owned()),
             _ => None,
         });
     assert_eq!(deleted_name.as_deref(), Some("Quarterly Report.PDF"));

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1648,7 +1648,7 @@ by `(deletion_seq, inode_id)` — paged with the standard `limit`/`cursor`
 pattern (the cursor is an ordering resume like every other). The listing is a
 range scan over the derived active-deletions family (format spec, section
 2.5), so a page costs the page rather than the namespace's deletion history.
-Those rows represent current state and are not removed when the retention floor advances. Each entry includes the inode id and deletion sequence required by `undelete`, plus `deleted_by` and `deleted_at_ms` from that deletion. When available, `deleted_binding` contains the directory binding that was removed. Entries without this binding still contain everything needed for recovery. Nested deletions remain separate entries, and recovering an outer deletion does not remove an inner deletion from the list.
+Those rows represent current state and are not removed when the retention floor advances. Each entry includes the inode id and deletion sequence required by `undelete`, plus `deleted_by`, `deleted_at_ms`, and the removed `deleted_binding`. Nested deletions remain separate entries, and recovering an outer deletion does not remove an inner deletion from the list.
 
 ```json
 {
@@ -1937,11 +1937,9 @@ exist and be visible, and its name must be free. When absent, the entry
 restores in place — it re-binds under the parent inode and name its
 deletion recorded, anchored on the parent's identity rather than a
 remembered spelling, so recovery lands correctly even when the enclosing
-directories were renamed after the delete. A deletion that recorded no
-binding (early tombstones carry none) answers `invalid_request` and needs
-the explicit path. The in-place parent and name obey the same rules a path
-would: the parent must not be deleted, and the name must be free, each
-answering its usual code otherwise.
+directories were renamed after the delete. The in-place parent and name obey
+the same rules a path would: the parent must not be deleted, and the name must
+be free, each answering its usual code otherwise.
 
 Only the root of a deletion can be undeleted, and `deletion_seq` must match the active deletion generation. A mismatch returns `not_deleted` with the expected and actual generations, preventing a stale recovery request from cancelling a later deletion.
 
@@ -2379,7 +2377,7 @@ Event kinds:
 | `file_created` | A file was created with its first revision. | `inode_id`, `parent_inode_id`, `display_name`, `binding_generation`, `revision_no`, `content_ref`. |
 | `content_changed` | A file received a new current revision — a replacing put or a revision restore (one durable fact for both). | `inode_id`, `revision_no`, `content_ref`. |
 | `moved` | An entry moved to a new parent directory or name. | `inode_id`, `from_parent_inode_id`, `from_display_name`, `to_parent_inode_id`, `to_display_name`, `binding_generation`. |
-| `deleted` | A file or directory subtree was deleted. Use the enclosing `committed_seq` as `deletion_seq` when restoring it. | `inode_id`, plus optional `deleted_binding` containing `parent_inode_id`, `name_key`, and `display_name`. |
+| `deleted` | A file or directory subtree was deleted. Use the enclosing `committed_seq` as `deletion_seq` when restoring it. | `inode_id`, plus `deleted_binding` containing `parent_inode_id`, `name_key`, and `display_name`. |
 | `undeleted` | A deleted inode was recovered and re-bound. | `inode_id`, `parent_inode_id`, `display_name`, `binding_generation`. |
 | `attributes_changed` | An inode's attributes changed. `attributes` is the complete flat string map after the update, so a consumer projects it without reading anything back; an empty map is the cleared state. | `inode_id`, `attributes_revision_no`, `attributes`. |
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -785,12 +785,10 @@ A `set` also carries the binding the delete removed, as one
 `deleted_direntry` value holding the `parent_inode_id`, `name_key`, and
 `display_name` together. Tombstone rows are immortal, so this is where a
 deleted name survives after unbind rows age out, and it is the binding
-undelete restores in place. A delete addressed by inode has no name to
-record and writes `deleted_direntry` as `null`; the field is always
-written, so omitting it is corruption rather than an unnamed deletion. Only a
-`set` includes this field. A reader ignores it on a `revoke`, just like any
-other unknown field (encoding conventions above). A partial binding is not
-valid.
+undelete restores in place. Every deletion records the binding it removed.
+Only a `set` includes this field. A reader ignores it on a `revoke`, just like
+any other unknown field (encoding conventions above). A partial binding is
+not valid.
 
 The `active_deletions` family tracks deletions that can still be restored. A
 `set` tombstone creates a `listed` row keyed by `(deletion_seq,
@@ -1498,7 +1496,7 @@ Five use inode IDs:
 
 Every `path`, `from_path`, and `to_path` is a canonical absolute path (section 2.3). Every `display_name` and `to_display_name` is one path component under the same grammar.
 
-Parameters marked `?` are optional and have no default. The optional `expected_*` parameters prevent races; omitting one disables that check. A revision guard requires its matching inode guard. Inode revision writes require `expected_revision_no`, while inode moves and deletes require `expected_binding_generation`. `undelete.path` overrides the original parent and name and is required when the deletion did not record a binding.
+Parameters marked `?` are optional and have no default. The optional `expected_*` parameters prevent races; omitting one disables that check. A revision guard requires its matching inode guard. Inode revision writes require `expected_revision_no`, while inode moves and deletes require `expected_binding_generation`. `undelete.path` overrides the original parent and name.
 
 `parents`, `behavior`, `set`, and `remove` have defaults. `parents` defaults to false. `behavior` defaults to `no_replace` for puts, moves, and copies, and to `non_recursive` for deletes. `set` and `remove` default to empty collections.
 
@@ -1531,8 +1529,8 @@ metadata deltas derived from the semantic operations: `create_inode`,
 standard client-facing commit operations.
 
 The two tombstone deltas carry the same values their rows do (section 2.5):
-`tombstone_subtree` states its `deleted_direntry`, as a whole binding or as
-`null`, and `revoke_subtree_tombstone` names its `target` generation. The
+`tombstone_subtree` states its `deleted_direntry` as a whole binding, and
+`revoke_subtree_tombstone` names its `target` generation. The
 delta's own generation is implied — its commit's sequence and its
 `delta_index` — so it is not written a second time.
 
@@ -1832,18 +1830,12 @@ Every durable lifecycle field is named `status`, is always present, and uses a
 `kind`-tagged object. HTTP responses flatten the same data beside their
 `status` field.
 
-Two rules govern an absent value in every durable encoding.
+One rule governs an absent value in every durable encoding.
 
-1. **An optional field is omitted when it has no value, and absence never
-   means a default.** Every field that has a value is written, including a
-   zero number and an empty list. "Absent means the default" would be a third
-   state beside present and absent, and no schema language states it, so no
-   durable encoding writes one.
-2. **One field is written as `null` instead of being omitted.** That field is
-   `deleted_direntry`, and three deletion records write it either way: the
-   tombstone `set` action, the `active_deletions` `listed` action, and the WAL
-   `tombstone_subtree` delta. A delete addressed by inode recorded no binding,
-   so it writes `null`. A record that omits the field fails to decode.
+**An optional field is omitted when it has no value, and absence never means a
+default.** Every field that has a value is written, including a zero number and
+an empty list. "Absent means the default" would be a third state beside present
+and absent, and no schema language states it, so no durable encoding writes one.
 
 ### 4.2 Format families and versions
 

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -3479,12 +3479,13 @@
       },
       "TrashEntry": {
         "type": "object",
-        "description": "One deletion that can still be restored.\n\n`inode_id` and `deletion_seq` are sufficient to restore it. The removed\ndirectory binding is included when available.",
+        "description": "One deletion that can still be restored.\n\n`inode_id` and `deletion_seq` identify it. The removed directory binding\ndetermines where an in-place restore binds it.",
         "required": [
           "inode_id",
           "deletion_seq",
           "deleted_at_ms",
-          "deleted_by"
+          "deleted_by",
+          "deleted_binding"
         ],
         "properties": {
           "deleted_at_ms": {
@@ -3495,7 +3496,7 @@
           },
           "deleted_binding": {
             "$ref": "#/components/schemas/DirectoryBinding",
-            "description": "Directory binding removed by the deletion, when available."
+            "description": "Directory binding removed by the deletion."
           },
           "deleted_by": {
             "$ref": "#/components/schemas/ActorRef",
@@ -3974,12 +3975,13 @@
         "description": "A file or directory subtree was deleted. Use the enclosing change's\n`committed_seq` as `deletion_seq` when restoring it.",
         "required": [
           "inode_id",
+          "deleted_binding",
           "kind"
         ],
         "properties": {
           "deleted_binding": {
             "$ref": "#/components/schemas/DirectoryBinding",
-            "description": "Directory binding removed by the deletion, when the delete\nrecorded one."
+            "description": "Directory binding removed by the deletion."
           },
           "inode_id": {
             "type": "string",
@@ -4439,7 +4441,7 @@
           },
           "path": {
             "$ref": "#/components/schemas/AbsolutePath",
-            "description": "Optional destination for the restored inode.\n\nWhen absent, the inode is rebound to the parent and name recorded by the\ndeletion. Parent identity, rather than an old path string, keeps this\ncorrect after ancestor renames. An explicit path is required when the\ndeletion recorded no binding."
+            "description": "Optional destination for the restored inode.\n\nWhen absent, the inode is rebound to the parent and name recorded by the\ndeletion. Parent identity, rather than an old path string, keeps this\ncorrect after ancestor renames."
           }
         }
       },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -6377,12 +6377,13 @@
       },
       "TrashEntry": {
         "type": "object",
-        "description": "One deletion that can still be restored.\n\n`inode_id` and `deletion_seq` are sufficient to restore it. The removed\ndirectory binding is included when available.",
+        "description": "One deletion that can still be restored.\n\n`inode_id` and `deletion_seq` identify it. The removed directory binding\ndetermines where an in-place restore binds it.",
         "required": [
           "inode_id",
           "deletion_seq",
           "deleted_at_ms",
-          "deleted_by"
+          "deleted_by",
+          "deleted_binding"
         ],
         "properties": {
           "deleted_at_ms": {
@@ -6393,7 +6394,7 @@
           },
           "deleted_binding": {
             "$ref": "#/components/schemas/DirectoryBinding",
-            "description": "Directory binding removed by the deletion, when available."
+            "description": "Directory binding removed by the deletion."
           },
           "deleted_by": {
             "$ref": "#/components/schemas/ActorRef",
@@ -6965,12 +6966,13 @@
         "description": "A file or directory subtree was deleted. Use the enclosing change's\n`committed_seq` as `deletion_seq` when restoring it.",
         "required": [
           "inode_id",
+          "deleted_binding",
           "kind"
         ],
         "properties": {
           "deleted_binding": {
             "$ref": "#/components/schemas/DirectoryBinding",
-            "description": "Directory binding removed by the deletion, when the delete\nrecorded one."
+            "description": "Directory binding removed by the deletion."
           },
           "inode_id": {
             "type": "string",
@@ -7430,7 +7432,7 @@
           },
           "path": {
             "$ref": "#/components/schemas/AbsolutePath",
-            "description": "Optional destination for the restored inode.\n\nWhen absent, the inode is rebound to the parent and name recorded by the\ndeletion. Parent identity, rather than an old path string, keeps this\ncorrect after ancestor renames. An explicit path is required when the\ndeletion recorded no binding."
+            "description": "Optional destination for the restored inode.\n\nWhen absent, the inode is rebound to the parent and name recorded by the\ndeletion. Parent identity, rather than an old path string, keeps this\ncorrect after ancestor renames."
           }
         }
       },


### PR DESCRIPTION
Every deletion already records the directory binding it removes, so this makes the field required in durable rows, WAL deltas, trash entries, and deleted change events. It also removes unreachable handling for deletions without a binding.

The format is updated in place. Existing fixtures already contain the field, so their encoded bytes do not change. API responses now require deleted_binding.