### PR TITLE
refactor(api): bind directory cursors to their snapshot without a compatibility path

### DIFF
--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -161,8 +161,6 @@ pub struct DirectoryPageCursor {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snapshot_id: Option<crate::CheckpointId>,
     /// Directory inode resolved at `head_seq`.
-    // The wire field is frozen as `dir_inode_id` in page cursor version 1.
-    #[serde(rename = "dir_inode_id")]
     pub directory_inode_id: InodeId,
     /// Last canonical name key returned to the client.
     pub last_name_key: NameKey,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -54,10 +54,11 @@ fn validate_pinned_directory_cursor(
             "directory cursor is bound to snapshot `{actual}`"
         ))
         .into()),
-        // A cursor minted before snapshot binding has no snapshot field.
-        // Matching the immutable head makes its resume safe; the next cursor
-        // is stamped below.
-        (None, _) => Ok(()),
+        (None, Some(expected)) => Err(CoreError::InvalidCursor(format!(
+            "directory cursor is not bound to snapshot `{expected}`"
+        ))
+        .into()),
+        (None, None) => Ok(()),
     }
 }
 

--- a/crates/loonfs/tests/it/read_snapshot.rs
+++ b/crates/loonfs/tests/it/read_snapshot.rs
@@ -107,15 +107,15 @@ async fn snapshot_directory_cursor_resumes_only_at_its_snapshot() {
             .await,
         ErrorCode::InvalidRequest,
     );
-    let mut legacy_cursor = cursor.clone();
-    legacy_cursor.snapshot_id = None;
+    let mut unbound_cursor = cursor.clone();
+    unbound_cursor.snapshot_id = None;
     assert_core_error_kind(
         second_view
             .list_path_entries_page(
                 "/",
                 PageRequest {
                     limit,
-                    cursor: Some(legacy_cursor.clone()),
+                    cursor: Some(unbound_cursor.clone()),
                 },
                 Default::default(),
             )
@@ -156,17 +156,19 @@ async fn snapshot_directory_cursor_resumes_only_at_its_snapshot() {
         ErrorCode::InvalidRequest,
     );
 
-    first_view
-        .list_path_entries_page(
-            "/",
-            PageRequest {
-                limit,
-                cursor: Some(legacy_cursor),
-            },
-            Default::default(),
-        )
-        .await
-        .expect("resume a legacy cursor at its exact pinned head");
+    assert_core_error_kind(
+        first_view
+            .list_path_entries_page(
+                "/",
+                PageRequest {
+                    limit,
+                    cursor: Some(unbound_cursor),
+                },
+                Default::default(),
+            )
+            .await,
+        ErrorCode::InvalidRequest,
+    );
 
     let second_page = first_view
         .list_path_entries_page(


### PR DESCRIPTION
Stacked on #820. Two pre-release compatibility paths on the directory page cursor are removed instead of documented.

- `validate_pinned_directory_cursor` accepted a cursor with no snapshot id against a snapshot read when the head matched, described as "a cursor minted before snapshot binding". No such cursor was ever issued: a snapshot read always stamps its id into the cursors it returns. A snapshot read now rejects an unbound cursor as `invalid_cursor`, and a live read rejects a bound one as before.
- The cursor's `directory_inode_id` was renamed to `dir_inode_id` on the wire with a comment calling the short spelling frozen in version 1. Cursors are opaque and minted only by this process, so the field now carries its own name and the rename attribute and comment are gone. A cursor minted by an earlier build stops decoding, which is already the rule for any cursor change.

`cargo test -p loonfs-api`, `-p loonfs`, `-p loonfs-server --features openapi`, `-p loonfs-cli`, clippy, and fmt pass.
