### PR TITLE
refactor(core): unify control-object writes and confirmation

### DIFF
--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -119,6 +119,8 @@ pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
         // the job is alive and owns its prefix. This pass keeps every object
         // under it.
         Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CompactionPrefixOwner::LiveJob),
+        // An ambiguous claim is left to a later collector, which reads the
+        // lease afresh and finishes whatever landed.
         Err(error) => Err(CoreError::store(&object_key, &error)),
     }
 }
@@ -239,6 +241,8 @@ impl<'a> CompactionLease<'a> {
                 );
                 Ok(LeaseHold::Fenced)
             }
+            // An unconfirmed heartbeat has no etag for the next fenced write,
+            // so the job ends here.
             Err(error) => Err(CoreError::store(&self.object_key, &error)),
         }
     }

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -21,7 +21,6 @@ use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::control::{CheckpointOwner, CheckpointRecordState, CheckpointStatus};
 use loonfs_api::{Checkpoint, CheckpointId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(test)]
 use super::load::append_rows_to_metadata;
@@ -56,70 +55,71 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     validate_checkpoint_owner(&owner)?;
     let timer = &StdMonotonicTimer::default();
     let owner = &owner;
-    let saw_root_cas_race = &AtomicBool::new(false);
-    let created = retry_while_contended(|| async move {
-        let basis = match try_flush_wal(store, namespace_id, context, timer).await? {
-            TryFlushWal::Settled(basis) => basis,
-            TryFlushWal::RaceLost => {
-                saw_root_cas_race.store(true, Ordering::Relaxed);
-                return Ok(CasAttempt::Contended);
-            }
-        };
-
-        let checkpoint_id = CheckpointId::generate();
-        let record = CheckpointRecordState {
-            checkpoint_id: checkpoint_id.clone(),
-            namespace_id: namespace_id.clone(),
-            manifest: basis.manifest.clone(),
-            head_commit_id: basis.head_commit_id.clone(),
-            created_at_ms: context.now_ms,
-            owner: owner.clone(),
-            status: CheckpointStatus::Active {},
-        };
-        let verify_started_ms = timer.monotonic_now_ms();
-        write_checkpoint_record(store, &record).await?;
-
-        let verification = match verify_checkpoint_basis(store, &record).await {
-            Ok(verification) => verification,
-            Err(error) => {
-                // Cleanup is best effort on an error and must not replace its
-                // original classification.
-                if let Err(cleanup_error) =
-                    release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms)
-                        .await
-                {
-                    tracing::warn!(
-                        namespace_id = %namespace_id,
-                        checkpoint_id = %checkpoint_id,
-                        original_error = %error,
-                        cleanup_error = %cleanup_error,
-                        "failed to release a checkpoint record after basis verification failed"
-                    );
+    let created = retry_while_contended(
+        || async move {
+            let basis = match try_flush_wal(store, namespace_id, context, timer).await? {
+                TryFlushWal::Settled(basis) => basis,
+                TryFlushWal::RaceLost => {
+                    return Ok(CasAttempt::Contended(CoreError::HeadPublish(
+                        CommitHeadPublishError::StaleHead,
+                    )))
                 }
-                return Err(error);
+            };
+
+            let checkpoint_id = CheckpointId::generate();
+            let record = CheckpointRecordState {
+                checkpoint_id: checkpoint_id.clone(),
+                namespace_id: namespace_id.clone(),
+                manifest: basis.manifest.clone(),
+                head_commit_id: basis.head_commit_id.clone(),
+                created_at_ms: context.now_ms,
+                owner: owner.clone(),
+                status: CheckpointStatus::Active {},
+            };
+            let verify_started_ms = timer.monotonic_now_ms();
+            write_checkpoint_record(store, &record).await?;
+
+            let verification = match verify_checkpoint_basis(store, &record).await {
+                Ok(verification) => verification,
+                Err(error) => {
+                    // Cleanup is best effort on an error and must not replace its
+                    // original classification.
+                    if let Err(cleanup_error) = release_checkpoint_record(
+                        store,
+                        namespace_id,
+                        &checkpoint_id,
+                        context.now_ms,
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            namespace_id = %namespace_id,
+                            checkpoint_id = %checkpoint_id,
+                            original_error = %error,
+                            cleanup_error = %cleanup_error,
+                            "failed to release a checkpoint record after basis verification failed"
+                        );
+                    }
+                    return Err(error);
+                }
+            };
+            let within_budget = timer.monotonic_now_ms().saturating_sub(verify_started_ms)
+                <= CHECKPOINT_VERIFY_BUDGET_MS;
+            if verification == CheckpointBasisVerification::Verified && within_budget {
+                return Ok(CasAttempt::Settled(super::checkpoint_summary(record)));
             }
-        };
-        let within_budget = timer.monotonic_now_ms().saturating_sub(verify_started_ms)
-            <= CHECKPOINT_VERIFY_BUDGET_MS;
-        if verification == CheckpointBasisVerification::Verified && within_budget {
-            return Ok(CasAttempt::Settled(super::checkpoint_summary(record)));
-        }
 
-        // Overrunning the budget counts as verification failure: the record
-        // may have raced the grace window, so it must not stand as a root.
-        release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms).await?;
-        Ok(CasAttempt::Contended)
-    })
+            // Overrunning the budget counts as verification failure: the record
+            // may have raced the grace window, so it must not stand as a root.
+            release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms).await?;
+            Ok(CasAttempt::Contended(CoreError::CheckpointUnavailable(
+                "checkpoint publication retry exhausted".to_owned(),
+            )))
+        },
+        |_, ()| async { Ok(crate::control_update::WriteEvidence::Unknown) },
+    )
     .await?;
-
-    match (created, saw_root_cas_race.load(Ordering::Relaxed)) {
-        (Some(checkpoint), _) => Ok(checkpoint),
-        // Root contention is retryable; other exhaustion means no basis verified.
-        (None, true) => Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead)),
-        (None, false) => Err(CoreError::CheckpointUnavailable(
-            "checkpoint publication retry exhausted".to_owned(),
-        )),
-    }
+    created
 }
 
 fn validate_checkpoint_owner(owner: &CheckpointOwner) -> Result<()> {

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -17,7 +17,7 @@ use super::runs::{flatten_manifest_segments, MetadataLsmPolicy, CHECKPOINT_BASE_
 use super::scan::VerifiedMetadataSegments;
 use crate::commit::CommitHeadPublishError;
 use crate::context::MutationContext;
-use crate::control_update::{retry_while_contended, CasAttempt};
+use crate::control_update::{retry_while_contended, CasAttempt, WriteEvidence};
 use crate::error::CoreError;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::Result;
@@ -86,22 +86,26 @@ pub(super) async fn flush_wal_with_timer<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     timer: &dyn MonotonicTimer,
 ) -> Result<FlushWalResponse> {
-    let flushed = retry_while_contended(|| async move {
-        Result::Ok(
-            match try_flush_wal(store, namespace_id, context, timer).await? {
-                TryFlushWal::Settled(basis) => CasAttempt::Settled(FlushWalResponse {
-                    namespace_id: namespace_id.clone(),
-                    target_head_seq: basis.target_head_seq,
-                    manifest_no: basis.root_after_manifest_no,
-                    manifest_head_seq: basis.root_after_head_seq,
-                    outcome: basis.outcome,
-                }),
-                TryFlushWal::RaceLost => CasAttempt::Contended,
-            },
-        )
-    })
-    .await?;
-    flushed.ok_or(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
+    retry_while_contended(
+        || async move {
+            Result::Ok(
+                match try_flush_wal(store, namespace_id, context, timer).await? {
+                    TryFlushWal::Settled(basis) => CasAttempt::Settled(FlushWalResponse {
+                        namespace_id: namespace_id.clone(),
+                        target_head_seq: basis.target_head_seq,
+                        manifest_no: basis.root_after_manifest_no,
+                        manifest_head_seq: basis.root_after_head_seq,
+                        outcome: basis.outcome,
+                    }),
+                    TryFlushWal::RaceLost => CasAttempt::Contended(CoreError::HeadPublish(
+                        CommitHeadPublishError::StaleHead,
+                    )),
+                },
+            )
+        },
+        |_, ()| async { Ok(WriteEvidence::Unknown) },
+    )
+    .await?
 }
 
 /// One flush attempt against one fresh projection.
@@ -200,7 +204,7 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
         ManifestPublicationOutcome::PredecessorChanged(_) => {
             return Ok(TryFlushWal::RaceLost);
         }
-        ManifestPublicationOutcome::RootCasRaceLost => return Ok(TryFlushWal::RaceLost),
+        ManifestPublicationOutcome::Installable => return Ok(TryFlushWal::RaceLost),
     };
     Ok(TryFlushWal::Settled(Box::new(FlushedBasis {
         manifest: manifest_ref_for(namespace_id, &manifest),

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -2,6 +2,7 @@
 //! advance `metadata/root.json` by monotonic compare-and-swap.
 
 use super::error::ManifestLoadError;
+use crate::control_update::{settle_control_write, CasAttempt, WriteEvidence};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::control::load_metadata_root_object_if_present;
@@ -17,14 +18,14 @@ use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
 /// The result of trying to publish a manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ManifestPublicationOutcome {
+    /// The candidate may still replace the current root.
+    Installable,
     /// The candidate is the current root.
     Published(MetadataRootState),
     /// The current root already covers the candidate's state.
     CoveredByCurrent(MetadataRootState),
     /// The expected predecessor changed without covering the candidate.
     PredecessorChanged(MetadataRootState),
-    /// The root changed during the compare-and-swap and should be retried.
-    RootCasRaceLost,
 }
 
 #[tracing::instrument(
@@ -126,9 +127,9 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
         )
         .await;
     };
-    match root_transition(&loaded.state, &candidate, expected_predecessor.as_ref()) {
-        RootTransition::InstallAgainstCurrent => {}
-        transition => return Ok(outcome_from(loaded.state, transition)),
+    match classify_root(&loaded.state, &candidate, expected_predecessor.as_ref()) {
+        ManifestPublicationOutcome::Installable => {}
+        outcome => return Ok(outcome),
     }
     ensure_legal_successor(namespace_id, &candidate, &loaded.state.manifest)?;
     let next = MetadataRootState {
@@ -157,60 +158,46 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
             )
             .await
         }
-        // Re-read the root to resolve an unknown write outcome.
         Err(error @ ObjectStoreError::Transport { .. }) => {
-            match classify_current_root(
-                store,
-                namespace_id,
-                &candidate,
-                expected_predecessor.as_ref(),
+            settle_control_write::<_, CoreError, (), CoreError, _, _>(
+                CasAttempt::Ambiguous(error, ()),
+                |_, ()| async {
+                    match classify_current_root(
+                        store,
+                        namespace_id,
+                        &candidate,
+                        expected_predecessor.as_ref(),
+                    )
+                    .await?
+                    {
+                        ManifestPublicationOutcome::Installable => Ok(WriteEvidence::Unknown),
+                        outcome => Ok(WriteEvidence::Landed(outcome)),
+                    }
+                },
             )
             .await?
-            {
-                ManifestPublicationOutcome::RootCasRaceLost => {
-                    Err(CoreError::store(&loaded.object_key, &error))
-                }
-                outcome => Ok(outcome),
-            }
         }
         Err(error) => Err(CoreError::store(&loaded.object_key, &error)),
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RootTransition {
-    InstallAgainstCurrent,
-    Published,
-    CoveredByCurrent,
-    PredecessorChanged,
-}
-
 /// A candidate may replace only the predecessor it was built from.
-fn root_transition(
+fn classify_root(
     root: &MetadataRootState,
     candidate: &ManifestRef,
     expected_predecessor: Option<&ManifestObjectId>,
-) -> RootTransition {
+) -> ManifestPublicationOutcome {
     if root.manifest == *candidate {
-        return RootTransition::Published;
+        return ManifestPublicationOutcome::Published(root.clone());
     }
     if root_supersedes_candidate(root, candidate) {
-        return RootTransition::CoveredByCurrent;
+        return ManifestPublicationOutcome::CoveredByCurrent(root.clone());
     }
     match expected_predecessor {
         Some(predecessor) if root.manifest.manifest_object_id == *predecessor => {
-            RootTransition::InstallAgainstCurrent
+            ManifestPublicationOutcome::Installable
         }
-        _ => RootTransition::PredecessorChanged,
-    }
-}
-
-fn outcome_from(root: MetadataRootState, transition: RootTransition) -> ManifestPublicationOutcome {
-    match transition {
-        RootTransition::InstallAgainstCurrent => ManifestPublicationOutcome::RootCasRaceLost,
-        RootTransition::Published => ManifestPublicationOutcome::Published(root),
-        RootTransition::CoveredByCurrent => ManifestPublicationOutcome::CoveredByCurrent(root),
-        RootTransition::PredecessorChanged => ManifestPublicationOutcome::PredecessorChanged(root),
+        _ => ManifestPublicationOutcome::PredecessorChanged(root.clone()),
     }
 }
 
@@ -225,10 +212,13 @@ async fn classify_current_root<S: ObjectStore + ?Sized>(
         .await
         .map_err(CoreError::ControlObjectLoad)?
     else {
-        return Ok(ManifestPublicationOutcome::RootCasRaceLost);
+        return Ok(ManifestPublicationOutcome::Installable);
     };
-    let transition = root_transition(&loaded.state, candidate, expected_predecessor);
-    Ok(outcome_from(loaded.state, transition))
+    Ok(classify_root(
+        &loaded.state,
+        candidate,
+        expected_predecessor,
+    ))
 }
 
 /// Rejects a candidate that does not advance its predecessor.
@@ -280,14 +270,23 @@ async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
             classify_current_root(store, namespace_id, candidate, expected_predecessor).await
         }
         Err(error @ ObjectStoreError::Transport { .. }) => {
-            match classify_current_root(store, namespace_id, candidate, expected_predecessor)
-                .await?
-            {
-                ManifestPublicationOutcome::RootCasRaceLost => {
-                    Err(CoreError::store(&object_key, &error))
-                }
-                outcome => Ok(outcome),
-            }
+            settle_control_write::<_, CoreError, (), CoreError, _, _>(
+                CasAttempt::Ambiguous(error, ()),
+                |_, ()| async {
+                    match classify_current_root(
+                        store,
+                        namespace_id,
+                        candidate,
+                        expected_predecessor,
+                    )
+                    .await?
+                    {
+                        ManifestPublicationOutcome::Installable => Ok(WriteEvidence::Unknown),
+                        outcome => Ok(WriteEvidence::Landed(outcome)),
+                    }
+                },
+            )
+            .await?
         }
         Err(error) => Err(CoreError::store(&object_key, &error)),
     }

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -12,7 +12,8 @@ use crate::control_object::{
     ControlObjectLoadError, LoadedControl,
 };
 use crate::control_update::{
-    create_control_object_under_generated_id, retry_while_contended, CasAttempt,
+    create_control_object_under_generated_id, retry_while_contended, settle_control_write,
+    CasAttempt, WriteEvidence,
 };
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::limits::FORK_CHECKPOINT_LEASE_MS;
@@ -159,27 +160,38 @@ pub(crate) async fn release_inspected_checkpoint_record<S: ObjectStore + ?Sized>
     let mut next = loaded.state;
     next.status = CheckpointStatus::Released { released_at_ms };
     let encoded = encode_checkpoint_record(&next)?;
-    match store
-        .compare_and_swap(object_key, &expected_etag, encoded)
-        .await
-    {
-        Ok(_) => Ok(CheckpointRelease::Released),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CheckpointRelease::LostRace),
-        Err(error @ ObjectStoreError::Transport { .. }) => {
+    let settled = settle_control_write(
+        match store
+            .compare_and_swap(object_key, &expected_etag, encoded)
+            .await
+        {
+            Ok(_) => CasAttempt::Settled(CheckpointRelease::Released),
+            Err(ObjectStoreError::PreconditionFailed { .. }) => {
+                CasAttempt::Contended(CheckpointRelease::LostRace)
+            }
+            Err(error @ ObjectStoreError::Transport { .. }) => CasAttempt::Ambiguous(error, ()),
+            Err(error) => return Err(CoreError::store(object_key, &error)),
+        },
+        |_, ()| async {
             match load_checkpoint_record_at_key(store, object_key).await {
                 Ok(current) if current.state.status != (CheckpointStatus::Active {}) => {
-                    Ok(CheckpointRelease::Released)
+                    Ok(WriteEvidence::Landed(CheckpointRelease::Released))
                 }
-                Ok(current) if current.etag != expected_etag => Ok(CheckpointRelease::LostRace),
-                Ok(_) => Err(CoreError::store(object_key, &error)),
+                Ok(current) if current.etag != expected_etag => {
+                    Ok(WriteEvidence::Lost(CheckpointRelease::LostRace))
+                }
+                Ok(_) => Ok(WriteEvidence::Unknown),
                 Err(ControlObjectLoadError::MissingObject { .. }) => {
-                    Ok(CheckpointRelease::Released)
+                    Ok(WriteEvidence::Landed(CheckpointRelease::Released))
                 }
-                Err(load_error) => Err(CoreError::ControlObjectLoad(load_error)),
+                Err(error) => Err(CoreError::ControlObjectLoad(error)),
             }
-        }
-        Err(error) => Err(CoreError::store(object_key, &error)),
-    }
+        },
+    )
+    .await?;
+    Ok(match settled {
+        Ok(outcome) | Err(outcome) => outcome,
+    })
 }
 
 /// Releases a checkpoint record, retrying CAS conflicts.
@@ -190,26 +202,28 @@ pub(crate) async fn release_checkpoint_record<S: ObjectStore + ?Sized>(
     released_at_ms: u64,
 ) -> Result<()> {
     let object_key = &checkpoint_record(namespace_id, checkpoint_id);
-    let released = retry_while_contended(|| async move {
-        let Some(loaded) = load_checkpoint_record(store, namespace_id, checkpoint_id)
-            .await?
-            .filter(|loaded| loaded.state.status == (CheckpointStatus::Active {}))
-        else {
-            // Reaped or released underneath us: either way no active pin
-            // stands under this id, which is what the release asked for.
-            return Ok::<_, CoreError>(CasAttempt::Settled(()));
-        };
-        Ok(
-            match release_inspected_checkpoint_record(store, object_key, loaded, released_at_ms)
+    retry_while_contended(
+        || async move {
+            let Some(loaded) = load_checkpoint_record(store, namespace_id, checkpoint_id)
                 .await?
-            {
-                CheckpointRelease::Released => CasAttempt::Settled(()),
-                CheckpointRelease::LostRace => CasAttempt::Contended,
-            },
-        )
-    })
-    .await?;
-    released.ok_or_else(|| CoreError::contention_exhausted(object_key))
+                .filter(|loaded| loaded.state.status == (CheckpointStatus::Active {}))
+            else {
+                return Ok::<_, CoreError>(CasAttempt::Settled(()));
+            };
+            Ok(
+                match release_inspected_checkpoint_record(store, object_key, loaded, released_at_ms)
+                    .await?
+                {
+                    CheckpointRelease::Released => CasAttempt::Settled(()),
+                    CheckpointRelease::LostRace => {
+                        CasAttempt::Contended(CoreError::contention_exhausted(object_key))
+                    }
+                },
+            )
+        },
+        |_, ()| async { Ok(WriteEvidence::Unknown) },
+    )
+    .await?
 }
 
 /// Renews a fork checkpoint immediately before installing its target.
@@ -224,81 +238,129 @@ pub(crate) async fn renew_fork_checkpoint_for_install<S: ObjectStore + ?Sized>(
     now_ms: u64,
 ) -> Result<u64> {
     let object_key = &checkpoint_record(source_namespace_id, checkpoint_id);
-    let unavailable = &|reason: String| {
-        CoreError::CheckpointUnavailable(format!(
-            "fork of `{source_namespace_id}` into `{expected_target_namespace_id}` cannot renew \
-             its source checkpoint `{checkpoint_id}`: {reason}"
-        ))
-    };
-    let renewed = retry_while_contended(|| async move {
-        let Some(loaded) =
-            load_checkpoint_record(store, source_namespace_id, checkpoint_id).await?
-        else {
-            return Err(unavailable("the record is gone".to_owned()));
-        };
-        let mut next = loaded.state;
-        if next.status != (CheckpointStatus::Active {}) {
-            return Err(unavailable(format!("the record is `{}`", next.status)));
-        }
-        let CheckpointOwner::Fork {
-            target_namespace_id,
-            expires_at_ms,
-        } = &mut next.owner
-        else {
-            return Err(unavailable("the record is not fork-owned".to_owned()));
-        };
-        if target_namespace_id != expected_target_namespace_id {
-            return Err(unavailable(format!(
-                "the record pins target `{target_namespace_id}`"
-            )));
-        }
-        let later_expiry = expires_at_ms
-            .checked_add(1)
-            .ok_or_else(|| unavailable("the lease expiry cannot be extended".to_owned()))?;
-        *expires_at_ms = later_expiry.max(now_ms.saturating_add(FORK_CHECKPOINT_LEASE_MS));
-        let renewed_expiry = *expires_at_ms;
-        let encoded = encode_checkpoint_record(&next)?;
-        match store
-            .compare_and_swap(object_key, &loaded.etag, encoded)
-            .await
-        {
-            Ok(_) => Ok(CasAttempt::Settled(renewed_expiry)),
-            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            Err(error @ ObjectStoreError::Transport { .. }) => {
-                let Some(current) =
-                    load_checkpoint_record(store, source_namespace_id, checkpoint_id).await?
-                else {
-                    return Err(unavailable("the record is gone".to_owned()));
-                };
-                if current.state.status != (CheckpointStatus::Active {}) {
-                    return Err(unavailable(format!(
-                        "the record is `{}`",
-                        current.state.status
-                    )));
+    retry_while_contended(
+        || async move {
+            let Some(loaded) =
+                load_checkpoint_record(store, source_namespace_id, checkpoint_id).await?
+            else {
+                return Err(fork_checkpoint_unavailable(
+                    source_namespace_id,
+                    checkpoint_id,
+                    expected_target_namespace_id,
+                    "the record is gone".to_owned(),
+                ));
+            };
+            let current_expiry = inspect_fork_record(
+                &loaded.state,
+                source_namespace_id,
+                checkpoint_id,
+                expected_target_namespace_id,
+            )?;
+            let later_expiry = current_expiry.checked_add(1).ok_or_else(|| {
+                fork_checkpoint_unavailable(
+                    source_namespace_id,
+                    checkpoint_id,
+                    expected_target_namespace_id,
+                    "the lease expiry cannot be extended".to_owned(),
+                )
+            })?;
+            let renewed_expiry = later_expiry.max(now_ms.saturating_add(FORK_CHECKPOINT_LEASE_MS));
+            let mut next = loaded.state;
+            next.owner = CheckpointOwner::Fork {
+                target_namespace_id: expected_target_namespace_id.clone(),
+                expires_at_ms: renewed_expiry,
+            };
+            let encoded = encode_checkpoint_record(&next)?;
+            match store
+                .compare_and_swap(object_key, &loaded.etag, encoded)
+                .await
+            {
+                Ok(_) => Ok(CasAttempt::Settled(renewed_expiry)),
+                Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended(
+                    CoreError::contention_exhausted(object_key),
+                )),
+                Err(error @ ObjectStoreError::Transport { .. }) => {
+                    Ok(CasAttempt::Ambiguous(error, renewed_expiry))
                 }
-                let CheckpointOwner::Fork {
-                    target_namespace_id,
-                    expires_at_ms,
-                } = current.state.owner
-                else {
-                    return Err(unavailable("the record is not fork-owned".to_owned()));
-                };
-                if &target_namespace_id != expected_target_namespace_id {
-                    return Err(unavailable(format!(
-                        "the record pins target `{target_namespace_id}`"
-                    )));
-                }
-                if expires_at_ms >= renewed_expiry {
-                    Ok(CasAttempt::Settled(expires_at_ms))
-                } else {
-                    Err(CoreError::store(object_key, &error))
-                }
+                Err(error) => Err(CoreError::store(object_key, &error)),
             }
-            Err(error) => Err(CoreError::store(object_key, &error)),
-        }
-    })
-    .await?;
-    renewed.ok_or_else(|| CoreError::contention_exhausted(object_key))
+        },
+        |_, renewed_expiry| async move {
+            let Some(current) =
+                load_checkpoint_record(store, source_namespace_id, checkpoint_id).await?
+            else {
+                return Err(fork_checkpoint_unavailable(
+                    source_namespace_id,
+                    checkpoint_id,
+                    expected_target_namespace_id,
+                    "the record is gone".to_owned(),
+                ));
+            };
+            let expires_at_ms = inspect_fork_record(
+                &current.state,
+                source_namespace_id,
+                checkpoint_id,
+                expected_target_namespace_id,
+            )?;
+            if expires_at_ms >= renewed_expiry {
+                Ok(WriteEvidence::Landed(expires_at_ms))
+            } else {
+                Ok(WriteEvidence::Lost(CoreError::contention_exhausted(
+                    object_key,
+                )))
+            }
+        },
+    )
+    .await?
+}
+
+fn inspect_fork_record(
+    state: &CheckpointRecordState,
+    source_namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+    expected_target_namespace_id: &NamespaceId,
+) -> Result<u64> {
+    if state.status != (CheckpointStatus::Active {}) {
+        return Err(fork_checkpoint_unavailable(
+            source_namespace_id,
+            checkpoint_id,
+            expected_target_namespace_id,
+            format!("the record is `{}`", state.status),
+        ));
+    }
+    let CheckpointOwner::Fork {
+        target_namespace_id,
+        expires_at_ms,
+    } = &state.owner
+    else {
+        return Err(fork_checkpoint_unavailable(
+            source_namespace_id,
+            checkpoint_id,
+            expected_target_namespace_id,
+            "the record is not fork-owned".to_owned(),
+        ));
+    };
+    if target_namespace_id != expected_target_namespace_id {
+        return Err(fork_checkpoint_unavailable(
+            source_namespace_id,
+            checkpoint_id,
+            expected_target_namespace_id,
+            format!("the record pins target `{target_namespace_id}`"),
+        ));
+    }
+    Ok(*expires_at_ms)
+}
+
+fn fork_checkpoint_unavailable(
+    source_namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+    expected_target_namespace_id: &NamespaceId,
+    reason: String,
+) -> CoreError {
+    CoreError::CheckpointUnavailable(format!(
+        "fork of `{source_namespace_id}` into `{expected_target_namespace_id}` cannot renew its \
+         source checkpoint `{checkpoint_id}`: {reason}"
+    ))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/loonfs-core/src/checkpoint/release.rs
+++ b/crates/loonfs-core/src/checkpoint/release.rs
@@ -10,37 +10,88 @@ use loonfs_api::wire::control::CheckpointOwner;
 use loonfs_api::{CheckpointId, NamespaceId, ReleaseCheckpointResponse};
 use loonfs_objectstore::ObjectStore;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CheckpointOwnerKind {
+    User,
+    Fork,
+    Snapshot,
+}
+
+impl CheckpointOwnerKind {
+    fn of(owner: &CheckpointOwner) -> Self {
+        match owner {
+            CheckpointOwner::User { .. } => Self::User,
+            CheckpointOwner::Fork { .. } => Self::Fork,
+            CheckpointOwner::Snapshot { .. } => Self::Snapshot,
+        }
+    }
+
+    fn release_guidance(self) -> &'static str {
+        match self {
+            Self::User => "release it through the checkpoint release operation",
+            Self::Fork => "it is released by deleting that namespace",
+            Self::Snapshot => {
+                "it is released through the snapshot release operation or by its expiry"
+            }
+        }
+    }
+}
+
+pub(super) fn ensure_owner_is(
+    checkpoint_id: &CheckpointId,
+    owner: &CheckpointOwner,
+    expected: CheckpointOwnerKind,
+) -> Result<()> {
+    let actual = CheckpointOwnerKind::of(owner);
+    if actual == expected {
+        return Ok(());
+    }
+    Err(CoreError::InvalidCheckpointRequest(format!(
+        "checkpoint `{checkpoint_id}` is {}; {}",
+        owner_description(owner),
+        actual.release_guidance()
+    )))
+}
+
+fn owner_description(owner: &CheckpointOwner) -> String {
+    match owner {
+        CheckpointOwner::User { .. } => "a user checkpoint".to_owned(),
+        CheckpointOwner::Fork {
+            target_namespace_id,
+            ..
+        } => format!("owned by fork target `{target_namespace_id}`"),
+        CheckpointOwner::Snapshot { .. } => "a snapshot".to_owned(),
+    }
+}
+
+pub(super) async fn release_owned_checkpoint<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+    expected: CheckpointOwnerKind,
+    context: &MutationContext,
+) -> Result<()> {
+    let Some(loaded) = load_checkpoint_record(store, namespace_id, checkpoint_id).await? else {
+        return Ok(());
+    };
+    ensure_owner_is(checkpoint_id, &loaded.state.owner, expected)?;
+    release_checkpoint_record(store, namespace_id, checkpoint_id, context.now_ms).await
+}
+
 pub(crate) async fn release_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     checkpoint_id: &CheckpointId,
     context: &MutationContext,
 ) -> Result<ReleaseCheckpointResponse> {
-    let Some(loaded) = load_checkpoint_record(store, namespace_id, checkpoint_id).await? else {
-        // Already reaped (or never created): the end state — no active pin
-        // under this id — already holds, so release is idempotent success.
-        return Ok(ReleaseCheckpointResponse {
-            namespace_id: namespace_id.clone(),
-            checkpoint_id: checkpoint_id.clone(),
-        });
-    };
-    if let CheckpointOwner::Fork {
-        target_namespace_id,
-        ..
-    } = &loaded.state.owner
-    {
-        return Err(CoreError::InvalidCheckpointRequest(format!(
-            "checkpoint `{checkpoint_id}` is owned by fork target `{target_namespace_id}`; \
-             it is released by deleting that namespace, not by this operation"
-        )));
-    }
-    if matches!(loaded.state.owner, CheckpointOwner::Snapshot { .. }) {
-        return Err(CoreError::InvalidCheckpointRequest(format!(
-            "checkpoint `{checkpoint_id}` is owned by a snapshot; it is released through the \
-             snapshot release operation or by its expiry, not by this operation"
-        )));
-    }
-    release_checkpoint_record(store, namespace_id, checkpoint_id, context.now_ms).await?;
+    release_owned_checkpoint(
+        store,
+        namespace_id,
+        checkpoint_id,
+        CheckpointOwnerKind::User,
+        context,
+    )
+    .await?;
     Ok(ReleaseCheckpointResponse {
         namespace_id: namespace_id.clone(),
         checkpoint_id: checkpoint_id.clone(),

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -329,7 +329,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         )),
         ManifestPublicationOutcome::CoveredByCurrent(_)
         | ManifestPublicationOutcome::PredecessorChanged(_)
-        | ManifestPublicationOutcome::RootCasRaceLost => {
+        | ManifestPublicationOutcome::Installable => {
             Ok(report(namespace_id, MetadataReorganizeOutcome::Superseded))
         }
     }

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -5,9 +5,10 @@ use super::load::{ensure_root_matches_manifest, load_verified_manifest_segments}
 use super::runs::MAX_MAINTENANCE_SEGMENT_IO;
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
-use crate::control_update::{retry_while_contended, CasAttempt};
+use crate::control_update::{retry_while_contended, CasAttempt, WriteEvidence};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
+use crate::namespace::basis::namespace_birth_seq;
 use crate::namespace::control::{
     load_head_object, load_metadata_root_object_if_present, load_wal_floor_object,
 };
@@ -111,9 +112,15 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     // Grep tolerates retention gaps by checkpointed rebootstrap, so its
     // independent watermark never holds the core WAL floor back.
     let target_floor = manifest_segments.manifest().payload.head_seq;
-    let current_floor = resolve_retention_floor_seq(store, &head)
-        .await
-        .map_err(CoreError::ControlObjectLoad)?;
+    let initial_floor = match load_wal_floor_object(store, namespace_id).await {
+        Ok(loaded) => Some(loaded),
+        Err(ControlObjectLoadError::MissingObject { .. }) => None,
+        Err(error) => return Err(CoreError::ControlObjectLoad(error)),
+    };
+    let current_floor = initial_floor.as_ref().map_or_else(
+        || namespace_birth_seq(&head),
+        |loaded| loaded.state.floor_seq,
+    );
     if current_floor >= target_floor {
         // Already advanced, so the idempotent re-invocation writes nothing.
         return Ok(AdvanceRetentionResponse {
@@ -128,52 +135,69 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
 
     // Monotonic floor publication: never decrease. The first advance
     // creates the object, because create and fork write no floor.
-    let object_key = &loonfs_objectstore::keys::wal_floor(namespace_id);
-    let advanced = retry_while_contended(|| async move {
-        let loaded = match load_wal_floor_object(store, namespace_id).await {
-            Ok(loaded) => Some(loaded),
-            Err(ControlObjectLoadError::MissingObject { .. }) => None,
-            Err(error) => return Err(CoreError::ControlObjectLoad(error)),
-        };
-        let published_floor = loaded.as_ref().map(|loaded| loaded.state.floor_seq);
-        if let Some(floor_seq) = published_floor.filter(|floor_seq| *floor_seq >= target_floor) {
-            return Ok(CasAttempt::Settled(floor_seq));
-        }
-        let next = WalFloorState {
-            namespace_id: namespace_id.clone(),
-            floor_seq: target_floor,
-            updated_at_ms: context.now_ms,
-        };
-        let encoded =
-            encode_control_state(ControlObjectKind::WalFloor, &next).map_err(|error| {
-                CoreError::Codec {
-                    object_key: object_key.clone(),
-                    message: error.to_string(),
+    let object_key = loonfs_objectstore::keys::wal_floor(namespace_id);
+    let mut first_floor = Some(initial_floor);
+    let advanced =
+        retry_while_contended(
+            || {
+                let first = first_floor.take();
+                async {
+                    let loaded = match first {
+                        Some(loaded) => loaded,
+                        None => match load_wal_floor_object(store, namespace_id).await {
+                            Ok(loaded) => Some(loaded),
+                            Err(ControlObjectLoadError::MissingObject { .. }) => None,
+                            Err(error) => return Err(CoreError::ControlObjectLoad(error)),
+                        },
+                    };
+                    if let Some(floor_seq) = loaded
+                        .as_ref()
+                        .map(|loaded| loaded.state.floor_seq)
+                        .filter(|floor_seq| *floor_seq >= target_floor)
+                    {
+                        return Ok(CasAttempt::Settled(floor_seq));
+                    }
+                    let next = WalFloorState {
+                        namespace_id: namespace_id.clone(),
+                        floor_seq: target_floor,
+                        updated_at_ms: context.now_ms,
+                    };
+                    let encoded = encode_control_state(ControlObjectKind::WalFloor, &next)
+                        .map_err(|error| CoreError::Codec {
+                            object_key: object_key.clone(),
+                            message: error.to_string(),
+                        })?;
+                    let published = match &loaded {
+                        Some(loaded) => {
+                            store
+                                .compare_and_swap(&object_key, &loaded.etag, Bytes::from(encoded))
+                                .await
+                        }
+                        None => store.put_if_absent(&object_key, Bytes::from(encoded)).await,
+                    };
+                    match published {
+                        Ok(_) => Ok(CasAttempt::Settled(target_floor)),
+                        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(
+                            CasAttempt::Contended(CoreError::contention_exhausted(&object_key)),
+                        ),
+                        Err(error @ ObjectStoreError::Transport { .. }) => {
+                            Ok(CasAttempt::Ambiguous(error, ()))
+                        }
+                        Err(error) => Err(CoreError::store(&object_key, &error)),
+                    }
                 }
-            })?;
-        let published = match &loaded {
-            Some(loaded) => {
-                store
-                    .compare_and_swap(object_key, &loaded.etag, Bytes::from(encoded))
-                    .await
-            }
-            // The retention floor is mutable control state, so its first publication is a conditional create.
-            None => store.put_if_absent(object_key, Bytes::from(encoded)).await,
-        };
-        match published {
-            Ok(_) => Ok(CasAttempt::Settled(target_floor)),
-            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            Err(error @ ObjectStoreError::Transport { .. }) => {
+            },
+            |_, ()| async {
                 match load_floor_at_or_above(store, namespace_id, target_floor).await? {
-                    Some(floor_seq) => Ok(CasAttempt::Settled(floor_seq)),
-                    None => Err(CoreError::store(object_key, &error)),
+                    Some(floor_seq) => Ok(WriteEvidence::Landed(floor_seq)),
+                    None => Ok(WriteEvidence::Lost(CoreError::contention_exhausted(
+                        &object_key,
+                    ))),
                 }
-            }
-            Err(error) => Err(CoreError::store(object_key, &error)),
-        }
-    })
-    .await?;
+            },
+        )
+        .await?;
     Ok(AdvanceRetentionResponse {
-        retention_floor_seq: advanced.ok_or_else(|| CoreError::contention_exhausted(object_key))?,
+        retention_floor_seq: advanced?,
     })
 }

--- a/crates/loonfs-core/src/checkpoint/snapshot.rs
+++ b/crates/loonfs-core/src/checkpoint/snapshot.rs
@@ -1,13 +1,11 @@
 //! Snapshot-owned checkpoint reads, expiry, and release transitions.
 
 use super::read_basis::{load_checkpoint_read_basis_from_record, CheckpointReadBasis};
-use super::record::{
-    encode_checkpoint_record, load_checkpoint_record, release_checkpoint_record,
-    LoadedCheckpointRecord,
-};
+use super::record::{encode_checkpoint_record, load_checkpoint_record, LoadedCheckpointRecord};
+use super::release::{ensure_owner_is, release_owned_checkpoint, CheckpointOwnerKind};
 use super::MetadataSegmentCache;
 use crate::context::MutationContext;
-use crate::control_update::{retry_while_contended, CasAttempt};
+use crate::control_update::{retry_while_contended, CasAttempt, WriteEvidence};
 use crate::error::{CoreError, Result};
 use loonfs_api::wire::control::{CheckpointOwner, CheckpointStatus, HeadState};
 use loonfs_api::{Checkpoint, CheckpointId, NamespaceId, ReleaseSnapshotResponse};
@@ -39,57 +37,65 @@ pub(crate) async fn extend_snapshot_expiry<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<Checkpoint> {
     let object_key = checkpoint_record(namespace_id, checkpoint_id);
-    let updated = retry_while_contended(|| async {
-        let loaded = classify_live_snapshot(
-            load_checkpoint_record(store, namespace_id, checkpoint_id).await?,
-            checkpoint_id,
-            context.now_ms,
-        )?;
-        let mut next = loaded.state.clone();
-        let lifetime_ceiling = next.created_at_ms.saturating_add(max_lifetime_ms);
-        let CheckpointOwner::Snapshot { expires_at_ms, .. } = &mut next.owner else {
-            return Err(CoreError::InvalidCheckpointRequest(format!(
-                "checkpoint `{checkpoint_id}` is not a snapshot"
-            )));
-        };
-        let new_expires_at_ms = requested_expires_at_ms
-            .min(lifetime_ceiling)
-            .max(*expires_at_ms);
-        if *expires_at_ms == new_expires_at_ms {
-            return Ok(CasAttempt::Settled(super::checkpoint_summary(next)));
-        }
-        *expires_at_ms = new_expires_at_ms;
-        let encoded = encode_checkpoint_record(&next)?;
-        match store
-            .compare_and_swap(&object_key, &loaded.etag, encoded)
-            .await
-        {
-            Ok(_) => Ok(CasAttempt::Settled(super::checkpoint_summary(next))),
-            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            Err(error @ ObjectStoreError::Transport { .. }) => {
+    retry_while_contended(
+        || async {
+            let loaded = classify_live_snapshot(
+                load_checkpoint_record(store, namespace_id, checkpoint_id).await?,
+                checkpoint_id,
+                context.now_ms,
+            )?;
+            let mut next = loaded.state.clone();
+            let lifetime_ceiling = next.created_at_ms.saturating_add(max_lifetime_ms);
+            let expires_at_ms = snapshot_expiry_mut(&mut next.owner)
+                .expect("a classified snapshot should carry a snapshot owner");
+            let new_expires_at_ms = requested_expires_at_ms
+                .min(lifetime_ceiling)
+                .max(*expires_at_ms);
+            if *expires_at_ms == new_expires_at_ms {
+                return Ok(CasAttempt::Settled(super::checkpoint_summary(next)));
+            }
+            *expires_at_ms = new_expires_at_ms;
+            let encoded = encode_checkpoint_record(&next)?;
+            match store
+                .compare_and_swap(&object_key, &loaded.etag, encoded)
+                .await
+            {
+                Ok(_) => Ok(CasAttempt::Settled(super::checkpoint_summary(next))),
+                Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended(
+                    CoreError::contention_exhausted(&object_key),
+                )),
+                Err(error @ ObjectStoreError::Transport { .. }) => {
+                    Ok(CasAttempt::Ambiguous(error, new_expires_at_ms))
+                }
+                Err(error) => Err(CoreError::store(&object_key, &error)),
+            }
+        },
+        |_, new_expires_at_ms| {
+            let object_key = object_key.clone();
+            async move {
                 let current = classify_live_snapshot(
                     load_checkpoint_record(store, namespace_id, checkpoint_id).await?,
                     checkpoint_id,
                     context.now_ms,
                 )?;
-                let CheckpointOwner::Snapshot { expires_at_ms, .. } = &current.state.owner else {
-                    return Err(CoreError::Internal(
-                        "live snapshot classification returned a non-snapshot owner".to_owned(),
-                    ));
-                };
-                if *expires_at_ms >= new_expires_at_ms {
-                    Ok(CasAttempt::Settled(super::checkpoint_summary(
+                let expires_at_ms = current
+                    .state
+                    .owner
+                    .expires_at_ms()
+                    .expect("a classified snapshot should carry an expiry");
+                if expires_at_ms >= new_expires_at_ms {
+                    Ok(WriteEvidence::Landed(super::checkpoint_summary(
                         current.state,
                     )))
                 } else {
-                    Err(CoreError::store(&object_key, &error))
+                    Ok(WriteEvidence::Lost(CoreError::contention_exhausted(
+                        &object_key,
+                    )))
                 }
             }
-            Err(error) => Err(CoreError::store(&object_key, &error)),
-        }
-    })
-    .await?;
-    updated.ok_or_else(|| CoreError::contention_exhausted(&object_key))
+        },
+    )
+    .await?
 }
 
 pub(crate) async fn release_snapshot<S: ObjectStore + ?Sized>(
@@ -98,31 +104,14 @@ pub(crate) async fn release_snapshot<S: ObjectStore + ?Sized>(
     checkpoint_id: &CheckpointId,
     context: &MutationContext,
 ) -> Result<ReleaseSnapshotResponse> {
-    let Some(loaded) = load_checkpoint_record(store, namespace_id, checkpoint_id).await? else {
-        return Ok(ReleaseSnapshotResponse {
-            namespace_id: namespace_id.clone(),
-            snapshot_id: checkpoint_id.clone(),
-        });
-    };
-    match &loaded.state.owner {
-        CheckpointOwner::Snapshot { .. } => {}
-        CheckpointOwner::User { .. } => {
-            return Err(CoreError::InvalidCheckpointRequest(format!(
-                "checkpoint `{checkpoint_id}` is user-owned; release it through the checkpoint \
-                 release operation, not the snapshot release operation"
-            )))
-        }
-        CheckpointOwner::Fork {
-            target_namespace_id,
-            ..
-        } => {
-            return Err(CoreError::InvalidCheckpointRequest(format!(
-                "checkpoint `{checkpoint_id}` is owned by fork target `{target_namespace_id}`; \
-                 it is released by deleting that namespace, not by the snapshot release operation"
-            )))
-        }
-    }
-    release_checkpoint_record(store, namespace_id, checkpoint_id, context.now_ms).await?;
+    release_owned_checkpoint(
+        store,
+        namespace_id,
+        checkpoint_id,
+        CheckpointOwnerKind::Snapshot,
+        context,
+    )
+    .await?;
     Ok(ReleaseSnapshotResponse {
         namespace_id: namespace_id.clone(),
         snapshot_id: checkpoint_id.clone(),
@@ -139,31 +128,30 @@ fn classify_live_snapshot(
             snapshot_id: checkpoint_id.clone(),
         });
     };
-    match &loaded.state.owner {
-        CheckpointOwner::Snapshot { expires_at_ms, .. } => {
-            if loaded.state.status != (CheckpointStatus::Active {}) {
-                return Err(snapshot_gone(checkpoint_id, "released"));
-            }
-            if *expires_at_ms <= now_ms {
-                return Err(snapshot_gone(checkpoint_id, "expired"));
-            }
-        }
-        CheckpointOwner::User { .. } => {
-            return Err(CoreError::InvalidCheckpointRequest(format!(
-                "`{checkpoint_id}` names a user-owned checkpoint, not a snapshot"
-            )))
-        }
-        CheckpointOwner::Fork {
-            target_namespace_id,
-            ..
-        } => {
-            return Err(CoreError::InvalidCheckpointRequest(format!(
-                "`{checkpoint_id}` names a checkpoint owned by fork target \
-                 `{target_namespace_id}`, not a snapshot"
-            )))
-        }
+    ensure_owner_is(
+        checkpoint_id,
+        &loaded.state.owner,
+        CheckpointOwnerKind::Snapshot,
+    )?;
+    let expires_at_ms = loaded
+        .state
+        .owner
+        .expires_at_ms()
+        .expect("a snapshot owner should carry an expiry");
+    if loaded.state.status != (CheckpointStatus::Active {}) {
+        return Err(snapshot_gone(checkpoint_id, "released"));
+    }
+    if expires_at_ms <= now_ms {
+        return Err(snapshot_gone(checkpoint_id, "expired"));
     }
     Ok(loaded)
+}
+
+fn snapshot_expiry_mut(owner: &mut CheckpointOwner) -> Option<&mut u64> {
+    match owner {
+        CheckpointOwner::Snapshot { expires_at_ms, .. } => Some(expires_at_ms),
+        CheckpointOwner::User { .. } | CheckpointOwner::Fork { .. } => None,
+    }
 }
 
 fn snapshot_gone(checkpoint_id: &CheckpointId, reason: &str) -> CoreError {

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -675,7 +675,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
             }
             ManifestPublicationOutcome::CoveredByCurrent(_) => "covered_by_current",
             ManifestPublicationOutcome::PredecessorChanged(_) => "predecessor_changed",
-            ManifestPublicationOutcome::RootCasRaceLost => "root_cas_race",
+            ManifestPublicationOutcome::Installable => "root_cas_race",
         };
         tracing::debug!(
             namespace_id = namespace_id.as_str(),

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -869,7 +869,7 @@ async fn root_cas_conflict_reports_a_race() {
     .await
     .expect("root publication should report CAS contention");
 
-    assert_eq!(outcome, ManifestPublicationOutcome::RootCasRaceLost);
+    assert_eq!(outcome, ManifestPublicationOutcome::Installable);
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -7,12 +7,13 @@ use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct LoadedControl<T> {
-    pub(crate) object_key: String,
-    pub(crate) etag: String,
-    pub(crate) state: T,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoadedControl<T> {
+    pub object_key: String,
+    pub etag: String,
+    pub state: T,
 }
 
 pub(crate) enum EmbeddedIdentityMismatch {

--- a/crates/loonfs-core/src/control_object/mod.rs
+++ b/crates/loonfs-core/src/control_object/mod.rs
@@ -4,7 +4,8 @@ mod error;
 mod load;
 
 pub use error::ControlObjectLoadError;
+pub use load::LoadedControl;
 pub(crate) use load::{
     expect_foreign_fork_basis, expect_identity_field, expect_namespace, expect_own_manifest,
-    load_control_object, LoadedControl,
+    load_control_object,
 };

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -13,41 +13,69 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::{NamespaceId, UploadId};
 use loonfs_objectstore::keys::{upload_session, wal_head};
-use loonfs_objectstore::{ImmutableWriteError, ObjectMetadata, ObjectStore, ObjectStoreError};
+use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::future::Future;
 use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CasAttempt<T> {
+#[derive(Debug)]
+pub(crate) enum CasAttempt<T, R = (), C = ()> {
     Settled(T),
-    Contended,
+    Contended(R),
+    Ambiguous(ObjectStoreError, C),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WriteEvidence<T, R = ()> {
+    Landed(T),
+    Lost(R),
+    Unknown,
+}
+
+pub(crate) async fn settle_control_write<T, R, C, E, F, Fut>(
+    attempt: CasAttempt<T, R, C>,
+    mut confirm: F,
+) -> std::result::Result<std::result::Result<T, R>, E>
+where
+    E: From<ControlUpdateError>,
+    F: FnMut(&ObjectStoreError, C) -> Fut,
+    Fut: Future<Output = std::result::Result<WriteEvidence<T, R>, E>>,
+{
+    match attempt {
+        CasAttempt::Settled(outcome) => Ok(Ok(outcome)),
+        CasAttempt::Contended(reason) => Ok(Err(reason)),
+        CasAttempt::Ambiguous(error, context) => match confirm(&error, context).await? {
+            WriteEvidence::Landed(outcome) => Ok(Ok(outcome)),
+            WriteEvidence::Lost(reason) => Ok(Err(reason)),
+            WriteEvidence::Unknown => Err(E::from(ControlUpdateError::store(&error))),
+        },
+    }
 }
 
 /// Runs up to [`CONTENTION_RETRY_LIMIT`] attempts.
-///
-/// Returns `None` if every attempt encounters contention.
-pub(crate) async fn retry_while_contended<T, E, F, Fut>(
+pub(crate) async fn retry_while_contended<T, R, C, E, F, Fut, Confirm, ConfirmFut>(
     mut attempt: F,
-) -> std::result::Result<Option<T>, E>
+    mut confirm: Confirm,
+) -> std::result::Result<std::result::Result<T, R>, E>
 where
+    E: From<ControlUpdateError>,
     F: FnMut() -> Fut,
-    Fut: Future<Output = std::result::Result<CasAttempt<T>, E>>,
+    Fut: Future<Output = std::result::Result<CasAttempt<T, R, C>, E>>,
+    Confirm: FnMut(&ObjectStoreError, C) -> ConfirmFut,
+    ConfirmFut: Future<Output = std::result::Result<WriteEvidence<T, R>, E>>,
 {
+    let mut last_reason = None;
     for _attempt in 0..CONTENTION_RETRY_LIMIT {
-        if let CasAttempt::Settled(outcome) = attempt().await? {
-            return Ok(Some(outcome));
+        match settle_control_write(attempt().await?, &mut confirm).await? {
+            Ok(outcome) => return Ok(Ok(outcome)),
+            Err(reason) => last_reason = Some(reason),
         }
     }
-    Ok(None)
+    Ok(Err(last_reason.expect(
+        "the positive contention retry limit should produce a contention reason",
+    )))
 }
 
 /// Creates a control object and reports a generated-ID collision as an internal error.
-///
-/// A transport failure from the first conditional write has an unknown
-/// outcome. Retry it through the immutable-write path, which accepts success
-/// only when the generated key contains the exact intended bytes. An immediate
-/// precondition failure remains a collision rather than adopting a record from
-/// another generated-ID owner.
 pub(crate) async fn create_control_object_under_generated_id<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
@@ -58,23 +86,33 @@ pub(crate) async fn create_control_object_under_generated_id<S: ObjectStore + ?S
             "a generated id collided with the existing control object `{object_key}`"
         ))
     };
-    match store.put_if_absent(object_key, encoded.clone()).await {
-        Ok(metadata) => Ok(metadata),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => Err(collision()),
-        Err(ObjectStoreError::Transport { .. }) => {
-            match store.put_immutable_verified(object_key, encoded).await {
-                Ok(metadata) => Ok(metadata),
-                Err(ImmutableWriteError::DifferentObject { .. }) => Err(collision()),
-                Err(ImmutableWriteError::Transport { source, .. }) => {
-                    Err(CoreError::store(object_key, &source))
+    retry_while_contended(
+        || async {
+            match store.put_if_absent(object_key, encoded.clone()).await {
+                Ok(metadata) => Ok(CasAttempt::Settled(metadata)),
+                Err(ObjectStoreError::PreconditionFailed { .. }) => Err(collision()),
+                Err(error @ ObjectStoreError::Transport { .. }) => {
+                    Ok(CasAttempt::Ambiguous(error, ()))
                 }
-                Err(error) => Err(CoreError::Internal(format!(
-                    "generated-id write reconciliation failed for `{object_key}`: {error}"
-                ))),
+                Err(error) => Err(CoreError::store(object_key, &error)),
             }
-        }
-        Err(error) => Err(CoreError::store(object_key, &error)),
-    }
+        },
+        |error, ()| {
+            let failed = CoreError::store(object_key, error);
+            let encoded = &encoded;
+            async move {
+                match store.get_with_metadata(object_key).await {
+                    Ok(Some(stored)) if stored.bytes == *encoded => {
+                        Ok(WriteEvidence::Landed(stored.metadata))
+                    }
+                    Ok(Some(_)) => Err(collision()),
+                    Ok(None) => Ok(WriteEvidence::Lost(failed)),
+                    Err(error) => Err(CoreError::store(object_key, &error)),
+                }
+            }
+        },
+    )
+    .await?
 }
 
 /// Replacement head state and the value returned after its CAS succeeds.
@@ -110,6 +148,19 @@ pub(crate) enum ControlUpdateError {
     RetryExhausted { object_key: String },
 }
 
+impl ControlUpdateError {
+    fn store(error: &ObjectStoreError) -> Self {
+        Self::Store {
+            object_key: error
+                .object_key()
+                .expect("an ambiguous control write should name its object")
+                .to_owned(),
+            message: error.public_message().into_owned(),
+            class: StoreFailureClass::of(error),
+        }
+    }
+}
+
 /// Reads the head, asks `update` to build a replacement, and applies it with
 /// a CAS against the loaded ETag. CAS conflicts retry the complete
 /// read-update-CAS cycle. Errors returned by `update` are returned immediately,
@@ -125,32 +176,39 @@ where
     F: Fn(&LoadedHeadObject) -> Result<HeadReplacement<T>, E>,
 {
     let update = &update;
-    let updated = retry_while_contended(|| async move {
-        let loaded = load_head_object(store, namespace_id)
-            .await
-            .map_err(|error| E::from(ControlUpdateError::LoadHead(error)))?;
-        let HeadReplacement { next, outcome } = update(&loaded)?;
-        let encoded = encode_head(*next, &loaded.object_key).map_err(E::from)?;
-        match store
-            .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
-            .await
-        {
-            Ok(_) => Ok(CasAttempt::Settled(outcome)),
-            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            // Do not retry an unknown outcome because each attempt allocates a new epoch.
-            Err(error) => Err(E::from(ControlUpdateError::Store {
-                object_key: loaded.object_key,
-                message: error.public_message().into_owned(),
-                class: StoreFailureClass::of(&error),
-            })),
-        }
-    })
-    .await?;
-    updated.ok_or_else(|| {
-        E::from(ControlUpdateError::RetryExhausted {
-            object_key: wal_head(namespace_id),
-        })
-    })
+    retry_while_contended(
+        || async move {
+            let loaded = load_head_object(store, namespace_id)
+                .await
+                .map_err(|error| E::from(ControlUpdateError::LoadHead(error)))?;
+            let HeadReplacement { next, outcome } = update(&loaded)?;
+            let encoded = encode_head(*next, &loaded.object_key).map_err(E::from)?;
+            match store
+                .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
+                .await
+            {
+                Ok(_) => Ok(CasAttempt::Settled(outcome)),
+                Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended(
+                    E::from(ControlUpdateError::RetryExhausted {
+                        object_key: wal_head(namespace_id),
+                    }),
+                )),
+                Err(error @ ObjectStoreError::Transport { .. }) => {
+                    Ok(CasAttempt::Ambiguous(error, ()))
+                }
+                Err(error) => Err(E::from(ControlUpdateError::Store {
+                    object_key: loaded.object_key,
+                    message: error.public_message().into_owned(),
+                    class: StoreFailureClass::of(&error),
+                })),
+            }
+        },
+        |_, ()| async {
+            // Each attempt allocates a new epoch, so a later head cannot prove which write landed.
+            Ok(WriteEvidence::Unknown)
+        },
+    )
+    .await?
 }
 
 pub(crate) async fn update_upload_session<S, T, F, Fut>(
@@ -165,11 +223,11 @@ where
     Fut: Future<Output = crate::error::Result<UploadSessionUpdate<T>>>,
 {
     let update = &update;
-    let updated = retry_while_contended(|| async move {
-        try_update_upload_session(store, namespace_id, upload_id, update).await
-    })
-    .await?;
-    updated.ok_or_else(|| CoreError::contention_exhausted(&upload_session(namespace_id, upload_id)))
+    retry_while_contended(
+        || async move { try_update_upload_session(store, namespace_id, upload_id, update).await },
+        |_, ()| async { Ok::<_, CoreError>(WriteEvidence::Unknown) },
+    )
+    .await?
 }
 
 /// Tries one upload-session update against the state and ETag loaded together.
@@ -178,7 +236,7 @@ pub(crate) async fn try_update_upload_session<S, T, F, Fut>(
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
     update: F,
-) -> crate::error::Result<CasAttempt<T>>
+) -> crate::error::Result<CasAttempt<T, CoreError>>
 where
     S: ObjectStore + ?Sized,
     F: FnOnce(UploadSessionState) -> Fut,
@@ -198,7 +256,11 @@ where
                 .await
             {
                 Ok(_) => Ok(CasAttempt::Settled(outcome)),
-                Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
+                Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended(
+                    CoreError::contention_exhausted(&loaded.object_key),
+                )),
+                // A generic upload update has no state predicate that proves an
+                // ambiguous write landed, so a transport failure is final.
                 Err(error) => Err(CoreError::store(&loaded.object_key, &error)),
             }
         }
@@ -303,7 +365,7 @@ mod tests {
                 .await
                 .expect("exact read-back reconciles the landed write");
 
-        assert_eq!(store.attempts(), 2);
+        assert_eq!(store.attempts(), 1);
         assert!(metadata.etag.is_some());
         assert_eq!(
             store.get(object_key, None).await.expect("read record"),
@@ -330,6 +392,27 @@ mod tests {
             error,
             CoreError::Internal(message) if message.contains("generated id collided")
         ));
+    }
+
+    #[tokio::test]
+    async fn retry_exhaustion_returns_the_last_contention_reason() {
+        let attempt = std::cell::Cell::new(0);
+        let exhausted = retry_while_contended(
+            || {
+                let reason = attempt.get();
+                attempt.set(reason + 1);
+                async move {
+                    Ok::<CasAttempt<(), usize, ()>, ControlUpdateError>(CasAttempt::Contended(
+                        reason,
+                    ))
+                }
+            },
+            |_, ()| async { Ok(WriteEvidence::Unknown) },
+        )
+        .await
+        .expect("contention attempts should not fail");
+
+        assert_eq!(exhausted, Err(CONTENTION_RETRY_LIMIT - 1));
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -24,6 +24,11 @@ pub(super) enum ForkCheckpointSweep {
     NotAnActiveFork,
 }
 
+pub(super) enum MissingBasisCheckpointSweep {
+    Released,
+    Retained,
+}
+
 /// Releases an active, non-fork checkpoint whose basis manifest is still
 /// missing after the grace period.
 pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
@@ -32,23 +37,25 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
     key: &str,
     grace_window_ms: u64,
     context: &MutationContext,
-) -> Result<bool> {
+) -> Result<MissingBasisCheckpointSweep> {
     let loaded = load_checkpoint_record_at_key(store, key).await;
     let loaded = match loaded {
         Ok(loaded) => loaded,
-        Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(false),
+        Err(ControlObjectLoadError::MissingObject { .. }) => {
+            return Ok(MissingBasisCheckpointSweep::Retained)
+        }
         Err(error) => return Err(CoreError::ControlObjectLoad(error)),
     };
     let record = loaded.state;
     if record.status != (CheckpointStatus::Active {}) {
-        return Ok(false);
+        return Ok(MissingBasisCheckpointSweep::Retained);
     }
     // Fork checkpoints remain until their target namespace is deleted.
     if matches!(record.owner, CheckpointOwner::Fork { .. }) {
-        return Ok(false);
+        return Ok(MissingBasisCheckpointSweep::Retained);
     }
     if context.now_ms.saturating_sub(record.created_at_ms) < grace_window_ms {
-        return Ok(false);
+        return Ok(MissingBasisCheckpointSweep::Retained);
     }
     let manifest_key = metadata_manifest_object(namespace_id, &record.manifest.manifest_object_id);
     if store
@@ -57,10 +64,10 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
         .map_err(|error| CoreError::store(&manifest_key, &error))?
         .is_some()
     {
-        return Ok(false);
+        return Ok(MissingBasisCheckpointSweep::Retained);
     }
     release_checkpoint_record(store, namespace_id, &record.checkpoint_id, context.now_ms).await?;
-    Ok(true)
+    Ok(MissingBasisCheckpointSweep::Released)
 }
 
 /// Rechecks a fork checkpoint and releases it if its target no longer uses it.

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -7,6 +7,7 @@ use super::config::{GcConfig, GcPolicy};
 use super::cursor::{CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
     maybe_release_fork_checkpoint, release_missing_basis_checkpoint, ForkCheckpointSweep,
+    MissingBasisCheckpointSweep,
 };
 use super::live_set::{collect_live_set, LiveSet, LiveSetCollection, SweepStep, SweepVerifier};
 use super::reap::{
@@ -348,7 +349,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
     }
 
     async fn process_missing_basis_checkpoint(&mut self, key: &str) -> Result<()> {
-        if release_missing_basis_checkpoint(
+        match release_missing_basis_checkpoint(
             self.store,
             self.namespace_id,
             key,
@@ -357,9 +358,12 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
         )
         .await?
         {
-            self.report.released_checkpoints.missing_basis += 1;
-        } else {
-            self.report.retain(RetainedReason::CheckpointNotReleasable);
+            MissingBasisCheckpointSweep::Released => {
+                self.report.released_checkpoints.missing_basis += 1;
+            }
+            MissingBasisCheckpointSweep::Retained => {
+                self.report.retain(RetainedReason::CheckpointNotReleasable);
+            }
         }
         Ok(())
     }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -3780,7 +3780,7 @@ async fn snapshot_owned_checkpoints_reject_user_release() {
         matches!(
             &error,
             CoreError::InvalidCheckpointRequest(message)
-                if message.contains("owned by a snapshot")
+                if message.contains("is a snapshot")
         ),
         "expected invalid checkpoint request, got {error:?}"
     );

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -229,7 +229,7 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
             ))
         }
         Ok(CasAttempt::Settled(None)) => Ok(retain_undated()),
-        Ok(CasAttempt::Contended) => {
+        Ok(CasAttempt::Contended(_)) => {
             tracing::debug!(
                 namespace_id = %sweep.namespace_id,
                 upload_id = %upload_id,
@@ -237,6 +237,10 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
             );
             Ok(retain_undated())
         }
+        Ok(CasAttempt::Ambiguous(error, ())) => Err(CoreError::store(
+            loonfs_objectstore::keys::upload_session(sweep.namespace_id, upload_id),
+            &error,
+        )),
         Err(CoreError::UploadNotFound { .. }) => Ok(retain_undated()),
         Err(error) => Err(error),
     }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -122,14 +122,13 @@ pub mod control {
     pub use crate::checkpoint::{
         load_checkpoint_read_basis, load_snapshot_read_basis, CheckpointReadBasis,
     };
-    pub use crate::control_object::ControlObjectLoadError;
+    pub use crate::control_object::{ControlObjectLoadError, LoadedControl};
     pub use crate::namespace::catalog::{
         load_namespace_catalog_entry, NamespaceCatalogLoadError, VerifiedNamespaceCatalogEntry,
     };
     pub use crate::namespace::control::{
         load_namespace_checkpoint_record_control, load_namespace_head_control,
-        load_namespace_metadata_root_control, load_namespace_read_anchor, ControlObjectIdentity,
-        LoadedHeadControl, LoadedMetadataRootControl,
+        load_namespace_metadata_root_control, load_namespace_read_anchor,
     };
     pub use crate::namespace::MetadataBasis;
 }

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -35,6 +35,9 @@ pub const MAX_COMMIT_MESSAGE_BYTES: usize = 4096;
 /// Maximum attempts for a bounded compare-and-swap or allocation contention loop.
 pub const CONTENTION_RETRY_LIMIT: usize = 8;
 
+/// Maximum targeted rereads while reconciling one namespace control snapshot.
+pub const CONTROL_SNAPSHOT_REREAD_LIMIT: usize = 3;
+
 /// Longest visible WAL tail, in segments, a namespace may carry unflushed.
 /// Every publish surface rejects at this length with `maintenance_required`,
 /// so a landed publication never leaves more than this behind.

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -7,6 +7,7 @@
 
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
+use crate::control_update::{retry_while_contended, CasAttempt, WriteEvidence};
 use crate::error::{CoreError, StoreFailureClass};
 use crate::metadata::{InodeRecord, MetadataState};
 use crate::namespace::control::load_head_object;
@@ -168,39 +169,48 @@ pub(super) async fn install_namespace_head<S: ObjectStore + ?Sized>(
             message: error.to_string(),
         }
     })?;
-    // The namespace head is mutable control state, so installation must be a conditional create.
-    match store.put_if_absent(&object_key, Bytes::from(bytes)).await {
-        Ok(_) => Ok(NamespaceHeadInstall::Landed),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => {
-            let existing = match load_head_object(store, namespace_id).await {
-                Ok(loaded) => loaded.state,
-                // An unreadable head still occupies the id: report the
-                // corruption rather than a lifecycle answer this attempt
-                // cannot support.
-                Err(error) => return Err(CoreError::ControlObjectLoad(error)),
-            };
-            if existing.status == (NamespaceStatus::Deleted {}) {
-                return Ok(NamespaceHeadInstall::Deleted);
-            }
-            Ok(NamespaceHeadInstall::Exists)
-        }
-        // The create may have reached the provider before its acknowledgment
-        // was lost. The immutable identity fields distinguish this attempt's
-        // installed head from a concurrent winner even after later head
-        // updates. An immediate precondition failure above remains a plain
-        // conflict because it carries no evidence that this attempt wrote.
-        Err(error @ ObjectStoreError::Transport { .. }) => {
-            let existing = match load_head_object(store, namespace_id).await {
-                Ok(loaded) => loaded.state,
-                Err(ControlObjectLoadError::MissingObject { .. }) => {
-                    return Err(CoreError::store(&object_key, &error))
+    retry_while_contended(
+        || async {
+            match store
+                .put_if_absent(&object_key, Bytes::copy_from_slice(&bytes))
+                .await
+            {
+                Ok(_) => Ok(CasAttempt::Settled(NamespaceHeadInstall::Landed)),
+                Err(ObjectStoreError::PreconditionFailed { .. }) => {
+                    let existing = load_head_object(store, namespace_id)
+                        .await
+                        .map_err(CoreError::ControlObjectLoad)?
+                        .state;
+                    let outcome = if existing.status == (NamespaceStatus::Deleted {}) {
+                        NamespaceHeadInstall::Deleted
+                    } else {
+                        NamespaceHeadInstall::Exists
+                    };
+                    Ok(CasAttempt::Settled(outcome))
                 }
-                Err(load_error) => return Err(CoreError::ControlObjectLoad(load_error)),
-            };
-            Ok(classify_ambiguous_namespace_install(head, &existing))
-        }
-        Err(error) => Err(CoreError::store(&object_key, &error)),
-    }
+                Err(error @ ObjectStoreError::Transport { .. }) => {
+                    Ok(CasAttempt::Ambiguous(error, ()))
+                }
+                Err(error) => Err(CoreError::store(&object_key, &error)),
+            }
+        },
+        |error, ()| {
+            let failed = CoreError::store(&object_key, error);
+            async move {
+                match load_head_object(store, namespace_id).await {
+                    Ok(loaded) => Ok(WriteEvidence::Landed(classify_ambiguous_namespace_install(
+                        head,
+                        &loaded.state,
+                    ))),
+                    Err(ControlObjectLoadError::MissingObject { .. }) => {
+                        Ok(WriteEvidence::Lost(failed))
+                    }
+                    Err(error) => Err(CoreError::ControlObjectLoad(error)),
+                }
+            }
+        },
+    )
+    .await?
 }
 
 /// Classifies the authoritative head after an ambiguous conditional create.

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -11,30 +11,10 @@ use loonfs_api::wire::control::{ControlObjectKind, HeadState, MetadataRootState,
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::keys::{metadata_root, wal_floor, wal_head};
 use loonfs_objectstore::ObjectStore;
-use serde::{Deserialize, Serialize};
 
 pub(crate) type LoadedHeadObject = LoadedControl<HeadState>;
 pub(crate) type LoadedMetadataRootObject = LoadedControl<MetadataRootState>;
 pub(crate) type LoadedWalFloorObject = LoadedControl<WalFloorState>;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ControlObjectIdentity {
-    pub etag: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadedMetadataRootControl {
-    pub object_key: String,
-    pub identity: ControlObjectIdentity,
-    pub state: MetadataRootState,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadedHeadControl {
-    pub object_key: String,
-    pub identity: ControlObjectIdentity,
-    pub state: HeadState,
-}
 
 pub(crate) async fn load_wal_floor_object<S: ObjectStore + ?Sized>(
     store: &S,
@@ -113,43 +93,24 @@ pub async fn load_namespace_checkpoint_record_control<S: ObjectStore + ?Sized>(
 pub async fn load_namespace_metadata_root_control<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<LoadedMetadataRootControl, ControlObjectLoadError> {
-    let loaded = load_metadata_root_object(store, expected_namespace_id).await?;
-    Ok(LoadedMetadataRootControl {
-        object_key: loaded.object_key,
-        identity: ControlObjectIdentity { etag: loaded.etag },
-        state: loaded.state,
-    })
+) -> Result<LoadedControl<MetadataRootState>, ControlObjectLoadError> {
+    load_metadata_root_object(store, expected_namespace_id).await
 }
 
 /// Loads the head and authorized metadata basis as one consistent read anchor.
 pub async fn load_namespace_read_anchor<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<(LoadedHeadControl, MetadataBasis), ControlObjectLoadError> {
+) -> Result<(LoadedControl<HeadState>, MetadataBasis), ControlObjectLoadError> {
     let loaded = load_head_and_metadata_basis(store, expected_namespace_id).await?;
-    Ok((
-        LoadedHeadControl {
-            object_key: loaded.head.object_key,
-            identity: ControlObjectIdentity {
-                etag: loaded.head.etag,
-            },
-            state: loaded.head.state,
-        },
-        loaded.basis,
-    ))
+    Ok((loaded.head, loaded.basis))
 }
 
 pub async fn load_namespace_head_control<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<LoadedHeadControl, ControlObjectLoadError> {
-    let loaded = load_head_object(store, expected_namespace_id).await?;
-    Ok(LoadedHeadControl {
-        object_key: loaded.object_key,
-        identity: ControlObjectIdentity { etag: loaded.etag },
-        state: loaded.state,
-    })
+) -> Result<LoadedControl<HeadState>, ControlObjectLoadError> {
+    load_head_object(store, expected_namespace_id).await
 }
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/namespace/control_snapshot.rs
+++ b/crates/loonfs-core/src/namespace/control_snapshot.rs
@@ -2,6 +2,7 @@
 //! retention floor.
 
 use crate::control_object::ControlObjectLoadError;
+use crate::limits::CONTROL_SNAPSHOT_REREAD_LIMIT;
 use crate::namespace::basis::{metadata_basis_without_root, namespace_birth_seq, MetadataBasis};
 use crate::namespace::control::{
     load_head_object, load_metadata_root_object_if_present, load_wal_floor_object,
@@ -10,9 +11,6 @@ use crate::namespace::control::{
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_objectstore::ObjectStore;
-
-/// Maximum targeted rereads before returning the remaining inconsistency.
-const RECONCILE_ROUNDS: usize = 3;
 
 /// The namespace's control objects, read as one reconciled observation.
 pub(crate) struct NamespaceControlSnapshot {
@@ -197,7 +195,7 @@ async fn reconcile_reads<S: ObjectStore + ?Sized>(
             Ok(()) => return Ok(reads),
             Err(inconsistency) => inconsistency,
         };
-        if rounds == RECONCILE_ROUNDS {
+        if rounds == CONTROL_SNAPSHOT_REREAD_LIMIT {
             return Err(inconsistency.error);
         }
         rounds += 1;

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -1,6 +1,7 @@
 //! Namespace deletion: a fenced, terminal head-state transition.
 
-use crate::control_update::{retry_while_contended, CasAttempt};
+use crate::commit::CommitHeadPublishError;
+use crate::control_update::{retry_while_contended, CasAttempt, WriteEvidence};
 use crate::error::CoreError;
 use crate::namespace::control::load_head_object;
 use crate::namespace::writer_epoch::ensure_writer_not_fenced;
@@ -10,96 +11,83 @@ use loonfs_api::wire::control::{
     encode_control_state, AcquiredWriter, ControlObjectKind, HeadState, NamespaceStatus,
 };
 use loonfs_api::{DeleteNamespaceResponse, NamespaceId};
-use loonfs_objectstore::{ObjectStore, ObjectStoreError, PutMode};
-use std::sync::atomic::{AtomicBool, Ordering};
+use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 
 /// Marks a namespace as deleted with a compare-and-swap on its head.
 ///
-/// Each retry verifies the writer epoch before attempting the swap. A deleted
-/// head is checked first because no further write is required: it indicates
-/// success after an ambiguous swap, or `namespace_deleted` if this call never
-/// attempted one.
+/// Each retry verifies the writer epoch before attempting the swap.
 pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     options: DeleteNamespaceOptions,
     acquired_writer: AcquiredWriter,
 ) -> Result<DeleteNamespaceResponse, CoreError> {
-    let attempted_swap = &AtomicBool::new(false);
     let acquired_writer = &acquired_writer;
-    let deleted = retry_while_contended(|| async move {
-        let loaded = load_head_object(store, namespace_id)
-            .await
-            .map_err(CoreError::ControlObjectLoad)?;
-        let head = loaded.state.clone();
-
-        // Check the terminal state before the writer fence because a deleted
-        // namespace requires no further write.
-        if head.status == (NamespaceStatus::Deleted {}) {
-            // A deleted head resolves an earlier ambiguous swap as success.
-            if attempted_swap.load(Ordering::Relaxed) {
-                return Ok(CasAttempt::Settled(DeleteNamespaceResponse {
+    retry_while_contended(
+        || async move {
+            let loaded = load_head_object(store, namespace_id)
+                .await
+                .map_err(CoreError::ControlObjectLoad)?;
+            let head = loaded.state.clone();
+            if head.status == (NamespaceStatus::Deleted {}) {
+                return Err(CoreError::NamespaceDeleted {
                     namespace_id: namespace_id.clone(),
-                    head_seq: head.seq,
-                }));
-            }
-            return Err(CoreError::NamespaceDeleted {
-                namespace_id: namespace_id.clone(),
-            });
-        }
-
-        ensure_writer_not_fenced(&head, acquired_writer)?;
-
-        if let Some(expected) = options.expected_head_seq {
-            if head.seq != expected {
-                return Err(CoreError::StaleHeadPrecondition {
-                    expected,
-                    actual: head.seq,
                 });
             }
-        }
 
-        let head_etag = loaded.etag;
-        let deleted_head = HeadState {
-            status: NamespaceStatus::Deleted {},
-            ..head.clone()
-        };
-        let encoded =
-            encode_control_state(ControlObjectKind::WalHead, &deleted_head).map_err(|error| {
-                CoreError::Codec {
+            ensure_writer_not_fenced(&head, acquired_writer)?;
+
+            if let Some(expected) = options.expected_head_seq {
+                if head.seq != expected {
+                    return Err(CoreError::StaleHeadPrecondition {
+                        expected,
+                        actual: head.seq,
+                    });
+                }
+            }
+
+            let deleted_head = HeadState {
+                status: NamespaceStatus::Deleted {},
+                ..head.clone()
+            };
+            let encoded = encode_control_state(ControlObjectKind::WalHead, &deleted_head).map_err(
+                |error| CoreError::Codec {
                     object_key: loaded.object_key.clone(),
                     message: error.to_string(),
-                }
-            })?;
-
-        let swap = store
-            .put(
-                &loaded.object_key,
-                Bytes::from(encoded),
-                PutMode::CompareAndSwap {
-                    expected_etag: head_etag,
                 },
-            )
-            .await;
-        match swap {
-            Ok(_) => Ok(CasAttempt::Settled(DeleteNamespaceResponse {
-                namespace_id: namespace_id.clone(),
-                head_seq: head.seq,
-            })),
-            // The head moved (a commit, fence takeover, or another deleter
-            // landed first). Reload and re-evaluate.
-            Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended),
-            // Reload to determine whether an unconfirmed delete succeeded.
-            Err(ObjectStoreError::Transport { .. }) => {
-                attempted_swap.store(true, Ordering::Relaxed);
-                Ok(CasAttempt::Contended)
+            )?;
+            match store
+                .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
+                .await
+            {
+                Ok(_) => Ok(CasAttempt::Settled(DeleteNamespaceResponse {
+                    namespace_id: namespace_id.clone(),
+                    head_seq: head.seq,
+                })),
+                Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CasAttempt::Contended(
+                    CoreError::HeadPublish(CommitHeadPublishError::StaleHead),
+                )),
+                Err(error @ ObjectStoreError::Transport { .. }) => {
+                    Ok(CasAttempt::Ambiguous(error, ()))
+                }
+                Err(error) => Err(CoreError::store(&loaded.object_key, &error)),
             }
-            Err(other) => Err(CoreError::store(&loaded.object_key, &other)),
-        }
-    })
-    .await?;
-
-    deleted.ok_or(CoreError::HeadPublish(
-        crate::commit::CommitHeadPublishError::StaleHead,
-    ))
+        },
+        |_, ()| async {
+            let loaded = load_head_object(store, namespace_id)
+                .await
+                .map_err(CoreError::ControlObjectLoad)?;
+            if loaded.state.status == (NamespaceStatus::Deleted {}) {
+                Ok(WriteEvidence::Landed(DeleteNamespaceResponse {
+                    namespace_id: namespace_id.clone(),
+                    head_seq: loaded.state.seq,
+                }))
+            } else {
+                Ok(WriteEvidence::Lost(CoreError::HeadPublish(
+                    CommitHeadPublishError::StaleHead,
+                )))
+            }
+        },
+    )
+    .await?
 }

--- a/crates/loonfs-core/tests/it/common/mod.rs
+++ b/crates/loonfs-core/tests/it/common/mod.rs
@@ -38,7 +38,7 @@ pub(crate) async fn read_context<S: ObjectStore + ?Sized>(
         .expect("load read anchor");
     RuntimeReadContext {
         head: head.state,
-        head_etag: head.identity.etag,
+        head_etag: head.etag,
         basis,
         segment_cache: Arc::new(MetadataSegmentCache::new(
             MetadataSegmentCacheConfig::default(),

--- a/crates/loonfs-server/tests/it/http_snapshot_reads.rs
+++ b/crates/loonfs-server/tests/it/http_snapshot_reads.rs
@@ -485,7 +485,7 @@ async fn snapshot_reads_enforce_lease_identity_and_revision_rules() {
     .expect_err("user checkpoint is not a snapshot");
     assert_eq!(status, 400);
     assert_eq!(error.code, "invalid_request");
-    assert!(error.message.contains("checkpoint, not a snapshot"));
+    assert!(error.message.contains("is a user checkpoint"));
 
     let unknown = "chk_ffffffffffffffffffffffffffffffff";
     let (status, error) = get_json::<PathEntry>(&stat_url(

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -13,8 +13,8 @@ use loonfs_api::wire::control::HeadState;
 use loonfs_core::cache::{MetadataSegmentCacheStats, WalTailProjectionCacheStats};
 use loonfs_core::control::{
     load_checkpoint_read_basis, load_namespace_read_anchor, load_snapshot_read_basis,
-    CheckpointReadBasis, ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl,
-    MetadataBasis, VerifiedNamespaceCatalogEntry,
+    CheckpointReadBasis, ControlObjectLoadError, LoadedControl, MetadataBasis,
+    VerifiedNamespaceCatalogEntry,
 };
 use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext, StoreFailureClass};
 use loonfs_objectstore::keys::wal_head;
@@ -30,7 +30,7 @@ pub(crate) struct RuntimeControlCache {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CachedControl<T> {
-    pub(crate) identity: ControlObjectIdentity,
+    pub(crate) etag: String,
     pub(crate) state: T,
 }
 
@@ -234,7 +234,7 @@ impl ReadCore {
             .cached_namespace_head(namespace_id);
         if let Some(head) = cached {
             match self
-                .cached_control_identity_matches(&wal_head(namespace_id), &head.head.identity)
+                .cached_control_identity_matches(&wal_head(namespace_id), &head.head.etag)
                 .await
             {
                 Ok(true) => return Ok(head),
@@ -287,7 +287,7 @@ impl ReadCore {
     async fn cached_control_identity_matches(
         &self,
         object_key: &str,
-        identity: &ControlObjectIdentity,
+        expected_etag: &str,
     ) -> std::result::Result<bool, ControlObjectLoadError> {
         let metadata = self
             .store()
@@ -308,7 +308,7 @@ impl ReadCore {
                 class: StoreFailureClass::Other,
             });
         };
-        Ok(etag == identity.etag)
+        Ok(etag == expected_etag)
     }
 
     pub(crate) fn control_cache_enabled(&self) -> bool {
@@ -327,7 +327,7 @@ impl ReadCore {
     ) -> RuntimeReadContext {
         RuntimeReadContext {
             head: anchor.head.state.clone(),
-            head_etag: anchor.head.identity.etag.clone(),
+            head_etag: anchor.head.etag.clone(),
             basis: anchor.basis.clone(),
             segment_cache: Arc::clone(&self.inner.metadata_segment_cache),
             tail_cache: Arc::clone(&self.inner.wal_tail_projection_cache),
@@ -403,9 +403,7 @@ impl ReadCore {
     ) {
         let read_context = self.runtime_read_context(&CachedNamespaceAnchor {
             head: CachedControl {
-                identity: ControlObjectIdentity {
-                    etag: pinned.head_etag,
-                },
+                etag: pinned.head_etag,
                 state: pinned.head,
             },
             basis: pinned.basis,
@@ -467,9 +465,7 @@ impl ReadCore {
             namespace_id,
             CachedNamespaceAnchor {
                 head: CachedControl {
-                    identity: ControlObjectIdentity {
-                        etag: state.head_etag.clone(),
-                    },
+                    etag: state.head_etag.clone(),
                     state: state.head,
                 },
                 basis: state.basis,
@@ -517,10 +513,12 @@ impl ReadCore {
     }
 }
 
-fn cached_anchor((head, basis): (LoadedHeadControl, MetadataBasis)) -> CachedNamespaceAnchor {
+fn cached_anchor(
+    (head, basis): (LoadedControl<HeadState>, MetadataBasis),
+) -> CachedNamespaceAnchor {
     CachedNamespaceAnchor {
         head: CachedControl {
-            identity: head.identity,
+            etag: head.etag,
             state: head.state,
         },
         basis,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -178,8 +178,8 @@ pub mod downloads {
 pub mod control {
     pub use loonfs_core::control::{
         load_namespace_catalog_entry, load_namespace_head_control,
-        load_namespace_metadata_root_control, ControlObjectLoadError, LoadedHeadControl,
-        LoadedMetadataRootControl, NamespaceCatalogLoadError, VerifiedNamespaceCatalogEntry,
+        load_namespace_metadata_root_control, ControlObjectLoadError, LoadedControl,
+        NamespaceCatalogLoadError, VerifiedNamespaceCatalogEntry,
     };
 }
 

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -831,7 +831,7 @@ async fn snapshot_create_recovers_an_ambiguously_landed_record_write() {
         .await
         .expect("reconcile the durable snapshot record");
 
-    assert_eq!(store.attempts(), 2);
+    assert_eq!(store.attempts(), 1);
     let listed = collect_checkpoints(&fs.admin, &namespace_id)
         .await
         .expect("list checkpoints");


### PR DESCRIPTION
This gives mutable control-object writes one result model for success, contention, and ambiguous transport failures. Each caller supplies a small read-back check that confirms whether an unacknowledged write landed, lost a race, or remains unknown.

Namespace creation and deletion, checkpoint operations, retention-floor updates, and manifest publication now use the same retry and confirmation path. An ambiguous write may require one extra read. Durable and HTTP formats are unchanged.