### PR TITLE
refactor(server): enforce authentication at the router

### DIFF
--- a/crates/loonfs-client/tests/snapshots.rs
+++ b/crates/loonfs-client/tests/snapshots.rs
@@ -5,7 +5,8 @@ use loonfs_client::{
     Client, ClientConfig, NamespacePath, PutFileOptions, ReadFileOptions, StatPathOptions,
 };
 use loonfs_server::{
-    app, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
+    app, AppOptions, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig,
+    StoreConfig,
 };
 use tempfile::TempDir;
 
@@ -55,7 +56,9 @@ async fn start_server(name: &str) -> TestServer {
         .await
         .expect("bind listener");
     let address = listener.local_addr().expect("listener address");
-    let (router, _writer, _cache) = app(config).await.expect("build server");
+    let (router, _state) = app(config, AppOptions::default())
+        .await
+        .expect("build server");
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });

--- a/crates/loonfs-conformance/src/server.rs
+++ b/crates/loonfs-conformance/src/server.rs
@@ -83,8 +83,14 @@ pub async fn start_server() -> Result<ConformanceServer, Box<dyn std::error::Err
     let config_path = temp_dir.path().join("loonfs-server.toml");
     write_server_config(&config_path, &store_root)?;
     let config = loonfs_server::load_server_config(&config_path)?;
-    let api_router =
-        loonfs_server::app_with_test_transfers(config, shared_store, transfers).await?;
+    let (api_router, _state) = loonfs_server::app(
+        config,
+        loonfs_server::AppOptions {
+            store: Some(shared_store),
+            direct_transfers: Some(transfers),
+        },
+    )
+    .await?;
     let server_task = tokio::spawn(async move {
         axum::serve(api_listener, api_router)
             .await

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -472,41 +472,24 @@ impl ServerConfig {
                 ),
             });
         }
-        if self.max_upload_bytes == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "max_upload_bytes",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if self.request_deadline_ms == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "request_deadline_ms",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if self.shutdown_deadline_ms == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "shutdown_deadline_ms",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if self.max_download_bytes == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "max_download_bytes",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if self.snapshot_max_ttl_ms == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "snapshot_max_ttl_ms",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if self.snapshot_max_lifetime_ms == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "snapshot_max_lifetime_ms",
-                reason: "must be greater than zero".to_owned(),
-            });
+        for (field, value) in [
+            ("max_upload_bytes", self.max_upload_bytes),
+            ("request_deadline_ms", self.request_deadline_ms),
+            ("shutdown_deadline_ms", self.shutdown_deadline_ms),
+            ("max_download_bytes", self.max_download_bytes),
+            ("snapshot_max_ttl_ms", self.snapshot_max_ttl_ms),
+            ("snapshot_max_lifetime_ms", self.snapshot_max_lifetime_ms),
+            (
+                "snapshot_max_live_per_namespace",
+                self.snapshot_max_live_per_namespace as u64,
+            ),
+            ("max_concurrent_uploads", self.max_concurrent_uploads as u64),
+            (
+                "max_concurrent_downloads",
+                self.max_concurrent_downloads as u64,
+            ),
+        ] {
+            require_positive(field, value, None)?;
         }
         if self.snapshot_max_ttl_ms > self.snapshot_max_lifetime_ms {
             return Err(ServerConfigError::InvalidField {
@@ -514,42 +497,18 @@ impl ServerConfig {
                 reason: "must not exceed `snapshot_max_lifetime_ms`".to_owned(),
             });
         }
-        if self.snapshot_max_live_per_namespace == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "snapshot_max_live_per_namespace",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if self.max_concurrent_uploads == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "max_concurrent_uploads",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if self.max_concurrent_downloads == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "max_concurrent_downloads",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if self.max_concurrent_maintenance == 0 {
-            return Err(ServerConfigError::InvalidField {
-                field: "max_concurrent_maintenance",
-                reason: "must be greater than zero; \
-                         set `maintenance = \"manual\"` to disable scheduling"
-                    .to_owned(),
-            });
-        }
+        require_positive(
+            "max_concurrent_maintenance",
+            self.max_concurrent_maintenance as u64,
+            Some("set `maintenance = \"manual\"` to disable scheduling"),
+        )?;
         if let Some(local_cache) = &self.local_cache {
             require_non_empty("local_cache.path", &local_cache.path)?;
-            if local_cache.memory_bytes == 0 {
-                return Err(ServerConfigError::InvalidField {
-                    field: "local_cache.memory_bytes",
-                    reason: "must be greater than zero; \
-                             omit the `[local_cache]` table to run without a local cache"
-                        .to_owned(),
-                });
-            }
+            require_positive(
+                "local_cache.memory_bytes",
+                local_cache.memory_bytes,
+                Some("omit the `[local_cache]` table to run without a local cache"),
+            )?;
             // The disk tier allocates whole blocks and never a partial one,
             // so a capacity under the floor is a cache that starts, holds
             // nothing on disk, and says nothing about it. Refuse it here
@@ -629,6 +588,22 @@ fn require_non_empty(field: &'static str, value: &str) -> Result<(), ServerConfi
     } else {
         Ok(())
     }
+}
+
+fn require_positive(
+    field: &'static str,
+    value: u64,
+    hint: Option<&str>,
+) -> Result<(), ServerConfigError> {
+    if value > 0 {
+        return Ok(());
+    }
+    let mut reason = "must be greater than zero".to_owned();
+    if let Some(hint) = hint {
+        reason.push_str("; ");
+        reason.push_str(hint);
+    }
+    Err(ServerConfigError::InvalidField { field, reason })
 }
 
 fn validate_socket_addr(field: &'static str, value: &str) -> Result<SocketAddr, ServerConfigError> {

--- a/crates/loonfs-server/src/http/download_body.rs
+++ b/crates/loonfs-server/src/http/download_body.rs
@@ -1,0 +1,41 @@
+//! Buffered download response bodies and their admission permits.
+
+use axum::body::Body;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use futures::Stream;
+use std::convert::Infallible;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::OwnedSemaphorePermit;
+
+/// One materialized download plus the permit accounting for its memory.
+///
+/// The stream owns the permit even after yielding its only chunk, so the
+/// response body releases admission only when it is fully consumed or
+/// abandoned and dropped.
+struct DownloadBodyStream {
+    bytes: Option<bytes::Bytes>,
+    _permit: OwnedSemaphorePermit,
+}
+
+pub(super) fn buffered_download_response(bytes: Vec<u8>, permit: OwnedSemaphorePermit) -> Response {
+    let body = Body::from_stream(DownloadBodyStream {
+        bytes: Some(bytes.into()),
+        _permit: permit,
+    });
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
+        body,
+    )
+        .into_response()
+}
+
+impl Stream for DownloadBodyStream {
+    type Item = Result<bytes::Bytes, Infallible>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.bytes.take().map(Ok))
+    }
+}

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -112,6 +112,12 @@ impl ApiResponseError {
 
         Self::runtime(error)
     }
+
+    pub(super) fn for_namespace(
+        namespace_id: &NamespaceId,
+    ) -> impl FnOnce(RuntimeError) -> Self + '_ {
+        |error| Self::runtime_for_namespace(namespace_id, error)
+    }
 }
 
 pub(super) fn status_for_core_error_code(code: ErrorCode) -> StatusCode {

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -12,7 +12,6 @@ use bytes::Bytes;
 use futures::StreamExt;
 use loonfs::{ByteStream, ErrorCode, MAX_MULTIPART_PARTS, MAX_SIGNED_PARTS_PER_REQUEST};
 use loonfs_api::{AbsolutePath, NamespaceId};
-use std::convert::Infallible;
 use std::sync::{Arc, Mutex};
 use tokio::sync::OwnedSemaphorePermit;
 
@@ -82,31 +81,20 @@ struct NamespaceSegment {
 }
 
 /// Parses the `{namespace_id}` path segment.
-///
-/// The handler reads the result after authorization. This keeps malformed
-/// namespace ids from changing an unauthorized response from 401 to 400.
-pub(super) struct NamespaceIdPath(Result<NamespaceId, ApiResponseError>);
-
-impl NamespaceIdPath {
-    /// Returns the parsed namespace id, or the same 400
-    /// `invalid_namespace_id` response [`parse_namespace_id`] produces.
-    pub(super) fn into_id(self) -> Result<NamespaceId, ApiResponseError> {
-        self.0
-    }
-}
+pub(super) struct NamespaceIdPath(pub(super) NamespaceId);
 
 impl<S> FromRequestParts<S> for NamespaceIdPath
 where
     S: Send + Sync,
 {
-    type Rejection = Infallible;
+    type Rejection = ApiResponseError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         match AxumPath::<NamespaceSegment>::from_request_parts(parts, state).await {
             Ok(AxumPath(NamespaceSegment { namespace_id })) => {
-                Ok(Self(parse_namespace_id(namespace_id)))
+                parse_namespace_id(namespace_id).map(Self)
             }
-            Err(rejection) => Ok(Self(Err(invalid_path_params(&rejection)))),
+            Err(rejection) => Err(invalid_path_params(&rejection)),
         }
     }
 }
@@ -118,51 +106,36 @@ fn invalid_path_params(rejection: &PathRejection) -> ApiResponseError {
     )
 }
 
-/// Path extractor that never rejects at extraction: the parse outcome is
-/// surfaced through [`AppPath::into_params`] inside the handler, after
-/// `authorize`, so malformed path parameters answer inside the JSON error
-/// envelope and never turn an unauthorized request's 401 into a 400.
-pub(super) struct AppPath<T>(Result<T, ApiResponseError>);
-
-impl<T> AppPath<T> {
-    pub(super) fn into_params(self) -> Result<T, ApiResponseError> {
-        self.0
-    }
-}
+/// Path extractor whose rejections stay inside the error contract.
+pub(super) struct AppPath<T>(pub(super) T);
 
 impl<S, T> FromRequestParts<S> for AppPath<T>
 where
     S: Send + Sync,
     T: serde::de::DeserializeOwned + Send,
 {
-    type Rejection = Infallible;
+    type Rejection = ApiResponseError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         match AxumPath::<T>::from_request_parts(parts, state).await {
-            Ok(AxumPath(value)) => Ok(Self(Ok(value))),
-            Err(rejection) => Ok(Self(Err(invalid_path_params(&rejection)))),
+            Ok(AxumPath(value)) => Ok(Self(value)),
+            Err(rejection) => Err(invalid_path_params(&rejection)),
         }
     }
 }
 
-/// Defers query-string errors until the handler has authorized the request.
-pub(super) struct AppQuery<T>(Result<T, ApiResponseError>);
-
-impl<T> AppQuery<T> {
-    pub(super) fn into_params(self) -> Result<T, ApiResponseError> {
-        self.0
-    }
-}
+/// Query extractor whose rejections stay inside the error contract.
+pub(super) struct AppQuery<T>(pub(super) T);
 
 impl<S, T> FromRequestParts<S> for AppQuery<T>
 where
     S: Send + Sync,
     T: serde::de::DeserializeOwned,
 {
-    type Rejection = Infallible;
+    type Rejection = ApiResponseError;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        Ok(Self(decode_query(parts.uri.query().unwrap_or_default())))
+        decode_query(parts.uri.query().unwrap_or_default()).map(Self)
     }
 }
 
@@ -206,6 +179,8 @@ fn failed_query_parameter(path: &serde_path_to_error::Path) -> Option<String> {
 /// the body is read so a malformed body never turns an unauthorized
 /// request's 401 into a 400.
 pub(super) struct AppJson<T>(pub(super) T);
+
+const MAX_JSON_BODY_BYTES: usize = 2 * 1024 * 1024;
 
 async fn extract_json<S, T>(
     req: axum::extract::Request,
@@ -314,11 +289,11 @@ where
     type Rejection = ApiResponseError;
 
     async fn from_request(
-        req: axum::extract::Request,
+        mut req: axum::extract::Request,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        authorize(state.config.auth_policy(), req.headers())?;
-        extract_json(req, state, json_body_too_large_error())
+        DefaultBodyLimit::max(MAX_JSON_BODY_BYTES).apply(&mut req);
+        extract_json(req, state, body_too_large_error(MAX_JSON_BODY_BYTES))
             .await
             .map(AppJson)
     }
@@ -373,9 +348,8 @@ where
         mut req: axum::extract::Request,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        authorize(state.config.auth_policy(), req.headers())?;
         DefaultBodyLimit::max(MAX_BYTES).apply(&mut req);
-        extract_json(req, state, upload_control_body_too_large_error(MAX_BYTES))
+        extract_json(req, state, body_too_large_error(MAX_BYTES))
             .await
             .map(Self)
     }
@@ -419,15 +393,9 @@ impl<const MAX_BYTES: usize> FromRequest<AppState> for UploadBodyBytes<MAX_BYTES
         req: axum::extract::Request,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        authorize(state.config.auth_policy(), req.headers())?;
-        extract_body_bytes(
-            req,
-            state,
-            MAX_BYTES,
-            upload_control_body_too_large_error(MAX_BYTES),
-        )
-        .await
-        .map(Self)
+        extract_body_bytes(req, state, MAX_BYTES, body_too_large_error(MAX_BYTES))
+            .await
+            .map(Self)
     }
 }
 
@@ -534,7 +502,6 @@ impl FromRequest<AppState> for UploadBodyStream {
         req: axum::extract::Request,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        authorize(state.config.auth_policy(), req.headers())?;
         let permit = state
             .upload_permits
             .clone()
@@ -579,29 +546,10 @@ fn upload_body_too_large_error() -> ApiResponseError {
     )
 }
 
-/// 413 for ordinary JSON routes that retain the framework's default bound.
-fn json_body_too_large_error() -> ApiResponseError {
+fn body_too_large_error(limit: usize) -> ApiResponseError {
     ApiResponseError::new(
         ErrorCode::ContentTooLarge,
-        "JSON request body exceeds this route's body limit",
-    )
-}
-
-/// Returns a 413 error for an upload request that exceeds its route's limit.
-fn upload_control_body_too_large_error(max_bytes: usize) -> ApiResponseError {
-    ApiResponseError::new(
-        ErrorCode::ContentTooLarge,
-        &format!("upload-control request body exceeds this route's limit of {max_bytes} bytes"),
-    )
-}
-
-/// Returns a 413 error when optional JSON exceeds its body-size limit.
-fn optional_json_body_too_large_error() -> ApiResponseError {
-    ApiResponseError::new(
-        ErrorCode::ContentTooLarge,
-        &format!(
-            "JSON request body exceeds this route's limit of {MAX_OPTIONAL_JSON_BODY_BYTES} bytes"
-        ),
+        &format!("request body exceeds this route's limit of {limit} bytes"),
     )
 }
 
@@ -621,12 +569,11 @@ where
         req: axum::extract::Request,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        authorize(state.config.auth_policy(), req.headers())?;
         let body = extract_body_bytes(
             req,
             state,
             MAX_OPTIONAL_JSON_BODY_BYTES,
-            optional_json_body_too_large_error(),
+            body_too_large_error(MAX_OPTIONAL_JSON_BODY_BYTES),
         )
         .await?;
         if body.is_empty() {

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -2,11 +2,12 @@
 
 use super::error::ApiResponseError;
 use super::handlers_filesystem::{
-    parse_optional_snapshot_id, parse_revision_no, pin_requested_snapshot,
-    reject_snapshot_with_revision, SnapshotQuery,
+    parse_optional_snapshot_id, pin_requested_snapshot, reject_snapshot_with_revision,
+    SnapshotQuery,
 };
 use super::handlers_inodes::{parse_inode_id, InodeRevisionPathParams};
 use super::handlers_uploads::{presign_issuer_error, presign_time};
+use super::query_params::parse_revision_no;
 use super::{AppJson, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery};
 use axum::extract::State;
 use axum::Json;
@@ -56,34 +57,26 @@ const DIRECT_GET_URL_TTL: Duration = Duration::from_secs(15 * 60);
 /// download limits do not apply.
 pub(super) async fn create_download(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    query: AppQuery<SnapshotQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<SnapshotQuery>,
     AppJson(request): AppJson<BeginDownloadRequest>,
 ) -> Result<Json<BeginDownloadResponse>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let snapshot_id = parse_optional_snapshot_id(query.snapshot_id)?;
     reject_snapshot_with_revision(snapshot_id.as_ref(), request.revision_no)?;
-    let snapshot = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
+    let target = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
     let issuer = direct_get_issuer(&state)?;
 
-    let target = match snapshot {
-        Some(snapshot) => snapshot.create_download(request.path.as_str()).await,
-        None => {
-            state
-                .reader
-                .create_download(&namespace_id, request.path.as_str(), request.revision_no)
-                .await
-        }
-    }
-    .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    let access = presigned_access(issuer, &target.object_key).await?;
+    let download = target
+        .create_download(request.path.as_str(), request.revision_no)
+        .await
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
+    let access = presigned_access(issuer, &download.object_key).await?;
 
     Ok(Json(BeginDownloadResponse {
         namespace_id,
-        path: target.absolute_path,
-        revision_no: target.revision_no,
-        content_ref: target.content_ref,
+        path: download.absolute_path,
+        revision_no: download.revision_no,
+        content_ref: download.content_ref,
         access,
     }))
 }
@@ -118,14 +111,11 @@ pub(super) async fn create_download(
 /// Authorizes a direct read of one retained inode revision.
 pub(super) async fn create_download_by_inode(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<InodeRevisionPathParams>,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(path): AppPath<InodeRevisionPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
     AppJson(_request): AppJson<BeginDownloadByInodeRequest>,
 ) -> Result<Json<BeginDownloadByInodeResponse>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    let path = path.into_params()?;
-    query.into_params()?;
     let inode_id = parse_inode_id(&path.inode_id)?;
     let revision_no = parse_revision_no(&path.revision_no)?;
     let issuer = direct_get_issuer(&state)?;
@@ -133,7 +123,7 @@ pub(super) async fn create_download_by_inode(
         .reader
         .create_download_by_inode(&namespace_id, inode_id, revision_no)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     let access = presigned_access(issuer, &target.object_key).await?;
     Ok(Json(BeginDownloadByInodeResponse {
         namespace_id,

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -2,23 +2,27 @@
 //! reads, revision listings, filesystem mutations, and the committed-change
 //! feed.
 
+use super::download_body::buffered_download_response;
 use super::error::ApiResponseError;
 use super::handlers_uploads::{
     content_preparation_for_puts, current_unix_ms, ContentTokenVerifier, PutContentPreparation,
 };
-use super::{
-    acquire_download_permit, authorize, AppJson, AppQuery, AppState, NamespaceIdPath, NoQuery,
+use super::query_params::{
+    decode_optional_cursor, parse_include_attributes, parse_path_id, parse_public_ordinal,
+    parse_revision_no, required_query_param, resolve_page_limit,
 };
-use axum::body::Body;
+#[cfg(feature = "openapi")]
+pub(super) use super::query_params::{
+    OpenApiDefaultFalseBoolean, OpenApiDefaultTrueBoolean, OpenApiPageLimit,
+};
+use super::{acquire_download_permit, AppJson, AppQuery, AppState, NamespaceIdPath, NoQuery};
 use axum::extract::State;
-use axum::http::{HeaderMap, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use axum::Json;
-use futures::Stream;
 use loonfs::publish::{CommitCandidate, CommitRequest, ContentPreparationError};
 use loonfs::{
-    payload_class, CheckpointId, ErrorCode, FsReadSnapshot, ListChangesOptions,
-    ListPathEntriesOptions, StatPathOptions, TraceMode, TraceStoreKind,
+    payload_class, CheckpointId, ErrorCode, FsReadSnapshot, FsReader, ListChangesOptions,
+    ListPathEntriesOptions, NamespaceId, StatPathOptions, TraceMode, TraceStoreKind,
 };
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -26,16 +30,10 @@ use loonfs_api::ApiError;
 // tokens, which this handler resolves and strips; the operations inside them
 // are one type. The alias keeps the two request names readable side by side.
 use loonfs_api::{
-    decode_cursor,
     v0::{CommitResponse as ApiCommitResponse, ListChangesResponse},
-    CommitRequest as ApiCommitRequest, FilesystemOperation, LimitError, ListFileRevisionsResponse,
-    ListTrashResponse, PageCursorError, PageRequest, PaginationPolicy, PublicOrdinalRangeError,
-    RevisionNo,
+    CommitRequest as ApiCommitRequest, FilesystemOperation, ListFileRevisionsResponse,
+    ListTrashResponse, PageRequest, RevisionNo,
 };
-use std::convert::Infallible;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use tokio::sync::OwnedSemaphorePermit;
 use tracing::Instrument;
 
 #[derive(Debug, serde::Deserialize)]
@@ -82,37 +80,6 @@ pub(super) struct ContentQuery {
     snapshot_id: Option<String>,
 }
 
-/// One materialized download plus the permit accounting for its memory.
-///
-/// The stream owns the permit even after yielding its only chunk, so the
-/// response body releases admission only when it is fully consumed or
-/// abandoned and dropped.
-struct DownloadBodyStream {
-    bytes: Option<bytes::Bytes>,
-    _permit: OwnedSemaphorePermit,
-}
-
-pub(super) fn buffered_download_response(bytes: Vec<u8>, permit: OwnedSemaphorePermit) -> Response {
-    let body = Body::from_stream(DownloadBodyStream {
-        bytes: Some(bytes.into()),
-        _permit: permit,
-    });
-    (
-        StatusCode::OK,
-        [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
-        body,
-    )
-        .into_response()
-}
-
-impl Stream for DownloadBodyStream {
-    type Item = Result<bytes::Bytes, Infallible>;
-
-    fn poll_next(mut self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Poll::Ready(self.bytes.take().map(Ok))
-    }
-}
-
 #[derive(Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct ChangesQuery {
@@ -127,61 +94,91 @@ pub(super) struct SnapshotQuery {
     pub(super) snapshot_id: Option<String>,
 }
 
-/// Schema-only override for the shared page-limit query contract.
-#[cfg(feature = "openapi")]
-pub(super) struct OpenApiPageLimit;
-
-#[cfg(feature = "openapi")]
-impl utoipa::PartialSchema for OpenApiPageLimit {
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        utoipa::openapi::schema::Object::builder()
-            .schema_type(utoipa::openapi::schema::Type::Integer)
-            .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
-                utoipa::openapi::KnownFormat::Int32,
-            )))
-            .minimum(Some(1u32))
-            .maximum(Some(loonfs_api::DEFAULT_MAX_PAGE_LIMIT))
-            .default(Some(serde_json::json!(loonfs_api::DEFAULT_PAGE_LIMIT)))
-            .into()
-    }
+pub(super) enum ReadTarget {
+    Snapshot(Box<FsReadSnapshot>),
+    Live {
+        reader: FsReader,
+        namespace_id: NamespaceId,
+    },
 }
 
-#[cfg(feature = "openapi")]
-impl utoipa::ToSchema for OpenApiPageLimit {}
+impl ReadTarget {
+    pub(super) async fn list_path_entries_page(
+        &self,
+        path: &str,
+        request: PageRequest<loonfs::DirectoryPageCursor>,
+        options: ListPathEntriesOptions,
+    ) -> loonfs::Result<loonfs::ListPathEntriesResponse> {
+        match self {
+            Self::Snapshot(snapshot) => {
+                snapshot
+                    .list_path_entries_page(path, request, options)
+                    .await
+            }
+            Self::Live {
+                reader,
+                namespace_id,
+            } => {
+                reader
+                    .list_path_entries_page(namespace_id, path, request, options)
+                    .await
+            }
+        }
+    }
 
-/// Schema-only override for an optional boolean that defaults to true.
-#[cfg(feature = "openapi")]
-pub(super) struct OpenApiDefaultTrueBoolean;
+    pub(super) async fn get_path_entry(
+        &self,
+        path: &str,
+        options: StatPathOptions,
+    ) -> loonfs::Result<loonfs::PathEntry> {
+        match self {
+            Self::Snapshot(snapshot) => snapshot.get_path_entry(path, options).await,
+            Self::Live {
+                reader,
+                namespace_id,
+            } => reader.get_path_entry(namespace_id, path, options).await,
+        }
+    }
 
-#[cfg(feature = "openapi")]
-impl utoipa::PartialSchema for OpenApiDefaultTrueBoolean {
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        utoipa::openapi::schema::Object::builder()
-            .schema_type(utoipa::openapi::schema::Type::Boolean)
-            .default(Some(serde_json::json!(true)))
-            .into()
+    pub(super) async fn get_file_bytes(
+        &self,
+        path: &str,
+        revision_no: Option<RevisionNo>,
+    ) -> loonfs::Result<loonfs::FileBytes> {
+        match self {
+            Self::Snapshot(snapshot) => snapshot.get_file_bytes(path).await,
+            Self::Live {
+                reader,
+                namespace_id,
+            } => match revision_no {
+                Some(revision_no) => {
+                    reader
+                        .get_file_revision_bytes(namespace_id, path, revision_no)
+                        .await
+                }
+                None => reader.get_file_bytes(namespace_id, path).await,
+            },
+        }
+    }
+
+    pub(super) async fn create_download(
+        &self,
+        path: &str,
+        revision_no: Option<RevisionNo>,
+    ) -> loonfs::Result<loonfs::downloads::DirectDownloadTarget> {
+        match self {
+            Self::Snapshot(snapshot) => snapshot.create_download(path).await,
+            Self::Live {
+                reader,
+                namespace_id,
+            } => {
+                reader
+                    .create_download(namespace_id, path, revision_no)
+                    .await
+            }
+        }
     }
 }
-
-#[cfg(feature = "openapi")]
-impl utoipa::ToSchema for OpenApiDefaultTrueBoolean {}
-
-/// Schema-only override for an optional boolean that defaults to false.
-#[cfg(feature = "openapi")]
-pub(super) struct OpenApiDefaultFalseBoolean;
-
-#[cfg(feature = "openapi")]
-impl utoipa::PartialSchema for OpenApiDefaultFalseBoolean {
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        utoipa::openapi::schema::Object::builder()
-            .schema_type(utoipa::openapi::schema::Type::Boolean)
-            .default(Some(serde_json::json!(false)))
-            .into()
-    }
-}
-
-#[cfg(feature = "openapi")]
-impl utoipa::ToSchema for OpenApiDefaultFalseBoolean {}
 
 #[cfg_attr(
     feature = "openapi",
@@ -212,13 +209,9 @@ impl utoipa::ToSchema for OpenApiDefaultFalseBoolean {}
 )]
 pub(super) async fn list_path_entries(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<ListPathPageQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<ListPathPageQuery>,
 ) -> Result<Json<loonfs_api::ListPathEntriesResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let path = required_query_param(query.path, "path")?;
     // An absent parameter leaves the option type's own default in place, so
     // the HTTP surface and the in-process one cannot answer differently.
@@ -231,24 +224,14 @@ pub(super) async fn list_path_entries(
         cursor: decode_optional_cursor(query.cursor)?,
     };
     let snapshot_id = parse_optional_snapshot_id(query.snapshot_id)?;
-    let snapshot = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
-    let listing = match snapshot {
-        Some(snapshot) => {
-            snapshot
-                .list_path_entries_page(&path, request, options)
-                .await
-        }
-        None => {
-            state
-                .reader
-                .list_path_entries_page(&namespace_id, &path, request, options)
-                .await
-        }
-    }
-    .map_err(|error| {
-        ApiResponseError::runtime_for_namespace(&namespace_id, error)
-            .with_invalid_request_param("path")
-    })?;
+    let target = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
+    let listing = target
+        .list_path_entries_page(&path, request, options)
+        .await
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("path")
+        })?;
     Ok(Json(listing))
 }
 
@@ -279,33 +262,23 @@ pub(super) async fn list_path_entries(
 )]
 pub(super) async fn get_path_entry(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<PathQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<PathQuery>,
 ) -> Result<Json<loonfs_api::PathEntry>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let path = required_query_param(query.path, "path")?;
     let mut options = StatPathOptions::default();
     if let Some(value) = query.include_attributes.as_deref() {
         options.include_attributes = parse_include_attributes(value)?;
     }
     let snapshot_id = parse_optional_snapshot_id(query.snapshot_id)?;
-    let snapshot = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
-    let entry = match snapshot {
-        Some(snapshot) => snapshot.get_path_entry(&path, options).await,
-        None => {
-            state
-                .reader
-                .get_path_entry(&namespace_id, &path, options)
-                .await
-        }
-    }
-    .map_err(|error| {
-        ApiResponseError::runtime_for_namespace(&namespace_id, error)
-            .with_invalid_request_param("path")
-    })?;
+    let target = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
+    let entry = target
+        .get_path_entry(&path, options)
+        .await
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("path")
+        })?;
     Ok(Json(entry))
 }
 
@@ -337,13 +310,9 @@ pub(super) async fn get_path_entry(
 )]
 pub(super) async fn get_file_bytes(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<ContentQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<ContentQuery>,
 ) -> Result<Response, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let path = required_query_param(query.path, "path")?;
     let revision_no = query
         .revision_no
@@ -352,24 +321,15 @@ pub(super) async fn get_file_bytes(
         .transpose()?;
     let snapshot_id = parse_optional_snapshot_id(query.snapshot_id)?;
     reject_snapshot_with_revision(snapshot_id.as_ref(), revision_no)?;
-    let snapshot = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
+    let target = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
     let permit = acquire_download_permit(&state)?;
-    let file = match snapshot {
-        Some(snapshot) => snapshot.get_file_bytes(&path).await,
-        None => match revision_no {
-            Some(revision_no) => {
-                state
-                    .reader
-                    .get_file_revision_bytes(&namespace_id, &path, revision_no)
-                    .await
-            }
-            None => state.reader.get_file_bytes(&namespace_id, &path).await,
-        },
-    }
-    .map_err(|error| {
-        ApiResponseError::runtime_for_namespace(&namespace_id, error)
-            .with_invalid_request_param("path")
-    })?;
+    let file = target
+        .get_file_bytes(&path, revision_no)
+        .await
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("path")
+        })?;
     Ok(buffered_download_response(file.bytes, permit))
 }
 
@@ -399,13 +359,9 @@ pub(super) async fn get_file_bytes(
 )]
 pub(super) async fn list_trash(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<PageQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<PageQuery>,
 ) -> Result<Json<ListTrashResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let response = state
         .reader
         .list_trash_page(
@@ -416,7 +372,7 @@ pub(super) async fn list_trash(
             },
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
 }
 
@@ -447,13 +403,9 @@ pub(super) async fn list_trash(
 )]
 pub(super) async fn list_file_revisions(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<PathPageQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<PathPageQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let path = required_query_param(query.path, "path")?;
     let response = state
         .reader
@@ -498,12 +450,10 @@ pub(super) async fn list_file_revisions(
 /// The server stores the actor from the request; the shared token does not verify it.
 pub(super) async fn create_commit(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
     AppJson(request): AppJson<ApiCommitRequest>,
 ) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let ApiCommitRequest {
         commit_id,
         actor,
@@ -612,19 +562,15 @@ pub(super) async fn create_commit(
 )]
 pub(super) async fn list_changes(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<ChangesQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<ChangesQuery>,
 ) -> Result<Json<ListChangesResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let after_seq = parse_after_seq(&required_query_param(query.after_seq, "after_seq")?)?;
     let limit = resolve_page_limit(query.limit)?;
     let snapshot_id = parse_optional_snapshot_id(query.snapshot_id)?;
-    let snapshot = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
-    let response = match snapshot {
-        Some(snapshot) => {
+    let target = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
+    let response = match target {
+        ReadTarget::Snapshot(snapshot) => {
             let captured_seq = snapshot.head_seq();
             if after_seq > captured_seq {
                 return Err(ApiResponseError::new(
@@ -650,9 +596,7 @@ pub(super) async fn list_changes(
                         ListChangesOptions { limit: Some(limit) },
                     )
                     .await
-                    .map_err(|error| {
-                        ApiResponseError::runtime_for_namespace(&namespace_id, error)
-                    })?;
+                    .map_err(ApiResponseError::for_namespace(&namespace_id))?;
                 page.changes
                     .retain(|change| change.committed_seq <= captured_seq);
                 page.through_seq = captured_seq;
@@ -664,15 +608,17 @@ pub(super) async fn list_changes(
                 page
             }
         }
-        None => state
-            .reader
+        ReadTarget::Live {
+            reader,
+            namespace_id,
+        } => reader
             .list_changes(
                 &namespace_id,
                 after_seq,
                 ListChangesOptions { limit: Some(limit) },
             )
             .await
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?,
+            .map_err(ApiResponseError::for_namespace(&namespace_id))?,
     };
     Ok(Json(response))
 }
@@ -681,15 +627,18 @@ pub(super) async fn pin_requested_snapshot(
     state: &AppState,
     namespace_id: &loonfs_api::NamespaceId,
     snapshot_id: Option<CheckpointId>,
-) -> Result<Option<FsReadSnapshot>, ApiResponseError> {
+) -> Result<ReadTarget, ApiResponseError> {
     let Some(snapshot_id) = snapshot_id else {
-        return Ok(None);
+        return Ok(ReadTarget::Live {
+            reader: state.reader.clone(),
+            namespace_id: namespace_id.clone(),
+        });
     };
     state
         .reader
         .pin_namespace_at_snapshot(namespace_id, &snapshot_id)
         .await
-        .map(Some)
+        .map(|snapshot| ReadTarget::Snapshot(Box::new(snapshot)))
         .map_err(|error| {
             ApiResponseError::runtime_for_namespace(namespace_id, error)
                 .with_invalid_request_param("snapshot_id")
@@ -713,117 +662,14 @@ pub(super) fn reject_snapshot_with_revision(
 pub(super) fn parse_optional_snapshot_id(
     snapshot_id: Option<String>,
 ) -> Result<Option<CheckpointId>, ApiResponseError> {
-    snapshot_id.as_deref().map(parse_snapshot_id).transpose()
-}
-
-pub(super) fn parse_snapshot_id(value: &str) -> Result<CheckpointId, ApiResponseError> {
-    CheckpointId::parse(value)
-        .map_err(|error| invalid_path_id_error("snapshot_id", value, error.reason()))
+    snapshot_id
+        .as_deref()
+        .map(|value| parse_path_id("snapshot_id", value))
+        .transpose()
 }
 
 fn parse_after_seq(value: &str) -> Result<loonfs_api::ChangeSeq, ApiResponseError> {
     parse_public_ordinal("after_seq", value, loonfs_api::ChangeSeq::parse)
-}
-
-pub(super) fn required_query_param(
-    value: Option<String>,
-    name: &str,
-) -> Result<String, ApiResponseError> {
-    value.ok_or_else(|| {
-        ApiResponseError::new(
-            ErrorCode::InvalidRequest,
-            &format!("missing required query parameter `{name}`"),
-        )
-        .with_param(name)
-    })
-}
-
-pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {
-    parse_boolean_query_param(value, "include_attributes")
-}
-
-pub(super) fn parse_boolean_query_param(value: &str, name: &str) -> Result<bool, ApiResponseError> {
-    match value {
-        "true" => Ok(true),
-        "false" => Ok(false),
-        other => Err(ApiResponseError::new(
-            ErrorCode::InvalidRequest,
-            &format!("invalid {name} `{other}`: expected `true` or `false`"),
-        )
-        .with_param(name)),
-    }
-}
-
-pub(super) fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
-    parse_public_ordinal("revision_no", value, RevisionNo::parse)
-}
-
-pub(super) fn invalid_path_id_error(name: &str, value: &str, reason: &str) -> ApiResponseError {
-    ApiResponseError::new(
-        ErrorCode::InvalidRequest,
-        &format!("invalid {name} {value:?}: {reason}"),
-    )
-    .with_param(name)
-}
-
-pub(super) fn parse_public_ordinal<T>(
-    name: &str,
-    value: &str,
-    constructor: impl FnOnce(u64) -> Result<T, PublicOrdinalRangeError>,
-) -> Result<T, ApiResponseError> {
-    let parsed = value
-        .parse::<u64>()
-        .map_err(|_| public_ordinal_response_error(name, value, PublicOrdinalRangeError))?;
-    constructor(parsed).map_err(|error| public_ordinal_response_error(name, value, error))
-}
-
-fn public_ordinal_response_error(
-    name: &str,
-    value: &str,
-    error: PublicOrdinalRangeError,
-) -> ApiResponseError {
-    ApiResponseError::new(
-        ErrorCode::InvalidRequest,
-        &format!("invalid {name} `{value}`: {error}"),
-    )
-    .with_param(name)
-}
-
-pub(super) fn resolve_page_limit(
-    limit: Option<String>,
-) -> Result<loonfs_api::EffectiveLimit, ApiResponseError> {
-    let requested = limit.as_deref().map(parse_page_limit).transpose()?;
-    PaginationPolicy::default()
-        .resolve_limit(requested)
-        .map_err(limit_response_error)
-}
-
-fn parse_page_limit(value: &str) -> Result<u32, ApiResponseError> {
-    value.parse::<u32>().map_err(|error| {
-        ApiResponseError::new(
-            ErrorCode::InvalidRequest,
-            &format!("invalid limit `{value}`: {error}"),
-        )
-        .with_param("limit")
-    })
-}
-
-pub(super) fn decode_optional_cursor<C: loonfs_api::PageCursor>(
-    cursor: Option<String>,
-) -> Result<Option<C>, ApiResponseError> {
-    cursor
-        .as_deref()
-        .map(decode_cursor)
-        .transpose()
-        .map_err(page_cursor_response_error)
-}
-
-fn limit_response_error(error: LimitError) -> ApiResponseError {
-    ApiResponseError::new(ErrorCode::InvalidRequest, &error.to_string()).with_param("limit")
-}
-
-fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
-    ApiResponseError::new(ErrorCode::InvalidRequest, &error.to_string()).with_param("cursor")
 }
 
 #[cfg(test)]

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -1,15 +1,14 @@
 //! HTTP reads addressed by inode ID.
 
+use super::download_body::buffered_download_response;
 use super::error::ApiResponseError;
-use super::handlers_filesystem::{
-    buffered_download_response, decode_optional_cursor, invalid_path_id_error,
-    parse_include_attributes, parse_revision_no, resolve_page_limit, PageQuery,
+use super::handlers_filesystem::PageQuery;
+use super::query_params::{
+    decode_optional_cursor, invalid_path_id_error, parse_include_attributes, parse_revision_no,
+    resolve_page_limit,
 };
-use super::{
-    acquire_download_permit, authorize, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery,
-};
+use super::{acquire_download_permit, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery};
 use axum::extract::State;
-use axum::http::HeaderMap;
 use axum::response::Response;
 use axum::Json;
 use loonfs::{ListInodeChildrenOptions, StatPathOptions};
@@ -32,6 +31,7 @@ pub(super) struct InodeRevisionPathParams {
 }
 
 pub(super) fn parse_inode_id(value: &str) -> Result<InodeId, ApiResponseError> {
+    // Public inode ids use numeric encoding rather than generated string ids.
     public_inode_id::decode(value)
         .map_err(|error| invalid_path_id_error("inode_id", value, error.reason()))
 }
@@ -68,15 +68,11 @@ pub(super) struct StatInodeQuery {
 )]
 pub(super) async fn get_inode(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<InodePathParams>,
-    headers: HeaderMap,
-    query: AppQuery<StatInodeQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(path): AppPath<InodePathParams>,
+    AppQuery(query): AppQuery<StatInodeQuery>,
 ) -> Result<Json<loonfs_api::PathEntry>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let inode_id = parse_inode_id(&path.into_params()?.inode_id)?;
-    let query = query.into_params()?;
+    let inode_id = parse_inode_id(&path.inode_id)?;
     let mut options = StatPathOptions::default();
     if let Some(value) = query.include_attributes.as_deref() {
         options.include_attributes = parse_include_attributes(value)?;
@@ -85,7 +81,7 @@ pub(super) async fn get_inode(
         .reader
         .get_inode(&namespace_id, inode_id, options)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(entry))
 }
 
@@ -126,15 +122,11 @@ pub(super) struct ListInodeChildrenQuery {
 )]
 pub(super) async fn list_inode_children(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<InodePathParams>,
-    headers: HeaderMap,
-    query: AppQuery<ListInodeChildrenQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(path): AppPath<InodePathParams>,
+    AppQuery(query): AppQuery<ListInodeChildrenQuery>,
 ) -> Result<Json<loonfs_api::ListInodeChildrenResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let inode_id = parse_inode_id(&path.into_params()?.inode_id)?;
-    let query = query.into_params()?;
+    let inode_id = parse_inode_id(&path.inode_id)?;
     let mut options = ListInodeChildrenOptions::default();
     if let Some(value) = query.include_attributes.as_deref() {
         options.include_attributes = parse_include_attributes(value)?;
@@ -151,7 +143,7 @@ pub(super) async fn list_inode_children(
             options,
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(listing))
 }
 
@@ -183,15 +175,11 @@ pub(super) async fn list_inode_children(
 )]
 pub(super) async fn list_file_revisions_by_inode(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<InodePathParams>,
-    headers: HeaderMap,
-    query: AppQuery<PageQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(path): AppPath<InodePathParams>,
+    AppQuery(query): AppQuery<PageQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let inode_id = parse_inode_id(&path.into_params()?.inode_id)?;
-    let query = query.into_params()?;
+    let inode_id = parse_inode_id(&path.inode_id)?;
     let response = state
         .reader
         .list_file_revisions_by_inode_page(
@@ -203,7 +191,7 @@ pub(super) async fn list_file_revisions_by_inode(
             },
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
 }
 
@@ -235,22 +223,17 @@ pub(super) async fn list_file_revisions_by_inode(
 )]
 pub(super) async fn get_file_revision_bytes_by_inode(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<InodeRevisionPathParams>,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(path): AppPath<InodeRevisionPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Response, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let path = path.into_params()?;
     let inode_id = parse_inode_id(&path.inode_id)?;
     let revision_no = parse_revision_no(&path.revision_no)?;
-    query.into_params()?;
     let permit = acquire_download_permit(&state)?;
     let bytes = state
         .reader
         .get_file_revision_bytes_by_inode(&namespace_id, inode_id, revision_no)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(buffered_download_response(bytes, permit))
 }

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -2,14 +2,9 @@
 //! handlers.
 
 use super::error::ApiResponseError;
-use super::handlers_filesystem::{
-    invalid_path_id_error, parse_public_ordinal, parse_snapshot_id, resolve_page_limit,
-};
-use super::{
-    authorize, AppJson, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery, OptionalAppJson,
-};
+use super::query_params::{parse_path_id, parse_public_ordinal, resolve_page_limit};
+use super::{AppJson, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery, OptionalAppJson};
 use axum::extract::State;
-use axum::http::HeaderMap;
 use axum::Json;
 use loonfs::{
     CheckpointPageCursor, CreateNamespaceOptions, CreateSnapshotOptions, DeleteNamespaceOptions,
@@ -76,11 +71,8 @@ pub(super) struct CheckpointPageQuery {
 )]
 pub(super) async fn get_capabilities(
     State(state): State<AppState>,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<loonfs_api::CapabilityDocument>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    query.into_params()?;
     let mut capabilities = state.reader.get_capabilities();
     // Each direct transport is advertised from the issuer that performs it,
     // so a provider that signs whole-object writes but has no multipart API
@@ -209,10 +201,9 @@ pub(super) async fn get_capabilities(
 )]
 pub(super) async fn create_namespace(
     State(state): State<AppState>,
-    query: AppQuery<NoQuery>,
+    AppQuery(_): AppQuery<NoQuery>,
     AppJson(request): AppJson<CreateNamespaceRequest>,
 ) -> Result<Json<loonfs_api::Namespace>, ApiResponseError> {
-    query.into_params()?;
     let namespace = state
         .writer
         .create_namespace(&request.namespace_id, CreateNamespaceOptions::default())
@@ -243,18 +234,14 @@ pub(super) async fn create_namespace(
 )]
 pub(super) async fn get_namespace(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<loonfs_api::Namespace>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let namespace = state
         .reader
         .get_namespace(&namespace_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(namespace))
 }
 
@@ -280,18 +267,14 @@ pub(super) async fn get_namespace(
 )]
 pub(super) async fn get_namespace_diagnostics(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<loonfs_api::NamespaceDiagnostics>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let diagnostics = state
         .admin
         .get_namespace_diagnostics(&namespace_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(diagnostics))
 }
 
@@ -321,13 +304,9 @@ pub(super) async fn get_namespace_diagnostics(
 )]
 pub(super) async fn delete_namespace(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    query: AppQuery<DeleteNamespaceQuery>,
-    headers: HeaderMap,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<DeleteNamespaceQuery>,
 ) -> Result<Json<loonfs_api::DeleteNamespaceResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let options = DeleteNamespaceOptions {
         expected_head_seq: query
             .expected_head_seq
@@ -339,7 +318,7 @@ pub(super) async fn delete_namespace(
         .writer
         .delete_namespace(&namespace_id, options)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
 }
 
@@ -371,17 +350,15 @@ fn parse_expected_head_seq(value: &str) -> Result<ChangeSeq, ApiResponseError> {
 )]
 pub(super) async fn fork_namespace(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(source_namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
     AppJson(request): AppJson<ForkNamespaceRequest>,
 ) -> Result<Json<loonfs_api::Namespace>, ApiResponseError> {
-    let source_namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let namespace = state
         .writer
         .fork_namespace(&source_namespace_id, &request.new_namespace_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&source_namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&source_namespace_id))?;
     Ok(Json(namespace))
 }
 
@@ -409,12 +386,10 @@ pub(super) async fn fork_namespace(
 )]
 pub(super) async fn create_snapshot(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
     AppJson(request): AppJson<CreateSnapshotRequest>,
 ) -> Result<Json<SnapshotSummary>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let now_ms = super::handlers_uploads::current_unix_ms()?;
     let expires_at_ms = snapshot_expiry_from_ttl(&state, now_ms, request.ttl_ms)?;
     let checkpoint = state
@@ -463,13 +438,9 @@ pub(super) async fn create_snapshot(
 )]
 pub(super) async fn list_snapshots(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<CheckpointPageQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<CheckpointPageQuery>,
 ) -> Result<Json<ListSnapshotsResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let cursor = decode_checkpoint_cursor(query.cursor.as_deref(), &namespace_id)?;
     let response = state
         .admin
@@ -481,7 +452,7 @@ pub(super) async fn list_snapshots(
             },
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
 }
 
@@ -511,15 +482,12 @@ pub(super) async fn list_snapshots(
 )]
 pub(super) async fn extend_snapshot(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<SnapshotPathParams>,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(SnapshotPathParams { snapshot_id }): AppPath<SnapshotPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
     AppJson(request): AppJson<ExtendSnapshotRequest>,
 ) -> Result<Json<SnapshotSummary>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    let SnapshotPathParams { snapshot_id } = path.into_params()?;
-    query.into_params()?;
-    let snapshot_id = parse_snapshot_id(&snapshot_id)?;
+    let snapshot_id = parse_path_id::<CheckpointId>("snapshot_id", &snapshot_id)?;
     let now_ms = super::handlers_uploads::current_unix_ms()?;
     let requested_expires_at_ms = snapshot_expiry_from_ttl(&state, now_ms, request.ttl_ms)?;
     let response = state
@@ -531,7 +499,7 @@ pub(super) async fn extend_snapshot(
             state.config.snapshot_max_lifetime_ms,
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
 }
 
@@ -558,21 +526,16 @@ pub(super) async fn extend_snapshot(
 )]
 pub(super) async fn release_snapshot(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<SnapshotPathParams>,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(SnapshotPathParams { snapshot_id }): AppPath<SnapshotPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<ReleaseSnapshotResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let SnapshotPathParams { snapshot_id } = path.into_params()?;
-    query.into_params()?;
-    let snapshot_id = parse_snapshot_id(&snapshot_id)?;
+    let snapshot_id = parse_path_id::<CheckpointId>("snapshot_id", &snapshot_id)?;
     let response = state
         .admin
         .release_snapshot(&namespace_id, &snapshot_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
 }
 
@@ -634,12 +597,10 @@ fn snapshot_expiry_from_ttl(
 )]
 pub(super) async fn create_checkpoint(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
     AppJson(request): AppJson<CreateCheckpointRequest>,
 ) -> Result<Json<Checkpoint>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let response = state
         .admin
         .create_checkpoint(
@@ -679,13 +640,9 @@ pub(super) async fn create_checkpoint(
 )]
 pub(super) async fn list_checkpoints(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<CheckpointPageQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(query): AppQuery<CheckpointPageQuery>,
 ) -> Result<Json<ListCheckpointsResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let query = query.into_params()?;
     let cursor = decode_checkpoint_cursor(query.cursor.as_deref(), &namespace_id)?;
     let response = state
         .admin
@@ -697,7 +654,7 @@ pub(super) async fn list_checkpoints(
             },
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
 }
 
@@ -725,32 +682,22 @@ pub(super) async fn list_checkpoints(
 )]
 pub(super) async fn release_checkpoint(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<CheckpointPathParams>,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(CheckpointPathParams { checkpoint_id }): AppPath<CheckpointPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<ReleaseCheckpointResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let CheckpointPathParams { checkpoint_id } = path.into_params()?;
-    query.into_params()?;
-    let checkpoint_id = parse_checkpoint_id(&checkpoint_id)?;
+    let checkpoint_id = parse_path_id::<CheckpointId>("checkpoint_id", &checkpoint_id)?;
     let response = state
         .admin
         .release_checkpoint(&namespace_id, &checkpoint_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
 }
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct CheckpointPathParams {
     checkpoint_id: String,
-}
-
-fn parse_checkpoint_id(value: &str) -> Result<CheckpointId, ApiResponseError> {
-    CheckpointId::parse(value)
-        .map_err(|error| invalid_path_id_error("checkpoint_id", value, error.reason()))
 }
 
 fn decode_checkpoint_cursor(
@@ -789,12 +736,10 @@ fn decode_checkpoint_cursor(
 )]
 pub(super) async fn run_maintenance(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
     OptionalAppJson(request): OptionalAppJson<MaintenanceStepRequest>,
 ) -> Result<Json<MaintenanceStepResponse>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let plan =
         loonfs::MaintenancePlan::from_request(request.unwrap_or_default()).map_err(|error| {
             ApiResponseError::runtime_for_namespace(&namespace_id, error)
@@ -804,6 +749,6 @@ pub(super) async fn run_maintenance(
         .admin
         .run_maintenance(&namespace_id, plan)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(result))
 }

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -1,16 +1,12 @@
 //! The `query/v0` plane: derived-index reads.
 
-#[cfg(feature = "openapi")]
-use super::handlers_filesystem::{OpenApiDefaultFalseBoolean, OpenApiPageLimit};
 use super::handlers_uploads::current_unix_ms;
-use super::{
-    authorize,
-    handlers_filesystem::{parse_boolean_query_param, required_query_param, resolve_page_limit},
-    AppQuery, AppState, NamespaceIdPath, NoQuery, OptionalAppJson,
-};
+use super::query_params::{parse_boolean_query_param, required_query_param, resolve_page_limit};
+#[cfg(feature = "openapi")]
+use super::query_params::{OpenApiDefaultFalseBoolean, OpenApiPageLimit};
+use super::{AppQuery, AppState, NamespaceIdPath, NoQuery, OptionalAppJson};
 use crate::http::error::ApiResponseError;
 use axum::extract::State;
-use axum::http::HeaderMap;
 use axum::Json;
 use loonfs_api::v0::{GrepGcRequest, GrepGcResponse, GrepIndex};
 #[cfg(feature = "openapi")]
@@ -68,13 +64,9 @@ pub(super) struct GrepQuery {
 )]
 pub(super) async fn grep(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<GrepQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(mut query): AppQuery<GrepQuery>,
 ) -> Result<Json<GrepResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let mut query = query.into_params()?;
     let limit = resolve_page_limit(query.limit.take())?;
     let request = grep_request(query)?;
     // First touch: on a deployment that maintains this index, a search is
@@ -135,30 +127,22 @@ fn parse_optional_boolean(value: Option<String>, name: &str) -> Result<bool, Api
 }
 
 /// Absent-capability response where this deployment answers no searches.
-pub(super) async fn grep_queries_not_served(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-) -> Result<Json<serde_json::Value>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    Err(ApiResponseError::not_supported(
+pub(super) async fn grep_queries_not_served() -> ApiResponseError {
+    ApiResponseError::not_supported(
         FEATURE_QUERY_GREP,
         "this deployment does not serve grep queries; set `[grep].mode` to `serve_only` \
          or `serve_and_maintain`",
-    ))
+    )
 }
 
 /// Absent-capability response where this deployment maintains no index, so
 /// nothing here may enable, disable, or collect one.
-pub(super) async fn grep_index_not_maintained(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-) -> Result<Json<serde_json::Value>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    Err(ApiResponseError::not_supported(
+pub(super) async fn grep_index_not_maintained() -> ApiResponseError {
+    ApiResponseError::not_supported(
         FEATURE_ADMIN_GREP_INDEX,
         "this deployment does not maintain the grep index; set `[grep].mode` to \
          `maintain_only` or `serve_and_maintain`, or administer the index where it is maintained",
-    ))
+    )
 }
 
 #[cfg_attr(
@@ -185,13 +169,9 @@ pub(super) async fn grep_index_not_maintained(
 )]
 pub(super) async fn enable_grep_index(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<GrepIndex>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let outcome = state
         .grep_worker()
         .enable(&namespace_id)
@@ -235,13 +215,9 @@ pub(super) async fn enable_grep_index(
 )]
 pub(super) async fn get_grep_index(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<GrepIndex>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     Ok(Json(read_grep_index_status(&state, &namespace_id).await?))
 }
 
@@ -280,13 +256,9 @@ async fn read_grep_index_status(
 )]
 pub(super) async fn disable_grep_index(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<GrepIndex>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     // Disabling is one durable compare-and-swap and nothing else. A step
     // already running loses its own publication race to this one and
     // retries; the retry reads a disabled root, concludes there is nothing
@@ -331,14 +303,10 @@ pub(super) async fn disable_grep_index(
 )]
 pub(super) async fn gc_grep_index(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    headers: HeaderMap,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
     OptionalAppJson(request): OptionalAppJson<GrepGcRequest>,
 ) -> Result<Json<GrepGcResponse>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     let request = request.unwrap_or_default();
     let report = state
         .grep_worker()

--- a/crates/loonfs-server/src/http/handlers_store.rs
+++ b/crates/loonfs-server/src/http/handlers_store.rs
@@ -32,10 +32,9 @@ use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome};
 )]
 pub(super) async fn probe_store(
     State(state): State<AppState>,
-    query: AppQuery<NoQuery>,
+    AppQuery(_): AppQuery<NoQuery>,
     OptionalAppJson(request): OptionalAppJson<StoreProbeRequest>,
 ) -> Result<Json<StoreProbeResponse>, ApiResponseError> {
-    query.into_params()?;
     let StoreProbeRequest {} = request.unwrap_or_default();
     // The run id scopes the objects this run writes, so two probes against
     // one store never collide, and a provider's own log names the run.

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -2,13 +2,12 @@
 //! backing them.
 
 use super::error::ApiResponseError;
-use super::handlers_filesystem::invalid_path_id_error;
+use super::query_params::parse_path_id;
 use super::{
-    authorize, AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery, UploadBodyBytes,
-    UploadBodyStream, UploadControlJson, MAX_COMPLETION_BODY_BYTES, MAX_UPLOAD_CONTROL_BODY_BYTES,
+    AppPath, AppQuery, AppState, NamespaceIdPath, NoQuery, UploadBodyBytes, UploadBodyStream,
+    UploadControlJson, MAX_COMPLETION_BODY_BYTES, MAX_UPLOAD_CONTROL_BODY_BYTES,
 };
 use axum::extract::State;
-use axum::http::HeaderMap;
 use axum::Json;
 use loonfs::content_tokens::{
     mint_content_token, CompletedUploadReceipt, ContentToken, ContentTokenError,
@@ -75,7 +74,7 @@ impl<'a> ContentTokenVerifier<'a> {
         writer
             .prepare_content_token(namespace_id, self.secret, token, now_ms)
             .await
-            .map_err(|error| ApiResponseError::runtime_for_namespace(namespace_id, error))
+            .map_err(ApiResponseError::for_namespace(namespace_id))
     }
 
     fn mint_receipt(
@@ -121,15 +120,13 @@ pub(super) struct UploadPathParams {
 )]
 pub(super) async fn create_upload(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppQuery(_): AppQuery<NoQuery>,
     UploadControlJson(request): UploadControlJson<
         BeginUploadRequest,
         MAX_UPLOAD_CONTROL_BODY_BYTES,
     >,
 ) -> Result<Json<BeginUploadResponse>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    query.into_params()?;
     // Decoding the body settled which transport this is and that it carries
     // that transport's fields and no other's, so there is nothing left here
     // to check before dispatching on it.
@@ -145,7 +142,7 @@ pub(super) async fn create_upload(
                 .writer
                 .create_upload(&namespace_id, request)
                 .await
-                .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+                .map_err(ApiResponseError::for_namespace(&namespace_id))?;
             Ok(Json(response))
         }
     }
@@ -188,7 +185,7 @@ async fn begin_direct_put_upload(
         .writer
         .create_direct_put_upload_target(&namespace_id, checksum_algorithm)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     let signed = issuer
         .presign_put(
             PresignedPutRequest {
@@ -280,18 +277,15 @@ async fn begin_direct_multipart_upload(
 )]
 pub(super) async fn sign_upload_parts(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<UploadPathParams>,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(UploadPathParams { upload_id }): AppPath<UploadPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
     UploadControlJson(request): UploadControlJson<
         SignUploadPartsRequest,
         MAX_UPLOAD_CONTROL_BODY_BYTES,
     >,
 ) -> Result<Json<SignUploadPartsResponse>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    let UploadPathParams { upload_id } = path.into_params()?;
-    query.into_params()?;
-    let upload_id = parse_upload_id(&upload_id)?;
+    let upload_id = parse_path_id::<UploadId>("upload_id", &upload_id)?;
     let Some(issuer) = state
         .direct_transfers
         .as_ref()
@@ -307,7 +301,7 @@ pub(super) async fn sign_upload_parts(
         .writer
         .sign_upload_parts(&namespace_id, &upload_id, &request.parts)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     let parts = sign_parts(issuer.as_ref(), &targets).await?;
 
     Ok(Json(SignUploadPartsResponse {
@@ -526,15 +520,12 @@ pub(super) fn current_unix_ms() -> Result<u64, ApiResponseError> {
 /// storage error.
 pub(super) async fn put_upload_content(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<UploadPathParams>,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(UploadPathParams { upload_id }): AppPath<UploadPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
     body: UploadBodyStream,
 ) -> Result<Json<UploadContentResponse>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    let UploadPathParams { upload_id } = path.into_params()?;
-    query.into_params()?;
-    let upload_id = parse_upload_id(&upload_id)?;
+    let upload_id = parse_path_id::<UploadId>("upload_id", &upload_id)?;
     let (stream, outcome) = body.into_stream();
     match state
         .writer
@@ -579,15 +570,12 @@ pub(super) async fn put_upload_content(
 )]
 pub(super) async fn complete_upload(
     State(state): State<AppState>,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<UploadPathParams>,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(UploadPathParams { upload_id }): AppPath<UploadPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
     body: UploadBodyBytes<MAX_COMPLETION_BODY_BYTES>,
 ) -> Result<Json<UploadSession>, ApiResponseError> {
-    let namespace_id = namespace_id_path.into_id()?;
-    let UploadPathParams { upload_id } = path.into_params()?;
-    query.into_params()?;
-    let upload_id = parse_upload_id(&upload_id)?;
+    let upload_id = parse_path_id::<UploadId>("upload_id", &upload_id)?;
     let body = body.into_bytes();
     let completed = state
         .writer
@@ -595,7 +583,7 @@ pub(super) async fn complete_upload(
             decode_completion_body(mode, &body)
         })
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(with_content_token(
         completed.response,
         ContentTokenVerifier::new(state.config.content_token_secret()),
@@ -785,23 +773,16 @@ mod completion_body_tests {
 )]
 pub(super) async fn get_upload(
     State(state): State<AppState>,
-    headers: HeaderMap,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<UploadPathParams>,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(UploadPathParams { upload_id }): AppPath<UploadPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<UploadSession>, ApiResponseError> {
-    // Completed sessions return a fresh token when they are still allowed to
-    // mint one. Authorization runs before the upload id is parsed.
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let UploadPathParams { upload_id } = path.into_params()?;
-    query.into_params()?;
-    let upload_id = parse_upload_id(&upload_id)?;
+    let upload_id = parse_path_id::<UploadId>("upload_id", &upload_id)?;
     let (response, receipt) = state
         .writer
         .get_upload(&namespace_id, &upload_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(with_content_token(
         response,
         ContentTokenVerifier::new(state.config.content_token_secret()),
@@ -835,25 +816,15 @@ pub(super) async fn get_upload(
 )]
 pub(super) async fn abort_upload(
     State(state): State<AppState>,
-    headers: HeaderMap,
-    namespace_id_path: NamespaceIdPath,
-    path: AppPath<UploadPathParams>,
-    query: AppQuery<NoQuery>,
+    NamespaceIdPath(namespace_id): NamespaceIdPath,
+    AppPath(UploadPathParams { upload_id }): AppPath<UploadPathParams>,
+    AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<UploadSession>, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace_id_path.into_id()?;
-    let UploadPathParams { upload_id } = path.into_params()?;
-    query.into_params()?;
-    let upload_id = parse_upload_id(&upload_id)?;
+    let upload_id = parse_path_id::<UploadId>("upload_id", &upload_id)?;
     let response = state
         .writer
         .abort_upload(&namespace_id, &upload_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(ApiResponseError::for_namespace(&namespace_id))?;
     Ok(Json(response))
-}
-
-fn parse_upload_id(value: &str) -> Result<UploadId, ApiResponseError> {
-    UploadId::parse(value)
-        .map_err(|error| invalid_path_id_error("upload_id", value, error.reason()))
 }

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -4,6 +4,7 @@
 //! [`extractors`], and handle construction and listener ownership live in
 //! [`serve`].
 
+mod download_body;
 mod error;
 mod extractors;
 mod handlers_downloads;
@@ -16,6 +17,7 @@ mod handlers_uploads;
 mod metrics;
 #[cfg(feature = "openapi")]
 mod openapi;
+mod query_params;
 mod serve;
 #[cfg(test)]
 mod tests;
@@ -23,10 +25,8 @@ mod tls;
 
 #[cfg(feature = "openapi")]
 pub use self::openapi::openapi_document;
-#[cfg(feature = "test-support")]
-pub use self::serve::app_with_test_transfers;
 pub use self::serve::{
-    app, app_with_store, check_config, probe_store, serve, serve_with_shutdown, ServeError,
+    app, check_config, probe_store, serve, serve_with_shutdown, AppOptions, AppState, ServeError,
 };
 pub use self::tls::TlsConfigError;
 
@@ -57,18 +57,14 @@ use self::handlers_store::probe_store as probe_store_handler;
 use self::handlers_uploads::{
     abort_upload, complete_upload, create_upload, get_upload, put_upload_content, sign_upload_parts,
 };
-use self::serve::AppState;
 #[cfg(test)]
-use self::serve::{
-    app_with_store_and_direct_transfers, app_with_store_and_state,
-    build_handles_with_metrics_jsonl_path, serve_on,
-};
+use self::serve::{build_handles, serve_on};
 use axum::extract::{MatchedPath, Request, State};
 use axum::http::header::CONTENT_TYPE;
-use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post, put};
+use axum::routing::{get, post, put, MethodRouter};
 use axum::Router;
 use loonfs::ErrorCode;
 #[cfg(test)]
@@ -235,6 +231,27 @@ fn request_clock() -> std::time::Instant {
     std::time::Instant::now()
 }
 
+async fn require_bearer_token(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, ApiResponseError> {
+    authorize(state.config.auth_policy(), request.headers())?;
+    Ok(next.run(request).await)
+}
+
+fn gated(
+    enabled: bool,
+    served: MethodRouter<AppState>,
+    denied: MethodRouter<AppState>,
+) -> MethodRouter<AppState> {
+    if enabled {
+        served
+    } else {
+        denied
+    }
+}
+
 fn router(state: AppState) -> Router {
     // Searching an index and keeping one built are separate jobs, so they
     // are separately deployable: the query route exists where this server
@@ -242,38 +259,11 @@ fn router(state: AppState) -> Router {
     // it maintains one.
     let serves_grep = state.config.grep.mode.serves_grep();
     let maintains_index = state.config.grep.mode.maintains_index();
-    let grep_route = if serves_grep {
-        get(grep)
-    } else {
-        get(grep_queries_not_served)
-    };
-    let enable_grep_route = if maintains_index {
-        post(enable_grep_index)
-    } else {
-        post(grep_index_not_maintained)
-    };
-    let disable_grep_route = if maintains_index {
-        post(disable_grep_index)
-    } else {
-        post(grep_index_not_maintained)
-    };
-    let grep_gc_route = if maintains_index {
-        post(gc_grep_index)
-    } else {
-        post(grep_index_not_maintained)
-    };
-    // Reading the index's lifecycle is administering it, not serving it: a
-    // deployment that only answers searches has no authority over the state
-    // this reports, so it gates with the mutating three.
-    let grep_status_route = if maintains_index {
-        get(get_grep_index)
-    } else {
-        get(grep_index_not_maintained)
-    };
     let request_deadline_ms = state.config.request_deadline_ms;
-    Router::new()
+    let public = Router::new()
         .route("/health", get(get_health))
-        .route("/readiness", get(get_readiness))
+        .route("/readiness", get(get_readiness));
+    let authenticated = Router::new()
         .route("/metrics", get(get_metrics))
         .route(
             "/v0/capabilities",
@@ -322,22 +312,41 @@ fn router(state: AppState) -> Router {
             "/v0/namespaces/{namespace_id}/filesystem/downloads",
             post(create_download),
         )
-        .route("/v0/namespaces/{namespace_id}/grep", grep_route)
+        .route(
+            "/v0/namespaces/{namespace_id}/grep",
+            gated(serves_grep, get(grep), get(grep_queries_not_served)),
+        )
         .route(
             "/v0/admin/namespaces/{namespace_id}/grep/index",
-            grep_status_route,
+            gated(
+                maintains_index,
+                get(get_grep_index),
+                get(grep_index_not_maintained),
+            ),
         )
         .route(
             "/v0/admin/namespaces/{namespace_id}/grep/index/enable",
-            enable_grep_route,
+            gated(
+                maintains_index,
+                post(enable_grep_index),
+                post(grep_index_not_maintained),
+            ),
         )
         .route(
             "/v0/admin/namespaces/{namespace_id}/grep/index/disable",
-            disable_grep_route,
+            gated(
+                maintains_index,
+                post(disable_grep_index),
+                post(grep_index_not_maintained),
+            ),
         )
         .route(
             "/v0/admin/namespaces/{namespace_id}/grep/index/gc",
-            grep_gc_route,
+            gated(
+                maintains_index,
+                post(gc_grep_index),
+                post(grep_index_not_maintained),
+            ),
         )
         .route(
             "/v0/namespaces/{namespace_id}/filesystem/revisions",
@@ -415,6 +424,13 @@ fn router(state: AppState) -> Router {
         .route_layer(middleware::from_fn(move |request: Request, next: Next| {
             with_request_deadline(request_deadline_ms, request, next)
         }))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_bearer_token,
+        ));
+    Router::new()
+        .merge(public)
+        .merge(authenticated)
         // Unmatched paths and wrong methods answer inside the error
         // contract instead of axum's empty default bodies.
         .fallback(route_not_found)
@@ -430,8 +446,7 @@ fn router(state: AppState) -> Router {
 }
 
 /// 404 for paths outside the served surface. Deliberately unauthenticated:
-/// the route set is public in the API spec, and `authorize` runs per
-/// matched handler.
+/// the route set is public in the API spec.
 async fn route_not_found() -> ApiResponseError {
     ApiResponseError::new(
         ErrorCode::RouteNotFound,
@@ -529,11 +544,7 @@ const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
         )
     )
 )]
-async fn get_metrics(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-) -> Result<Response, ApiResponseError> {
-    authorize(state.config.auth_policy(), &headers)?;
+async fn get_metrics(State(state): State<AppState>) -> Result<Response, ApiResponseError> {
     // Sample server state here because these values can change between
     // scrapes. Cache activity is already included in the recorder snapshot.
     let rendered = state.metrics.render(

--- a/crates/loonfs-server/src/http/query_params.rs
+++ b/crates/loonfs-server/src/http/query_params.rs
@@ -1,0 +1,175 @@
+//! Shared query-parameter and path-id parsing for HTTP handlers.
+
+use super::error::ApiResponseError;
+use loonfs::ErrorCode;
+use loonfs_api::{
+    decode_cursor, GeneratedIdValidationError, LimitError, PageCursorError, PaginationPolicy,
+    PublicOrdinalRangeError, RevisionNo,
+};
+use std::str::FromStr;
+
+pub(super) fn required_query_param(
+    value: Option<String>,
+    name: &str,
+) -> Result<String, ApiResponseError> {
+    value.ok_or_else(|| {
+        ApiResponseError::new(
+            ErrorCode::InvalidRequest,
+            &format!("missing required query parameter `{name}`"),
+        )
+        .with_param(name)
+    })
+}
+
+pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {
+    parse_boolean_query_param(value, "include_attributes")
+}
+
+pub(super) fn parse_boolean_query_param(value: &str, name: &str) -> Result<bool, ApiResponseError> {
+    match value {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        other => Err(ApiResponseError::new(
+            ErrorCode::InvalidRequest,
+            &format!("invalid {name} `{other}`: expected `true` or `false`"),
+        )
+        .with_param(name)),
+    }
+}
+
+pub(super) fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
+    parse_public_ordinal("revision_no", value, RevisionNo::parse)
+}
+
+pub(super) fn parse_public_ordinal<T>(
+    name: &str,
+    value: &str,
+    constructor: impl FnOnce(u64) -> Result<T, PublicOrdinalRangeError>,
+) -> Result<T, ApiResponseError> {
+    let parsed = value
+        .parse::<u64>()
+        .map_err(|_| public_ordinal_response_error(name, value, PublicOrdinalRangeError))?;
+    constructor(parsed).map_err(|error| public_ordinal_response_error(name, value, error))
+}
+
+fn public_ordinal_response_error(
+    name: &str,
+    value: &str,
+    error: PublicOrdinalRangeError,
+) -> ApiResponseError {
+    ApiResponseError::new(
+        ErrorCode::InvalidRequest,
+        &format!("invalid {name} `{value}`: {error}"),
+    )
+    .with_param(name)
+}
+
+pub(super) fn invalid_path_id_error(name: &str, value: &str, reason: &str) -> ApiResponseError {
+    ApiResponseError::new(
+        ErrorCode::InvalidRequest,
+        &format!("invalid {name} {value:?}: {reason}"),
+    )
+    .with_param(name)
+}
+
+pub(super) fn parse_path_id<T>(name: &'static str, value: &str) -> Result<T, ApiResponseError>
+where
+    T: FromStr<Err = GeneratedIdValidationError>,
+{
+    value.parse().map_err(|error: GeneratedIdValidationError| {
+        invalid_path_id_error(name, value, error.reason())
+    })
+}
+
+pub(super) fn resolve_page_limit(
+    limit: Option<String>,
+) -> Result<loonfs_api::EffectiveLimit, ApiResponseError> {
+    let requested = limit.as_deref().map(parse_page_limit).transpose()?;
+    PaginationPolicy::default()
+        .resolve_limit(requested)
+        .map_err(limit_response_error)
+}
+
+fn parse_page_limit(value: &str) -> Result<u32, ApiResponseError> {
+    value.parse::<u32>().map_err(|error| {
+        ApiResponseError::new(
+            ErrorCode::InvalidRequest,
+            &format!("invalid limit `{value}`: {error}"),
+        )
+        .with_param("limit")
+    })
+}
+
+pub(super) fn decode_optional_cursor<C: loonfs_api::PageCursor>(
+    cursor: Option<String>,
+) -> Result<Option<C>, ApiResponseError> {
+    cursor
+        .as_deref()
+        .map(decode_cursor)
+        .transpose()
+        .map_err(page_cursor_response_error)
+}
+
+fn limit_response_error(error: LimitError) -> ApiResponseError {
+    ApiResponseError::new(ErrorCode::InvalidRequest, &error.to_string()).with_param("limit")
+}
+
+fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
+    ApiResponseError::new(ErrorCode::InvalidRequest, &error.to_string()).with_param("cursor")
+}
+
+/// Schema-only override for the shared page-limit query contract.
+#[cfg(feature = "openapi")]
+pub(super) struct OpenApiPageLimit;
+
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for OpenApiPageLimit {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::Object::builder()
+            .schema_type(utoipa::openapi::schema::Type::Integer)
+            .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+                utoipa::openapi::KnownFormat::Int32,
+            )))
+            .minimum(Some(1u32))
+            .maximum(Some(loonfs_api::DEFAULT_MAX_PAGE_LIMIT))
+            .default(Some(serde_json::json!(loonfs_api::DEFAULT_PAGE_LIMIT)))
+            .into()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for OpenApiPageLimit {}
+
+/// Schema-only override for an optional boolean that defaults to true.
+#[cfg(feature = "openapi")]
+pub(super) struct OpenApiDefaultTrueBoolean;
+
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for OpenApiDefaultTrueBoolean {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::Object::builder()
+            .schema_type(utoipa::openapi::schema::Type::Boolean)
+            .default(Some(serde_json::json!(true)))
+            .into()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for OpenApiDefaultTrueBoolean {}
+
+/// Schema-only override for an optional boolean that defaults to false.
+#[cfg(feature = "openapi")]
+pub(super) struct OpenApiDefaultFalseBoolean;
+
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for OpenApiDefaultFalseBoolean {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::Object::builder()
+            .schema_type(utoipa::openapi::schema::Type::Boolean)
+            .default(Some(serde_json::json!(false)))
+            .into()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for OpenApiDefaultFalseBoolean {}

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -25,8 +25,9 @@ use loonfs_grep::{
 use loonfs_objectstore::presign::DirectTransferIssuers;
 use loonfs_objectstore::{run_store_contract_probe, StoreProbeReport};
 use std::ffi::OsString;
-use std::future::IntoFuture;
+use std::future::{Future, IntoFuture};
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -128,9 +129,10 @@ impl http_body::Body for DrainedBody {
 /// `reader` is stored separately because most handlers require only read
 /// access.
 #[derive(Clone)]
-pub(super) struct AppState {
+pub struct AppState {
     pub(super) config: Arc<ServerConfig>,
-    pub(super) writer: FsWriter,
+    /// Writer handle that owns publication and maintenance work.
+    pub writer: FsWriter,
     pub(super) reader: FsReader,
     pub(super) admin: FsAdmin,
     /// The store itself, for the one endpoint whose subject is the store
@@ -169,7 +171,7 @@ pub(super) struct AppState {
     /// Runtime handles use it through the shared cache interface. The server
     /// retains the concrete type to read foyer statistics and close it during
     /// shutdown.
-    pub(super) local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
+    pub local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
 }
 
 impl AppState {
@@ -217,69 +219,42 @@ impl GrepMaintenance {
     }
 }
 
-/// Builds the router and returns the resources the host must shut down.
+/// Optional inputs for building the HTTP application.
+#[derive(Default)]
+pub struct AppOptions {
+    /// Existing object store to use instead of building one from the config.
+    pub store: Option<SharedObjectStore>,
+    /// Direct-transfer issuers to use instead of the store's issuers.
+    pub direct_transfers: Option<DirectTransferIssuers>,
+}
+
+/// Builds the router and returns its state.
 ///
 /// After an embedded listener drains, the host must call
-/// [`FsWriter::shutdown`] to settle publication and maintenance tasks, then
-/// close the returned cache so in-memory entries are flushed. [`serve`]
-/// performs both steps automatically. The cache is present only when
-/// `[local_cache]` is configured.
+/// [`FsWriter::shutdown`] on [`AppState::writer`] to settle publication and
+/// maintenance tasks, then close [`AppState::local_cache`] so in-memory
+/// entries are flushed. [`serve`] performs both steps automatically. The
+/// cache is present only when `[local_cache]` is configured.
 pub async fn app(
     config: ServerConfig,
-) -> Result<(Router, FsWriter, Option<Arc<FoyerStoredMetadataBlockCache>>), ServerConfigError> {
+    options: AppOptions,
+) -> Result<(Router, AppState), ServerConfigError> {
     // The one unavoidable validation point: configs that skipped
     // `load_server_config` (direct Rust construction) fail here exactly as
     // file-loaded ones fail at load.
     config.validate()?;
-    let store = config.object_store()?;
-    // Provider construction already validated direct-transfer signing and endpoint
-    // support. Reuse that decision without reinterpreting configuration here.
-    let direct_transfers = store.direct_transfers();
-    let store = store.into_shared();
-    let (router, state) =
-        app_with_store_and_direct_transfers(config, store, direct_transfers).await?;
-    Ok((router, state.writer, state.local_cache))
-}
-
-/// Builds the router around an existing object store for tests.
-pub async fn app_with_store(
-    config: ServerConfig,
-    store: SharedObjectStore,
-) -> Result<Router, ServerConfigError> {
-    Ok(app_with_store_and_direct_transfers(config, store, None)
-        .await?
-        .0)
-}
-
-/// Builds the server router with custom direct-transfer providers for tests.
-#[cfg(feature = "test-support")]
-pub async fn app_with_test_transfers(
-    config: ServerConfig,
-    store: SharedObjectStore,
-    direct_transfers: DirectTransferIssuers,
-) -> Result<Router, ServerConfigError> {
-    Ok(
-        app_with_store_and_direct_transfers(config, store, Some(direct_transfers))
-            .await?
-            .0,
-    )
-}
-
-/// Test-only: the router plus its state, so tests can hold admission
-/// permits or close publisher admission and observe the served answers.
-#[cfg(test)]
-pub(super) async fn app_with_store_and_state(
-    config: ServerConfig,
-    store: SharedObjectStore,
-) -> Result<(Router, AppState), ServerConfigError> {
-    app_with_store_and_direct_transfers(config, store, None).await
-}
-
-pub(super) async fn app_with_store_and_direct_transfers(
-    config: ServerConfig,
-    store: SharedObjectStore,
-    direct_transfers: Option<DirectTransferIssuers>,
-) -> Result<(Router, AppState), ServerConfigError> {
+    let AppOptions {
+        store,
+        direct_transfers,
+    } = options;
+    let (store, direct_transfers) = match store {
+        Some(store) => (store, direct_transfers),
+        None => {
+            let store = config.object_store()?;
+            let direct_transfers = direct_transfers.or_else(|| store.direct_transfers());
+            (store.into_shared(), direct_transfers)
+        }
+    };
     let metrics = ServerMetrics::new();
     // Two switches decide automatic grep indexing and nothing else does:
     // whether this server maintains anything automatically, and whether its
@@ -400,28 +375,12 @@ async fn open_local_cache(
     }
 }
 
-#[cfg(test)]
-pub(super) async fn build_handles_with_metrics_jsonl_path(
-    config: &ServerConfig,
-    store: SharedObjectStore,
-    metrics_jsonl_path: Option<OsString>,
-) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
-    build_handles(
-        config,
-        store,
-        &ServerMetrics::new(),
-        metrics_jsonl_path,
-        None,
-    )
-    .await
-}
-
 /// Builds the process handles over one store and one metrics recorder.
 ///
 /// An optional JSONL recorder receives the same object-store samples. The
 /// local block cache is installed once on the writer's shared runtime core,
 /// so the reader and admin use the same decoded cache hierarchy.
-async fn build_handles(
+pub(super) async fn build_handles(
     config: &ServerConfig,
     store: SharedObjectStore,
     metrics: &ServerMetrics,
@@ -605,12 +564,12 @@ where
     L: axum::serve::Listener<Addr = SocketAddr>,
 {
     let shutdown_deadline_ms = config.shutdown_deadline_ms;
-    let (router, writer, local_cache) = app(config).await?;
+    let (router, state) = app(config, AppOptions::default()).await?;
     serve_and_settle(
         listener,
         router,
-        writer,
-        local_cache,
+        state.writer,
+        state.local_cache,
         shutdown_deadline_ms,
         shutdown,
     )
@@ -649,11 +608,6 @@ where
             .into_future(),
     );
     let mut shutdown = Box::pin(shutdown);
-    enum DrainOutcome {
-        Server(std::io::Result<()>),
-        Settled,
-        Deadline,
-    }
     let served = tokio::select! {
         result = server.as_mut() => result,
         () = shutdown.as_mut() => {
@@ -663,35 +617,14 @@ where
             let deadline = tokio::time::Instant::now()
                 + Duration::from_millis(shutdown_deadline_ms);
             let mut deadline = Box::pin(tokio::time::sleep_until(deadline));
-            let drain = tokio::select! {
-                result = server.as_mut() => DrainOutcome::Server(result),
-                () = requests.settle() => DrainOutcome::Settled,
-                () = deadline.as_mut() => DrainOutcome::Deadline,
-            };
-            match drain {
-                DrainOutcome::Server(result) => result,
-                DrainOutcome::Settled => {
-                    let _ = listener_close_tx.send(());
-                    tokio::select! {
-                        result = server.as_mut() => result,
-                        () = deadline.as_mut() => {
-                            tracing::warn!(
-                                shutdown_deadline_ms,
-                                "graceful drain deadline passed; remaining requests are abandoned"
-                            );
-                            Ok(())
-                        }
-                    }
-                }
-                DrainOutcome::Deadline => {
-                    tracing::warn!(
-                        shutdown_deadline_ms,
-                        "graceful drain deadline passed; remaining requests are abandoned"
-                    );
-                    let _ = listener_close_tx.send(());
-                    Ok(())
-                }
-            }
+            drain_with_deadline(
+                server.as_mut(),
+                &requests,
+                listener_close_tx,
+                deadline.as_mut(),
+                shutdown_deadline_ms,
+            )
+            .await
         }
     };
     // Dropping the server cancels requests left behind by an expired drain.
@@ -711,6 +644,42 @@ where
         None => Ok(()),
     };
     settled.and(closed)
+}
+
+async fn drain_with_deadline<S>(
+    mut server: Pin<&mut S>,
+    requests: &RequestDrain,
+    listener_close_tx: tokio::sync::oneshot::Sender<()>,
+    mut deadline: Pin<&mut tokio::time::Sleep>,
+    shutdown_deadline_ms: u64,
+) -> std::io::Result<()>
+where
+    S: Future<Output = std::io::Result<()>> + ?Sized,
+{
+    let deadline_passed = tokio::select! {
+        result = server.as_mut() => return result,
+        () = requests.settle() => false,
+        () = deadline.as_mut() => true,
+    };
+    let _ = listener_close_tx.send(());
+    let result = if deadline_passed {
+        None
+    } else {
+        tokio::select! {
+            result = server.as_mut() => Some(result),
+            () = deadline.as_mut() => None,
+        }
+    };
+    match result {
+        Some(result) => result,
+        None => {
+            tracing::warn!(
+                shutdown_deadline_ms,
+                "graceful drain deadline passed; remaining requests are abandoned"
+            );
+            Ok(())
+        }
+    }
 }
 
 /// Resolves on ctrl-c or, on unix, SIGTERM — the stop signal container

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2,9 +2,10 @@
 // HTTP smoke helpers panic in unexpected match arms for precise diagnostics.
 
 use super::error::{status_for_core_error_code, ServedErrorCode};
+use super::metrics::ServerMetrics;
 use super::{
-    app_with_store, app_with_store_and_state, build_handles_with_metrics_jsonl_path,
-    request_log_severity, AppState, RequestLogSeverity, SharedObjectStore,
+    app, build_handles, request_log_severity, AppOptions, AppState, RequestLogSeverity,
+    SharedObjectStore,
 };
 use crate::config::RuntimeCacheConfigOverrides;
 use crate::{ServerConfig, StoreConfig};
@@ -34,6 +35,13 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::path::Path;
+
+fn options_with_store(store: SharedObjectStore) -> AppOptions {
+    AppOptions {
+        store: Some(store),
+        direct_transfers: None,
+    }
+}
 
 const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "aborted_at_ms",
@@ -519,12 +527,13 @@ async fn provider_failure_is_projected_in_the_remote_api_envelope() {
     use tower::ServiceExt;
 
     let temp_dir = tempdir().expect("tempdir");
-    let router = app_with_store(
+    let router = app(
         test_config(temp_dir.path(), "provider-hygiene-writer"),
-        Arc::new(PoisonProviderStore),
+        options_with_store(Arc::new(PoisonProviderStore)),
     )
     .await
-    .expect("build app");
+    .expect("build app")
+    .0;
     let response = router
         .oneshot(
             axum::http::Request::builder()
@@ -674,10 +683,12 @@ async fn build_handles_installs_jsonl_object_store_metrics_recorder() {
     let metrics_path = metrics_dir.path().join("object-store.ndjson");
 
     {
-        let (writer, _reader, _admin) = build_handles_with_metrics_jsonl_path(
+        let (writer, _reader, _admin) = build_handles(
             &config,
             store,
+            &ServerMetrics::new(),
             Some(metrics_path.clone().into_os_string()),
+            None,
         )
         .await
         .expect("build handles");
@@ -697,7 +708,7 @@ async fn app_validates_directly_built_configs() {
     let temp_dir = tempdir().expect("tempdir");
     let mut config = test_config(temp_dir.path(), "app-validate-writer");
     config.max_concurrent_uploads = 0;
-    match super::app(config).await {
+    match app(config, AppOptions::default()).await {
         Err(crate::config::ServerConfigError::InvalidField { field, .. }) => {
             assert_eq!(field, "max_concurrent_uploads");
         }
@@ -712,9 +723,9 @@ async fn admin_namespace_diagnostics_route_answers_storage_fields() {
 
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
-    let (router, state) = app_with_store_and_state(
+    let (router, state) = app(
         test_config(temp_dir.path(), "namespace-diagnostics-route-writer"),
-        store,
+        options_with_store(store),
     )
     .await
     .expect("build app");
@@ -840,12 +851,13 @@ async fn deadline_exemptions_name_served_routes_and_cover_both_content_spellings
 
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
-    let router = app_with_store(
+    let router = app(
         test_config(temp_dir.path(), "deadline-exempt-route-writer"),
-        store,
+        options_with_store(store),
     )
     .await
-    .expect("build app");
+    .expect("build app")
+    .0;
 
     for content_route in [
         "/v0/namespaces/{namespace_id}/filesystem/content",
@@ -887,7 +899,7 @@ async fn a_server_without_the_table_builds_no_local_cache() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let config = test_config(temp_dir.path(), "no-local-cache-writer");
 
-    let (_router, state) = app_with_store_and_state(config, store)
+    let (_router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     assert!(state.local_cache.is_none());
@@ -901,7 +913,7 @@ async fn runtime_and_grep_cache_metrics_render_from_the_recorder() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let config = test_config(temp_dir.path(), "cache-metrics-writer");
 
-    let (_router, state) = app_with_store_and_state(config, store)
+    let (_router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     let rendered = state.metrics.render(None, 0, 0);
@@ -951,7 +963,7 @@ async fn a_configured_local_cache_is_built_and_scraped() {
     let mut config = test_config(temp_dir.path(), "local-cache-writer");
     config.local_cache = Some(test_local_cache_config(cache_dir.path()));
 
-    let (_router, state) = app_with_store_and_state(config, store)
+    let (_router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     let local_cache = state.local_cache.clone().expect("a local cache");
@@ -973,7 +985,7 @@ async fn graceful_shutdown_closes_the_local_cache() {
     config.local_cache = Some(test_local_cache_config(cache_dir.path()));
     let shutdown_deadline_ms = config.shutdown_deadline_ms;
 
-    let (router, state) = app_with_store_and_state(config, store)
+    let (router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     let local_cache = state.local_cache.clone().expect("a local cache");
@@ -1151,7 +1163,7 @@ async fn embedded_shutdown_drains_an_active_grep_step() {
 
     blocking_store.block_next();
     let config = test_config(temp_dir.path(), "grep-shutdown-server");
-    let (_router, state) = super::app_with_store_and_direct_transfers(config, store, None)
+    let (_router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     state
@@ -1223,10 +1235,9 @@ async fn shutdown_closes_maintenance_admission_before_draining_publications() {
         OperationClass::CompareAndSwap,
     ));
     let config = test_config(temp_dir.path(), "shutdown-order-server");
-    let (_router, state) = super::app_with_store_and_direct_transfers(
+    let (_router, state) = app(
         config,
-        blocking.clone() as SharedObjectStore,
-        None,
+        options_with_store(blocking.clone() as SharedObjectStore),
     )
     .await
     .expect("build app");
@@ -1322,7 +1333,7 @@ async fn a_namespace_advance_nudges_the_enabled_namespaces_index() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let config = test_config(temp_dir.path(), "grep-observer-server");
-    let (_router, state) = super::app_with_store_and_direct_transfers(config, store, None)
+    let (_router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     let namespace_id = namespace_id("grep-observer");
@@ -2143,7 +2154,10 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app_with_store(config, store).await.expect("build app");
+    let router = app(config, options_with_store(store))
+        .await
+        .expect("build app")
+        .0;
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });
@@ -2175,6 +2189,105 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
     }
 
     server.abort();
+}
+
+#[tokio::test]
+async fn every_route_except_health_and_readiness_requires_authorization() {
+    use tower::ServiceExt;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let router = app(
+        test_config(temp_dir.path(), "server-writer"),
+        options_with_store(store),
+    )
+    .await
+    .expect("build app")
+    .0;
+    let protected_routes = [
+        ("GET", "/metrics"),
+        ("GET", "/v0/capabilities"),
+        ("POST", "/v0/namespaces"),
+        ("GET", "/v0/namespaces/demo"),
+        ("DELETE", "/v0/namespaces/demo"),
+        ("POST", "/v0/namespaces/demo/forks"),
+        ("GET", "/v0/namespaces/demo/snapshots"),
+        ("POST", "/v0/namespaces/demo/snapshots"),
+        ("POST", "/v0/namespaces/demo/snapshots/chk_test/extend"),
+        ("POST", "/v0/namespaces/demo/snapshots/chk_test/release"),
+        ("GET", "/v0/admin/namespaces/demo/diagnostics"),
+        ("GET", "/v0/namespaces/demo/filesystem/entries"),
+        ("GET", "/v0/namespaces/demo/filesystem/entry"),
+        ("GET", "/v0/namespaces/demo/filesystem/content"),
+        ("POST", "/v0/namespaces/demo/filesystem/downloads"),
+        ("GET", "/v0/namespaces/demo/grep"),
+        ("GET", "/v0/admin/namespaces/demo/grep/index"),
+        ("POST", "/v0/admin/namespaces/demo/grep/index/enable"),
+        ("POST", "/v0/admin/namespaces/demo/grep/index/disable"),
+        ("POST", "/v0/admin/namespaces/demo/grep/index/gc"),
+        ("GET", "/v0/namespaces/demo/filesystem/revisions"),
+        ("GET", "/v0/namespaces/demo/inodes/ino_1"),
+        ("GET", "/v0/namespaces/demo/inodes/ino_1/children"),
+        ("GET", "/v0/namespaces/demo/inodes/ino_1/revisions"),
+        (
+            "GET",
+            "/v0/namespaces/demo/inodes/ino_1/revisions/1/content",
+        ),
+        (
+            "POST",
+            "/v0/namespaces/demo/inodes/ino_1/revisions/1/downloads",
+        ),
+        ("GET", "/v0/namespaces/demo/filesystem/trash"),
+        ("POST", "/v0/namespaces/demo/commits"),
+        ("POST", "/v0/namespaces/demo/uploads"),
+        ("PUT", "/v0/namespaces/demo/uploads/upl_test/content"),
+        ("POST", "/v0/namespaces/demo/uploads/upl_test/parts"),
+        ("POST", "/v0/namespaces/demo/uploads/upl_test/complete"),
+        ("POST", "/v0/namespaces/demo/uploads/upl_test/abort"),
+        ("GET", "/v0/namespaces/demo/uploads/upl_test"),
+        ("GET", "/v0/namespaces/demo/changes"),
+        ("GET", "/v0/admin/namespaces/demo/checkpoints"),
+        ("POST", "/v0/admin/namespaces/demo/checkpoints"),
+        (
+            "POST",
+            "/v0/admin/namespaces/demo/checkpoints/chk_test/release",
+        ),
+        ("POST", "/v0/admin/namespaces/demo/maintenance/run"),
+        ("POST", "/v0/admin/store/probe"),
+    ];
+
+    for (method, uri) in protected_routes {
+        let response = router
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .body(axum::body::Body::empty())
+                    .expect("route request"),
+            )
+            .await
+            .expect("route response");
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri}"
+        );
+    }
+
+    for uri in ["/health", "/readiness"] {
+        let response = router
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(uri)
+                    .body(axum::body::Body::empty())
+                    .expect("public request"),
+            )
+            .await
+            .expect("public response");
+        assert_eq!(response.status(), StatusCode::OK, "GET {uri}");
+    }
 }
 
 /// Sends a request and checks its JSON error response.
@@ -2215,7 +2328,10 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app_with_store(config, store).await.expect("build app");
+    let router = app(config, options_with_store(store))
+        .await
+        .expect("build app")
+        .0;
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });
@@ -2461,7 +2577,10 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app_with_store(config, store).await.expect("build app");
+    let router = app(config, options_with_store(store))
+        .await
+        .expect("build app")
+        .0;
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });
@@ -2631,7 +2750,10 @@ async fn http_unknown_routes_and_methods_answer_in_envelope() {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app_with_store(config, store).await.expect("build app");
+    let router = app(config, options_with_store(store))
+        .await
+        .expect("build app")
+        .0;
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });
@@ -2693,7 +2815,10 @@ async fn http_revisions_cursor_resumes_after_head_drift_and_rejects_the_future()
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app_with_store(config, store).await.expect("build app");
+    let router = app(config, options_with_store(store))
+        .await
+        .expect("build app")
+        .0;
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });
@@ -2790,7 +2915,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let (router, state) = app_with_store_and_state(config, store)
+    let (router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     let server = tokio::spawn(async move {
@@ -2870,7 +2995,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let (router, state) = app_with_store_and_state(config, store)
+    let (router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     let server = tokio::spawn(async move {
@@ -2984,7 +3109,7 @@ async fn download_admission_is_held_until_the_response_body_is_consumed() {
     .await;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.max_concurrent_downloads = 1;
-    let (router, state) = app_with_store_and_state(config, store)
+    let (router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
 
@@ -3064,7 +3189,10 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app_with_store(config, store).await.expect("build app");
+    let router = app(config, options_with_store(store))
+        .await
+        .expect("build app")
+        .0;
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });
@@ -3152,7 +3280,7 @@ async fn shutdown_keeps_readiness_reachable_until_an_active_request_finishes() {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let (router, state) = app_with_store_and_state(config, store)
+    let (router, state) = app(config, options_with_store(store))
         .await
         .expect("build app");
     let slow_started = Arc::new(tokio::sync::Notify::new());
@@ -3406,7 +3534,10 @@ async fn start_server_with_config(store: SharedObjectStore, config: ServerConfig
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app_with_store(config, store).await.expect("build app");
+    let router = app(config, options_with_store(store))
+        .await
+        .expect("build app")
+        .0;
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });
@@ -3564,7 +3695,6 @@ fn assert_api_error<T: std::fmt::Debug>(
 /// verification) runs end to end without a real bucket.
 mod direct_download {
     use super::*;
-    use crate::http::app_with_store_and_direct_transfers;
     use loonfs_api::{
         v0::{CompleteMultipartUploadRequest, UploadContentClaim},
         Checksum, ChecksumAlgorithm, RevisionNo, FEATURE_DOWNLOADS_DIRECT_GET,
@@ -3779,9 +3909,15 @@ mod direct_download {
         if let Some(max_upload_bytes) = max_upload_bytes {
             config.max_upload_bytes = max_upload_bytes;
         }
-        let (router, _state) = app_with_store_and_direct_transfers(config, store, direct_transfers)
-            .await
-            .expect("build app");
+        let (router, _state) = app(
+            config,
+            AppOptions {
+                store: Some(store),
+                direct_transfers,
+            },
+        )
+        .await
+        .expect("build app");
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind listener");

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -15,12 +15,10 @@ pub use config::{
     MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig,
     TlsServerConfig,
 };
-#[cfg(feature = "test-support")]
-pub use http::app_with_test_transfers;
 #[cfg(feature = "openapi")]
 pub use http::openapi_document;
 pub use http::{
-    app, app_with_store, check_config, probe_store, serve, serve_with_shutdown, ServeError,
+    app, check_config, probe_store, serve, serve_with_shutdown, AppOptions, AppState, ServeError,
     TlsConfigError,
 };
 pub use local_cache::FoyerStoredMetadataBlockCache;

--- a/crates/loonfs-server/src/local_cache.rs
+++ b/crates/loonfs-server/src/local_cache.rs
@@ -529,11 +529,10 @@ fn kind_label(kind: StoredMetadataBlockKind) -> &'static str {
 
 /// Where one block kind's counter sits in a [`PerKind`] array.
 fn kind_index(kind: StoredMetadataBlockKind) -> usize {
-    match kind {
-        StoredMetadataBlockKind::Data => 0,
-        StoredMetadataBlockKind::Index => 1,
-        StoredMetadataBlockKind::Filter => 2,
-    }
+    BLOCK_KINDS
+        .iter()
+        .position(|candidate| *candidate == kind)
+        .expect("every block kind should be listed")
 }
 
 /// The counters this cache reports, every one registered at construction.

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -10,8 +10,8 @@
 use loonfs_api::{ListCheckpointsResponse, ListPathEntriesResponse, NamespaceId};
 use loonfs_client::{Client, ClientConfig, ListPathEntriesOptions, NamespacePath};
 use loonfs_server::{
-    app, serve_with_shutdown, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides,
-    ServeError, ServerConfig, StoreConfig, TlsServerConfig,
+    app, serve_with_shutdown, AppOptions, GrepConfig, GrepMode, MaintenanceMode,
+    RuntimeCacheConfigOverrides, ServeError, ServerConfig, StoreConfig, TlsServerConfig,
 };
 use loonfs_test_support::http::raw_agent;
 use std::collections::BTreeMap;
@@ -119,9 +119,7 @@ pub(crate) async fn start_server(config: ServerConfig) -> TestServer {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    // The writer is dropped: tests abort the server task instead of shutting
-    // it down gracefully.
-    let (router, _writer, _local_cache) = app(config).await.expect("build app");
+    let (router, _state) = app(config, AppOptions::default()).await.expect("build app");
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -18,8 +18,8 @@ use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker, GREP_INDEX
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
 use loonfs_server::{
-    app, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig,
-    StoreConfig,
+    app, AppOptions, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides,
+    ServerConfig, StoreConfig,
 };
 use serde::de::DeserializeOwned;
 use std::num::NonZeroUsize;
@@ -32,9 +32,12 @@ use tower::ServiceExt;
 async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
     let temp_dir = tempdir().expect("store tempdir");
     let (_store, _writer, namespace_id) = seed_namespace(temp_dir.path(), "disabled").await;
-    let (router, server, _local_cache) = app(test_config(temp_dir.path(), GrepMode::Disabled))
-        .await
-        .expect("build app");
+    let (router, server) = app(
+        test_config(temp_dir.path(), GrepMode::Disabled),
+        AppOptions::default(),
+    )
+    .await
+    .expect("build app");
 
     let capabilities = capabilities(&router).await;
     assert!(!capabilities.features.contains_key(FEATURE_QUERY_GREP));
@@ -47,7 +50,7 @@ async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
     for limit in grep_limits() {
         assert!(!capabilities.limits.contains_key(limit));
     }
-    assert!(!maintains_grep_index(&server));
+    assert!(!maintains_grep_index(&server.writer));
 
     // Searching and administering gate on their own keys, so a refusal names
     // the key whose absence the client just read.
@@ -70,16 +73,23 @@ async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
         FEATURE_ADMIN_GREP_INDEX,
     )
     .await;
-    server.shutdown().await.expect("settle the server writer");
+    server
+        .writer
+        .shutdown()
+        .await
+        .expect("settle the server writer");
 }
 
 #[tokio::test]
 async fn grep_get_query_parameters_use_the_list_route_grammar() {
     let temp_dir = tempdir().expect("store tempdir");
     let (_store, _writer, namespace_id) = seed_namespace(temp_dir.path(), "query-grammar").await;
-    let (router, server, _local_cache) = app(test_config(temp_dir.path(), GrepMode::ServeOnly))
-        .await
-        .expect("build app");
+    let (router, server) = app(
+        test_config(temp_dir.path(), GrepMode::ServeOnly),
+        AppOptions::default(),
+    )
+    .await
+    .expect("build app");
     let path = query_path(&namespace_id);
 
     let response = send(&router, Method::GET, &path, None).await;
@@ -138,18 +148,24 @@ async fn grep_get_query_parameters_use_the_list_route_grammar() {
     assert_eq!(error.param.as_deref(), Some("pattern"));
     assert!(error.message.contains("maximum is 1024 bytes"));
 
-    server.shutdown().await.expect("settle the server writer");
+    server
+        .writer
+        .shutdown()
+        .await
+        .expect("settle the server writer");
 }
 
 #[tokio::test]
 async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespace() {
     let temp_dir = tempdir().expect("store tempdir");
     let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "both").await;
-    let (router, server, _local_cache) =
-        app(test_config(temp_dir.path(), GrepMode::ServeAndMaintain))
-            .await
-            .expect("build app");
-    assert!(maintains_grep_index(&server));
+    let (router, server) = app(
+        test_config(temp_dir.path(), GrepMode::ServeAndMaintain),
+        AppOptions::default(),
+    )
+    .await
+    .expect("build app");
+    assert!(maintains_grep_index(&server.writer));
     // Before anything is enabled the status route answers honestly rather
     // than inventing a namespace-not-found.
     assert_eq!(
@@ -186,7 +202,7 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
         enabled.lifecycle,
         "the status route and the enable response describe the same root"
     );
-    settle(&server).await;
+    settle(&server.writer).await;
     assert_eq!(watermark(&store, &namespace_id).await, ChangeSeq(0));
     let active = index_status(&router, &namespace_id).await;
     assert_eq!(
@@ -223,7 +239,7 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
         )
         .await
         .expect("write file");
-    settle(&server).await;
+    settle(&server.writer).await;
     assert_eq!(watermark(&store, &namespace_id).await, ChangeSeq(0));
 
     let capabilities = capabilities(&router).await;
@@ -243,7 +259,7 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
     let response = grep(&router, &namespace_id, "automatic needle").await;
     assert_eq!(response.matches.len(), 1);
     assert_eq!(response.matches[0].path, "/note.txt");
-    settle(&server).await;
+    settle(&server.writer).await;
     assert_eq!(watermark(&store, &namespace_id).await, ChangeSeq(1));
     let caught_up = grep(&router, &namespace_id, "automatic needle").await;
     assert_eq!(caught_up.matches.len(), 1);
@@ -261,7 +277,7 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
         disabled.manifest_state().status(),
         GrepIndexStatus::Disabled {}
     ));
-    settle(&server).await;
+    settle(&server.writer).await;
     assert!(
         matches!(
             load_grep_root(&*store, &namespace_id)
@@ -292,11 +308,15 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
     );
 
     assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
-    settle(&server).await;
+    settle(&server.writer).await;
     assert_eq!(watermark(&store, &namespace_id).await, ChangeSeq(1));
     let reenabled = grep(&router, &namespace_id, "automatic needle").await;
     assert_eq!(reenabled.matches.len(), 1);
-    server.shutdown().await.expect("settle the server writer");
+    server
+        .writer
+        .shutdown()
+        .await
+        .expect("settle the server writer");
 }
 
 #[tokio::test]
@@ -380,13 +400,15 @@ async fn first_query_after_restart_resumes_stale_and_mid_backfill_namespaces() {
 
     // Nothing has nudged either namespace in this process: the first search
     // is what re-admits the index that trails its head.
-    let (router, server, _local_cache) =
-        app(test_config(temp_dir.path(), GrepMode::ServeAndMaintain))
-            .await
-            .expect("reopen app");
+    let (router, server) = app(
+        test_config(temp_dir.path(), GrepMode::ServeAndMaintain),
+        AppOptions::default(),
+    )
+    .await
+    .expect("reopen app");
     let stale_response = grep(&router, &stale, "stale steady needle").await;
     assert_eq!(stale_response.matches.len(), 1);
-    settle(&server).await;
+    settle(&server.writer).await;
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     assert_eq!(watermark(&store, &stale).await, ChangeSeq(2));
 
@@ -404,21 +426,28 @@ async fn first_query_after_restart_resumes_stale_and_mid_backfill_namespaces() {
         ),
         "first touch either observes backfill or its concurrently completed root"
     );
-    settle(&server).await;
+    settle(&server.writer).await;
     assert_eq!(watermark(&store, &backfill).await, ChangeSeq(3));
     let resumed = grep(&router, &backfill, "mid-backfill needle").await;
     assert_eq!(resumed.matches.len(), 3);
-    server.shutdown().await.expect("settle the server writer");
+    server
+        .writer
+        .shutdown()
+        .await
+        .expect("settle the server writer");
 }
 
 #[tokio::test]
 async fn serve_only_answers_searches_over_an_index_it_refuses_to_administer() {
     let temp_dir = tempdir().expect("store tempdir");
     let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "serve-only").await;
-    let (router, server, _local_cache) = app(test_config(temp_dir.path(), GrepMode::ServeOnly))
-        .await
-        .expect("build app");
-    assert!(!maintains_grep_index(&server));
+    let (router, server) = app(
+        test_config(temp_dir.path(), GrepMode::ServeOnly),
+        AppOptions::default(),
+    )
+    .await
+    .expect("build app");
+    assert!(!maintains_grep_index(&server.writer));
 
     // The document says the same thing the routes do: searches yes,
     // administration no.
@@ -470,7 +499,7 @@ async fn serve_only_answers_searches_over_an_index_it_refuses_to_administer() {
         )
         .await
         .expect("write file");
-    settle(&server).await;
+    settle(&server.writer).await;
     assert_eq!(
         lifecycle_of(&store, &namespace_id).await.active_watermark(),
         None,
@@ -481,17 +510,24 @@ async fn serve_only_answers_searches_over_an_index_it_refuses_to_administer() {
     let response = grep(&router, &namespace_id, "external needle").await;
     assert_eq!(response.matches.len(), 1);
     assert_eq!(response.built_through_seq, ChangeSeq(1));
-    server.shutdown().await.expect("settle the server writer");
+    server
+        .writer
+        .shutdown()
+        .await
+        .expect("settle the server writer");
 }
 
 #[tokio::test]
 async fn maintain_only_keeps_the_index_built_without_serving_searches() {
     let temp_dir = tempdir().expect("store tempdir");
     let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "maintain-only").await;
-    let (router, server, _local_cache) = app(test_config(temp_dir.path(), GrepMode::MaintainOnly))
-        .await
-        .expect("build app");
-    assert!(maintains_grep_index(&server));
+    let (router, server) = app(
+        test_config(temp_dir.path(), GrepMode::MaintainOnly),
+        AppOptions::default(),
+    )
+    .await
+    .expect("build app");
+    assert!(maintains_grep_index(&server.writer));
 
     let capabilities = capabilities(&router).await;
     assert!(
@@ -536,7 +572,7 @@ async fn maintain_only_keeps_the_index_built_without_serving_searches() {
         .await
         .expect("write file");
     assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
-    settle(&server).await;
+    settle(&server.writer).await;
     assert_eq!(watermark(&store, &namespace_id).await, ChangeSeq(1));
     let root = load_grep_root(&*store, &namespace_id)
         .await
@@ -550,21 +586,28 @@ async fn maintain_only_keeps_the_index_built_without_serving_searches() {
         !root.manifest_state().segments().is_empty(),
         "the index this deployment maintains holds real segments"
     );
-    server.shutdown().await.expect("settle the server writer");
+    server
+        .writer
+        .shutdown()
+        .await
+        .expect("settle the server writer");
 }
 
 #[tokio::test]
 async fn manual_maintenance_registers_no_index_job_and_still_administers_one() {
     let temp_dir = tempdir().expect("store tempdir");
     let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "manual-maintenance").await;
-    let (router, server, _local_cache) = app(ServerConfig {
-        maintenance: MaintenanceMode::Manual,
-        ..test_config(temp_dir.path(), GrepMode::ServeAndMaintain)
-    })
+    let (router, server) = app(
+        ServerConfig {
+            maintenance: MaintenanceMode::Manual,
+            ..test_config(temp_dir.path(), GrepMode::ServeAndMaintain)
+        },
+        AppOptions::default(),
+    )
     .await
     .expect("build app");
     assert!(
-        !maintains_grep_index(&server),
+        !maintains_grep_index(&server.writer),
         "a manual deployment registers no automatic index job, whatever the grep mode maintains"
     );
 
@@ -588,7 +631,7 @@ async fn manual_maintenance_registers_no_index_job_and_still_administers_one() {
         "the enable published a backfill this deployment left for someone else"
     );
 
-    settle(&server).await;
+    settle(&server.writer).await;
     assert_eq!(
         lifecycle_of(&store, &namespace_id).await.active_watermark(),
         None,
@@ -606,7 +649,11 @@ async fn manual_maintenance_registers_no_index_job_and_still_administers_one() {
             .len(),
         1
     );
-    server.shutdown().await.expect("settle the server writer");
+    server
+        .writer
+        .shutdown()
+        .await
+        .expect("settle the server writer");
 }
 
 async fn seed_namespace(root: &Path, name: &str) -> (SharedObjectStore, FsWriter, NamespaceId) {

--- a/crates/loonfs-server/tests/logging.rs
+++ b/crates/loonfs-server/tests/logging.rs
@@ -14,7 +14,7 @@ use common::http_split_support::test_config;
 use loonfs::{CreateNamespaceOptions, FsWriter, SharedObjectStore, TraceMode, TraceStoreKind};
 use loonfs_api::v0::BeginUploadRequest;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_server::{app, app_with_store, MaintenanceMode};
+use loonfs_server::{app, AppOptions, MaintenanceMode};
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{FailStore, InjectedError, KeyPredicate, OperationClass};
 use std::convert::Infallible;
@@ -217,7 +217,8 @@ async fn missing_path_has_one_debug_completion_and_no_errors() {
         "logging-missing-path",
     );
     config.maintenance = MaintenanceMode::Manual;
-    let (router, writer, _local_cache) = app(config).await.expect("build app");
+    let (router, state) = app(config, AppOptions::default()).await.expect("build app");
+    let writer = state.writer;
     writer
         .create_namespace(&namespace_id("demo"), CreateNamespaceOptions::default())
         .await
@@ -260,7 +261,8 @@ async fn expected_typed_errors_use_debug_or_warn_and_keep_completion_fields() {
     );
     config.maintenance = MaintenanceMode::Manual;
     config.max_concurrent_uploads = 1;
-    let (router, writer, _local_cache) = app(config).await.expect("build app");
+    let (router, state) = app(config, AppOptions::default()).await.expect("build app");
+    let writer = state.writer;
     let namespace = namespace_id("demo");
     writer
         .create_namespace(&namespace, CreateNamespaceOptions::default())
@@ -397,7 +399,16 @@ async fn store_fault_has_one_error_from_the_boundary() {
         .expect("shutdown bootstrap writer");
 
     failing.fail_all();
-    let router = app_with_store(config, store).await.expect("build app");
+    let router = app(
+        config,
+        AppOptions {
+            store: Some(store),
+            direct_transfers: None,
+        },
+    )
+    .await
+    .expect("build app")
+    .0;
     capture.clear();
     let (status, body, request_id) = request_error(&router, "/v0/namespaces/faulty").await;
     assert_eq!(status, 500);


### PR DESCRIPTION
This applies bearer-token authentication once to the protected router instead of repeating it in every handler. Health and readiness remain public. Path, query, and body extraction and server construction are also consolidated to remove duplicate code.

The HTTP and OpenAPI shapes are unchanged. Oversized JSON and upload-control bodies now use the same error message.