### PR TITLE
fix(api): limit recent segments and report snapshot expiry once

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -405,7 +405,13 @@ fn strict_wal_segment_pointers<'de, D>(deserializer: D) -> Result<Vec<WalSegment
 where
     D: Deserializer<'de>,
 {
-    Vec::<StrictWalSegmentPointer>::deserialize(deserializer)?
+    let pointers = Vec::<StrictWalSegmentPointer>::deserialize(deserializer)?;
+    if pointers.len() > RECENT_SEGMENTS_LIMIT {
+        return Err(serde::de::Error::custom(format_args!(
+            "head `recent_segments` exceeds {RECENT_SEGMENTS_LIMIT} entries"
+        )));
+    }
+    pointers
         .into_iter()
         .map(|pointer| validated_wal_segment_pointer(pointer.into()))
         .collect()
@@ -475,6 +481,9 @@ pub struct ForkBasis {
     /// Source checkpoint record pinning the basis for as long as the target lives.
     pub source_checkpoint_id: CheckpointId,
 }
+
+/// Maximum number of pointers accepted in a head's `recent_segments` accelerator.
+pub const RECENT_SEGMENTS_LIMIT: usize = 256;
 
 /// Carries the authoritative visibility, allocation, and fencing state of a namespace.
 ///
@@ -1201,6 +1210,22 @@ mod tests {
         assert_eq!(
             head.recent_segments,
             vec![serde_json::from_value(older).expect("valid predecessor pointer")]
+        );
+    }
+
+    #[test]
+    fn a_head_rejects_too_many_predecessor_hints() {
+        let pointer = wal_pointer_json("wal_00000000000000000001-0123456789abcdef", 1, 1);
+        let error = serde_json::from_value::<HeadState>(head_json(
+            None,
+            vec![pointer; RECENT_SEGMENTS_LIMIT + 1],
+        ))
+        .expect_err("the head rejects an oversized predecessor accelerator");
+        assert!(
+            error
+                .to_string()
+                .contains("head `recent_segments` exceeds 256 entries"),
+            "the rejection should name the field and limit: {error}"
         );
     }
 

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -758,8 +758,6 @@ pub enum CheckpointOwnerSummary {
     Snapshot {
         /// A label that does not need to be unique.
         name: String,
-        /// When the snapshot lease expires, in Unix milliseconds.
-        expires_at_ms: u64,
     },
 }
 
@@ -809,12 +807,11 @@ pub struct SnapshotSummary {
 
 impl SnapshotSummary {
     /// Converts a snapshot-owned checkpoint to a snapshot summary.
+    ///
+    /// Returns `None` for another owner. A snapshot owner always carries the
+    /// checkpoint's top-level `expires_at_ms`.
     pub fn from_checkpoint(checkpoint: Checkpoint) -> Option<Self> {
-        let CheckpointOwnerSummary::Snapshot {
-            name,
-            expires_at_ms,
-        } = checkpoint.owner
-        else {
+        let CheckpointOwnerSummary::Snapshot { name } = checkpoint.owner else {
             return None;
         };
         Some(Self {
@@ -823,7 +820,7 @@ impl SnapshotSummary {
             name,
             head_seq: checkpoint.checkpoint_seq,
             created_at_ms: checkpoint.created_at_ms,
-            expires_at_ms,
+            expires_at_ms: checkpoint.expires_at_ms?,
         })
     }
 }

--- a/crates/loonfs-cli/src/render/summaries.rs
+++ b/crates/loonfs-cli/src/render/summaries.rs
@@ -218,7 +218,7 @@ pub(super) fn checkpoint_owner_label(owner: &CheckpointOwnerSummary) -> String {
         CheckpointOwnerSummary::Fork {
             target_namespace_id,
         } => format!("fork -> {target_namespace_id}"),
-        CheckpointOwnerSummary::Snapshot { name, .. } => format!("snapshot {name}"),
+        CheckpointOwnerSummary::Snapshot { name } => format!("snapshot {name}"),
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -94,13 +94,9 @@ fn checkpoint_summary(
         } => loonfs_api::CheckpointOwnerSummary::Fork {
             target_namespace_id,
         },
-        loonfs_api::wire::control::CheckpointOwner::Snapshot {
-            name,
-            expires_at_ms,
-        } => loonfs_api::CheckpointOwnerSummary::Snapshot {
-            name,
-            expires_at_ms,
-        },
+        loonfs_api::wire::control::CheckpointOwner::Snapshot { name, .. } => {
+            loonfs_api::CheckpointOwnerSummary::Snapshot { name }
+        }
     };
     loonfs_api::Checkpoint {
         namespace_id: record.namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/inventory.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inventory.rs
@@ -483,7 +483,6 @@ async fn a_snapshot_lists_with_its_owner_and_its_required_expiry() {
         listed.checkpoints[0].owner,
         CheckpointOwnerSummary::Snapshot {
             name: "report-run".to_owned(),
-            expires_at_ms,
         }
     );
     assert_eq!(listed.checkpoints[0].expires_at_ms, Some(expires_at_ms));

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -45,7 +45,7 @@ pub const MAX_UNFLUSHED_WAL_SEGMENTS: u64 = 128;
 /// legal unflushed tail rather than to keep the head small: a full list
 /// encodes to roughly 68 KiB at realistic identifier lengths and 107 KiB at
 /// the worst case the grammars allow.
-pub(crate) const RECENT_SEGMENTS_LIMIT: usize = 256;
+pub(crate) use loonfs_api::wire::control::RECENT_SEGMENTS_LIMIT;
 
 /// The head-coverage inequality, shared by the compile-time assertion below
 /// and the test that proves the assertion has teeth.

--- a/crates/loonfs-server/tests/it/http_snapshots.rs
+++ b/crates/loonfs-server/tests/it/http_snapshots.rs
@@ -3,10 +3,10 @@
 #![allow(clippy::panic)]
 
 use crate::common::http_split_support::test_config;
-use crate::common::{collect_checkpoints, start_server};
+use crate::common::start_server;
 use loonfs_api::{
-    ApiError, ChangeSeq, CheckpointOwnerSummary, CreateCheckpointRequest, ListSnapshotsResponse,
-    ReleaseSnapshotResponse, SnapshotSummary,
+    ApiError, ChangeSeq, CreateCheckpointRequest, ListSnapshotsResponse, ReleaseSnapshotResponse,
+    SnapshotSummary,
 };
 use loonfs_server::MaintenanceMode;
 use loonfs_test_support::http::{raw_agent, retry_result_on_macos_teardown_einval};
@@ -354,16 +354,34 @@ async fn http_snapshots_keep_owner_operations_and_listings_separate() {
     assert_eq!(status, 400);
     assert!(error.message.contains("checkpoint release operation"));
 
-    let checkpoints = collect_checkpoints(&harness.client, &namespace)
-        .await
-        .expect("list checkpoints");
-    assert_eq!(checkpoints.checkpoints.len(), 2);
-    assert!(checkpoints.checkpoints.iter().any(|item| {
-        matches!(
-            &item.owner,
-            CheckpointOwnerSummary::Snapshot { name, .. } if name == "brief"
+    let checkpoints: serde_json::Value = retry_result_on_macos_teardown_einval(|| {
+        decode_response(
+            raw_agent()
+                .get(&format!(
+                    "{}/v0/admin/namespaces/{}/checkpoints",
+                    harness.server_url, namespace
+                ))
+                .set("authorization", "Bearer test-token")
+                .call(),
         )
-    }));
+    })
+    .expect("list checkpoints");
+    let checkpoints = checkpoints["checkpoints"]
+        .as_array()
+        .expect("checkpoint list is an array");
+    assert_eq!(checkpoints.len(), 2);
+    let listed_snapshot = checkpoints
+        .iter()
+        .find(|item| item["owner"]["kind"] == "snapshot")
+        .expect("snapshot checkpoint is listed");
+    assert_eq!(
+        listed_snapshot["owner"],
+        serde_json::json!({"kind": "snapshot", "name": "brief"})
+    );
+    assert_eq!(
+        listed_snapshot["expires_at_ms"],
+        serde_json::json!(snapshot.expires_at_ms)
+    );
     assert_eq!(
         list_snapshots(&harness.server_url, namespace.as_str())
             .expect("list live snapshots")

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -1244,7 +1244,7 @@ fn openapi_names_tagged_one_of_alternatives() {
     let snapshot_owner = schemas
         .get("CheckpointOwnerSnapshot")
         .expect("snapshot checkpoint-owner schema");
-    assert!(required_fields(snapshot_owner).contains("expires_at_ms"));
+    assert!(!required_fields(snapshot_owner).contains("expires_at_ms"));
 }
 
 /// Responses that flatten a Rust enum, and the fields their envelope adds to

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -188,8 +188,10 @@ impl FsAdmin {
                         diagnostics.live_checkpoints =
                             diagnostics.live_checkpoints.saturating_add(1);
                     }
-                    loonfs_api::CheckpointOwnerSummary::Snapshot { expires_at_ms, .. }
-                        if expires_at_ms > now_ms =>
+                    loonfs_api::CheckpointOwnerSummary::Snapshot { .. }
+                        if checkpoint
+                            .expires_at_ms
+                            .is_some_and(|expiry| expiry > now_ms) =>
                     {
                         diagnostics.live_snapshots = diagnostics.live_snapshots.saturating_add(1);
                     }
@@ -804,11 +806,9 @@ impl FsAdmin {
                 .await
                 .map_err(RuntimeError::from)?;
             for checkpoint in page.items {
-                if matches!(
-                    checkpoint.owner,
-                    loonfs_api::CheckpointOwnerSummary::Snapshot { expires_at_ms, .. }
-                        if expires_at_ms > now_ms
-                ) {
+                if SnapshotSummary::from_checkpoint(checkpoint)
+                    .is_some_and(|snapshot| snapshot.expires_at_ms > now_ms)
+                {
                     live_with_additional = live_with_additional.saturating_add(1);
                     if live_with_additional > max_live {
                         return Err(quota_error());

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -780,7 +780,6 @@ fn a_created_snapshot_is_listed_with_its_snapshot_owner() {
         snapshot.owner,
         CheckpointOwnerSummary::Snapshot {
             name: "report-run".to_owned(),
-            expires_at_ms,
         }
     );
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -6767,16 +6767,9 @@
         "description": "An application-created read view.",
         "required": [
           "name",
-          "expires_at_ms",
           "kind"
         ],
         "properties": {
-          "expires_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "description": "When the snapshot lease expires, in Unix milliseconds.",
-            "minimum": 0
-          },
           "kind": {
             "type": "string",
             "enum": [


### PR DESCRIPTION
Limits the recent_segments list accepted from a namespace head to 256 entries, matching the limit already enforced when heads are written.

Snapshot checkpoint responses now report expires_at_ms only at the checkpoint level instead of repeating it inside the snapshot owner. This changes the public response shape but does not change durable data.