### PR TITLE
fix(cli): handle oversized uploads and existing copy directories

### DIFF
--- a/crates/loonfs-cli/src/backend_error.rs
+++ b/crates/loonfs-cli/src/backend_error.rs
@@ -121,6 +121,12 @@ impl From<ClientError> for BackendError {
                 request_id,
                 details,
             },
+            ClientError::UploadTooLarge { size_bytes, reason } => Self::new(
+                ErrorCode::ContentTooLarge.as_str(),
+                format!(
+                    "payload of {size_bytes} bytes exceeds every upload transport this deployment offers: {reason}"
+                ),
+            ),
             ClientError::Io(message) => Self::io_error(format!("i/o error: {message}")),
             // `ClientError` is non-exhaustive across crate boundaries, so future
             // variants map to a generic transport failure. Add an explicit arm when a
@@ -241,6 +247,12 @@ mod tests {
         let error = BackendError::from(ClientError::Io("read failed".to_owned()));
         assert_eq!(error.code, "io_error");
         assert_eq!(error.message, "i/o error: read failed");
+
+        let error = BackendError::from(ClientError::UploadTooLarge {
+            size_bytes: 1024,
+            reason: "proxied and direct limits are lower".to_owned(),
+        });
+        assert_eq!(error.code, loonfs_api::ErrorCode::ContentTooLarge.as_str());
     }
 
     #[test]

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -2,15 +2,17 @@
 
 use super::output::CommandFailure;
 use crate::args::{ActorSelectorArgs, CommandKind, TargetSelectorArgs};
+use crate::backend_error::BackendError;
 use crate::config::{ConfigLocation, ConfigSource};
 use crate::error::CliError;
 use crate::resolve::{
     load_cli_config, resolve_actor, resolve_namespace, resolve_target_profile_from_config,
 };
 use loonfs_api::{
-    AbsolutePath, ActorRef, ChangeSeq, ErrorCode, InodeId, NamespaceId, PublicOrdinalRangeError,
+    AbsolutePath, ActorRef, ChangeSeq, CommitResponse, ErrorCode, InodeId, InodeKind, NamespaceId,
+    PublicOrdinalRangeError,
 };
-use loonfs_client::NamespacePath;
+use loonfs_client::{CreateDirectoryOptions, NamespacePath};
 use std::path::{Path, PathBuf};
 
 pub(crate) struct CommandContext {
@@ -19,6 +21,38 @@ pub(crate) struct CommandContext {
     pub(crate) namespace: NamespaceId,
     pub(crate) actor: ActorRef,
     pub(crate) target: crate::resolve::ResolvedTarget,
+}
+
+pub(crate) enum RemoteDirectoryOutcome {
+    Created(CommitResponse),
+    AlreadyExists {
+        inode_id: InodeId,
+        head_seq: ChangeSeq,
+    },
+}
+
+pub(crate) async fn create_directory_tolerating_existing(
+    context: &CommandContext,
+    spec: &NamespacePath,
+    options: &CreateDirectoryOptions,
+) -> Result<RemoteDirectoryOutcome, BackendError> {
+    match context.target.create_directory(spec, options).await {
+        Ok(result) => Ok(RemoteDirectoryOutcome::Created(result)),
+        Err(error) if error.code == ErrorCode::PathConflict.as_str() => {
+            let existing = context
+                .target
+                .get_path_entry_without_attributes(spec)
+                .await?;
+            if existing.inode_kind() != InodeKind::Directory {
+                return Err(error);
+            }
+            Ok(RemoteDirectoryOutcome::AlreadyExists {
+                inode_id: existing.inode_id,
+                head_seq: existing.head_seq,
+            })
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// Attributes a failure to a resolved profile and mode, for command paths

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -2,9 +2,10 @@
 //! and grep.
 
 use super::context::{
-    default_remote_put_path, destination_path_for_get, destination_user_path, directory_intent,
-    fail, namespace_path, parse_public_ordinal_arg, parse_user_path_arg, render_target,
-    resolve_command_context, resolve_mutation_context, CommandContext, UndeleteHint,
+    create_directory_tolerating_existing, default_remote_put_path, destination_path_for_get,
+    destination_user_path, directory_intent, fail, namespace_path, parse_public_ordinal_arg,
+    parse_user_path_arg, render_target, resolve_command_context, resolve_mutation_context,
+    CommandContext, RemoteDirectoryOutcome, UndeleteHint,
 };
 use super::output::{
     CommandData, CommandFailure, CommandOutput, ListingHeadDrift, ListingHeadObservation,
@@ -29,7 +30,7 @@ use loonfs_api::v0::UploadSessionStatus;
 use loonfs_api::{
     AbsolutePath, ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue, ChangeSeq,
     CheckpointId, CommitId, CommitResponse, ContentRef, DeleteDirectoryBehavior,
-    DestinationBehavior, ErrorCode, InodeKind, ListPathEntriesResponse, NamespaceId, RevisionNo,
+    DestinationBehavior, InodeKind, ListPathEntriesResponse, NamespaceId, RevisionNo,
 };
 use loonfs_client::{
     CommitOptions, CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions,
@@ -1398,35 +1399,30 @@ pub(crate) async fn run_filesystem_mkdir(
         parents: args.parents,
         commit: commit_options(&context.actor, commit_id, args.message.clone()),
     };
-    let result = match context.target.create_directory(&spec, &options).await {
-        Ok(result) => result,
-        // Unix `mkdir -p` treats a directory that is already there as
-        // success. The conflict is what says the path is occupied, and a
-        // stat then says by what: a directory is the state `-p` asked for,
-        // anything else is the conflict the caller has to hear about.
-        // Reading the conflict rather than pre-checking keeps the ordinary
-        // path one round trip, and a pre-check would race just the same.
-        Err(error) if args.parents && error.code == ErrorCode::PathConflict.as_str() => {
-            let existing = context
-                .target
-                .get_path_entry_without_attributes(&spec)
-                .await
-                .map_err(|_| context.fail(kind, error.clone()))?;
-            if existing.inode_kind() != InodeKind::Directory {
-                return Err(context.fail(kind, error));
-            }
+    let outcome = if args.parents {
+        create_directory_tolerating_existing(&context, &spec, &options).await
+    } else {
+        context
+            .target
+            .create_directory(&spec, &options)
+            .await
+            .map(RemoteDirectoryOutcome::Created)
+    }
+    .map_err(|error| context.fail(kind, error))?;
+    let result = match outcome {
+        RemoteDirectoryOutcome::Created(result) => result,
+        RemoteDirectoryOutcome::AlreadyExists { inode_id, head_seq } => {
             return Ok(CommandOutput {
                 kind,
                 profile: Some(context.profile_name),
                 mode: Some(context.mode),
                 data: CommandData::DirectoryAlreadyExists {
                     target: render_target(&context.namespace, spec.absolute_path()),
-                    inode_id: existing.inode_id,
-                    head_seq: existing.head_seq,
+                    inode_id,
+                    head_seq,
                 },
             });
         }
-        Err(error) => return Err(context.fail(kind, error)),
     };
 
     Ok(CommandOutput {

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -4,7 +4,9 @@
 //! uses the corresponding single-file operation and commits independently.
 //! Transfers use bounded concurrency and report failures per file.
 
-use super::context::CommandContext;
+use super::context::{
+    create_directory_tolerating_existing, CommandContext, RemoteDirectoryOutcome,
+};
 use super::output::{
     CommandData, CommandFailure, CommandOutput, ListingHeadDrift, ListingHeadObservation,
     TreeTransferFailure,
@@ -15,7 +17,7 @@ use crate::payload::LocalPayload;
 use crate::progress::{ProgressOp, ProgressReporter};
 use crate::render::write_stderr_progress;
 use futures::StreamExt;
-use loonfs_api::{CheckpointId, DestinationBehavior, ErrorCode, InodeKind, PathEntryKind};
+use loonfs_api::{CheckpointId, DestinationBehavior, PathEntryKind};
 use loonfs_client::{CommitOptions, CreateDirectoryOptions, NamespacePath, PutFileOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -161,41 +163,22 @@ pub(crate) async fn run_put_tree(
                 continue;
             }
         };
-        let outcome = match context
-            .target
-            .create_directory(
-                &spec,
-                &CreateDirectoryOptions {
-                    commit: CommitOptions {
-                        actor: context.actor.clone(),
-                        commit_id: None,
-                        message: message.clone(),
-                    },
-                    parents: true,
+        let outcome = match create_directory_tolerating_existing(
+            context,
+            &spec,
+            &CreateDirectoryOptions {
+                commit: CommitOptions {
+                    actor: context.actor.clone(),
+                    commit_id: None,
+                    message: message.clone(),
                 },
-            )
-            .await
+                parents: true,
+            },
+        )
+        .await
         {
-            Ok(_) => DirectoryOutcome::Created,
-            Err(error) if error.code == ErrorCode::PathConflict.as_str() => {
-                match context
-                    .target
-                    .get_path_entry_without_attributes(&spec)
-                    .await
-                {
-                    Ok(entry) if entry.inode_kind() == InodeKind::Directory => {
-                        DirectoryOutcome::AlreadyExists
-                    }
-                    Ok(_) => {
-                        tally.fail(remote, error.into());
-                        continue;
-                    }
-                    Err(error) => {
-                        tally.fail(remote, error.into());
-                        continue;
-                    }
-                }
-            }
+            Ok(RemoteDirectoryOutcome::Created(_)) => DirectoryOutcome::Created,
+            Ok(RemoteDirectoryOutcome::AlreadyExists { .. }) => DirectoryOutcome::AlreadyExists,
             Err(error) => {
                 tally.fail(remote, error.into());
                 continue;
@@ -426,28 +409,34 @@ pub(crate) async fn run_copy_tree(
                 continue;
             }
         };
-        match context
-            .target
-            .create_directory(
-                &spec,
-                &CreateDirectoryOptions {
-                    commit: CommitOptions {
-                        actor: context.actor.clone(),
-                        commit_id: None,
-                        message: message.clone(),
-                    },
-                    parents: components.is_empty(),
+        let outcome = match create_directory_tolerating_existing(
+            context,
+            &spec,
+            &CreateDirectoryOptions {
+                commit: CommitOptions {
+                    actor: context.actor.clone(),
+                    commit_id: None,
+                    message: message.clone(),
                 },
-            )
-            .await
+                parents: components.is_empty(),
+            },
+        )
+        .await
         {
-            Ok(_) => {
-                tally.record_directory(DirectoryOutcome::Created);
-                if runtime.progress.human_lines_enabled() {
-                    write_stderr_progress(format_args!("created {}", spec_target(&spec)));
-                }
+            Ok(RemoteDirectoryOutcome::Created(_)) => DirectoryOutcome::Created,
+            Ok(RemoteDirectoryOutcome::AlreadyExists { .. }) => DirectoryOutcome::AlreadyExists,
+            Err(error) => {
+                tally.fail(remote, error.into());
+                continue;
             }
-            Err(error) => tally.fail(remote, error.into()),
+        };
+        tally.record_directory(outcome);
+        if runtime.progress.human_lines_enabled() {
+            write_stderr_progress(format_args!(
+                "{} {}",
+                outcome.progress_label(),
+                spec_target(&spec)
+            ));
         }
     }
 

--- a/crates/loonfs-cli/tests/it/recursive.rs
+++ b/crates/loonfs-cli/tests/it/recursive.rs
@@ -415,6 +415,39 @@ fn recursive_put_reuses_existing_directories_but_rejects_files() {
 }
 
 #[test]
+fn recursive_copy_accepts_existing_destination_directories() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let tree = harness.temp_dir.path().join("copy-tree");
+    fs::create_dir_all(tree.join("docs/nested")).expect("create nested directory");
+    fs::create_dir_all(tree.join("empty/inner")).expect("create empty directory");
+    fs::write(tree.join("docs/nested/b.txt"), b"beta").expect("write payload");
+    assert_success(&harness.run(&["put", "-r", tree.to_str().expect("utf-8 path"), "/src"]));
+
+    // Copying into an existing destination lands at `/dst/src`, and every
+    // directory the copy would create is already there; only the file is new.
+    assert_success(&harness.run(&["mkdir", "-p", "/dst/src/docs/nested"]));
+    assert_success(&harness.run(&["mkdir", "-p", "/dst/src/empty/inner"]));
+    let cp = harness.run(&["--json", "cp", "-r", "/src", "/dst"]);
+    assert_success(&cp);
+    let data = json_data(&cp);
+    assert_eq!(data["files"], 1, "{data}");
+    assert_eq!(
+        data["directories"], 0,
+        "existing directories are accepted, not created: {data}"
+    );
+    assert_eq!(
+        data["failures"].as_array().expect("failures").len(),
+        0,
+        "{data}"
+    );
+    assert_success(&harness.run(&["--json", "stat", "/dst/src/docs/nested/b.txt"]));
+}
+
+#[test]
 fn recursive_get_creates_an_absent_destination_root_in_both_modes() {
     let harness = Harness::new();
     harness.add_embedded_profile("embedded");

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -98,7 +98,7 @@ writer_id = "loonfs-server-local"
 
 # Omit the `[grep]` table and this server composes no grep at all: uniform
 # `not_supported` responses, and no `query.grep` feature or limits advertised.
-# A `[grep]` table with no `mode` both serves searches and maintains the index.
+# A `[grep]` table must set `mode`.
 # `serve_only` answers searches over an index another process maintains;
 # `maintain_only` maintains the index without answering searches; `disabled`
 # turns both off again.

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -52,9 +52,8 @@ pub struct ServerConfig {
     pub local_cache: Option<LocalCacheConfig>,
     /// What this server does about grep, plus the bounded-step budgets its
     /// index maintenance runs under. A config with no `[grep]` table
-    /// composes no grep at all; a table that names no `mode` both serves
-    /// queries and maintains the index.
-    #[serde(default = "grep_absent")]
+    /// composes no grep at all; a present table must name its `mode`.
+    #[serde(default)]
     pub grep: GrepConfig,
     /// Whether this server maintains the namespaces it touches by itself.
     /// Automatic by default; see [`MaintenanceMode`].
@@ -205,17 +204,6 @@ fn default_max_concurrent_maintenance() -> usize {
     loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE
 }
 
-/// Default used when no `[grep]` table is present.
-///
-/// This disables grep routes and maintenance until the deployment explicitly
-/// configures grep.
-fn grep_absent() -> GrepConfig {
-    GrepConfig {
-        mode: GrepMode::Disabled,
-        ..GrepConfig::default()
-    }
-}
-
 /// The server's `[local_cache]` table: where the node-local cache of encoded
 /// metadata blocks lives, and how much memory and disk it may use.
 ///
@@ -297,7 +285,7 @@ impl MaintenanceMode {
 /// namespaces it never answers searches about; the reference deployment
 /// does both. Every combination is named here, so none has to be validated
 /// away.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GrepMode {
     /// Neither answer grep queries nor maintain the index.
@@ -307,7 +295,6 @@ pub enum GrepMode {
     /// Maintain the index without answering queries about it.
     MaintainOnly,
     /// Answer queries and maintain the index in this process.
-    #[default]
     ServeAndMaintain,
 }
 
@@ -325,14 +312,23 @@ impl GrepMode {
 }
 
 /// The server's `[grep]` table.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
-#[serde(default, deny_unknown_fields)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GrepConfig {
     pub mode: GrepMode,
     /// Flattening preserves the existing `[grep]` keys while leaving the
     /// worker policy itself as their one in-memory owner.
     #[serde(flatten)]
     pub worker: GrepWorkerConfig,
+}
+
+impl Default for GrepConfig {
+    fn default() -> Self {
+        Self {
+            mode: GrepMode::Disabled,
+            worker: GrepWorkerConfig::default(),
+        }
+    }
 }
 
 impl GrepConfig {
@@ -1337,6 +1333,7 @@ auth_token = "dev-token"
 writer_id = "loonfs-server"
 
 [grep]
+mode = "serve_and_maintain"
 max_decoded_input_rows_per_step = 0
 
 [store]
@@ -1526,6 +1523,7 @@ auth_token = "dev-token"
 writer_id = "loonfs-server"
 
 [grep]
+mode = "serve_and_maintain"
 max_files_per_stepp = 3
 
 [store]
@@ -1839,7 +1837,7 @@ root = "/tmp/loonfs-server"
     }
 
     #[test]
-    fn a_grep_table_without_a_mode_serves_and_maintains() {
+    fn a_grep_table_without_a_mode_is_rejected() {
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"
@@ -1854,18 +1852,8 @@ root = "/tmp/loonfs-server"
 "#,
         );
 
-        let config = load_server_config(&path).expect("load config");
-        assert_eq!(config.grep, super::GrepConfig::default());
-        assert_eq!(config.grep.mode, super::GrepMode::ServeAndMaintain);
-        assert_eq!(config.grep.worker, loonfs_grep::GrepWorkerConfig::default());
-        assert_eq!(
-            config
-                .grep
-                .worker_config()
-                .build_policy()
-                .expect("valid default grep policy"),
-            loonfs_grep::GramIndexBuildPolicy::default(),
-        );
+        let error = load_server_config(&path).expect_err("mode is required");
+        assert!(error.to_string().contains("mode"), "{error}");
     }
 
     #[test]
@@ -1914,6 +1902,7 @@ auth_token = "dev-token"
 writer_id = "loonfs-server"
 
 [grep]
+mode = "serve_and_maintain"
 max_concurrent_steps = 7
 
 [store]
@@ -1977,6 +1966,7 @@ auth_token = "dev-token"
 writer_id = "loonfs-server"
 
 [grep]
+mode = "serve_and_maintain"
 max_files_per_step = 1024
 max_delta_runs = 3
 

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -3442,7 +3442,10 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         writer_id: writer_id.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
-        grep: crate::config::GrepConfig::default(),
+        grep: crate::config::GrepConfig {
+            mode: crate::config::GrepMode::ServeAndMaintain,
+            ..crate::config::GrepConfig::default()
+        },
         maintenance: crate::config::MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,
         request_deadline_ms: 60_000,

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -10,8 +10,8 @@
 use loonfs_api::{ListCheckpointsResponse, ListPathEntriesResponse, NamespaceId};
 use loonfs_client::{Client, ClientConfig, ListPathEntriesOptions, NamespacePath};
 use loonfs_server::{
-    app, serve_with_shutdown, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServeError,
-    ServerConfig, StoreConfig, TlsServerConfig,
+    app, serve_with_shutdown, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides,
+    ServeError, ServerConfig, StoreConfig, TlsServerConfig,
 };
 use loonfs_test_support::http::raw_agent;
 use std::collections::BTreeMap;
@@ -307,7 +307,10 @@ pub(crate) fn test_config(
         writer_id: writer_id.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
-        grep: GrepConfig::default(),
+        grep: GrepConfig {
+            mode: GrepMode::ServeAndMaintain,
+            ..GrepConfig::default()
+        },
         maintenance: MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,
         request_deadline_ms: 60_000,


### PR DESCRIPTION
Aligns several CLI and server behaviors. Oversized uploads now report content_too_large whether the client or server rejects them. Recursive copy accepts destination directories that already exist, matching mkdir -p and recursive put.

A grep configuration table must now set mode explicitly. Omitting the entire grep table still disables grep. No wire or durable formats change.