### PR TITLE
refactor(runtime): simplify publisher state and runtime ownership

### DIFF
--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -13,8 +13,8 @@ use loonfs_api::wire::control::HeadState;
 use loonfs_core::cache::{MetadataSegmentCacheStats, WalTailProjectionCacheStats};
 use loonfs_core::control::{
     load_checkpoint_read_basis, load_namespace_read_anchor, load_snapshot_read_basis,
-    ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl, MetadataBasis,
-    VerifiedNamespaceCatalogEntry,
+    CheckpointReadBasis, ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl,
+    MetadataBasis, VerifiedNamespaceCatalogEntry,
 };
 use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext, StoreFailureClass};
 use loonfs_objectstore::keys::wal_head;
@@ -24,16 +24,8 @@ use std::sync::Arc;
 
 #[derive(Debug, Default)]
 pub(crate) struct RuntimeControlCache {
-    namespaces: HashMap<NamespaceId, NamespaceControlCacheEntry>,
+    namespaces: HashMap<NamespaceId, (CachedNamespaceAnchor, u64)>,
     namespace_order: Recency<NamespaceId>,
-}
-
-#[derive(Debug, Default)]
-struct NamespaceControlCacheEntry {
-    head: Option<CachedNamespaceAnchor>,
-    /// Recency stamp assigned on the most recent access. Recency records with
-    /// an older stamp for this namespace are ignored.
-    last_touch: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -163,7 +155,7 @@ impl RuntimeControlCache {
         &mut self,
         namespace_id: &NamespaceId,
     ) -> Option<CachedNamespaceAnchor> {
-        let head = self.namespaces.get(namespace_id)?.head.clone()?;
+        let head = self.namespaces.get(namespace_id)?.0.clone();
         self.touch_namespace(namespace_id);
         Some(head)
     }
@@ -177,29 +169,9 @@ impl RuntimeControlCache {
         if max_cached_namespaces == 0 {
             return;
         }
-        self.namespace_entry(namespace_id, max_cached_namespaces)
-            .head = Some(head);
-    }
-
-    fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
-        // The head anchor goes stale on every mutation.
-        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
-            entry.head = None;
-        }
-    }
-
-    /// Removes all cached control state for a deleted namespace.
-    fn remove_namespace(&mut self, namespace_id: &NamespaceId) {
-        self.namespaces.remove(namespace_id);
-    }
-
-    fn namespace_entry(
-        &mut self,
-        namespace_id: &NamespaceId,
-        max_cached_namespaces: usize,
-    ) -> &mut NamespaceControlCacheEntry {
-        self.namespaces.entry(namespace_id.clone()).or_default();
-        self.touch_namespace(namespace_id);
+        let last_touch = self.namespace_order.touch(namespace_id);
+        self.namespaces
+            .insert(namespace_id.clone(), (head, last_touch));
         let Self {
             namespaces,
             namespace_order,
@@ -212,15 +184,19 @@ impl RuntimeControlCache {
             };
             namespaces.remove(&evicted);
         }
-        namespaces
-            .get_mut(namespace_id)
-            .expect("namespace cache entry should exist")
+        namespace_order.compact(namespaces.len(), |key, stamp| {
+            namespace_slot_is_live(namespaces, key, stamp)
+        });
+    }
+
+    fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
+        self.namespaces.remove(namespace_id);
     }
 
     fn touch_namespace(&mut self, namespace_id: &NamespaceId) {
         let stamp = self.namespace_order.touch(namespace_id);
-        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
-            entry.last_touch = stamp;
+        if let Some((_, last_touch)) = self.namespaces.get_mut(namespace_id) {
+            *last_touch = stamp;
         }
         let namespaces = &self.namespaces;
         self.namespace_order
@@ -231,13 +207,13 @@ impl RuntimeControlCache {
 }
 
 fn namespace_slot_is_live(
-    namespaces: &HashMap<NamespaceId, NamespaceControlCacheEntry>,
+    namespaces: &HashMap<NamespaceId, (CachedNamespaceAnchor, u64)>,
     namespace_id: &NamespaceId,
     stamp: u64,
 ) -> bool {
     namespaces
         .get(namespace_id)
-        .is_some_and(|entry| entry.last_touch == stamp)
+        .is_some_and(|(_, last_touch)| *last_touch == stamp)
 }
 
 impl ReadCore {
@@ -392,16 +368,7 @@ impl ReadCore {
             checkpoint_id,
         )
         .await?;
-        let read_context = self.runtime_read_context(&CachedNamespaceAnchor {
-            head: CachedControl {
-                identity: ControlObjectIdentity {
-                    etag: pinned.head_etag,
-                },
-                state: pinned.head,
-            },
-            basis: pinned.basis,
-        });
-        Ok((self.reader_engine(namespace_id), read_context))
+        Ok(self.pinned_read_at_basis(namespace_id, pinned))
     }
 
     /// Pins a snapshot-owned checkpoint while enforcing its live lease.
@@ -423,6 +390,17 @@ impl ReadCore {
             now_ms,
         )
         .await?;
+        Ok(self.pinned_read_at_basis(namespace_id, pinned))
+    }
+
+    fn pinned_read_at_basis(
+        &self,
+        namespace_id: &NamespaceId,
+        pinned: CheckpointReadBasis,
+    ) -> (
+        loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
+        RuntimeReadContext,
+    ) {
         let read_context = self.runtime_read_context(&CachedNamespaceAnchor {
             head: CachedControl {
                 identity: ControlObjectIdentity {
@@ -432,7 +410,7 @@ impl ReadCore {
             },
             basis: pinned.basis,
         });
-        Ok((self.reader_engine(namespace_id), read_context))
+        (self.reader_engine(namespace_id), read_context)
     }
 
     /// Pins the latest metadata view and records the read in cache metrics.
@@ -462,7 +440,9 @@ impl ReadCore {
     /// the namespace itself is gone. The publisher that ran the delete is
     /// evicted with its engine and session by the publication service.
     pub(crate) fn invalidate_namespace_cache_for_delete(&self, namespace_id: &NamespaceId) {
-        self.inner.control_cache().remove_namespace(namespace_id);
+        self.inner
+            .control_cache()
+            .invalidate_namespace(namespace_id);
         self.inner
             .wal_tail_projection_cache
             .invalidate_namespace(namespace_id);

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -946,6 +946,19 @@ impl FsAdmin {
     }
 
     /// Extends a live snapshot, capped from its durable creation time.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.snapshot_extend",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.snapshot_extend",
+            namespace_id = %namespace_id,
+            snapshot_id = %snapshot_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn extend_snapshot(
         &self,
         namespace_id: &NamespaceId,
@@ -970,6 +983,19 @@ impl FsAdmin {
     }
 
     /// Releases a snapshot. Repeated releases succeed.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.snapshot_release",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.snapshot_release",
+            namespace_id = %namespace_id,
+            snapshot_id = %snapshot_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn release_snapshot(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -512,26 +512,62 @@ fn advance_typed_cursor<C: PageCursor>(
 }
 
 impl FsReader {
+    fn read_snapshot(
+        &self,
+        engine: NamespaceReaderEngine<SharedObjectStore>,
+        context: RuntimeReadContext,
+        snapshot_id: Option<CheckpointId>,
+    ) -> FsReadSnapshot {
+        FsReadSnapshot {
+            engine,
+            context,
+            snapshot_id,
+            max_read_content_bytes: self.core.inner.config.max_read_content_bytes,
+        }
+    }
+
     /// Pins one namespace metadata view for a sequence of related reads.
     ///
     /// The returned snapshot keeps path lookup, directory listing, inode
     /// resolution, and content selection on the same head even if commits
     /// publish concurrently. It is intended to be short-lived for one
     /// request or unit of work.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.pin_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "pin_namespace",
+            method = "pin_namespace",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn pin_namespace(&self, namespace_id: &NamespaceId) -> Result<FsReadSnapshot> {
         self.core.record_trace_context(&tracing::Span::current());
         let (engine, context) = self.core.pinned_metadata_read(namespace_id).await?;
-        Ok(FsReadSnapshot {
-            engine,
-            context,
-            snapshot_id: None,
-            max_read_content_bytes: self.core.inner.config.max_read_content_bytes,
-        })
+        Ok(self.read_snapshot(engine, context, None))
     }
 
     /// Pins the namespace state captured by a checkpoint.
     ///
     /// Missing or released checkpoints return `checkpoint_unavailable`.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.pin_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "pin_namespace",
+            method = "pin_namespace_at_checkpoint",
+            namespace_id = %namespace_id,
+            checkpoint_id = %checkpoint_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn pin_namespace_at_checkpoint(
         &self,
         namespace_id: &NamespaceId,
@@ -542,15 +578,24 @@ impl FsReader {
             .core
             .pinned_read_at_checkpoint(namespace_id, checkpoint_id)
             .await?;
-        Ok(FsReadSnapshot {
-            engine,
-            context,
-            snapshot_id: None,
-            max_read_content_bytes: self.core.inner.config.max_read_content_bytes,
-        })
+        Ok(self.read_snapshot(engine, context, None))
     }
 
     /// Pins the namespace state captured by a live snapshot.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.pin_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "pin_namespace",
+            method = "pin_namespace_at_snapshot",
+            namespace_id = %namespace_id,
+            snapshot_id = %snapshot_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn pin_namespace_at_snapshot(
         &self,
         namespace_id: &NamespaceId,
@@ -563,12 +608,7 @@ impl FsReader {
             .pinned_read_at_snapshot(namespace_id, snapshot_id, now_ms)
             .await?;
         self.core.inner.cache_stats.record_snapshot_view_read();
-        Ok(FsReadSnapshot {
-            engine,
-            context,
-            snapshot_id: Some(snapshot_id.clone()),
-            max_read_content_bytes: self.core.inner.config.max_read_content_bytes,
-        })
+        Ok(self.read_snapshot(engine, context, Some(snapshot_id.clone())))
     }
 
     /// Returns a namespace's current state.

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -11,14 +11,14 @@ use crate::content_tokens::{CompletedUpload, CompletedUploadReceipt};
 use crate::maintenance_runner::{completed_upload_reclaim_at_ms, upload_session_reclaim_at_ms};
 use crate::uploads::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse,
-    MultipartPartTargets,
+    MultipartPartTargets, ResolvedUploadCompletion,
 };
 use crate::ByteStream;
 use crate::FsWriter;
 use crate::Result;
 use crate::{
-    BeginUploadRequest, BeginUploadResponse, ChecksumAlgorithm, CompleteMultipartUploadRequest,
-    MaintenanceJobId, NamespaceId, UploadContentResponse, UploadMode, UploadSession,
+    BeginUploadRequest, BeginUploadResponse, ChecksumAlgorithm, MaintenanceJobId, NamespaceId,
+    UploadContentResponse, UploadMode, UploadSession,
 };
 use loonfs_api::options::DirectMultipartUploadOptions;
 use loonfs_api::v0::UploadPartChecksumClaim;
@@ -222,7 +222,10 @@ impl FsWriter {
             .await?)
     }
 
-    /// Completes a service-proxied or direct-PUT upload session.
+    /// Completes an upload session and returns proof for later publication.
+    ///
+    /// Service-proxied completion performs no content-blob I/O. Direct-put
+    /// completion performs one content-blob HEAD and no content-blob GET.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.complete_upload",
@@ -240,115 +243,9 @@ impl FsWriter {
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
-    ) -> Result<UploadSession> {
-        self.core.record_trace_context(&tracing::Span::current());
-        Ok(self
-            .complete_upload_prepared_inner(
-                namespace_id,
-                upload_id,
-                loonfs_core::ResolvedUploadCompletion::KnownContent,
-            )
-            .await?
-            .response)
-    }
-
-    /// Completes a direct-multipart upload session.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.complete_upload",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "complete_upload",
-            method = "complete_multipart_upload",
-            namespace_id = %namespace_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn complete_multipart_upload(
-        &self,
-        namespace_id: &NamespaceId,
-        upload_id: &UploadId,
-        request: &CompleteMultipartUploadRequest,
-    ) -> Result<UploadSession> {
-        self.core.record_trace_context(&tracing::Span::current());
-        Ok(self
-            .complete_upload_prepared_inner(
-                namespace_id,
-                upload_id,
-                loonfs_core::ResolvedUploadCompletion::Multipart(request.clone()),
-            )
-            .await?
-            .response)
-    }
-
-    /// Completes an upload session and returns proof for later publication.
-    ///
-    /// Service-proxied completion performs no content-blob I/O. Direct-put
-    /// completion performs one content-blob HEAD and no content-blob GET.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.complete_upload",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "complete_upload",
-            method = "complete_upload_prepared",
-            namespace_id = %namespace_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn complete_upload_prepared(
-        &self,
-        namespace_id: &NamespaceId,
-        upload_id: &UploadId,
+        completion: ResolvedUploadCompletion,
     ) -> Result<CompletedUpload> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.complete_upload_prepared_inner(
-            namespace_id,
-            upload_id,
-            loonfs_core::ResolvedUploadCompletion::KnownContent,
-        )
-        .await
-    }
-
-    /// Completes a multipart upload and returns its publication proof.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.complete_upload",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "complete_upload",
-            method = "complete_multipart_upload_prepared",
-            namespace_id = %namespace_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn complete_multipart_upload_prepared(
-        &self,
-        namespace_id: &NamespaceId,
-        upload_id: &UploadId,
-        request: &CompleteMultipartUploadRequest,
-    ) -> Result<CompletedUpload> {
-        self.core.record_trace_context(&tracing::Span::current());
-        self.complete_upload_prepared_inner(
-            namespace_id,
-            upload_id,
-            loonfs_core::ResolvedUploadCompletion::Multipart(request.clone()),
-        )
-        .await
-    }
-
-    async fn complete_upload_prepared_inner(
-        &self,
-        namespace_id: &NamespaceId,
-        upload_id: &UploadId,
-        completion: loonfs_core::ResolvedUploadCompletion,
-    ) -> Result<CompletedUpload> {
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -562,15 +562,13 @@ impl FsWriter {
         options: CreateDirectoryOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit_candidate_inner(
+        self.commit_one(
             namespace_id,
-            CommitCandidate::new(single_operation(
-                &options.commit,
-                FilesystemOperation::CreateDirectory {
-                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
-                    parents: options.parents,
-                },
-            )),
+            &options.commit,
+            FilesystemOperation::CreateDirectory {
+                path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                parents: options.parents,
+            },
         )
         .await
     }
@@ -601,16 +599,14 @@ impl FsWriter {
         options: DeleteOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit_candidate_inner(
+        self.commit_one(
             namespace_id,
-            CommitCandidate::new(single_operation(
-                &options.commit,
-                FilesystemOperation::DeletePath {
-                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
-                    behavior: options.behavior,
-                    expected_inode_id: options.expected_inode_id,
-                },
-            )),
+            &options.commit,
+            FilesystemOperation::DeletePath {
+                path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                behavior: options.behavior,
+                expected_inode_id: options.expected_inode_id,
+            },
         )
         .await
     }
@@ -637,18 +633,16 @@ impl FsWriter {
         options: MoveOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit_candidate_inner(
+        self.commit_one(
             namespace_id,
-            CommitCandidate::new(single_operation(
-                &options.commit,
-                FilesystemOperation::MovePath {
-                    from_path: loonfs_core::path::parse_mutation_path(from_path)?,
-                    to_path: loonfs_core::path::parse_mutation_path(to_path)?,
-                    behavior: options.behavior,
-                    expected_destination_inode_id: options.expected_destination_inode_id,
-                    expected_destination_revision_no: options.expected_destination_revision_no,
-                },
-            )),
+            &options.commit,
+            FilesystemOperation::MovePath {
+                from_path: loonfs_core::path::parse_mutation_path(from_path)?,
+                to_path: loonfs_core::path::parse_mutation_path(to_path)?,
+                behavior: options.behavior,
+                expected_destination_inode_id: options.expected_destination_inode_id,
+                expected_destination_revision_no: options.expected_destination_revision_no,
+            },
         )
         .await
     }
@@ -676,18 +670,16 @@ impl FsWriter {
         options: CopyOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit_candidate_inner(
+        self.commit_one(
             namespace_id,
-            CommitCandidate::new(single_operation(
-                &options.commit,
-                FilesystemOperation::CopyPath {
-                    from_path: loonfs_core::path::parse_mutation_path(from_path)?,
-                    to_path: loonfs_core::path::parse_mutation_path(to_path)?,
-                    behavior: options.behavior,
-                    expected_destination_inode_id: options.expected_destination_inode_id,
-                    expected_destination_revision_no: options.expected_destination_revision_no,
-                },
-            )),
+            &options.commit,
+            FilesystemOperation::CopyPath {
+                from_path: loonfs_core::path::parse_mutation_path(from_path)?,
+                to_path: loonfs_core::path::parse_mutation_path(to_path)?,
+                behavior: options.behavior,
+                expected_destination_inode_id: options.expected_destination_inode_id,
+                expected_destination_revision_no: options.expected_destination_revision_no,
+            },
         )
         .await
     }
@@ -714,15 +706,13 @@ impl FsWriter {
         options: RestoreRevisionOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit_candidate_inner(
+        self.commit_one(
             namespace_id,
-            CommitCandidate::new(single_operation(
-                &options.commit,
-                FilesystemOperation::RestoreRevision {
-                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
-                    source_revision_no,
-                },
-            )),
+            &options.commit,
+            FilesystemOperation::RestoreRevision {
+                path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                source_revision_no,
+            },
         )
         .await
     }
@@ -753,18 +743,16 @@ impl FsWriter {
         options: UpdateAttributesOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit_candidate_inner(
+        self.commit_one(
             namespace_id,
-            CommitCandidate::new(single_operation(
-                &options.commit,
-                FilesystemOperation::UpdateAttributes {
-                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
-                    set: options.set,
-                    remove: options.remove,
-                    expected_inode_id: options.expected_inode_id,
-                    expected_attributes_revision_no: options.expected_attributes_revision_no,
-                },
-            )),
+            &options.commit,
+            FilesystemOperation::UpdateAttributes {
+                path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                set: options.set,
+                remove: options.remove,
+                expected_inode_id: options.expected_inode_id,
+                expected_attributes_revision_no: options.expected_attributes_revision_no,
+            },
         )
         .await
     }
@@ -797,16 +785,14 @@ impl FsWriter {
         let path = absolute_path
             .map(loonfs_core::path::parse_mutation_path)
             .transpose()?;
-        self.commit_candidate_inner(
+        self.commit_one(
             namespace_id,
-            CommitCandidate::new(single_operation(
-                &options.commit,
-                FilesystemOperation::Undelete {
-                    inode_id,
-                    deletion_seq,
-                    path,
-                },
-            )),
+            &options.commit,
+            FilesystemOperation::Undelete {
+                inode_id,
+                deletion_seq,
+                path,
+            },
         )
         .await
     }
@@ -909,6 +895,19 @@ impl FsWriter {
         self.publisher
             .submit_candidate(namespace_id.clone(), candidate)
             .await
+    }
+
+    async fn commit_one(
+        &self,
+        namespace_id: &NamespaceId,
+        commit: &CommitOptions,
+        operation: FilesystemOperation,
+    ) -> Result<CommitResponse> {
+        self.commit_candidate_inner(
+            namespace_id,
+            CommitCandidate::new(single_operation(commit, operation)),
+        )
+        .await
     }
 }
 

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -398,20 +398,20 @@ impl FsWriterBuilder {
                         .to_owned(),
                 )
             })?;
-        let runtime = Some(owning_runtime()?);
+        let runtime = owning_runtime()?;
         let core = self.core.open_read_core()?;
         let instruments = Arc::clone(core.instruments());
         let maintenance = match self.maintenance_clock {
             Some(clock) => MaintenanceRunner::with_clock(
                 self.background_work,
-                runtime,
+                runtime.clone(),
                 max_concurrent_maintenance,
                 clock,
                 instruments,
             ),
             None => MaintenanceRunner::new(
                 self.background_work,
-                runtime,
+                runtime.clone(),
                 max_concurrent_maintenance,
                 instruments,
             ),
@@ -424,6 +424,7 @@ impl FsWriterBuilder {
         let publisher = PublisherRegistry::new(
             core.clone(),
             Arc::downgrade(&bits),
+            runtime,
             std::time::Duration::from_millis(self.min_publish_interval_ms),
         );
         // The runtime's own executors register last: they run as an admin

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -76,24 +76,22 @@ pub use loonfs_api::v0::{
     UploadSessionStatus,
 };
 pub use loonfs_api::{
-    ActorId, ActorKind, ActorRef, AdvanceRetentionRequest, AdvanceRetentionResponse, AttributeKey,
-    AttributeRevisionNo, AttributeValue, Attributes, AttributesProjection, CapabilityDocument,
-    ChangeSeq, Checkpoint, CheckpointId, CheckpointOwnerSummary, ChecksumAlgorithm, CommitId,
-    ContentId, ContentRef, ContentRefKind, CreateCheckpointRequest, CreateSnapshotRequest,
-    DeleteDirectoryBehavior, DeleteNamespaceResponse, DeletedObjectCounts, DestinationBehavior,
-    DirectoryPageCursor, EffectiveLimit, ExtendSnapshotRequest, FileBytes, FileRevision,
-    FileRevisionsPageCursor, FlushWalOutcome, FlushWalResponse, GcRequest, GcResponse, InodeId,
-    InodeKind, ListCheckpointsResponse, ListFileRevisionsResponse, ListInodeChildrenResponse,
-    ListPathEntriesResponse, ListSnapshotsResponse, MaintenanceStepRequest,
-    MaintenanceStepResponse, ManifestNo, MetadataMaintenanceRequest, MetadataMaintenanceResponse,
-    NameKey, Namespace, NamespaceDiagnostics, NamespaceId, Page, PageRequest, PaginationPolicy,
-    PathEntry, PathEntryKind, ReleaseCheckpointResponse, ReleaseSnapshotResponse,
-    ReleasedCheckpointCounts, ReorganizeStepOutcome, RetainedCandidates, RetainedReason,
-    RevisionNo, SnapshotSummary, TrashEntry, UploadId, WalFlushStepOutcome, FEATURE_ATTRIBUTES,
-    FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_INODES_LIST_CHILDREN, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_SNAPSHOTS,
-    FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0,
-    PROFILE_CORE_V0, PROTOCOL_VERSION,
+    ActorId, ActorKind, ActorRef, AdvanceRetentionResponse, AttributeKey, AttributeRevisionNo,
+    AttributeValue, Attributes, AttributesProjection, CapabilityDocument, ChangeSeq, Checkpoint,
+    CheckpointId, CheckpointOwnerSummary, ChecksumAlgorithm, CommitId, ContentId, ContentRef,
+    ContentRefKind, DeleteDirectoryBehavior, DeleteNamespaceResponse, DeletedObjectCounts,
+    DestinationBehavior, DirectoryPageCursor, EffectiveLimit, FileBytes, FileRevision,
+    FileRevisionsPageCursor, FlushWalOutcome, FlushWalResponse, GcResponse, InodeId, InodeKind,
+    ListCheckpointsResponse, ListFileRevisionsResponse, ListInodeChildrenResponse,
+    ListPathEntriesResponse, ListSnapshotsResponse, MaintenanceStepResponse, ManifestNo,
+    MetadataMaintenanceResponse, NameKey, Namespace, NamespaceDiagnostics, NamespaceId, Page,
+    PageRequest, PaginationPolicy, PathEntry, PathEntryKind, ReleaseCheckpointResponse,
+    ReleaseSnapshotResponse, ReleasedCheckpointCounts, ReorganizeStepOutcome, RetainedCandidates,
+    RetainedReason, RevisionNo, SnapshotSummary, TrashEntry, UploadId, WalFlushStepOutcome,
+    FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_INODES_LIST_CHILDREN,
+    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
+    FEATURE_SNAPSHOTS, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
+    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::{
     DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver, DecodedBlockCacheStats,
@@ -113,6 +111,14 @@ pub use loonfs_core::{
     CONTENT_READ_CHUNK_BYTES, MAX_RESOLVE_CURRENT_FILES,
 };
 pub use publisher::{NamespaceAdvanceHint, NamespaceAdvanceObserver};
+
+/// Request shapes a serving host decodes before converting them to runtime options.
+pub mod wire {
+    pub use loonfs_api::{
+        AdvanceRetentionRequest, CreateCheckpointRequest, CreateSnapshotRequest,
+        ExtendSnapshotRequest, GcRequest, MaintenanceStepRequest, MetadataMaintenanceRequest,
+    };
+}
 
 /// Commit types used by integrations that submit classified mutations to
 /// the runtime publisher.

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -290,7 +290,7 @@ impl MaintenanceHandle {
     pub fn now_ms(&self) -> u64 {
         match self.inner.upgrade() {
             Some(inner) => inner.clock.now_ms(),
-            None => SystemMaintenanceClock::default().now_ms(),
+            None => loonfs_core::time::current_time_ms().unwrap_or(0),
         }
     }
 
@@ -346,10 +346,8 @@ impl RunnerCounters {
 
 pub(crate) struct RunnerInner {
     policy: FsBackgroundWork,
-    /// Runtime that owns spawned work. Handle builders pin the runtime they
-    /// were opened on; `None` resolves the runtime driving the triggering
-    /// call at spawn time.
-    runtime: Option<tokio::runtime::Handle>,
+    /// Runtime that owns spawned work.
+    runtime: tokio::runtime::Handle,
     clock: Arc<dyn MaintenanceClock>,
     jobs: Mutex<BTreeMap<MaintenanceJobId, Arc<dyn MaintenanceJob>>>,
     /// One lock over the shutdown flag, the admission book, and the task
@@ -393,7 +391,7 @@ struct RunnerState {
 impl MaintenanceRunner {
     pub(crate) fn new(
         policy: FsBackgroundWork,
-        runtime: Option<tokio::runtime::Handle>,
+        runtime: tokio::runtime::Handle,
         max_concurrent: std::num::NonZeroUsize,
         instruments: Arc<RuntimeInstruments>,
     ) -> Self {
@@ -408,7 +406,7 @@ impl MaintenanceRunner {
 
     pub(crate) fn with_clock(
         policy: FsBackgroundWork,
-        runtime: Option<tokio::runtime::Handle>,
+        runtime: tokio::runtime::Handle,
         max_concurrent: std::num::NonZeroUsize,
         clock: Arc<dyn MaintenanceClock>,
         instruments: Arc<RuntimeInstruments>,
@@ -611,20 +609,11 @@ impl RunnerInner {
         self.lock_jobs().get(&id).cloned()
     }
 
-    fn runtime(&self) -> Option<tokio::runtime::Handle> {
-        self.runtime
-            .clone()
-            .or_else(|| tokio::runtime::Handle::try_current().ok())
-    }
-
     /// Spawns maintenance on the owning runtime and tracks it for shutdown.
     ///
-    /// If no runtime is available or admission has closed, the future is
-    /// dropped. It must release any claimed key or permit when dropped.
+    /// If admission has closed, the future is dropped. It must release any
+    /// claimed key or permit when dropped.
     pub(super) fn spawn(&self, future: impl Future<Output = ()> + Send + 'static) {
-        let Some(runtime) = self.runtime() else {
-            return;
-        };
         let mut state = self.lock_state();
         if state.admission.is_closed() {
             // A shutdown between this work's claim and now must win: the
@@ -648,7 +637,7 @@ impl RunnerInner {
             }
             false
         });
-        state.tasks.push(runtime.spawn(future));
+        state.tasks.push(self.runtime.spawn(future));
     }
 }
 
@@ -810,16 +799,13 @@ async fn run_step(inner: &Arc<RunnerInner>, dispatch: &MaintenanceDispatch) -> S
 
 /// Starts the timer task if it is not already running.
 fn ensure_scheduler(inner: &Arc<RunnerInner>) {
-    let Some(runtime) = inner.runtime() else {
-        return;
-    };
     let mut state = inner.lock_state();
     if state.scheduler.is_some() || state.admission.is_closed() {
         return;
     }
     let weak = Arc::downgrade(inner);
     let wake = Arc::clone(&inner.wake);
-    state.scheduler = Some(runtime.spawn(scheduler_loop(weak, wake)));
+    state.scheduler = Some(inner.runtime.spawn(scheduler_loop(weak, wake)));
 }
 
 /// Scheduler task for deadlines and periodic reconciliation.

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -281,7 +281,7 @@ fn runner_with(
 ) -> MaintenanceRunner {
     let runner = MaintenanceRunner::with_clock(
         policy,
-        Some(tokio::runtime::Handle::current()),
+        tokio::runtime::Handle::current(),
         nonzero_usize(1),
         clock,
         RuntimeInstruments::new(None),
@@ -901,7 +901,11 @@ async fn upload_paths_plant_the_collection_deadlines_they_create() {
         .await
         .expect("upload content");
     writer
-        .complete_upload(&namespace_id, begun.upload_id())
+        .complete_upload(
+            &namespace_id,
+            begun.upload_id(),
+            crate::uploads::ResolvedUploadCompletion::KnownContent,
+        )
         .await
         .expect("complete upload");
     // The session's own lease comes due first, so it stays the next wake;

--- a/crates/loonfs/src/metrics.rs
+++ b/crates/loonfs/src/metrics.rs
@@ -218,12 +218,6 @@ impl DefaultMetricsRecorder {
 
     /// Returns the instrument registered under `key`, installing `build`'s
     /// if there is none.
-    ///
-    /// A second registration of the same name and labels shares the first
-    /// one's value. A registration that reuses a name with a different
-    /// instrument kind keeps the first kind and hands back a detached
-    /// instrument, so a mistake costs the new instrument's readings rather
-    /// than corrupting the established one.
     fn register(
         &self,
         key: InstrumentKey,
@@ -234,9 +228,42 @@ impl DefaultMetricsRecorder {
             .or_insert_with(build)
             .clone()
     }
+
+    fn register_instrument<T>(
+        &self,
+        name: &'static str,
+        labels: &[(&'static str, &'static str)],
+        fresh: Arc<T>,
+        build: impl FnOnce(Arc<T>) -> RegisteredInstrument,
+        extract: impl FnOnce(&RegisteredInstrument) -> Option<Arc<T>>,
+        expected_kind: &'static str,
+    ) -> Arc<T> {
+        let registered = self.register(InstrumentKey::new(name, labels), || {
+            build(Arc::clone(&fresh))
+        });
+        if let Some(instrument) = extract(&registered) {
+            return instrument;
+        }
+        tracing::error!(
+            metric = name,
+            expected_kind,
+            actual_kind = registered.kind(),
+            "metric registered with conflicting kind"
+        );
+        debug_assert!(false, "metric `{name}` registered with conflicting kind");
+        fresh
+    }
 }
 
 impl RegisteredInstrument {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Counter(_) => "counter",
+            Self::Gauge(_) => "gauge",
+            Self::Histogram(_) => "histogram",
+        }
+    }
+
     fn description(&self) -> &'static str {
         match self {
             Self::Counter(counter) => counter.description,
@@ -262,12 +289,17 @@ impl MetricsRecorder for DefaultMetricsRecorder {
         labels: &[(&'static str, &'static str)],
     ) -> Arc<dyn CounterHandle> {
         let fresh = Arc::new(CounterValue::new(description));
-        match self.register(InstrumentKey::new(name, labels), || {
-            RegisteredInstrument::Counter(Arc::clone(&fresh))
-        }) {
-            RegisteredInstrument::Counter(counter) => counter,
-            _ => fresh,
-        }
+        self.register_instrument::<CounterValue>(
+            name,
+            labels,
+            fresh,
+            RegisteredInstrument::Counter,
+            |registered| match registered {
+                RegisteredInstrument::Counter(counter) => Some(Arc::clone(counter)),
+                _ => None,
+            },
+            "counter",
+        )
     }
 
     fn register_gauge(
@@ -277,12 +309,17 @@ impl MetricsRecorder for DefaultMetricsRecorder {
         labels: &[(&'static str, &'static str)],
     ) -> Arc<dyn GaugeHandle> {
         let fresh = Arc::new(GaugeValue::new(description));
-        match self.register(InstrumentKey::new(name, labels), || {
-            RegisteredInstrument::Gauge(Arc::clone(&fresh))
-        }) {
-            RegisteredInstrument::Gauge(gauge) => gauge,
-            _ => fresh,
-        }
+        self.register_instrument::<GaugeValue>(
+            name,
+            labels,
+            fresh,
+            RegisteredInstrument::Gauge,
+            |registered| match registered {
+                RegisteredInstrument::Gauge(gauge) => Some(Arc::clone(gauge)),
+                _ => None,
+            },
+            "gauge",
+        )
     }
 
     fn register_histogram(
@@ -293,12 +330,17 @@ impl MetricsRecorder for DefaultMetricsRecorder {
         boundaries: &'static [f64],
     ) -> Arc<dyn HistogramHandle> {
         let fresh = Arc::new(HistogramValue::new(description, boundaries));
-        match self.register(InstrumentKey::new(name, labels), || {
-            RegisteredInstrument::Histogram(Arc::clone(&fresh))
-        }) {
-            RegisteredInstrument::Histogram(histogram) => histogram,
-            _ => fresh,
-        }
+        self.register_instrument::<HistogramValue>(
+            name,
+            labels,
+            fresh,
+            RegisteredInstrument::Histogram,
+            |registered| match registered {
+                RegisteredInstrument::Histogram(histogram) => Some(Arc::clone(histogram)),
+                _ => None,
+            },
+            "histogram",
+        )
     }
 }
 

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -16,7 +16,54 @@ use crate::{
 };
 use loonfs_core::cache::{MetadataSegmentCacheObserver, WalTailProjectionCacheObserver};
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard};
+
+trait MetricLabel: Copy + PartialEq + 'static {
+    const VALUES: &'static [Self];
+
+    fn as_str(self) -> &'static str;
+
+    fn index(self) -> usize {
+        Self::VALUES
+            .iter()
+            .position(|value| *value == self)
+            .expect("`MetricLabel::VALUES` should contain every label")
+    }
+}
+
+#[derive(Clone)]
+struct LabeledCounters<E> {
+    handles: Vec<Arc<dyn CounterHandle>>,
+    marker: PhantomData<fn(E)>,
+}
+
+impl<E: MetricLabel> LabeledCounters<E> {
+    fn register(
+        recorder: &dyn MetricsRecorder,
+        name: &'static str,
+        description: &'static str,
+        label_name: &'static str,
+        common_labels: &[(&'static str, &'static str)],
+    ) -> Self {
+        let handles = E::VALUES
+            .iter()
+            .map(|value| {
+                let mut labels = common_labels.to_vec();
+                labels.push((label_name, value.as_str()));
+                recorder.register_counter(name, description, &labels)
+            })
+            .collect();
+        Self {
+            handles,
+            marker: PhantomData,
+        }
+    }
+
+    fn get(&self, label: E) -> &Arc<dyn CounterHandle> {
+        &self.handles[label.index()]
+    }
+}
 
 /// The closed outcome vocabulary for a finished streaming compaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,8 +75,16 @@ pub(crate) enum CompactionOutcome {
     Fenced,
 }
 
-impl CompactionOutcome {
-    const fn as_str(self) -> &'static str {
+impl MetricLabel for CompactionOutcome {
+    const VALUES: &'static [Self] = &[
+        Self::Completed,
+        Self::Failed,
+        Self::Superseded,
+        Self::Cancelled,
+        Self::Fenced,
+    ];
+
+    fn as_str(self) -> &'static str {
         match self {
             Self::Completed => "completed",
             Self::Failed => "failed",
@@ -53,6 +108,28 @@ impl PublishOutcome {
             Self::Ok => RESULT_OK,
             Self::Error => RESULT_ERROR,
         }
+    }
+}
+
+impl MetricLabel for PublishOutcome {
+    const VALUES: &'static [Self] = &[Self::Ok, Self::Error];
+
+    fn as_str(self) -> &'static str {
+        PublishOutcome::as_str(self)
+    }
+}
+
+impl MetricLabel for MaintenanceStepConclusion {
+    const VALUES: &'static [Self] = &[
+        Self::Progressed,
+        Self::Idle,
+        Self::Blocked,
+        Self::Superseded,
+        Self::NotEnabled,
+    ];
+
+    fn as_str(self) -> &'static str {
+        MaintenanceStepConclusion::as_str(self)
     }
 }
 
@@ -172,7 +249,7 @@ impl RuntimeInstruments {
             return;
         };
         let instruments = installed.maintenance_job(job);
-        instruments.step(conclusion).increment(1);
+        instruments.steps.get(conclusion).increment(1);
         instruments.step_seconds.record(seconds_from_ms(elapsed_ms));
         instruments
             .queue_wait_seconds
@@ -263,10 +340,10 @@ impl RuntimeInstruments {
         let Some(installed) = &self.installed else {
             return;
         };
-        let outcome_instruments = installed.compactions.outcome(outcome);
-        outcome_instruments.count.increment(1);
-        outcome_instruments
-            .seconds
+        installed.compactions.outcomes.get(outcome).increment(1);
+        installed
+            .compactions
+            .outcome_seconds(outcome)
             .record(seconds_from_ms(elapsed_ms));
         let Some((input_rows, output_rows, input_bytes, output_bytes)) = totals else {
             return;
@@ -318,7 +395,7 @@ impl RuntimeInstruments {
         let Some(installed) = &self.installed else {
             return;
         };
-        installed.publisher.publish(outcome).increment(1);
+        installed.publisher.publishes.get(outcome).increment(1);
     }
 
     /// Reports what one collection pass reclaimed and retained.
@@ -508,11 +585,7 @@ impl ObjectStoreOperationInstruments {
 /// build registers.
 #[derive(Clone)]
 struct MaintenanceJobInstruments {
-    progressed: Arc<dyn CounterHandle>,
-    idle: Arc<dyn CounterHandle>,
-    blocked: Arc<dyn CounterHandle>,
-    superseded: Arc<dyn CounterHandle>,
-    not_enabled: Arc<dyn CounterHandle>,
+    steps: LabeledCounters<MaintenanceStepConclusion>,
     failures: Arc<dyn CounterHandle>,
     probe_failures: Arc<dyn CounterHandle>,
     step_seconds: Arc<dyn HistogramHandle>,
@@ -522,19 +595,15 @@ struct MaintenanceJobInstruments {
 impl MaintenanceJobInstruments {
     fn register(recorder: &dyn MetricsRecorder, job: MaintenanceJobId) -> Self {
         let job = job.as_str();
-        let steps = |conclusion: MaintenanceStepConclusion| {
-            recorder.register_counter(
+        let common_labels = [("job", job)];
+        Self {
+            steps: LabeledCounters::register(
+                recorder,
                 "loonfs.maintenance.steps",
                 "Maintenance steps by job and conclusion",
-                &[("job", job), ("conclusion", conclusion.as_str())],
-            )
-        };
-        Self {
-            progressed: steps(MaintenanceStepConclusion::Progressed),
-            idle: steps(MaintenanceStepConclusion::Idle),
-            blocked: steps(MaintenanceStepConclusion::Blocked),
-            superseded: steps(MaintenanceStepConclusion::Superseded),
-            not_enabled: steps(MaintenanceStepConclusion::NotEnabled),
+                "conclusion",
+                &common_labels,
+            ),
             failures: recorder.register_counter(
                 "loonfs.maintenance.step_failures",
                 "Maintenance steps that failed before concluding",
@@ -557,16 +626,6 @@ impl MaintenanceJobInstruments {
                 &[("job", job)],
                 LATENCY_SECONDS_BOUNDARIES,
             ),
-        }
-    }
-
-    fn step(&self, conclusion: MaintenanceStepConclusion) -> &Arc<dyn CounterHandle> {
-        match conclusion {
-            MaintenanceStepConclusion::Progressed => &self.progressed,
-            MaintenanceStepConclusion::Idle => &self.idle,
-            MaintenanceStepConclusion::Blocked => &self.blocked,
-            MaintenanceStepConclusion::Superseded => &self.superseded,
-            MaintenanceStepConclusion::NotEnabled => &self.not_enabled,
         }
     }
 }
@@ -789,37 +848,16 @@ fn metric_level(value: usize) -> i64 {
 struct CompactionInstruments {
     running: Arc<dyn GaugeHandle>,
     queued: Arc<dyn GaugeHandle>,
-    completed: CompactionOutcomeInstruments,
-    failed: CompactionOutcomeInstruments,
-    superseded: CompactionOutcomeInstruments,
-    cancelled: CompactionOutcomeInstruments,
-    fenced: CompactionOutcomeInstruments,
+    outcomes: LabeledCounters<CompactionOutcome>,
+    outcome_seconds: Vec<Arc<dyn HistogramHandle>>,
     input_rows: Arc<dyn CounterHandle>,
     output_rows: Arc<dyn CounterHandle>,
     input_bytes: Arc<dyn CounterHandle>,
     output_bytes: Arc<dyn CounterHandle>,
 }
 
-struct CompactionOutcomeInstruments {
-    count: Arc<dyn CounterHandle>,
-    seconds: Arc<dyn HistogramHandle>,
-}
-
 impl CompactionInstruments {
     fn register(recorder: &dyn MetricsRecorder) -> Self {
-        let outcome = |outcome: CompactionOutcome| CompactionOutcomeInstruments {
-            count: recorder.register_counter(
-                "loonfs.maintenance.compactions",
-                "Streaming metadata compactions by outcome",
-                &[("outcome", outcome.as_str())],
-            ),
-            seconds: recorder.register_histogram(
-                "loonfs.maintenance.compaction_seconds",
-                "Duration of a finished streaming metadata compaction in seconds",
-                &[("outcome", outcome.as_str())],
-                LATENCY_SECONDS_BOUNDARIES,
-            ),
-        };
         let rows = |direction: &'static str| {
             recorder.register_counter(
                 "loonfs.maintenance.compaction_rows",
@@ -846,11 +884,24 @@ impl CompactionInstruments {
                  process permit",
                 &[],
             ),
-            completed: outcome(CompactionOutcome::Completed),
-            failed: outcome(CompactionOutcome::Failed),
-            superseded: outcome(CompactionOutcome::Superseded),
-            cancelled: outcome(CompactionOutcome::Cancelled),
-            fenced: outcome(CompactionOutcome::Fenced),
+            outcomes: LabeledCounters::register(
+                recorder,
+                "loonfs.maintenance.compactions",
+                "Streaming metadata compactions by outcome",
+                "outcome",
+                &[],
+            ),
+            outcome_seconds: CompactionOutcome::VALUES
+                .iter()
+                .map(|outcome| {
+                    recorder.register_histogram(
+                        "loonfs.maintenance.compaction_seconds",
+                        "Duration of a finished streaming metadata compaction in seconds",
+                        &[("outcome", outcome.as_str())],
+                        LATENCY_SECONDS_BOUNDARIES,
+                    )
+                })
+                .collect(),
             input_rows: rows("input"),
             output_rows: rows("output"),
             input_bytes: bytes("input"),
@@ -858,14 +909,8 @@ impl CompactionInstruments {
         }
     }
 
-    fn outcome(&self, outcome: CompactionOutcome) -> &CompactionOutcomeInstruments {
-        match outcome {
-            CompactionOutcome::Completed => &self.completed,
-            CompactionOutcome::Failed => &self.failed,
-            CompactionOutcome::Superseded => &self.superseded,
-            CompactionOutcome::Cancelled => &self.cancelled,
-            CompactionOutcome::Fenced => &self.fenced,
-        }
+    fn outcome_seconds(&self, outcome: CompactionOutcome) -> &Arc<dyn HistogramHandle> {
+        &self.outcome_seconds[outcome.index()]
     }
 }
 
@@ -877,19 +922,11 @@ struct PublisherInstruments {
     queue_depth: Arc<dyn GaugeHandle>,
     retained_projections: Arc<dyn GaugeHandle>,
     retained_projection_bytes: Arc<dyn GaugeHandle>,
-    published_ok: Arc<dyn CounterHandle>,
-    published_error: Arc<dyn CounterHandle>,
+    publishes: LabeledCounters<PublishOutcome>,
 }
 
 impl PublisherInstruments {
     fn register(recorder: &dyn MetricsRecorder) -> Self {
-        let publishes = |outcome: PublishOutcome| {
-            recorder.register_counter(
-                "loonfs.publisher.publishes",
-                "Publication results delivered to their callers",
-                &[("result", outcome.as_str())],
-            )
-        };
         Self {
             batches: recorder.register_counter(
                 "loonfs.publisher.batches",
@@ -922,15 +959,13 @@ impl PublisherInstruments {
                 "Decoded bytes held by the retained WAL-tail projections",
                 &[],
             ),
-            published_ok: publishes(PublishOutcome::Ok),
-            published_error: publishes(PublishOutcome::Error),
-        }
-    }
-
-    fn publish(&self, outcome: PublishOutcome) -> &Arc<dyn CounterHandle> {
-        match outcome {
-            PublishOutcome::Ok => &self.published_ok,
-            PublishOutcome::Error => &self.published_error,
+            publishes: LabeledCounters::register(
+                recorder,
+                "loonfs.publisher.publishes",
+                "Publication results delivered to their callers",
+                "result",
+                &[],
+            ),
         }
     }
 }

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -11,24 +11,27 @@
 use crate::fs::{ReadCore, WriterBits};
 use crate::metrics::{PublishOutcome, RESULT_OK};
 use crate::publish::CommitCandidate;
-use crate::trace::phase_span;
+use crate::trace::{phase_event, phase_span};
 use crate::{
     CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeCacheConfig, RuntimeError,
 };
 use futures::FutureExt;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::{ChangeSeq, CommitId, NamespaceId};
+use loonfs_core::cache::Recency;
 use loonfs_core::commit::{CommitFingerprint, CommitHeadPublishError};
 use loonfs_core::limits::CONTENTION_RETRY_LIMIT;
 use loonfs_core::publish::{NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState};
+use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::collections::{HashMap, VecDeque};
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
-use tokio::sync::oneshot;
+use tokio::runtime::Handle;
 use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
-use tokio::time::{Duration, Instant};
+use tokio::time::Duration;
 use tracing::Instrument;
 
 type CommitResult = Result<ApiCommitResponse, RuntimeError>;
@@ -82,6 +85,8 @@ pub struct PublisherRegistry {
     /// once the writer is gone, so dropping the writer stops new work
     /// without ever leaving the caches or store dangling.
     writer: Weak<WriterBits>,
+    runtime: Handle,
+    timer: Arc<dyn MonotonicTimer>,
     min_publish_interval: Duration,
 }
 
@@ -131,45 +136,26 @@ impl RegistryShared {
         weight: Option<PublishTailWeight>,
         budget: &RuntimeCacheConfig,
     ) -> RetainedProjectionTotals {
-        let victims = {
-            let mut state = self.lock_state();
-            state.projections.record(namespace_id, weight);
-            let selected = state.projections.over_budget_victims(budget);
-            selected
-                .into_iter()
-                .map(|victim| {
-                    let publisher = state.publishers.get(&victim.namespace_id).cloned();
-                    (victim, publisher)
-                })
-                .collect::<Vec<_>>()
-        };
-        // Invalidate projections without holding the registry lock.
-        // Publication may acquire the engine lock before the registry lock,
-        // so eviction must not acquire them in the opposite order.
-        let dropped = victims
-            .into_iter()
-            .filter(|(_, publisher)| {
-                // No publisher means no engine, so nothing is retained under
-                // that namespace either way.
-                publisher
-                    .as_ref()
-                    .is_none_or(NamespacePublisher::invalidate_projection)
-            })
-            .map(|(victim, _)| victim)
-            .collect::<Vec<_>>();
-
         let mut state = self.lock_state();
-        for victim in dropped {
-            state.projections.forget_recorded(&victim);
+        state.projections.record(namespace_id, weight);
+        let attempts = state.projections.len();
+        for _ in 0..attempts {
+            if !state.projections.is_over_budget(budget) {
+                break;
+            }
+            let Some(victim) = state.projections.oldest() else {
+                break;
+            };
+            if state
+                .publishers
+                .get(&victim)
+                .is_none_or(NamespacePublisher::invalidate_projection)
+            {
+                state.projections.remove_entry(&victim);
+            } else {
+                state.projections.retain(&victim);
+            }
         }
-        state.projections.totals()
-    }
-
-    /// Forgets one namespace's retained projection after something outside
-    /// the publish path dropped it.
-    fn forget_projection(&self, namespace_id: &NamespaceId) -> RetainedProjectionTotals {
-        let mut state = self.lock_state();
-        state.projections.forget(namespace_id);
         state.projections.totals()
     }
 }
@@ -182,22 +168,10 @@ impl RegistryShared {
 /// namespaces actually holds.
 #[derive(Debug, Default)]
 struct RetainedProjections {
-    /// Least-recently-published first, one entry per namespace whose engine
-    /// retains a projection.
-    entries: VecDeque<RetainedProjection>,
+    entries: HashMap<NamespaceId, (PublishTailWeight, u64)>,
+    order: Recency<NamespaceId>,
     rows: usize,
     decoded_bytes: usize,
-    next_stamp: u64,
-}
-
-#[derive(Debug, Clone)]
-struct RetainedProjection {
-    namespace_id: NamespaceId,
-    weight: PublishTailWeight,
-    /// Distinguishes the projection a sweep selected from a newer one the
-    /// namespace published while that sweep ran outside the lock, so a
-    /// completed eviction never forgets a live projection.
-    stamp: u64,
 }
 
 /// What the writer retains right now, for the gauges and for tests.
@@ -212,74 +186,59 @@ impl RetainedProjections {
     /// Records what one namespace retains after a publish; `None` is a
     /// publish that kept nothing.
     fn record(&mut self, namespace_id: &NamespaceId, weight: Option<PublishTailWeight>) {
-        self.forget(namespace_id);
+        self.remove_entry(namespace_id);
         let Some(weight) = weight else {
             return;
         };
-        self.next_stamp += 1;
+        let last_touch = self.order.touch(namespace_id);
         self.rows = self.rows.saturating_add(weight.rows);
         self.decoded_bytes = self.decoded_bytes.saturating_add(weight.decoded_bytes);
-        self.entries.push_back(RetainedProjection {
-            namespace_id: namespace_id.clone(),
-            weight,
-            stamp: self.next_stamp,
-        });
+        self.entries
+            .insert(namespace_id.clone(), (weight, last_touch));
+        self.compact_order();
     }
 
     fn forget(&mut self, namespace_id: &NamespaceId) {
-        let index = self
-            .entries
-            .iter()
-            .position(|entry| entry.namespace_id == *namespace_id);
-        self.remove_entry(index);
+        self.remove_entry(namespace_id);
     }
 
-    /// Forgets exactly the projection an eviction dropped. A namespace that
-    /// published again while the sweep ran outside the lock carries a newer
-    /// stamp, so its live projection stays accounted.
-    fn forget_recorded(&mut self, recorded: &RetainedProjection) {
-        let index = self
-            .entries
-            .iter()
-            .position(|entry| entry.stamp == recorded.stamp);
-        self.remove_entry(index);
+    fn retain(&mut self, namespace_id: &NamespaceId) {
+        let last_touch = self.order.touch(namespace_id);
+        if let Some((_, entry_last_touch)) = self.entries.get_mut(namespace_id) {
+            *entry_last_touch = last_touch;
+        }
+        self.compact_order();
     }
 
-    /// Drops one entry and its weight from the totals. At most one entry per
-    /// namespace exists, so callers locate it by whichever key they hold.
-    fn remove_entry(&mut self, index: Option<usize>) {
-        let Some(entry) = index.and_then(|index| self.entries.remove(index)) else {
+    fn remove_entry(&mut self, namespace_id: &NamespaceId) {
+        let Some((weight, _)) = self.entries.remove(namespace_id) else {
             return;
         };
-        self.rows = self.rows.saturating_sub(entry.weight.rows);
-        self.decoded_bytes = self
-            .decoded_bytes
-            .saturating_sub(entry.weight.decoded_bytes);
+        self.rows = self.rows.saturating_sub(weight.rows);
+        self.decoded_bytes = self.decoded_bytes.saturating_sub(weight.decoded_bytes);
     }
 
-    /// Selects least-recently-published projections until the remaining totals
-    /// fit the same three limits used by the read-side projection cache.
-    ///
-    /// Selection does not change accounting. Totals are updated only after a
-    /// selected projection is actually invalidated.
-    fn over_budget_victims(&self, budget: &RuntimeCacheConfig) -> Vec<RetainedProjection> {
-        let mut projections = self.entries.len();
-        let mut rows = self.rows;
-        let mut decoded_bytes = self.decoded_bytes;
-        let mut victims = Vec::new();
-        for entry in &self.entries {
-            if projections <= budget.max_cached_namespaces
-                && rows <= budget.max_cached_wal_tail_projection_rows
-                && decoded_bytes <= budget.max_cached_wal_tail_projection_decoded_bytes
-            {
-                break;
-            }
-            projections = projections.saturating_sub(1);
-            rows = rows.saturating_sub(entry.weight.rows);
-            decoded_bytes = decoded_bytes.saturating_sub(entry.weight.decoded_bytes);
-            victims.push(entry.clone());
-        }
-        victims
+    fn oldest(&mut self) -> Option<NamespaceId> {
+        let entries = &self.entries;
+        self.order
+            .pop_oldest(|namespace_id, stamp| projection_is_live(entries, namespace_id, stamp))
+    }
+
+    fn compact_order(&mut self) {
+        let entries = &self.entries;
+        self.order.compact(entries.len(), |namespace_id, stamp| {
+            projection_is_live(entries, namespace_id, stamp)
+        });
+    }
+
+    fn is_over_budget(&self, budget: &RuntimeCacheConfig) -> bool {
+        self.entries.len() > budget.max_cached_namespaces
+            || self.rows > budget.max_cached_wal_tail_projection_rows
+            || self.decoded_bytes > budget.max_cached_wal_tail_projection_decoded_bytes
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
     }
 
     fn totals(&self) -> RetainedProjectionTotals {
@@ -291,6 +250,16 @@ impl RetainedProjections {
     }
 }
 
+fn projection_is_live(
+    entries: &HashMap<NamespaceId, (PublishTailWeight, u64)>,
+    namespace_id: &NamespaceId,
+    stamp: u64,
+) -> bool {
+    entries
+        .get(namespace_id)
+        .is_some_and(|(_, last_touch)| *last_touch == stamp)
+}
+
 impl PublisherRegistry {
     /// Creates the registry a writer owns. Batches publish through each
     /// publisher's own commit engine and writer session, and the writer's
@@ -299,6 +268,7 @@ impl PublisherRegistry {
     pub(crate) fn new(
         read_core: ReadCore,
         writer: Weak<WriterBits>,
+        runtime: Handle,
         min_publish_interval: Duration,
     ) -> Self {
         Self {
@@ -312,6 +282,8 @@ impl PublisherRegistry {
             }),
             read_core,
             writer,
+            runtime,
+            timer: Arc::new(StdMonotonicTimer::default()),
             min_publish_interval,
         }
     }
@@ -346,21 +318,20 @@ impl PublisherRegistry {
     /// operation validates the live head and reports its retained projection when
     /// it completes.
     pub(crate) fn invalidate_projection(&self, namespace_id: &NamespaceId) {
-        let publisher = self
-            .shared
-            .lock_state()
-            .publishers
-            .get(namespace_id)
-            .cloned();
-        let Some(publisher) = publisher else {
-            return;
+        let totals = {
+            let mut state = self.shared.lock_state();
+            let Some(publisher) = state.publishers.get(namespace_id) else {
+                return;
+            };
+            if !publisher.invalidate_projection() {
+                return;
+            }
+            state.projections.remove_entry(namespace_id);
+            state.projections.totals()
         };
-        if publisher.invalidate_projection() {
-            let totals = self.shared.forget_projection(namespace_id);
-            self.read_core
-                .instruments()
-                .publisher_retained_projections(totals.projections, totals.decoded_bytes);
-        }
+        self.read_core
+            .instruments()
+            .publisher_retained_projections(totals.projections, totals.decoded_bytes);
     }
 
     /// Looks up or creates the namespace's publisher, refusing once
@@ -379,6 +350,8 @@ impl PublisherRegistry {
                     self.read_core.clone(),
                     self.writer.clone(),
                     Arc::downgrade(&self.shared),
+                    self.runtime.clone(),
+                    Arc::clone(&self.timer),
                     self.min_publish_interval,
                 )
             })
@@ -452,6 +425,8 @@ struct NamespacePublisher {
     /// back would cycle the whole structure into a leak. A publisher whose
     /// registry is gone keeps serving, with an unowned worker.
     shared: Weak<RegistryShared>,
+    runtime: Handle,
+    timer: Arc<dyn MonotonicTimer>,
     min_publish_interval: Duration,
 }
 
@@ -497,17 +472,20 @@ struct NamespacePublisherState {
     worker: Option<WorkerHandle>,
     /// Earliest instant the next head compare-and-swap may start. `None` is
     /// a cold namespace: it publishes immediately.
-    next_allowed_cas_at: Option<Instant>,
+    next_allowed_cas_at: Option<u64>,
 }
 
-/// One publisher's worker task, split so a drain can await it without
-/// making the publisher look idle.
 struct WorkerHandle {
-    /// Taken by a drain, which awaits it. The task itself is unaffected.
-    task: Option<JoinHandle<()>>,
-    /// Answers admission's single-flight check, which must stay answerable
-    /// while a drain holds `task`. Never used to abort.
-    liveness: tokio::task::AbortHandle,
+    _task: JoinHandle<()>,
+    liveness: watch::Receiver<bool>,
+}
+
+struct WorkerExit(watch::Sender<bool>);
+
+impl Drop for WorkerExit {
+    fn drop(&mut self) {
+        let _ = self.0.send(true);
+    }
 }
 
 struct PendingDelete {
@@ -528,7 +506,7 @@ struct OpenBatch {
 struct BatchCandidate {
     commit_id: CommitId,
     candidate: CommitCandidate,
-    enqueued_at: Instant,
+    enqueued_at: u64,
 }
 
 struct InFlightRequest {
@@ -556,6 +534,8 @@ impl NamespacePublisher {
         read_core: ReadCore,
         writer: Weak<WriterBits>,
         shared: Weak<RegistryShared>,
+        runtime: Handle,
+        timer: Arc<dyn MonotonicTimer>,
         min_publish_interval: Duration,
     ) -> Self {
         Self {
@@ -574,6 +554,8 @@ impl NamespacePublisher {
                 session: SharedWriterSessionState::default(),
             })),
             shared,
+            runtime,
+            timer,
             min_publish_interval,
         }
     }
@@ -623,9 +605,8 @@ impl NamespacePublisher {
     /// writer's shared projection budget.
     ///
     /// The caller still holds the engine lock, so the recorded weight matches the
-    /// projection in the engine. This path may acquire the registry lock while
-    /// holding the engine lock. Eviction avoids deadlock by releasing the
-    /// registry lock before attempting to lock any engine.
+    /// projection in the engine. Eviction only tries engine locks, so it
+    /// does not wait while holding the registry lock.
     fn settle_retained_projection(&self, weight: Option<PublishTailWeight>) {
         let Some(shared) = self.shared.upgrade() else {
             return;
@@ -647,11 +628,9 @@ impl NamespacePublisher {
     /// claim on its commit ID, or returns an error. Once the candidate enters
     /// the queue, cancelling the caller only drops result delivery; the worker
     /// still owns and publishes the request.
-    #[allow(clippy::disallowed_methods)]
-    // Monotonic time is used only to record queue latency.
     async fn submit(&self, candidate: CommitCandidate) -> CommitResult {
         let commit_id = candidate.commit_id().clone();
-        let enqueued_at = Instant::now();
+        let enqueued_at = self.timer.monotonic_now_ms();
         let mut candidate = candidate;
         let mut semantic_identity = candidate.semantic_identity(&self.namespace_id)?;
         for _ in 0..CONTENTION_RETRY_LIMIT {
@@ -704,7 +683,7 @@ impl NamespacePublisher {
         candidate: CommitCandidate,
         semantic_identity: CommitFingerprint,
         waiter: oneshot::Sender<CommitResult>,
-        enqueued_at: Instant,
+        enqueued_at: u64,
     ) -> Result<SubmissionAdmission, CoreError> {
         let mut state = self.lock_state();
         self.check_admission(&state)?;
@@ -799,31 +778,32 @@ impl NamespacePublisher {
         if state
             .worker
             .as_ref()
-            .is_some_and(|worker| !worker.liveness.is_finished())
+            .is_some_and(|worker| !*worker.liveness.borrow())
         {
             return;
         }
         let publisher = self.clone();
-        let task = tokio::spawn(async move {
+        let (exit, liveness) = watch::channel(false);
+        let exit = WorkerExit(exit);
+        let task = self.runtime.spawn(async move {
+            let _exit = exit;
             publisher.run_worker().await;
         });
         state.worker = Some(WorkerHandle {
-            liveness: task.abort_handle(),
-            task: Some(task),
+            _task: task,
+            liveness,
         });
     }
 
     /// Drains the queue in admission order, then exits.
-    #[allow(clippy::disallowed_methods)]
-    // Monotonic time is used only to record batch collection latency.
     async fn run_worker(self) {
         loop {
-            let collect_started = Instant::now();
+            let collect_started = self.timer.monotonic_now_ms();
             let queue_depth_start = queued_candidates(&self.lock_state());
             // Do not add a separate batching delay. The first request for an idle
             // namespace publishes immediately; requests arriving during a publish or
             // pacing interval form the next batch.
-            self.await_cas_slot(false).await;
+            self.await_cas_slot().await;
             let Some(item) = self.take_next_item() else {
                 return;
             };
@@ -833,14 +813,15 @@ impl NamespacePublisher {
                     self.read_core
                         .instruments()
                         .publisher_batch(batch.candidates.len());
-                    tracing::info!(
-                        phase = "batch_collect",
-                        mode = self.read_core.trace_mode(),
-                        store_kind = self.read_core.trace_store_kind(),
+                    phase_event!(
+                        self.read_core,
+                        "batch_collect",
+                        self.namespace_id,
+                        tracing::Level::INFO,
                         batch_size = usize_to_u64(batch.candidates.len()),
                         queue_depth_start = usize_to_u64(queue_depth_start),
                         queue_depth_end = usize_to_u64(batch.candidates.len()),
-                        collect_ms = elapsed_ms_since(collect_started)
+                        collect_ms = self.elapsed_ms_since(collect_started)
                     );
                     self.publish_batch(batch.candidates).await;
                 }
@@ -858,8 +839,6 @@ impl NamespacePublisher {
     /// Ownership is released under the same lock that finds the queue empty,
     /// so a racing admission either queued before this check and is taken
     /// here, or finds no worker and spawns one.
-    #[allow(clippy::disallowed_methods)]
-    // Monotonic time is used only to pace CAS attempts.
     fn take_next_item(&self) -> Option<WorkItem> {
         let mut state = self.lock_state();
         // Terminal: a successful delete emptied the queue and set this
@@ -869,7 +848,7 @@ impl NamespacePublisher {
             return None;
         }
         let item = state.queue.pop_front();
-        state.next_allowed_cas_at = Some(Instant::now() + self.min_publish_interval);
+        self.reserve_next_cas_slot(&mut state);
         let queue_depth = queued_candidates(&state);
         drop(state);
         self.read_core
@@ -914,15 +893,14 @@ impl NamespacePublisher {
         }
     }
 
-    #[allow(clippy::disallowed_methods)]
-    // Monotonic time is used only to record publication latency.
     async fn publish_taken_batch(&self, candidates: Vec<BatchCandidate>) {
-        let selected_at = Instant::now();
+        let selected_at = self.timer.monotonic_now_ms();
         for candidate in &candidates {
-            tracing::info!(
-                phase = "wait_for_batch",
-                mode = self.read_core.trace_mode(),
-                store_kind = self.read_core.trace_store_kind(),
+            phase_event!(
+                self.read_core,
+                "wait_for_batch",
+                self.namespace_id,
+                tracing::Level::DEBUG,
                 result = RESULT_OK,
                 wait_ms = elapsed_ms_from(candidate.enqueued_at, selected_at)
             );
@@ -959,7 +937,7 @@ impl NamespacePublisher {
                     break;
                 }
                 retry_count += 1;
-                self.await_cas_slot(true).await;
+                self.claim_cas_slot().await;
             }
             (results, retry_count)
         }
@@ -1090,48 +1068,57 @@ impl NamespacePublisher {
 
     /// Waits for the running worker, if any.
     ///
-    /// Only the join handle is taken; the liveness half stays in the slot,
-    /// so an admission racing this drain still sees a live worker instead of
-    /// spawning a second one for the same queue.
     async fn wait_for_worker(&self) {
-        let task = self
+        let mut liveness = self
             .lock_state()
             .worker
-            .as_mut()
-            .and_then(|worker| worker.task.take());
-        if let Some(task) = task {
-            let _ = task.await;
+            .as_ref()
+            .map(|worker| worker.liveness.clone());
+        if let Some(liveness) = liveness.as_mut() {
+            while !*liveness.borrow_and_update() {
+                if liveness.changed().await.is_err() {
+                    break;
+                }
+            }
         }
     }
 
     /// Waits until the namespace may start another head CAS.
-    ///
-    /// When `claim` is true, this method also reserves the next slot by advancing
-    /// the deadline one pacing interval. When false, it only waits; the caller
-    /// reserves the slot when it removes work from the queue.
-    #[allow(clippy::disallowed_methods)]
-    // Monotonic time is used only to wait between CAS attempts.
-    async fn await_cas_slot(&self, claim: bool) {
+    async fn await_cas_slot(&self) {
         loop {
             let Some(sleep_until) = self.lock_state().next_allowed_cas_at else {
                 break;
             };
-            if sleep_until <= Instant::now() {
+            let now_ms = self.timer.monotonic_now_ms();
+            if sleep_until <= now_ms {
                 break;
             }
-            tokio::time::sleep_until(sleep_until).await;
+            wait_for_cas_pacing(Duration::from_millis(sleep_until - now_ms)).await;
         }
-        if claim {
-            let mut state = self.lock_state();
-            state.next_allowed_cas_at = Some(Instant::now() + self.min_publish_interval);
-        }
+    }
+
+    async fn claim_cas_slot(&self) {
+        self.await_cas_slot().await;
+        self.reserve_next_cas_slot(&mut self.lock_state());
+    }
+
+    fn reserve_next_cas_slot(&self, state: &mut NamespacePublisherState) {
+        state.next_allowed_cas_at = Some(
+            self.timer
+                .monotonic_now_ms()
+                .saturating_add(duration_ms(self.min_publish_interval)),
+        );
+    }
+
+    fn elapsed_ms_since(&self, started_at_ms: u64) -> u64 {
+        elapsed_ms_from(started_at_ms, self.timer.monotonic_now_ms())
     }
 
     fn deliver_batch_results(
         &self,
         candidates: Vec<BatchCandidate>,
         results: Vec<CommitResult>,
-        selected_at: Instant,
+        selected_at: u64,
     ) {
         let mut deliveries = Vec::new();
         let mut wait_traces = Vec::new();
@@ -1155,7 +1142,7 @@ impl NamespacePublisher {
                         .next()
                         .expect("equal-length batch should hold one result per candidate"),
                 };
-                wait_traces.push((result_label(&result), elapsed_ms_since(selected_at)));
+                wait_traces.push((result_label(&result), self.elapsed_ms_since(selected_at)));
                 if let Some(in_flight) = state.in_flight.remove(&candidate.commit_id) {
                     for waiter in in_flight.waiters {
                         deliveries.push((waiter, result.clone()));
@@ -1166,10 +1153,11 @@ impl NamespacePublisher {
 
         for (outcome, wait_ms) in wait_traces {
             self.read_core.instruments().publisher_publish(outcome);
-            tracing::info!(
-                phase = "wait_for_result",
-                mode = self.read_core.trace_mode(),
-                store_kind = self.read_core.trace_store_kind(),
+            phase_event!(
+                self.read_core,
+                "wait_for_result",
+                self.namespace_id,
+                tracing::Level::DEBUG,
                 result = outcome.as_str(),
                 wait_ms
             );
@@ -1184,10 +1172,11 @@ impl NamespacePublisher {
         self.read_core
             .instruments()
             .publisher_queue_depth(queue_depth);
-        tracing::info!(
-            phase = "enqueue",
-            mode = self.read_core.trace_mode(),
-            store_kind = self.read_core.trace_store_kind(),
+        phase_event!(
+            self.read_core,
+            "enqueue",
+            self.namespace_id,
+            tracing::Level::DEBUG,
             queue_depth = usize_to_u64(queue_depth),
             reason
         );
@@ -1264,16 +1253,18 @@ fn batch_result_label(results: &[CommitResult]) -> PublishOutcome {
     }
 }
 
-fn elapsed_ms_since(start: Instant) -> u64 {
-    duration_ms(start.elapsed())
-}
-
-fn elapsed_ms_from(start: Instant, end: Instant) -> u64 {
-    duration_ms(end.saturating_duration_since(start))
+fn elapsed_ms_from(start: u64, end: u64) -> u64 {
+    end.saturating_sub(start)
 }
 
 fn duration_ms(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[allow(clippy::disallowed_methods)]
+// The configured CAS pacing delay does not affect publication validity.
+async fn wait_for_cas_pacing(delay: Duration) {
+    tokio::time::sleep(delay).await;
 }
 
 fn usize_to_u64(value: usize) -> u64 {

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -28,6 +28,7 @@ use loonfs_test_support::stores::{
     BlockingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
 };
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Condvar;
 use tempfile::tempdir;
 use tokio::time::timeout;
@@ -211,7 +212,7 @@ fn test_writer_bits() -> Arc<WriterBits> {
         identity: WriterIdentity::new("writer-a".to_owned()).expect("valid writer identity"),
         maintenance: MaintenanceRunner::new(
             crate::FsBackgroundWork::ManualOnly,
-            None,
+            tokio::runtime::Handle::current(),
             std::num::NonZeroUsize::new(1).expect("nonzero"),
             RuntimeInstruments::new(None),
         ),
@@ -287,13 +288,18 @@ fn retained_projections(registry: &PublisherRegistry) -> RetainedProjectionTotal
 /// The namespaces whose projections the registry still holds, least
 /// recently published first.
 fn retained_namespaces(registry: &PublisherRegistry) -> Vec<NamespaceId> {
-    registry
+    let mut entries = registry
         .shared
         .lock_state()
         .projections
         .entries
         .iter()
-        .map(|entry| entry.namespace_id.clone())
+        .map(|(namespace_id, (_, last_touch))| (namespace_id.clone(), *last_touch))
+        .collect::<Vec<_>>();
+    entries.sort_by_key(|(_, last_touch)| *last_touch);
+    entries
+        .into_iter()
+        .map(|(namespace_id, _)| namespace_id)
         .collect()
 }
 
@@ -340,6 +346,21 @@ async fn create_namespace(runtime: &TestRuntime, namespace_id: &NamespaceId) {
 /// `wait_past_cas_pacing` outlasting it is meaningful.
 const TEST_STANDALONE_PACING: Duration = Duration::from_secs(1);
 
+#[derive(Debug, Default)]
+struct ManualMonotonicTimer(AtomicU64);
+
+impl ManualMonotonicTimer {
+    fn set(&self, now_ms: u64) {
+        self.0.store(now_ms, AtomicOrdering::Release);
+    }
+}
+
+impl loonfs_objectstore::timing::MonotonicTimer for ManualMonotonicTimer {
+    fn monotonic_now_ms(&self) -> u64 {
+        self.0.load(AtomicOrdering::Acquire)
+    }
+}
+
 fn publisher_state(
     publisher: &NamespacePublisher,
 ) -> std::sync::MutexGuard<'_, NamespacePublisherState> {
@@ -354,7 +375,7 @@ fn single_live_worker(publisher: &NamespacePublisher) -> bool {
     publisher_state(publisher)
         .worker
         .as_ref()
-        .is_some_and(|worker| !worker.liveness.is_finished())
+        .is_some_and(|worker| !*worker.liveness.borrow())
 }
 
 /// Yields until the publisher's queue holds at least `expected` candidates
@@ -440,6 +461,8 @@ fn standalone_publisher(namespace_id: &NamespaceId, runtime: &TestRuntime) -> Na
         runtime.core.clone(),
         Arc::downgrade(&runtime.bits),
         Weak::new(),
+        tokio::runtime::Handle::current(),
+        Arc::new(loonfs_objectstore::timing::StdMonotonicTimer::default()),
         TEST_STANDALONE_PACING,
     )
 }
@@ -489,8 +512,6 @@ fn try_admit_commit(
     try_admit_candidate(publisher, namespace_id, candidate)
 }
 
-#[allow(clippy::disallowed_methods)]
-// This timestamp is used only by publisher wait metrics.
 fn try_admit_candidate(
     publisher: &NamespacePublisher,
     namespace_id: &NamespaceId,
@@ -504,7 +525,7 @@ fn try_admit_candidate(
         candidate,
         semantic_identity,
         sender,
-        Instant::now(),
+        publisher.timer.monotonic_now_ms(),
     )?;
     assert!(matches!(admission, SubmissionAdmission::OwnOutcome));
     Ok(receiver)
@@ -533,8 +554,6 @@ fn publisher_trace_labels_are_low_cardinality() {
 }
 
 #[tokio::test]
-#[allow(clippy::disallowed_methods)]
-// Monotonic time is used only by publisher wait metrics in this test.
 async fn publisher_delivery_preserves_bootstrap_namespace_exists_code() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -554,7 +573,7 @@ async fn publisher_delivery_preserves_bootstrap_namespace_exists_code() {
             waiters: vec![sender],
         },
     );
-    let selected_at = Instant::now();
+    let selected_at = publisher.timer.monotonic_now_ms();
     publisher.deliver_batch_results(
         vec![BatchCandidate {
             commit_id,
@@ -995,7 +1014,9 @@ async fn hot_submissions_wait_out_the_pacing_interval() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let writer = test_writer_with_interval(store.clone(), 400).await;
+    let mut writer = test_writer_with_interval(store.clone(), 400).await;
+    let timer = Arc::new(ManualMonotonicTimer::default());
+    writer.publisher.timer = timer.clone();
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -1023,12 +1044,14 @@ async fn hot_submissions_wait_out_the_pacing_interval() {
         }
     });
     tokio::task::yield_now().await;
+    timer.set(399);
     tokio::time::advance(Duration::from_millis(399)).await;
     tokio::task::yield_now().await;
     assert!(
         !hot.is_finished(),
         "a follow-up publication must remain paced before the interval boundary"
     );
+    timer.set(400);
     tokio::time::advance(Duration::from_millis(1)).await;
     hot.await
         .expect("join hot publication")

--- a/crates/loonfs/src/trace.rs
+++ b/crates/loonfs/src/trace.rs
@@ -82,6 +82,21 @@ macro_rules! phase_span {
 
 pub(crate) use phase_span;
 
+macro_rules! phase_event {
+    ($core:expr, $phase:literal, $namespace_id:expr, $level:expr $(, $($field:tt)+)?) => {
+        tracing::event!(
+            $level,
+            phase = $phase,
+            namespace_id = %$namespace_id,
+            mode = $core.trace_mode(),
+            store_kind = $core.trace_store_kind(),
+            $($($field)+)?
+        )
+    };
+}
+
+pub(crate) use phase_event;
+
 /// The `cache_path` trace label for a read served through the materialized
 /// metadata segments. The only value the label takes today.
 pub(crate) const CACHE_MATERIALIZED_SEGMENTS: &str = "materialized_segments";

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -11,7 +11,6 @@ use loonfs::{
     PutFileOptions, StatPathOptions, UpdateAttributesOptions,
 };
 use loonfs_api::semantic_commit_fingerprint;
-use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::{attribute_key, attribute_text, namespace_id, page_limit};
 use std::collections::BTreeMap;
 use tempfile::tempdir;

--- a/crates/loonfs/tests/it/attribution_rows.rs
+++ b/crates/loonfs/tests/it/attribution_rows.rs
@@ -8,7 +8,6 @@ use loonfs::{
     DestinationBehavior, MaintenancePlan, MoveOptions, PageRequest, PutFileOptions,
     RestoreRevisionOptions, RevisionNo, UpdateAttributesOptions,
 };
-use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::{attribute_key, attribute_text, namespace_id, page_limit};
 use std::collections::BTreeMap;
 use tempfile::tempdir;

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -5,6 +5,7 @@
 // Fixture assertions panic for precise diagnostics, as the test modules do.
 
 use loonfs::publish::{CommitCandidate, CommitRequest};
+use loonfs::uploads::ResolvedUploadCompletion;
 use loonfs::{
     AdvanceRetentionResponse, BeginUploadRequest, BeginUploadResponse, ChangeSeq, Checkpoint,
     ChecksumAlgorithm, CommitResponse, ContentRef, CopyOptions, CreateCheckpointOptions,
@@ -16,12 +17,22 @@ use loonfs::{
     UploadSession,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::stores::{
     CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
 };
 use std::path::Path;
 use std::sync::Arc;
+
+thread_local! {
+    static BLOCKING_RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime");
+}
+
+pub(crate) fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+    BLOCKING_RUNTIME.with(|runtime| runtime.block_on(future))
+}
 
 pub(crate) fn store(root: &Path) -> SharedObjectStore {
     Arc::new(LocalFsStore::new(root).expect("create local-fs store"))
@@ -560,7 +571,12 @@ impl RuntimeTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
     ) -> loonfs::Result<UploadSession> {
-        block_on(self.writer.complete_upload(namespace_id, upload_id))
+        block_on(self.writer.complete_upload(
+            namespace_id,
+            upload_id,
+            ResolvedUploadCompletion::KnownContent,
+        ))
+        .map(|completed| completed.response)
     }
 
     fn mutate_blocking(

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -6,6 +6,7 @@ use loonfs::publish::{
     parse_mutation_path, CommitCandidate, CommitRequest, ContentPreparationError,
     FilesystemOperation, PreparedContent,
 };
+use loonfs::uploads::ResolvedUploadCompletion;
 use loonfs::{
     BeginUploadRequest, CommitId, CoreError, CreateDirectoryOptions, CreateNamespaceOptions,
     DestinationBehavior, ErrorCode, FsWriter, NamespaceId, PutFileOptions, RevisionNo,
@@ -589,7 +590,11 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
 
     let completed = harness
         .writer
-        .complete_upload_prepared(&harness.namespace_id, begin.upload_id())
+        .complete_upload(
+            &harness.namespace_id,
+            begin.upload_id(),
+            ResolvedUploadCompletion::KnownContent,
+        )
         .await
         .expect("complete upload with proof");
     let prepared = completed.prepared;

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -6,6 +6,7 @@
 use crate::common::*;
 use bytes::Bytes;
 use loonfs::publish::{parse_mutation_path, CommitCandidate, CommitRequest, FilesystemOperation};
+use loonfs::uploads::ResolvedUploadCompletion;
 use loonfs::{
     BeginUploadRequest, ChangeSeq, ChecksumAlgorithm, CommitId, CreateDirectoryOptions,
     CreateNamespaceOptions, DestinationBehavior, ErrorCode, NamespaceId, PutFileOptions,
@@ -24,7 +25,6 @@ fn direct_put_claim(bytes: &[u8]) -> UploadContentClaim {
 }
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
-use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{
     CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
@@ -460,7 +460,11 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
                 .expect("upload content");
             let completed = fs
                 .writer
-                .complete_upload(&namespace_id, begin.upload_id())
+                .complete_upload(
+                    &namespace_id,
+                    begin.upload_id(),
+                    ResolvedUploadCompletion::KnownContent,
+                )
                 .await
                 .expect("complete upload");
             prepared_contents.push(
@@ -468,6 +472,7 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
                     &object_store,
                     &catalog,
                     completed
+                        .response
                         .content_ref()
                         .expect("completed content ref")
                         .clone(),

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -21,7 +21,6 @@ use loonfs_objectstore::keys::{
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
-use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{
     BlockingStore, CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,

--- a/crates/loonfs/tests/it/pagination.rs
+++ b/crates/loonfs/tests/it/pagination.rs
@@ -8,7 +8,6 @@ use loonfs::{
     CreateDirectoryOptions, CreateNamespaceOptions, DeleteDirectoryBehavior, DeleteOptions,
     DestinationBehavior, ErrorCode, InodeId, MoveOptions, PageRequest, PathEntry, PutFileOptions,
 };
-use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::{namespace_id, page_limit};
 use tempfile::tempdir;
 

--- a/crates/loonfs/tests/it/undelete.rs
+++ b/crates/loonfs/tests/it/undelete.rs
@@ -9,7 +9,6 @@ use loonfs::{
     ChangeSeq, CommitId, CreateNamespaceOptions, DeleteDirectoryBehavior, DeleteOptions,
     DestinationBehavior, ErrorCode, InodeId, ListChangesOptions, PutFileOptions, RuntimeError,
 };
-use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
 


### PR DESCRIPTION
This simplifies publisher state and makes background work run on the Tokio runtime that created the writer. Retained projections are updated and evicted under one registry lock, workers report completion through one channel, and publisher timing uses an injected monotonic clock.

The same pass shares common read, mutation, upload-completion, and metrics helpers. Wire formats, durable formats, and error codes are unchanged. The affected request types are now exported from loonfs::wire.