### PR TITLE
refactor(core): unify upload staging and completion

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -700,6 +700,17 @@ pub enum UploadSessionMode {
 }
 
 impl UploadSessionMode {
+    /// Returns the checksum algorithm fixed by a direct upload mode.
+    pub fn checksum_algorithm(&self) -> Option<ChecksumAlgorithm> {
+        match self {
+            Self::ServiceProxied { .. } => None,
+            Self::DirectPut { checksum_algorithm }
+            | Self::DirectMultipart {
+                checksum_algorithm, ..
+            } => Some(*checksum_algorithm),
+        }
+    }
+
     /// Returns the content reference stored by this mode, when present.
     fn content_ref(&self) -> Option<&ContentRef> {
         match self {
@@ -825,11 +836,11 @@ impl UploadSessionState {
             }
         }
         if let (
-            UploadSessionMode::DirectPut { checksum_algorithm },
+            Some(checksum_algorithm),
             UploadSessionRecordStatus::Completed { content_ref, .. },
-        ) = (&self.mode, &self.status)
+        ) = (self.mode.checksum_algorithm(), &self.status)
         {
-            if content_ref.checksum.algorithm != *checksum_algorithm {
+            if content_ref.checksum.algorithm != checksum_algorithm {
                 return Err(format!(
                     "upload session `{}` requires `{checksum_algorithm}` but its completed \
                      content uses `{}`",

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -1211,21 +1211,29 @@ fn direct_put_sessions_reject_the_pre_completion_claim_record() {
 }
 
 #[test]
-fn completed_direct_put_sessions_require_the_session_algorithm() {
-    let message = assert_control_payload_edit_is_corrupt::<UploadSessionState>(
-        "control_upload_session.v1.json",
-        ControlObjectKind::UploadSession,
-        |payload| {
-            payload["mode"] = serde_json::json!({
-                "kind": "direct_put",
-                "checksum_algorithm": "crc32c"
-            });
-        },
-    );
-    assert!(
-        message.contains("requires `crc32c` but its completed content uses `sha256`"),
-        "unexpected refusal: {message}"
-    );
+fn completed_direct_sessions_require_the_session_algorithm() {
+    for mode in [
+        serde_json::json!({
+            "kind": "direct_put",
+            "checksum_algorithm": "crc32c"
+        }),
+        serde_json::json!({
+            "kind": "direct_multipart",
+            "provider_upload_id": "provider-upload",
+            "part_size_bytes": 8_388_608,
+            "checksum_algorithm": "crc32c"
+        }),
+    ] {
+        let message = assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+            "control_upload_session.v1.json",
+            ControlObjectKind::UploadSession,
+            |payload| payload["mode"] = mode,
+        );
+        assert!(
+            message.contains("requires `crc32c` but its completed content uses `sha256`"),
+            "unexpected refusal: {message}"
+        );
+    }
 }
 
 #[test]

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -76,12 +76,7 @@ impl CommitCandidate {
     pub fn prepared(request: CommitRequest, content: Vec<PreparedContent>) -> Self {
         Self {
             request,
-            content: ContentPreparation::Ready(
-                content
-                    .into_iter()
-                    .map(PreparedContent::into_admission)
-                    .collect(),
-            ),
+            content: ContentPreparation::Ready(content),
         }
     }
 
@@ -607,12 +602,11 @@ mod tests {
             .expect("operation limits must not affect identity");
 
         let content_ref = ContentRef::blob_v1(ContentId::generate(), b"proof");
-        let admission = ContentAdmission::for_durable_content_write(
+        let prepared = PreparedContent::for_durable_content_write(
             namespace_id.clone(),
             ContentStoreId::parse("cs_00000000000000000000000000000001").expect("content store id"),
             content_ref,
         );
-        let prepared = PreparedContent::from_admission(admission);
         let oversized_proofs = CommitCandidate::prepared(
             create_dir_request("too-many-proofs", "docs"),
             vec![prepared; crate::limits::MAX_COMMIT_CONTENT_TOKENS + 1],

--- a/crates/loonfs-core/src/content.rs
+++ b/crates/loonfs-core/src/content.rs
@@ -4,11 +4,11 @@
 // resolves the namespace's content store from the pinned head and applies
 // the caller's byte budget, so no consumer needs the raw store read.
 pub use crate::protocol::CompletedUpload;
+pub use crate::storage::content::DurableContentValidationError;
 #[cfg(any(test, feature = "test-support"))]
 pub use crate::storage::content::{
     prepare_existing_content_ref, prepare_stored_content, store_bytes_as_content,
 };
-pub use crate::storage::content::{DurableContentValidationError, StoredContent};
 pub use crate::storage::content_admission::{
     mint_content_token, verify_content_token, CompletedUploadReceipt, ContentTokenError,
     PreparedContent,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -18,17 +18,15 @@ use crate::protocol::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
     MultipartPartTargets, ResolvedUploadCompletion,
 };
-use crate::storage::content::{
-    ensure_imported_ref_matches, open_content_import_reader, FileContentStream,
-};
+use crate::storage::content::{open_content_import_reader, FileContentStream, StreamedPayloadKind};
 use crate::storage::content_admission::{CompletedUploadReceipt, PreparedContent};
 use crate::time::current_time_ms;
 use loonfs_api::options::{
     DirectMultipartUploadOptions, ListInodeChildrenOptions, ListPathEntriesOptions, StatPathOptions,
 };
 use loonfs_api::v0::{
-    BeginUploadRequest, BeginUploadResponse, CommitResponse, CompleteMultipartUploadRequest,
-    ListChangesResponse, UploadContentResponse, UploadMode, UploadPartChecksumClaim, UploadSession,
+    BeginUploadResponse, CommitResponse, ListChangesResponse, UploadContentResponse, UploadMode,
+    UploadPartChecksumClaim, UploadSession,
 };
 use loonfs_api::wire::control::{CheckpointOwner, HeadState, NamespaceStatus};
 use loonfs_api::EffectiveLimit;
@@ -561,11 +559,10 @@ impl<S: ObjectStore, M> NamespaceEngine<S, M> {
 
 impl<S: ObjectStore> NamespaceEngine<S, Writable> {
     /// Starts a durable upload session with explicit transport options.
-    pub async fn begin_upload(&self, request: BeginUploadRequest) -> Result<BeginUploadResponse> {
-        crate::protocol::begin_upload(
+    pub async fn begin_upload(&self) -> Result<BeginUploadResponse> {
+        crate::protocol::begin_service_proxied_upload(
             &self.store,
             &self.namespace_id,
-            request,
             &self.mutation_context()?,
         )
         .await
@@ -641,64 +638,10 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
             .await
     }
 
-    /// Completes a service-proxied or direct-PUT upload session.
-    pub async fn complete_upload(&self, upload_id: &UploadId) -> Result<UploadSession> {
-        Ok(self.complete_upload_prepared(upload_id).await?.response)
-    }
-
-    /// Completes a direct-multipart upload session.
-    pub async fn complete_multipart_upload(
-        &self,
-        upload_id: &UploadId,
-        request: &CompleteMultipartUploadRequest,
-    ) -> Result<UploadSession> {
-        Ok(self
-            .complete_multipart_upload_prepared(upload_id, request)
-            .await?
-            .response)
-    }
-
     /// Completes an upload session and returns time-bounded proof for later
-    /// publication.
-    ///
-    /// Service-proxied completion performs no content-blob I/O. Direct-put
-    /// completion performs one content-blob HEAD and no content-blob GET.
-    pub async fn complete_upload_prepared(&self, upload_id: &UploadId) -> Result<CompletedUpload> {
-        self.complete_upload_prepared_inner(upload_id, ResolvedUploadCompletion::KnownContent)
-            .await
-    }
-
-    /// Completes a multipart upload and returns time-bounded proof for later
-    /// publication.
-    pub async fn complete_multipart_upload_prepared(
-        &self,
-        upload_id: &UploadId,
-        request: &CompleteMultipartUploadRequest,
-    ) -> Result<CompletedUpload> {
-        self.complete_upload_prepared_inner(
-            upload_id,
-            ResolvedUploadCompletion::Multipart(request.clone()),
-        )
-        .await
-    }
-
-    async fn complete_upload_prepared_inner(
-        &self,
-        upload_id: &UploadId,
-        completion: ResolvedUploadCompletion,
-    ) -> Result<CompletedUpload> {
-        let catalog = crate::namespace::catalog::load_namespace_catalog_entry(
-            &self.store,
-            &self.namespace_id,
-        )
-        .await?;
-        self.complete_upload_prepared_with_catalog(&catalog, upload_id, completion)
-            .await
-    }
-
-    /// Completes an upload with a namespace catalog binding already resolved
-    /// by the runtime.
-    pub async fn complete_upload_prepared_with_catalog(
+    /// publication. The caller passes the catalog it already holds, so
+    /// completion adds no head read.
+    pub async fn complete_upload(
         &self,
         catalog: &VerifiedNamespaceCatalogEntry,
         upload_id: &UploadId,
@@ -721,7 +664,7 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
     /// Server integrations use this to decode raw request bytes without a
     /// second upload-session read. A resolver failure is classified as an
     /// invalid upload request.
-    pub async fn complete_upload_prepared_with_catalog_for_mode<F>(
+    pub async fn complete_upload_for_mode<F>(
         &self,
         catalog: &VerifiedNamespaceCatalogEntry,
         upload_id: &UploadId,
@@ -775,25 +718,23 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
         &self,
         catalog: &VerifiedNamespaceCatalogEntry,
         content_ref: &ContentRef,
-    ) -> Result<PreparedContent> {
+    ) -> Result<PreparedContent>
+    where
+        S: Clone + 'static,
+    {
         let catalog = self.own_catalog(catalog)?;
         let context = self.mutation_context()?;
-        let (object_key, pump, body) =
-            open_content_import_reader(&self.store, catalog.content_store_id(), content_ref)
+        let (_object_key, body) =
+            open_content_import_reader(self.store.clone(), catalog.content_store_id(), content_ref)
                 .await?;
-        let (source_checksum, staged) = futures::future::join(
-            pump,
-            crate::protocol::stage_owned_stream(&self.store, catalog, body, &context),
+        crate::protocol::stage_owned_stream(
+            &self.store,
+            catalog,
+            body,
+            StreamedPayloadKind::ContentImport,
+            &context,
         )
-        .await;
-        let prepared = staged?;
-        ensure_imported_ref_matches(
-            object_key,
-            content_ref,
-            prepared.content_ref(),
-            &source_checksum,
-        )?;
-        Ok(prepared)
+        .await
     }
 
     /// Stages a streamed payload as content a session owns, hashing it on
@@ -810,6 +751,7 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
             &self.store,
             self.own_catalog(catalog)?,
             body,
+            StreamedPayloadKind::Request,
             &self.mutation_context()?,
         )
         .await
@@ -1131,10 +1073,7 @@ mod tests {
             .bootstrap_namespace(BootstrapOptions::default())
             .await
             .expect("bootstrap namespace");
-        let begun = writer
-            .begin_upload(BeginUploadRequest::ServiceProxied {})
-            .await
-            .expect("begin upload");
+        let begun = writer.begin_upload().await.expect("begin upload");
 
         let reader = NamespaceEngine::reader(
             LocalFsStore::new(temp_dir.path()).expect("reader store"),

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -761,8 +761,11 @@ fn classify_durable_content_error(error: &DurableContentValidationError) -> Erro
         DurableContentValidationError::InvalidContentRef(_)
         | DurableContentValidationError::MissingContentObject { .. }
         | DurableContentValidationError::ContentLengthMismatch { .. }
-        | DurableContentValidationError::ContentChecksumMismatch { .. }
-        | DurableContentValidationError::ContentStoreMismatch { .. } => ErrorCode::NamespaceCorrupt,
+        | DurableContentValidationError::ContentChecksumMismatch { .. } => {
+            ErrorCode::NamespaceCorrupt
+        }
+        #[cfg(any(test, feature = "test-support"))]
+        DurableContentValidationError::ContentStoreMismatch { .. } => ErrorCode::NamespaceCorrupt,
         DurableContentValidationError::Store { .. } => ErrorCode::ServerError,
     }
 }

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -16,12 +16,26 @@ pub(crate) use self::publish_view::{load_publish_metadata_view, PublishTailProje
 pub use self::publish_view::{PublishTailOptions, PublishTailWeight};
 pub(crate) use self::uploads::{
     abort_upload, begin_direct_multipart_upload_target, begin_direct_put_upload_target,
-    begin_upload, complete_upload, complete_upload_for_mode, direct_multipart_part_targets,
-    get_upload_status, stage_owned_bytes, stage_owned_stream, upload_content,
-    upload_streamed_content, AbandonedUpload,
+    begin_service_proxied_upload, complete_upload, complete_upload_for_mode,
+    direct_multipart_part_targets, get_upload_status, stage_owned_bytes, stage_owned_stream,
+    upload_content, upload_streamed_content, AbandonedUpload,
 };
 pub use self::uploads::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
     DirectMultipartUploadTarget, MultipartPartTarget, MultipartPartTargets,
     ResolvedUploadCompletion,
 };
+
+#[cfg(test)]
+pub(crate) async fn begin_upload<S: loonfs_objectstore::ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &loonfs_api::NamespaceId,
+    request: loonfs_api::v0::BeginUploadRequest,
+    context: &crate::MutationContext,
+) -> crate::error::Result<loonfs_api::v0::BeginUploadResponse> {
+    assert!(matches!(
+        request,
+        loonfs_api::v0::BeginUploadRequest::ServiceProxied {}
+    ));
+    uploads::begin_service_proxied_upload(store, namespace_id, context).await
+}

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -25,17 +25,14 @@ use crate::namespace::control::load_namespace_head_control;
 use crate::storage::content::{
     abort_unpublished_multipart_upload, delete_unpublished_content_object,
     identify_streamed_payload, stage_bytes_under_content_id, stage_streamed_under_content_id,
-    verify_durable_content_checksum, DurableContentValidationError,
+    verify_durable_content_checksum, DurableContentValidationError, StreamedPayloadKind,
 };
-use crate::storage::content_admission::{
-    CompletedUploadReceipt, ContentAdmission, PreparedContent,
-};
+use crate::storage::content_admission::{CompletedUploadReceipt, PreparedContent};
 use bytes::Bytes;
 use loonfs_api::options::DirectMultipartUploadOptions;
 use loonfs_api::v0::{
-    BeginUploadRequest, BeginUploadResponse, CompleteMultipartUploadRequest, CompletedUploadPart,
-    UploadContentClaim, UploadContentResponse, UploadMode, UploadPartChecksumClaim, UploadSession,
-    UploadSessionStatus,
+    BeginUploadResponse, CompleteMultipartUploadRequest, CompletedUploadPart, UploadContentClaim,
+    UploadContentResponse, UploadMode, UploadPartChecksumClaim, UploadSession, UploadSessionStatus,
 };
 use loonfs_api::wire::control::{
     encode_control_state, ControlObjectKind, NamespaceStatus, ProxiedStaging, UploadSessionMode,
@@ -92,6 +89,17 @@ pub enum ResolvedUploadCompletion {
     Multipart(CompleteMultipartUploadRequest),
 }
 
+impl ResolvedUploadCompletion {
+    /// Returns the upload mode this completion describes.
+    pub fn mode(&self) -> UploadMode {
+        match self {
+            Self::KnownContent => UploadMode::ServiceProxied,
+            Self::DirectPut { .. } => UploadMode::DirectPut,
+            Self::Multipart(_) => UploadMode::DirectMultipart,
+        }
+    }
+}
+
 /// One part a server integration is about to sign.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MultipartPartTarget {
@@ -107,20 +115,12 @@ pub struct MultipartPartTargets {
     pub parts: Vec<MultipartPartTarget>,
 }
 
-pub(crate) async fn begin_upload<S: ObjectStore + ?Sized>(
+pub(crate) async fn begin_service_proxied_upload<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    request: BeginUploadRequest,
     context: &MutationContext,
 ) -> Result<BeginUploadResponse> {
     ensure_upload_namespace_available(store, namespace_id).await?;
-    if !matches!(request, BeginUploadRequest::ServiceProxied {}) {
-        // Direct uploads require a presigned URL issuer.
-        return Err(CoreError::InvalidUploadContent(format!(
-            "{} requires a presigned URL issuer",
-            upload_mode_name(request.mode())
-        )));
-    }
     let upload_id = create_upload_session(
         store,
         namespace_id,
@@ -132,14 +132,6 @@ pub(crate) async fn begin_upload<S: ObjectStore + ?Sized>(
         namespace_id: namespace_id.clone(),
         upload_id,
     })
-}
-
-fn upload_mode_name(mode: UploadMode) -> &'static str {
-    match mode {
-        UploadMode::ServiceProxied => "service_proxied",
-        UploadMode::DirectPut => "direct_put",
-        UploadMode::DirectMultipart => "direct_multipart",
-    }
 }
 
 /// Starts a direct PUT session and assigns its content identity.
@@ -578,15 +570,6 @@ async fn release_staging_claim<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Returns the public name of an upload mode.
-fn mode_name(mode: &UploadSessionMode) -> &'static str {
-    match mode {
-        UploadSessionMode::ServiceProxied { .. } => "service_proxied",
-        UploadSessionMode::DirectPut { .. } => "direct_put",
-        UploadSessionMode::DirectMultipart { .. } => "direct_multipart",
-    }
-}
-
 async fn read_open_proxied_session<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -600,10 +583,15 @@ async fn read_open_proxied_session<S: ObjectStore + ?Sized>(
     if !matches!(session.mode, UploadSessionMode::ServiceProxied { .. }) {
         return Err(CoreError::InvalidUploadContent(format!(
             "{} sessions must be completed after using the presigned URLs",
-            mode_name(&session.mode)
+            upload_mode(&session.mode).as_str()
         )));
     }
     Ok((content_store_id, session))
+}
+
+pub(crate) enum ProxiedPayload<'a> {
+    Bytes(&'a [u8]),
+    Stream(ByteStream),
 }
 
 /// Stores bytes in a service-proxied upload session.
@@ -617,6 +605,24 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     bytes: &[u8],
 ) -> Result<UploadContentResponse> {
+    upload_proxied_content(store, namespace_id, upload_id, ProxiedPayload::Bytes(bytes)).await
+}
+
+pub(crate) async fn upload_streamed_content<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &UploadId,
+    body: ByteStream,
+) -> Result<UploadContentResponse> {
+    upload_proxied_content(store, namespace_id, upload_id, ProxiedPayload::Stream(body)).await
+}
+
+pub(crate) async fn upload_proxied_content<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &UploadId,
+    payload: ProxiedPayload<'_>,
+) -> Result<UploadContentResponse> {
     let (content_store_id, loaded) =
         read_open_proxied_session(store, namespace_id, upload_id).await?;
 
@@ -624,7 +630,14 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
     // byte is written and released by the same swap that records the result.
     match claim_staging_slot(store, namespace_id, upload_id).await? {
         StagingSlot::AlreadyStaged(staged) => {
-            let content_ref = ContentRef::blob_v1(loaded.content_id.clone(), bytes);
+            let content_ref = match payload {
+                ProxiedPayload::Bytes(bytes) => {
+                    ContentRef::blob_v1(loaded.content_id.clone(), bytes)
+                }
+                ProxiedPayload::Stream(body) => {
+                    identify_streamed_payload(loaded.content_id.clone(), body).await?
+                }
+            };
             if staged != content_ref {
                 return Err(CoreError::UploadContentConflict {
                     upload_id: upload_id.clone(),
@@ -639,23 +652,31 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
         StagingSlot::Claimed => {}
     }
 
-    let stored = match stage_bytes_under_content_id(
-        store,
-        content_store_id,
-        loaded.content_id.clone(),
-        bytes,
-    )
-    .await
-    {
-        Ok(stored) => stored,
+    let staged = match payload {
+        ProxiedPayload::Bytes(bytes) => {
+            stage_bytes_under_content_id(store, content_store_id, loaded.content_id.clone(), bytes)
+                .await
+                .map(|stored| (stored.into_content_ref(), false))
+        }
+        ProxiedPayload::Stream(body) => stage_streamed_under_content_id(
+            store,
+            content_store_id,
+            loaded.content_id.clone(),
+            body,
+            StreamedPayloadKind::Request,
+        )
+        .await
+        .map(|staged| (staged.content_ref, staged.already_present)),
+    };
+    let (content_ref, already_present) = match staged {
+        Ok(staged) => staged,
         Err(error) => {
             release_staging_claim(store, namespace_id, upload_id).await;
             return Err(error);
         }
     };
 
-    let content_ref = stored.into_content_ref();
-    record_staged_content(store, namespace_id, upload_id, content_ref, false).await
+    record_staged_content(store, namespace_id, upload_id, content_ref, already_present).await
 }
 
 /// Records a staging result and releases its claim in the same
@@ -714,70 +735,6 @@ async fn record_staged_content<S: ObjectStore + ?Sized>(
     .await
 }
 
-/// Streams content into a service-proxied session while computing its
-/// reference.
-///
-/// The payload is written before the session compare-and-swap because the
-/// stream cannot be replayed inside a retry loop. The compare-and-swap
-/// compares the computed reference with any value already stored in the
-/// session, making an identical retry idempotent and a different payload a
-/// conflict.
-pub(crate) async fn upload_streamed_content<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    upload_id: &UploadId,
-    body: ByteStream,
-) -> Result<UploadContentResponse> {
-    let (content_store_id, loaded) =
-        read_open_proxied_session(store, namespace_id, upload_id).await?;
-
-    // A session that has already staged content must not have its object
-    // rewritten while the answer is being worked out. Reading the body
-    // without writing it decides the question: the same bytes are one
-    // upload arriving twice, and different bytes are a conflict either way.
-    // Taking the claim is what establishes that nothing else is writing.
-    match claim_staging_slot(store, namespace_id, upload_id).await? {
-        StagingSlot::AlreadyStaged(staged) => {
-            let content_ref = identify_streamed_payload(loaded.content_id.clone(), body).await?;
-            if staged != content_ref {
-                return Err(CoreError::UploadContentConflict {
-                    upload_id: upload_id.clone(),
-                });
-            }
-            return Ok(UploadContentResponse {
-                namespace_id: namespace_id.clone(),
-                upload_id: upload_id.clone(),
-                content_ref,
-            });
-        }
-        StagingSlot::Claimed => {}
-    }
-
-    let staged = match stage_streamed_under_content_id(
-        store,
-        content_store_id,
-        loaded.content_id.clone(),
-        body,
-    )
-    .await
-    {
-        Ok(staged) => staged,
-        Err(error) => {
-            release_staging_claim(store, namespace_id, upload_id).await;
-            return Err(error);
-        }
-    };
-
-    record_staged_content(
-        store,
-        namespace_id,
-        upload_id,
-        staged.content_ref,
-        staged.already_present,
-    )
-    .await
-}
-
 /// Completes an upload by verifying the content and then recording the
 /// terminal state.
 ///
@@ -829,7 +786,8 @@ where
     let mode = upload_mode(&loaded.mode);
     let completion = resolve(mode).map_err(CoreError::InvalidUploadContent)?;
     let plan = completion_plan(&loaded, &completion)?;
-    if let Some(completed) = already_completed_outcome(
+    // The aborted status was rejected above; the compare-and-swap caller also uses this helper.
+    if let Some(completed) = replay_terminal_completion(
         &loaded.status,
         namespace_id,
         content_store_id,
@@ -899,7 +857,7 @@ async fn freeze_completed_session<S: ObjectStore + ?Sized>(
         let upload_id = upload_id.to_owned();
         let verified = verified.clone();
         async move {
-            if let Some(completed) = already_completed_outcome(
+            if let Some(completed) = replay_terminal_completion(
                 &state.status,
                 &namespace_id,
                 &content_store_id,
@@ -979,12 +937,19 @@ pub(crate) async fn stage_owned_stream<S: ObjectStore + ?Sized>(
     store: &S,
     catalog: &VerifiedNamespaceCatalogEntry,
     body: ByteStream,
+    payload_kind: StreamedPayloadKind,
     context: &MutationContext,
 ) -> Result<PreparedContent> {
     let session = open_owned_staging_session(store, catalog, context).await?;
     let content_store_id = catalog.content_store_id().clone();
-    let staged =
-        stage_streamed_under_content_id(store, content_store_id, session.content_id, body).await?;
+    let staged = stage_streamed_under_content_id(
+        store,
+        content_store_id,
+        session.content_id,
+        body,
+        payload_kind,
+    )
+    .await?;
     if staged.already_present {
         // The identity is 128 fresh random bits and this session has made no
         // earlier attempt, so an occupied key is corruption rather than a
@@ -1101,7 +1066,13 @@ pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
         })
         .await?;
 
-    let _ = abandoned.release(store, content_store_id).await;
+    if !abandoned.release(store, content_store_id).await {
+        tracing::debug!(
+            namespace_id = %namespace_id,
+            upload_id = %upload_id,
+            "upload cleanup remains for garbage collection"
+        );
+    }
     Ok(response)
 }
 
@@ -1233,12 +1204,12 @@ fn completed_upload(
             mode,
             status: completed_status(content_ref, completed_at_ms),
         },
-        prepared: PreparedContent::from_admission(ContentAdmission::for_completed_upload(
+        prepared: PreparedContent::for_completed_upload(
             namespace_id.clone(),
             content_store_id.clone(),
             content_ref.clone(),
             completed_at_ms.saturating_add(COMPLETED_UPLOAD_ADMISSION_WINDOW_MS),
-        )),
+        ),
         receipt: receipt_within_window(
             namespace_id,
             content_store_id,
@@ -1282,7 +1253,7 @@ fn receipt_within_window(
 /// Answers a completion against a session that has already reached a
 /// terminal status: a replay of the same content succeeds idempotently,
 /// anything else is the terminal error for that status.
-fn already_completed_outcome(
+fn replay_terminal_completion(
     status: &UploadSessionRecordStatus,
     namespace_id: &NamespaceId,
     content_store_id: &ContentStoreId,
@@ -1369,6 +1340,16 @@ fn completion_plan<'a>(
     session: &'a UploadSessionState,
     completion: &'a ResolvedUploadCompletion,
 ) -> Result<CompletionPlan<'a>> {
+    let session_mode = upload_mode(&session.mode);
+    let completion_mode = completion.mode();
+    if completion_mode != session_mode {
+        return Err(CoreError::InvalidUploadContent(format!(
+            "completion mode `{}` does not match stored upload mode `{}`",
+            completion_mode.as_str(),
+            session_mode.as_str()
+        )));
+    }
+
     match (&session.mode, completion) {
         (UploadSessionMode::ServiceProxied { staging }, ResolvedUploadCompletion::KnownContent) => {
             Ok(CompletionPlan::Proxied {
@@ -1405,28 +1386,8 @@ fn completion_plan<'a>(
             checksum_algorithm: *checksum_algorithm,
             parts,
         }),
-        (UploadSessionMode::ServiceProxied { .. }, ResolvedUploadCompletion::DirectPut { .. }) => {
-            Err(CoreError::InvalidUploadContent(
-                "service_proxied completion carries no content claim".to_owned(),
-            ))
-        }
-        (UploadSessionMode::DirectPut { .. }, ResolvedUploadCompletion::KnownContent) => {
-            Err(CoreError::InvalidUploadContent(
-                "direct_put completion requires a content claim".to_owned(),
-            ))
-        }
-        (
-            UploadSessionMode::ServiceProxied { .. } | UploadSessionMode::DirectPut { .. },
-            ResolvedUploadCompletion::Multipart(_),
-        ) => Err(CoreError::InvalidUploadContent(format!(
-            "{} completion carries no multipart claim",
-            mode_name(&session.mode)
-        ))),
-        (
-            UploadSessionMode::DirectMultipart { .. },
-            ResolvedUploadCompletion::KnownContent | ResolvedUploadCompletion::DirectPut { .. },
-        ) => Err(CoreError::InvalidUploadContent(
-            "direct_multipart completion requires a content claim and parts".to_owned(),
+        _ => Err(CoreError::Internal(
+            "upload completion mode should match the session mode".to_owned(),
         )),
     }
 }
@@ -1548,7 +1509,6 @@ fn content_failure_reason(error: DurableContentValidationError) -> Result<String
 mod tests {
     use super::*;
     use crate::namespace::bootstrap::bootstrap_namespace;
-    use loonfs_api::v0::BeginUploadRequest;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::PutMode;
     use tempfile::tempdir;
@@ -1571,14 +1531,9 @@ mod tests {
         bootstrap_namespace(store, &namespace_id, context, false)
             .await
             .expect("bootstrap");
-        let begin = begin_upload(
-            store,
-            &namespace_id,
-            BeginUploadRequest::ServiceProxied {},
-            context,
-        )
-        .await
-        .expect("begin upload");
+        let begin = begin_service_proxied_upload(store, &namespace_id, context)
+            .await
+            .expect("begin upload");
         let staged = upload_content(store, &namespace_id, begin.upload_id(), BYTES)
             .await
             .expect("stage upload");
@@ -2014,14 +1969,9 @@ mod tests {
             .expect_err("a completed session takes no more bytes");
         assert!(matches!(error, CoreError::UploadAlreadyCompleted { .. }));
 
-        let aborted = begin_upload(
-            &store,
-            &namespace_id,
-            BeginUploadRequest::ServiceProxied {},
-            &setup,
-        )
-        .await
-        .expect("begin a second upload");
+        let aborted = begin_service_proxied_upload(&store, &namespace_id, &setup)
+            .await
+            .expect("begin a second upload");
         abort_upload(
             &store,
             &namespace_id,
@@ -2075,14 +2025,9 @@ mod tests {
         );
 
         // A second session, aborted, to check the other terminal state.
-        let begin = begin_upload(
-            &store,
-            &namespace_id,
-            BeginUploadRequest::ServiceProxied {},
-            &setup,
-        )
-        .await
-        .expect("begin second upload");
+        let begin = begin_service_proxied_upload(&store, &namespace_id, &setup)
+            .await
+            .expect("begin second upload");
         abort_upload(
             &store,
             &namespace_id,

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -7,9 +7,9 @@ use crate::namespace::catalog::load_namespace_content_store_id;
 #[cfg(any(test, feature = "test-support"))]
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 #[cfg(any(test, feature = "test-support"))]
-use crate::storage::content_admission::{ContentAdmission, PreparedContent};
+use crate::storage::content_admission::PreparedContent;
 use bytes::Bytes;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 #[cfg(any(test, feature = "test-support"))]
 use loonfs_api::NamespaceId;
 use loonfs_api::{
@@ -24,17 +24,18 @@ use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
 /// Confirms that LoonFS durably stored the content described by this reference.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+// Test-support functions return this proof without exporting its type.
+#[allow(unreachable_pub)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoredContent {
     content_store_id: ContentStoreId,
     #[cfg(any(test, feature = "test-support"))]
     object_key: String,
     content_ref: ContentRef,
-    #[cfg(any(test, feature = "test-support"))]
-    #[serde(skip)]
-    _write_acknowledged: StoredContentWriteAcknowledgement,
 }
 
+// Test-support callers use these methods on an inferred return type.
+#[allow(dead_code, unreachable_pub)]
 impl StoredContent {
     pub fn content_ref(&self) -> &ContentRef {
         &self.content_ref
@@ -54,10 +55,6 @@ impl StoredContent {
         &self.object_key
     }
 }
-
-#[cfg(any(test, feature = "test-support"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct StoredContentWriteAcknowledgement;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum DurableContentValidationError {
@@ -82,6 +79,7 @@ pub enum DurableContentValidationError {
     #[error(
         "stored content belongs to content store `{actual}`, not namespace-bound store `{expected}`"
     )]
+    #[cfg(any(test, feature = "test-support"))]
     ContentStoreMismatch {
         expected: ContentStoreId,
         actual: ContentStoreId,
@@ -102,82 +100,30 @@ pub(crate) async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     validate_loaded_content_bytes(object_key, content_ref, &bytes)
 }
 
-/// Opens a chunked reader over an existing object for import: one HEAD, then
-/// ranged reads pumped through a one-chunk channel, so nothing holds the
-/// whole object. Drive the pump and the staging consumer together.
-pub(crate) async fn open_content_import_reader<'a, S: ObjectStore + ?Sized>(
-    store: &'a S,
+/// Opens a verified chunked reader over an existing object for import.
+pub(crate) async fn open_content_import_reader<S: ObjectStore + 'static>(
+    store: S,
     content_store_id: &ContentStoreId,
     content_ref: &ContentRef,
-) -> Result<
-    (
-        String,
-        impl std::future::Future<Output = Checksum> + 'a,
-        ByteStream,
-    ),
-    DurableContentValidationError,
-> {
-    let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
-    validate_content_size(store, &object_key, content_ref).await?;
-    let size_bytes = content_ref.size_bytes;
-    let checksum_algorithm = content_ref.checksum.algorithm;
-    let (mut sender, receiver) = futures::channel::mpsc::channel(1);
-    let pump_key = object_key.clone();
-    let pump = async move {
-        let mut checksum = StreamingChecksum::for_algorithm(checksum_algorithm);
-        let mut offset = 0u64;
-        while offset < size_bytes {
-            let end = offset
-                .saturating_add(CONTENT_READ_CHUNK_BYTES)
-                .min(size_bytes);
-            let range = ByteRange {
-                start_inclusive: offset,
-                end_exclusive: end,
-            };
-            let chunk = match store.get(&pump_key, Some(range)).await {
-                Ok(Some(bytes)) => Ok(bytes),
-                Ok(None) => Err(ObjectStoreError::transport(
-                    &pump_key,
-                    "content object disappeared during import",
-                )),
-                Err(error) => Err(error),
-            };
-            let failed = chunk.is_err();
-            if let Ok(bytes) = &chunk {
-                checksum.update(bytes);
+) -> Result<(String, ByteStream), DurableContentValidationError> {
+    let source =
+        FileContentStream::open_import(store, content_store_id, content_ref.clone()).await?;
+    let object_key = source.object_key.clone();
+    let stream_key = object_key.clone();
+    let body = futures::stream::try_unfold(source, move |mut source| {
+        let stream_key = stream_key.clone();
+        async move {
+            match source.next_verified_chunk().await {
+                Ok(chunk) => Ok(chunk.map(|bytes| (bytes, source))),
+                Err(error @ DurableContentValidationError::ContentChecksumMismatch { .. }) => {
+                    Err(ObjectStoreError::InvalidContentRef(error.to_string()))
+                }
+                Err(error) => Err(ObjectStoreError::transport(stream_key, error.to_string())),
             }
-            if sender.send(chunk).await.is_err() || failed {
-                return checksum.finish();
-            }
-            offset = end;
         }
-        checksum.finish()
-    };
-    Ok((object_key, pump, receiver.boxed()))
-}
-
-/// Checks that a staged import carries the bytes the source ref claimed.
-pub(crate) fn ensure_imported_ref_matches(
-    object_key: String,
-    expected: &ContentRef,
-    staged: &ContentRef,
-    source_checksum: &Checksum,
-) -> Result<(), DurableContentValidationError> {
-    if staged.size_bytes != expected.size_bytes {
-        return Err(DurableContentValidationError::ContentLengthMismatch {
-            object_key,
-            expected: expected.size_bytes,
-            actual: staged.size_bytes,
-        });
-    }
-    if source_checksum != &expected.checksum {
-        return Err(DurableContentValidationError::ContentChecksumMismatch {
-            object_key,
-            expected: describe_checksum(&expected.checksum),
-            actual: describe_checksum(source_checksum),
-        });
-    }
-    Ok(())
+    })
+    .boxed();
+    Ok((object_key, body))
 }
 
 /// Prepares content from an acknowledged LoonFS-managed durable write.
@@ -199,12 +145,11 @@ pub fn prepare_stored_content(
     }
     let content_store_id = stored_content.content_store_id;
     let content_ref = stored_content.content_ref;
-    let admission = ContentAdmission::for_durable_content_write(
+    Ok(PreparedContent::for_durable_content_write(
         catalog.namespace_id().clone(),
         content_store_id,
         content_ref,
-    );
-    Ok(PreparedContent::from_admission(admission))
+    ))
 }
 
 /// Fully validates an existing durable content reference for publication.
@@ -219,12 +164,11 @@ pub async fn prepare_existing_content_ref<S: ObjectStore + ?Sized>(
 ) -> Result<PreparedContent, DurableContentValidationError> {
     let content_store_id = catalog.content_store_id();
     validate_durable_content_reference(store, content_store_id, &content_ref).await?;
-    let admission = ContentAdmission::for_durable_content_write(
+    Ok(PreparedContent::for_durable_content_write(
         catalog.namespace_id().clone(),
         content_store_id.clone(),
         content_ref,
-    );
-    Ok(PreparedContent::from_admission(admission))
+    ))
 }
 
 /// Compares a content reference with the size and checksum stored by the provider.
@@ -337,7 +281,7 @@ pub const CONTENT_READ_CHUNK_BYTES: u64 = 8 * 1024 * 1024;
 /// that stops earlier has not verified the complete object.
 pub struct FileContentStream<S> {
     store: S,
-    entry: PathEntry,
+    entry: Option<PathEntry>,
     object_key: String,
     content_ref: ContentRef,
     chunk_bytes: NonZeroU64,
@@ -365,6 +309,42 @@ impl<S: ObjectStore> FileContentStream<S> {
         store: S,
         content_store_id: &ContentStoreId,
         entry: PathEntry,
+        content_ref: ContentRef,
+        chunk_bytes: NonZeroU64,
+        start_offset: u64,
+    ) -> Result<Self, DurableContentValidationError> {
+        Self::open_inner(
+            store,
+            content_store_id,
+            Some(entry),
+            content_ref,
+            chunk_bytes,
+            start_offset,
+        )
+        .await
+    }
+
+    async fn open_import(
+        store: S,
+        content_store_id: &ContentStoreId,
+        content_ref: ContentRef,
+    ) -> Result<Self, DurableContentValidationError> {
+        Self::open_inner(
+            store,
+            content_store_id,
+            None,
+            content_ref,
+            NonZeroU64::new(CONTENT_READ_CHUNK_BYTES)
+                .expect("content read chunk size should be nonzero"),
+            0,
+        )
+        .await
+    }
+
+    async fn open_inner(
+        store: S,
+        content_store_id: &ContentStoreId,
+        entry: Option<PathEntry>,
         content_ref: ContentRef,
         chunk_bytes: NonZeroU64,
         start_offset: u64,
@@ -421,7 +401,9 @@ impl<S: ObjectStore> FileContentStream<S> {
 
     /// The authoritative metadata entry the path resolved to.
     pub fn entry(&self) -> &PathEntry {
-        &self.entry
+        self.entry
+            .as_ref()
+            .expect("path content stream should carry its metadata entry")
     }
 
     /// Complete length of the content this stream reads.
@@ -676,6 +658,12 @@ pub(crate) struct StagedStream {
     pub already_present: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StreamedPayloadKind {
+    Request,
+    ContentImport,
+}
+
 /// Stages and hashes a payload without buffering the complete stream.
 ///
 /// The write is create-only. Multipart providers may check for an existing
@@ -686,6 +674,7 @@ pub(crate) async fn stage_streamed_under_content_id<S: ObjectStore + ?Sized>(
     content_store_id: ContentStoreId,
     content_id: ContentId,
     body: ByteStream,
+    payload_kind: StreamedPayloadKind,
 ) -> Result<StagedStream, CoreError> {
     let object_key = content_blob(&content_store_id, &content_id);
     let observed = Arc::new(Mutex::new(StreamedPayload::default()));
@@ -716,6 +705,11 @@ pub(crate) async fn stage_streamed_under_content_id<S: ObjectStore + ?Sized>(
         Ok(_) => false,
         // The caller compares the checksum with the session's recorded value.
         Err(ObjectStoreError::PreconditionFailed { .. }) => true,
+        Err(ObjectStoreError::InvalidContentRef(message))
+            if payload_kind == StreamedPayloadKind::ContentImport =>
+        {
+            return Err(CoreError::NamespaceCorrupt(message));
+        }
         Err(err) => return Err(CoreError::store(&object_key, &err)),
     };
 
@@ -773,8 +767,6 @@ pub(crate) async fn stage_bytes_under_content_id<S: ObjectStore + ?Sized>(
         #[cfg(any(test, feature = "test-support"))]
         object_key,
         content_ref,
-        #[cfg(any(test, feature = "test-support"))]
-        _write_acknowledged: StoredContentWriteAcknowledgement,
     })
 }
 

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -47,15 +47,16 @@ impl CompletedUploadReceipt {
     }
 }
 
+/// Opaque evidence that a content reference was prepared for publication.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ContentAdmission {
+pub struct PreparedContent {
     namespace_id: NamespaceId,
     content_store_id: ContentStoreId,
     content_ref: ContentRef,
     expires_at_ms: u64,
 }
 
-impl ContentAdmission {
+impl PreparedContent {
     pub(crate) fn content_id(&self) -> &ContentId {
         &self.content_ref.content_id
     }
@@ -102,28 +103,19 @@ impl ContentAdmission {
             && self.content_ref == *content_ref
             && now_ms <= self.expires_at_ms
     }
-}
-
-/// Opaque evidence that a content reference was prepared for publication.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PreparedContent {
-    admission: ContentAdmission,
-}
-
-impl PreparedContent {
-    pub(crate) fn from_admission(admission: ContentAdmission) -> Self {
-        Self { admission }
-    }
 
     /// Returns the prepared content reference.
     pub fn content_ref(&self) -> &ContentRef {
-        &self.admission.content_ref
+        &self.content_ref
     }
 
-    pub(crate) fn into_admission(self) -> ContentAdmission {
-        self.admission
+    #[cfg(test)]
+    pub(crate) fn from_admission(admission: Self) -> Self {
+        admission
     }
 }
+
+pub(crate) type ContentAdmission = PreparedContent;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct ContentTokenPayload {
@@ -230,13 +222,12 @@ pub fn verify_content_token(
         return Err(ContentTokenError::Expired);
     }
 
-    let admission = ContentAdmission::for_completed_upload(
+    Ok(PreparedContent::for_completed_upload(
         payload.namespace_id,
         payload.content_store_id,
         payload.content_ref,
         payload.expires_at_ms,
-    );
-    Ok(PreparedContent::from_admission(admission))
+    ))
 }
 
 fn base64_url(bytes: &[u8]) -> String {
@@ -305,7 +296,7 @@ mod tests {
             verify_content_token("secret", &catalog, &token, 1_000).expect("verify token");
 
         assert_eq!(prepared.content_ref(), &content);
-        assert!(prepared.into_admission().admits(
+        assert!(prepared.admits(
             catalog.namespace_id(),
             catalog.content_store_id(),
             &content,
@@ -325,9 +316,8 @@ mod tests {
         )
         .expect("mint");
         let catalog = catalog_entry(namespace, CONTENT_STORE);
-        let admission = verify_content_token("secret", &catalog, &token, 1_000)
-            .expect("verify token")
-            .into_admission();
+        let admission =
+            verify_content_token("secret", &catalog, &token, 1_000).expect("verify token");
 
         assert!(!admission.admits(
             &other_namespace,
@@ -338,7 +328,7 @@ mod tests {
     }
 
     #[test]
-    fn public_wrapper_does_not_change_the_signed_payload_encoding() {
+    fn prepared_content_does_not_change_the_signed_payload_encoding() {
         let namespace = NamespaceId::parse("demo").expect("namespace");
         let content = ContentRef::blob_v1(
             ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
@@ -381,14 +371,13 @@ mod tests {
         )
         .expect("verify token before expiry");
 
-        let admission = prepared.into_admission();
-        assert!(admission.admits(
+        assert!(prepared.admits(
             catalog.namespace_id(),
             catalog.content_store_id(),
             &content,
             issued_at_ms + CONTENT_RECEIPT_TTL_MS,
         ));
-        assert!(!admission.admits(
+        assert!(!prepared.admits(
             catalog.namespace_id(),
             catalog.content_store_id(),
             &content,

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -20,7 +20,7 @@ use loonfs_core::content::{
 };
 use loonfs_core::limits::{COMPLETED_UPLOAD_ADMISSION_WINDOW_MS, CONTENT_RECEIPT_TTL_MS};
 use loonfs_core::publish::{CommitCandidate, CommitRequest, FilesystemOperation};
-use loonfs_core::{Error as CoreError, ErrorCode};
+use loonfs_core::{Error as CoreError, ErrorCode, ResolvedUploadCompletion};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -221,16 +221,20 @@ async fn valid_content_admission_skips_durable_content_validation() {
     // A receipt exists only for a session the store already says completed,
     // so the token this test admits has to come from a real upload.
     let engine = namespace_engine(&store, &namespace_id, &context);
-    let upload = engine
-        .begin_upload(loonfs_api::v0::BeginUploadRequest::ServiceProxied {})
-        .await
-        .expect("begin upload");
+    let upload = engine.begin_upload().await.expect("begin upload");
     engine
         .upload_content(upload.upload_id(), b"admitted")
         .await
         .expect("stage content");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
     let completed = engine
-        .complete_upload_prepared(upload.upload_id())
+        .complete_upload(
+            &catalog,
+            upload.upload_id(),
+            ResolvedUploadCompletion::KnownContent,
+        )
         .await
         .expect("complete upload");
     let content_ref = completed
@@ -247,9 +251,6 @@ async fn valid_content_admission_skips_durable_content_validation() {
         context.now_ms,
     )
     .expect("mint token");
-    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
-        .await
-        .expect("load namespace catalog");
     let prepared = verify_content_token(
         "test-content-token-secret",
         &catalog,
@@ -291,16 +292,20 @@ async fn completed_upload_proof_is_rejected_after_its_admission_deadline() {
         .await
         .expect("bootstrap");
     let engine = namespace_engine(&store, &namespace_id, &context);
-    let upload = engine
-        .begin_upload(loonfs_api::v0::BeginUploadRequest::ServiceProxied {})
-        .await
-        .expect("begin upload");
+    let upload = engine.begin_upload().await.expect("begin upload");
     engine
         .upload_content(upload.upload_id(), b"deadline")
         .await
         .expect("stage content");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
     let completed = engine
-        .complete_upload_prepared(upload.upload_id())
+        .complete_upload(
+            &catalog,
+            upload.upload_id(),
+            ResolvedUploadCompletion::KnownContent,
+        )
         .await
         .expect("complete upload");
     let completed_at_ms = match &completed.response.status {
@@ -1052,22 +1057,22 @@ async fn a_re_minted_receipt_publishes_after_the_first_one_expired() {
         .await
         .expect("bootstrap");
     let engine = namespace_engine(&store, &namespace_id, &context);
-    let upload = engine
-        .begin_upload(loonfs_api::v0::BeginUploadRequest::ServiceProxied {})
-        .await
-        .expect("begin upload");
+    let upload = engine.begin_upload().await.expect("begin upload");
     let staged = engine
         .upload_content(upload.upload_id(), b"re-minted")
         .await
         .expect("stage content");
-    let completed = engine
-        .complete_upload_prepared(upload.upload_id())
-        .await
-        .expect("complete upload");
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
         .await
         .expect("load namespace catalog");
-
+    let completed = engine
+        .complete_upload(
+            &catalog,
+            upload.upload_id(),
+            ResolvedUploadCompletion::KnownContent,
+        )
+        .await
+        .expect("complete upload");
     // The receipt the completion handed back, past its life.
     let first = mint_content_token(
         "test-content-token-secret",

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -5,7 +5,6 @@
 
 use crate::common::{mutation_context, namespace_engine, read_context};
 use bytes::Bytes;
-use loonfs_api::v0::BeginUploadRequest;
 use loonfs_api::AbsolutePath;
 use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_core::content::{prepare_existing_content_ref, store_bytes_as_content};
@@ -13,7 +12,7 @@ use loonfs_core::publish::{
     CommitCandidate, CommitRequest, FilesystemOperation, NamespaceCommitEngine, PublishTailOptions,
 };
 use loonfs_core::{gc_namespace, GcConfig};
-use loonfs_core::{BootstrapOptions, MutationContext};
+use loonfs_core::{BootstrapOptions, MutationContext, ResolvedUploadCompletion};
 use loonfs_objectstore::keys::{wal_head, wal_segment_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
@@ -91,16 +90,20 @@ async fn reads_commits_and_change_feed_never_list() {
         .expect("write junk");
 
     let baseline = store.count(OperationClass::List);
-    let staged = engine
-        .begin_upload(BeginUploadRequest::ServiceProxied {})
-        .await
-        .expect("begin upload");
+    let staged = engine.begin_upload().await.expect("begin upload");
     engine
         .upload_content(staged.upload_id(), b"uploaded\n")
         .await
         .expect("upload content");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
     engine
-        .complete_upload(staged.upload_id())
+        .complete_upload(
+            &catalog,
+            staged.upload_id(),
+            ResolvedUploadCompletion::KnownContent,
+        )
         .await
         .expect("complete upload");
     put_file(
@@ -189,16 +192,20 @@ async fn maintenance_never_touches_the_wal_head() {
     gc_namespace(&store, &namespace_id, &GcConfig::default(), &context)
         .await
         .expect("gc pass");
-    let staged = engine
-        .begin_upload(BeginUploadRequest::ServiceProxied {})
-        .await
-        .expect("second upload");
+    let staged = engine.begin_upload().await.expect("second upload");
     engine
         .upload_content(staged.upload_id(), b"more\n")
         .await
         .expect("second upload content");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
     engine
-        .complete_upload(staged.upload_id())
+        .complete_upload(
+            &catalog,
+            staged.upload_id(),
+            ResolvedUploadCompletion::KnownContent,
+        )
         .await
         .expect("second upload complete");
 

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -14,6 +14,7 @@ use loonfs_api::{
 use loonfs_api::{Checksum, ChecksumAlgorithm};
 use loonfs_core::{
     BeginDirectPutUploadTargetResponse, Error as CoreError, ErrorCode, MutationContext,
+    ResolvedUploadCompletion,
 };
 use loonfs_objectstore::keys::upload_session;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -31,7 +32,7 @@ async fn begin_upload<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<loonfs_api::v0::BeginUploadResponse, CoreError> {
     namespace_engine(store, namespace_id, context)
-        .begin_upload(loonfs_api::v0::BeginUploadRequest::ServiceProxied {})
+        .begin_upload()
         .await
 }
 
@@ -64,9 +65,11 @@ async fn complete_upload<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     context: &MutationContext,
 ) -> Result<loonfs_api::v0::UploadSession, CoreError> {
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id).await?;
     namespace_engine(store, namespace_id, context)
-        .complete_upload(upload_id)
+        .complete_upload(&catalog, upload_id, ResolvedUploadCompletion::KnownContent)
         .await
+        .map(|completed| completed.response)
 }
 
 fn replay_read_guard_store(root: impl AsRef<Path>, namespace: &str) -> FailStore<LocalFsStore> {
@@ -562,9 +565,16 @@ mod direct_multipart {
         request: &CompleteMultipartUploadRequest,
         context: &MutationContext,
     ) -> Result<loonfs_api::v0::UploadSession, CoreError> {
+        let catalog =
+            loonfs_core::control::load_namespace_catalog_entry(store, namespace_id).await?;
         namespace_engine(store, namespace_id, context)
-            .complete_multipart_upload(upload_id, request)
+            .complete_upload(
+                &catalog,
+                upload_id,
+                ResolvedUploadCompletion::Multipart(request.clone()),
+            )
             .await
+            .map(|completed| completed.response)
     }
 
     #[tokio::test]

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -140,7 +140,7 @@ pub(super) async fn create_upload(
         BeginUploadRequest::ServiceProxied {} => {
             let response = state
                 .writer
-                .create_upload(&namespace_id, request)
+                .create_upload(&namespace_id)
                 .await
                 .map_err(ApiResponseError::for_namespace(&namespace_id))?;
             Ok(Json(response))
@@ -579,7 +579,7 @@ pub(super) async fn complete_upload(
     let body = body.into_bytes();
     let completed = state
         .writer
-        .complete_upload_prepared_for_mode(&namespace_id, &upload_id, |mode| {
+        .complete_upload_for_mode(&namespace_id, &upload_id, |mode| {
             decode_completion_body(mode, &body)
         })
         .await

--- a/crates/loonfs-server/tests/logging.rs
+++ b/crates/loonfs-server/tests/logging.rs
@@ -12,7 +12,6 @@ use axum::Router;
 use bytes::Bytes;
 use common::http_split_support::test_config;
 use loonfs::{CreateNamespaceOptions, FsWriter, SharedObjectStore, TraceMode, TraceStoreKind};
-use loonfs_api::v0::BeginUploadRequest;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_server::{app, AppOptions, MaintenanceMode};
 use loonfs_test_support::ids::namespace_id;
@@ -269,7 +268,7 @@ async fn expected_typed_errors_use_debug_or_warn_and_keep_completion_fields() {
         .await
         .expect("create namespace");
     let upload = writer
-        .create_upload(&namespace, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace)
         .await
         .expect("begin upload");
 

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -17,8 +17,8 @@ use crate::ByteStream;
 use crate::FsWriter;
 use crate::Result;
 use crate::{
-    BeginUploadRequest, BeginUploadResponse, ChecksumAlgorithm, MaintenanceJobId, NamespaceId,
-    UploadContentResponse, UploadMode, UploadSession,
+    BeginUploadResponse, ChecksumAlgorithm, MaintenanceJobId, NamespaceId, UploadContentResponse,
+    UploadMode, UploadSession,
 };
 use loonfs_api::options::DirectMultipartUploadOptions;
 use loonfs_api::v0::UploadPartChecksumClaim;
@@ -61,13 +61,9 @@ impl FsWriter {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn create_upload(
-        &self,
-        namespace_id: &NamespaceId,
-        request: BeginUploadRequest,
-    ) -> Result<BeginUploadResponse> {
+    pub async fn create_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        let response = self.engine(namespace_id).begin_upload(request).await?;
+        let response = self.engine(namespace_id).begin_upload().await?;
         self.schedule_upload_session_reclamation(namespace_id);
         Ok(response)
     }
@@ -223,9 +219,6 @@ impl FsWriter {
     }
 
     /// Completes an upload session and returns proof for later publication.
-    ///
-    /// Service-proxied completion performs no content-blob I/O. Direct-put
-    /// completion performs one content-blob HEAD and no content-blob GET.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.complete_upload",
@@ -251,7 +244,7 @@ impl FsWriter {
             .await?;
         let completed = self
             .engine(namespace_id)
-            .complete_upload_prepared_with_catalog(&catalog, upload_id, completion)
+            .complete_upload(&catalog, upload_id, completion)
             .await?;
         self.schedule_completed_upload_reclamation(namespace_id);
         Ok(completed)
@@ -265,13 +258,13 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "complete_upload",
-            method = "complete_upload_prepared_for_mode",
+            method = "complete_upload_for_mode",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn complete_upload_prepared_for_mode<F>(
+    pub async fn complete_upload_for_mode<F>(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
@@ -288,7 +281,7 @@ impl FsWriter {
             .await?;
         let completed = self
             .engine(namespace_id)
-            .complete_upload_prepared_with_catalog_for_mode(&catalog, upload_id, resolve)
+            .complete_upload_for_mode(&catalog, upload_id, resolve)
             .await?;
         self.schedule_completed_upload_reclamation(namespace_id);
         Ok(completed)

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -6,7 +6,7 @@
 // The drain test injects a step panic to assert it is surfaced.
 
 use super::*;
-use crate::{BeginUploadRequest, CreateNamespaceOptions, FsWriter, SharedObjectStore};
+use crate::{CreateNamespaceOptions, FsWriter, SharedObjectStore};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::ids::{namespace_id, nonzero_usize};
 use std::collections::VecDeque;
@@ -884,7 +884,7 @@ async fn upload_paths_plant_the_collection_deadlines_they_create() {
         .expect("create namespace");
 
     let begun = writer
-        .create_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace_id)
         .await
         .expect("begin upload");
     assert_eq!(

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -11,7 +11,7 @@ use crate::maintenance_runner::MaintenanceRunner;
 use crate::metrics::{DefaultMetricsRecorder, MetricValue, RuntimeInstruments};
 use crate::publish::{CommitRequest, ContentPreparationError, FilesystemOperation};
 use crate::{
-    BeginUploadRequest, CreateNamespaceOptions, ErrorCode, FsAdmin, RuntimeCacheConfig,
+    CreateNamespaceOptions, ErrorCode, FsAdmin, RuntimeCacheConfig,
     SharedObjectStore as SharedStore, TraceMode, TraceStoreKind,
 };
 use async_trait::async_trait;
@@ -1644,7 +1644,7 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
         .await
         .expect("bootstrap");
     let upload = writer
-        .create_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace_id)
         .await
         .expect("begin upload");
     let staged = writer

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -7,14 +7,13 @@
 use loonfs::publish::{CommitCandidate, CommitRequest};
 use loonfs::uploads::ResolvedUploadCompletion;
 use loonfs::{
-    AdvanceRetentionResponse, BeginUploadRequest, BeginUploadResponse, ChangeSeq, Checkpoint,
-    ChecksumAlgorithm, CommitResponse, ContentRef, CopyOptions, CreateCheckpointOptions,
-    CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions, DirectoryPageCursor, ErrorCode,
-    FileBytes, FsAdmin, FsReader, FsWriter, FsWriterBuilder, ListChangesOptions,
-    ListChangesResponse, MaintenancePlan, MaintenanceStepResponse, MetadataMaintenanceResponse,
-    MoveOptions, NamespaceDiagnostics, NamespaceId, PageRequest, PaginationPolicy, PathEntry,
-    PutFileOptions, RuntimeError, SharedObjectStore, UploadContentResponse, UploadId,
-    UploadSession,
+    AdvanceRetentionResponse, BeginUploadResponse, ChangeSeq, Checkpoint, ChecksumAlgorithm,
+    CommitResponse, ContentRef, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
+    CreateNamespaceOptions, DeleteOptions, DirectoryPageCursor, ErrorCode, FileBytes, FsAdmin,
+    FsReader, FsWriter, FsWriterBuilder, ListChangesOptions, ListChangesResponse, MaintenancePlan,
+    MaintenanceStepResponse, MetadataMaintenanceResponse, MoveOptions, NamespaceDiagnostics,
+    NamespaceId, PageRequest, PaginationPolicy, PathEntry, PutFileOptions, RuntimeError,
+    SharedObjectStore, UploadContentResponse, UploadId, UploadSession,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::stores::{
@@ -281,7 +280,7 @@ impl TestRuntime {
         content: loonfs::UploadContentClaim,
     ) -> loonfs::Result<UploadSession> {
         self.writer
-            .complete_upload_prepared_for_mode(namespace_id, upload_id, |_| {
+            .complete_upload_for_mode(namespace_id, upload_id, |_| {
                 Ok(loonfs::uploads::ResolvedUploadCompletion::DirectPut { content })
             })
             .await
@@ -548,10 +547,7 @@ impl RuntimeTestExt for TestRuntime {
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<BeginUploadResponse> {
-        block_on(
-            self.writer
-                .create_upload(namespace_id, BeginUploadRequest::ServiceProxied {}),
-        )
+        block_on(self.writer.create_upload(namespace_id))
     }
 
     fn upload_content_blocking(

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -8,9 +8,9 @@ use loonfs::publish::{
 };
 use loonfs::uploads::ResolvedUploadCompletion;
 use loonfs::{
-    BeginUploadRequest, CommitId, CoreError, CreateDirectoryOptions, CreateNamespaceOptions,
-    DestinationBehavior, ErrorCode, FsWriter, NamespaceId, PutFileOptions, RevisionNo,
-    RuntimeError, SharedObjectStore, CONTENT_READ_CHUNK_BYTES,
+    CommitId, CoreError, CreateDirectoryOptions, CreateNamespaceOptions, DestinationBehavior,
+    ErrorCode, FsWriter, NamespaceId, PutFileOptions, RevisionNo, RuntimeError, SharedObjectStore,
+    CONTENT_READ_CHUNK_BYTES,
 };
 use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
 use loonfs_api::{ContentId, ContentStoreId};
@@ -565,7 +565,7 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
     let bytes = b"service proxied upload";
     let begin = harness
         .writer
-        .create_upload(&harness.namespace_id, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&harness.namespace_id)
         .await
         .expect("begin upload");
     harness.recording.reset();
@@ -646,7 +646,7 @@ async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_cont
 
     let completed = harness
         .writer
-        .complete_upload_prepared_for_mode(&harness.namespace_id, &begin.upload_id, |_| {
+        .complete_upload_for_mode(&harness.namespace_id, &begin.upload_id, |_| {
             Ok(loonfs::uploads::ResolvedUploadCompletion::DirectPut {
                 content: loonfs::UploadContentClaim {
                     size_bytes: bytes.len() as u64,

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -8,9 +8,9 @@ use bytes::Bytes;
 use loonfs::publish::{parse_mutation_path, CommitCandidate, CommitRequest, FilesystemOperation};
 use loonfs::uploads::ResolvedUploadCompletion;
 use loonfs::{
-    BeginUploadRequest, ChangeSeq, ChecksumAlgorithm, CommitId, CreateDirectoryOptions,
-    CreateNamespaceOptions, DestinationBehavior, ErrorCode, NamespaceId, PutFileOptions,
-    RuntimeCacheConfig, SharedObjectStore, UploadMode,
+    ChangeSeq, ChecksumAlgorithm, CommitId, CreateDirectoryOptions, CreateNamespaceOptions,
+    DestinationBehavior, ErrorCode, NamespaceId, PutFileOptions, RuntimeCacheConfig,
+    SharedObjectStore, UploadMode,
 };
 use loonfs_api::v0::{UploadContentClaim, UploadSessionStatus};
 use loonfs_api::Checksum;
@@ -451,7 +451,7 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         for bytes in [b"alpha" as &[u8], b"beta", b"gamma", b"delta"] {
             let begin = fs
                 .writer
-                .create_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
+                .create_upload(&namespace_id)
                 .await
                 .expect("begin upload");
             fs.writer

--- a/crates/loonfs/tests/it/publication.rs
+++ b/crates/loonfs/tests/it/publication.rs
@@ -6,8 +6,8 @@
 use futures::future::BoxFuture;
 use loonfs::publish::{parse_mutation_path, CommitCandidate, CommitRequest, FilesystemOperation};
 use loonfs::{
-    BeginUploadRequest, CommitId, CommitResponse, CreateNamespaceOptions, DestinationBehavior,
-    FsWriter, NamespaceId, PutFileOptions, SharedObjectStore,
+    CommitId, CommitResponse, CreateNamespaceOptions, DestinationBehavior, FsWriter, NamespaceId,
+    PutFileOptions, SharedObjectStore,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
@@ -64,7 +64,7 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
     // callers start being cancelled, the only work still in flight is
     // publication, the thing under test.
     let upload = writer
-        .create_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
+        .create_upload(&namespace_id)
         .await
         .expect("begin upload");
     let staged = writer

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1765,7 +1765,7 @@ The following invariants are checked when a record is read:
   `content_id`.
 - The record carries a `mode` and a `status`. Neither has a default and
   neither may be omitted.
-- A completed `direct_put` session's checksum uses the mode's stored
+- A completed direct session's checksum uses the mode's stored
   `checksum_algorithm`.
 
 A record that fails any invariant is rejected as corrupt. Upload sessions use


### PR DESCRIPTION
This sends buffered and streamed service uploads through one staging path and uses one completion method for all upload modes. Completion resolves the stored mode once, validates mode-specific input, and returns the same CompletedUpload proof to the runtime.

Imported streams verify their source checksum while bytes are read, and direct multipart completions must use the checksum algorithm stored in the session. The HTTP and durable formats are unchanged.