### PR TITLE
refactor(objectstore): use one adapter for cloud providers

### DIFF
--- a/crates/loonfs-conformance/src/server.rs
+++ b/crates/loonfs-conformance/src/server.rs
@@ -76,9 +76,11 @@ pub async fn start_server() -> Result<ConformanceServer, Box<dyn std::error::Err
     let issuer = Arc::new(LoopbackIssuer {
         base_url: format!("http://{provider_address}"),
     });
-    let transfers = DirectTransferIssuers::read_only(issuer.clone())
-        .with_put(issuer.clone())
-        .with_multipart(issuer);
+    let transfers = DirectTransferIssuers {
+        get: issuer.clone(),
+        put: Some(issuer.clone()),
+        multipart: Some(issuer),
+    };
 
     let config_path = temp_dir.path().join("loonfs-server.toml");
     write_server_config(&config_path, &store_root)?;

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -54,7 +54,7 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
         .put_immutable_verified(&manifest_key, manifest_bytes)
         .await
     {
-        Ok(()) => Ok(()),
+        Ok(_) => Ok(()),
         Err(ImmutableWriteError::DifferentObject { .. }) => Err(
             MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestObjectConflict {
                 object_key: manifest_key,

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -62,10 +62,7 @@ pub(crate) async fn create_control_object_under_generated_id<S: ObjectStore + ?S
         Ok(metadata) => Ok(metadata),
         Err(ObjectStoreError::PreconditionFailed { .. }) => Err(collision()),
         Err(ObjectStoreError::Transport { .. }) => {
-            match store
-                .put_immutable_verified_with_metadata(object_key, encoded)
-                .await
-            {
+            match store.put_immutable_verified(object_key, encoded).await {
                 Ok(metadata) => Ok(metadata),
                 Err(ImmutableWriteError::DifferentObject { .. }) => Err(collision()),
                 Err(ImmutableWriteError::Transport { source, .. }) => {

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -1,12 +1,11 @@
 //! Azure Blob Storage provider.
 
-use super::{ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::configured::ConfiguredObjectStoreKind;
+use crate::endpoint::parse_endpoint_url;
 use crate::object_store::Result;
+use crate::provider_object_store::CompareToken;
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs_api::SecretString;
 use object_store::azure::MicrosoftAzureBuilder;
 use std::sync::Arc;
@@ -18,7 +17,7 @@ pub struct AzureAbsStoreConfig {
     pub account_name: String,
     /// Blob container that acts as the LoonFS object-store root.
     pub container_name: String,
-    /// Shared account key; empty or whitespace-only credentials are rejected.
+    /// Shared account key used for request signing.
     pub access_key: SecretString,
     /// Azure-compatible service endpoint override, or `None` for the public Azure endpoint.
     pub endpoint_url: Option<String>,
@@ -26,150 +25,53 @@ pub struct AzureAbsStoreConfig {
     pub key_prefix: Option<String>,
 }
 
-/// Azure Blob Storage through its native API.
-///
-/// Authentication intentionally has one path: the caller must provide an
-/// account name and account access key explicitly. The adapter does not use SAS
-/// tokens, bearer tokens, managed identity, Azure CLI credentials, or ambient
-/// environment fallback.
-#[derive(Debug)]
-pub struct AzureAbsStore {
-    inner: ProviderObjectStore,
-    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
-    /// the connector inside the client holds only a handle onto it.
-    _io_runtime: StoreIoRuntime,
-}
-
-impl AzureAbsStore {
-    /// Builds a native Azure Blob adapter with its own bounded HTTP runtime.
-    ///
-    /// Construction fails for blank account, container, key, or endpoint
-    /// values, an invalid key prefix, runtime initialization, or provider-client configuration.
-    pub fn new(config: AzureAbsStoreConfig) -> Result<Self> {
-        if config.account_name.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "account name must not be empty".to_owned(),
-            ));
+/// Builds a native Azure Blob adapter with its own bounded HTTP runtime.
+pub fn azure_abs(config: AzureAbsStoreConfig) -> Result<ProviderObjectStore> {
+    let io_runtime = StoreIoRuntime::new()?;
+    let mut builder = MicrosoftAzureBuilder::new()
+        .with_http_connector(io_runtime.connector())
+        .with_client_options(crate::provider_object_store::provider_client_options())
+        .with_retry(crate::provider_object_store::provider_retry_config())
+        .with_account(config.account_name)
+        .with_container_name(config.container_name)
+        .with_access_key(config.access_key.expose());
+    if let Some(endpoint_url) = config.endpoint_url {
+        let endpoint_url = endpoint_url.trim();
+        let parsed = parse_endpoint_url(endpoint_url)?;
+        if parsed.scheme == "http" {
+            builder = builder.with_allow_http(true);
         }
-        if config.container_name.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "container name must not be empty".to_owned(),
-            ));
-        }
-        if config.access_key.expose().trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "access key must not be empty".to_owned(),
-            ));
-        }
-
-        let io_runtime = StoreIoRuntime::new()?;
-        let mut builder = MicrosoftAzureBuilder::new()
-            .with_http_connector(io_runtime.connector())
-            .with_client_options(crate::provider_object_store::provider_client_options())
-            .with_retry(crate::provider_object_store::provider_retry_config())
-            .with_account(config.account_name)
-            .with_container_name(config.container_name)
-            .with_access_key(config.access_key.expose());
-        if let Some(endpoint_url) = config.endpoint_url {
-            let endpoint_url = endpoint_url.trim();
-            if endpoint_url.is_empty() {
-                return Err(ObjectStoreError::Configuration(
-                    "endpoint url must not be empty".to_owned(),
-                ));
-            }
-            let endpoint_url = normalize_http_endpoint_scheme(endpoint_url);
-            if endpoint_url.starts_with("http://") {
-                builder = builder.with_allow_http(true);
-            }
-            builder = builder.with_endpoint(endpoint_url);
-        }
-
-        let provider = Arc::new(
-            builder
-                .build()
-                .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?,
-        );
-        let inner = ProviderObjectStore::new(
-            Arc::clone(&provider) as Arc<dyn object_store::ObjectStore>,
-            Some(provider),
-            ProviderObjectStoreConfig {
-                key_prefix: config.key_prefix,
-            },
-        )?;
-        Ok(Self {
-            inner,
-            _io_runtime: io_runtime,
-        })
-    }
-}
-
-fn normalize_http_endpoint_scheme(endpoint_url: &str) -> String {
-    match endpoint_url.split_once("://") {
-        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("http") => format!("http://{rest}"),
-        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("https") => format!("https://{rest}"),
-        _ => endpoint_url.to_owned(),
-    }
-}
-
-#[async_trait]
-impl ObjectStore for AzureAbsStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
-        self.inner.head(key).await
+        let endpoint_url = if parsed.path.is_empty() {
+            format!("{}://{}", parsed.scheme, parsed.authority)
+        } else {
+            format!("{}://{}/{}", parsed.scheme, parsed.authority, parsed.path)
+        };
+        builder = builder.with_endpoint(endpoint_url);
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
-        self.inner.put_streamed(key, body, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<()> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_from_stream(
-        &self,
-        prefix: &str,
-        start_after: Option<&str>,
-    ) -> BoxStream<'static, Result<String>> {
-        // Azure has no native start-after key, so the provider adapter filters
-        // results while following its normal continuation pages.
-        self.inner.list_prefix_from_stream(prefix, start_after)
-    }
+    let provider = Arc::new(
+        builder
+            .build()
+            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?,
+    );
+    ProviderObjectStore::new(
+        Arc::clone(&provider) as Arc<dyn object_store::ObjectStore>,
+        provider,
+        ProviderObjectStoreConfig {
+            key_prefix: config.key_prefix,
+        },
+        ConfiguredObjectStoreKind::AzureAbs,
+        io_runtime,
+    )
+    .map(|store| store.compare_token(CompareToken::Etag))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AzureAbsStore, AzureAbsStoreConfig};
+    use super::{azure_abs, AzureAbsStoreConfig};
     use crate::test_support::AZURITE_ACCOUNT_KEY;
     use crate::ObjectStore;
     use crate::ObjectStoreError;
-
-    #[test]
-    fn access_key_is_required() {
-        let error = AzureAbsStore::new(AzureAbsStoreConfig {
-            account_name: "account".to_owned(),
-            container_name: "container".to_owned(),
-            access_key: " ".into(),
-            endpoint_url: None,
-            key_prefix: None,
-        })
-        .expect_err("blank access key should be rejected");
-
-        assert!(
-            matches!(error, ObjectStoreError::Configuration(message) if message.contains("access key"))
-        );
-    }
 
     #[test]
     fn http_endpoint_is_allowed_for_emulator() {
@@ -177,7 +79,7 @@ mod tests {
             "http://127.0.0.1:10000/devstoreaccount1",
             "HTTP://127.0.0.1:10000/devstoreaccount1",
         ] {
-            let store = AzureAbsStore::new(AzureAbsStoreConfig {
+            let store = azure_abs(AzureAbsStoreConfig {
                 account_name: "devstoreaccount1".to_owned(),
                 container_name: "container".to_owned(),
                 access_key: AZURITE_ACCOUNT_KEY.into(),
@@ -193,7 +95,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_keys_are_rejected_before_compare_tokens() {
-        let store = AzureAbsStore::new(AzureAbsStoreConfig {
+        let store = azure_abs(AzureAbsStoreConfig {
             account_name: "devstoreaccount1".to_owned(),
             container_name: "container".to_owned(),
             access_key: AZURITE_ACCOUNT_KEY.into(),

--- a/crates/loonfs-objectstore/src/aws_credentials.rs
+++ b/crates/loonfs-objectstore/src/aws_credentials.rs
@@ -51,33 +51,13 @@ pub(crate) fn aws_credentials_source(
             access_key_id,
             secret_access_key,
             session_token,
-        } => {
-            if access_key_id.expose().trim().is_empty() {
-                return Err(ObjectStoreError::Configuration(
-                    "access key id must not be empty".to_owned(),
-                ));
-            }
-            if secret_access_key.expose().trim().is_empty() {
-                return Err(ObjectStoreError::Configuration(
-                    "secret access key must not be empty".to_owned(),
-                ));
-            }
-            if session_token
-                .as_ref()
-                .is_some_and(|token| token.expose().trim().is_empty())
-            {
-                return Err(ObjectStoreError::Configuration(
-                    "session token must not be empty".to_owned(),
-                ));
-            }
-            Ok(Arc::new(StaticAwsCredentialsSource::new(
-                AwsSigningCredentials {
-                    access_key_id: access_key_id.clone(),
-                    secret_access_key: secret_access_key.clone(),
-                    session_token: session_token.clone(),
-                },
-            )))
-        }
+        } => Ok(Arc::new(StaticAwsCredentialsSource::new(
+            AwsSigningCredentials {
+                access_key_id: access_key_id.clone(),
+                secret_access_key: secret_access_key.clone(),
+                session_token: session_token.clone(),
+            },
+        ))),
     }
 }
 

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -1,16 +1,16 @@
 //! [`ConfiguredObjectStore`]: one provider client built from configuration,
 //! paired with the direct transfers that provider can authorize.
 
-use crate::abs::{AzureAbsStore, AzureAbsStoreConfig};
+use crate::abs::{azure_abs, AzureAbsStoreConfig};
 use crate::aws_credentials::{aws_credentials_source, static_aws_credentials_source};
-use crate::gcs::{GcpGcsStore, GcpGcsStoreConfig};
+use crate::gcs::{gcp_gcs_with_issuers, GcpGcsStoreConfig};
 use crate::local_fs_store::LocalFsStore;
 use crate::object_store::{Result, SharedObjectStore};
-use crate::presign::{
-    DirectTransferIssuers, GcsPresignerConfig, GcsV4Presigner, S3CompatiblePresigner,
-    S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES, CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
+use crate::presign::DirectTransferIssuers;
+use crate::s3_compatible::{
+    aws_s3_with_credentials, cloudflare_r2_with_credentials, AwsS3StoreConfig,
+    CloudflareR2StoreConfig,
 };
-use crate::s3_compatible::{AwsS3StoreConfig, CloudflareR2StoreConfig, S3CompatibleStore};
 use http::Uri;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -83,24 +83,10 @@ impl ConfiguredObjectStore {
     /// Construction fails when signing, provider, runtime, or key-prefix configuration is invalid.
     pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self> {
         let credentials = aws_credentials_source(&config.credentials, &config.region)?;
-        let direct_transfers =
-            endpoint_is_proven(config.endpoint_url.as_deref(), AWS_S3_PROVEN_DOMAINS)
-                .then(|| {
-                    S3CompatiblePresigner::with_credentials(
-                        S3PresignerConfig {
-                            bucket: config.bucket.clone(),
-                            region: config.region.clone(),
-                            endpoint_url: config.endpoint_url.clone(),
-                            key_prefix: config.key_prefix.clone(),
-                            force_path_style: config.force_path_style,
-                            direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
-                        },
-                        Arc::clone(&credentials),
-                    )
-                    .map(s3_compatible_transfers)
-                })
-                .transpose()?;
-        let store = S3CompatibleStore::aws_s3_with_credentials(config, credentials)?;
+        let direct_transfers_enabled =
+            endpoint_is_proven(config.endpoint_url.as_deref(), AWS_S3_PROVEN_DOMAINS);
+        let (store, issuers) = aws_s3_with_credentials(config, credentials)?;
+        let direct_transfers = direct_transfers_enabled.then_some(issuers);
         Ok(Self {
             inner: Arc::new(store),
             direct_transfers,
@@ -117,26 +103,12 @@ impl ConfiguredObjectStore {
             config.secret_access_key.clone(),
             None,
         );
-        let direct_transfers = endpoint_is_proven(
+        let direct_transfers_enabled = endpoint_is_proven(
             Some(config.endpoint_url.as_str()),
             CLOUDFLARE_R2_PROVEN_DOMAINS,
-        )
-        .then(|| {
-            S3CompatiblePresigner::with_credentials(
-                S3PresignerConfig {
-                    bucket: config.bucket.clone(),
-                    region: "auto".to_owned(),
-                    endpoint_url: Some(config.endpoint_url.clone()),
-                    key_prefix: config.key_prefix.clone(),
-                    force_path_style: true,
-                    direct_put_max_content_bytes: CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
-                },
-                Arc::clone(&credentials),
-            )
-            .map(s3_compatible_transfers)
-        })
-        .transpose()?;
-        let store = S3CompatibleStore::cloudflare_r2_with_credentials(config, credentials)?;
+        );
+        let (store, issuers) = cloudflare_r2_with_credentials(config, credentials)?;
+        let direct_transfers = direct_transfers_enabled.then_some(issuers);
         Ok(Self {
             inner: Arc::new(store),
             direct_transfers,
@@ -153,7 +125,7 @@ impl ConfiguredObjectStore {
     /// carries no endpoint override, so every capability is `https` to
     /// Google's own host.
     ///
-    /// Construction fails when credentials, provider runtime, or key-prefix configuration is invalid.
+    /// Construction fails when the key file, provider, runtime, or key prefix is invalid.
     pub fn gcp_gcs(config: GcpGcsStoreConfig) -> Result<Self> {
         Self::gcp_gcs_proven(config, GCS_DIRECT_TRANSFERS_PROVEN)
     }
@@ -167,24 +139,19 @@ impl ConfiguredObjectStore {
     /// at the first transfer — so `proven` decides only whether the bundle is
     /// handed out, never whether it exists.
     fn gcp_gcs_proven(config: GcpGcsStoreConfig, proven: bool) -> Result<Self> {
-        let presigner = Arc::new(GcsV4Presigner::new(GcsPresignerConfig {
-            bucket: config.bucket.clone(),
-            service_account_key_path: config.service_account_key_path.clone(),
-            key_prefix: config.key_prefix.clone(),
-        })?);
-        let store = GcpGcsStore::new(config)?;
+        let (store, issuers) = gcp_gcs_with_issuers(config)?;
+        let direct_transfers = proven.then_some(issuers);
         Ok(Self {
             inner: Arc::new(store),
-            direct_transfers: proven
-                .then(|| DirectTransferIssuers::read_only(presigner.clone()).with_put(presigner)),
+            direct_transfers,
         })
     }
 
     /// Builds a native Azure Blob store without direct-transfer issuance.
     ///
-    /// Construction fails when credentials, provider runtime, or key-prefix configuration is invalid.
+    /// Construction fails when the endpoint, provider, runtime, or key prefix is invalid.
     pub fn azure_abs(config: AzureAbsStoreConfig) -> Result<Self> {
-        let store = AzureAbsStore::new(config)?;
+        let store = azure_abs(config)?;
         Ok(Self {
             inner: Arc::new(store),
             direct_transfers: None,
@@ -208,14 +175,6 @@ impl ConfiguredObjectStore {
     pub fn into_shared(self) -> SharedObjectStore {
         self.inner
     }
-}
-
-/// The S3-compatible providers sign all three directions with one presigner.
-fn s3_compatible_transfers(presigner: S3CompatiblePresigner) -> DirectTransferIssuers {
-    let presigner = Arc::new(presigner);
-    DirectTransferIssuers::read_only(presigner.clone())
-        .with_put(presigner.clone())
-        .with_multipart(presigner)
 }
 
 /// Returns whether an endpoint uses TLS and belongs to a provider domain
@@ -460,7 +419,11 @@ mod tests {
             )
             .expect("presigner"),
         );
-        let transfers = DirectTransferIssuers::read_only(presigner.clone()).with_put(presigner);
+        let transfers = DirectTransferIssuers {
+            get: presigner.clone(),
+            put: Some(presigner),
+            multipart: None,
+        };
 
         assert!(transfers.put.is_some());
         assert!(transfers.multipart.is_none());

--- a/crates/loonfs-objectstore/src/endpoint.rs
+++ b/crates/loonfs-objectstore/src/endpoint.rs
@@ -1,0 +1,46 @@
+//! Shared endpoint parsing and addressing helpers.
+
+use crate::object_store::Result;
+use crate::ObjectStoreError;
+
+pub(crate) struct ParsedEndpoint<'a> {
+    pub(crate) scheme: &'static str,
+    pub(crate) authority: &'a str,
+    pub(crate) path: &'a str,
+}
+
+pub(crate) fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>> {
+    let (scheme, rest) = value.split_once("://").ok_or_else(|| {
+        ObjectStoreError::Configuration(
+            "endpoint url must start with http:// or https://".to_owned(),
+        )
+    })?;
+    let scheme = if scheme.eq_ignore_ascii_case("https") {
+        "https"
+    } else if scheme.eq_ignore_ascii_case("http") {
+        "http"
+    } else {
+        return Err(ObjectStoreError::Configuration(
+            "endpoint url must start with http:// or https://".to_owned(),
+        ));
+    };
+    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
+    if authority.is_empty() {
+        return Err(ObjectStoreError::Configuration(
+            "endpoint url must include authority".to_owned(),
+        ));
+    }
+    Ok(ParsedEndpoint {
+        scheme,
+        authority,
+        path: path.trim_end_matches('/'),
+    })
+}
+
+pub(crate) fn virtual_hosted_authority(bucket: &str, authority: &str) -> String {
+    let bucket = bucket.trim();
+    if authority.starts_with(&format!("{bucket}.")) {
+        return authority.to_owned();
+    }
+    format!("{bucket}.{authority}")
+}

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -1,16 +1,17 @@
 //! Google Cloud Storage provider.
 
-use super::{ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::configured::ConfiguredObjectStoreKind;
 use crate::object_store::Result;
-use crate::presign::{stored_crc32c, GcsPresignerConfig, GcsV4Presigner, CHECKSUM_HEAD_TTL};
-use crate::signed_request::{execute_signed, stored_checksum_from_signed_head};
+use crate::presign::{
+    stored_crc32c, DirectTransferIssuers, GcsPresignerConfig, GcsV4Presigner, CHECKSUM_HEAD_TTL,
+};
+use crate::provider_object_store::{CompareToken, StoredChecksumReader};
+use crate::signed_request::{send_signed, stored_checksum_from_signed_head};
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig, StoredObjectChecksum,
 };
 use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs_api::Checksum;
 use object_store::client::{HttpClient, HttpConnector, HttpRequestBody};
 use object_store::gcp::GoogleCloudStorageBuilder;
@@ -28,188 +29,87 @@ pub struct GcpGcsStoreConfig {
     pub key_prefix: Option<String>,
 }
 
-/// Google Cloud Storage through its native API.
-///
-/// GCS conditions writes on object generations, not ETags, and silently
-/// ignores HTTP `If-Match`/`If-None-Match` on its S3-interoperability
-/// surface — conformance proved interop overwrites instead of failing
-/// preconditions. The native API is therefore the only correct backend, and
-/// this adapter hands out the generation as the opaque compare token.
-#[derive(Debug)]
-pub struct GcpGcsStore {
-    inner: ProviderObjectStore,
-    /// Signs the one request the provider client cannot express: the metadata
-    /// read that reports an object's stored CRC-32C back. The V4 signer this
-    /// crate already owns for direct-transfer URLs expresses it, so the store
-    /// needs no second credential path.
-    request_signer: GcsV4Presigner,
-    /// Sends that signed request over the store's own IO runtime and timeout
-    /// scheme, exactly like every provider-client request.
+struct GcsRequestSigner {
+    request_signer: Arc<GcsV4Presigner>,
     http: HttpClient,
-    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
-    /// the connector inside the client holds only a handle onto it.
-    _io_runtime: StoreIoRuntime,
 }
 
-impl GcpGcsStore {
-    /// Builds a native GCS adapter whose compare tokens are object generations.
-    ///
-    /// Construction fails for a blank bucket or credential path, an invalid
-    /// key prefix, runtime initialization, or provider-client configuration.
-    pub fn new(config: GcpGcsStoreConfig) -> Result<Self> {
-        if config.bucket.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "bucket must not be empty".to_owned(),
-            ));
-        }
-        if config.service_account_key_path.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "service account key path must not be empty".to_owned(),
-            ));
-        }
+/// Builds a native GCS adapter whose compare tokens are object generations.
+pub fn gcp_gcs(config: GcpGcsStoreConfig) -> Result<ProviderObjectStore> {
+    gcp_gcs_with_issuers(config).map(|(store, _)| store)
+}
 
-        let request_signer = GcsV4Presigner::new(GcsPresignerConfig {
-            bucket: config.bucket.clone(),
-            service_account_key_path: config.service_account_key_path.clone(),
-            key_prefix: config.key_prefix.clone(),
-        })?;
+/// Returns the store and the issuers that sign direct transfers against it.
+pub(crate) fn gcp_gcs_with_issuers(
+    config: GcpGcsStoreConfig,
+) -> Result<(ProviderObjectStore, DirectTransferIssuers)> {
+    let request_signer = Arc::new(GcsV4Presigner::new(GcsPresignerConfig {
+        bucket: config.bucket.clone(),
+        service_account_key_path: config.service_account_key_path.clone(),
+        key_prefix: config.key_prefix.clone(),
+    })?);
 
-        let io_runtime = StoreIoRuntime::new()?;
-        let http = io_runtime
-            .connector()
-            .connect(&crate::provider_object_store::provider_client_options())
-            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?;
-        let builder = GoogleCloudStorageBuilder::new()
-            .with_http_connector(io_runtime.connector())
-            .with_client_options(crate::provider_object_store::provider_client_options())
-            .with_retry(crate::provider_object_store::provider_retry_config())
-            .with_bucket_name(config.bucket)
-            .with_service_account_path(config.service_account_key_path);
+    let io_runtime = StoreIoRuntime::new()?;
+    let http = io_runtime
+        .connector()
+        .connect(&crate::provider_object_store::provider_client_options())
+        .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?;
+    let builder = GoogleCloudStorageBuilder::new()
+        .with_http_connector(io_runtime.connector())
+        .with_client_options(crate::provider_object_store::provider_client_options())
+        .with_retry(crate::provider_object_store::provider_retry_config())
+        .with_bucket_name(config.bucket)
+        .with_service_account_path(config.service_account_key_path);
 
-        let provider = Arc::new(
-            builder
-                .build()
-                .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?,
-        );
-        let inner = ProviderObjectStore::new(
-            Arc::clone(&provider) as Arc<dyn object_store::ObjectStore>,
-            Some(provider),
-            ProviderObjectStoreConfig {
-                key_prefix: config.key_prefix,
-            },
-        )?;
+    let provider = Arc::new(
+        builder
+            .build()
+            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?,
+    );
+    let store = ProviderObjectStore::new(
+        Arc::clone(&provider) as Arc<dyn object_store::ObjectStore>,
+        provider,
+        ProviderObjectStoreConfig {
+            key_prefix: config.key_prefix,
+        },
+        ConfiguredObjectStoreKind::GcpGcs,
+        io_runtime,
+    )?;
+    let signer = Arc::new(GcsRequestSigner {
+        request_signer: Arc::clone(&request_signer),
+        http,
+    });
+    let direct_transfers = DirectTransferIssuers {
+        get: request_signer.clone(),
+        put: Some(request_signer),
+        multipart: None,
+    };
 
-        Ok(Self {
-            inner,
-            request_signer,
-            http,
-            _io_runtime: io_runtime,
-        })
-    }
+    let store = store
+        .compare_token(CompareToken::Generation)
+        .checksum_reader(signer);
+    Ok((store, direct_transfers))
+}
 
+impl GcsRequestSigner {
     #[allow(clippy::disallowed_methods)]
     fn signing_time() -> SystemTime {
         // A V4 signature is dated, so this internally issued request enters
         // wall time here. Nothing durable is derived from it.
         SystemTime::now()
     }
-
-    fn generation_as_compare_token(metadata: ObjectMetadata) -> ObjectMetadata {
-        ObjectMetadata {
-            etag: metadata.version.clone(),
-            ..metadata
-        }
-    }
-
-    fn require_generation_compare_token(key: &str, expected_etag: &str) -> Result<()> {
-        expected_etag
-            .parse::<u64>()
-            .map(|_| ())
-            .map_err(|_| ObjectStoreError::PreconditionFailed {
-                object_key: key.to_owned(),
-            })
-    }
 }
 
 #[async_trait]
-impl ObjectStore for GcpGcsStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
-        Ok(self
-            .inner
-            .head(key)
-            .await?
-            .map(Self::generation_as_compare_token))
-    }
-
-    /// Reads size and the stored CRC-32C back from one signed metadata
-    /// request.
-    ///
-    /// GCS reports the stored checksum in `x-goog-hash` on an ordinary object
-    /// request, so this is a `HEAD` and nothing more. The provider client
-    /// surfaces neither that header nor any other checksum, which is why the
-    /// request is signed here rather than asked of the client.
+impl StoredChecksumReader for GcsRequestSigner {
     async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
         let signed = self.request_signer.presign_head_stored_checksum(
             key,
             CHECKSUM_HEAD_TTL,
             Self::signing_time(),
         )?;
-        let response = execute_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
+        let response = send_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
         stored_checksum_from_signed_head(key, &response, stored_crc32c_from_headers)
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
-        Ok(self
-            .inner
-            .get_with_metadata(key)
-            .await?
-            .map(|body| ObjectBody {
-                metadata: Self::generation_as_compare_token(body.metadata),
-                bytes: body.bytes,
-            }))
-    }
-
-    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
-        self.inner.validate_key(key)?;
-        if let PutMode::CompareAndSwap { expected_etag } = &mode {
-            Self::require_generation_compare_token(key, expected_etag)?;
-        }
-        Ok(Self::generation_as_compare_token(
-            self.inner.put(key, bytes, mode).await?,
-        ))
-    }
-
-    async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
-        self.inner.validate_key(key)?;
-        if matches!(mode, PutMode::CompareAndSwap { .. }) {
-            // The public GCS compare token is an object generation, while
-            // `ProviderObjectStore` can only compare the raw e-tag returned
-            // by its provider HEAD before multipart completion. Forwarding
-            // streamed CAS would therefore enforce a different condition
-            // from `head`; reject it instead of claiming false CAS safety.
-            return Err(ObjectStoreError::Unsupported(
-                "streamed compare-and-swap with GCS generation tokens",
-            ));
-        }
-        self.inner.put_streamed(key, body, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<()> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_from_stream(
-        &self,
-        prefix: &str,
-        start_after: Option<&str>,
-    ) -> BoxStream<'static, Result<String>> {
-        // GCS offsets are inclusive. The provider adapter removes the offset
-        // key so this method remains strictly after it.
-        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -230,17 +130,16 @@ fn stored_crc32c_from_headers(headers: &http::HeaderMap) -> Option<Checksum> {
 
 #[cfg(test)]
 mod tests {
-    use super::{stored_crc32c_from_headers, GcpGcsStore, GcpGcsStoreConfig};
+    use super::{gcp_gcs, stored_crc32c_from_headers, GcpGcsStoreConfig};
     use crate::test_support::gcs_fixture_service_account_key_file;
-    use crate::{ObjectStore, ObjectStoreError, PutMode};
+    use crate::{ObjectStore, ObjectStoreError};
     use bytes::Bytes;
-    use futures::StreamExt;
 
     #[tokio::test]
     async fn invalid_keys_are_rejected_before_generation_tokens() {
         let (_key_dir, service_account_key_path) =
             gcs_fixture_service_account_key_file("gcs-invalid-key");
-        let store = GcpGcsStore::new(GcpGcsStoreConfig {
+        let store = gcp_gcs(GcpGcsStoreConfig {
             bucket: "bucket".to_owned(),
             service_account_key_path: service_account_key_path.display().to_string(),
             key_prefix: None,
@@ -256,35 +155,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn streamed_compare_and_swap_rejects_the_mismatched_token_semantics() {
+    async fn compare_and_swap_rejects_a_non_generation_token() {
         let (_key_dir, service_account_key_path) =
             gcs_fixture_service_account_key_file("gcs-streamed-cas");
-        let store = GcpGcsStore::new(GcpGcsStoreConfig {
+        let store = gcp_gcs(GcpGcsStoreConfig {
             bucket: "bucket".to_owned(),
             service_account_key_path: service_account_key_path.display().to_string(),
             key_prefix: None,
         })
         .expect("construct gcs store");
-        let body = futures::stream::iter([Ok(Bytes::from_static(b"payload"))]).boxed();
-
         let error = store
-            .put_streamed(
+            .compare_and_swap(
                 "namespaces/demo/wal/head.json",
-                body,
-                PutMode::CompareAndSwap {
-                    expected_etag: "123".to_owned(),
-                },
+                "not-a-generation",
+                Bytes::from_static(b"payload"),
             )
             .await
-            .expect_err("streamed GCS CAS must not compare an e-tag to a generation");
+            .expect_err("non-generation compare token should fail");
 
-        assert!(matches!(error, ObjectStoreError::Unsupported(_)));
+        assert!(matches!(error, ObjectStoreError::PreconditionFailed { .. }));
     }
 
     #[test]
     fn service_account_key_path_is_required() {
         assert!(matches!(
-            GcpGcsStore::new(GcpGcsStoreConfig {
+            gcp_gcs(GcpGcsStoreConfig {
                 bucket: "bucket".to_owned(),
                 service_account_key_path: " ".to_owned(),
                 key_prefix: None,
@@ -304,7 +199,7 @@ mod tests {
         .expect("write unsignable service account key");
 
         assert!(matches!(
-            GcpGcsStore::new(GcpGcsStoreConfig {
+            gcp_gcs(GcpGcsStoreConfig {
                 bucket: "bucket".to_owned(),
                 service_account_key_path: unsignable.display().to_string(),
                 key_prefix: None,

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -1,6 +1,11 @@
-//! Key construction for every durable object family.
+//! Key construction for every [durable object family].
+//!
+//! [durable object family]: ../../../docs/specs/format.md#12-durable-object-families
 
-use crate::layout::ObjectLayout;
+use crate::layout::{
+    metadata_compaction_job_id_from_key as parse_metadata_compaction_job_id,
+    wal_segment_id_from_key as parse_wal_segment_id,
+};
 use loonfs_api::wire::manifest::MetadataSegmentRef;
 use loonfs_api::{
     CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
@@ -8,102 +13,77 @@ use loonfs_api::{
 };
 
 /// Builds the listing prefix containing every durable object owned by one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn namespace_prefix(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().namespace_root_prefix(namespace_id)
+    format!("namespaces/{namespace_id}/")
 }
 
 /// Builds the authoritative WAL head key for one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn wal_head(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().wal_head(namespace_id)
+    format!("namespaces/{namespace_id}/wal/head.json")
 }
 
 /// Builds the retained-history floor key for one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn wal_floor(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().wal_floor(namespace_id)
+    format!("namespaces/{namespace_id}/wal/floor.json")
 }
 
 /// Builds the immutable WAL object key for a segment identity.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn wal_segment(namespace_id: &NamespaceId, wal_segment_id: &WalSegmentId) -> String {
-    ObjectLayout::new().wal_segment(namespace_id, wal_segment_id)
+    format!("namespaces/{namespace_id}/wal/segments/{wal_segment_id}.wal.zst")
 }
 
 /// Builds the listing prefix containing only WAL segment objects for one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn wal_segment_prefix(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().wal_segment_prefix(namespace_id)
+    format!("namespaces/{namespace_id}/wal/segments/")
 }
 
 /// Extracts a segment identity from a current-format WAL object key.
 ///
-/// Returns `None` for foreign or differently suffixed objects. See
-/// [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+/// Returns `None` for foreign or differently suffixed objects.
 pub fn wal_segment_id_from_key(key: &str) -> Option<&str> {
-    ObjectLayout::new().wal_segment_id_from_key(key)
+    parse_wal_segment_id(key)
 }
 
 /// Builds the materialized metadata-root key for one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_root(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().metadata_root(namespace_id)
+    format!("namespaces/{namespace_id}/metadata/root.json")
 }
 
 /// Builds the listing prefix containing namespace-manifest candidates.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_manifest_prefix(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().metadata_manifest_prefix(namespace_id)
+    format!("namespaces/{namespace_id}/metadata/manifests/")
 }
 
 /// Builds the listing prefix containing metadata segment objects owned by one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_segment_prefix(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().metadata_segment_prefix(namespace_id)
+    format!("namespaces/{namespace_id}/metadata/segments/")
 }
 
 /// Builds the immutable manifest key for one speculative manifest identity.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_manifest_object(
     namespace_id: &NamespaceId,
     manifest_object_id: &ManifestObjectId,
 ) -> String {
-    ObjectLayout::new().metadata_manifest_object(namespace_id, manifest_object_id)
+    format!("namespaces/{namespace_id}/metadata/manifests/{manifest_object_id}.manifest.json")
 }
 
 /// Builds the immutable metadata segment key for one segment identity.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_segment(
     namespace_id: &NamespaceId,
     metadata_segment_id: &MetadataSegmentId,
 ) -> String {
-    ObjectLayout::new().metadata_segment(namespace_id, metadata_segment_id)
+    format!("namespaces/{namespace_id}/metadata/segments/{metadata_segment_id}.sst.zst")
 }
 
 /// Builds the immutable staging key one streaming compaction job writes a
 /// metadata segment to before any manifest references it.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_compaction_segment(
     namespace_id: &NamespaceId,
     metadata_compaction_id: &MetadataCompactionId,
     metadata_segment_id: &MetadataSegmentId,
 ) -> String {
-    ObjectLayout::new().metadata_compaction_segment(
-        namespace_id,
-        metadata_compaction_id,
-        metadata_segment_id,
+    format!(
+        "namespaces/{namespace_id}/metadata/compactions/{metadata_compaction_id}/segments/{metadata_segment_id}.sst.zst"
     )
 }
 
@@ -111,8 +91,6 @@ pub fn metadata_compaction_segment(
 ///
 /// `compaction_job_id` selects the compaction prefix. Descriptors without a
 /// job id use the namespace's `metadata/segments/` prefix.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_segment_object_key(descriptor: &MetadataSegmentRef) -> String {
     match &descriptor.compaction_job_id {
         Some(compaction_job_id) => metadata_compaction_segment(
@@ -126,65 +104,51 @@ pub fn metadata_segment_object_key(descriptor: &MetadataSegmentRef) -> String {
 
 /// Builds the mutable lease key one streaming compaction job holds over its
 /// own prefix.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_compaction_lease(
     namespace_id: &NamespaceId,
     metadata_compaction_id: &MetadataCompactionId,
 ) -> String {
-    ObjectLayout::new().metadata_compaction_lease(namespace_id, metadata_compaction_id)
+    format!("namespaces/{namespace_id}/metadata/compactions/{metadata_compaction_id}/lease.json")
 }
 
 /// Builds the listing prefix containing every streaming compaction job's
 /// objects for one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn metadata_compaction_prefix(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().metadata_compaction_prefix(namespace_id)
+    format!("namespaces/{namespace_id}/metadata/compactions/")
 }
 
 /// Extracts the job id from a key under one namespace's compaction prefix.
 ///
 /// Returns `None` for a key under the prefix that is neither a job's lease
-/// nor one of its staged segments. See
-/// [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+/// nor one of its staged segments.
 pub fn metadata_compaction_job_id_from_key(key: &str) -> Option<&str> {
-    ObjectLayout::new().metadata_compaction_job_id_from_key(key)
+    parse_metadata_compaction_job_id(key)
 }
 
 /// Builds the mutable lifecycle key for one checkpoint record.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn checkpoint_record(namespace_id: &NamespaceId, checkpoint_id: &CheckpointId) -> String {
-    ObjectLayout::new().checkpoint_record(namespace_id, checkpoint_id)
+    format!("namespaces/{namespace_id}/checkpoints/{checkpoint_id}.json")
 }
 
 /// Builds the listing prefix containing checkpoint records for one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn checkpoint_prefix(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().checkpoint_prefix(namespace_id)
+    format!("namespaces/{namespace_id}/checkpoints/")
 }
 
 /// Builds the listing prefix containing durable upload sessions for one namespace.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn upload_session_prefix(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().upload_session_prefix(namespace_id)
+    format!("namespaces/{namespace_id}/uploads/")
 }
 
 /// Builds the mutable lifecycle key for one upload session.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn upload_session(namespace_id: &NamespaceId, upload_id: &UploadId) -> String {
-    ObjectLayout::new().upload_session(namespace_id, upload_id)
+    format!("namespaces/{namespace_id}/uploads/{upload_id}.json")
 }
 
 /// Builds the immutable content-object key for one content identity.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn content_blob(content_store_id: &ContentStoreId, content_id: &ContentId) -> String {
-    ObjectLayout::new().content_blob(content_store_id, content_id)
+    let [first_shard, second_shard] = content_id.shard_prefixes();
+    format!("content-stores/{content_store_id}/objects/{first_shard}/{second_shard}/{content_id}")
 }
 
 #[cfg(test)]

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -1,4 +1,4 @@
-//! Shared key and endpoint helpers for provider stores.
+//! Shared key helpers for provider stores.
 
 use crate::object_store::Result;
 use crate::ObjectStoreError;
@@ -77,45 +77,6 @@ pub(crate) fn unscope_listed_key(key_prefix: Option<&str>, scoped_key: &str) -> 
     let key_prefix = key_prefix.filter(|value| !value.is_empty())?;
     let prefix = format!("{key_prefix}/");
     scoped_key.strip_prefix(&prefix).map(str::to_owned)
-}
-
-/// A parsed `http(s)://authority[/base-path]` endpoint, shared by the
-/// provider client and the presigner so the two cannot drift.
-pub(crate) struct ParsedEndpoint<'a> {
-    pub(crate) scheme: &'a str,
-    pub(crate) authority: &'a str,
-    pub(crate) path: &'a str,
-}
-
-pub(crate) fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>> {
-    let (scheme, rest) = value
-        .strip_prefix("https://")
-        .map(|rest| ("https", rest))
-        .or_else(|| value.strip_prefix("http://").map(|rest| ("http", rest)))
-        .ok_or_else(|| {
-            ObjectStoreError::Configuration(
-                "endpoint url must start with http:// or https://".to_owned(),
-            )
-        })?;
-    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
-    if authority.is_empty() {
-        return Err(ObjectStoreError::Configuration(
-            "endpoint url must include authority".to_owned(),
-        ));
-    }
-    Ok(ParsedEndpoint {
-        scheme,
-        authority,
-        path: path.trim_end_matches('/'),
-    })
-}
-
-pub(crate) fn virtual_hosted_authority(bucket: &str, authority: &str) -> String {
-    let bucket = bucket.trim();
-    if authority.starts_with(&format!("{bucket}.")) {
-        return authority.to_owned();
-    }
-    format!("{bucket}.{authority}")
 }
 
 #[cfg(test)]

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -1,13 +1,4 @@
-//! The durable key grammar: object families, their path shapes, and
-//! parsing keys back into classified families.
-
-use loonfs_api::{
-    CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
-    MetadataSegmentId, NamespaceId, UploadId, WalSegmentId,
-};
-
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct ObjectLayout;
+//! The durable key grammar: object families and key classification.
 
 /// One family in the [durable object key grammar].
 ///
@@ -15,60 +6,35 @@ pub(crate) struct ObjectLayout;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DurableObjectFamily {
     /// Classifies the mutable visibility and fencing head.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     WalHead,
     /// Classifies the mutable retained-history floor.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     WalFloor,
     /// Classifies an immutable segment in a namespace's WAL chain.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     WalSegment,
     /// Classifies the mutable materialized metadata pointer.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     MetadataRoot,
     /// Classifies an immutable namespace-manifest candidate.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     MetadataManifest,
     /// Classifies an immutable metadata segment.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     MetadataSegment,
-    /// Classifies an immutable metadata segment a streaming compaction
-    /// wrote before any manifest referenced it.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+    /// Classifies an immutable metadata segment written by a streaming compaction.
     MetadataCompactionStaging,
-    /// Classifies the mutable lease one streaming compaction holds over its
-    /// own staged output.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+    /// Classifies the mutable lease for one streaming compaction.
     MetadataCompactionLease,
     /// Classifies a mutable checkpoint lifecycle record.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     CheckpointRecord,
     /// Classifies a mutable upload-session lifecycle record.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     UploadSession,
     /// Classifies immutable whole-file content bytes.
-    ///
-    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     ContentBlob,
 }
 
-/// Reports the durable family and namespace ownership recoverable from a recognized key.
-///
-/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+/// Reports the durable family and identifiers recoverable from a recognized key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedObjectKey<'a> {
     family: DurableObjectFamily,
     owner_namespace_id: Option<&'a str>,
+    identifier: Option<&'a str>,
 }
 
 impl<'a> ParsedObjectKey<'a> {
@@ -81,167 +47,10 @@ impl<'a> ParsedObjectKey<'a> {
     pub fn owner_namespace_id(&self) -> Option<&'a str> {
         self.owner_namespace_id
     }
-}
 
-impl ObjectLayout {
-    pub(crate) fn new() -> Self {
-        Self
-    }
-
-    pub(crate) fn namespace_root_prefix(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/")
-    }
-
-    /// Hot head of the semantic commit stream: the only object whose CAS
-    /// gates user-write throughput.
-    pub(crate) fn wal_head(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/wal/head.json")
-    }
-
-    /// Cold lower bound of retained WAL/change history.
-    pub(crate) fn wal_floor(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/wal/floor.json")
-    }
-
-    pub(crate) fn wal_segment(
-        &self,
-        namespace_id: &NamespaceId,
-        wal_segment_id: &WalSegmentId,
-    ) -> String {
-        format!("namespaces/{namespace_id}/wal/segments/{wal_segment_id}.wal.zst")
-    }
-
-    /// Listing prefix that contains every WAL segment of `namespace` and
-    /// nothing else: `wal/head.json` and `wal/floor.json` live outside it,
-    /// so a GC listing yields only segment keys.
-    ///
-    /// Every segment file name starts with `wal_` and the segment's 20-digit
-    /// `start_seq`, so a listing comes back in history order as an
-    /// operator/GC convenience; no protocol depends on listing order.
-    pub(crate) fn wal_segment_prefix(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/wal/segments/")
-    }
-
-    /// Extracts the WAL segment id from a listed object key.
-    ///
-    /// Returns `None` for keys that are not current-format WAL segments, so
-    /// listings can skip foreign objects.
-    pub(crate) fn wal_segment_id_from_key<'a>(&self, key: &'a str) -> Option<&'a str> {
-        let (_, file_name) = key.rsplit_once('/')?;
-        file_name.strip_suffix(".wal.zst")
-    }
-
-    /// Cold pointer to the best known materialized metadata root.
-    pub(crate) fn metadata_root(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/metadata/root.json")
-    }
-
-    pub(crate) fn metadata_manifest_object(
-        &self,
-        namespace_id: &NamespaceId,
-        manifest_object_id: &ManifestObjectId,
-    ) -> String {
-        format!("namespaces/{namespace_id}/metadata/manifests/{manifest_object_id}.manifest.json")
-    }
-
-    pub(crate) fn metadata_manifest_prefix(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/metadata/manifests/")
-    }
-
-    pub(crate) fn metadata_segment(
-        &self,
-        namespace_id: &NamespaceId,
-        metadata_segment_id: &MetadataSegmentId,
-    ) -> String {
-        format!("namespaces/{namespace_id}/metadata/segments/{metadata_segment_id}.sst.zst")
-    }
-
-    pub(crate) fn metadata_segment_prefix(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/metadata/segments/")
-    }
-
-    /// Returns the staging key for a compaction output segment. Each job has a
-    /// separate prefix so garbage collection can protect its output with one
-    /// lease.
-    pub(crate) fn metadata_compaction_segment(
-        &self,
-        namespace_id: &NamespaceId,
-        metadata_compaction_id: &MetadataCompactionId,
-        metadata_segment_id: &MetadataSegmentId,
-    ) -> String {
-        format!(
-            "namespaces/{namespace_id}/metadata/compactions/{metadata_compaction_id}/segments/{metadata_segment_id}.sst.zst"
-        )
-    }
-
-    /// Returns the lease key for a compaction job. It sorts before the job's
-    /// staged segments.
-    pub(crate) fn metadata_compaction_lease(
-        &self,
-        namespace_id: &NamespaceId,
-        metadata_compaction_id: &MetadataCompactionId,
-    ) -> String {
-        format!(
-            "namespaces/{namespace_id}/metadata/compactions/{metadata_compaction_id}/lease.json"
-        )
-    }
-
-    pub(crate) fn metadata_compaction_prefix(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/metadata/compactions/")
-    }
-
-    /// Extracts a compaction job id from a recognized lease or segment key.
-    /// Returns `None` for other keys.
-    pub(crate) fn metadata_compaction_job_id_from_key<'a>(&self, key: &'a str) -> Option<&'a str> {
-        match key.split('/').collect::<Vec<_>>().as_slice() {
-            ["namespaces", _, "metadata", "compactions", job_id, "lease.json"] => Some(job_id),
-            ["namespaces", _, "metadata", "compactions", job_id, "segments", segment]
-                if segment.ends_with(".sst.zst") =>
-            {
-                Some(job_id)
-            }
-            _ => None,
-        }
-    }
-
-    /// Durable stable-view pin to a metadata manifest.
-    pub(crate) fn checkpoint_record(
-        &self,
-        namespace_id: &NamespaceId,
-        checkpoint_id: &CheckpointId,
-    ) -> String {
-        format!("namespaces/{namespace_id}/checkpoints/{checkpoint_id}.json")
-    }
-
-    pub(crate) fn checkpoint_prefix(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/checkpoints/")
-    }
-
-    pub(crate) fn upload_session(
-        &self,
-        namespace_id: &NamespaceId,
-        upload_id: &UploadId,
-    ) -> String {
-        format!("namespaces/{namespace_id}/uploads/{upload_id}.json")
-    }
-
-    pub(crate) fn upload_session_prefix(&self, namespace_id: &NamespaceId) -> String {
-        format!("namespaces/{namespace_id}/uploads/")
-    }
-
-    /// Content objects shard across two directory levels selected by the
-    /// content id's leading characters. Those characters are random, so
-    /// ingest spreads evenly and filesystem-backed stores keep bounded
-    /// directory fanout.
-    pub(crate) fn content_blob(
-        &self,
-        content_store_id: &ContentStoreId,
-        content_id: &ContentId,
-    ) -> String {
-        let [first_shard, second_shard] = content_id.shard_prefixes();
-        format!(
-            "content-stores/{content_store_id}/objects/{first_shard}/{second_shard}/{content_id}"
-        )
+    /// Returns the family-specific identifier when the key carries one.
+    pub fn identifier(&self) -> Option<&'a str> {
+        self.identifier
     }
 }
 
@@ -252,394 +61,245 @@ impl ObjectLayout {
 pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
     let segments: Vec<_> = key.split('/').collect();
     match segments.as_slice() {
-        ["content-stores", _, "objects", _, _, _] => parsed(DurableObjectFamily::ContentBlob, None),
+        ["content-stores", _, "objects", _, _, content_id] => Some(parsed(
+            DurableObjectFamily::ContentBlob,
+            None,
+            Some(content_id),
+        )),
         ["namespaces", namespace, "wal", "head.json"] => {
-            parsed(DurableObjectFamily::WalHead, Some(namespace))
+            Some(parsed(DurableObjectFamily::WalHead, Some(namespace), None))
         }
         ["namespaces", namespace, "wal", "floor.json"] => {
-            parsed(DurableObjectFamily::WalFloor, Some(namespace))
+            Some(parsed(DurableObjectFamily::WalFloor, Some(namespace), None))
         }
-        ["namespaces", namespace, "wal", "segments", segment] if segment.ends_with(".wal.zst") => {
-            parsed(DurableObjectFamily::WalSegment, Some(namespace))
+        ["namespaces", namespace, "wal", "segments", segment] => {
+            segment.strip_suffix(".wal.zst").map(|identifier| {
+                parsed(
+                    DurableObjectFamily::WalSegment,
+                    Some(namespace),
+                    Some(identifier),
+                )
+            })
         }
-        ["namespaces", namespace, "metadata", "root.json"] => {
-            parsed(DurableObjectFamily::MetadataRoot, Some(namespace))
+        ["namespaces", namespace, "metadata", "root.json"] => Some(parsed(
+            DurableObjectFamily::MetadataRoot,
+            Some(namespace),
+            None,
+        )),
+        ["namespaces", namespace, "metadata", "manifests", manifest] => {
+            manifest.strip_suffix(".manifest.json").map(|identifier| {
+                parsed(
+                    DurableObjectFamily::MetadataManifest,
+                    Some(namespace),
+                    Some(identifier),
+                )
+            })
         }
-        ["namespaces", namespace, "metadata", "manifests", manifest]
-            if manifest.ends_with(".json") =>
-        {
-            parsed(DurableObjectFamily::MetadataManifest, Some(namespace))
+        ["namespaces", namespace, "metadata", "segments", segment] => {
+            segment.strip_suffix(".sst.zst").map(|identifier| {
+                parsed(
+                    DurableObjectFamily::MetadataSegment,
+                    Some(namespace),
+                    Some(identifier),
+                )
+            })
         }
-        ["namespaces", namespace, "metadata", "segments", segment]
+        ["namespaces", namespace, "metadata", "compactions", job_id, "segments", segment]
             if segment.ends_with(".sst.zst") =>
         {
-            parsed(DurableObjectFamily::MetadataSegment, Some(namespace))
-        }
-        ["namespaces", namespace, "metadata", "compactions", _job_id, "segments", segment]
-            if segment.ends_with(".sst.zst") =>
-        {
-            parsed(
+            Some(parsed(
                 DurableObjectFamily::MetadataCompactionStaging,
                 Some(namespace),
-            )
+                Some(job_id),
+            ))
         }
-        ["namespaces", namespace, "metadata", "compactions", _job_id, "lease.json"] => parsed(
+        ["namespaces", namespace, "metadata", "compactions", job_id, "lease.json"] => Some(parsed(
             DurableObjectFamily::MetadataCompactionLease,
             Some(namespace),
-        ),
-        ["namespaces", namespace, "checkpoints", checkpoint] if checkpoint.ends_with(".json") => {
-            parsed(DurableObjectFamily::CheckpointRecord, Some(namespace))
+            Some(job_id),
+        )),
+        ["namespaces", namespace, "checkpoints", checkpoint] => {
+            checkpoint.strip_suffix(".json").map(|identifier| {
+                parsed(
+                    DurableObjectFamily::CheckpointRecord,
+                    Some(namespace),
+                    Some(identifier),
+                )
+            })
         }
-        ["namespaces", namespace, "uploads", upload] if upload.ends_with(".json") => {
-            parsed(DurableObjectFamily::UploadSession, Some(namespace))
+        ["namespaces", namespace, "uploads", upload] => {
+            upload.strip_suffix(".json").map(|identifier| {
+                parsed(
+                    DurableObjectFamily::UploadSession,
+                    Some(namespace),
+                    Some(identifier),
+                )
+            })
         }
         _ => None,
     }
 }
 
-fn parsed(
+pub(crate) fn wal_segment_id_from_key(key: &str) -> Option<&str> {
+    parse_object_key(key)
+        .filter(|parsed| parsed.family() == DurableObjectFamily::WalSegment)
+        .and_then(|parsed| parsed.identifier())
+}
+
+pub(crate) fn metadata_compaction_job_id_from_key(key: &str) -> Option<&str> {
+    parse_object_key(key)
+        .filter(|parsed| {
+            matches!(
+                parsed.family(),
+                DurableObjectFamily::MetadataCompactionStaging
+                    | DurableObjectFamily::MetadataCompactionLease
+            )
+        })
+        .and_then(|parsed| parsed.identifier())
+}
+
+fn parsed<'a>(
     family: DurableObjectFamily,
-    owner_namespace_id: Option<&str>,
-) -> Option<ParsedObjectKey<'_>> {
-    Some(ParsedObjectKey {
+    owner_namespace_id: Option<&'a str>,
+    identifier: Option<&'a str>,
+) -> ParsedObjectKey<'a> {
+    ParsedObjectKey {
         family,
         owner_namespace_id,
-    })
+        identifier,
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_object_key, DurableObjectFamily, ObjectLayout};
+    use super::{parse_object_key, DurableObjectFamily};
+    use crate::keys::{
+        checkpoint_record, content_blob, metadata_compaction_lease, metadata_compaction_segment,
+        metadata_manifest_object, metadata_root, metadata_segment, metadata_segment_prefix,
+        upload_session, wal_floor, wal_head, wal_segment, wal_segment_prefix,
+    };
     use loonfs_api::{
         CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
         MetadataSegmentId, NamespaceId, UploadId, WalSegmentId,
     };
 
-    fn content_id() -> ContentId {
-        ContentId::parse("con_abcdef0123456789abcdef0123456789").expect("valid content id")
-    }
-
-    fn namespace_id() -> NamespaceId {
-        NamespaceId::parse("ns-1").expect("valid namespace id")
-    }
-
-    fn content_store_id() -> ContentStoreId {
-        ContentStoreId::parse("cs_00000000000000000000000000000001")
-            .expect("valid content store id")
-    }
-
-    fn checkpoint_id() -> CheckpointId {
-        CheckpointId::parse("chk_00000000000000000000000000000001").expect("valid checkpoint id")
-    }
-
-    fn metadata_compaction_id(value: u128) -> MetadataCompactionId {
-        MetadataCompactionId::parse(format!("cmp_{value:032x}"))
-            .expect("valid metadata compaction id")
-    }
-
-    fn metadata_segment_id() -> MetadataSegmentId {
-        MetadataSegmentId::parse("seg_00000000000000000000000000000001")
-            .expect("valid metadata segment id")
-    }
-
-    fn upload_id() -> UploadId {
-        UploadId::parse("upl_00000000000000000000000000000001").expect("valid upload id")
-    }
-
-    fn wal_segment_id(value: &str) -> WalSegmentId {
-        WalSegmentId::parse(value).expect("valid WAL segment id")
-    }
-
     #[test]
-    fn layout_golden_tree_matches_target_paths() {
-        let layout = ObjectLayout::new();
-
-        assert_eq!(
-            layout.namespace_root_prefix(&namespace_id()),
-            "namespaces/ns-1/"
-        );
-        assert_eq!(
-            layout.wal_head(&namespace_id()),
-            "namespaces/ns-1/wal/head.json"
-        );
-        assert_eq!(
-            layout.wal_floor(&namespace_id()),
-            "namespaces/ns-1/wal/floor.json"
-        );
-        assert_eq!(
-            layout.wal_segment(
-                &namespace_id(),
-                &wal_segment_id("wal_00000000000000000001-0123456789abcdef")
-            ),
-            "namespaces/ns-1/wal/segments/wal_00000000000000000001-0123456789abcdef.wal.zst"
-        );
-        assert_eq!(
-            layout.metadata_root(&namespace_id()),
-            "namespaces/ns-1/metadata/root.json"
-        );
+    fn built_keys_parse_to_their_family_owner_and_identifier() {
+        let namespace_id = NamespaceId::parse("ns-1").expect("namespace id");
+        let wal_segment_id = WalSegmentId::parse("wal_00000000000000000001-0123456789abcdef")
+            .expect("WAL segment id");
         let manifest_object_id =
             ManifestObjectId::parse("man_00000000000000000400-0123456789abcdef")
-                .expect("valid manifest object id");
-        assert_eq!(
-            layout
-                .metadata_manifest_object(&namespace_id(), &manifest_object_id),
-            "namespaces/ns-1/metadata/manifests/man_00000000000000000400-0123456789abcdef.manifest.json"
-        );
-        assert_eq!(
-            layout.metadata_segment(&namespace_id(), &metadata_segment_id()),
-            "namespaces/ns-1/metadata/segments/seg_00000000000000000000000000000001.sst.zst"
-        );
-        assert_eq!(
-            layout
-                .metadata_compaction_segment(
-                    &namespace_id(),
-                    &metadata_compaction_id(1),
-                    &metadata_segment_id()
-                ),
-            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/segments/seg_00000000000000000000000000000001.sst.zst"
-        );
-        assert_eq!(
-            layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1)),
-            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/lease.json"
-        );
-        assert_eq!(
-            layout.checkpoint_record(&namespace_id(), &checkpoint_id()),
-            "namespaces/ns-1/checkpoints/chk_00000000000000000000000000000001.json"
-        );
-        assert_eq!(
-            layout.upload_session(&namespace_id(), &upload_id()),
-            "namespaces/ns-1/uploads/upl_00000000000000000000000000000001.json"
-        );
-        assert_eq!(
-            layout
-                .content_blob(&content_store_id(), &content_id()),
-            "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
-        );
-    }
-
-    #[test]
-    fn control_objects_live_outside_the_segment_listing_prefix() {
-        let layout = ObjectLayout::new();
-        let prefix = layout.wal_segment_prefix(&namespace_id());
-        assert_eq!(prefix, "namespaces/ns-1/wal/segments/");
-        assert!(!layout
-            .wal_head(&namespace_id())
-            .as_str()
-            .starts_with(&prefix));
-        assert!(!layout
-            .wal_floor(&namespace_id())
-            .as_str()
-            .starts_with(&prefix));
-        assert!(layout
-            .wal_segment(
-                &namespace_id(),
-                &wal_segment_id("wal_00000000000000000002-0123456789abcdef")
-            )
-            .as_str()
-            .starts_with(&prefix));
-    }
-
-    #[test]
-    fn staged_compaction_segments_live_outside_the_segment_listing_prefix() {
-        let layout = ObjectLayout::new();
-        let segments = layout.metadata_segment_prefix(&namespace_id());
-        let staging = layout.metadata_compaction_prefix(&namespace_id());
-
-        assert!(!staging.starts_with(&segments));
-        assert!(!layout
-            .metadata_compaction_segment(
-                &namespace_id(),
-                &metadata_compaction_id(1),
-                &metadata_segment_id()
-            )
-            .starts_with(&segments));
-        assert!(layout
-            .metadata_compaction_segment(
-                &namespace_id(),
-                &metadata_compaction_id(1),
-                &metadata_segment_id()
-            )
-            .starts_with(&staging));
-        assert!(layout
-            .metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1))
-            .starts_with(&staging));
-        assert!(!layout
-            .metadata_segment(&namespace_id(), &metadata_segment_id())
-            .starts_with(&staging));
-    }
-
-    #[test]
-    fn a_jobs_lease_sorts_before_its_staged_segments() {
-        let layout = ObjectLayout::new();
-        let lease = layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1));
-        let segment_key = layout.metadata_compaction_segment(
-            &namespace_id(),
-            &metadata_compaction_id(1),
-            &metadata_segment_id(),
-        );
-        assert!(lease < segment_key);
-        // Each job occupies one contiguous key range.
-        assert!(
-            segment_key
-                < layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(2))
-        );
-    }
-
-    #[test]
-    fn compaction_keys_report_the_job_that_owns_them() {
-        let layout = ObjectLayout::new();
-        assert_eq!(
-            layout.metadata_compaction_job_id_from_key(
-                &layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1))
-            ),
-            Some("cmp_00000000000000000000000000000001")
-        );
-        assert_eq!(
-            layout.metadata_compaction_job_id_from_key(&layout.metadata_compaction_segment(
-                &namespace_id(),
-                &metadata_compaction_id(1),
-                &metadata_segment_id()
-            )),
-            Some("cmp_00000000000000000000000000000001")
-        );
-        for foreign in [
-            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/segments/seg_00000000000000000000000000000001.tmp",
-            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/notes.json",
-            "namespaces/ns-1/metadata/compactions/stray.json",
-            "namespaces/ns-1/metadata/segments/seg_00000000000000000000000000000001.sst.zst",
-        ] {
-            assert_eq!(layout.metadata_compaction_job_id_from_key(foreign), None);
-        }
-    }
-
-    #[test]
-    fn parse_build_round_trips_for_namespace_key_families() {
-        let layout = ObjectLayout::new();
+                .expect("manifest object id");
+        let metadata_segment_id = MetadataSegmentId::parse("seg_00000000000000000000000000000001")
+            .expect("metadata segment id");
+        let compaction_id = MetadataCompactionId::parse("cmp_00000000000000000000000000000001")
+            .expect("compaction id");
+        let checkpoint_id =
+            CheckpointId::parse("chk_00000000000000000000000000000001").expect("checkpoint id");
+        let upload_id = UploadId::parse("upl_00000000000000000000000000000001").expect("upload id");
+        let content_store_id =
+            ContentStoreId::parse("cs_00000000000000000000000000000001").expect("content store id");
+        let content_id =
+            ContentId::parse("con_abcdef0123456789abcdef0123456789").expect("content id");
         let cases = [
+            (wal_head(&namespace_id), DurableObjectFamily::WalHead, None),
             (
-                layout.wal_head(&namespace_id()),
-                DurableObjectFamily::WalHead,
-            ),
-            (
-                layout.wal_floor(&namespace_id()),
+                wal_floor(&namespace_id),
                 DurableObjectFamily::WalFloor,
+                None,
             ),
             (
-                layout.wal_segment(
-                    &namespace_id(),
-                    &wal_segment_id("wal_00000000000000000001-0123456789abcdef"),
-                ),
+                wal_segment(&namespace_id, &wal_segment_id),
                 DurableObjectFamily::WalSegment,
+                Some(wal_segment_id.as_str()),
             ),
             (
-                layout.metadata_root(&namespace_id()),
+                metadata_root(&namespace_id),
                 DurableObjectFamily::MetadataRoot,
+                None,
             ),
             (
-                layout.metadata_manifest_object(
-                    &namespace_id(),
-                    &ManifestObjectId::parse("man_00000000000000000001-0123456789abcdef")
-                        .expect("valid manifest object id"),
-                ),
+                metadata_manifest_object(&namespace_id, &manifest_object_id),
                 DurableObjectFamily::MetadataManifest,
+                Some(manifest_object_id.as_str()),
             ),
             (
-                layout.metadata_segment(&namespace_id(), &metadata_segment_id()),
+                metadata_segment(&namespace_id, &metadata_segment_id),
                 DurableObjectFamily::MetadataSegment,
+                Some(metadata_segment_id.as_str()),
             ),
             (
-                layout.metadata_compaction_segment(
-                    &namespace_id(),
-                    &metadata_compaction_id(1),
-                    &metadata_segment_id(),
-                ),
+                metadata_compaction_segment(&namespace_id, &compaction_id, &metadata_segment_id),
                 DurableObjectFamily::MetadataCompactionStaging,
+                Some(compaction_id.as_str()),
             ),
             (
-                layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1)),
+                metadata_compaction_lease(&namespace_id, &compaction_id),
                 DurableObjectFamily::MetadataCompactionLease,
+                Some(compaction_id.as_str()),
             ),
             (
-                layout.checkpoint_record(&namespace_id(), &checkpoint_id()),
+                checkpoint_record(&namespace_id, &checkpoint_id),
                 DurableObjectFamily::CheckpointRecord,
+                Some(checkpoint_id.as_str()),
             ),
             (
-                layout.upload_session(&namespace_id(), &upload_id()),
+                upload_session(&namespace_id, &upload_id),
                 DurableObjectFamily::UploadSession,
+                Some(upload_id.as_str()),
+            ),
+            (
+                content_blob(&content_store_id, &content_id),
+                DurableObjectFamily::ContentBlob,
+                Some(content_id.as_str()),
             ),
         ];
 
-        for (key, family) in cases {
-            let parsed = parse_object_key(&key).expect("known namespace key parses");
+        for (key, family, identifier) in cases {
+            let parsed = parse_object_key(&key).expect("built key should parse");
             assert_eq!(parsed.family(), family);
-            assert_eq!(parsed.owner_namespace_id(), Some("ns-1"));
+            assert_eq!(
+                parsed.owner_namespace_id(),
+                (family != DurableObjectFamily::ContentBlob).then_some("ns-1")
+            );
+            assert_eq!(parsed.identifier(), identifier);
         }
     }
 
     #[test]
-    fn parser_rejects_retired_layout_paths() {
-        for old in [
+    fn listing_prefixes_hold_only_their_family_and_a_lease_sorts_first() {
+        let namespace_id = NamespaceId::parse("ns-1").expect("namespace id");
+        let job = MetadataCompactionId::parse("cmp_00000000000000000000000000000001")
+            .expect("compaction id");
+        let next_job = MetadataCompactionId::parse("cmp_00000000000000000000000000000002")
+            .expect("compaction id");
+        let segment_id =
+            MetadataSegmentId::parse("seg_00000000000000000000000000000001").expect("segment id");
+        let lease = metadata_compaction_lease(&namespace_id, &job);
+        let staged = metadata_compaction_segment(&namespace_id, &job, &segment_id);
+
+        assert!(lease < staged);
+        assert!(staged < metadata_compaction_lease(&namespace_id, &next_job));
+        assert!(!staged.starts_with(&metadata_segment_prefix(&namespace_id)));
+        let wal_segments = wal_segment_prefix(&namespace_id);
+        assert!(!wal_head(&namespace_id).starts_with(&wal_segments));
+        assert!(!wal_floor(&namespace_id).starts_with(&wal_segments));
+    }
+
+    #[test]
+    fn parser_rejects_retired_and_malformed_paths() {
+        for key in [
             "namespaces/ns-1/descriptor.json",
             "namespaces/ns-1/control/head.json",
-            "namespaces/ns-1/control/lease.json",
             "namespaces/ns-1/wal/wal_00000000000000000001-0123456789abcdef.wal.zst",
-            "namespaces/ns-1/manifest/00000000000000000400.manifest.json",
-            "namespaces/ns-1/segments/metadata/seg_00000000000000000000000000000001.sst.zst",
-            "namespaces/ns-1/gc/manifest.boundary.json",
-            "namespaces/ns-1/gc/pins/pin_00000000000000000000000000000001.json",
-            "namespaces/ns-1/pins/pin_00000000000000000000000000000001.json",
-            "namespaces/ns-1/metadata/compaction-staging/seg_00000000000000000000000000000001.sst.zst",
-        ] {
-            assert!(
-                parse_object_key(old).is_none(),
-                "retired path parsed: {old}"
-            );
-        }
-    }
-
-    #[test]
-    fn parse_wal_segment_requires_current_wal_suffix() {
-        let parsed = parse_object_key(
-            "namespaces/ns-1/wal/segments/wal_00000000000000000001-0123456789abcdef.wal.zst",
-        )
-        .expect("current WAL key parses");
-        assert_eq!(parsed.family(), DurableObjectFamily::WalSegment);
-        assert_eq!(parsed.owner_namespace_id(), Some("ns-1"));
-
-        assert!(parse_object_key(
-            "namespaces/ns-1/wal/segments/wal_00000000000000000001-0123456789abcdef.sst"
-        )
-        .is_none());
-        assert!(parse_object_key("namespaces/ns-1/wal/segments/random.tmp").is_none());
-    }
-
-    #[test]
-    fn parse_build_round_trips_for_global_key_families() {
-        let layout = ObjectLayout::new();
-        let content_key = layout.content_blob(&content_store_id(), &content_id());
-        let cases = [(content_key, DurableObjectFamily::ContentBlob)];
-
-        for (key, family) in cases {
-            let parsed = parse_object_key(&key).expect("known global key parses");
-            assert_eq!(parsed.family(), family);
-            assert_eq!(parsed.owner_namespace_id(), None);
-        }
-
-        assert!(parse_object_key("namespaces/ns-1/unknown/file").is_none());
-    }
-
-    #[test]
-    fn parser_admits_exactly_one_content_layout() {
-        for foreign in [
-            "content-stores/cs-1/blobs/ab/cd/deadbeef",
+            "namespaces/ns-1/wal/segments/random.tmp",
+            "namespaces/ns-1/metadata/compactions/cmp_1/segments/seg_1.tmp",
             "content-stores/cs-1/objects/ab/deadbeef",
-            "content-stores/cs-1/objects/ab/cd/ef/deadbeef",
-            "content-stores/cs-1/objects/deadbeef",
-            "content-stores/cs-1/objects/",
         ] {
             assert!(
-                parse_object_key(foreign).is_none(),
-                "foreign content path parsed: {foreign}"
+                parse_object_key(key).is_none(),
+                "unexpected key parsed: {key}"
             );
         }
     }

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -16,6 +16,7 @@ mod attempts;
 mod aws_credentials;
 mod configured;
 pub mod crypto;
+mod endpoint;
 pub mod gcs;
 mod immutable_write;
 pub mod keys;

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -6,7 +6,7 @@ use crate::layout::{parse_object_key, DurableObjectFamily};
 use crate::object_store::Result;
 use crate::{
     ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
-    ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
+    ObjectStore, ObjectStoreErrorClass, PutMode, StoredObjectChecksum,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -56,6 +56,32 @@ pub struct ObjectStoreMetricSample {
     pub put_mode: Option<PutModeClass>,
     /// Deployment-supplied provider label, or `None` when the wrapper was left unlabeled.
     pub store_kind: Option<String>,
+}
+
+impl ObjectStoreMetricSample {
+    /// Builds a sample with the fields shared by every object-store operation.
+    pub fn new(
+        operation: ObjectStoreOperation,
+        key: &str,
+        elapsed: Duration,
+        attempts: u32,
+        result: ObjectStoreResultClass,
+        store_kind: Option<String>,
+    ) -> Self {
+        Self {
+            operation,
+            elapsed_micros: elapsed.as_micros(),
+            attempts,
+            result,
+            bytes_in: None,
+            bytes_out: None,
+            item_count: None,
+            key_class: classify_key(key),
+            range_class: None,
+            put_mode: None,
+            store_kind,
+        }
+    }
 }
 
 /// Classifies the method measured by one object-store sample.
@@ -116,20 +142,22 @@ pub enum ObjectStoreResultClass {
     NotFound,
     /// Indicates key or prefix validation failed before provider IO.
     InvalidKey,
-    /// Indicates a content reference could not resolve to an immutable key.
-    InvalidContentRef,
-    /// Indicates requested byte-range bounds were invalid for the object.
-    InvalidRange,
+    /// Indicates a content reference or byte range was invalid.
+    InvalidRequest,
     /// Indicates a create-if-absent or compare-and-swap condition did not hold.
     PreconditionFailed,
     /// Indicates the provider rejected identity or authorization.
     PermissionDenied,
     /// Indicates the configured store lacks a required capability.
     Unsupported,
-    /// Indicates configuration, IO, timeout, protocol, or provider transport failure.
-    Transport,
-    /// Reserves a forward-compatible bucket for errors outside the current registry.
-    OtherError,
+    /// Indicates an object lacks required stored checksum metadata.
+    StoredChecksumMissing,
+    /// Indicates store construction or configuration failed.
+    Configuration,
+    /// Indicates a transient transport failure may succeed when repeated.
+    RetryableTransport,
+    /// Indicates a non-retryable transport or provider protocol failure.
+    Other,
 }
 
 impl ObjectStoreResultClass {
@@ -140,13 +168,31 @@ impl ObjectStoreResultClass {
             Self::Ok => "ok",
             Self::NotFound => "not_found",
             Self::InvalidKey => "invalid_key",
-            Self::InvalidContentRef => "invalid_content_ref",
-            Self::InvalidRange => "invalid_range",
+            Self::InvalidRequest => "invalid_request",
             Self::PreconditionFailed => "precondition_failed",
             Self::PermissionDenied => "permission_denied",
             Self::Unsupported => "unsupported",
-            Self::Transport => "transport",
-            Self::OtherError => "other_error",
+            Self::StoredChecksumMissing => "stored_checksum_missing",
+            Self::Configuration => "configuration",
+            Self::RetryableTransport => "retryable_transport",
+            Self::Other => "other",
+        }
+    }
+}
+
+impl From<ObjectStoreErrorClass> for ObjectStoreResultClass {
+    fn from(class: ObjectStoreErrorClass) -> Self {
+        match class {
+            ObjectStoreErrorClass::NotFound => Self::NotFound,
+            ObjectStoreErrorClass::InvalidRequest => Self::InvalidRequest,
+            ObjectStoreErrorClass::InvalidKey => Self::InvalidKey,
+            ObjectStoreErrorClass::PreconditionFailed => Self::PreconditionFailed,
+            ObjectStoreErrorClass::PermissionDenied => Self::PermissionDenied,
+            ObjectStoreErrorClass::StoredChecksumMissing => Self::StoredChecksumMissing,
+            ObjectStoreErrorClass::Unsupported => Self::Unsupported,
+            ObjectStoreErrorClass::Configuration => Self::Configuration,
+            ObjectStoreErrorClass::RetryableTransport => Self::RetryableTransport,
+            ObjectStoreErrorClass::Other => Self::Other,
         }
     }
 }
@@ -446,19 +492,17 @@ where
         let start = sample_clock();
         let (result, attempts) =
             counting_attempts(self.inner.put_streamed(key, body, mode.clone())).await;
-        self.record(ObjectStoreMetricSample {
-            operation: ObjectStoreOperation::PutStreamed,
-            elapsed_micros: start.elapsed().as_micros(),
+        let mut sample = ObjectStoreMetricSample::new(
+            ObjectStoreOperation::PutStreamed,
+            key,
+            start.elapsed(),
             attempts,
-            result: classify_result(&result),
-            bytes_in: result.as_ref().ok().copied(),
-            bytes_out: None,
-            item_count: None,
-            key_class: classify_key(key),
-            range_class: None,
-            put_mode: Some(classify_put_mode(&mode)),
-            store_kind: self.store_kind.clone(),
-        });
+            classify_result(&result),
+            self.store_kind.clone(),
+        );
+        sample.bytes_in = result.as_ref().ok().copied();
+        sample.put_mode = Some(classify_put_mode(&mode));
+        self.record(sample);
         result
     }
 
@@ -488,7 +532,7 @@ where
             inner: self.inner.list_prefix_from_stream(prefix, start_after),
             recorder: Arc::clone(&self.recorder),
             store_kind: self.store_kind.clone(),
-            key_class: classify_key(prefix),
+            prefix: prefix.to_owned(),
             started: sample_clock(),
             items: 0,
             first_error: None,
@@ -522,19 +566,14 @@ impl<S> InstrumentedObjectStore<S> {
         attempts: u32,
         result: &Result<Option<T>>,
     ) {
-        self.record(ObjectStoreMetricSample {
+        self.record(ObjectStoreMetricSample::new(
             operation,
-            elapsed_micros: elapsed.as_micros(),
+            key,
+            elapsed,
             attempts,
-            result: classify_optional_result(result),
-            bytes_in: None,
-            bytes_out: None,
-            item_count: None,
-            key_class: classify_key(key),
-            range_class: None,
-            put_mode: None,
-            store_kind: self.store_kind.clone(),
-        });
+            classify_optional_result(result),
+            self.store_kind.clone(),
+        ));
     }
 
     fn record_get(
@@ -545,22 +584,20 @@ impl<S> InstrumentedObjectStore<S> {
         attempts: u32,
         result: &Result<Option<Bytes>>,
     ) {
-        self.record(ObjectStoreMetricSample {
-            operation: ObjectStoreOperation::Get,
-            elapsed_micros: elapsed.as_micros(),
+        let mut sample = ObjectStoreMetricSample::new(
+            ObjectStoreOperation::Get,
+            key,
+            elapsed,
             attempts,
-            result: classify_optional_result(result),
-            bytes_in: None,
-            bytes_out: result
-                .as_ref()
-                .ok()
-                .and_then(|bytes| bytes.as_ref().map(|bytes| bytes.len() as u64)),
-            item_count: None,
-            key_class: classify_key(key),
-            range_class: Some(classify_range(range)),
-            put_mode: None,
-            store_kind: self.store_kind.clone(),
-        });
+            classify_optional_result(result),
+            self.store_kind.clone(),
+        );
+        sample.bytes_out = result
+            .as_ref()
+            .ok()
+            .and_then(|bytes| bytes.as_ref().map(|bytes| bytes.len() as u64));
+        sample.range_class = Some(classify_range(range));
+        self.record(sample);
     }
 
     fn record_get_with_metadata(
@@ -570,22 +607,20 @@ impl<S> InstrumentedObjectStore<S> {
         attempts: u32,
         result: &Result<Option<ObjectBody>>,
     ) {
-        self.record(ObjectStoreMetricSample {
-            operation: ObjectStoreOperation::GetWithMetadata,
-            elapsed_micros: elapsed.as_micros(),
+        let mut sample = ObjectStoreMetricSample::new(
+            ObjectStoreOperation::GetWithMetadata,
+            key,
+            elapsed,
             attempts,
-            result: classify_optional_result(result),
-            bytes_in: None,
-            bytes_out: result
-                .as_ref()
-                .ok()
-                .and_then(|body| body.as_ref().map(|body| body.bytes.len() as u64)),
-            item_count: None,
-            key_class: classify_key(key),
-            range_class: Some(RangeClass::FullObject),
-            put_mode: None,
-            store_kind: self.store_kind.clone(),
-        });
+            classify_optional_result(result),
+            self.store_kind.clone(),
+        );
+        sample.bytes_out = result
+            .as_ref()
+            .ok()
+            .and_then(|body| body.as_ref().map(|body| body.bytes.len() as u64));
+        sample.range_class = Some(RangeClass::FullObject);
+        self.record(sample);
     }
 
     fn record_put(
@@ -597,19 +632,17 @@ impl<S> InstrumentedObjectStore<S> {
         attempts: u32,
         result: &Result<ObjectMetadata>,
     ) {
-        self.record(ObjectStoreMetricSample {
-            operation: ObjectStoreOperation::Put,
-            elapsed_micros: elapsed.as_micros(),
+        let mut sample = ObjectStoreMetricSample::new(
+            ObjectStoreOperation::Put,
+            key,
+            elapsed,
             attempts,
-            result: classify_result(result),
-            bytes_in: Some(bytes_in),
-            bytes_out: None,
-            item_count: None,
-            key_class: classify_key(key),
-            range_class: None,
-            put_mode: Some(classify_put_mode(mode)),
-            store_kind: self.store_kind.clone(),
-        });
+            classify_result(result),
+            self.store_kind.clone(),
+        );
+        sample.bytes_in = Some(bytes_in);
+        sample.put_mode = Some(classify_put_mode(mode));
+        self.record(sample);
     }
 
     fn record_unit<T>(
@@ -620,19 +653,14 @@ impl<S> InstrumentedObjectStore<S> {
         attempts: u32,
         result: &Result<T>,
     ) {
-        self.record(ObjectStoreMetricSample {
+        self.record(ObjectStoreMetricSample::new(
             operation,
-            elapsed_micros: elapsed.as_micros(),
+            key,
+            elapsed,
             attempts,
-            result: classify_result(result),
-            bytes_in: None,
-            bytes_out: None,
-            item_count: None,
-            key_class: classify_key(key),
-            range_class: None,
-            put_mode: None,
-            store_kind: self.store_kind.clone(),
-        });
+            classify_result(result),
+            self.store_kind.clone(),
+        ));
     }
 
     fn record_list(
@@ -642,19 +670,17 @@ impl<S> InstrumentedObjectStore<S> {
         attempts: u32,
         result: &Result<Vec<String>>,
     ) {
-        self.record(ObjectStoreMetricSample {
-            operation: ObjectStoreOperation::ListPrefix,
-            elapsed_micros: elapsed.as_micros(),
+        let mut sample = ObjectStoreMetricSample::new(
+            ObjectStoreOperation::ListPrefix,
+            prefix,
+            elapsed,
             attempts,
-            result: classify_result(result),
-            bytes_in: None,
-            bytes_out: None,
-            item_count: result.as_ref().ok().map(|items| items.len() as u64),
-            key_class: classify_key(prefix),
-            range_class: Some(RangeClass::Prefix),
-            put_mode: None,
-            store_kind: self.store_kind.clone(),
-        });
+            classify_result(result),
+            self.store_kind.clone(),
+        );
+        sample.item_count = result.as_ref().ok().map(|items| items.len() as u64);
+        sample.range_class = Some(RangeClass::Prefix);
+        self.record(sample);
     }
 
     fn record(&self, sample: ObjectStoreMetricSample) {
@@ -666,7 +692,7 @@ struct RecordedListStream {
     inner: BoxStream<'static, Result<String>>,
     recorder: Arc<dyn ObjectStoreMetricsRecorder>,
     store_kind: Option<String>,
-    key_class: KeyClass,
+    prefix: String,
     started: Instant,
     items: u64,
     first_error: Option<ObjectStoreResultClass>,
@@ -685,7 +711,7 @@ impl futures::Stream for RecordedListStream {
                 Ok(_) => self.items += 1,
                 Err(error) => {
                     if self.first_error.is_none() {
-                        self.first_error = Some(classify_error(error));
+                        self.first_error = Some(error.class().into());
                     }
                 }
             }
@@ -696,23 +722,16 @@ impl futures::Stream for RecordedListStream {
 
 impl Drop for RecordedListStream {
     fn drop(&mut self) {
-        self.recorder.record(ObjectStoreMetricSample {
-            operation: ObjectStoreOperation::ListPrefixStream,
-            elapsed_micros: self.started.elapsed().as_micros(),
-            // A listing stream is polled by whoever holds it, across tasks a
-            // tally cannot follow, and no LoonFS-owned retry gate sits on
-            // the listing path: what retries a provider client does there
-            // are its own and were never countable from here.
-            attempts: 1,
-            result: self.first_error.unwrap_or(ObjectStoreResultClass::Ok),
-            bytes_in: None,
-            bytes_out: None,
-            item_count: Some(self.items),
-            key_class: self.key_class,
-            range_class: None,
-            put_mode: None,
-            store_kind: self.store_kind.clone(),
-        });
+        let mut sample = ObjectStoreMetricSample::new(
+            ObjectStoreOperation::ListPrefixStream,
+            &self.prefix,
+            self.started.elapsed(),
+            1,
+            self.first_error.unwrap_or(ObjectStoreResultClass::Ok),
+            self.store_kind.clone(),
+        );
+        sample.item_count = Some(self.items);
+        self.recorder.record(sample);
     }
 }
 
@@ -742,31 +761,14 @@ fn classify_optional_result<T>(result: &Result<Option<T>>) -> ObjectStoreResultC
     match result {
         Ok(Some(_)) => ObjectStoreResultClass::Ok,
         Ok(None) => ObjectStoreResultClass::NotFound,
-        Err(error) => classify_error(error),
+        Err(error) => error.class().into(),
     }
 }
 
 fn classify_result<T>(result: &Result<T>) -> ObjectStoreResultClass {
     match result {
         Ok(_) => ObjectStoreResultClass::Ok,
-        Err(error) => classify_error(error),
-    }
-}
-
-fn classify_error(error: &ObjectStoreError) -> ObjectStoreResultClass {
-    match error {
-        ObjectStoreError::NotFound { .. } => ObjectStoreResultClass::NotFound,
-        ObjectStoreError::InvalidKey { .. } => ObjectStoreResultClass::InvalidKey,
-        ObjectStoreError::InvalidContentRef(_) => ObjectStoreResultClass::InvalidContentRef,
-        ObjectStoreError::InvalidRange { .. } => ObjectStoreResultClass::InvalidRange,
-        ObjectStoreError::PreconditionFailed { .. } => ObjectStoreResultClass::PreconditionFailed,
-        ObjectStoreError::PermissionDenied { .. } => ObjectStoreResultClass::PermissionDenied,
-        ObjectStoreError::StoredChecksumMissing { .. } => ObjectStoreResultClass::Unsupported,
-        ObjectStoreError::Unsupported(_) => ObjectStoreResultClass::Unsupported,
-        // Configuration failures happen at store construction, before any
-        // metered operation; classify defensively as transport.
-        ObjectStoreError::Configuration(_) => ObjectStoreResultClass::Transport,
-        ObjectStoreError::Transport { .. } => ObjectStoreResultClass::Transport,
+        Err(error) => error.class().into(),
     }
 }
 

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -530,19 +530,8 @@ pub trait ObjectStore: Send + Sync + Debug {
     /// because every writer allowed to name this immutable key must supply
     /// identical bytes. Mutable keys must use [`Self::put`] and own their
     /// protocol-specific ambiguity resolution.
+    /// Returns metadata from the confirmed write or exact read-back.
     async fn put_immutable_verified(
-        &self,
-        key: &str,
-        bytes: Bytes,
-    ) -> std::result::Result<(), crate::ImmutableWriteError> {
-        self.put_immutable_verified_with_metadata(key, bytes)
-            .await
-            .map(|_| ())
-    }
-
-    /// Performs [`Self::put_immutable_verified`] and returns metadata from the
-    /// confirmed write or exact read-back.
-    async fn put_immutable_verified_with_metadata(
         &self,
         key: &str,
         bytes: Bytes,
@@ -652,18 +641,8 @@ impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
         &self,
         key: &str,
         bytes: Bytes,
-    ) -> std::result::Result<(), crate::ImmutableWriteError> {
-        self.as_ref().put_immutable_verified(key, bytes).await
-    }
-
-    async fn put_immutable_verified_with_metadata(
-        &self,
-        key: &str,
-        bytes: Bytes,
     ) -> std::result::Result<ObjectMetadata, crate::ImmutableWriteError> {
-        self.as_ref()
-            .put_immutable_verified_with_metadata(key, bytes)
-            .await
+        self.as_ref().put_immutable_verified(key, bytes).await
     }
 
     async fn compare_and_swap(
@@ -758,18 +737,8 @@ impl<T: ObjectStore + ?Sized> ObjectStore for &T {
         &self,
         key: &str,
         bytes: Bytes,
-    ) -> std::result::Result<(), crate::ImmutableWriteError> {
-        (*self).put_immutable_verified(key, bytes).await
-    }
-
-    async fn put_immutable_verified_with_metadata(
-        &self,
-        key: &str,
-        bytes: Bytes,
     ) -> std::result::Result<ObjectMetadata, crate::ImmutableWriteError> {
-        (*self)
-            .put_immutable_verified_with_metadata(key, bytes)
-            .await
+        (*self).put_immutable_verified(key, bytes).await
     }
 
     async fn compare_and_swap(

--- a/crates/loonfs-objectstore/src/presign/gcs.rs
+++ b/crates/loonfs-objectstore/src/presign/gcs.rs
@@ -4,17 +4,14 @@
 //! enforce write preconditions in live tests. The native API supports object
 //! generation checks and stores CRC-32C checksums.
 //!
-//! [`GcpGcsStore`]: crate::gcs::GcpGcsStore
-
 use super::{
     DirectGetIssuer, DirectPutIssuer, PresignedGetRequest, PresignedPutRequest, PresignedUrl,
-    MAX_PRESIGN_EXPIRY,
 };
 use crate::keyspace::{normalize_key_prefix, scope_object_key};
 use crate::object_store::Result;
 use crate::presign::v4::{
-    canonical_query_string, hex_lower, normalize_header_value, percent_encode_path,
-    percent_encode_segment, signing_dates, unix_ms,
+    hex_lower, percent_encode_path, percent_encode_segment, presign_v4, signing_dates, V4Endpoint,
+    V4RequestParts, V4Scheme,
 };
 use crate::ObjectStoreError;
 use async_trait::async_trait;
@@ -23,10 +20,8 @@ use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::{Checksum, ChecksumAlgorithm};
 use ring::rand::SystemRandom;
 use ring::signature::{RsaKeyPair, RSA_PKCS1_SHA256};
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt;
-use std::fmt::Write as _;
 use std::time::{Duration, SystemTime};
 
 /// Host used for every GCS signed URL.
@@ -102,24 +97,10 @@ impl GcsV4Presigner {
     /// the store's own reads, listings, and collection never look — an
     /// object committed, invisible, and unreclaimable.
     ///
-    /// Construction fails for a blank bucket or key path, an unusable key
-    /// prefix, an unreadable or malformed key file, or a private key that is
-    /// not an RSA key in PKCS#8 form. Failing here is deliberate: a GCS
-    /// deployment whose key cannot sign also cannot authenticate its
-    /// provider client, so the fault belongs at startup rather than at the
-    /// first transfer.
+    /// Construction fails for an unusable key prefix, an unreadable or
+    /// malformed key file, or a private key that is not an RSA key in PKCS#8
+    /// form.
     pub fn new(config: GcsPresignerConfig) -> Result<Self> {
-        if config.bucket.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "bucket must not be empty".to_owned(),
-            ));
-        }
-        if config.service_account_key_path.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "service account key path must not be empty".to_owned(),
-            ));
-        }
-
         let raw = std::fs::read(&config.service_account_key_path).map_err(|err| {
             ObjectStoreError::Configuration(format!("service account key is unreadable: {err}"))
         })?;
@@ -174,19 +155,6 @@ impl GcsV4Presigner {
         expires_in: Duration,
         now: SystemTime,
     ) -> Result<PresignedUrl> {
-        // Expiry comes from deployment configuration, not the transport: a
-        // bad value is a config bug and must not look like network weather.
-        if expires_in.is_zero() {
-            return Err(ObjectStoreError::Configuration(
-                "presigned URL expiry must be greater than zero".to_owned(),
-            ));
-        }
-        if expires_in.as_secs() > MAX_PRESIGN_EXPIRY {
-            return Err(ObjectStoreError::Configuration(format!(
-                "presigned URL expiry must not exceed {MAX_PRESIGN_EXPIRY} seconds"
-            )));
-        }
-
         let scoped_key = scope_object_key(self.key_prefix.as_deref(), object_key)?;
         let canonical_uri = format!(
             "/{}/{}",
@@ -195,59 +163,30 @@ impl GcsV4Presigner {
         );
         let dates = signing_dates(object_key, now)?;
         let credential_scope = format!("{}/{GCS_CREDENTIAL_SCOPE_SUFFIX}", dates.short_date);
-
-        let mut headers_to_sign = BTreeMap::from([("host".to_owned(), GCS_HOST.to_owned())]);
-        for (name, value) in &required_headers {
-            headers_to_sign.insert(name.to_ascii_lowercase(), normalize_header_value(value));
-        }
-        let signed_headers = headers_to_sign
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(";");
-        let mut canonical_headers = String::new();
-        for (name, value) in &headers_to_sign {
-            writeln!(&mut canonical_headers, "{name}:{value}")
-                .expect("writing to a String should not fail");
-        }
-
-        let query = BTreeMap::from([
-            (
-                "X-Goog-Algorithm".to_owned(),
-                GCS_SIGNING_ALGORITHM.to_owned(),
-            ),
-            (
-                "X-Goog-Credential".to_owned(),
-                format!("{}/{credential_scope}", self.client_email),
-            ),
-            ("X-Goog-Date".to_owned(), dates.timestamp.clone()),
-            (
-                "X-Goog-Expires".to_owned(),
-                expires_in.as_secs().to_string(),
-            ),
-            ("X-Goog-SignedHeaders".to_owned(), signed_headers.clone()),
-        ]);
-        let canonical_query = canonical_query_string(&query);
-        let canonical_request = format!(
-            "{method}\n{canonical_uri}\n{canonical_query}\n{canonical_headers}\n{signed_headers}\nUNSIGNED-PAYLOAD"
-        );
-        let string_to_sign = format!(
-            "{GCS_SIGNING_ALGORITHM}\n{}\n{credential_scope}\n{}",
-            dates.timestamp,
-            hex_lower(&Sha256::digest(canonical_request.as_bytes()))
-        );
-        let signature = self.sign(object_key, string_to_sign.as_bytes())?;
-        let url = format!(
-            "https://{GCS_HOST}{canonical_uri}?{canonical_query}&X-Goog-Signature={signature}"
-        );
-        let expires_at_ms = unix_ms(object_key, now)? + expires_in.as_millis() as u64;
-
-        Ok(PresignedUrl {
-            method: method.to_owned(),
-            url,
-            headers: required_headers,
-            expires_at_ms,
-        })
+        presign_v4(
+            V4Scheme {
+                algorithm: GCS_SIGNING_ALGORITHM,
+                query_prefix: "X-Goog",
+                credential: format!("{}/{credential_scope}", self.client_email),
+                credential_scope,
+                extra_query: BTreeMap::new(),
+                signing_dates: dates,
+            },
+            V4Endpoint {
+                scheme: "https".to_owned(),
+                host: GCS_HOST.to_owned(),
+                canonical_uri,
+            },
+            method,
+            V4RequestParts {
+                object_key,
+                operation_query: BTreeMap::new(),
+                required_headers,
+            },
+            expires_in,
+            now,
+            |message| self.sign(object_key, message),
+        )
     }
 
     /// Produces the hex-encoded RSASSA-PKCS1-v1_5 SHA-256 signature GCS

--- a/crates/loonfs-objectstore/src/presign/issuer.rs
+++ b/crates/loonfs-objectstore/src/presign/issuer.rs
@@ -136,29 +136,3 @@ pub struct DirectTransferIssuers {
     /// one.
     pub multipart: Option<Arc<dyn DirectMultipartIssuer>>,
 }
-
-impl DirectTransferIssuers {
-    /// Builds a read-only bundle: reads are signed, neither write direction
-    /// is offered.
-    pub fn read_only(get: Arc<dyn DirectGetIssuer>) -> Self {
-        Self {
-            get,
-            put: None,
-            multipart: None,
-        }
-    }
-
-    /// Adds whole-object write signing to this bundle.
-    #[must_use]
-    pub fn with_put(mut self, put: Arc<dyn DirectPutIssuer>) -> Self {
-        self.put = Some(put);
-        self
-    }
-
-    /// Adds multipart part signing to this bundle.
-    #[must_use]
-    pub fn with_multipart(mut self, multipart: Arc<dyn DirectMultipartIssuer>) -> Self {
-        self.multipart = Some(multipart);
-        self
-    }
-}

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -2,28 +2,25 @@
 
 use super::{
     DirectGetIssuer, DirectMultipartIssuer, DirectPutIssuer, PresignedGetRequest,
-    PresignedPartRequest, PresignedPutRequest, PresignedUrl, MAX_PRESIGN_EXPIRY,
+    PresignedPartRequest, PresignedPutRequest, PresignedUrl,
 };
 use crate::aws_credentials::{
     aws_credentials_source, AwsSigningCredentials, SharedAwsCredentialsSource,
 };
 use crate::crypto::hmac_sha256;
-use crate::keyspace::{
-    normalize_key_prefix, parse_endpoint_url, scope_object_key, virtual_hosted_authority,
-};
+use crate::endpoint::{parse_endpoint_url, virtual_hosted_authority};
+use crate::keyspace::{normalize_key_prefix, scope_object_key};
 use crate::object_store::Result;
 use crate::presign::v4::{
-    canonical_query_string, hex_lower, normalize_header_value, percent_encode_path,
-    percent_encode_segment, signing_dates, unix_ms,
+    hex_lower, percent_encode_path, percent_encode_segment, presign_v4, signing_dates, V4Endpoint,
+    V4RequestParts, V4Scheme,
 };
 use crate::ObjectStoreError;
 use async_trait::async_trait;
 use base64::Engine as _;
 use loonfs_api::wire::hex::hex_decode_bytes;
 use loonfs_api::{Checksum, ChecksumAlgorithm};
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::fmt::Write as _;
 use std::time::{Duration, SystemTime};
 
 const S3_CREATE_ONLY_HEADER: &str = "if-none-match";
@@ -106,16 +103,6 @@ impl S3CompatiblePresigner {
         mut config: S3PresignerConfig,
         credentials: SharedAwsCredentialsSource,
     ) -> Result<Self> {
-        if config.bucket.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "bucket must not be empty".to_owned(),
-            ));
-        }
-        if config.region.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "region must not be empty".to_owned(),
-            ));
-        }
         config.key_prefix = normalize_key_prefix(config.key_prefix.as_deref())?;
         Ok(Self {
             config,
@@ -273,20 +260,6 @@ impl S3CompatiblePresigner {
         expires_in: Duration,
         now: SystemTime,
     ) -> Result<PresignedUrl> {
-        // Expiry comes from deployment configuration, not the transport:
-        // a bad value is a config bug and must not look like network
-        // weather.
-        if expires_in.is_zero() {
-            return Err(ObjectStoreError::Configuration(
-                "presigned URL expiry must be greater than zero".to_owned(),
-            ));
-        }
-        if expires_in.as_secs() > MAX_PRESIGN_EXPIRY {
-            return Err(ObjectStoreError::Configuration(format!(
-                "presigned URL expiry must not exceed {MAX_PRESIGN_EXPIRY} seconds"
-            )));
-        }
-
         let endpoint = self.endpoint(object_key)?;
         let dates = signing_dates(object_key, now)?;
         let credential_scope = format!(
@@ -298,64 +271,38 @@ impl S3CompatiblePresigner {
             credentials.access_key_id.expose(),
             credential_scope
         );
-
-        let mut headers_to_sign = BTreeMap::from([("host".to_owned(), endpoint.host.clone())]);
-        for (name, value) in &request_parts.required_headers {
-            headers_to_sign.insert(name.to_ascii_lowercase(), normalize_header_value(value));
-        }
-        let signed_headers = headers_to_sign
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(";");
-        let mut canonical_headers = String::new();
-        for (name, value) in &headers_to_sign {
-            writeln!(&mut canonical_headers, "{name}:{value}")
-                .expect("writing to a String should not fail");
-        }
-
-        let mut query = request_parts.operation_query;
-        query.extend([
-            ("X-Amz-Algorithm".to_owned(), "AWS4-HMAC-SHA256".to_owned()),
-            ("X-Amz-Credential".to_owned(), credential),
-            ("X-Amz-Date".to_owned(), dates.timestamp.clone()),
-            ("X-Amz-Expires".to_owned(), expires_in.as_secs().to_string()),
-            ("X-Amz-SignedHeaders".to_owned(), signed_headers.clone()),
-        ]);
+        let mut extra_query = BTreeMap::new();
         if let Some(token) = &credentials.session_token {
-            query.insert("X-Amz-Security-Token".to_owned(), token.expose().to_owned());
+            extra_query.insert("X-Amz-Security-Token".to_owned(), token.expose().to_owned());
         }
-        let canonical_query = canonical_query_string(&query);
-        let canonical_request = format!(
-            "{}\n{}\n{}\n{}\n{}\nUNSIGNED-PAYLOAD",
-            method, endpoint.canonical_uri, canonical_query, canonical_headers, signed_headers
-        );
-        let hashed_request = hex_lower(&Sha256::digest(canonical_request.as_bytes()));
-        let string_to_sign = format!(
-            "AWS4-HMAC-SHA256\n{}\n{}\n{}",
-            dates.timestamp, credential_scope, hashed_request
-        );
         let signing_key = signing_key(
             credentials.secret_access_key.expose(),
             &dates.short_date,
             &self.config.region,
         );
-        let signature = hex_lower(&hmac_sha256(&signing_key, string_to_sign.as_bytes()));
-        let url = format!(
-            "{}://{}{}?{}&X-Amz-Signature={}",
-            endpoint.scheme, endpoint.host, endpoint.canonical_uri, canonical_query, signature
-        );
-        let expires_at_ms = unix_ms(object_key, now)? + expires_in.as_millis() as u64;
-
-        Ok(PresignedUrl {
-            method: method.to_owned(),
-            url,
-            headers: request_parts.required_headers,
-            expires_at_ms,
-        })
+        presign_v4(
+            V4Scheme {
+                algorithm: "AWS4-HMAC-SHA256",
+                query_prefix: "X-Amz",
+                credential,
+                credential_scope,
+                extra_query,
+                signing_dates: dates,
+            },
+            endpoint,
+            method,
+            V4RequestParts {
+                object_key,
+                operation_query: request_parts.operation_query,
+                required_headers: request_parts.required_headers,
+            },
+            expires_in,
+            now,
+            |message| Ok(hex_lower(&hmac_sha256(&signing_key, message))),
+        )
     }
 
-    fn endpoint(&self, object_key: &str) -> Result<S3Endpoint> {
+    fn endpoint(&self, object_key: &str) -> Result<V4Endpoint> {
         let scoped_key = scope_object_key(self.config.key_prefix.as_deref(), object_key)?;
         let encoded_key = percent_encode_path(&scoped_key);
 
@@ -368,7 +315,7 @@ impl S3CompatiblePresigner {
                     format!("/{}", parsed.path)
                 };
                 if self.config.force_path_style {
-                    Ok(S3Endpoint {
+                    Ok(V4Endpoint {
                         scheme: parsed.scheme.to_owned(),
                         host: parsed.authority.to_owned(),
                         canonical_uri: format!(
@@ -379,7 +326,7 @@ impl S3CompatiblePresigner {
                         ),
                     })
                 } else {
-                    Ok(S3Endpoint {
+                    Ok(V4Endpoint {
                         scheme: parsed.scheme.to_owned(),
                         host: virtual_hosted_authority(&self.config.bucket, parsed.authority),
                         canonical_uri: format!("{}/{}", base_path, encoded_key),
@@ -389,7 +336,7 @@ impl S3CompatiblePresigner {
             None => {
                 let scheme = "https".to_owned();
                 if self.config.force_path_style {
-                    Ok(S3Endpoint {
+                    Ok(V4Endpoint {
                         scheme,
                         host: format!("s3.{}.amazonaws.com", self.config.region),
                         canonical_uri: format!(
@@ -399,7 +346,7 @@ impl S3CompatiblePresigner {
                         ),
                     })
                 } else {
-                    Ok(S3Endpoint {
+                    Ok(V4Endpoint {
                         scheme,
                         host: format!(
                             "{}.s3.{}.amazonaws.com",
@@ -516,13 +463,6 @@ pub(crate) fn base64_crc64nvme(checksum: &Checksum) -> Result<String> {
 
 fn invalid_direct_put_content(message: &str) -> ObjectStoreError {
     ObjectStoreError::InvalidContentRef(message.to_owned())
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct S3Endpoint {
-    scheme: String,
-    host: String,
-    canonical_uri: String,
 }
 
 fn signing_key(secret: &str, date: &str, region: &str) -> Vec<u8> {

--- a/crates/loonfs-objectstore/src/presign/v4.rs
+++ b/crates/loonfs-objectstore/src/presign/v4.rs
@@ -9,9 +9,12 @@
 //! primitive stay in its own presigner.
 
 use crate::object_store::Result;
+use crate::presign::{PresignedUrl, MAX_PRESIGN_EXPIRY};
 use crate::ObjectStoreError;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
+use std::fmt::Write as _;
+use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
 
 /// The two date spellings a V4 signature carries: the credential scope's day
 /// and the request's full timestamp, which must agree.
@@ -19,6 +22,118 @@ use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 pub(crate) struct SigningDates {
     pub(crate) short_date: String,
     pub(crate) timestamp: String,
+}
+
+pub(crate) struct V4Scheme {
+    pub(crate) algorithm: &'static str,
+    pub(crate) query_prefix: &'static str,
+    pub(crate) credential: String,
+    pub(crate) credential_scope: String,
+    pub(crate) extra_query: BTreeMap<String, String>,
+    pub(crate) signing_dates: SigningDates,
+}
+
+pub(crate) struct V4Endpoint {
+    pub(crate) scheme: String,
+    pub(crate) host: String,
+    pub(crate) canonical_uri: String,
+}
+
+pub(crate) struct V4RequestParts<'a> {
+    pub(crate) object_key: &'a str,
+    pub(crate) operation_query: BTreeMap<String, String>,
+    pub(crate) required_headers: BTreeMap<String, String>,
+}
+
+pub(crate) fn presign_v4(
+    scheme: V4Scheme,
+    endpoint: V4Endpoint,
+    method: &str,
+    request_parts: V4RequestParts<'_>,
+    expires_in: Duration,
+    now: SystemTime,
+    sign: impl FnOnce(&[u8]) -> Result<String>,
+) -> Result<PresignedUrl> {
+    if expires_in.is_zero() {
+        return Err(ObjectStoreError::Configuration(
+            "presigned URL expiry must be greater than zero".to_owned(),
+        ));
+    }
+    if expires_in.as_secs() > MAX_PRESIGN_EXPIRY {
+        return Err(ObjectStoreError::Configuration(format!(
+            "presigned URL expiry must not exceed {MAX_PRESIGN_EXPIRY} seconds"
+        )));
+    }
+
+    let mut headers_to_sign = BTreeMap::from([("host".to_owned(), endpoint.host.clone())]);
+    for (name, value) in &request_parts.required_headers {
+        headers_to_sign.insert(name.to_ascii_lowercase(), normalize_header_value(value));
+    }
+    let signed_headers = headers_to_sign
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(";");
+    let mut canonical_headers = String::new();
+    for (name, value) in &headers_to_sign {
+        writeln!(&mut canonical_headers, "{name}:{value}")
+            .expect("writing to a String should not fail");
+    }
+
+    let mut query = request_parts.operation_query;
+    query.extend(scheme.extra_query);
+    query.extend([
+        (
+            format!("{}-Algorithm", scheme.query_prefix),
+            scheme.algorithm.to_owned(),
+        ),
+        (
+            format!("{}-Credential", scheme.query_prefix),
+            scheme.credential,
+        ),
+        (
+            format!("{}-Date", scheme.query_prefix),
+            scheme.signing_dates.timestamp.clone(),
+        ),
+        (
+            format!("{}-Expires", scheme.query_prefix),
+            expires_in.as_secs().to_string(),
+        ),
+        (
+            format!("{}-SignedHeaders", scheme.query_prefix),
+            signed_headers.clone(),
+        ),
+    ]);
+    let canonical_query = canonical_query_string(&query);
+    let canonical_request = format!(
+        "{method}\n{}\n{canonical_query}\n{canonical_headers}\n{signed_headers}\nUNSIGNED-PAYLOAD",
+        endpoint.canonical_uri
+    );
+    let string_to_sign = format!(
+        "{}\n{}\n{}\n{}",
+        scheme.algorithm,
+        scheme.signing_dates.timestamp,
+        scheme.credential_scope,
+        hex_lower(&Sha256::digest(canonical_request.as_bytes()))
+    );
+    let signature = sign(string_to_sign.as_bytes())?;
+    let url = format!(
+        "{}://{}{}?{}&{}-Signature={}",
+        endpoint.scheme,
+        endpoint.host,
+        endpoint.canonical_uri,
+        canonical_query,
+        scheme.query_prefix,
+        signature
+    );
+    let expires_at_ms = unix_ms(request_parts.object_key, now)? + expires_in.as_millis() as u64;
+
+    Ok(PresignedUrl {
+        method: method.to_owned(),
+        url,
+        headers: request_parts.required_headers,
+        expires_at_ms,
+    })
 }
 
 pub(crate) fn signing_dates(object_key: &str, time: SystemTime) -> Result<SigningDates> {

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -8,15 +8,18 @@ use crate::keyspace::{
 };
 use crate::object_store::Result;
 use crate::retry::{
-    next_retry_backoff, transport_retry_pause, OperationDeadline, TransportRetryPolicy,
+    provider_transport_retryable, with_transport_retry, OperationDeadline, TransportRetryPolicy,
 };
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use crate::{
-    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+    ByteRange, ByteStream, ConfiguredObjectStoreKind, MultipartCompletion, MultipartPart,
+    ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode, StoredObjectChecksum,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream, FuturesUnordered, StreamExt};
+use loonfs_api::Checksum;
 use object_store as provider_store;
 use provider_store::multipart::{MultipartStore, PartId};
 use provider_store::path::Path;
@@ -145,15 +148,42 @@ impl MultipartGeometry {
     };
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompareToken {
+    Etag,
+    Generation,
+}
+
+#[async_trait]
+pub(crate) trait StoredChecksumReader: Send + Sync {
+    async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>>;
+}
+
+#[async_trait]
+pub(crate) trait MultipartController: Send + Sync {
+    async fn create_multipart_upload(&self, key: &str) -> Result<String>;
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion>;
+
+    async fn abort_multipart_upload(&self, key: &str, provider_upload_id: &str) -> Result<()>;
+}
+
 /// Adapts the upstream `object_store` provider surface to the narrower LoonFS contract.
 #[derive(Clone)]
 pub struct ProviderObjectStore {
     inner: Arc<dyn provider_store::ObjectStore>,
-    /// The provider's native multipart surface, used for payloads at or
-    /// above [`PROVIDER_MULTIPART_THRESHOLD_BYTES`]. `None` only for
-    /// providers without one; their large puts stay whole-object PUTs under
-    /// the payload-scaled bounds.
-    multipart: Option<Arc<dyn MultipartStore>>,
+    multipart: Arc<dyn MultipartStore>,
+    checksum_reader: Option<Arc<dyn StoredChecksumReader>>,
+    multipart_controller: Option<Arc<dyn MultipartController>>,
+    compare_token: CompareToken,
+    kind: ConfiguredObjectStoreKind,
+    io_runtime: StoreIoRuntime,
     multipart_geometry: MultipartGeometry,
     key_prefix: Option<String>,
     transport_retry: TransportRetryPolicy,
@@ -163,30 +193,59 @@ pub struct ProviderObjectStore {
 impl fmt::Debug for ProviderObjectStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProviderObjectStore")
+            .field("kind", &self.kind.as_str())
             .field("key_prefix", &self.key_prefix)
-            .field("multipart_upload", &self.multipart.is_some())
+            .field("io_runtime", &self.io_runtime)
             .finish_non_exhaustive()
     }
 }
 
 impl ProviderObjectStore {
-    /// Wraps a provider client and optional native multipart surface.
+    /// Wraps a provider client and its native multipart surface.
     ///
     /// Construction fails when `config.key_prefix` is not a normalized,
     /// non-escaping logical prefix.
-    pub fn new(
+    pub(crate) fn new(
         inner: Arc<dyn provider_store::ObjectStore>,
-        multipart: Option<Arc<dyn MultipartStore>>,
+        multipart: Arc<dyn MultipartStore>,
         config: ProviderObjectStoreConfig,
+        kind: ConfiguredObjectStoreKind,
+        io_runtime: StoreIoRuntime,
     ) -> Result<Self> {
         Ok(Self {
             inner,
             multipart,
+            checksum_reader: None,
+            multipart_controller: None,
+            compare_token: CompareToken::Etag,
+            kind,
+            io_runtime,
             multipart_geometry: MultipartGeometry::DEFAULT,
             key_prefix: normalize_key_prefix(config.key_prefix.as_deref())?,
             transport_retry: TransportRetryPolicy::DEFAULT,
             timer: Arc::new(StdMonotonicTimer::default()),
         })
+    }
+
+    pub(crate) fn compare_token(mut self, compare_token: CompareToken) -> Self {
+        self.compare_token = compare_token;
+        self
+    }
+
+    pub(crate) fn checksum_reader(
+        mut self,
+        checksum_reader: Arc<dyn StoredChecksumReader>,
+    ) -> Self {
+        self.checksum_reader = Some(checksum_reader);
+        self
+    }
+
+    pub(crate) fn multipart_controller(
+        mut self,
+        multipart_controller: Arc<dyn MultipartController>,
+    ) -> Self {
+        self.multipart_controller = Some(multipart_controller);
+        self
     }
 
     #[cfg(test)]
@@ -218,10 +277,6 @@ impl ProviderObjectStore {
         })
     }
 
-    pub(crate) fn validate_key(&self, key: &str) -> Result<()> {
-        self.to_path(key).map(|_| ())
-    }
-
     fn list_path(&self, prefix: &str) -> Result<Option<Path>> {
         let scoped = scope_list_prefix(self.key_prefix.as_deref(), prefix)?;
         if scoped.is_empty() {
@@ -235,22 +290,45 @@ impl ProviderObjectStore {
             })
     }
 
-    fn from_meta(meta: ObjectMeta) -> ObjectMetadata {
-        ObjectMetadata {
+    fn metadata_from_meta(&self, meta: ObjectMeta) -> ObjectMetadata {
+        self.with_compare_token(ObjectMetadata {
             etag: meta.e_tag,
             version: meta.version,
             size_bytes: meta.size,
             last_modified_ms: last_modified_ms(meta.last_modified.timestamp_millis()),
-        }
+        })
     }
 
-    fn from_put_result(result: PutResult, size_bytes: u64) -> ObjectMetadata {
-        ObjectMetadata {
+    fn metadata_from_put_result(&self, result: PutResult, size_bytes: u64) -> ObjectMetadata {
+        self.with_compare_token(ObjectMetadata {
             etag: result.e_tag,
             version: result.version,
             size_bytes,
             last_modified_ms: None,
+        })
+    }
+
+    fn with_compare_token(&self, metadata: ObjectMetadata) -> ObjectMetadata {
+        match self.compare_token {
+            CompareToken::Etag => metadata,
+            CompareToken::Generation => ObjectMetadata {
+                etag: metadata.version.clone(),
+                ..metadata
+            },
         }
+    }
+
+    fn validate_compare_token(&self, key: &str, mode: &PutMode) -> Result<()> {
+        if self.compare_token == CompareToken::Generation {
+            if let PutMode::CompareAndSwap { expected_etag } = mode {
+                expected_etag
+                    .parse::<u64>()
+                    .map_err(|_| ObjectStoreError::PreconditionFailed {
+                        object_key: key.to_owned(),
+                    })?;
+            }
+        }
+        Ok(())
     }
 
     async fn ranged_get(&self, path: &Path, start: u64, end: u64) -> RangedGet {
@@ -448,33 +526,21 @@ impl MultipartWrite<'_> {
             self.store.timer.as_ref(),
             self.store.transport_retry.operation_deadline,
         );
-        let mut retries: u32 = 0;
-        loop {
-            let err = match self.multipart.create_multipart(self.path).await {
-                Ok(upload_id) => {
-                    return Ok(AbortUploadOnDrop::new(
-                        Arc::clone(&self.multipart),
-                        self.path.clone(),
-                        upload_id,
-                    ));
-                }
-                Err(err) => err,
-            };
-            if !provider_transport_retryable(&err) {
-                return Err(map_provider_error(self.key, err));
-            }
-            let Some(backoff) = next_retry_backoff(
-                &self.store.transport_retry,
-                self.key,
-                "create_multipart",
-                payload_bytes,
-                &mut retries,
-                Some(&deadline),
-            ) else {
-                return Err(map_provider_error(self.key, err));
-            };
-            transport_retry_pause(backoff).await;
-        }
+        let upload_id = with_transport_retry(
+            &self.store.transport_retry,
+            self.key,
+            "create_multipart",
+            payload_bytes,
+            Some(&deadline),
+            || self.multipart.create_multipart(self.path),
+        )
+        .await
+        .map_err(|error| map_provider_error(self.key, error))?;
+        Ok(AbortUploadOnDrop::new(
+            Arc::clone(&self.multipart),
+            self.path.clone(),
+            upload_id,
+        ))
     }
 
     /// Uploads a stream as fixed-size parts while retaining at most one part.
@@ -599,36 +665,23 @@ impl MultipartWrite<'_> {
             self.store.timer.as_ref(),
             self.store.transport_retry.operation_deadline,
         );
-        let mut retries: u32 = 0;
-        loop {
-            let err = match self
-                .multipart
-                .put_part(
+        with_transport_retry(
+            &self.store.transport_retry,
+            self.key,
+            "put_part",
+            payload_bytes,
+            Some(&deadline),
+            || {
+                self.multipart.put_part(
                     self.path,
                     upload_id,
                     part_index,
                     PutPayload::from(payload.clone()),
                 )
-                .await
-            {
-                Ok(part_id) => return Ok(part_id),
-                Err(err) => err,
-            };
-            if !provider_transport_retryable(&err) {
-                return Err(map_provider_error(self.key, err));
-            }
-            let Some(backoff) = next_retry_backoff(
-                &self.store.transport_retry,
-                self.key,
-                "put_part",
-                payload_bytes,
-                &mut retries,
-                Some(&deadline),
-            ) else {
-                return Err(map_provider_error(self.key, err));
-            };
-            transport_retry_pause(backoff).await;
-        }
+            },
+        )
+        .await
+        .map_err(|error| map_provider_error(self.key, error))
     }
 
     async fn complete(
@@ -643,7 +696,7 @@ impl MultipartWrite<'_> {
             .complete_multipart(self.path, upload_id, parts)
             .await
         {
-            Ok(result) => Ok(ProviderObjectStore::from_put_result(result, size_bytes)),
+            Ok(result) => Ok(self.store.metadata_from_put_result(result, size_bytes)),
             Err(err) if provider_transport_retryable(&err) => {
                 self.resolve_ambiguous_completion(upload_id, bytes, err)
                     .await
@@ -728,9 +781,59 @@ impl ObjectStore for ProviderObjectStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         let path = self.to_path(key)?;
         match self.inner.head(&path).await {
-            Ok(meta) => Ok(Some(Self::from_meta(meta))),
+            Ok(meta) => Ok(Some(self.metadata_from_meta(meta))),
             Err(err) if provider_not_found(&err) => Ok(None),
             Err(err) => Err(map_provider_error(key, err)),
+        }
+    }
+
+    async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
+        match &self.checksum_reader {
+            Some(reader) => reader.head_stored_checksum(key).await,
+            None => Err(ObjectStoreError::Unsupported(
+                "stored full-object checksum readback",
+            )),
+        }
+    }
+
+    async fn create_multipart_upload(&self, key: &str) -> Result<String> {
+        match &self.multipart_controller {
+            Some(controller) => controller.create_multipart_upload(key).await,
+            None => Err(ObjectStoreError::Unsupported(
+                "client-driven multipart upload",
+            )),
+        }
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        key: &str,
+        provider_upload_id: &str,
+        parts: &[MultipartPart],
+        checksum: &Checksum,
+    ) -> Result<MultipartCompletion> {
+        match &self.multipart_controller {
+            Some(controller) => {
+                controller
+                    .complete_multipart_upload(key, provider_upload_id, parts, checksum)
+                    .await
+            }
+            None => Err(ObjectStoreError::Unsupported(
+                "client-driven multipart upload",
+            )),
+        }
+    }
+
+    async fn abort_multipart_upload(&self, key: &str, provider_upload_id: &str) -> Result<()> {
+        match &self.multipart_controller {
+            Some(controller) => {
+                controller
+                    .abort_multipart_upload(key, provider_upload_id)
+                    .await
+            }
+            None => Err(ObjectStoreError::Unsupported(
+                "client-driven multipart upload",
+            )),
         }
     }
 
@@ -738,7 +841,7 @@ impl ObjectStore for ProviderObjectStore {
         let path = self.to_path(key)?;
         match self.inner.get(&path).await {
             Ok(result) => {
-                let metadata = Self::from_meta(result.meta.clone());
+                let metadata = self.metadata_from_meta(result.meta.clone());
                 let bytes = result
                     .bytes()
                     .await
@@ -831,13 +934,14 @@ impl ObjectStore for ProviderObjectStore {
 
     async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         let path = self.to_path(key)?;
+        self.validate_compare_token(key, &mode)?;
         let size_bytes = bytes.len() as u64;
         if matches!(mode, PutMode::Overwrite)
             && size_bytes >= self.multipart_geometry.threshold_bytes
         {
-            if let Some(multipart) = self.multipart.clone() {
-                return self.put_large_multipart(multipart, key, &path, bytes).await;
-            }
+            return self
+                .put_large_multipart(Arc::clone(&self.multipart), key, &path, bytes)
+                .await;
         }
         // Raw flat writes are deliberately one attempt. In particular, a
         // mutable overwrite cannot be replayed after an ambiguous transport
@@ -845,7 +949,7 @@ impl ObjectStore for ProviderObjectStore {
         // `put_immutable_verified`, whose name supplies the retry invariant.
         let compare_and_swap = matches!(mode, PutMode::CompareAndSwap { .. });
         let options = PutOptions {
-            mode: map_put_mode(mode),
+            mode: self.map_put_mode(mode),
             ..Default::default()
         };
         match self
@@ -853,7 +957,7 @@ impl ObjectStore for ProviderObjectStore {
             .put_opts(&path, PutPayload::from(bytes), options)
             .await
         {
-            Ok(result) => Ok(Self::from_put_result(result, size_bytes)),
+            Ok(result) => Ok(self.metadata_from_put_result(result, size_bytes)),
             Err(err) if compare_and_swap && provider_not_found(&err) => {
                 Err(ObjectStoreError::PreconditionFailed {
                     object_key: key.to_owned(),
@@ -877,20 +981,9 @@ impl ObjectStore for ProviderObjectStore {
     /// consumed and immediately before completion.
     async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
         let path = self.to_path(key)?;
+        self.validate_compare_token(key, &mode)?;
         let mut reader = PartReader::new(body, self.multipart_geometry.part_bytes as usize);
         let head = reader.next_part().await?.unwrap_or_else(Bytes::new);
-        let Some(multipart) = self.multipart.clone() else {
-            // No provider multipart surface: fall back to the buffered
-            // contract rather than pretend, exactly as the default does.
-            let mut bytes = bytes::BytesMut::from(head.as_ref());
-            while let Some(part) = reader.next_part().await? {
-                bytes.extend_from_slice(&part);
-            }
-            let bytes = bytes.freeze();
-            let size_bytes = bytes.len() as u64;
-            self.put(key, bytes, mode).await?;
-            return Ok(size_bytes);
-        };
         if reader.exhausted() {
             let size_bytes = head.len() as u64;
             self.put(key, head, mode).await?;
@@ -899,7 +992,7 @@ impl ObjectStore for ProviderObjectStore {
 
         let upload = MultipartWrite {
             store: self,
-            multipart,
+            multipart: Arc::clone(&self.multipart),
             key,
             path: &path,
         };
@@ -926,31 +1019,21 @@ impl ObjectStore for ProviderObjectStore {
         let path = self.to_path(key)?;
         let deadline =
             OperationDeadline::start(self.timer.as_ref(), self.transport_retry.operation_deadline);
-        let mut retries: u32 = 0;
-        loop {
-            // Delete is idempotent under this contract: not-found already
-            // reports success, so a retry after an attempt that landed
-            // converges to the same outcome.
-            let err = match self.inner.delete(&path).await {
-                Ok(()) => return Ok(()),
-                Err(err) if provider_not_found(&err) => return Ok(()),
-                Err(err) => err,
-            };
-            if !provider_transport_retryable(&err) {
-                return Err(map_provider_error(key, err));
-            }
-            let Some(backoff) = next_retry_backoff(
-                &self.transport_retry,
-                key,
-                "delete",
-                0,
-                &mut retries,
-                Some(&deadline),
-            ) else {
-                return Err(map_provider_error(key, err));
-            };
-            transport_retry_pause(backoff).await;
-        }
+        with_transport_retry(
+            &self.transport_retry,
+            key,
+            "delete",
+            0,
+            Some(&deadline),
+            || async {
+                match self.inner.delete(&path).await {
+                    Err(error) if provider_not_found(&error) => Ok(()),
+                    result => result,
+                }
+            },
+        )
+        .await
+        .map_err(|error| map_provider_error(key, error))
     }
 
     fn list_prefix_from_stream(
@@ -1005,19 +1088,24 @@ impl ObjectStore for ProviderObjectStore {
     }
 }
 
-fn map_put_mode(mode: PutMode) -> provider_store::PutMode {
-    match mode {
-        PutMode::Overwrite => provider_store::PutMode::Overwrite,
-        PutMode::CreateIfAbsent => provider_store::PutMode::Create,
-        PutMode::CompareAndSwap { expected_etag } => {
-            // The compare token is opaque and provider-issued: S3-family
-            // backends condition on `e_tag`, GCS conditions on `version`
-            // (its generation). Populate both so each backend reads the
-            // field it understands.
-            provider_store::PutMode::Update(UpdateVersion {
-                e_tag: Some(expected_etag.clone()),
-                version: Some(expected_etag),
-            })
+impl ProviderObjectStore {
+    fn map_put_mode(&self, mode: PutMode) -> provider_store::PutMode {
+        match mode {
+            PutMode::Overwrite => provider_store::PutMode::Overwrite,
+            PutMode::CreateIfAbsent => provider_store::PutMode::Create,
+            PutMode::CompareAndSwap { expected_etag } => {
+                let version = match self.compare_token {
+                    CompareToken::Etag => UpdateVersion {
+                        e_tag: Some(expected_etag),
+                        version: None,
+                    },
+                    CompareToken::Generation => UpdateVersion {
+                        e_tag: None,
+                        version: Some(expected_etag),
+                    },
+                };
+                provider_store::PutMode::Update(version)
+            }
         }
     }
 }
@@ -1043,17 +1131,6 @@ enum RangedGet {
 
 fn provider_not_found(err: &provider_store::Error) -> bool {
     matches!(err, provider_store::Error::NotFound { .. })
-}
-
-fn provider_transport_retryable(err: &provider_store::Error) -> bool {
-    // `Generic` is where the provider client surfaces request failures after
-    // its own retry policy gives up: for writes that includes mid-flight
-    // transport errors it refuses to re-send because a non-idempotent HTTP
-    // request may already have reached the store. The remaining variants are
-    // definite outcomes (not-found, already-exists, precondition), hard
-    // rejections (auth, invalid path, unsupported), or the store IO runtime
-    // shutting down (join error); re-sending those is wrong or futile.
-    matches!(err, provider_store::Error::Generic { .. })
 }
 
 fn map_provider_error(object_key: &str, err: provider_store::Error) -> ObjectStoreError {
@@ -1191,10 +1268,12 @@ mod tests {
         let inner = Arc::new(InMemory::default());
         ProviderObjectStore::new(
             Arc::clone(&inner) as Arc<dyn provider_store::ObjectStore>,
-            Some(inner),
+            inner,
             ProviderObjectStoreConfig {
                 key_prefix: Some("tenant-a".to_owned()),
             },
+            ConfiguredObjectStoreKind::LocalFs,
+            StoreIoRuntime::new().expect("store io runtime"),
         )
         .expect("provider store")
     }
@@ -1219,6 +1298,26 @@ mod tests {
             map_provider_error("private-key", auth_rejection(&path)).class(),
             crate::ObjectStoreErrorClass::PermissionDenied
         );
+    }
+
+    #[test]
+    fn compare_tokens_populate_only_the_matching_provider_field() {
+        for (compare_token, expected_etag, expected_version) in [
+            (CompareToken::Etag, Some("token"), None),
+            (CompareToken::Generation, None, Some("token")),
+        ] {
+            let store = memory_store().compare_token(compare_token);
+            let provider_store::PutMode::Update(version) =
+                store.map_put_mode(PutMode::CompareAndSwap {
+                    expected_etag: "token".to_owned(),
+                })
+            else {
+                panic!("compare-and-swap maps to an update")
+            };
+
+            assert_eq!(version.e_tag.as_deref(), expected_etag);
+            assert_eq!(version.version.as_deref(), expected_version);
+        }
     }
 
     #[test]
@@ -1743,10 +1842,12 @@ mod tests {
     fn retrying_store(flaky: Arc<FlakyStore>) -> ProviderObjectStore {
         ProviderObjectStore::new(
             Arc::clone(&flaky) as Arc<dyn provider_store::ObjectStore>,
-            Some(flaky),
+            flaky,
             ProviderObjectStoreConfig {
                 key_prefix: Some("tenant-a".to_owned()),
             },
+            ConfiguredObjectStoreKind::LocalFs,
+            StoreIoRuntime::new().expect("store io runtime"),
         )
         .expect("provider store")
         .transport_retry(TransportRetryPolicy {

--- a/crates/loonfs-objectstore/src/retry.rs
+++ b/crates/loonfs-objectstore/src/retry.rs
@@ -3,6 +3,7 @@
 use crate::attempts::count_retry_attempt;
 use crate::timing::MonotonicTimer;
 use crate::PROVIDER_OPERATION_DEADLINE;
+use std::future::Future;
 use std::time::Duration;
 
 /// Bounded retry configuration matching the provider client's read budget.
@@ -79,6 +80,45 @@ pub(crate) fn next_retry_backoff(
         "transient object store write failure, backing off before retry",
     );
     Some(backoff)
+}
+
+pub(crate) async fn with_transport_retry<T, F, Fut>(
+    policy: &TransportRetryPolicy,
+    key: &str,
+    operation: &'static str,
+    payload_bytes: u64,
+    deadline: Option<&OperationDeadline<'_>>,
+    mut attempt: F,
+) -> object_store::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = object_store::Result<T>>,
+{
+    let mut retries = 0;
+    loop {
+        let error = match attempt().await {
+            Ok(value) => return Ok(value),
+            Err(error) => error,
+        };
+        if !provider_transport_retryable(&error) {
+            return Err(error);
+        }
+        let Some(backoff) = next_retry_backoff(
+            policy,
+            key,
+            operation,
+            payload_bytes,
+            &mut retries,
+            deadline,
+        ) else {
+            return Err(error);
+        };
+        transport_retry_pause(backoff).await;
+    }
+}
+
+pub(crate) fn provider_transport_retryable(error: &object_store::Error) -> bool {
+    matches!(error, object_store::Error::Generic { .. })
 }
 
 /// Elapsed-time state for one logical operation's retry loop.

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -1,4 +1,4 @@
-//! [`S3CompatibleStore`]: the S3-API store, constructed per provider.
+//! S3-compatible provider constructors.
 //!
 //! AWS S3 and Cloudflare R2 differ by addressing, credentials, and whether
 //! uploads carry a client-computed checksum -- not by behaviour worth a type
@@ -8,30 +8,28 @@ use crate::aws_credentials::{
     aws_credentials_source, static_aws_credentials_source, ObjectStoreAwsCredentialProvider,
     SharedAwsCredentialsSource,
 };
-use crate::keyspace::{parse_endpoint_url, virtual_hosted_authority};
+use crate::configured::ConfiguredObjectStoreKind;
+use crate::endpoint::{parse_endpoint_url, virtual_hosted_authority};
 use crate::object_store::Result;
 use crate::presign::{
-    base64_crc64nvme, S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES,
-    CHECKSUM_HEAD_TTL, CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
+    base64_crc64nvme, DirectTransferIssuers, S3CompatiblePresigner, S3PresignerConfig,
+    AWS_S3_MAX_DIRECT_PUT_BYTES, CHECKSUM_HEAD_TTL, CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
 };
+use crate::provider_object_store::{CompareToken, MultipartController, StoredChecksumReader};
 use crate::signed_request::{
-    execute_signed, execute_signed_with_body, stored_checksum_from_signed_head, SignedResponse,
+    classify_signed_response, send_signed, stored_checksum_from_signed_head, SignedResponse,
 };
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
-    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
-    ObjectStore, ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig, PutMode,
-    StoredObjectChecksum,
+    MultipartCompletion, MultipartPart, ObjectStoreError, ProviderObjectStore,
+    ProviderObjectStoreConfig, StoredObjectChecksum,
 };
 use async_trait::async_trait;
 use base64::Engine as _;
-use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs_api::{wire::hex::hex_encode_bytes, SecretString};
 use loonfs_api::{Checksum, ChecksumAlgorithm};
 use object_store::aws::{AmazonS3Builder, Checksum as ProviderChecksum};
 use object_store::client::{HttpClient, HttpConnector, HttpRequestBody};
-use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -83,7 +81,7 @@ pub struct CloudflareR2StoreConfig {
 
 #[derive(Debug, Clone)]
 struct S3CompatibleConfig {
-    provider_name: &'static str,
+    kind: ConfiguredObjectStoreKind,
     bucket: String,
     region: String,
     endpoint_url: Option<String>,
@@ -93,195 +91,162 @@ struct S3CompatibleConfig {
     /// Attach a client-computed SHA-256 to every upload so the provider
     /// verifies the bytes on PUT (`x-amz-checksum-sha256`). Enabling it also
     /// gives the provider a stored full-object checksum that
-    /// [`ObjectStore::head_stored_checksum`] can read back.
+    /// [`crate::ObjectStore::head_stored_checksum`] can read back.
     sha256_upload_checksum: bool,
     /// This provider's documented maximum for a single PUT, carried through
     /// to the signer so a direct-put issuer can advertise it.
     direct_put_max_content_bytes: u64,
 }
 
-/// Implements the LoonFS storage contract on an S3-API endpoint.
-#[derive(Clone)]
-pub struct S3CompatibleStore {
-    provider_name: &'static str,
-    inner: ProviderObjectStore,
-    /// Signs the requests the provider client cannot express: the
-    /// `HeadObject` that reads a stored checksum back, and the multipart
-    /// control calls that have to carry checksum headers. The SigV4 signer
-    /// this crate already owns for direct-put URLs can express all of them.
-    request_signer: S3CompatiblePresigner,
-    /// Sends those signed requests over the store's own IO runtime and
-    /// timeout scheme, exactly like every provider-client request.
+struct S3RequestSigner {
+    request_signer: Arc<S3CompatiblePresigner>,
     http: HttpClient,
-    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
-    /// the connector inside the client holds only a handle onto it.
-    _io_runtime: StoreIoRuntime,
 }
 
-impl fmt::Debug for S3CompatibleStore {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("S3CompatibleStore")
-            .field("provider_name", &self.provider_name)
-            .finish_non_exhaustive()
-    }
+/// Builds an AWS S3 store with bounded retries and SHA-256 upload checksums.
+pub fn aws_s3(config: AwsS3StoreConfig) -> Result<ProviderObjectStore> {
+    let credentials = aws_credentials_source(&config.credentials, &config.region)?;
+    aws_s3_with_credentials(config, credentials).map(|(store, _)| store)
 }
 
-impl S3CompatibleStore {
-    /// Builds an AWS S3 store with bounded retries and SHA-256 upload checksums.
-    ///
-    /// Construction fails for invalid static credentials, bucket, region,
-    /// endpoint, key prefix, runtime initialization, or provider-client
-    /// configuration. Ambient credential resolution remains lazy.
-    pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self> {
-        let credentials = aws_credentials_source(&config.credentials, &config.region)?;
-        Self::aws_s3_with_credentials(config, credentials)
-    }
+/// Returns the store and the issuers that sign direct transfers against it.
+pub(crate) fn aws_s3_with_credentials(
+    config: AwsS3StoreConfig,
+    credentials: SharedAwsCredentialsSource,
+) -> Result<(ProviderObjectStore, DirectTransferIssuers)> {
+    new(S3CompatibleConfig {
+        kind: ConfiguredObjectStoreKind::AwsS3,
+        bucket: config.bucket,
+        region: config.region,
+        endpoint_url: config.endpoint_url,
+        credentials,
+        key_prefix: config.key_prefix,
+        force_path_style: config.force_path_style,
+        sha256_upload_checksum: true,
+        direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
+    })
+}
 
-    pub(crate) fn aws_s3_with_credentials(
-        config: AwsS3StoreConfig,
-        credentials: SharedAwsCredentialsSource,
-    ) -> Result<Self> {
-        Self::new(S3CompatibleConfig {
-            provider_name: "aws-s3",
-            bucket: config.bucket,
-            region: config.region,
-            endpoint_url: config.endpoint_url,
-            credentials,
-            key_prefix: config.key_prefix,
+/// Builds a Cloudflare R2 store with path-style addressing.
+pub fn cloudflare_r2(config: CloudflareR2StoreConfig) -> Result<ProviderObjectStore> {
+    let credentials = static_aws_credentials_source(
+        config.access_key_id.clone(),
+        config.secret_access_key.clone(),
+        None,
+    );
+    cloudflare_r2_with_credentials(config, credentials).map(|(store, _)| store)
+}
+
+/// Returns the store and the issuers that sign direct transfers against it.
+pub(crate) fn cloudflare_r2_with_credentials(
+    config: CloudflareR2StoreConfig,
+    credentials: SharedAwsCredentialsSource,
+) -> Result<(ProviderObjectStore, DirectTransferIssuers)> {
+    new(S3CompatibleConfig {
+        kind: ConfiguredObjectStoreKind::CloudflareR2,
+        bucket: config.bucket,
+        region: "auto".to_owned(),
+        endpoint_url: Some(config.endpoint_url),
+        credentials,
+        key_prefix: config.key_prefix,
+        // The configured endpoint is the bucket-less account host; path
+        // style makes the client append the bucket. Virtual hosting would
+        // use the endpoint verbatim and address keys as buckets.
+        force_path_style: true,
+        // Measured live 2026-07-31: must stay off. With a checksum
+        // algorithm configured, the provider client signs multipart part
+        // uploads with the aws-chunked streaming-trailer encoding, and R2
+        // answers 501 Not Implemented to every part PUT. Plain PUTs with
+        // the header succeed (the first nine conformance assertions pass;
+        // the multipart-overwrite and streamed-write assertions fail), but
+        // one upstream knob configures both shapes, so it stays off
+        // wholesale. Nothing is lost: R2 stores its self-computed
+        // CRC-64/NVME, which `head_stored_checksum` reads back, and the
+        // presigned direct paths carry their own enforced checksum
+        // headers independent of this flag.
+        sha256_upload_checksum: false,
+        direct_put_max_content_bytes: CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
+    })
+}
+
+fn new(config: S3CompatibleConfig) -> Result<(ProviderObjectStore, DirectTransferIssuers)> {
+    let endpoint_url = config
+        .endpoint_url
+        .as_deref()
+        .map(|endpoint| {
+            object_store_endpoint_url(&config.bucket, endpoint, config.force_path_style)
+        })
+        .transpose()?;
+    let request_signer = Arc::new(S3CompatiblePresigner::with_credentials(
+        S3PresignerConfig {
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+            endpoint_url: config.endpoint_url.clone(),
+            key_prefix: config.key_prefix.clone(),
             force_path_style: config.force_path_style,
-            sha256_upload_checksum: true,
-            direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
-        })
+            direct_put_max_content_bytes: config.direct_put_max_content_bytes,
+        },
+        Arc::clone(&config.credentials),
+    )?);
+
+    let io_runtime = StoreIoRuntime::new()?;
+    let http = io_runtime
+        .connector()
+        .connect(&crate::provider_object_store::provider_client_options())
+        .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?;
+    let mut builder = AmazonS3Builder::new()
+        .with_http_connector(io_runtime.connector())
+        .with_client_options(crate::provider_object_store::provider_client_options())
+        .with_retry(crate::provider_object_store::provider_retry_config())
+        .with_bucket_name(config.bucket)
+        .with_region(config.region)
+        .with_credentials(Arc::new(ObjectStoreAwsCredentialProvider::new(
+            config.credentials,
+        )))
+        .with_virtual_hosted_style_request(!config.force_path_style);
+
+    if let Some(endpoint_url) = endpoint_url {
+        let allow_http = endpoint_url.starts_with("http://");
+        builder = builder
+            .with_endpoint(endpoint_url)
+            .with_allow_http(allow_http);
+    }
+    if config.sha256_upload_checksum {
+        builder = builder.with_checksum_algorithm(ProviderChecksum::SHA256);
     }
 
-    /// Builds a Cloudflare R2 store with path-style addressing.
-    ///
-    /// Construction fails for a blank account id or any invalid shared
-    /// configuration, including credentials, endpoint, and key prefix.
-    pub fn cloudflare_r2(config: CloudflareR2StoreConfig) -> Result<Self> {
-        let credentials = static_aws_credentials_source(
-            config.access_key_id.clone(),
-            config.secret_access_key.clone(),
-            None,
-        );
-        Self::cloudflare_r2_with_credentials(config, credentials)
-    }
-
-    pub(crate) fn cloudflare_r2_with_credentials(
-        config: CloudflareR2StoreConfig,
-        credentials: SharedAwsCredentialsSource,
-    ) -> Result<Self> {
-        if config.account_id.trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "account id must not be empty".to_owned(),
-            ));
-        }
-        if config.access_key_id.expose().trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "access key id must not be empty".to_owned(),
-            ));
-        }
-        if config.secret_access_key.expose().trim().is_empty() {
-            return Err(ObjectStoreError::Configuration(
-                "secret access key must not be empty".to_owned(),
-            ));
-        }
-        Self::new(S3CompatibleConfig {
-            provider_name: "cloudflare-r2",
-            bucket: config.bucket,
-            region: "auto".to_owned(),
-            endpoint_url: Some(config.endpoint_url),
-            credentials,
+    let provider = Arc::new(
+        builder
+            .build()
+            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?,
+    );
+    let store = ProviderObjectStore::new(
+        Arc::clone(&provider) as Arc<dyn object_store::ObjectStore>,
+        provider,
+        ProviderObjectStoreConfig {
             key_prefix: config.key_prefix,
-            // The configured endpoint is the bucket-less account host; path
-            // style makes the client append the bucket. Virtual hosting would
-            // use the endpoint verbatim and address keys as buckets.
-            force_path_style: true,
-            // Measured live 2026-07-31: must stay off. With a checksum
-            // algorithm configured, the provider client signs multipart part
-            // uploads with the aws-chunked streaming-trailer encoding, and R2
-            // answers 501 Not Implemented to every part PUT. Plain PUTs with
-            // the header succeed (the first nine conformance assertions pass;
-            // the multipart-overwrite and streamed-write assertions fail), but
-            // one upstream knob configures both shapes, so it stays off
-            // wholesale. Nothing is lost: R2 stores its self-computed
-            // CRC-64/NVME, which `head_stored_checksum` reads back, and the
-            // presigned direct paths carry their own enforced checksum
-            // headers independent of this flag.
-            sha256_upload_checksum: false,
-            direct_put_max_content_bytes: CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
-        })
-    }
+        },
+        config.kind,
+        io_runtime,
+    )?;
+    let signer = Arc::new(S3RequestSigner {
+        request_signer: Arc::clone(&request_signer),
+        http,
+    });
+    let direct_transfers = DirectTransferIssuers {
+        get: request_signer.clone(),
+        put: Some(request_signer.clone()),
+        multipart: Some(request_signer),
+    };
 
-    fn new(config: S3CompatibleConfig) -> Result<Self> {
-        validate_config(&config)?;
-        let endpoint_url = config
-            .endpoint_url
-            .as_deref()
-            .map(|endpoint| {
-                object_store_endpoint_url(&config.bucket, endpoint, config.force_path_style)
-            })
-            .transpose()?;
-        let request_signer = S3CompatiblePresigner::with_credentials(
-            S3PresignerConfig {
-                bucket: config.bucket.clone(),
-                region: config.region.clone(),
-                endpoint_url: config.endpoint_url.clone(),
-                key_prefix: config.key_prefix.clone(),
-                force_path_style: config.force_path_style,
-                direct_put_max_content_bytes: config.direct_put_max_content_bytes,
-            },
-            Arc::clone(&config.credentials),
-        )?;
+    let store = store
+        .compare_token(CompareToken::Etag)
+        .checksum_reader(signer.clone())
+        .multipart_controller(signer);
+    Ok((store, direct_transfers))
+}
 
-        let io_runtime = StoreIoRuntime::new()?;
-        let http = io_runtime
-            .connector()
-            .connect(&crate::provider_object_store::provider_client_options())
-            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?;
-        let mut builder = AmazonS3Builder::new()
-            .with_http_connector(io_runtime.connector())
-            .with_client_options(crate::provider_object_store::provider_client_options())
-            .with_retry(crate::provider_object_store::provider_retry_config())
-            .with_bucket_name(config.bucket)
-            .with_region(config.region)
-            .with_credentials(Arc::new(ObjectStoreAwsCredentialProvider::new(
-                config.credentials,
-            )))
-            .with_virtual_hosted_style_request(!config.force_path_style);
-
-        if let Some(endpoint_url) = endpoint_url {
-            let allow_http = endpoint_url.starts_with("http://");
-            builder = builder
-                .with_endpoint(endpoint_url)
-                .with_allow_http(allow_http);
-        }
-        if config.sha256_upload_checksum {
-            builder = builder.with_checksum_algorithm(ProviderChecksum::SHA256);
-        }
-
-        let provider = Arc::new(
-            builder
-                .build()
-                .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?,
-        );
-        let inner = ProviderObjectStore::new(
-            Arc::clone(&provider) as Arc<dyn object_store::ObjectStore>,
-            Some(provider),
-            ProviderObjectStoreConfig {
-                key_prefix: config.key_prefix,
-            },
-        )?;
-
-        Ok(Self {
-            provider_name: config.provider_name,
-            inner,
-            request_signer,
-            http,
-            _io_runtime: io_runtime,
-        })
-    }
-
+impl S3RequestSigner {
     #[allow(clippy::disallowed_methods)]
     fn signing_time() -> SystemTime {
         // A SigV4 signature is dated, so these internally issued requests
@@ -322,29 +287,28 @@ impl SignedResponse {
 }
 
 #[async_trait]
-impl ObjectStore for S3CompatibleStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
-        self.inner.head(key).await
-    }
-
+impl StoredChecksumReader for S3RequestSigner {
     async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
         let signed = self
             .request_signer
             .presign_head_stored_checksum(key, CHECKSUM_HEAD_TTL, Self::signing_time())
             .await?;
-        let response = execute_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
+        let response = send_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
         stored_checksum_from_signed_head(key, &response, s3_stored_checksum)
     }
+}
 
+#[async_trait]
+impl MultipartController for S3RequestSigner {
     async fn create_multipart_upload(&self, key: &str) -> Result<String> {
         let signed = self
             .request_signer
             .presign_create_multipart(key, MULTIPART_CONTROL_TTL, Self::signing_time())
             .await?;
-        let response =
-            execute_signed_with_body(&self.http, key, signed, HttpRequestBody::empty()).await?;
-        if let Some(code) = response.provider_error_code() {
-            return Err(multipart_error(key, "create", &code));
+        let response = send_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
+        let code = response.provider_error_code();
+        if let Some(error) = classify_signed_response(key, response.status, code.as_deref()) {
+            return Err(error);
         }
         xml_element(&response.text(), "UploadId").ok_or_else(|| {
             ObjectStoreError::transport(key, "multipart create returned no upload id")
@@ -368,20 +332,20 @@ impl ObjectStore for S3CompatibleStore {
                 Self::signing_time(),
             )
             .await?;
-        let response = execute_signed_with_body(
+        let response = send_signed(
             &self.http,
             key,
             signed,
             complete_multipart_body(parts)?.into(),
         )
         .await?;
-        match response.provider_error_code().as_deref() {
+        let code = response.provider_error_code();
+        if code.as_deref() == Some("NoSuchUpload") {
+            return Ok(MultipartCompletion::UnknownUpload);
+        }
+        match classify_signed_response(key, response.status, code.as_deref()) {
+            Some(error) => Err(error),
             None => Ok(MultipartCompletion::Assembled),
-            // The upload is gone, which says nothing about the object: an
-            // earlier completion may have consumed it and assembled exactly
-            // what was asked for. The caller decides from the object.
-            Some("NoSuchUpload") => Ok(MultipartCompletion::UnknownUpload),
-            Some(code) => Err(multipart_error(key, "complete", code)),
         }
     }
 
@@ -395,41 +359,15 @@ impl ObjectStore for S3CompatibleStore {
                 Self::signing_time(),
             )
             .await?;
-        let response =
-            execute_signed_with_body(&self.http, key, signed, HttpRequestBody::empty()).await?;
-        match response.provider_error_code().as_deref() {
-            // Nothing to abandon is the state an abort is trying to reach.
-            None | Some("NoSuchUpload") => Ok(()),
-            Some(code) => Err(multipart_error(key, "abort", code)),
+        let response = send_signed(&self.http, key, signed, HttpRequestBody::empty()).await?;
+        let code = response.provider_error_code();
+        if code.as_deref() == Some("NoSuchUpload") {
+            return Ok(());
         }
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
-        self.inner.put_streamed(key, body, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<()> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_from_stream(
-        &self,
-        prefix: &str,
-        start_after: Option<&str>,
-    ) -> BoxStream<'static, Result<String>> {
-        self.inner.list_prefix_from_stream(prefix, start_after)
+        match classify_signed_response(key, response.status, code.as_deref()) {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 }
 
@@ -510,46 +448,6 @@ fn complete_multipart_body(parts: &[MultipartPart]) -> Result<String> {
     Ok(body)
 }
 
-fn multipart_error(key: &str, operation: &str, code: &str) -> ObjectStoreError {
-    match code {
-        "AccessDenied" | "InvalidAccessKeyId" | "SignatureDoesNotMatch" => {
-            ObjectStoreError::PermissionDenied {
-                object_key: key.to_owned(),
-                message: format!("provider refused multipart {operation}: {code}"),
-            }
-        }
-        "NoSuchBucket" | "NoSuchKey" => ObjectStoreError::NotFound {
-            object_key: key.to_owned(),
-        },
-        "ConditionalRequestConflict" | "PreconditionFailed" => {
-            ObjectStoreError::PreconditionFailed {
-                object_key: key.to_owned(),
-            }
-        }
-        "InternalError" | "RequestTimeout" | "ServiceUnavailable" | "SlowDown" => {
-            ObjectStoreError::retryable_transport(
-                key,
-                format!("multipart {operation} failed: {code}"),
-            )
-        }
-        code => ObjectStoreError::transport(key, format!("multipart {operation} failed: {code}")),
-    }
-}
-
-fn validate_config(config: &S3CompatibleConfig) -> Result<()> {
-    if config.bucket.trim().is_empty() {
-        return Err(ObjectStoreError::Configuration(
-            "bucket must not be empty".to_owned(),
-        ));
-    }
-    if config.region.trim().is_empty() {
-        return Err(ObjectStoreError::Configuration(
-            "region must not be empty".to_owned(),
-        ));
-    }
-    Ok(())
-}
-
 fn object_store_endpoint_url(
     bucket: &str,
     endpoint_url: &str,
@@ -572,7 +470,8 @@ fn object_store_endpoint_url(
 
 #[cfg(test)]
 mod tests {
-    use super::{multipart_error, object_store_endpoint_url, AwsS3StoreConfig, S3CompatibleStore};
+    use super::{aws_s3, object_store_endpoint_url, AwsS3StoreConfig};
+    use crate::signed_request::classify_signed_response;
     use crate::test_support::{aws_environment_lock, isolated_aws_environment};
     use crate::{AwsS3Credentials, ObjectStoreErrorClass};
 
@@ -582,7 +481,7 @@ mod tests {
         let tempdir = tempfile::tempdir().expect("create temporary AWS config directory");
         let _environment = isolated_aws_environment(&tempdir, None);
 
-        S3CompatibleStore::aws_s3(AwsS3StoreConfig {
+        aws_s3(AwsS3StoreConfig {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: Some("http://127.0.0.1:9000".to_owned()),
@@ -606,7 +505,9 @@ mod tests {
             ("MalformedXML", ObjectStoreErrorClass::Other),
         ] {
             assert_eq!(
-                multipart_error("private-key", "complete", code).class(),
+                classify_signed_response("private-key", http::StatusCode::BAD_REQUEST, Some(code),)
+                    .expect("provider error should classify")
+                    .class(),
                 expected,
                 "wrong class for {code}"
             );

--- a/crates/loonfs-objectstore/src/signed_request.rs
+++ b/crates/loonfs-objectstore/src/signed_request.rs
@@ -4,7 +4,14 @@ use crate::object_store::Result;
 use crate::presign::PresignedUrl;
 use crate::{ObjectStoreError, StoredObjectChecksum};
 use loonfs_api::Checksum;
-use object_store::client::{HttpClient, HttpRequestBody, HttpResponse};
+use object_store::client::{HttpClient, HttpRequestBody};
+
+const RETRYABLE_SIGNED_ERROR_CODES: &[&str] = &[
+    "InternalError",
+    "RequestTimeout",
+    "ServiceUnavailable",
+    "SlowDown",
+];
 
 pub(crate) struct SignedResponse {
     pub(crate) status: http::StatusCode,
@@ -12,12 +19,12 @@ pub(crate) struct SignedResponse {
     pub(crate) body: bytes::Bytes,
 }
 
-pub(crate) async fn execute_signed(
+pub(crate) async fn send_signed(
     client: &HttpClient,
     key: &str,
     signed: PresignedUrl,
     body: HttpRequestBody,
-) -> Result<HttpResponse> {
+) -> Result<SignedResponse> {
     let mut builder = http::Request::builder()
         .method(signed.method.as_str())
         .uri(&signed.url);
@@ -27,19 +34,10 @@ pub(crate) async fn execute_signed(
     let request = builder
         .body(body)
         .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
-    client
+    let response = client
         .execute(request)
         .await
-        .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))
-}
-
-pub(crate) async fn execute_signed_with_body(
-    client: &HttpClient,
-    key: &str,
-    signed: PresignedUrl,
-    body: HttpRequestBody,
-) -> Result<SignedResponse> {
-    let response = execute_signed(client, key, signed, body).await?;
+        .map_err(|err| ObjectStoreError::retryable_transport(key, err.to_string()))?;
     let status = response.status();
     let headers = response.headers().clone();
     let body = response
@@ -55,36 +53,25 @@ pub(crate) async fn execute_signed_with_body(
 }
 
 /// Reads an object's size and checksum from a signed `HEAD` response.
-pub(crate) fn stored_checksum_from_signed_head<B>(
+pub(crate) fn stored_checksum_from_signed_head(
     key: &str,
-    response: &http::Response<B>,
+    response: &SignedResponse,
     stored_checksum: impl FnOnce(&http::HeaderMap) -> Option<Checksum>,
 ) -> Result<Option<StoredObjectChecksum>> {
-    let status = response.status();
-    if status == http::StatusCode::NOT_FOUND {
-        return Ok(None);
-    }
-    if status == http::StatusCode::FORBIDDEN || status == http::StatusCode::UNAUTHORIZED {
-        return Err(ObjectStoreError::PermissionDenied {
-            object_key: key.to_owned(),
-            message: format!("provider refused the checksum head with {status}"),
-        });
-    }
-    if !status.is_success() {
-        return Err(transport_for_status(
-            key,
-            status,
-            format!("checksum head failed with {status}"),
-        ));
+    if let Some(error) = classify_signed_response(key, response.status, None) {
+        return match error {
+            ObjectStoreError::NotFound { .. } => Ok(None),
+            error => Err(error),
+        };
     }
 
-    let Some(checksum) = stored_checksum(response.headers()) else {
+    let Some(checksum) = stored_checksum(&response.headers) else {
         return Err(ObjectStoreError::StoredChecksumMissing {
             object_key: key.to_owned(),
         });
     };
     let size_bytes = response
-        .headers()
+        .headers
         .get(http::header::CONTENT_LENGTH)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<u64>().ok())
@@ -98,17 +85,60 @@ pub(crate) fn stored_checksum_from_signed_head<B>(
     }))
 }
 
-fn transport_for_status(
+pub(crate) fn classify_signed_response(
     key: &str,
     status: http::StatusCode,
-    message: impl Into<String>,
-) -> ObjectStoreError {
-    if status == http::StatusCode::REQUEST_TIMEOUT
-        || status == http::StatusCode::TOO_MANY_REQUESTS
-        || status.is_server_error()
-    {
-        ObjectStoreError::retryable_transport(key, message)
-    } else {
-        ObjectStoreError::transport(key, message)
+    code: Option<&str>,
+) -> Option<ObjectStoreError> {
+    if status.is_success() && code.is_none() {
+        return None;
     }
+
+    let message = match code {
+        Some(code) => format!("provider request failed: {code}"),
+        None => format!("provider request failed with {status}"),
+    };
+    let error = match code {
+        Some("AccessDenied" | "InvalidAccessKeyId" | "SignatureDoesNotMatch") => {
+            ObjectStoreError::PermissionDenied {
+                object_key: key.to_owned(),
+                message,
+            }
+        }
+        Some("NoSuchBucket" | "NoSuchKey") => ObjectStoreError::NotFound {
+            object_key: key.to_owned(),
+        },
+        Some("ConditionalRequestConflict" | "PreconditionFailed") => {
+            ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            }
+        }
+        Some(code) if RETRYABLE_SIGNED_ERROR_CODES.contains(&code) => {
+            ObjectStoreError::retryable_transport(key, message)
+        }
+        _ if status == http::StatusCode::NOT_FOUND => ObjectStoreError::NotFound {
+            object_key: key.to_owned(),
+        },
+        _ if status == http::StatusCode::FORBIDDEN || status == http::StatusCode::UNAUTHORIZED => {
+            ObjectStoreError::PermissionDenied {
+                object_key: key.to_owned(),
+                message,
+            }
+        }
+        _ if status == http::StatusCode::PRECONDITION_FAILED
+            || status == http::StatusCode::CONFLICT =>
+        {
+            ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            }
+        }
+        _ if status == http::StatusCode::REQUEST_TIMEOUT
+            || status == http::StatusCode::TOO_MANY_REQUESTS
+            || status.is_server_error() =>
+        {
+            ObjectStoreError::retryable_transport(key, message)
+        }
+        _ => ObjectStoreError::transport(key, message),
+    };
+    Some(error)
 }

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -226,6 +226,8 @@ impl StoreConfig {
     /// [`ConfiguredObjectStore::direct_transfers`](crate::ConfiguredObjectStore::direct_transfers)
     /// from the constructed store instead of checking this config again.
     pub fn configured_object_store(&self) -> crate::object_store::Result<ConfiguredObjectStore> {
+        self.validate()
+            .map_err(|error| ObjectStoreError::Configuration(error.to_string()))?;
         match self {
             StoreConfig::LocalFs { root, key_prefix } => {
                 ConfiguredObjectStore::local_fs(root, key_prefix.as_deref())

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -13,7 +13,8 @@ use loonfs_objectstore::metrics::{
     VecObjectStoreMetricsRecorder,
 };
 use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, ObjectStoreErrorClass,
+    PutMode,
 };
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
@@ -26,6 +27,53 @@ const SECRET_KEY_SEGMENT: &str = "secret-segment";
 
 fn secret_key() -> String {
     format!("namespaces/ns-1/wal/{SECRET_KEY_SEGMENT}.wal.zst")
+}
+
+#[test]
+fn metric_result_classes_preserve_every_error_class() {
+    let cases = [
+        (
+            ObjectStoreErrorClass::NotFound,
+            ObjectStoreResultClass::NotFound,
+        ),
+        (
+            ObjectStoreErrorClass::InvalidRequest,
+            ObjectStoreResultClass::InvalidRequest,
+        ),
+        (
+            ObjectStoreErrorClass::InvalidKey,
+            ObjectStoreResultClass::InvalidKey,
+        ),
+        (
+            ObjectStoreErrorClass::PreconditionFailed,
+            ObjectStoreResultClass::PreconditionFailed,
+        ),
+        (
+            ObjectStoreErrorClass::PermissionDenied,
+            ObjectStoreResultClass::PermissionDenied,
+        ),
+        (
+            ObjectStoreErrorClass::StoredChecksumMissing,
+            ObjectStoreResultClass::StoredChecksumMissing,
+        ),
+        (
+            ObjectStoreErrorClass::Unsupported,
+            ObjectStoreResultClass::Unsupported,
+        ),
+        (
+            ObjectStoreErrorClass::Configuration,
+            ObjectStoreResultClass::Configuration,
+        ),
+        (
+            ObjectStoreErrorClass::RetryableTransport,
+            ObjectStoreResultClass::RetryableTransport,
+        ),
+        (ObjectStoreErrorClass::Other, ObjectStoreResultClass::Other),
+    ];
+
+    for (error_class, result_class) in cases {
+        assert_eq!(ObjectStoreResultClass::from(error_class), result_class);
+    }
 }
 
 #[tokio::test]

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -8,13 +8,13 @@ use crate::provider_env::{
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
 use loonfs_api::{Checksum, ContentId};
-use loonfs_objectstore::abs::{AzureAbsStore, AzureAbsStoreConfig};
-use loonfs_objectstore::gcs::{GcpGcsStore, GcpGcsStoreConfig};
+use loonfs_objectstore::abs::{azure_abs, AzureAbsStoreConfig};
+use loonfs_objectstore::gcs::{gcp_gcs, GcpGcsStoreConfig};
 use loonfs_objectstore::keys::content_blob;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, StoreProbeReport};
 use loonfs_objectstore::s3_compatible::{
-    AwsS3StoreConfig, CloudflareR2StoreConfig, S3CompatibleStore,
+    aws_s3, cloudflare_r2, AwsS3StoreConfig, CloudflareR2StoreConfig,
 };
 use loonfs_objectstore::ObjectStoreError;
 use loonfs_objectstore::{AwsS3Credentials, ObjectStore};
@@ -67,7 +67,7 @@ async fn local_fs_streamed_write_round_trips() {
 async fn aws_s3_real_provider_conformance() {
     let config = AwsS3ConformanceConfig::from_env()
         .expect("load AWS S3 real-provider conformance environment");
-    let store = S3CompatibleStore::aws_s3(AwsS3StoreConfig {
+    let store = aws_s3(AwsS3StoreConfig {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
@@ -88,7 +88,7 @@ async fn aws_s3_real_provider_conformance() {
 async fn aws_s3_streamed_write_round_trips() {
     let config = AwsS3ConformanceConfig::from_env()
         .expect("load AWS S3 real-provider conformance environment");
-    let store = S3CompatibleStore::aws_s3(AwsS3StoreConfig {
+    let store = aws_s3(AwsS3StoreConfig {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
@@ -109,7 +109,7 @@ async fn aws_s3_streamed_write_round_trips() {
 async fn cloudflare_r2_streamed_write_round_trips() {
     let config = CloudflareR2ConformanceConfig::from_env()
         .expect("load Cloudflare R2 real-provider conformance environment");
-    let store = S3CompatibleStore::cloudflare_r2(CloudflareR2StoreConfig {
+    let store = cloudflare_r2(CloudflareR2StoreConfig {
         bucket: config.bucket,
         account_id: config.account_id,
         endpoint_url: config.endpoint,
@@ -126,7 +126,7 @@ async fn cloudflare_r2_streamed_write_round_trips() {
 async fn aws_s3_put_stores_a_trustworthy_checksum() {
     let config = AwsS3ConformanceConfig::from_env()
         .expect("load AWS S3 real-provider conformance environment");
-    let store = S3CompatibleStore::aws_s3(AwsS3StoreConfig {
+    let store = aws_s3(AwsS3StoreConfig {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
@@ -147,7 +147,7 @@ async fn aws_s3_put_stores_a_trustworthy_checksum() {
 async fn cloudflare_r2_checksumless_put_stores_a_trustworthy_checksum() {
     let config = CloudflareR2ConformanceConfig::from_env()
         .expect("load Cloudflare R2 real-provider conformance environment");
-    let store = S3CompatibleStore::cloudflare_r2(CloudflareR2StoreConfig {
+    let store = cloudflare_r2(CloudflareR2StoreConfig {
         bucket: config.bucket,
         account_id: config.account_id,
         endpoint_url: config.endpoint,
@@ -164,7 +164,7 @@ async fn cloudflare_r2_checksumless_put_stores_a_trustworthy_checksum() {
 async fn gcp_gcs_checksumless_put_stores_a_trustworthy_checksum() {
     let config = GcpGcsConformanceConfig::from_env()
         .expect("load GCP GCS real-provider conformance environment");
-    let store = GcpGcsStore::new(GcpGcsStoreConfig {
+    let store = gcp_gcs(GcpGcsStoreConfig {
         bucket: config.bucket,
         service_account_key_path: config.service_account_key_path,
         key_prefix: Some(config.prefix),
@@ -182,7 +182,7 @@ fn aws_s3_store_survives_alternating_current_thread_runtimes() {
     // caller runtime topology, so alternating runtimes stays fast.
     let config = AwsS3ConformanceConfig::from_env()
         .expect("load AWS S3 real-provider conformance environment");
-    let store = S3CompatibleStore::aws_s3(AwsS3StoreConfig {
+    let store = aws_s3(AwsS3StoreConfig {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
@@ -241,7 +241,7 @@ fn aws_s3_store_survives_alternating_current_thread_runtimes() {
 async fn cloudflare_r2_real_provider_conformance() {
     let config = CloudflareR2ConformanceConfig::from_env()
         .expect("load Cloudflare R2 real-provider conformance environment");
-    let store = S3CompatibleStore::cloudflare_r2(CloudflareR2StoreConfig {
+    let store = cloudflare_r2(CloudflareR2StoreConfig {
         bucket: config.bucket,
         account_id: config.account_id,
         endpoint_url: config.endpoint,
@@ -258,7 +258,7 @@ async fn cloudflare_r2_real_provider_conformance() {
 async fn gcp_gcs_real_provider_conformance() {
     let config = GcpGcsConformanceConfig::from_env()
         .expect("load GCP GCS real-provider conformance environment");
-    let store = GcpGcsStore::new(GcpGcsStoreConfig {
+    let store = gcp_gcs(GcpGcsStoreConfig {
         bucket: config.bucket,
         service_account_key_path: config.service_account_key_path,
         key_prefix: Some(config.prefix),
@@ -272,7 +272,7 @@ async fn gcp_gcs_real_provider_conformance() {
 async fn gcp_gcs_streamed_write_round_trips() {
     let config = GcpGcsConformanceConfig::from_env()
         .expect("load GCP GCS real-provider conformance environment");
-    let store = GcpGcsStore::new(GcpGcsStoreConfig {
+    let store = gcp_gcs(GcpGcsStoreConfig {
         bucket: config.bucket,
         service_account_key_path: config.service_account_key_path,
         key_prefix: Some(config.prefix),
@@ -286,7 +286,7 @@ async fn gcp_gcs_streamed_write_round_trips() {
 async fn azure_abs_real_provider_conformance() {
     let config = AzureAbsConformanceConfig::from_env()
         .expect("load Azure Blob Storage real-provider conformance environment");
-    let store = AzureAbsStore::new(AzureAbsStoreConfig {
+    let store = azure_abs(AzureAbsStoreConfig {
         account_name: config.account_name,
         container_name: config.container_name,
         access_key: config.access_key,
@@ -302,7 +302,7 @@ async fn azure_abs_real_provider_conformance() {
 async fn azure_abs_streamed_write_round_trips() {
     let config = AzureAbsConformanceConfig::from_env()
         .expect("load Azure Blob Storage real-provider conformance environment");
-    let store = AzureAbsStore::new(AzureAbsStoreConfig {
+    let store = azure_abs(AzureAbsStoreConfig {
         account_name: config.account_name,
         container_name: config.container_name,
         access_key: config.access_key,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -3882,7 +3882,11 @@ mod direct_download {
     async fn a_file_past_the_proxy_cap_round_trips_through_a_download_grant() {
         let temp_dir = tempdir().expect("tempdir");
         let object_base_url = serve_objects(object_store_at(temp_dir.path())).await;
-        let transfers = DirectTransferIssuers::read_only(LoopbackIssuer::at(object_base_url));
+        let transfers = DirectTransferIssuers {
+            get: LoopbackIssuer::at(object_base_url),
+            put: None,
+            multipart: None,
+        };
         let client = start(temp_dir.path(), "direct-download", Some(transfers)).await;
 
         let namespace = namespace_id("direct-download");
@@ -3957,7 +3961,11 @@ mod direct_download {
     async fn a_grant_keeps_reading_the_revision_it_was_issued_for() {
         let temp_dir = tempdir().expect("tempdir");
         let object_base_url = serve_objects(object_store_at(temp_dir.path())).await;
-        let transfers = DirectTransferIssuers::read_only(LoopbackIssuer::at(object_base_url));
+        let transfers = DirectTransferIssuers {
+            get: LoopbackIssuer::at(object_base_url),
+            put: None,
+            multipart: None,
+        };
         let client = start(temp_dir.path(), "grant-pins", Some(transfers)).await;
 
         let namespace = namespace_id("grant-pins");
@@ -4071,7 +4079,11 @@ mod direct_download {
     async fn a_provider_without_multipart_advertises_put_and_get_and_denies_multipart() {
         let temp_dir = tempdir().expect("tempdir");
         let issuer = LoopbackIssuer::at("http://object.invalid");
-        let transfers = DirectTransferIssuers::read_only(issuer.clone()).with_put(issuer);
+        let transfers = DirectTransferIssuers {
+            get: issuer.clone(),
+            put: Some(issuer),
+            multipart: None,
+        };
         let advertised = start(temp_dir.path(), "put-without-multipart", Some(transfers))
             .await
             .get_capabilities()
@@ -4102,7 +4114,11 @@ mod direct_download {
     async fn a_direct_put_session_rejects_multipart_completion_fields_precisely() {
         let temp_dir = tempdir().expect("tempdir");
         let issuer = LoopbackIssuer::at("http://object.invalid");
-        let transfers = DirectTransferIssuers::read_only(issuer.clone()).with_put(issuer);
+        let transfers = DirectTransferIssuers {
+            get: issuer.clone(),
+            put: Some(issuer),
+            multipart: None,
+        };
         let client = start(
             temp_dir.path(),
             "direct-put-completion-shape",
@@ -4158,7 +4174,11 @@ mod direct_download {
         let temp_dir = tempdir().expect("tempdir");
         let object_base_url = serve_objects(object_store_at(temp_dir.path())).await;
         let issuer = LoopbackIssuer::crc32c_at(object_base_url);
-        let transfers = DirectTransferIssuers::read_only(issuer.clone()).with_put(issuer);
+        let transfers = DirectTransferIssuers {
+            get: issuer.clone(),
+            put: Some(issuer),
+            multipart: None,
+        };
         let store: SharedObjectStore = Arc::new(Crc32cReadbackStore {
             inner: LocalFsStore::new(temp_dir.path()).expect("construct local store"),
         });
@@ -4213,7 +4233,11 @@ mod direct_download {
         let temp_dir = tempdir().expect("tempdir");
         let object_base_url = serve_objects(object_store_at(temp_dir.path())).await;
         let issuer = LoopbackIssuer::at(object_base_url);
-        let transfers = DirectTransferIssuers::read_only(issuer.clone()).with_put(issuer);
+        let transfers = DirectTransferIssuers {
+            get: issuer.clone(),
+            put: Some(issuer),
+            multipart: None,
+        };
         let client = start_with_upload_cap(
             temp_dir.path(),
             "ladder-direct-put",
@@ -4260,7 +4284,11 @@ mod direct_download {
         let object_base_url = serve_objects(object_store_at(temp_dir.path())).await;
         // Reads only: neither write direction is on offer, which is the
         // shape that used to push an oversized payload into the proxy.
-        let transfers = DirectTransferIssuers::read_only(LoopbackIssuer::at(object_base_url));
+        let transfers = DirectTransferIssuers {
+            get: LoopbackIssuer::at(object_base_url),
+            put: None,
+            multipart: None,
+        };
         let client = start_with_upload_cap(
             temp_dir.path(),
             "ladder-too-large",


### PR DESCRIPTION
This replaces the separate cloud-provider adapters with one ProviderObjectStore implementation. S3, R2, GCS, and Azure now share key scoping, retries, metrics, request bounds, and multipart upload handling, while provider-specific signing and checksum behavior stay behind small interfaces.

Provider construction now requires a native multipart implementation. The conformance and server tests continue to cover the same object-store contract.