### PR TITLE
perf(runtime): reduce maintenance and publication overhead

### DIFF
--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -112,7 +112,7 @@ pub mod cache {
     };
     pub use crate::namespace::status::{
         load_deleted_namespace_diagnostics, load_namespace, load_namespace_diagnostics,
-        load_namespace_flush_basis, NamespaceFlushBasis,
+        load_namespace_flush_basis, NamespaceFlushBasis, NamespaceStorageDiagnostics,
     };
 }
 

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -1,12 +1,11 @@
 //! Reads namespace state and storage diagnostics.
 
-use crate::checkpoint::load_namespace_manifest_envelope;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::control_snapshot::{load_control_snapshot, load_head_and_retention_floor};
 use crate::wal::{count_visible_wal_tail_segments, WalChainLoadRequest};
 use loonfs_api::wire::control::{HeadState, NamespaceStatus};
-use loonfs_api::{ChangeSeq, ManifestNo, Namespace, NamespaceDiagnostics, NamespaceId};
+use loonfs_api::{ChangeSeq, ManifestNo, Namespace, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 
 /// Whether a namespace carries visible commits its basis manifest does not
@@ -17,7 +16,17 @@ pub struct NamespaceFlushBasis {
     pub has_unflushed_wal_tail: bool,
 }
 
-/// Namespace diagnostics before the WAL tail is counted.
+/// Namespace storage diagnostics that do not require checkpoint enumeration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceStorageDiagnostics {
+    pub namespace_id: NamespaceId,
+    pub head_seq: ChangeSeq,
+    pub retention_floor_seq: ChangeSeq,
+    pub current_manifest_no: Option<ManifestNo>,
+    pub wal_tail_segments: u64,
+}
+
+/// Namespace head state needed for storage diagnostics.
 struct LoadedHeadBasis {
     head: HeadState,
     current_manifest_no: Option<ManifestNo>,
@@ -43,21 +52,12 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
     }
     // An unflushed fork measures its WAL tail from the fork point.
     let (current_manifest_no, basis_head_seq) = match basis.manifest() {
-        Some(manifest) => {
-            let envelope = load_namespace_manifest_envelope(
-                store,
-                &manifest.owner_namespace_id,
-                &manifest.manifest_object_id,
-            )
-            .await
-            .map_err(|error| {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-            })?;
-            let own_manifest_no = basis
+        Some(manifest) => (
+            basis
                 .is_owned_by(expected_namespace_id)
-                .then_some(manifest.manifest_no);
-            (own_manifest_no, envelope.payload.head_seq)
-        }
+                .then_some(manifest.manifest_no),
+            manifest.manifest_head_seq,
+        ),
         None => (None, ChangeSeq(0)),
     };
     Ok(LoadedHeadBasis {
@@ -97,7 +97,7 @@ pub async fn load_namespace<S: ObjectStore + ?Sized>(
 pub async fn load_namespace_diagnostics<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<NamespaceDiagnostics> {
+) -> Result<NamespaceStorageDiagnostics> {
     let loaded = load_namespace_head_basis(store, expected_namespace_id).await?;
     let wal_tail_segments = count_visible_wal_tail_segments(&WalChainLoadRequest {
         namespace_id: expected_namespace_id,
@@ -110,14 +110,12 @@ pub async fn load_namespace_diagnostics<S: ObjectStore + ?Sized>(
     .map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
-    Ok(NamespaceDiagnostics {
+    Ok(NamespaceStorageDiagnostics {
         namespace_id: loaded.head.namespace_id,
         head_seq: loaded.head.seq,
         retention_floor_seq: loaded.retention_floor_seq,
         current_manifest_no: loaded.current_manifest_no,
         wal_tail_segments,
-        live_snapshots: 0,
-        live_checkpoints: 0,
     })
 }
 
@@ -144,7 +142,7 @@ pub async fn load_namespace_flush_basis<S: ObjectStore + ?Sized>(
 pub async fn load_deleted_namespace_diagnostics<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<NamespaceDiagnostics> {
+) -> Result<NamespaceStorageDiagnostics> {
     let (head, retention_floor_seq) = load_head_and_retention_floor(store, expected_namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
@@ -154,13 +152,11 @@ pub async fn load_deleted_namespace_diagnostics<S: ObjectStore + ?Sized>(
             "namespace `{expected_namespace_id}` is live; deleted diagnostics require a deleted namespace"
         )));
     }
-    Ok(NamespaceDiagnostics {
+    Ok(NamespaceStorageDiagnostics {
         namespace_id: head.namespace_id,
         head_seq: head.seq,
         retention_floor_seq,
         current_manifest_no: None,
         wal_tail_segments: 0,
-        live_snapshots: 0,
-        live_checkpoints: 0,
     })
 }

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -461,15 +461,11 @@ async fn build_handles(
         // The admin honors the configured cache sizing and shares the
         // writer's decoded-block cache instance, so explicit maintenance
         // reuses blocks reader traffic already decoded instead of
-        // populating a second, default-sized cache.
+        // populating a second, default-sized cache. It also shares the
+        // publisher and background compactions so maintenance invalidates
+        // writer projections and uses the writer's runner.
         .runtime_cache(config.runtime_cache_config())
-        .shared_metadata_segment_cache(&writer)
-        // A maintenance step this server runs on request may plan a
-        // background streaming compaction. Sharing the writer's runner is
-        // what lets it start one, makes the operator's step and the writer's
-        // own steps agree that a namespace runs one job at a time, and puts
-        // the job under the shutdown that settles the writer.
-        .background_maintenance(&writer)
+        .over_writer(&writer)
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind)
         .metrics_recorder(metrics.recorder());

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use crate::{ChangeSeq, Result, RuntimeError};
 use loonfs_api::PageRequest;
-use loonfs_core::cache::load_namespace_flush_basis;
+use loonfs_core::cache::{load_namespace_flush_basis, NamespaceStorageDiagnostics};
 use loonfs_core::CheckpointPageCursor;
 use std::num::NonZeroU32;
 use tokio::time::Instant;
@@ -134,8 +134,8 @@ impl FsAdmin {
     /// rebuildable half of that namespace's publisher state.
     pub(crate) fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
         self.core.invalidate_namespace_read_cache(namespace_id);
-        if let Some(publisher) = &self.publisher {
-            publisher.invalidate_projection(namespace_id);
+        if let Some(writer) = &self.writer {
+            writer.publisher.invalidate_projection(namespace_id);
         }
     }
 
@@ -168,11 +168,22 @@ impl FsAdmin {
         namespace_id: &NamespaceId,
     ) -> Result<NamespaceDiagnostics> {
         self.core.record_trace_context(&tracing::Span::current());
-        let mut diagnostics =
+        let diagnostics =
             loonfs_core::cache::load_namespace_diagnostics(self.core.store(), namespace_id).await?;
+        let (live_checkpoints, live_snapshots) = self.count_live_checkpoints(namespace_id).await?;
+        Ok(Self::namespace_diagnostics(
+            diagnostics,
+            live_checkpoints,
+            live_snapshots,
+        ))
+    }
+
+    async fn count_live_checkpoints(&self, namespace_id: &NamespaceId) -> Result<(u64, u64)> {
         let now_ms = self.actor.mutation_context()?.now_ms;
         let page_limit = loonfs_api::PaginationPolicy::default().max_limit();
         let mut cursor = None;
+        let mut live_checkpoints = 0_u64;
+        let mut live_snapshots = 0_u64;
         loop {
             let page = self
                 .engine(namespace_id)
@@ -185,23 +196,61 @@ impl FsAdmin {
             for checkpoint in page.items {
                 match checkpoint.owner {
                     loonfs_api::CheckpointOwnerSummary::User { .. } => {
-                        diagnostics.live_checkpoints =
-                            diagnostics.live_checkpoints.saturating_add(1);
+                        live_checkpoints = live_checkpoints.saturating_add(1);
                     }
                     loonfs_api::CheckpointOwnerSummary::Snapshot { expires_at_ms, .. }
                         if expires_at_ms > now_ms =>
                     {
-                        diagnostics.live_snapshots = diagnostics.live_snapshots.saturating_add(1);
+                        live_snapshots = live_snapshots.saturating_add(1);
                     }
                     loonfs_api::CheckpointOwnerSummary::Fork { .. }
                     | loonfs_api::CheckpointOwnerSummary::Snapshot { .. } => {}
                 }
             }
             let Some(next_cursor) = page.next_cursor else {
-                return Ok(diagnostics);
+                return Ok((live_checkpoints, live_snapshots));
             };
             cursor = Some(next_cursor);
         }
+    }
+
+    fn namespace_diagnostics(
+        diagnostics: NamespaceStorageDiagnostics,
+        live_checkpoints: u64,
+        live_snapshots: u64,
+    ) -> NamespaceDiagnostics {
+        NamespaceDiagnostics {
+            namespace_id: diagnostics.namespace_id,
+            head_seq: diagnostics.head_seq,
+            retention_floor_seq: diagnostics.retention_floor_seq,
+            current_manifest_no: diagnostics.current_manifest_no,
+            wal_tail_segments: diagnostics.wal_tail_segments,
+            live_snapshots,
+            live_checkpoints,
+        }
+    }
+
+    async fn load_maintenance_status_before(
+        &self,
+        namespace_id: &NamespaceId,
+        collects_only: bool,
+    ) -> Result<NamespaceDiagnostics> {
+        let diagnostics =
+            match loonfs_core::cache::load_namespace_diagnostics(self.core.store(), namespace_id)
+                .await
+            {
+                Ok(diagnostics) => diagnostics,
+                Err(error) if error.code() == ErrorCode::NamespaceDeleted && collects_only => {
+                    // These control objects survive deleted-namespace reclamation.
+                    loonfs_core::cache::load_deleted_namespace_diagnostics(
+                        self.core.store(),
+                        namespace_id,
+                    )
+                    .await?
+                }
+                Err(error) => return Err(error.into()),
+            };
+        Ok(Self::namespace_diagnostics(diagnostics, 0, 0))
     }
 
     /// Runs one bounded maintenance step against a namespace.
@@ -243,27 +292,9 @@ impl FsAdmin {
                 .get_or_insert(loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS);
         }
         let collects_only = plan.gc.is_some() && plan.metadata.is_none() && !plan.advance_retention;
-        let status_before = match self.get_namespace_diagnostics(namespace_id).await {
-            Ok(status) => status,
-            // A tombstoned namespace keeps reclaimable derived state — WAL
-            // segments, metadata segments, manifests, checkpoint records — until GC
-            // ages it out, and a collection-only step is the reclamation
-            // path. It proceeds against the tombstone; the summary comes
-            // from the two control objects that outlive reclamation,
-            // because the manifest and chain a live summary consults may
-            // already be reaped. Any other plan still refuses: a tombstone
-            // has nothing to flush, reorganize, or retain.
-            Err(RuntimeError::Core(error))
-                if error.code() == ErrorCode::NamespaceDeleted && collects_only =>
-            {
-                loonfs_core::cache::load_deleted_namespace_diagnostics(
-                    self.core.store(),
-                    namespace_id,
-                )
-                .await?
-            }
-            Err(error) => return Err(error),
-        };
+        let status_before = self
+            .load_maintenance_status_before(namespace_id, collects_only)
+            .await?;
 
         let metadata_maintenance = if let Some(options) = plan.metadata {
             Some(
@@ -359,8 +390,8 @@ impl FsAdmin {
         // Writers with background maintenance spread a rebuild across delta
         // merges. Manual-only handles report that compaction is required
         // instead of starting work they cannot finish in the background.
-        let frozen_base = match &self.compactions {
-            Some(compactions) => compactions.amortization(namespace_id),
+        let frozen_base = match &self.writer {
+            Some(writer) => writer.compactions.amortization(namespace_id),
             None => loonfs_core::FrozenBasePolicy::CompactImmediately,
         };
         Ok(
@@ -395,9 +426,9 @@ impl FsAdmin {
         // exactly as a namespace nothing is running for. It could not start
         // one either way.
         let active = self
-            .compactions
+            .writer
             .as_ref()
-            .and_then(|compactions| compactions.active_spec(namespace_id));
+            .and_then(|writer| writer.compactions.active_spec(namespace_id));
         let report = self
             .engine(namespace_id)
             .reorganize_metadata(loonfs_core::MetadataCompactionView {
@@ -422,8 +453,12 @@ impl FsAdmin {
                 self.invalidate_namespace(namespace_id);
                 // Track delta-only merges across steps so the runner knows
                 // when to schedule a full compaction.
-                if let Some(compactions) = &self.compactions {
-                    compactions.record_merge(namespace_id, group, bottom_anchored_merge_blocked);
+                if let Some(writer) = &self.writer {
+                    writer.compactions.record_merge(
+                        namespace_id,
+                        group,
+                        bottom_anchored_merge_blocked,
+                    );
                 }
                 tracing::info!(
                     families = ?group.families(),
@@ -458,8 +493,8 @@ impl FsAdmin {
         let families = spec.families();
         let input_runs = spec.input_runs();
         let input_rows = spec.input_rows();
-        let started = match &self.compactions {
-            Some(compactions) => compactions.start(self, namespace_id, spec),
+        let started = match &self.writer {
+            Some(writer) => writer.compactions.start(self, namespace_id, spec),
             None => CompactionStart::NoRunner,
         };
         match started {
@@ -539,7 +574,7 @@ impl FsAdmin {
             }
             ReorganizationStep::Concluded(_) => return Ok(MetadataCompactionOutcome::NoWork),
         };
-        let Some(compactions) = &self.compactions else {
+        let Some(writer) = &self.writer else {
             // Standalone handles have no shared concurrency limit.
             let cancellation = loonfs_core::MetadataCompactionCancellation::default();
             let outcome = self
@@ -547,7 +582,7 @@ impl FsAdmin {
                 .await;
             return Ok(MetadataCompactionOutcome::Ran(outcome?));
         };
-        let Some(mut claim) = compactions.claim(namespace_id, &spec) else {
+        let Some(mut claim) = writer.compactions.claim(namespace_id, &spec) else {
             return Ok(MetadataCompactionOutcome::AlreadyRunning);
         };
         if !claim.admitted().await {
@@ -604,8 +639,10 @@ impl FsAdmin {
                 self.invalidate_namespace(namespace_id);
                 // A full compaction includes the base run, so reset the count
                 // of delta-only merges.
-                if let Some(compactions) = &self.compactions {
-                    compactions.clear_published_delta_merges(namespace_id, spec.group());
+                if let Some(writer) = &self.writer {
+                    writer
+                        .compactions
+                        .clear_published_delta_merges(namespace_id, spec.group());
                 }
                 tracing::info!(
                     namespace_id = %namespace_id,
@@ -740,9 +777,8 @@ impl FsAdmin {
 
     /// Creates a snapshot only when the namespace has quota for it.
     ///
-    /// The second quota check closes the race between concurrent callers that
-    /// both observe the same free slot. A caller that loses that race releases
-    /// its tentative snapshot before returning the quota error.
+    /// A caller that exceeds the quota releases its tentative snapshot before
+    /// returning the quota error.
     pub async fn create_snapshot_with_quota(
         &self,
         namespace_id: &NamespaceId,
@@ -750,8 +786,6 @@ impl FsAdmin {
         now_ms: u64,
         max_live: usize,
     ) -> Result<Checkpoint> {
-        self.ensure_snapshot_quota(namespace_id, now_ms, max_live)
-            .await?;
         let checkpoint = self.create_snapshot(namespace_id, options).await?;
         if let Err(error) = self
             .ensure_live_snapshot_limit(namespace_id, now_ms, max_live, 0)
@@ -762,17 +796,6 @@ impl FsAdmin {
             return Err(error);
         }
         Ok(checkpoint)
-    }
-
-    /// Checks whether the namespace has room for another live snapshot.
-    pub async fn ensure_snapshot_quota(
-        &self,
-        namespace_id: &NamespaceId,
-        now_ms: u64,
-        max_live: usize,
-    ) -> Result<()> {
-        self.ensure_live_snapshot_limit(namespace_id, now_ms, max_live, 1)
-            .await
     }
 
     async fn ensure_live_snapshot_limit(

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -61,7 +61,7 @@ async fn manual_deployment(
         .expect("build the standalone admin");
     let scheduled = FsAdmin::builder_with_store(store)
         .actor_id("scheduled-admin")
-        .background_maintenance(&writer)
+        .over_writer(&writer)
         .build()
         .await
         .expect("build the writer-backed admin");

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -23,24 +23,18 @@ use std::sync::Arc;
 pub struct FsAdmin {
     pub(crate) core: ReadCore,
     pub(crate) actor: WriterIdentity,
-    /// A tail projection to invalidate exists only where a publisher does,
-    /// so a standalone admin holds `None`, and an admin built over a
-    /// writer's runtime for background maintenance holds that writer's
-    /// registry.
-    pub(crate) publisher: Option<PublisherRegistry>,
-    /// The streaming metadata compactions a writer's maintenance runner is
-    /// running, when this handle has a writer behind it.
-    ///
-    /// A maintenance step consults it twice: to leave alone the group a job
-    /// is rebuilding, and to start a job when it plans one. A handle with no
-    /// writer behind it holds `None`, schedules no background work of any
-    /// kind, and reports the plan instead of starting it.
-    pub(crate) compactions: Option<BackgroundCompactions>,
+    pub(crate) writer: Option<WriterParts>,
     /// A narrowed per-step row budget for the tests that need a family group
     /// whose base run no bounded step can fold. See
     /// [`Self::starve_reorganization_row_budget`].
     #[cfg(test)]
     pub(crate) reorganization_row_budget: Option<std::num::NonZeroUsize>,
+}
+
+#[derive(Clone)]
+pub(crate) struct WriterParts {
+    pub(crate) publisher: PublisherRegistry,
+    pub(crate) compactions: BackgroundCompactions,
 }
 
 impl FsAdmin {
@@ -73,8 +67,10 @@ impl FsAdmin {
         Self {
             core,
             actor,
-            publisher: Some(publisher),
-            compactions: Some(compactions),
+            writer: Some(WriterParts {
+                publisher,
+                compactions,
+            }),
             #[cfg(test)]
             reorganization_row_budget: None,
         }
@@ -111,7 +107,7 @@ impl FsAdmin {
 pub struct FsAdminBuilder {
     core: HandleBuilderCore,
     actor_id: Option<String>,
-    compactions: Option<BackgroundCompactions>,
+    writer: Option<WriterParts>,
 }
 
 impl FsAdminBuilder {
@@ -119,7 +115,7 @@ impl FsAdminBuilder {
         Self {
             core,
             actor_id: None,
-            compactions: None,
+            writer: None,
         }
     }
 
@@ -136,31 +132,18 @@ impl FsAdminBuilder {
         self
     }
 
-    /// Shares the writer's decoded-block cache with this admin handle. Use a
-    /// writer from the same runtime. The shared cache keeps the writer's byte
+    /// Connects this admin to a writer from the same runtime.
+    ///
+    /// The admin shares the writer's decoded-block cache, publisher, and
+    /// background compactions. The shared cache keeps the writer's byte
     /// budget; [`Self::runtime_cache`] still configures this handle's other
     /// caches.
-    pub fn shared_metadata_segment_cache(mut self, writer: &super::FsWriter) -> Self {
+    pub fn over_writer(mut self, writer: &super::FsWriter) -> Self {
         self.core.shared_metadata_segment_cache = Some(writer.metadata_segment_cache());
-        self
-    }
-
-    /// Lets this handle's maintenance steps start background work on
-    /// `writer`'s maintenance runner instead of declining it.
-    ///
-    /// One kind of upkeep does not fit in a step: a family group that has
-    /// outgrown one step's budgets is rebuilt by a streaming compaction that
-    /// runs for as long as it takes and publishes once at the end. Without
-    /// this, an explicit step reports that the group needs one and starts
-    /// nothing, because a handle that owns no background work has nowhere to
-    /// run it. With it, an operator's step starts the same job the writer's
-    /// own steps start, the two share the one-job-per-namespace rule, and
-    /// `writer`'s shutdown cancels and drains it.
-    ///
-    /// Only for a writer in the same runtime ownership domain, like
-    /// [`Self::shared_metadata_segment_cache`].
-    pub fn background_maintenance(mut self, writer: &super::FsWriter) -> Self {
-        self.compactions = Some(writer.background_compactions());
+        self.writer = Some(WriterParts {
+            publisher: writer.publisher(),
+            compactions: writer.background_compactions(),
+        });
         self
     }
 
@@ -209,8 +192,7 @@ impl FsAdminBuilder {
         Ok(FsAdmin {
             core: self.core.open_read_core()?,
             actor,
-            publisher: None,
-            compactions: self.compactions,
+            writer: self.writer,
             #[cfg(test)]
             reorganization_row_budget: None,
         })

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -310,7 +310,7 @@ impl FsWriterBuilder {
     /// Handles that share this writer's decoded cache also share this local
     /// cache. The host owns and closes it; object storage remains authoritative.
     ///
-    /// [`FsAdminBuilder::shared_metadata_segment_cache`]: crate::FsAdminBuilder::shared_metadata_segment_cache
+    /// [`FsAdminBuilder::over_writer`]: crate::FsAdminBuilder::over_writer
     pub fn stored_metadata_block_cache(
         mut self,
         stored_metadata_block_cache: Arc<dyn StoredMetadataBlockCache>,

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -16,6 +16,7 @@ use crate::{
     MetadataMaintenanceResponse, NamespaceId, ReorganizeStepOutcome, Result, RuntimeError,
     WalFlushStepOutcome,
 };
+use loonfs_core::cache::load_namespace_diagnostics;
 use loonfs_core::limits::{
     CONTENT_RECLAMATION_GRACE_MS, GC_SAFETY_MARGIN_MS, UPLOAD_SESSION_LEASE_MS,
 };
@@ -154,21 +155,31 @@ impl MaintenanceJob for MetadataJob {
     }
 
     async fn probe(&self, namespace_id: &NamespaceId) -> Result<MaintenanceProbe> {
-        let Some((_writer, admin)) = self.context.admin() else {
+        let Some(_writer) = self.context.bits.upgrade() else {
             return Ok(MaintenanceProbe::Idle);
         };
-        // One head summary, the same read the step opens with. Reorganize
-        // debt has no comparably cheap question, and it needs none: a
-        // publishing unit concludes `Progressed`, so a backlog is folded by
-        // the run that found it rather than left for a sweep.
-        match admin.get_namespace_diagnostics(namespace_id).await {
-            Ok(status) => Ok(if self.options.flush_is_due(status.wal_tail_segments) {
-                MaintenanceProbe::Due
-            } else {
-                MaintenanceProbe::Idle
-            }),
-            Err(error) if metadata_has_nothing_to_maintain(&error) => Ok(MaintenanceProbe::Idle),
-            Err(error) => Err(error),
+        // The same durable read the step opens with: control objects plus
+        // the WAL tail count, without listing checkpoints. Reorganize debt
+        // has no comparably cheap question, and it needs none: a publishing
+        // unit concludes `Progressed`, so a backlog is folded by the run that
+        // found it rather than left for a sweep.
+        match load_namespace_diagnostics(self.context.core.store(), namespace_id).await {
+            Ok(diagnostics) => Ok(
+                if self.options.flush_is_due(diagnostics.wal_tail_segments) {
+                    MaintenanceProbe::Due
+                } else {
+                    MaintenanceProbe::Idle
+                },
+            ),
+            Err(error)
+                if matches!(
+                    error.code(),
+                    ErrorCode::NamespaceNotFound | ErrorCode::NamespaceDeleted
+                ) =>
+            {
+                Ok(MaintenanceProbe::Idle)
+            }
+            Err(error) => Err(error.into()),
         }
     }
 }

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -543,7 +543,11 @@ enum SubmissionAdmission {
     /// A different claim currently owns the commit ID. Its successful outcome
     /// supplies the receipt evidence this submission needs for a useful
     /// conflict; if it fails, this submission gets another turn at admission.
-    Contended { primary_identity: CommitFingerprint },
+    Contended {
+        primary_identity: CommitFingerprint,
+        candidate: CommitCandidate,
+        semantic_identity: CommitFingerprint,
+    },
 }
 
 impl NamespacePublisher {
@@ -648,13 +652,14 @@ impl NamespacePublisher {
     async fn submit(&self, candidate: CommitCandidate) -> CommitResult {
         let commit_id = candidate.commit_id().clone();
         let enqueued_at = Instant::now();
-        let semantic_identity = candidate.semantic_identity(&self.namespace_id)?;
-        loop {
+        let mut candidate = candidate;
+        let mut semantic_identity = candidate.semantic_identity(&self.namespace_id)?;
+        for _ in 0..CONTENTION_RETRY_LIMIT {
             let (sender, receiver) = oneshot::channel();
             let admission = self.admit(
                 commit_id.clone(),
-                candidate.clone(),
-                semantic_identity.clone(),
+                candidate,
+                semantic_identity,
                 sender,
                 enqueued_at,
             )?;
@@ -665,7 +670,11 @@ impl NamespacePublisher {
             })?;
             match admission {
                 SubmissionAdmission::OwnOutcome => return result,
-                SubmissionAdmission::Contended { primary_identity } => match result {
+                SubmissionAdmission::Contended {
+                    primary_identity,
+                    candidate: returned_candidate,
+                    semantic_identity: returned_identity,
+                } => match result {
                     Ok(response) => {
                         return Err(CoreError::CommitIdReuseConflict {
                             commit_id: commit_id.to_string(),
@@ -674,10 +683,19 @@ impl NamespacePublisher {
                         }
                         .into())
                     }
-                    Err(_) => continue,
+                    Err(_) => {
+                        candidate = returned_candidate;
+                        semantic_identity = returned_identity;
+                    }
                 },
             }
         }
+        Err(CoreError::CommitIdReuseConflict {
+            commit_id: commit_id.to_string(),
+            committed_seq: None,
+            committed_fingerprint: None,
+        }
+        .into())
     }
 
     fn admit(
@@ -695,7 +713,11 @@ impl NamespacePublisher {
                 let primary_identity = existing.semantic_identity.clone();
                 existing.waiters.push(waiter);
                 self.trace_enqueue(queued_candidates(&state), "contended");
-                return Ok(SubmissionAdmission::Contended { primary_identity });
+                return Ok(SubmissionAdmission::Contended {
+                    primary_identity,
+                    candidate,
+                    semantic_identity,
+                });
             }
             existing.waiters.push(waiter);
             self.trace_enqueue(queued_candidates(&state), "duplicate");

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -11,7 +11,7 @@ use crate::maintenance_runner::MaintenanceRunner;
 use crate::metrics::{DefaultMetricsRecorder, MetricValue, RuntimeInstruments};
 use crate::publish::{CommitRequest, ContentPreparationError, FilesystemOperation};
 use crate::{
-    BeginUploadRequest, CreateNamespaceOptions, ErrorCode, RuntimeCacheConfig,
+    BeginUploadRequest, CreateNamespaceOptions, ErrorCode, FsAdmin, RuntimeCacheConfig,
     SharedObjectStore as SharedStore, TraceMode, TraceStoreKind,
 };
 use async_trait::async_trait;
@@ -796,6 +796,63 @@ async fn publisher_contender_retries_after_active_request_fails() {
         .expect("contender publishes after the failed primary");
     assert_eq!(response.commit_id, commit_id);
     assert_eq!(response.committed_seq, ChangeSeq(1));
+}
+
+#[tokio::test]
+async fn publisher_contender_reports_conflict_after_retry_limit() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let runtime = test_runtime(store);
+    let publisher = standalone_publisher(&namespace_id, &runtime);
+    let commit_id = CommitId::parse("bounded-handoff").expect("valid commit id");
+    let primary_identity =
+        CommitCandidate::new(create_directory_request("bounded-handoff", "first"))
+            .semantic_identity(&namespace_id)
+            .expect("primary identity");
+    publisher_state(&publisher).in_flight.insert(
+        commit_id.clone(),
+        InFlightRequest {
+            semantic_identity: primary_identity,
+            waiters: Vec::new(),
+        },
+    );
+
+    let contender = {
+        let publisher = publisher.clone();
+        tokio::spawn(async move {
+            publisher
+                .submit(CommitCandidate::new(create_directory_request(
+                    "bounded-handoff",
+                    "second",
+                )))
+                .await
+        })
+    };
+    for _ in 0..CONTENTION_RETRY_LIMIT {
+        wait_for_commit_waiters(&publisher, &commit_id, 1).await;
+        let waiter = publisher_state(&publisher)
+            .in_flight
+            .get_mut(&commit_id)
+            .expect("in-flight primary")
+            .waiters
+            .pop()
+            .expect("contender waiter");
+        let _ = waiter.send(Err(CoreError::Internal("primary failed".to_owned()).into()));
+    }
+
+    let error = contender
+        .await
+        .expect("contender task")
+        .expect_err("retry limit reports a conflict");
+    assert!(matches!(
+        error,
+        RuntimeError::Core(CoreError::CommitIdReuseConflict {
+            commit_id: conflicting_id,
+            committed_seq: None,
+            committed_fingerprint: None,
+        }) if conflicting_id == commit_id.as_str()
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2137,6 +2194,37 @@ async fn retained_tail_projections_stay_within_the_namespace_count_cap() {
         .drain()
         .await
         .expect("drain settles every publisher");
+}
+
+#[tokio::test]
+async fn admin_over_writer_invalidates_publisher_projection() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let writer = test_writer_with_interval(store.clone(), 0).await;
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .publisher()
+        .submit_candidate(
+            namespace_id.clone(),
+            CommitCandidate::new(create_directory_request("seed", "docs")),
+        )
+        .await
+        .expect("publish commit");
+    assert_eq!(retained_projections(&writer.publisher()).projections, 1);
+
+    let admin = FsAdmin::builder_with_store(store)
+        .actor_id("admin")
+        .over_writer(&writer)
+        .build()
+        .await
+        .expect("build admin");
+    admin.invalidate_namespace(&namespace_id);
+
+    assert_eq!(retained_projections(&writer.publisher()).projections, 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -155,6 +155,12 @@ fn namespace_diagnostics_counts_user_and_live_snapshot_records_only() {
         .expect("read diagnostics");
     assert_eq!(diagnostics.live_snapshots, 1);
     assert_eq!(diagnostics.live_checkpoints, 2);
+
+    let step = fs
+        .maintenance_step_namespace_blocking(&source, MaintenancePlan::metadata())
+        .expect("run maintenance");
+    assert_eq!(step.status_before.live_snapshots, 0);
+    assert_eq!(step.status_before.live_checkpoints, 0);
 }
 
 /// Pointers a head published before the accelerator was sized to cover the
@@ -1053,12 +1059,9 @@ async fn concurrent_snapshot_creates_cannot_both_claim_the_last_quota_slot() {
             .await
     });
 
-    wait_for_operations(&checkpoint_lists, 2).await;
-    checkpoint_list_gate.release();
     wait_for_operations(&checkpoint_writes, 2).await;
-    checkpoint_list_gate.arm();
     checkpoint_write_gate.release();
-    wait_for_operations(&checkpoint_lists, 4).await;
+    wait_for_operations(&checkpoint_lists, 2).await;
     checkpoint_list_gate.release();
 
     let first = first.await.expect("first create task");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -826,7 +826,7 @@ This request selects all three actions:
 {"metadata_maintenance":{"max_wal_tail_segments":8},"retention":{},"gc":{"max_objects":1024}}
 ```
 
-Each selected action reports under the same field that selected it. `metadata_maintenance` contains `wal_flush` and `reorganize`, `retention` contains `retention_floor_seq`, and `gc` contains the collection result. An absent field means the action was not selected. Compare `retention.retention_floor_seq` with `status_before.retention_floor_seq` to see whether the floor moved. Races and supersessions are outcomes, not errors.
+Each selected action reports under the same field that selected it. `metadata_maintenance` contains `wal_flush` and `reorganize`, `retention` contains `retention_floor_seq`, and `gc` contains the collection result. An absent field means the action was not selected. `status_before.live_snapshots` and `status_before.live_checkpoints` are zero because a maintenance step does not list checkpoints. Compare `retention.retention_floor_seq` with `status_before.retention_floor_seq` to see whether the floor moved. Races and supersessions are outcomes, not errors.
 
 Outcome names describe what the step observed. The same name has the same meaning in every maintenance response.
 


### PR DESCRIPTION
Reduces repeated work in maintenance and commit publication. Maintenance probes now read namespace storage state without listing checkpoints, and namespace diagnostics use the manifest reference instead of loading the manifest object. Writer-backed admin handles also share the writer's cache, publisher, and background compactions.

Snapshot quota checks now list checkpoints once. An over-quota request creates and releases its snapshot before returning an error. Commit submission avoids cloning candidates on the common path and returns commit_id_reuse_conflict after eight consecutive conflicting claims. No wire or durable formats change.