### PR TITLE
refactor(core): simplify garbage collection lifecycles

### DIFF
--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -31,7 +31,7 @@ pub(crate) enum CompactionPrefixOwner {
     /// A job owns it: its lease is `Active` and was refreshed within
     /// [`METADATA_COMPACTION_LEASE_EXPIRY_MS`], or it heartbeated out from
     /// under this pass's claim. Nothing about the objects' age matters.
-    ALiveJob,
+    LiveJob,
     /// This pass claimed the prefix, or found a claim someone else won. The
     /// job that wrote the objects is fenced, so they are orphans — and the
     /// lease is deleted after them, once nothing unreferenced is left under
@@ -92,7 +92,7 @@ pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
             .heartbeat_at_ms
             .saturating_add(METADATA_COMPACTION_LEASE_EXPIRY_MS)
     {
-        return Ok(CompactionPrefixOwner::ALiveJob);
+        return Ok(CompactionPrefixOwner::LiveJob);
     }
 
     // Expired. Nothing is decided until the claim lands.
@@ -118,7 +118,7 @@ pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
         // The job wrote the lease between this pass's read and its claim, so
         // the job is alive and owns its prefix. This pass keeps every object
         // under it.
-        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CompactionPrefixOwner::ALiveJob),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CompactionPrefixOwner::LiveJob),
         Err(error) => Err(CoreError::store(&object_key, &error)),
     }
 }
@@ -143,56 +143,43 @@ pub(super) enum LeaseHold {
 pub(super) struct CompactionLease<'a> {
     object_key: String,
     state: MetadataCompactionLeaseState,
-    /// The etag of the last lease write this job made, which every later
-    /// write compare-and-swaps against. `None` before the create, and never
-    /// `None` after one: a store that returns no etag on the create fails the
-    /// job there rather than letting it run unfenceable.
-    etag: Option<String>,
+    etag: String,
     timer: &'a dyn MonotonicTimer,
     started_monotonic_ms: u64,
     next_heartbeat_monotonic_ms: u64,
 }
 
 impl<'a> CompactionLease<'a> {
-    pub(super) fn new(
+    /// Writes the lease before the job's first output object.
+    pub(super) async fn create<S: ObjectStore + ?Sized>(
+        store: &S,
         namespace_id: &NamespaceId,
         job_id: &MetadataCompactionId,
         writer_id: &str,
         started_at_ms: u64,
         timer: &'a dyn MonotonicTimer,
-    ) -> Self {
+    ) -> Result<Self> {
         let started_monotonic_ms = timer.monotonic_now_ms();
-        Self {
-            object_key: metadata_compaction_lease(namespace_id, job_id),
-            state: MetadataCompactionLeaseState {
-                job_id: job_id.clone(),
-                namespace_id: namespace_id.clone(),
-                writer_id: writer_id.to_owned(),
-                status: CompactionLeaseStatus::Active {},
-                started_at_ms,
-                heartbeat_at_ms: started_at_ms,
-            },
-            etag: None,
+        let object_key = metadata_compaction_lease(namespace_id, job_id);
+        let state = initial_lease_state(namespace_id, job_id, writer_id, started_at_ms);
+        let encoded = encode_lease(&state)?;
+        let metadata =
+            create_control_object_under_generated_id(store, &object_key, encoded).await?;
+        let etag = required_etag(&object_key, metadata.etag)?;
+        Ok(Self {
+            object_key,
+            state,
+            etag,
             timer,
             started_monotonic_ms,
             next_heartbeat_monotonic_ms: started_monotonic_ms,
-        }
+        })
     }
 
     /// The clock the job paces itself by. One clock for the job's heartbeat
     /// and its publication budget, because they measure the same span.
     pub(super) fn timer(&self) -> &'a dyn MonotonicTimer {
         self.timer
-    }
-
-    /// Writes the lease for the first time, before the job's first output
-    /// object, so no object under the prefix is ever unclaimed.
-    pub(super) async fn create<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
-        let encoded = encode_lease(&self.state)?;
-        let metadata =
-            create_control_object_under_generated_id(store, &self.object_key, encoded).await?;
-        self.etag = Some(self.required_etag(metadata.etag)?);
-        Ok(())
     }
 
     /// Refreshes the lease when the interval has passed since the last write.
@@ -219,13 +206,7 @@ impl<'a> CompactionLease<'a> {
         &mut self,
         store: &S,
     ) -> Result<LeaseHold> {
-        let expected_etag = self.etag.clone().ok_or_else(|| {
-            CoreError::Internal(
-                "a compaction lease heartbeat ran before the \
-                 lease was created"
-                    .to_owned(),
-            )
-        })?;
+        let expected_etag = self.etag.clone();
         let elapsed_ms = self
             .timer
             .monotonic_now_ms()
@@ -237,7 +218,7 @@ impl<'a> CompactionLease<'a> {
             .await
         {
             Ok(metadata) => {
-                self.etag = Some(self.required_etag(metadata.etag)?);
+                self.etag = required_etag(&self.object_key, metadata.etag)?;
                 self.next_heartbeat_monotonic_ms = self
                     .timer
                     .monotonic_now_ms()
@@ -269,37 +250,68 @@ impl<'a> CompactionLease<'a> {
     /// creates the lease for the first of them and adopts the existing one for
     /// the second. A job never creates its lease twice.
     #[cfg(test)]
-    pub(super) async fn open_for_test<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
-        let namespace_id = self.state.namespace_id.clone();
-        let job_id = self.state.job_id.clone();
+    pub(super) async fn open_for_test<S: ObjectStore + ?Sized>(
+        store: &S,
+        namespace_id: &NamespaceId,
+        job_id: &MetadataCompactionId,
+        writer_id: &str,
+        started_at_ms: u64,
+        timer: &'a dyn MonotonicTimer,
+    ) -> Result<Self> {
+        let object_key = metadata_compaction_lease(namespace_id, job_id);
         let loaded = load_control_object(
             store,
-            self.object_key.clone(),
+            object_key.clone(),
             ControlObjectKind::CompactionLease,
             |state: &MetadataCompactionLeaseState| {
-                expect_namespace(&namespace_id, &state.namespace_id)?;
+                expect_namespace(namespace_id, &state.namespace_id)?;
                 expect_identity_field("compaction job id", job_id.as_str(), state.job_id.as_str())
             },
         )
         .await;
         let loaded = match loaded {
             Ok(loaded) => loaded,
-            Err(ControlObjectLoadError::MissingObject { .. }) => return self.create(store).await,
+            Err(ControlObjectLoadError::MissingObject { .. }) => {
+                return Self::create(store, namespace_id, job_id, writer_id, started_at_ms, timer)
+                    .await
+            }
             Err(error) => return Err(CoreError::ControlObjectLoad(error)),
         };
-        self.etag = Some(loaded.etag);
-        Ok(())
-    }
-
-    fn required_etag(&self, etag: Option<String>) -> Result<String> {
-        etag.ok_or_else(|| {
-            CoreError::Internal(format!(
-                "the store returned no etag for the compaction lease `{}`, so the job cannot be \
-                 fenced against garbage collection",
-                self.object_key
-            ))
+        let started_monotonic_ms = timer.monotonic_now_ms();
+        Ok(Self {
+            object_key,
+            state: initial_lease_state(namespace_id, job_id, writer_id, started_at_ms),
+            etag: loaded.etag,
+            timer,
+            started_monotonic_ms,
+            next_heartbeat_monotonic_ms: started_monotonic_ms,
         })
     }
+}
+
+fn initial_lease_state(
+    namespace_id: &NamespaceId,
+    job_id: &MetadataCompactionId,
+    writer_id: &str,
+    started_at_ms: u64,
+) -> MetadataCompactionLeaseState {
+    MetadataCompactionLeaseState {
+        job_id: job_id.clone(),
+        namespace_id: namespace_id.clone(),
+        writer_id: writer_id.to_owned(),
+        status: CompactionLeaseStatus::Active {},
+        started_at_ms,
+        heartbeat_at_ms: started_at_ms,
+    }
+}
+
+fn required_etag(object_key: &str, etag: Option<String>) -> Result<String> {
+    etag.ok_or_else(|| {
+        CoreError::Internal(format!(
+            "the store returned no etag for the compaction lease `{object_key}`, so the job cannot \
+             be fenced against garbage collection"
+        ))
+    })
 }
 
 fn encode_lease(state: &MetadataCompactionLeaseState) -> Result<Bytes> {

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -443,14 +443,15 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
     };
     // The lease is written before the first output object, so no object under
     // the job's prefix is ever unclaimed.
-    let mut lease = CompactionLease::new(
+    let mut lease = CompactionLease::create(
+        store,
         namespace_id,
         spec.job_id(),
         &context.writer_id,
         context.now_ms,
         &timer,
-    );
-    lease.create(store).await?;
+    )
+    .await?;
     tracing::info!(
         namespace_id = namespace_id.as_str(),
         job_id = spec.job_id().as_str(),

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -619,18 +619,16 @@ async fn test_lease<'a, S: ObjectStore + ?Sized>(
     timer: &'a dyn MonotonicTimer,
 ) -> CompactionLease<'a> {
     let context = test_context();
-    let mut lease = CompactionLease::new(
+    CompactionLease::open_for_test(
+        store,
         namespace_id,
         spec.job_id(),
         &context.writer_id,
         context.now_ms,
         timer,
-    );
-    lease
-        .open_for_test(store)
-        .await
-        .expect("open the job's lease");
-    lease
+    )
+    .await
+    .expect("open the job's lease")
 }
 
 async fn run_compaction<S: ObjectStore + ?Sized>(
@@ -2351,7 +2349,7 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
     );
     assert_eq!(
         claimed.expect("claim the prefix"),
-        CompactionPrefixOwner::ALiveJob,
+        CompactionPrefixOwner::LiveJob,
         "and the claim behind it is refused, so exactly one of the two won"
     );
 

--- a/crates/loonfs-core/src/gc/compaction_staging.rs
+++ b/crates/loonfs-core/src/gc/compaction_staging.rs
@@ -15,46 +15,36 @@ use loonfs_objectstore::ObjectStore;
 /// that must be deleted after that prefix is processed.
 #[derive(Debug, Default)]
 pub(super) struct CompactionLeases {
-    /// The most recently checked job and the confirmed owner of its prefix.
-    last_read: Option<(String, CompactionPrefixOwner)>,
+    last_read: Option<LastPrefixRead>,
     /// A successfully claimed lease, retained until all earlier staged objects
     /// in the same job prefix have been processed.
     claimed_lease: Option<String>,
 }
 
-/// What the sweep should do with one key under the compaction prefix.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum StagedObject {
-    /// The job has a current lease, so the object must be retained.
-    OwnedByALiveJob,
-    /// No active job can publish the object. Apply the normal grace period for
-    /// unreferenced objects.
-    Orphaned,
-    /// The collector claimed this lease. Delete it after processing the
-    /// remaining objects in the job prefix.
-    ClaimedLease,
-    /// The key is neither a recognized lease nor a staged segment, so the
-    /// collector retains it.
-    UnrecognizedKey,
+#[derive(Debug)]
+struct LastPrefixRead {
+    job_id: MetadataCompactionId,
+    owner: CompactionPrefixOwner,
 }
 
 impl CompactionLeases {
-    /// Returns the collection state for `key`, reusing the current job's
-    /// confirmed lease state when possible.
+    /// Returns the confirmed owner of `key`'s job prefix, or `None` when the
+    /// key names no job. One claim per job prefix is reused for every key
+    /// under it.
     pub(super) async fn owner_of<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,
         namespace_id: &NamespaceId,
         key: &str,
         now_ms: u64,
-    ) -> Result<StagedObject> {
+    ) -> Result<Option<CompactionPrefixOwner>> {
         let Some(metadata_compaction_id) = metadata_compaction_job_id_from_key(key)
             .and_then(|job_id| MetadataCompactionId::parse(job_id).ok())
         else {
-            return Ok(StagedObject::UnrecognizedKey);
+            return Ok(None);
         };
         let owner = match &self.last_read {
-            Some((read_job_id, owner)) if read_job_id == metadata_compaction_id.as_str() => *owner,
+            Some(read) if read.job_id == metadata_compaction_id => read.owner,
             _ => {
                 // A different job prefix has started, so the previously
                 // claimed lease can now be deleted.
@@ -62,25 +52,25 @@ impl CompactionLeases {
                 let owner =
                     claim_compaction_prefix(store, namespace_id, &metadata_compaction_id, now_ms)
                         .await?;
-                self.last_read = Some((metadata_compaction_id.to_string(), owner));
                 if owner == CompactionPrefixOwner::ThisCollector {
                     self.claimed_lease = Some(metadata_compaction_lease(
                         namespace_id,
                         &metadata_compaction_id,
                     ));
                 }
+                self.last_read = Some(LastPrefixRead {
+                    job_id: metadata_compaction_id,
+                    owner,
+                });
                 owner
             }
         };
-        Ok(match owner {
-            CompactionPrefixOwner::ALiveJob => StagedObject::OwnedByALiveJob,
-            CompactionPrefixOwner::ThisCollector if self.claimed_lease.as_deref() == Some(key) => {
-                StagedObject::ClaimedLease
-            }
-            CompactionPrefixOwner::ThisCollector | CompactionPrefixOwner::NoOne => {
-                StagedObject::Orphaned
-            }
-        })
+        Ok(Some(owner))
+    }
+
+    /// Whether `key` is the lease this collector claimed for the current job.
+    pub(super) fn is_claimed_lease(&self, key: &str) -> bool {
+        self.claimed_lease.as_deref() == Some(key)
     }
 
     /// Deletes a claimed lease after its job prefix has been processed.

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -41,10 +41,14 @@ impl CandidateFamily {
 
     /// This family's position in [`Self::ALL`], which is the sweep order.
     pub(super) fn index(self) -> usize {
-        Self::ALL
-            .iter()
-            .position(|family| *family == self)
-            .expect("every family is listed in ALL")
+        match self {
+            Self::WalSegments => 0,
+            Self::MetadataSegments => 1,
+            Self::CompactionStaging => 2,
+            Self::Manifests => 3,
+            Self::Checkpoints => 4,
+            Self::UploadSessions => 5,
+        }
     }
 
     /// Returns whether `key` matches this family's durable grammar.
@@ -126,9 +130,6 @@ impl GcCursor {
     pub(super) fn decode(token: &str, namespace_id: &NamespaceId) -> Result<Self> {
         decode_namespace_cursor(token, namespace_id).map_err(|error| match error {
             NamespaceCursorError::ForeignNamespace => CoreError::InvalidGcConfig(error.to_string()),
-            NamespaceCursorError::Malformed(_) | NamespaceCursorError::OutsideKeyspace => {
-                invalid_cursor()
-            }
             _ => invalid_cursor(),
         })
     }

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -94,10 +94,16 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
     .await?
     {
         ForkCheckpointReachability::Reclaimable => {}
-        ForkCheckpointReachability::ReferencedByLiveTarget
-        | ForkCheckpointReachability::MayHaveLiveDescendant
-        | ForkCheckpointReachability::InFlight
-        | ForkCheckpointReachability::Ambiguous => return Ok(ForkCheckpointSweep::Retained),
+        ForkCheckpointReachability::Retained { reason } => {
+            tracing::debug!(
+                namespace_id = %loaded.state.namespace_id,
+                target_namespace_id = %target_namespace_id,
+                checkpoint_id = %loaded.state.checkpoint_id,
+                reason,
+                "retaining a fork checkpoint its target may still need"
+            );
+            return Ok(ForkCheckpointSweep::Retained);
+        }
     }
     if loaded.state.status != (CheckpointStatus::Active {}) {
         return Ok(ForkCheckpointSweep::NotAnActiveFork);
@@ -112,11 +118,8 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
 
 /// Whether a fork checkpoint is still needed.
 pub(super) enum ForkCheckpointReachability {
-    ReferencedByLiveTarget,
-    MayHaveLiveDescendant,
-    InFlight,
     Reclaimable,
-    Ambiguous,
+    Retained { reason: &'static str },
 }
 
 /// Compares a fork checkpoint with the target head that may reference it.
@@ -134,7 +137,9 @@ pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
             return Ok(if lease_expires_at_ms <= context.now_ms {
                 ForkCheckpointReachability::Reclaimable
             } else {
-                ForkCheckpointReachability::InFlight
+                ForkCheckpointReachability::Retained {
+                    reason: "target_creation_in_flight",
+                }
             })
         }
         Err(error) => match &error {
@@ -145,7 +150,9 @@ pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
                     error = %error,
                     "the fork target head did not read; retaining its source checkpoint"
                 );
-                return Ok(ForkCheckpointReachability::Ambiguous);
+                return Ok(ForkCheckpointReachability::Retained {
+                    reason: "target_head_unreadable",
+                });
             }
             _ => {
                 return Err(CoreError::NamespaceCorrupt(format!(
@@ -166,7 +173,9 @@ pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
             .map_err(CoreError::ControlObjectLoad)?
             .is_some()
         {
-            return Ok(ForkCheckpointReachability::MayHaveLiveDescendant);
+            return Ok(ForkCheckpointReachability::Retained {
+                reason: "target_may_have_live_descendant",
+            });
         }
         return Ok(ForkCheckpointReachability::Reclaimable);
     }
@@ -185,5 +194,7 @@ pub(super) async fn classify_fork_checkpoint<S: ObjectStore + ?Sized>(
             record.checkpoint_id
         )));
     }
-    Ok(ForkCheckpointReachability::ReferencedByLiveTarget)
+    Ok(ForkCheckpointReachability::Retained {
+        reason: "referenced_by_live_target",
+    })
 }

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -18,7 +18,7 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
-    manifest_object_id_manifest_no, wal_segment_id_start_seq, ChangeSeq, ContentId,
+    manifest_object_id_manifest_no, wal_segment_id_start_seq, ChangeSeq, ContentId, ManifestNo,
     ManifestObjectId, NamespaceId,
 };
 use loonfs_objectstore::keys::{
@@ -588,20 +588,52 @@ async fn collect_retained_wal<S: ObjectStore + ?Sized>(
 /// timestamp, so a manifest with no timestamp reads as young here exactly as
 /// a candidate without one does there.
 ///
-pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
+#[derive(Default)]
+struct GenerationScan {
+    candidate_seen: bool,
+    current_no: Option<ManifestNo>,
+    current: Vec<(ManifestObjectId, String)>,
+    aged: Vec<(ManifestObjectId, String)>,
+    found_young: bool,
+}
+
+impl GenerationScan {
+    fn begin_candidate(&mut self, manifest_no: ManifestNo) {
+        if self.current_no != Some(manifest_no) {
+            if !self.current.is_empty() {
+                self.aged = std::mem::take(&mut self.current);
+            }
+            self.current_no = Some(manifest_no);
+        }
+        self.candidate_seen = true;
+    }
+
+    fn finish(mut self) -> AgedGeneration {
+        if !self.found_young && !self.current.is_empty() {
+            self.aged = self.current;
+        }
+        AgedGeneration {
+            candidate_seen: self.candidate_seen,
+            candidates: self.aged,
+        }
+    }
+}
+
+struct AgedGeneration {
+    candidate_seen: bool,
+    candidates: Vec<(ManifestObjectId, String)>,
+}
+
+async fn newest_fully_aged_generation<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     grace_window_ms: u64,
     budget: &mut PassBudget,
     context: &MutationContext,
-) -> CollectResult<ReferenceAnchor> {
+) -> CollectResult<AgedGeneration> {
     let prefix = metadata_manifest_prefix(namespace_id);
     let mut keys = store.list_prefix_stream(&prefix);
-    let mut manifest_candidate_seen = false;
-    let mut current_generation_no = None;
-    let mut current_generation = Vec::new();
-    let mut aged_generation = Vec::new();
-    let mut found_young = false;
+    let mut scan = GenerationScan::default();
     while let Some(item) = keys.next().await {
         let key = item.map_err(|error| CoreError::store(&prefix, &error))?;
         // Keys this collector does not recognize are never manifests of
@@ -611,15 +643,7 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
         };
         let manifest_no = manifest_object_id_manifest_no(manifest_object_id.as_str())
             .expect("a parsed manifest object id carries its manifest number");
-        if current_generation_no.is_some_and(|current| current != manifest_no) {
-            if !current_generation.is_empty() {
-                aged_generation = std::mem::take(&mut current_generation);
-            }
-            current_generation_no = Some(manifest_no);
-        } else if current_generation_no.is_none() {
-            current_generation_no = Some(manifest_no);
-        }
-        manifest_candidate_seen = true;
+        scan.begin_candidate(manifest_no);
         charge(budget)?;
         let Some(metadata) = store
             .head(&key)
@@ -632,20 +656,29 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
             context.now_ms.saturating_sub(written_at_ms) >= grace_window_ms
         });
         if !aged_out {
-            found_young = true;
+            scan.found_young = true;
             break;
         }
-        current_generation.push((manifest_object_id, key));
+        scan.current.push((manifest_object_id, key));
     }
-    if !found_young && !current_generation.is_empty() {
-        aged_generation = current_generation;
-    }
+    Ok(scan.finish())
+}
 
-    if aged_generation.is_empty() {
+pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    grace_window_ms: u64,
+    budget: &mut PassBudget,
+    context: &MutationContext,
+) -> CollectResult<ReferenceAnchor> {
+    let aged_generation =
+        newest_fully_aged_generation(store, namespace_id, grace_window_ms, budget, context).await?;
+
+    if aged_generation.candidates.is_empty() {
         // Nothing published, nothing unreferenced: a namespace with no
         // manifest of its own has never taken an object out of a file set,
         // and its floor cannot have advanced past its birth without a root.
-        return Ok(match manifest_candidate_seen {
+        return Ok(match aged_generation.candidate_seen {
             true => ReferenceAnchor::Missing,
             false => ReferenceAnchor::NotNeeded,
         });
@@ -654,7 +687,7 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
     let mut manifest_object_ids = BTreeSet::new();
     let mut head_seq = None;
     let mut segments = BTreeSet::new();
-    for (manifest_object_id, key) in aged_generation {
+    for (manifest_object_id, key) in aged_generation.candidates {
         charge(budget)?;
         let manifest = match load_namespace_manifest_envelope_if_present(
             store,

--- a/crates/loonfs-core/src/gc/mod.rs
+++ b/crates/loonfs-core/src/gc/mod.rs
@@ -19,5 +19,5 @@ mod uploads;
 
 pub use budget::PassBudget;
 pub use config::GcConfig;
-pub use reap::{delete_if_aged, AgedSweep};
+pub use reap::{delete_if_aged, GraceAge};
 pub use run::gc_namespace;

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -101,42 +101,9 @@ pub(super) async fn sweep_checkpoint_record<S: ObjectStore + ?Sized>(
     }
 }
 
-/// What aging one unreferenced candidate decided.
+/// Where one unreferenced candidate stands against the grace window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AgedSweep {
-    /// The grace window had passed over the object and it was deleted.
-    Deleted,
-    /// The object was already gone; nothing was decided and nothing counts.
-    AlreadyGone,
-    /// Younger than the grace window by its own provider timestamp.
-    RetainedInGraceWindow,
-    /// The provider reported no last-modified time, so the object's age is
-    /// unknown and it is treated as young (rule 1).
-    RetainedWithoutTimestamp,
-}
-
-impl AgedSweep {
-    /// True when the key was deleted.
-    pub fn deleted(self) -> bool {
-        self == Self::Deleted
-    }
-
-    /// The retention reason this outcome is, for a caller reporting why a
-    /// pass kept what it kept. `None` for the two outcomes that retained
-    /// nothing.
-    pub fn retained_reason(self) -> Option<RetainedReason> {
-        match self {
-            Self::Deleted | Self::AlreadyGone => None,
-            Self::RetainedInGraceWindow => Some(RetainedReason::WithinGraceWindow),
-            Self::RetainedWithoutTimestamp => Some(RetainedReason::NoProviderTimestamp),
-        }
-    }
-}
-
-/// Where one unreferenced candidate stands against the grace window, before
-/// anything acts on the answer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum GraceAge {
+pub enum GraceAge {
     /// The window has passed over the object.
     Aged,
     /// Younger than the window by its own provider timestamp.
@@ -146,6 +113,19 @@ pub(super) enum GraceAge {
     Unknown,
     /// The object is not there any more.
     Gone,
+}
+
+impl GraceAge {
+    /// The retention reason this outcome is, for a caller reporting why a
+    /// pass kept what it kept. `None` for the two outcomes that retained
+    /// nothing.
+    pub fn retained_reason(self) -> Option<RetainedReason> {
+        match self {
+            Self::Aged | Self::Gone => None,
+            Self::Young => Some(RetainedReason::WithinGraceWindow),
+            Self::Unknown => Some(RetainedReason::NoProviderTimestamp),
+        }
+    }
 }
 
 /// Reads how one candidate stands against the grace window.
@@ -191,16 +171,12 @@ pub async fn delete_if_aged<S: ObjectStore + ?Sized>(
     key: &str,
     grace_window_ms: u64,
     now_ms: u64,
-) -> std::result::Result<AgedSweep, ObjectStoreError> {
-    match grace_age(store, key, grace_window_ms, now_ms).await? {
-        GraceAge::Gone => Ok(AgedSweep::AlreadyGone),
-        GraceAge::Unknown => Ok(AgedSweep::RetainedWithoutTimestamp),
-        GraceAge::Young => Ok(AgedSweep::RetainedInGraceWindow),
-        GraceAge::Aged => {
-            store.delete(key).await?;
-            Ok(AgedSweep::Deleted)
-        }
+) -> std::result::Result<GraceAge, ObjectStoreError> {
+    let age = grace_age(store, key, grace_window_ms, now_ms).await?;
+    if age == GraceAge::Aged {
+        store.delete(key).await?;
     }
+    Ok(age)
 }
 
 pub(super) fn manifest_object_id_of(

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -2,7 +2,7 @@
 //! and the bounded, resumable sweep.
 
 use super::budget::PassBudget;
-use super::compaction_staging::{CompactionLeases, StagedObject};
+use super::compaction_staging::CompactionLeases;
 use super::config::{GcConfig, GcPolicy};
 use super::cursor::{CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
@@ -12,24 +12,32 @@ use super::live_set::{collect_live_set, LiveSet, LiveSetCollection, SweepStep, S
 use super::reap::{
     grace_age, manifest_object_id_of, sweep_checkpoint_record, CheckpointSweep, GraceAge,
 };
-use super::uploads::{sweep_upload_session, ContentReferences, UploadSessionSweep};
+use super::uploads::{
+    sweep_upload_session, ContentReferences, UploadSessionSweep, UploadSweepContext,
+};
+use crate::checkpoint::CompactionPrefixOwner;
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
 use crate::limits::METADATA_COMPACTION_STAGING_GRACE_MS;
 use crate::namespace::control_snapshot::load_control_snapshot;
 use futures::StreamExt;
-use loonfs_api::{ContentStoreId, GcResponse, NamespaceId, RetainedReason, UploadId};
+use loonfs_api::{DeletedObjectCounts, GcResponse, NamespaceId, RetainedReason, UploadId};
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SweepCandidateFamily {
-    WalSegments,
-    MetadataSegments,
-    CompactionStaging,
-    Manifests,
-    Checkpoints,
+fn is_live(live: &LiveSet, family: CandidateFamily, key: &str) -> bool {
+    match family {
+        CandidateFamily::WalSegments => live.protects_wal_segment(key),
+        CandidateFamily::MetadataSegments | CandidateFamily::CompactionStaging => {
+            live.segments.contains(key)
+        }
+        CandidateFamily::Manifests => manifest_object_id_of(key)
+            .and_then(std::result::Result::ok)
+            .is_some_and(|manifest_object_id| live.manifests.contains(&manifest_object_id)),
+        CandidateFamily::Checkpoints => live.checkpoint_keys.contains(key),
+        CandidateFamily::UploadSessions => false,
+    }
 }
 
 pub async fn gc_namespace<S: ObjectStore + ?Sized>(
@@ -101,15 +109,22 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     // A pass exists only after root collection succeeds. From here on it is
     // the one owner of every mutable sweep concern, including cleanup owed by
     // an early budget stop or error.
-    GcPass {
+    let upload_sweep = UploadSweepContext::new(
         store,
         namespace_id,
         content_store_id,
+        policy.grace_window_ms,
+        context,
+    );
+    GcPass {
+        store,
+        namespace_id,
         policy,
         mutation: context,
         initial_live: Arc::clone(&initial_live),
         sweep: SweepVerifier::seeded(Arc::clone(&initial_live), reverify_chunk),
         references: ContentReferences::over(initial_live),
+        upload_sweep,
         leases: CompactionLeases::default(),
         budget,
         report,
@@ -128,7 +143,6 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
 struct GcPass<'a, S: ?Sized> {
     store: &'a S,
     namespace_id: &'a NamespaceId,
-    content_store_id: ContentStoreId,
     policy: GcPolicy,
     mutation: &'a MutationContext,
     /// The root snapshot used to select candidates and collect content
@@ -136,6 +150,7 @@ struct GcPass<'a, S: ?Sized> {
     initial_live: Arc<LiveSet>,
     sweep: SweepVerifier,
     references: ContentReferences,
+    upload_sweep: UploadSweepContext<'a, S>,
     leases: CompactionLeases,
     budget: PassBudget,
     report: GcResponse,
@@ -208,7 +223,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             self.report.retain(RetainedReason::UnrecognizedKey);
             return Ok(SweepStep::Continue);
         }
-        let family = match family {
+        match family {
             CandidateFamily::UploadSessions => {
                 self.process_upload_session(key).await?;
                 return Ok(SweepStep::Continue);
@@ -219,17 +234,17 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
                 self.process_missing_basis_checkpoint(key).await?;
                 return Ok(SweepStep::Continue);
             }
-            CandidateFamily::WalSegments => SweepCandidateFamily::WalSegments,
-            CandidateFamily::MetadataSegments => SweepCandidateFamily::MetadataSegments,
-            CandidateFamily::CompactionStaging => SweepCandidateFamily::CompactionStaging,
-            CandidateFamily::Manifests => SweepCandidateFamily::Manifests,
-            CandidateFamily::Checkpoints => SweepCandidateFamily::Checkpoints,
+            CandidateFamily::WalSegments
+            | CandidateFamily::MetadataSegments
+            | CandidateFamily::CompactionStaging
+            | CandidateFamily::Manifests
+            | CandidateFamily::Checkpoints => {}
         };
 
         // Objects reachable from the invocation's root snapshot — either
         // anchor's — are skipped, while every selected candidate is
         // re-verified immediately before its decision.
-        if !self.is_selected(family, key) {
+        if is_live(&self.initial_live, family, key) {
             return Ok(SweepStep::Continue);
         }
         if self
@@ -248,51 +263,47 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
         }
 
         match family {
-            SweepCandidateFamily::WalSegments => self.process_wal_segment(key).await?,
-            SweepCandidateFamily::MetadataSegments => self.process_metadata_segment(key).await?,
-            SweepCandidateFamily::CompactionStaging => self.process_compaction_staging(key).await?,
-            SweepCandidateFamily::Manifests => self.process_manifest(key).await?,
-            SweepCandidateFamily::Checkpoints => self.process_checkpoint(key).await?,
+            CandidateFamily::WalSegments => {
+                self.process_aged_family(family, key, |deleted| &mut deleted.wal_segments)
+                    .await?
+            }
+            CandidateFamily::MetadataSegments => {
+                self.process_aged_family(family, key, |deleted| &mut deleted.metadata_segments)
+                    .await?
+            }
+            CandidateFamily::Manifests => {
+                self.process_aged_family(family, key, |deleted| &mut deleted.manifests)
+                    .await?
+            }
+            CandidateFamily::CompactionStaging => self.process_compaction_staging(key).await?,
+            CandidateFamily::Checkpoints => self.process_checkpoint(key).await?,
+            CandidateFamily::UploadSessions => self.process_upload_session(key).await?,
         }
         Ok(SweepStep::Continue)
     }
 
-    fn is_selected(&self, family: SweepCandidateFamily, key: &str) -> bool {
-        match family {
-            SweepCandidateFamily::WalSegments => !self.initial_live.protects_wal_segment(key),
-            // A staged segment a publication landed is named by the manifest
-            // like any other segment, so the same root set answers for both
-            // families.
-            SweepCandidateFamily::MetadataSegments | SweepCandidateFamily::CompactionStaging => {
-                !self.initial_live.segments.contains(key)
-            }
-            SweepCandidateFamily::Manifests => match manifest_object_id_of(key) {
-                Some(Ok(id)) => !self.initial_live.manifests.contains(&id),
-                // A key that names no readable manifest is reachable from no
-                // root. The family decision retains unrecognized names.
-                None | Some(Err(_)) => true,
-            },
-            SweepCandidateFamily::Checkpoints => !self.initial_live.checkpoint_keys.contains(key),
-        }
-    }
-
-    async fn process_wal_segment(&mut self, key: &str) -> Result<()> {
-        if self.sweep.live.protects_wal_segment(key) {
-            self.report.retain(RetainedReason::Referenced);
-        } else if self.sweep_aged(key, self.policy.grace_window_ms).await? {
-            self.report.deleted.wal_segments += 1;
-        }
-        Ok(())
-    }
-
-    async fn process_metadata_segment(&mut self, key: &str) -> Result<()> {
+    async fn process_aged_family(
+        &mut self,
+        family: CandidateFamily,
+        key: &str,
+        deleted: fn(&mut DeletedObjectCounts) -> &mut u64,
+    ) -> Result<()> {
         // Rule 5 is sticky across every re-collection in this pass.
-        if self.sweep.degraded {
+        if self.sweep.degraded
+            && matches!(
+                family,
+                CandidateFamily::MetadataSegments | CandidateFamily::Manifests
+            )
+        {
             self.report.retain(RetainedReason::DegradedRoots);
-        } else if self.sweep.live.segments.contains(key) {
+            return Ok(());
+        }
+        if is_live(&self.sweep.live, family, key) {
             self.report.retain(RetainedReason::Referenced);
-        } else if self.sweep_aged(key, self.policy.grace_window_ms).await? {
-            self.report.deleted.metadata_segments += 1;
+            return Ok(());
+        }
+        if self.sweep_aged(key, self.policy.grace_window_ms).await? {
+            *deleted(&mut self.report.deleted) += 1;
         }
         Ok(())
     }
@@ -302,7 +313,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             self.report.retain(RetainedReason::DegradedRoots);
             return Ok(());
         }
-        if self.sweep.live.segments.contains(key) {
+        if is_live(&self.sweep.live, CandidateFamily::CompactionStaging, key) {
             self.report.retain(RetainedReason::Referenced);
             return Ok(());
         }
@@ -315,12 +326,15 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             .owner_of(self.store, self.namespace_id, key, self.mutation.now_ms)
             .await?
         {
-            StagedObject::OwnedByALiveJob => self.report.retain(RetainedReason::WithinGraceWindow),
-            StagedObject::UnrecognizedKey => {
+            Some(CompactionPrefixOwner::LiveJob) => {
+                self.report.retain(RetainedReason::WithinGraceWindow);
+            }
+            None => {
                 self.report.retain(RetainedReason::UnrecognizedKey);
             }
-            StagedObject::ClaimedLease => {}
-            StagedObject::Orphaned => {
+            // The claimed lease is deleted once its prefix is processed.
+            Some(CompactionPrefixOwner::ThisCollector) if self.leases.is_claimed_lease(key) => {}
+            Some(CompactionPrefixOwner::ThisCollector | CompactionPrefixOwner::NoOne) => {
                 if key.ends_with(".sst.zst")
                     && self
                         .sweep_aged(key, METADATA_COMPACTION_STAGING_GRACE_MS)
@@ -329,27 +343,6 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
                     self.report.deleted.metadata_segments += 1;
                 }
             }
-        }
-        Ok(())
-    }
-
-    async fn process_manifest(&mut self, key: &str) -> Result<()> {
-        if self.sweep.degraded {
-            self.report.retain(RetainedReason::DegradedRoots);
-            return Ok(());
-        }
-        match manifest_object_id_of(key) {
-            Some(Ok(id)) if self.sweep.live.manifests.contains(&id) => {
-                self.report.retain(RetainedReason::Referenced);
-            }
-            Some(Ok(_)) => {
-                if self.sweep_aged(key, self.policy.grace_window_ms).await? {
-                    self.report.deleted.manifests += 1;
-                }
-            }
-            // A key under the manifest prefix that does not name a manifest
-            // is never deleted because this pass cannot tell what wrote it.
-            None | Some(Err(_)) => self.report.retain(RetainedReason::UnrecognizedKey),
         }
         Ok(())
     }
@@ -372,7 +365,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
     }
 
     async fn process_checkpoint(&mut self, key: &str) -> Result<()> {
-        if self.sweep.live.checkpoint_keys.contains(key) {
+        if is_live(&self.sweep.live, CandidateFamily::Checkpoints, key) {
             self.report.retain(RetainedReason::Referenced);
             return Ok(());
         }
@@ -414,14 +407,10 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             return Ok(());
         };
         match sweep_upload_session(
-            self.store,
-            self.namespace_id,
-            &self.content_store_id,
+            &self.upload_sweep,
             &upload_id,
-            self.policy.grace_window_ms,
             &mut self.references,
             &mut self.budget,
-            self.mutation,
         )
         .await?
         {

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -55,29 +55,47 @@ pub(super) enum UploadSessionSweep {
     ContentReclamationDeferred,
 }
 
+pub(super) struct UploadSweepContext<'a, S: ?Sized> {
+    store: &'a S,
+    namespace_id: &'a NamespaceId,
+    content_store_id: ContentStoreId,
+    grace_window_ms: u64,
+    context: &'a MutationContext,
+}
+
+impl<'a, S: ?Sized> UploadSweepContext<'a, S> {
+    pub(super) fn new(
+        store: &'a S,
+        namespace_id: &'a NamespaceId,
+        content_store_id: ContentStoreId,
+        grace_window_ms: u64,
+        context: &'a MutationContext,
+    ) -> Self {
+        Self {
+            store,
+            namespace_id,
+            content_store_id,
+            grace_window_ms,
+            context,
+        }
+    }
+}
+
 /// Advances one upload session and reclaims content it no longer owns.
 ///
 /// State transitions use a CAS against the ETag that was read with the
 /// session. A CAS conflict keeps the session for a later pass. Provider
 /// cleanup runs only after the durable state transition, so a crash may leave
 /// extra data to clean up but cannot delete data from an open session.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "the sweep decision needs session state, policy, budget, and context together"
-)]
 pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    content_store_id: &ContentStoreId,
+    sweep: &UploadSweepContext<'_, S>,
     upload_id: &UploadId,
-    grace_window_ms: u64,
     references: &mut ContentReferences,
     budget: &mut PassBudget,
-    context: &MutationContext,
 ) -> Result<UploadSessionSweep> {
     // This read selects the lifecycle branch only. Any state change is applied
     // through a later CAS using a fresh ETag.
-    let state = match load_upload_session_state(store, namespace_id, upload_id).await {
+    let state = match load_upload_session_state(sweep.store, sweep.namespace_id, upload_id).await {
         Ok(state) => state,
         Err(CoreError::UploadNotFound { .. }) => return Ok(retain_undated()),
         Err(error) => return Err(error),
@@ -85,25 +103,18 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
 
     match state.status {
         UploadSessionRecordStatus::Open { expires_at_ms, .. } => {
-            abort_expired_session(
-                store,
-                namespace_id,
-                content_store_id,
-                upload_id,
-                expires_at_ms,
-                grace_window_ms,
-                context,
-            )
-            .await
+            abort_expired_session(sweep, upload_id, expires_at_ms).await
         }
         UploadSessionRecordStatus::Aborted { aborted_at_ms } => {
-            if context.now_ms.saturating_sub(aborted_at_ms) < grace_window_ms {
-                return Ok(retain_until(aborted_at_ms.saturating_add(grace_window_ms)));
+            if sweep.context.now_ms.saturating_sub(aborted_at_ms) < sweep.grace_window_ms {
+                return Ok(retain_until(
+                    aborted_at_ms.saturating_add(sweep.grace_window_ms),
+                ));
             }
             // Repeat provider cleanup so a later pass completes work left by a crash
             // after the abort CAS.
             if !AbandonedUpload::of(&state)
-                .release(store, content_store_id)
+                .release(sweep.store, &sweep.content_store_id)
                 .await
             {
                 return Ok(retain_undated());
@@ -119,13 +130,18 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
             completed_at_ms,
             content_ref,
         } => {
-            if context.now_ms.saturating_sub(completed_at_ms) < CONTENT_RECLAMATION_GRACE_MS {
+            if sweep.context.now_ms.saturating_sub(completed_at_ms) < CONTENT_RECLAMATION_GRACE_MS {
                 return Ok(retain_until(
                     completed_at_ms.saturating_add(CONTENT_RECLAMATION_GRACE_MS),
                 ));
             }
             match references
-                .lookup(store, namespace_id, &content_ref.content_id, budget)
+                .lookup(
+                    sweep.store,
+                    sweep.namespace_id,
+                    &content_ref.content_id,
+                    budget,
+                )
                 .await?
             {
                 ContentReference::Unknown => Ok(retain_undated()),
@@ -137,8 +153,8 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
                 }),
                 ContentReference::Absent => {
                     if !delete_unpublished_content_object(
-                        store,
-                        content_store_id,
+                        sweep.store,
+                        &sweep.content_store_id,
                         &content_ref.content_id,
                     )
                     .await
@@ -174,20 +190,18 @@ fn retain_undated() -> UploadSessionSweep {
 /// The CAS provides safety. The additional grace period only reduces races
 /// with completions that arrive shortly after lease expiry.
 async fn abort_expired_session<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    content_store_id: &ContentStoreId,
+    sweep: &UploadSweepContext<'_, S>,
     upload_id: &UploadId,
     expires_at_ms: u64,
-    grace_window_ms: u64,
-    context: &MutationContext,
 ) -> Result<UploadSessionSweep> {
-    if context.now_ms.saturating_sub(expires_at_ms) < grace_window_ms {
-        return Ok(retain_until(expires_at_ms.saturating_add(grace_window_ms)));
+    if sweep.context.now_ms.saturating_sub(expires_at_ms) < sweep.grace_window_ms {
+        return Ok(retain_until(
+            expires_at_ms.saturating_add(sweep.grace_window_ms),
+        ));
     }
     let aborted = try_update_upload_session(
-        store,
-        namespace_id,
+        sweep.store,
+        sweep.namespace_id,
         upload_id,
         |mut state: UploadSessionState| async move {
             if !matches!(state.status, UploadSessionRecordStatus::Open { .. }) {
@@ -195,7 +209,7 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
             }
             let abandoned = AbandonedUpload::of(&state);
             state.status = UploadSessionRecordStatus::Aborted {
-                aborted_at_ms: context.now_ms,
+                aborted_at_ms: sweep.context.now_ms,
             };
             Ok(UploadSessionUpdate::Replace {
                 next: Box::new(state),
@@ -207,13 +221,17 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
     match aborted {
         // Keep the newly aborted record until its post-abort grace period expires.
         Ok(CasAttempt::Settled(Some(abandoned))) => {
-            let _ = abandoned.release(store, content_store_id).await;
-            Ok(retain_until(context.now_ms.saturating_add(grace_window_ms)))
+            let _ = abandoned
+                .release(sweep.store, &sweep.content_store_id)
+                .await;
+            Ok(retain_until(
+                sweep.context.now_ms.saturating_add(sweep.grace_window_ms),
+            ))
         }
         Ok(CasAttempt::Settled(None)) => Ok(retain_undated()),
         Ok(CasAttempt::Contended) => {
             tracing::debug!(
-                namespace_id = %namespace_id,
+                namespace_id = %sweep.namespace_id,
                 upload_id = %upload_id,
                 "upload-session abort lost its inspected etag; retaining"
             );
@@ -241,8 +259,6 @@ enum ContentReference {
 /// What the reference scan has produced for this invocation.
 #[derive(Debug)]
 pub(super) enum CollectedReferences {
-    /// The scan has not run yet. Only the memo starts here.
-    NotYet,
     /// A root could not be read, so this pass has no reference set at all
     /// (format spec, "Garbage collection", rule 5).
     Unavailable,
@@ -262,14 +278,14 @@ pub(super) enum CollectedReferences {
 /// delete. A resumed invocation performs a new budgeted scan.
 pub(super) struct ContentReferences {
     live: Arc<LiveSet>,
-    collected: CollectedReferences,
+    collected: Option<CollectedReferences>,
 }
 
 impl ContentReferences {
     pub(super) fn over(live: Arc<LiveSet>) -> Self {
         Self {
             live,
-            collected: CollectedReferences::NotYet,
+            collected: None,
         }
     }
 
@@ -280,19 +296,17 @@ impl ContentReferences {
         content_id: &ContentId,
         budget: &mut PassBudget,
     ) -> Result<ContentReference> {
-        if matches!(self.collected, CollectedReferences::NotYet) {
-            self.collected = if self.live.degraded {
+        if self.collected.is_none() {
+            self.collected = Some(if self.live.degraded {
                 CollectedReferences::Unavailable
             } else {
                 collect_referenced_content(store, namespace_id, &self.live, budget).await?
-            };
+            });
         }
         Ok(match &self.collected {
-            CollectedReferences::NotYet | CollectedReferences::Unavailable => {
-                ContentReference::Unknown
-            }
-            CollectedReferences::Deferred => ContentReference::Deferred,
-            CollectedReferences::Referenced(referenced) => {
+            None | Some(CollectedReferences::Unavailable) => ContentReference::Unknown,
+            Some(CollectedReferences::Deferred) => ContentReference::Deferred,
+            Some(CollectedReferences::Referenced(referenced)) => {
                 if referenced.contains(content_id) {
                     ContentReference::Referenced
                 } else {

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -168,7 +168,7 @@ pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, StoreFailureClass,
     WriterFence,
 };
-pub use gc::{delete_if_aged, gc_namespace, AgedSweep, GcConfig, PassBudget};
+pub use gc::{delete_if_aged, gc_namespace, GcConfig, GraceAge, PassBudget};
 pub use namespace::BootstrapNamespaceError;
 pub use options::{BootstrapOptions, DeleteNamespaceOptions};
 pub use path::read::{

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -24,7 +24,7 @@ use futures::future::try_join_all;
 use futures::StreamExt as _;
 use loonfs::{
     delete_if_aged, CheckpointFilesPageCursor, CoreError, CreateCheckpointOptions, FsAdmin,
-    FsReader, PassBudget, RuntimeError, StoreFailureClass, DEFAULT_GC_MAX_OBJECTS,
+    FsReader, GraceAge, PassBudget, RuntimeError, StoreFailureClass, DEFAULT_GC_MAX_OBJECTS,
     GC_MIN_GRACE_WINDOW_MS, METADATA_PUBLICATION_BUDGET_MS,
 };
 use loonfs_api::v0::{FilesystemChange, GrepIndex, GrepIndexLifecycle};
@@ -1457,7 +1457,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         if outcome.retained_reason().is_some() {
             report.retained_candidates += 1;
         }
-        if outcome.deleted() {
+        if outcome == GraceAge::Aged {
             count_deleted_key(key, report);
             return Ok(true);
         }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -106,9 +106,9 @@ pub use loonfs_core::limits::{
 };
 pub use loonfs_core::time::current_time_ms;
 pub use loonfs_core::{
-    delete_if_aged, AgedSweep, BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage,
+    delete_if_aged, BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage,
     CheckpointFilesPageCursor, CheckpointPageCursor, CurrentFileState, DeleteNamespaceOptions,
-    Error as CoreError, ErrorCode, ErrorKind, FileContentStream, GcConfig,
+    Error as CoreError, ErrorCode, ErrorKind, FileContentStream, GcConfig, GraceAge,
     MetadataCompactionJobOutcome, MetadataViewError, PassBudget, StoreFailureClass, WriterFence,
     CONTENT_READ_CHUNK_BYTES, MAX_RESOLVE_CURRENT_FILES,
 };


### PR DESCRIPTION
This simplifies garbage collection by sharing the age-based sweep logic used for WAL segments, metadata segments, and manifests. It also replaces several temporary lifecycle types with smaller state representations for fork checkpoints, upload sessions, and compaction prefixes.

Compaction leases are now created before a job can heartbeat or write output, so the lease always has an ETag. Garbage-collection behavior is otherwise unchanged.