### PR TITLE
refactor(core): share metadata row types with the API crate

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -142,153 +142,184 @@ pub struct MetadataSegmentRef {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MetadataRow {
     /// Establishes one inode's immutable identity and kind.
-    Inode {
-        /// Namespace-scoped inode identity allocated by the publishing writer.
-        inode_id: InodeId,
-        /// Classification fixed when the inode was created.
-        inode_kind: InodeKind,
-        /// Commit sequence from which the inode can become visible.
-        created_seq: ChangeSeq,
-        /// Commit ID associated with this row.
-        commit_id: CommitId,
-        /// Actor that created the inode, as supplied by the application.
-        created_by: crate::ActorRef,
-        /// Time the inode was created, in Unix milliseconds.
-        created_at_ms: u64,
-    },
+    Inode(InodeRecord),
     /// Records one generation of a directory name binding.
-    DirentryBind {
-        /// Directory in which the name was bound.
-        parent_inode_id: InodeId,
-        /// Policy-derived key used for uniqueness and lookup.
-        name_key: NameKey,
-        /// User-facing component spelling retained for directory responses.
-        display_name: DisplayName,
-        /// Inode reached while this binding generation remains active.
-        child_inode_id: InodeId,
-        /// Commit sequence that created this binding generation.
-        bind_seq: ChangeSeq,
-        /// Position that disambiguates the binding within `bind_seq`.
-        bind_delta_index: u32,
-    },
+    DirentryBind(DirentryBindRecord),
     /// Retires one exact directory-binding generation.
-    DirentryUnbind {
-        /// Directory that held the targeted binding.
-        parent_inode_id: InodeId,
-        /// Canonical name key of the targeted binding.
-        name_key: NameKey,
-        /// User-facing spelling the retired binding carried.
-        display_name: DisplayName,
-        /// Child identity recorded by the targeted binding.
-        child_inode_id: InodeId,
-        /// Commit sequence that created the binding being retired.
-        bind_seq: ChangeSeq,
-        /// Delta position of the binding being retired.
-        bind_delta_index: u32,
-        /// Commit sequence from which this unbind takes effect.
-        unbind_seq: ChangeSeq,
-        /// Position that disambiguates the unbind within `unbind_seq`.
-        unbind_delta_index: u32,
-    },
+    DirentryUnbind(DirentryUnbindRecord),
     /// Publishes one immutable content revision for a file inode.
-    FileRevision {
-        /// File inode whose history contains the revision.
-        inode_id: InodeId,
-        /// Monotonic revision number within that file's history.
-        revision_no: RevisionNo,
-        /// Namespace sequence that published the revision.
-        committed_seq: ChangeSeq,
-        /// Commit ID associated with this row.
-        commit_id: CommitId,
-        /// The owning commit's observational wall-clock stamp, denormalized
-        /// onto the row so revision reads answer times without a receipt
-        /// join. Never a validity input; `committed_seq` is the order.
-        committed_at_ms: u64,
-        /// Actor that committed this revision, as supplied by the application.
-        committed_by: crate::ActorRef,
-        /// Delta position that disambiguates the revision within `committed_seq`.
-        delta_index: u32,
-        /// Immutable bytes published by the revision.
-        content_ref: ContentRef,
-    },
+    FileRevision(RevisionRecord),
     /// Changes whether one root inode has an active subtree tombstone.
-    Tombstone {
-        /// Inode whose rooted subtree the event governs.
-        root_inode_id: InodeId,
-        /// Where this event sits in the namespace's history, and the
-        /// generation a later `revoke` names.
-        generation: TombstoneGeneration,
-        /// Commit ID associated with this row.
-        commit_id: CommitId,
-        /// What this event did; readers take the newest row per root and
-        /// treat a `revoke` newest row as "no active tombstone".
-        action: TombstoneRowAction,
-        /// Wall-clock stamp of the recording commit. Observational, like
-        /// every `committed_at_ms`.
-        deleted_at_ms: u64,
-        /// Actor that recorded this tombstone event.
-        deleted_by: crate::ActorRef,
-    },
+    Tombstone(SubtreeTombstoneRecord),
     /// Derived row used to list currently recoverable deletions.
     ///
     /// Materialization writes `listed` for each tombstone set and `removed` for
     /// each revoke. This lets trash listing use an ordered range scan instead of
     /// replaying all historical deletion events.
-    ActiveDeletion {
-        /// Subtree root the deletion covers. With `deletion_seq` this is
-        /// exactly the handle `undelete` addresses.
-        root_inode_id: InodeId,
-        /// Commit sequence of the deletion. A `removed` row repeats the
-        /// original deletion sequence so both rows sort together.
-        deletion_seq: ChangeSeq,
-        /// Whether the deletion is still recoverable, and the listing detail
-        /// it carries while it is.
-        action: ActiveDeletionRowAction,
-    },
+    ActiveDeletion(ActiveDeletionRecord),
     /// Preserves the evidence needed to answer a retried logical commit.
-    CommitReceipt {
-        /// Caller idempotency key whose later reuse is checked against this row.
-        commit_id: CommitId,
-        /// Actor that committed the change, as supplied by the application.
-        committed_by: crate::ActorRef,
-        /// Digest used to distinguish a safe retry from conflicting id reuse.
-        semantic_commit_fingerprint: String,
-        /// Namespace sequence assigned to the accepted commit.
-        committed_seq: ChangeSeq,
-        /// The commit's observational wall-clock stamp. Receipts are the
-        /// durable per-commit record once WAL history drops below the
-        /// retention floor, so the stamp lives here for every commit,
-        /// revision-bearing or not.
-        committed_at_ms: u64,
-        /// Caller annotation preserved for idempotent response reconstruction.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        message: Option<String>,
-    },
+    CommitReceipt(CommitReceiptRecord),
     /// Publishes one inode's complete attribute map at one revision.
     ///
     /// The row is whole state, not a change: a reader takes the newest row
     /// for an inode and needs nothing older. An inode with no row anywhere is
     /// at revision 0 with an empty map, so nothing is written until a caller
     /// writes an attribute.
-    AttributesRevision {
-        /// Inode whose attributes this revision states.
-        inode_id: InodeId,
-        /// Monotonic per-inode attribute revision.
-        attributes_revision_no: AttributeRevisionNo,
-        /// Namespace sequence that published the revision.
-        committed_seq: ChangeSeq,
-        /// Commit ID associated with this row.
-        commit_id: CommitId,
-        /// Delta position that disambiguates the revision within `committed_seq`.
-        delta_index: u32,
-        /// Actor that updated the attributes.
-        updated_by: crate::ActorRef,
-        /// Time of the attribute update, in Unix milliseconds.
-        updated_at_ms: u64,
-        /// The inode's complete attribute map at this revision. An empty map
-        /// is the cleared state.
-        attributes: Attributes,
-    },
+    AttributesRevision(AttributesRevisionRecord),
+}
+
+/// One inode's immutable identity and creation metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InodeRecord {
+    /// Namespace-scoped inode identity allocated by the publishing writer.
+    pub inode_id: InodeId,
+    /// Classification fixed when the inode was created.
+    pub inode_kind: InodeKind,
+    /// Commit sequence from which the inode can become visible.
+    pub created_seq: ChangeSeq,
+    /// Commit ID associated with this row.
+    pub commit_id: CommitId,
+    /// Actor that created the inode, as supplied by the application.
+    pub created_by: crate::ActorRef,
+    /// Time the inode was created, in Unix milliseconds.
+    pub created_at_ms: u64,
+}
+
+/// One generation of a directory name binding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirentryBindRecord {
+    /// Directory in which the name was bound.
+    pub parent_inode_id: InodeId,
+    /// Policy-derived key used for uniqueness and lookup.
+    pub name_key: NameKey,
+    /// User-facing component spelling retained for directory responses.
+    pub display_name: DisplayName,
+    /// Inode reached while this binding generation remains active.
+    pub child_inode_id: InodeId,
+    /// Commit sequence that created this binding generation.
+    pub bind_seq: ChangeSeq,
+    /// Position that disambiguates the binding within `bind_seq`.
+    pub bind_delta_index: u32,
+}
+
+/// One event that retires an exact directory-binding generation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirentryUnbindRecord {
+    /// Directory that held the targeted binding.
+    pub parent_inode_id: InodeId,
+    /// Canonical name key of the targeted binding.
+    pub name_key: NameKey,
+    /// User-facing spelling the retired binding carried.
+    pub display_name: DisplayName,
+    /// Child identity recorded by the targeted binding.
+    pub child_inode_id: InodeId,
+    /// Commit sequence that created the binding being retired.
+    pub bind_seq: ChangeSeq,
+    /// Delta position of the binding being retired.
+    pub bind_delta_index: u32,
+    /// Commit sequence from which this unbind takes effect.
+    pub unbind_seq: ChangeSeq,
+    /// Position that disambiguates the unbind within `unbind_seq`.
+    pub unbind_delta_index: u32,
+}
+
+/// One immutable content revision for a file inode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevisionRecord {
+    /// File inode whose history contains the revision.
+    pub inode_id: InodeId,
+    /// Monotonic revision number within that file's history.
+    pub revision_no: RevisionNo,
+    /// Namespace sequence that published the revision.
+    pub committed_seq: ChangeSeq,
+    /// Commit ID associated with this row.
+    pub commit_id: CommitId,
+    /// The owning commit's observational wall-clock stamp.
+    pub committed_at_ms: u64,
+    /// Actor that committed this revision, as supplied by the application.
+    pub committed_by: crate::ActorRef,
+    /// Delta position that disambiguates the revision within `committed_seq`.
+    pub delta_index: u32,
+    /// Immutable bytes published by the revision.
+    pub content_ref: ContentRef,
+}
+
+/// One event that changes whether a root inode has an active subtree tombstone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubtreeTombstoneRecord {
+    /// Inode whose rooted subtree the event governs.
+    pub root_inode_id: InodeId,
+    /// Position of the event in namespace history.
+    pub generation: TombstoneGeneration,
+    /// Commit ID associated with this row.
+    pub commit_id: CommitId,
+    /// What this event did.
+    pub action: TombstoneRowAction,
+    /// Wall-clock stamp of the recording commit.
+    pub deleted_at_ms: u64,
+    /// Actor that recorded this tombstone event.
+    pub deleted_by: crate::ActorRef,
+}
+
+/// One current-state row for a recoverable deletion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActiveDeletionRecord {
+    /// Subtree root the deletion covers.
+    pub root_inode_id: InodeId,
+    /// Commit sequence of the deletion.
+    pub deletion_seq: ChangeSeq,
+    /// Current listing state for the deletion.
+    pub action: ActiveDeletionRowAction,
+}
+
+impl ActiveDeletionRecord {
+    /// Builds this row's durable key in trash-listing order.
+    pub fn row_key(&self) -> String {
+        lookup_keys::active_deletion_row_key(
+            self.deletion_seq,
+            self.root_inode_id,
+            self.action.sort_rank(),
+        )
+    }
+}
+
+/// One durable commit idempotency receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitReceiptRecord {
+    /// Caller idempotency key whose later reuse is checked against this row.
+    pub commit_id: CommitId,
+    /// Actor that committed the change, as supplied by the application.
+    pub committed_by: crate::ActorRef,
+    /// Digest used to distinguish a safe retry from conflicting ID reuse.
+    pub semantic_commit_fingerprint: String,
+    /// Namespace sequence assigned to the accepted commit.
+    pub committed_seq: ChangeSeq,
+    /// The commit's observational wall-clock stamp.
+    pub committed_at_ms: u64,
+    /// Caller annotation preserved for idempotent response reconstruction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// One inode's complete attribute map at one revision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttributesRevisionRecord {
+    /// Inode whose attributes this revision states.
+    pub inode_id: InodeId,
+    /// Monotonic per-inode attribute revision.
+    pub attributes_revision_no: AttributeRevisionNo,
+    /// Namespace sequence that published the revision.
+    pub committed_seq: ChangeSeq,
+    /// Commit ID associated with this row.
+    pub commit_id: CommitId,
+    /// Delta position that disambiguates the revision within `committed_seq`.
+    pub delta_index: u32,
+    /// Actor that updated the attributes.
+    pub updated_by: crate::ActorRef,
+    /// Time of the attribute update, in Unix milliseconds.
+    pub updated_at_ms: u64,
+    /// The inode's complete attribute map at this revision.
+    pub attributes: Attributes,
 }
 
 /// Names one deletion generation: the commit that recorded a tombstone
@@ -408,14 +439,14 @@ impl MetadataRow {
     /// See [metadata segments](../../../docs/specs/format.md#421-metadata-segments).
     pub fn row_key(&self) -> String {
         self.row_key_for_family(match self {
-            Self::Inode { .. } => MetadataRowFamily::Inodes,
-            Self::DirentryBind { .. } => MetadataRowFamily::DirentryBinds,
-            Self::DirentryUnbind { .. } => MetadataRowFamily::DirentryUnbinds,
-            Self::FileRevision { .. } => MetadataRowFamily::Revisions,
-            Self::Tombstone { .. } => MetadataRowFamily::Tombstones,
-            Self::ActiveDeletion { .. } => MetadataRowFamily::ActiveDeletions,
-            Self::CommitReceipt { .. } => MetadataRowFamily::CommitReceipts,
-            Self::AttributesRevision { .. } => MetadataRowFamily::Attributes,
+            Self::Inode(_) => MetadataRowFamily::Inodes,
+            Self::DirentryBind(_) => MetadataRowFamily::DirentryBinds,
+            Self::DirentryUnbind(_) => MetadataRowFamily::DirentryUnbinds,
+            Self::FileRevision(_) => MetadataRowFamily::Revisions,
+            Self::Tombstone(_) => MetadataRowFamily::Tombstones,
+            Self::ActiveDeletion(_) => MetadataRowFamily::ActiveDeletions,
+            Self::CommitReceipt(_) => MetadataRowFamily::CommitReceipts,
+            Self::AttributesRevision(_) => MetadataRowFamily::Attributes,
         })
     }
 
@@ -424,28 +455,21 @@ impl MetadataRow {
     /// See [metadata segments](../../../docs/specs/format.md#421-metadata-segments).
     pub fn row_key_for_family(&self, family: MetadataRowFamily) -> String {
         match self {
-            Self::Inode { inode_id, .. } => lookup_keys::inode_key(*inode_id),
-            Self::DirentryBind {
-                parent_inode_id,
-                name_key,
-                child_inode_id,
-                bind_seq,
-                bind_delta_index,
-                ..
-            } => match family {
+            Self::Inode(record) => lookup_keys::inode_key(record.inode_id),
+            Self::DirentryBind(record) => match family {
                 MetadataRowFamily::DirentryBinds => Some(lookup_keys::direntry_bind_row_key(
-                    *parent_inode_id,
-                    name_key.as_str(),
-                    *bind_seq,
-                    *bind_delta_index,
+                    record.parent_inode_id,
+                    record.name_key.as_str(),
+                    record.bind_seq,
+                    record.bind_delta_index,
                 )),
                 MetadataRowFamily::DirentryChildBinds => {
                     Some(lookup_keys::direntry_child_bind_row_key(
-                        *child_inode_id,
-                        *bind_seq,
-                        *bind_delta_index,
-                        *parent_inode_id,
-                        name_key.as_str(),
+                        record.child_inode_id,
+                        record.bind_seq,
+                        record.bind_delta_index,
+                        record.parent_inode_id,
+                        record.name_key.as_str(),
                     ))
                 }
                 MetadataRowFamily::Inodes
@@ -458,40 +482,26 @@ impl MetadataRow {
                 | MetadataRowFamily::Attributes => None,
             }
             .expect("a direntry bind row should use a direntry bind family"),
-            Self::DirentryUnbind {
-                parent_inode_id,
-                name_key,
-                bind_seq,
-                bind_delta_index,
-                unbind_seq,
-                unbind_delta_index,
-                ..
-            } => lookup_keys::direntry_unbind_row_key(
-                *parent_inode_id,
-                name_key.as_str(),
-                *bind_seq,
-                *bind_delta_index,
-                *unbind_seq,
-                *unbind_delta_index,
+            Self::DirentryUnbind(record) => lookup_keys::direntry_unbind_row_key(
+                record.parent_inode_id,
+                record.name_key.as_str(),
+                record.bind_seq,
+                record.bind_delta_index,
+                record.unbind_seq,
+                record.unbind_delta_index,
             ),
-            Self::FileRevision {
-                inode_id,
-                revision_no,
-                committed_seq,
-                delta_index,
-                ..
-            } => match family {
+            Self::FileRevision(record) => match family {
                 MetadataRowFamily::Revisions => Some(lookup_keys::revision_row_key(
-                    *inode_id,
-                    *revision_no,
-                    *delta_index,
+                    record.inode_id,
+                    record.revision_no,
+                    record.delta_index,
                 )),
                 MetadataRowFamily::RevisionsByInodeDesc => {
                     Some(lookup_keys::revision_by_inode_desc_row_key(
-                        *inode_id,
-                        *revision_no,
-                        *committed_seq,
-                        *delta_index,
+                        record.inode_id,
+                        record.revision_no,
+                        record.committed_seq,
+                        record.delta_index,
                     ))
                 }
                 MetadataRowFamily::Inodes
@@ -504,36 +514,22 @@ impl MetadataRow {
                 | MetadataRowFamily::Attributes => None,
             }
             .expect("a file revision row should use a revision family"),
-            Self::Tombstone {
-                root_inode_id,
-                generation,
-                ..
-            } => lookup_keys::tombstone_row_key(*root_inode_id, *generation),
-            Self::ActiveDeletion {
-                root_inode_id,
-                deletion_seq,
-                action,
-            } => lookup_keys::active_deletion_row_key(
-                *deletion_seq,
-                *root_inode_id,
-                action.sort_rank(),
+            Self::Tombstone(record) => {
+                lookup_keys::tombstone_row_key(record.root_inode_id, record.generation)
+            }
+            Self::ActiveDeletion(record) => lookup_keys::active_deletion_row_key(
+                record.deletion_seq,
+                record.root_inode_id,
+                record.action.sort_rank(),
             ),
-            Self::CommitReceipt {
-                committed_seq,
-                commit_id,
-                ..
-            } => lookup_keys::commit_receipt_row_key(commit_id.as_str(), *committed_seq),
-            Self::AttributesRevision {
-                inode_id,
-                attributes_revision_no,
-                committed_seq,
-                delta_index,
-                ..
-            } => lookup_keys::attributes_row_key(
-                *inode_id,
-                *attributes_revision_no,
-                *committed_seq,
-                *delta_index,
+            Self::CommitReceipt(record) => {
+                lookup_keys::commit_receipt_row_key(record.commit_id.as_str(), record.committed_seq)
+            }
+            Self::AttributesRevision(record) => lookup_keys::attributes_row_key(
+                record.inode_id,
+                record.attributes_revision_no,
+                record.committed_seq,
+                record.delta_index,
             ),
         }
     }
@@ -541,19 +537,14 @@ impl MetadataRow {
     /// Returns the Bloom filter key for this row in `family`.
     pub fn filter_key_for_family(&self, family: MetadataRowFamily) -> String {
         match self {
-            Self::Inode { .. } => self.row_key_for_family(family),
-            Self::DirentryBind {
-                parent_inode_id,
-                name_key,
-                child_inode_id,
-                ..
-            } => match family {
+            Self::Inode(_) => self.row_key_for_family(family),
+            Self::DirentryBind(record) => match family {
                 MetadataRowFamily::DirentryBinds => Some(lookup_keys::direntry_bind_probe(
-                    *parent_inode_id,
-                    name_key.as_str(),
+                    record.parent_inode_id,
+                    record.name_key.as_str(),
                 )),
                 MetadataRowFamily::DirentryChildBinds => {
-                    Some(lookup_keys::direntry_child_probe(*child_inode_id))
+                    Some(lookup_keys::direntry_child_probe(record.child_inode_id))
                 }
                 MetadataRowFamily::Inodes
                 | MetadataRowFamily::DirentryUnbinds
@@ -565,15 +556,13 @@ impl MetadataRow {
                 | MetadataRowFamily::Attributes => None,
             }
             .expect("a direntry bind row should use a direntry bind family"),
-            Self::DirentryUnbind {
-                parent_inode_id,
-                name_key,
-                ..
-            } => lookup_keys::direntry_unbind_probe(*parent_inode_id, name_key.as_str()),
-            Self::FileRevision { inode_id, .. } => match family {
-                MetadataRowFamily::Revisions => Some(lookup_keys::revision_probe(*inode_id)),
+            Self::DirentryUnbind(record) => {
+                lookup_keys::direntry_unbind_probe(record.parent_inode_id, record.name_key.as_str())
+            }
+            Self::FileRevision(record) => match family {
+                MetadataRowFamily::Revisions => Some(lookup_keys::revision_probe(record.inode_id)),
                 MetadataRowFamily::RevisionsByInodeDesc => {
-                    Some(lookup_keys::revision_by_inode_desc_probe(*inode_id))
+                    Some(lookup_keys::revision_by_inode_desc_probe(record.inode_id))
                 }
                 MetadataRowFamily::Inodes
                 | MetadataRowFamily::DirentryBinds
@@ -585,14 +574,14 @@ impl MetadataRow {
                 | MetadataRowFamily::Attributes => None,
             }
             .expect("a file revision row should use a revision family"),
-            Self::Tombstone { root_inode_id, .. } => lookup_keys::tombstone_probe(*root_inode_id),
+            Self::Tombstone(record) => lookup_keys::tombstone_probe(record.root_inode_id),
             // The family is only ever range-scanned in key order, never
             // probed for one deletion, so the filter key is the row key.
-            Self::ActiveDeletion { .. } => self.row_key_for_family(family),
-            Self::CommitReceipt { commit_id, .. } => {
-                lookup_keys::commit_receipt_probe(commit_id.as_str())
+            Self::ActiveDeletion(_) => self.row_key_for_family(family),
+            Self::CommitReceipt(record) => {
+                lookup_keys::commit_receipt_probe(record.commit_id.as_str())
             }
-            Self::AttributesRevision { inode_id, .. } => lookup_keys::attributes_probe(*inode_id),
+            Self::AttributesRevision(record) => lookup_keys::attributes_probe(record.inode_id),
         }
     }
 }
@@ -1216,14 +1205,14 @@ mod tests {
 
     #[test]
     fn direntry_bind_row_key_supports_parent_and_child_indexes() {
-        let row = super::MetadataRow::DirentryBind {
+        let row = super::MetadataRow::DirentryBind(super::DirentryBindRecord {
             parent_inode_id: InodeId(9),
             name_key: NameKey::parse("report.txt").expect("valid name key"),
             display_name: crate::DisplayName::parse("Report.txt").expect("valid display name"),
             child_inode_id: InodeId(42),
             bind_seq: ChangeSeq(17),
             bind_delta_index: 3,
-        };
+        });
 
         assert_eq!(
             row.row_key_for_family(MetadataRowFamily::DirentryBinds),
@@ -1237,14 +1226,14 @@ mod tests {
 
     #[test]
     fn row_keys_hex_encode_dash_containing_variable_components() {
-        let row = super::MetadataRow::DirentryBind {
+        let row = super::MetadataRow::DirentryBind(super::DirentryBindRecord {
             parent_inode_id: InodeId(9),
             name_key: NameKey::parse("report-2024").expect("valid name key"),
             display_name: crate::DisplayName::parse("report-2024").expect("valid display name"),
             child_inode_id: InodeId(42),
             bind_seq: ChangeSeq(17),
             bind_delta_index: 3,
-        };
+        });
 
         assert_eq!(
             row.row_key_for_family(MetadataRowFamily::DirentryBinds),
@@ -1254,7 +1243,7 @@ mod tests {
 
     #[test]
     fn revision_row_key_supports_newest_first_inode_index() {
-        let row = super::MetadataRow::FileRevision {
+        let row = super::MetadataRow::FileRevision(super::RevisionRecord {
             inode_id: InodeId(42),
             revision_no: crate::RevisionNo(7),
             committed_seq: ChangeSeq(12),
@@ -1267,7 +1256,7 @@ mod tests {
                     .expect("valid content id"),
                 b"row key sample",
             ),
-        };
+        });
 
         assert_eq!(
             row.row_key_for_family(MetadataRowFamily::Revisions),
@@ -1281,8 +1270,8 @@ mod tests {
 
     #[test]
     fn attributes_row_keys_sort_newest_revision_first_under_the_inode_prefix() {
-        let row_of =
-            |revision: u64, seq: u64, delta_index: u32| super::MetadataRow::AttributesRevision {
+        let row_of = |revision: u64, seq: u64, delta_index: u32| {
+            super::MetadataRow::AttributesRevision(super::AttributesRevisionRecord {
                 inode_id: InodeId(42),
                 attributes_revision_no: crate::AttributeRevisionNo(revision),
                 committed_seq: ChangeSeq(seq),
@@ -1291,7 +1280,8 @@ mod tests {
                 updated_by: crate::ActorRef::loonfs_system(),
                 updated_at_ms: 12_000 + seq,
                 attributes: crate::Attributes::default(),
-            };
+            })
+        };
         let newest = row_of(3, 12, 1);
         let older = row_of(2, 11, 0);
 
@@ -1326,15 +1316,15 @@ mod tests {
     fn row_key_prefixes_match_the_row_keys_they_front() {
         let name_key = NameKey::parse("report.txt").expect("valid name key");
         let display_name = crate::DisplayName::parse("report.txt").expect("valid display name");
-        let bind = super::MetadataRow::DirentryBind {
+        let bind = super::MetadataRow::DirentryBind(super::DirentryBindRecord {
             parent_inode_id: InodeId(9),
             name_key: name_key.clone(),
             display_name: display_name.clone(),
             child_inode_id: InodeId(42),
             bind_seq: ChangeSeq(17),
             bind_delta_index: 3,
-        };
-        let revision = super::MetadataRow::FileRevision {
+        });
+        let revision = super::MetadataRow::FileRevision(super::RevisionRecord {
             inode_id: InodeId(42),
             revision_no: crate::RevisionNo(7),
             committed_seq: ChangeSeq(12),
@@ -1347,24 +1337,24 @@ mod tests {
                     .expect("valid content id"),
                 b"row key prefix sample",
             ),
-        };
+        });
         let rows: [(MetadataRowFamily, super::MetadataRow); 10] = [
             (
                 MetadataRowFamily::Inodes,
-                super::MetadataRow::Inode {
+                super::MetadataRow::Inode(super::InodeRecord {
                     inode_id: InodeId(42),
                     inode_kind: crate::InodeKind::File,
                     created_seq: ChangeSeq(3),
                     commit_id: row_commit_id(),
                     created_by: crate::ActorRef::loonfs_system(),
                     created_at_ms: 3_000,
-                },
+                }),
             ),
             (MetadataRowFamily::DirentryBinds, bind.clone()),
             (MetadataRowFamily::DirentryChildBinds, bind),
             (
                 MetadataRowFamily::DirentryUnbinds,
-                super::MetadataRow::DirentryUnbind {
+                super::MetadataRow::DirentryUnbind(super::DirentryUnbindRecord {
                     parent_inode_id: InodeId(9),
                     name_key,
                     display_name,
@@ -1373,13 +1363,13 @@ mod tests {
                     bind_delta_index: 3,
                     unbind_seq: ChangeSeq(19),
                     unbind_delta_index: 0,
-                },
+                }),
             ),
             (MetadataRowFamily::Revisions, revision.clone()),
             (MetadataRowFamily::RevisionsByInodeDesc, revision),
             (
                 MetadataRowFamily::Tombstones,
-                super::MetadataRow::Tombstone {
+                super::MetadataRow::Tombstone(super::SubtreeTombstoneRecord {
                     root_inode_id: InodeId(42),
                     generation: super::TombstoneGeneration {
                         seq: ChangeSeq(12),
@@ -1391,21 +1381,21 @@ mod tests {
                     },
                     deleted_at_ms: 12_000,
                     deleted_by: crate::ActorRef::loonfs_system(),
-                },
+                }),
             ),
             (
                 MetadataRowFamily::ActiveDeletions,
-                super::MetadataRow::ActiveDeletion {
+                super::MetadataRow::ActiveDeletion(super::ActiveDeletionRecord {
                     root_inode_id: InodeId(42),
                     deletion_seq: ChangeSeq(12),
                     action: super::ActiveDeletionRowAction::Removed {
                         revocation_seq: ChangeSeq(15),
                     },
-                },
+                }),
             ),
             (
                 MetadataRowFamily::CommitReceipts,
-                super::MetadataRow::CommitReceipt {
+                super::MetadataRow::CommitReceipt(super::CommitReceiptRecord {
                     commit_id: CommitId::parse("c_00000000000000000000000000000001")
                         .expect("commit id"),
                     committed_by: crate::ActorRef::loonfs_system(),
@@ -1413,11 +1403,11 @@ mod tests {
                     committed_seq: ChangeSeq(12),
                     committed_at_ms: 12_000,
                     message: None,
-                },
+                }),
             ),
             (
                 MetadataRowFamily::Attributes,
-                super::MetadataRow::AttributesRevision {
+                super::MetadataRow::AttributesRevision(super::AttributesRevisionRecord {
                     inode_id: InodeId(42),
                     attributes_revision_no: crate::AttributeRevisionNo(3),
                     committed_seq: ChangeSeq(12),
@@ -1426,7 +1416,7 @@ mod tests {
                     updated_by: crate::ActorRef::loonfs_system(),
                     updated_at_ms: 12_000,
                     attributes: crate::Attributes::default(),
-                },
+                }),
             ),
         ];
 
@@ -1450,18 +1440,18 @@ mod tests {
             vec![
                 (
                     MetadataRowFamily::Inodes,
-                    super::MetadataRow::Inode {
+                    super::MetadataRow::Inode(super::InodeRecord {
                         inode_id: InodeId(42),
                         inode_kind: crate::InodeKind::File,
                         created_seq: ChangeSeq(3),
                         commit_id: row_commit_id(),
                         created_by: actor.clone(),
                         created_at_ms: 3_000,
-                    },
+                    }),
                 ),
                 (
                     MetadataRowFamily::RevisionsByInodeDesc,
-                    super::MetadataRow::FileRevision {
+                    super::MetadataRow::FileRevision(super::RevisionRecord {
                         inode_id: InodeId(42),
                         revision_no: crate::RevisionNo(7),
                         committed_seq: ChangeSeq(12),
@@ -1474,11 +1464,11 @@ mod tests {
                                 .expect("content id"),
                             b"attribution key test",
                         ),
-                    },
+                    }),
                 ),
                 (
                     MetadataRowFamily::Tombstones,
-                    super::MetadataRow::Tombstone {
+                    super::MetadataRow::Tombstone(super::SubtreeTombstoneRecord {
                         root_inode_id: InodeId(42),
                         generation: super::TombstoneGeneration {
                             seq: ChangeSeq(12),
@@ -1490,11 +1480,11 @@ mod tests {
                         },
                         deleted_at_ms: 12_000,
                         deleted_by: actor.clone(),
-                    },
+                    }),
                 ),
                 (
                     MetadataRowFamily::ActiveDeletions,
-                    super::MetadataRow::ActiveDeletion {
+                    super::MetadataRow::ActiveDeletion(super::ActiveDeletionRecord {
                         root_inode_id: InodeId(42),
                         deletion_seq: ChangeSeq(12),
                         action: super::ActiveDeletionRowAction::Listed {
@@ -1502,11 +1492,11 @@ mod tests {
                             deleted_by: actor.clone(),
                             deleted_direntry: deleted_direntry(),
                         },
-                    },
+                    }),
                 ),
                 (
                     MetadataRowFamily::Attributes,
-                    super::MetadataRow::AttributesRevision {
+                    super::MetadataRow::AttributesRevision(super::AttributesRevisionRecord {
                         inode_id: InodeId(42),
                         attributes_revision_no: crate::AttributeRevisionNo(2),
                         committed_seq: ChangeSeq(12),
@@ -1515,7 +1505,7 @@ mod tests {
                         updated_by: actor,
                         updated_at_ms: 12_000,
                         attributes: crate::Attributes::default(),
-                    },
+                    }),
                 ),
             ]
         }

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -674,7 +674,7 @@ mod tests {
     use crate::{ChangeSeq, InodeId, InodeKind};
 
     fn inode_row(inode_id: u64) -> (String, String, MetadataRow) {
-        let row = MetadataRow::Inode {
+        let row = MetadataRow::Inode(crate::manifest::InodeRecord {
             inode_id: InodeId(inode_id),
             inode_kind: InodeKind::File,
             created_seq: ChangeSeq(inode_id),
@@ -682,7 +682,7 @@ mod tests {
                 .expect("valid commit id"),
             created_by: crate::ActorRef::loonfs_system(),
             created_at_ms: inode_id,
-        };
+        });
         let key = row.row_key();
         (key.clone(), key, row)
     }

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -1842,7 +1842,7 @@ fn wal_delta_wire_tags_match_spec_names() {
 
 /// A delete by path: the tombstone records the binding it removed.
 fn sample_tombstone_set_row() -> MetadataRow {
-    MetadataRow::Tombstone {
+    MetadataRow::Tombstone(loonfs_api::wire::manifest::SubtreeTombstoneRecord {
         root_inode_id: InodeId(5),
         generation: TombstoneGeneration {
             seq: ChangeSeq(8),
@@ -1859,12 +1859,12 @@ fn sample_tombstone_set_row() -> MetadataRow {
         },
         deleted_at_ms: 4_000,
         deleted_by: actor(),
-    }
+    })
 }
 
 /// The undelete that cancels it, naming the exact generation it revokes.
 fn sample_tombstone_revoke_row() -> MetadataRow {
-    MetadataRow::Tombstone {
+    MetadataRow::Tombstone(loonfs_api::wire::manifest::SubtreeTombstoneRecord {
         root_inode_id: InodeId(5),
         generation: TombstoneGeneration {
             seq: ChangeSeq(9),
@@ -1879,14 +1879,14 @@ fn sample_tombstone_revoke_row() -> MetadataRow {
         },
         deleted_at_ms: 4_100,
         deleted_by: actor(),
-    }
+    })
 }
 
 /// The active-deletion row the materializer derives from the set above. It
 /// carries the deletion's stamp and the binding the trash entry renders, both
 /// copied from the tombstone event.
 fn sample_active_deletion_listed_row() -> MetadataRow {
-    MetadataRow::ActiveDeletion {
+    MetadataRow::ActiveDeletion(loonfs_api::wire::manifest::ActiveDeletionRecord {
         root_inode_id: InodeId(5),
         deletion_seq: ChangeSeq(8),
         action: ActiveDeletionRowAction::Listed {
@@ -1899,26 +1899,26 @@ fn sample_active_deletion_listed_row() -> MetadataRow {
                     .expect("valid display name"),
             },
         },
-    }
+    })
 }
 
 /// The active-deletion row the materializer derives from the revoke above. It
 /// repeats the deletion's sequence rather than the undelete's, so the two rows
 /// share a key prefix, and its rank sorts it ahead of the row it removes.
 fn sample_active_deletion_removed_row() -> MetadataRow {
-    MetadataRow::ActiveDeletion {
+    MetadataRow::ActiveDeletion(loonfs_api::wire::manifest::ActiveDeletionRecord {
         root_inode_id: InodeId(5),
         deletion_seq: ChangeSeq(8),
         action: ActiveDeletionRowAction::Removed {
             revocation_seq: ChangeSeq(9),
         },
-    }
+    })
 }
 
 /// An attribute revision that cleared the map. The empty map has an encoding
 /// of its own, so the sample carries a row that states it.
 fn sample_cleared_attributes_row() -> MetadataRow {
-    MetadataRow::AttributesRevision {
+    MetadataRow::AttributesRevision(loonfs_api::wire::manifest::AttributesRevisionRecord {
         inode_id: InodeId(2),
         attributes_revision_no: AttributeRevisionNo(3),
         committed_seq: ChangeSeq(7),
@@ -1927,12 +1927,12 @@ fn sample_cleared_attributes_row() -> MetadataRow {
         updated_by: actor(),
         updated_at_ms: 7_000,
         attributes: Attributes::default(),
-    }
+    })
 }
 
 /// An attribute revision that states a populated map.
 fn sample_populated_attributes_row() -> MetadataRow {
-    MetadataRow::AttributesRevision {
+    MetadataRow::AttributesRevision(loonfs_api::wire::manifest::AttributesRevisionRecord {
         inode_id: InodeId(5),
         attributes_revision_no: AttributeRevisionNo(2),
         committed_seq: ChangeSeq(5),
@@ -1941,44 +1941,44 @@ fn sample_populated_attributes_row() -> MetadataRow {
         updated_by: actor(),
         updated_at_ms: 5_000,
         attributes: sample_attributes(),
-    }
+    })
 }
 
 fn sample_commit_receipt_row() -> MetadataRow {
-    MetadataRow::CommitReceipt {
+    MetadataRow::CommitReceipt(loonfs_api::wire::manifest::CommitReceiptRecord {
         commit_id: commit_id(),
         committed_by: actor(),
         semantic_commit_fingerprint: "fp:golden".to_owned(),
         committed_seq: ChangeSeq(9),
         committed_at_ms: 9_000,
         message: None,
-    }
+    })
 }
 
 fn sample_inode_rows() -> [MetadataRow; 2] {
     [
-        MetadataRow::Inode {
+        MetadataRow::Inode(loonfs_api::wire::manifest::InodeRecord {
             inode_id: InodeId(1),
             inode_kind: InodeKind::Directory,
             created_seq: ChangeSeq(1),
             commit_id: commit_id(),
             created_by: actor(),
             created_at_ms: 1_000,
-        },
-        MetadataRow::Inode {
+        }),
+        MetadataRow::Inode(loonfs_api::wire::manifest::InodeRecord {
             inode_id: InodeId(2),
             inode_kind: InodeKind::File,
             created_seq: ChangeSeq(3),
             commit_id: commit_id(),
             created_by: actor(),
             created_at_ms: 3_000,
-        },
+        }),
     ]
 }
 
 fn sample_revision_rows() -> [MetadataRow; 2] {
     [
-        MetadataRow::FileRevision {
+        MetadataRow::FileRevision(loonfs_api::wire::manifest::RevisionRecord {
             inode_id: InodeId(2),
             revision_no: RevisionNo(1),
             committed_seq: ChangeSeq(3),
@@ -1987,8 +1987,8 @@ fn sample_revision_rows() -> [MetadataRow; 2] {
             committed_by: actor(),
             delta_index: 0,
             content_ref: sample_content_ref(),
-        },
-        MetadataRow::FileRevision {
+        }),
+        MetadataRow::FileRevision(loonfs_api::wire::manifest::RevisionRecord {
             inode_id: InodeId(2),
             revision_no: RevisionNo(2),
             committed_seq: ChangeSeq(4),
@@ -1997,7 +1997,7 @@ fn sample_revision_rows() -> [MetadataRow; 2] {
             committed_by: actor(),
             delta_index: 0,
             content_ref: sample_crc_content_ref(),
-        },
+        }),
     ]
 }
 
@@ -2024,15 +2024,15 @@ fn sample_segment_blocks() -> loonfs_api::wire::sst_blocks::BuiltSegmentBlocks {
         sample_cleared_attributes_row(),
         sample_populated_attributes_row(),
         sample_commit_receipt_row(),
-        MetadataRow::DirentryBind {
+        MetadataRow::DirentryBind(loonfs_api::wire::manifest::DirentryBindRecord {
             parent_inode_id: InodeId(1),
             name_key: name_key("docs"),
             display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
             child_inode_id: InodeId(2),
             bind_seq: ChangeSeq(3),
             bind_delta_index: 0,
-        },
-        MetadataRow::DirentryBind {
+        }),
+        MetadataRow::DirentryBind(loonfs_api::wire::manifest::DirentryBindRecord {
             parent_inode_id: InodeId(1),
             name_key: name_key("docs-archive"),
             display_name: loonfs_api::DisplayName::parse("docs-archive")
@@ -2040,8 +2040,8 @@ fn sample_segment_blocks() -> loonfs_api::wire::sst_blocks::BuiltSegmentBlocks {
             child_inode_id: InodeId(5),
             bind_seq: ChangeSeq(6),
             bind_delta_index: 0,
-        },
-        MetadataRow::DirentryUnbind {
+        }),
+        MetadataRow::DirentryUnbind(loonfs_api::wire::manifest::DirentryUnbindRecord {
             parent_inode_id: InodeId(1),
             name_key: name_key("docs-archive"),
             display_name: loonfs_api::DisplayName::parse("Docs-Archive")
@@ -2051,7 +2051,7 @@ fn sample_segment_blocks() -> loonfs_api::wire::sst_blocks::BuiltSegmentBlocks {
             bind_delta_index: 0,
             unbind_seq: ChangeSeq(8),
             unbind_delta_index: 0,
-        },
+        }),
     ];
     rows.extend(sample_inode_rows());
     rows.extend(sample_revision_rows());
@@ -2431,18 +2431,18 @@ fn active_deletion_rows_reject_a_partial_or_absent_deleted_direntry() {
 fn provenance_rows_reject_every_missing_required_field() {
     let cases = [
         (
-            MetadataRow::Inode {
+            MetadataRow::Inode(loonfs_api::wire::manifest::InodeRecord {
                 inode_id: InodeId(2),
                 inode_kind: InodeKind::File,
                 created_seq: ChangeSeq(3),
                 commit_id: commit_id(),
                 created_by: actor(),
                 created_at_ms: 3_000,
-            },
+            }),
             &["commit_id", "created_by", "created_at_ms"][..],
         ),
         (
-            MetadataRow::FileRevision {
+            MetadataRow::FileRevision(loonfs_api::wire::manifest::RevisionRecord {
                 inode_id: InodeId(2),
                 revision_no: RevisionNo(1),
                 committed_seq: ChangeSeq(3),
@@ -2451,7 +2451,7 @@ fn provenance_rows_reject_every_missing_required_field() {
                 committed_by: actor(),
                 delta_index: 0,
                 content_ref: sample_content_ref(),
-            },
+            }),
             &["commit_id", "committed_by"][..],
         ),
         (sample_tombstone_set_row(), &["commit_id", "deleted_by"][..]),
@@ -2461,14 +2461,14 @@ fn provenance_rows_reject_every_missing_required_field() {
             &["commit_id", "updated_by", "updated_at_ms"][..],
         ),
         (
-            MetadataRow::CommitReceipt {
+            MetadataRow::CommitReceipt(loonfs_api::wire::manifest::CommitReceiptRecord {
                 commit_id: commit_id(),
                 committed_by: actor(),
                 semantic_commit_fingerprint: "v1:sha256:receipt".to_owned(),
                 committed_seq: ChangeSeq(9),
                 committed_at_ms: 9_000,
                 message: None,
-            },
+            }),
             &["committed_by"][..],
         ),
     ];
@@ -2476,7 +2476,10 @@ fn provenance_rows_reject_every_missing_required_field() {
     for (row, required_fields) in cases {
         // The active-deletion row states its attribution inside `action`;
         // every other row states it at the top level.
-        let nested_in_action = matches!(row, MetadataRow::ActiveDeletion { .. });
+        let nested_in_action = matches!(
+            row,
+            MetadataRow::ActiveDeletion(loonfs_api::wire::manifest::ActiveDeletionRecord { .. })
+        );
         for required_field in required_fields {
             let mut encoded = row_cbor(&row);
             let map = if nested_in_action {
@@ -2501,16 +2504,18 @@ fn provenance_rows_reject_every_missing_required_field() {
 
 #[test]
 fn attribute_rows_reject_the_retired_tagged_value_shape() {
-    let mut row = row_cbor(&MetadataRow::AttributesRevision {
-        inode_id: InodeId(2),
-        attributes_revision_no: AttributeRevisionNo(1),
-        committed_seq: ChangeSeq(5),
-        commit_id: commit_id(),
-        delta_index: 0,
-        updated_by: actor(),
-        updated_at_ms: 5_000,
-        attributes: sample_attributes(),
-    });
+    let mut row = row_cbor(&MetadataRow::AttributesRevision(
+        loonfs_api::wire::manifest::AttributesRevisionRecord {
+            inode_id: InodeId(2),
+            attributes_revision_no: AttributeRevisionNo(1),
+            committed_seq: ChangeSeq(5),
+            commit_id: commit_id(),
+            delta_index: 0,
+            updated_by: actor(),
+            updated_at_ms: 5_000,
+            attributes: sample_attributes(),
+        },
+    ));
     let owner = cbor_entry(cbor_entry(&mut row, "attributes"), "owner");
     *owner = ciborium::Value::Map(vec![
         (
@@ -2529,16 +2534,18 @@ fn attribute_rows_reject_the_retired_tagged_value_shape() {
 
 #[test]
 fn attribute_rows_reject_a_map_over_its_limits() {
-    let mut row = row_cbor(&MetadataRow::AttributesRevision {
-        inode_id: InodeId(2),
-        attributes_revision_no: AttributeRevisionNo(1),
-        committed_seq: ChangeSeq(5),
-        commit_id: commit_id(),
-        delta_index: 0,
-        updated_by: actor(),
-        updated_at_ms: 5_000,
-        attributes: sample_attributes(),
-    });
+    let mut row = row_cbor(&MetadataRow::AttributesRevision(
+        loonfs_api::wire::manifest::AttributesRevisionRecord {
+            inode_id: InodeId(2),
+            attributes_revision_no: AttributeRevisionNo(1),
+            committed_seq: ChangeSeq(5),
+            commit_id: commit_id(),
+            delta_index: 0,
+            updated_by: actor(),
+            updated_at_ms: 5_000,
+            attributes: sample_attributes(),
+        },
+    ));
     let owner = cbor_entry(cbor_entry(&mut row, "attributes"), "owner");
     *owner = ciborium::Value::from("v".repeat(loonfs_api::MAX_ATTRIBUTE_VALUE_BYTES + 1));
 
@@ -2583,14 +2590,14 @@ fn sst_block_filter_matches_golden_bytes_and_answers() {
     assert_matches_golden("sst_block_filter.v1.bin", stored);
     let filter = decode_filter_block(stored, &built.filter).expect("decode filter");
     assert!(filter.may_contain(
-        &MetadataRow::Inode {
+        &MetadataRow::Inode(loonfs_api::wire::manifest::InodeRecord {
             inode_id: InodeId(1),
             inode_kind: InodeKind::Directory,
             created_seq: ChangeSeq(1),
             commit_id: commit_id(),
             created_by: actor(),
             created_at_ms: 1_000,
-        }
+        })
         .row_key()
     ));
     assert!(!filter.may_contain("inode-99999999999999999999"));

--- a/crates/loonfs-core/src/checkpoint/compaction_merge.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_merge.rs
@@ -261,18 +261,18 @@ mod tests {
     use loonfs_api::{ChangeSeq, DisplayName, InodeId, NameKey};
 
     fn bind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
-        MetadataRow::DirentryBind {
+        MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
             parent_inode_id: InodeId(parent),
             name_key: NameKey::parse(name).expect("name key"),
             display_name: DisplayName::parse(name).expect("display name"),
             child_inode_id: InodeId(42),
             bind_seq: ChangeSeq(bind_seq),
             bind_delta_index: 0,
-        }
+        })
     }
 
     fn unbind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
-        MetadataRow::DirentryUnbind {
+        MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
             parent_inode_id: InodeId(parent),
             name_key: NameKey::parse(name).expect("name key"),
             display_name: DisplayName::parse(name).expect("display name"),
@@ -281,7 +281,7 @@ mod tests {
             bind_delta_index: 0,
             unbind_seq: ChangeSeq(bind_seq + 1),
             unbind_delta_index: 0,
-        }
+        })
     }
 
     /// The grouping the bindings cluster merges by.

--- a/crates/loonfs-core/src/checkpoint/compaction_retention.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_retention.rs
@@ -115,7 +115,9 @@ impl RetentionOperator {
 /// mutation (format spec, section 3.3).
 fn keep_receipt(row: MetadataRow, floor_seq: ChangeSeq) -> Option<MetadataRow> {
     match &row {
-        MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq < floor_seq => None,
+        MetadataRow::CommitReceipt(crate::metadata::CommitReceiptRecord {
+            committed_seq, ..
+        }) if *committed_seq < floor_seq => None,
         _ => Some(row),
     }
 }
@@ -142,12 +144,12 @@ pub(super) struct AttributeRetention {
 
 impl AttributeRetention {
     fn push(&mut self, row: MetadataRow, floor_seq: ChangeSeq) -> Result<Option<MetadataRow>> {
-        let MetadataRow::AttributesRevision {
+        let MetadataRow::AttributesRevision(crate::metadata::AttributesRevisionRecord {
             inode_id,
             attributes_revision_no,
             committed_seq,
             ..
-        } = &row
+        }) = &row
         else {
             return Ok(Some(row));
         };
@@ -193,7 +195,9 @@ pub(super) struct ActiveDeletionRetention {
 
 impl ActiveDeletionRetention {
     fn push(&mut self, row: MetadataRow) -> Option<MetadataRow> {
-        let MetadataRow::ActiveDeletion { action, .. } = &row else {
+        let MetadataRow::ActiveDeletion(crate::metadata::ActiveDeletionRecord { action, .. }) =
+            &row
+        else {
             return Some(row);
         };
         match action {
@@ -240,14 +244,14 @@ pub(super) struct BindingRetention {
 impl BindingRetention {
     fn push(&mut self, row: MetadataRow, floor_seq: ChangeSeq) -> Option<MetadataRow> {
         match &row {
-            MetadataRow::DirentryUnbind {
+            MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
                 parent_inode_id,
                 name_key,
                 bind_seq,
                 bind_delta_index,
                 unbind_seq,
                 ..
-            } => {
+            }) => {
                 if *unbind_seq > floor_seq {
                     return Some(row);
                 }
@@ -264,8 +268,12 @@ impl BindingRetention {
             }
             // A bind above the floor survives whatever retired it later, so
             // it needs no verdict and is written straight through.
-            MetadataRow::DirentryBind { bind_seq, .. } if *bind_seq > floor_seq => Some(row),
-            MetadataRow::DirentryBind { .. } => {
+            MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord { bind_seq, .. })
+                if *bind_seq > floor_seq =>
+            {
+                Some(row)
+            }
+            MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord { .. }) => {
                 self.held_bind = Some(row);
                 None
             }
@@ -278,13 +286,13 @@ impl BindingRetention {
         let Some(row) = self.held_bind.take() else {
             return Ok(None);
         };
-        let MetadataRow::DirentryBind {
+        let MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
             parent_inode_id,
             name_key,
             bind_seq,
             bind_delta_index,
             ..
-        } = &row
+        }) = &row
         else {
             return Ok(Some(row));
         };
@@ -335,7 +343,7 @@ mod tests {
     }
 
     fn attribute_row(inode: u64, revision: u64, committed_seq: u64) -> MetadataRow {
-        MetadataRow::AttributesRevision {
+        MetadataRow::AttributesRevision(crate::metadata::AttributesRevisionRecord {
             inode_id: InodeId(inode),
             attributes_revision_no: AttributeRevisionNo(revision),
             committed_seq: ChangeSeq(committed_seq),
@@ -345,22 +353,22 @@ mod tests {
             updated_by: loonfs_api::ActorRef::loonfs_system(),
             updated_at_ms: 1_000 + committed_seq,
             attributes: Default::default(),
-        }
+        })
     }
 
     fn bind_row(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
-        MetadataRow::DirentryBind {
+        MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
             parent_inode_id: InodeId(parent),
             name_key: NameKey::parse(name).expect("name key"),
             display_name: DisplayName::parse(name).expect("display name"),
             child_inode_id: InodeId(42),
             bind_seq: ChangeSeq(bind_seq),
             bind_delta_index: 0,
-        }
+        })
     }
 
     fn unbind_row(parent: u64, name: &str, bind_seq: u64, unbind_seq: u64) -> MetadataRow {
-        MetadataRow::DirentryUnbind {
+        MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
             parent_inode_id: InodeId(parent),
             name_key: NameKey::parse(name).expect("name key"),
             display_name: DisplayName::parse(name).expect("display name"),
@@ -369,7 +377,7 @@ mod tests {
             bind_delta_index: 0,
             unbind_seq: ChangeSeq(unbind_seq),
             unbind_delta_index: 0,
-        }
+        })
     }
 
     #[test]
@@ -429,14 +437,14 @@ mod tests {
     #[test]
     fn a_cancelled_deletion_leaves_and_a_live_one_stays() {
         let mut operator = RetentionRule::ActiveDeletions.operator();
-        let removed = MetadataRow::ActiveDeletion {
+        let removed = MetadataRow::ActiveDeletion(crate::metadata::ActiveDeletionRecord {
             root_inode_id: InodeId(9),
             deletion_seq: ChangeSeq(3),
             action: ActiveDeletionRowAction::Removed {
                 revocation_seq: ChangeSeq(4),
             },
-        };
-        let listed = MetadataRow::ActiveDeletion {
+        });
+        let listed = MetadataRow::ActiveDeletion(crate::metadata::ActiveDeletionRecord {
             root_inode_id: InodeId(9),
             deletion_seq: ChangeSeq(3),
             action: ActiveDeletionRowAction::Listed {
@@ -449,7 +457,7 @@ mod tests {
                         .expect("valid display name"),
                 },
             },
-        };
+        });
         assert!(operator
             .push(MetadataRowFamily::ActiveDeletions, removed.clone(), floor())
             .expect("push")

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -14,9 +14,13 @@ use super::block_load::SessionBlockMemo;
 use super::cache::{DecodedMetadataSegmentBlock, MetadataSegmentBlockKind, MetadataSegmentCache};
 use super::error::ManifestLoadError;
 use super::stored_block_cache::StoredMetadataBlockKind;
-use crate::metadata::content_ref_evidence_bytes;
-use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow, MetadataSegmentRef};
+use loonfs_api::wire::manifest::{
+    ActiveDeletionRecord, ActiveDeletionRowAction, AttributesRevisionRecord, CommitReceiptRecord,
+    DeletedDirentry, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataRow,
+    MetadataSegmentRef, RevisionRecord, SubtreeTombstoneRecord, TombstoneRowAction,
+};
 use loonfs_api::wire::sst_blocks::{decode_data_block, DecodedDataBlock, SegmentIndexEntry};
+use loonfs_api::ActorRef;
 use loonfs_objectstore::keys::metadata_segment_object_key;
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -268,68 +272,115 @@ pub(super) fn decoded_manifest_block_weight(block: &DecodedDataBlock) -> usize {
         .rows
         .iter()
         .zip(&block.row_keys)
-        .map(|(row, row_key)| {
-            BLOCK_ENTRY_OVERHEAD + row_key.len() + decoded_manifest_row_weight(row)
-        })
+        .map(|(row, row_key)| BLOCK_ENTRY_OVERHEAD + row_key.len() + row.decoded_weight())
         .sum::<usize>();
     row_weight.saturating_add(BLOCK_ALLOCATION_OVERHEAD)
 }
 
-pub(super) fn decoded_manifest_row_weight(row: &MetadataRow) -> usize {
-    // Approximate inline row storage and heap allocation metadata.
-    const FIXED_ROW_OVERHEAD: usize = 32;
-    const ALLOCATED_ROW_OVERHEAD: usize = 96;
-    match row {
-        MetadataRow::Inode { commit_id, .. } => ALLOCATED_ROW_OVERHEAD + commit_id.as_str().len(),
-        MetadataRow::DirentryBind {
-            name_key,
-            display_name,
-            ..
-        } => ALLOCATED_ROW_OVERHEAD + name_key.as_str().len() + display_name.as_str().len(),
-        MetadataRow::DirentryUnbind { name_key, .. } => {
-            ALLOCATED_ROW_OVERHEAD + name_key.as_str().len()
+/// The approximate decoded size of one row. The block cache and the
+/// WAL-tail projection both charge rows with this.
+pub(crate) trait DecodedRowWeight {
+    fn decoded_weight(&self) -> usize;
+}
+
+// Approximate inline row storage and heap allocation metadata.
+const FIXED_ROW_OVERHEAD: usize = 32;
+const ALLOCATED_ROW_OVERHEAD: usize = 96;
+
+fn actor_bytes(actor: &ActorRef) -> usize {
+    actor.kind.as_str().len() + actor.id.as_str().len()
+}
+
+fn direntry_bytes(direntry: &DeletedDirentry) -> usize {
+    direntry.name_key.as_str().len() + direntry.display_name.as_str().len()
+}
+
+impl DecodedRowWeight for MetadataRow {
+    fn decoded_weight(&self) -> usize {
+        match self {
+            MetadataRow::Inode(record) => record.decoded_weight(),
+            MetadataRow::DirentryBind(record) => record.decoded_weight(),
+            MetadataRow::DirentryUnbind(record) => record.decoded_weight(),
+            MetadataRow::FileRevision(record) => record.decoded_weight(),
+            MetadataRow::Tombstone(record) => record.decoded_weight(),
+            MetadataRow::ActiveDeletion(record) => record.decoded_weight(),
+            MetadataRow::CommitReceipt(record) => record.decoded_weight(),
+            MetadataRow::AttributesRevision(record) => record.decoded_weight(),
         }
-        MetadataRow::FileRevision {
-            commit_id,
-            content_ref,
-            ..
-        } => {
-            ALLOCATED_ROW_OVERHEAD
-                + commit_id.as_str().len()
-                + content_ref_evidence_bytes(content_ref)
-        }
-        MetadataRow::Tombstone { commit_id, .. } => {
-            ALLOCATED_ROW_OVERHEAD + commit_id.as_str().len()
-        }
-        MetadataRow::ActiveDeletion { action, .. } => match action {
+    }
+}
+
+impl DecodedRowWeight for InodeRecord {
+    fn decoded_weight(&self) -> usize {
+        ALLOCATED_ROW_OVERHEAD + self.commit_id.as_str().len() + actor_bytes(&self.created_by)
+    }
+}
+
+impl DecodedRowWeight for DirentryBindRecord {
+    fn decoded_weight(&self) -> usize {
+        ALLOCATED_ROW_OVERHEAD + self.name_key.as_str().len() + self.display_name.as_str().len()
+    }
+}
+
+impl DecodedRowWeight for DirentryUnbindRecord {
+    fn decoded_weight(&self) -> usize {
+        ALLOCATED_ROW_OVERHEAD + self.name_key.as_str().len() + self.display_name.as_str().len()
+    }
+}
+
+impl DecodedRowWeight for RevisionRecord {
+    fn decoded_weight(&self) -> usize {
+        ALLOCATED_ROW_OVERHEAD
+            + self.commit_id.as_str().len()
+            + actor_bytes(&self.committed_by)
+            + self.content_ref.content_id.as_str().len()
+            + self.content_ref.checksum.value.len()
+    }
+}
+
+impl DecodedRowWeight for SubtreeTombstoneRecord {
+    fn decoded_weight(&self) -> usize {
+        let action_bytes = match &self.action {
+            TombstoneRowAction::Set { deleted_direntry } => direntry_bytes(deleted_direntry),
+            TombstoneRowAction::Revoke { .. } => 0,
+        };
+        ALLOCATED_ROW_OVERHEAD
+            + self.commit_id.as_str().len()
+            + actor_bytes(&self.deleted_by)
+            + action_bytes
+    }
+}
+
+impl DecodedRowWeight for ActiveDeletionRecord {
+    fn decoded_weight(&self) -> usize {
+        match &self.action {
             ActiveDeletionRowAction::Listed {
-                deleted_direntry, ..
+                deleted_by,
+                deleted_direntry,
+                ..
             } => {
-                ALLOCATED_ROW_OVERHEAD
-                    + deleted_direntry.name_key.as_str().len()
-                    + deleted_direntry.display_name.as_str().len()
+                ALLOCATED_ROW_OVERHEAD + actor_bytes(deleted_by) + direntry_bytes(deleted_direntry)
             }
             ActiveDeletionRowAction::Removed { .. } => FIXED_ROW_OVERHEAD,
-        },
-        MetadataRow::CommitReceipt {
-            commit_id,
-            committed_by,
-            semantic_commit_fingerprint,
-            message,
-            ..
-        } => {
-            ALLOCATED_ROW_OVERHEAD
-                + commit_id.as_str().len()
-                + committed_by.kind.as_str().len()
-                + committed_by.id.as_str().len()
-                + semantic_commit_fingerprint.len()
-                + message.as_ref().map_or(0, String::len)
         }
-        // The map's key and value bytes are what an attribute row weighs.
-        MetadataRow::AttributesRevision {
-            commit_id,
-            attributes,
-            ..
-        } => ALLOCATED_ROW_OVERHEAD + commit_id.as_str().len() + attributes.logical_bytes(),
+    }
+}
+
+impl DecodedRowWeight for CommitReceiptRecord {
+    fn decoded_weight(&self) -> usize {
+        ALLOCATED_ROW_OVERHEAD
+            + self.commit_id.as_str().len()
+            + actor_bytes(&self.committed_by)
+            + self.semantic_commit_fingerprint.len()
+            + self.message.as_ref().map_or(0, String::len)
+    }
+}
+
+impl DecodedRowWeight for AttributesRevisionRecord {
+    fn decoded_weight(&self) -> usize {
+        ALLOCATED_ROW_OVERHEAD
+            + self.commit_id.as_str().len()
+            + actor_bytes(&self.updated_by)
+            + self.attributes.logical_bytes()
     }
 }

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -94,11 +94,11 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
         let inode_rows = rows
             .into_iter()
             .map(|(row_key, row)| match row {
-                MetadataRow::Inode {
+                MetadataRow::Inode(crate::metadata::InodeRecord {
                     inode_id,
                     inode_kind,
                     ..
-                } => Ok((inode_id, inode_kind)),
+                }) => Ok((inode_id, inode_kind)),
                 _ => Err(CoreError::NamespaceCorrupt(format!(
                     "inodes family returned a non-inode row at `{row_key}`"
                 ))),

--- a/crates/loonfs-core/src/checkpoint/frozen_floor.rs
+++ b/crates/loonfs-core/src/checkpoint/frozen_floor.rs
@@ -47,14 +47,14 @@ pub(super) fn unbinding_at_or_below_floor(
     row: &MetadataRow,
     retention_floor_seq: ChangeSeq,
 ) -> Option<BindingGeneration> {
-    let MetadataRow::DirentryUnbind {
+    let MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
         parent_inode_id,
         name_key,
         bind_seq,
         bind_delta_index,
         unbind_seq,
         ..
-    } = row
+    }) = row
     else {
         return None;
     };
@@ -79,13 +79,13 @@ pub(super) fn bind_survives_frozen_floor(
     retention_floor_seq: ChangeSeq,
     unbound_at_floor: &BTreeSet<BindingGeneration>,
 ) -> bool {
-    let MetadataRow::DirentryBind {
+    let MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
         parent_inode_id,
         name_key,
         bind_seq,
         bind_delta_index,
         ..
-    } = row
+    }) = row
     else {
         return true;
     };

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -62,6 +62,7 @@ pub use self::streaming_compaction::{
 
 pub(crate) use self::compaction_lease::{claim_compaction_prefix, CompactionPrefixOwner};
 pub(crate) use self::create::create_checkpoint;
+pub(crate) use self::data_block_load::DecodedRowWeight;
 pub(crate) use self::files::list_checkpoint_files_page;
 pub(crate) use self::flush::flush_wal;
 pub(crate) use self::list::list_checkpoints_page;

--- a/crates/loonfs-core/src/checkpoint/row.rs
+++ b/crates/loonfs-core/src/checkpoint/row.rs
@@ -1,10 +1,8 @@
 //! Converts in-memory metadata state into manifest rows, per family and in
 //! row-key order.
 
-use crate::metadata::{active_deletion_from_tombstone, ActiveDeletionAction, MetadataState};
-use loonfs_api::wire::manifest::{
-    ActiveDeletionRowAction, MetadataRow, MetadataRowFamily, TombstoneRowAction,
-};
+use crate::metadata::{active_deletion_from_tombstone, MetadataState};
+use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow, MetadataRowFamily};
 use loonfs_api::ChangeSeq;
 
 #[cfg(test)]
@@ -17,41 +15,6 @@ pub(super) fn metadata_states_equivalent(left: &MetadataState, right: &MetadataS
     })
 }
 
-fn tombstone_row_action(action: &crate::metadata::SubtreeTombstoneAction) -> TombstoneRowAction {
-    use crate::metadata::SubtreeTombstoneAction;
-    match action {
-        SubtreeTombstoneAction::Set { deleted_direntry } => TombstoneRowAction::Set {
-            deleted_direntry: deleted_direntry.clone(),
-        },
-        SubtreeTombstoneAction::Revoke { target } => TombstoneRowAction::Revoke { target: *target },
-    }
-}
-
-/// Projects one tombstone event onto its derived active-deletion row. The
-/// reducer itself lives beside the tombstone rules in `metadata::rows`; this
-/// is only the record-to-wire half.
-fn active_deletion_row(tombstone: &crate::metadata::SubtreeTombstoneRecord) -> MetadataRow {
-    let record = active_deletion_from_tombstone(tombstone);
-    MetadataRow::ActiveDeletion {
-        root_inode_id: record.root_inode_id,
-        deletion_seq: record.deletion_seq,
-        action: match record.action {
-            ActiveDeletionAction::Listed {
-                deleted_at_ms,
-                deleted_by,
-                deleted_direntry,
-            } => ActiveDeletionRowAction::Listed {
-                deleted_at_ms,
-                deleted_by,
-                deleted_direntry,
-            },
-            ActiveDeletionAction::Removed { revocation_seq } => {
-                ActiveDeletionRowAction::Removed { revocation_seq }
-            }
-        },
-    }
-}
-
 pub(super) fn manifest_rows_for_family(
     metadata_state: &MetadataState,
     family: MetadataRowFamily,
@@ -60,97 +23,50 @@ pub(super) fn manifest_rows_for_family(
         MetadataRowFamily::Inodes => metadata_state
             .inodes()
             .iter()
-            .map(|inode| MetadataRow::Inode {
-                inode_id: inode.inode_id,
-                inode_kind: inode.inode_kind,
-                created_seq: inode.created_seq,
-                commit_id: inode.commit_id.clone(),
-                created_by: inode.created_by.clone(),
-                created_at_ms: inode.created_at_ms,
-            })
+            .cloned()
+            .map(MetadataRow::Inode)
             .collect::<Vec<_>>(),
         MetadataRowFamily::DirentryBinds | MetadataRowFamily::DirentryChildBinds => metadata_state
             .direntry_binds()
             .iter()
-            .map(|direntry| MetadataRow::DirentryBind {
-                parent_inode_id: direntry.parent_inode_id,
-                name_key: direntry.name_key.clone(),
-                display_name: direntry.display_name.clone(),
-                child_inode_id: direntry.child_inode_id,
-                bind_seq: direntry.bind_seq,
-                bind_delta_index: direntry.bind_delta_index,
-            })
+            .cloned()
+            .map(MetadataRow::DirentryBind)
             .collect::<Vec<_>>(),
         MetadataRowFamily::DirentryUnbinds => metadata_state
             .direntry_unbinds()
             .iter()
-            .map(|unbind| MetadataRow::DirentryUnbind {
-                parent_inode_id: unbind.parent_inode_id,
-                name_key: unbind.name_key.clone(),
-                display_name: unbind.display_name.clone(),
-                child_inode_id: unbind.child_inode_id,
-                bind_seq: unbind.bind_seq,
-                bind_delta_index: unbind.bind_delta_index,
-                unbind_seq: unbind.unbind_seq,
-                unbind_delta_index: unbind.unbind_delta_index,
-            })
+            .cloned()
+            .map(MetadataRow::DirentryUnbind)
             .collect::<Vec<_>>(),
         MetadataRowFamily::Revisions | MetadataRowFamily::RevisionsByInodeDesc => metadata_state
             .revisions()
             .iter()
-            .map(|revision| MetadataRow::FileRevision {
-                inode_id: revision.inode_id,
-                revision_no: revision.revision_no,
-                committed_seq: revision.committed_seq,
-                commit_id: revision.commit_id.clone(),
-                committed_at_ms: revision.committed_at_ms,
-                committed_by: revision.committed_by.clone(),
-                delta_index: revision.revision_delta_index,
-                content_ref: revision.content_ref.clone(),
-            })
+            .cloned()
+            .map(MetadataRow::FileRevision)
             .collect::<Vec<_>>(),
         MetadataRowFamily::Tombstones => metadata_state
             .subtree_tombstones()
             .iter()
-            .map(|tombstone| MetadataRow::Tombstone {
-                root_inode_id: tombstone.root_inode_id,
-                generation: tombstone.generation,
-                commit_id: tombstone.commit_id.clone(),
-                action: tombstone_row_action(&tombstone.action),
-                deleted_at_ms: tombstone.deleted_at_ms,
-                deleted_by: tombstone.deleted_by.clone(),
-            })
+            .cloned()
+            .map(MetadataRow::Tombstone)
             .collect::<Vec<_>>(),
         MetadataRowFamily::ActiveDeletions => metadata_state
             .subtree_tombstones()
             .iter()
-            .map(active_deletion_row)
+            .map(active_deletion_from_tombstone)
+            .map(MetadataRow::ActiveDeletion)
             .collect::<Vec<_>>(),
         MetadataRowFamily::CommitReceipts => metadata_state
             .commit_receipts()
             .iter()
-            .map(|record| MetadataRow::CommitReceipt {
-                commit_id: record.commit_id.clone(),
-                committed_by: record.committed_by.clone(),
-                semantic_commit_fingerprint: record.semantic_commit_fingerprint.clone(),
-                committed_seq: record.committed_seq,
-                committed_at_ms: record.committed_at_ms,
-                message: record.message.clone(),
-            })
+            .cloned()
+            .map(MetadataRow::CommitReceipt)
             .collect::<Vec<_>>(),
         MetadataRowFamily::Attributes => metadata_state
             .attributes_revisions()
             .iter()
-            .map(|record| MetadataRow::AttributesRevision {
-                inode_id: record.inode_id,
-                attributes_revision_no: record.attributes_revision_no,
-                committed_seq: record.committed_seq,
-                commit_id: record.commit_id.clone(),
-                delta_index: record.delta_index,
-                updated_by: record.updated_by.clone(),
-                updated_at_ms: record.updated_at_ms,
-                attributes: record.attributes.clone(),
-            })
+            .cloned()
+            .map(MetadataRow::AttributesRevision)
             .collect::<Vec<_>>(),
     };
     rows.sort_by_key(|row| row.row_key_for_family(family));
@@ -170,36 +86,32 @@ pub(super) fn manifest_rows_for_family_after_seq(
 
 pub(super) fn manifest_row_commit_seq(row: &MetadataRow) -> ChangeSeq {
     match row {
-        MetadataRow::Inode { created_seq, .. } => *created_seq,
-        MetadataRow::DirentryBind { bind_seq, .. } => *bind_seq,
-        MetadataRow::DirentryUnbind { unbind_seq, .. } => *unbind_seq,
-        MetadataRow::FileRevision { committed_seq, .. } => *committed_seq,
-        MetadataRow::Tombstone { generation, .. } => generation.seq,
+        MetadataRow::Inode(record) => record.created_seq,
+        MetadataRow::DirentryBind(record) => record.bind_seq,
+        MetadataRow::DirentryUnbind(record) => record.unbind_seq,
+        MetadataRow::FileRevision(record) => record.committed_seq,
+        MetadataRow::Tombstone(record) => record.generation.seq,
         // A removal marker belongs to the run of the undelete that produced
         // it, not to the run of the deletion whose key it repeats.
-        MetadataRow::ActiveDeletion {
-            deletion_seq,
-            action,
-            ..
-        } => match action {
-            ActiveDeletionRowAction::Listed { .. } => *deletion_seq,
+        MetadataRow::ActiveDeletion(record) => match &record.action {
+            ActiveDeletionRowAction::Listed { .. } => record.deletion_seq,
             ActiveDeletionRowAction::Removed { revocation_seq } => *revocation_seq,
         },
-        MetadataRow::CommitReceipt { committed_seq, .. }
-        | MetadataRow::AttributesRevision { committed_seq, .. } => *committed_seq,
+        MetadataRow::CommitReceipt(record) => record.committed_seq,
+        MetadataRow::AttributesRevision(record) => record.committed_seq,
     }
 }
 
 #[cfg(test)]
 pub(super) fn manifest_row_kind(row: &MetadataRow) -> &'static str {
     match row {
-        MetadataRow::Inode { .. } => "inode",
-        MetadataRow::DirentryBind { .. } => "direntry_bind",
-        MetadataRow::DirentryUnbind { .. } => "direntry_unbind",
-        MetadataRow::FileRevision { .. } => "file_revision",
-        MetadataRow::Tombstone { .. } => "tombstone",
-        MetadataRow::ActiveDeletion { .. } => "active_deletion",
-        MetadataRow::CommitReceipt { .. } => "commit_receipt",
-        MetadataRow::AttributesRevision { .. } => "attributes_revision",
+        MetadataRow::Inode(_) => "inode",
+        MetadataRow::DirentryBind(_) => "direntry_bind",
+        MetadataRow::DirentryUnbind(_) => "direntry_unbind",
+        MetadataRow::FileRevision(_) => "file_revision",
+        MetadataRow::Tombstone(_) => "tombstone",
+        MetadataRow::ActiveDeletion(_) => "active_deletion",
+        MetadataRow::CommitReceipt(_) => "commit_receipt",
+        MetadataRow::AttributesRevision(_) => "attributes_revision",
     }
 }

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -1166,13 +1166,13 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
     /// below the floor cost one: a bind above the floor survives whatever
     /// retired it later.
     async fn reverse_bind_survives(&mut self, row: &MetadataRow) -> Result<bool> {
-        let MetadataRow::DirentryBind {
+        let MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
             parent_inode_id,
             name_key,
             bind_seq,
             bind_delta_index,
             ..
-        } = row
+        }) = row
         else {
             return Ok(true);
         };
@@ -1350,18 +1350,18 @@ mod tests {
     use loonfs_api::{ChangeSeq, DisplayName, InodeId, NameKey};
 
     fn bind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
-        MetadataRow::DirentryBind {
+        MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
             parent_inode_id: InodeId(parent),
             name_key: NameKey::parse(name).expect("name key"),
             display_name: DisplayName::parse(name).expect("display name"),
             child_inode_id: InodeId(42),
             bind_seq: ChangeSeq(bind_seq),
             bind_delta_index: 0,
-        }
+        })
     }
 
     fn unbind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
-        MetadataRow::DirentryUnbind {
+        MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
             parent_inode_id: InodeId(parent),
             name_key: NameKey::parse(name).expect("name key"),
             display_name: DisplayName::parse(name).expect("display name"),
@@ -1370,7 +1370,7 @@ mod tests {
             bind_delta_index: 0,
             unbind_seq: ChangeSeq(bind_seq + 1),
             unbind_delta_index: 0,
-        }
+        })
     }
 
     fn fold_row(digest: &mut RowDigest, row: &MetadataRow) {

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -7,8 +7,7 @@
 
 use super::*;
 use crate::metadata::{
-    active_tombstone_from_records, MetadataStateBuilder, SubtreeTombstoneAction,
-    SubtreeTombstoneRecord,
+    active_tombstone_from_records, MetadataStateBuilder, SubtreeTombstoneRecord, TombstoneRowAction,
 };
 use crate::path::read::{load_current_metadata_view, AttributeInclusion};
 use loonfs_api::v0::DirectoryBinding;
@@ -29,7 +28,7 @@ fn tombstone_set(root_inode_id: InodeId, seq: u64, name: &str) -> SubtreeTombsto
         commit_id: CommitId::parse(format!("c_tombstone_{seq}")).expect("commit id"),
         deleted_at_ms: 1_000 + seq,
         deleted_by: loonfs_api::ActorRef::loonfs_system(),
-        action: SubtreeTombstoneAction::Set {
+        action: TombstoneRowAction::Set {
             deleted_direntry: DeletedDirentry {
                 parent_inode_id: InodeId(1),
                 name_key: NameKey::parse(name).expect("name key"),
@@ -46,7 +45,7 @@ fn tombstone_revoke(root_inode_id: InodeId, seq: u64, target_seq: u64) -> Subtre
         commit_id: CommitId::parse(format!("c_tombstone_{seq}")).expect("commit id"),
         deleted_at_ms: 1_000 + seq,
         deleted_by: loonfs_api::ActorRef::loonfs_system(),
-        action: SubtreeTombstoneAction::Revoke {
+        action: TombstoneRowAction::Revoke {
             target: generation(target_seq),
         },
     }
@@ -68,14 +67,14 @@ fn active_deletion_rows(state: &MetadataState) -> Vec<(String, &'static str)> {
         .map(|row| {
             let row_key = row.row_key_for_family(ApiMetadataRowFamily::ActiveDeletions);
             let kind = match row {
-                MetadataRow::ActiveDeletion {
+                MetadataRow::ActiveDeletion(crate::metadata::ActiveDeletionRecord {
                     action: ActiveDeletionRowAction::Listed { .. },
                     ..
-                } => "listed",
-                MetadataRow::ActiveDeletion {
+                }) => "listed",
+                MetadataRow::ActiveDeletion(crate::metadata::ActiveDeletionRecord {
                     action: ActiveDeletionRowAction::Removed { .. },
                     ..
-                } => "removed",
+                }) => "removed",
                 other => panic!("unexpected row in the active-deletions family: {other:?}"),
             };
             (row_key, kind)
@@ -152,10 +151,10 @@ fn a_removal_carries_the_undeletes_sequence_so_it_lands_in_that_commits_run() {
     assert!(
         matches!(
             &delta_rows[0],
-            MetadataRow::ActiveDeletion {
+            MetadataRow::ActiveDeletion (crate::metadata::ActiveDeletionRecord {
                 action: ActiveDeletionRowAction::Removed { revocation_seq },
                 ..
-            } if *revocation_seq == ChangeSeq(9)
+            }) if *revocation_seq == ChangeSeq(9)
         ),
         "unexpected delta row: {:?}",
         delta_rows[0]
@@ -325,8 +324,8 @@ fn trash_by_walking_every_tombstone(state: &MetadataState, head_seq: ChangeSeq) 
         .filter_map(|(root_inode_id, records)| {
             let active = active_tombstone_from_records(records, head_seq)?;
             let deleted_direntry = match active.action {
-                SubtreeTombstoneAction::Set { deleted_direntry } => deleted_direntry,
-                SubtreeTombstoneAction::Revoke { .. } => {
+                TombstoneRowAction::Set { deleted_direntry } => deleted_direntry,
+                TombstoneRowAction::Revoke { .. } => {
                     panic!("the active tombstone is a set by construction")
                 }
             };

--- a/crates/loonfs-core/src/checkpoint/tests/attributes.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/attributes.rs
@@ -62,11 +62,11 @@ fn kept_revisions(
         .expect("family rows")
         .iter()
         .map(|row| match row {
-            MetadataRow::AttributesRevision {
+            MetadataRow::AttributesRevision(crate::metadata::AttributesRevisionRecord {
                 inode_id,
                 attributes_revision_no,
                 ..
-            } => (inode_id.0, attributes_revision_no.0),
+            }) => (inode_id.0, attributes_revision_no.0),
             other => panic!("unexpected row: {other:?}"),
         })
         .collect()
@@ -141,11 +141,11 @@ fn the_fold_keeps_a_latest_empty_revision() {
     assert!(
         matches!(
             kept.as_slice(),
-            [MetadataRow::AttributesRevision {
+            [MetadataRow::AttributesRevision (crate::metadata::AttributesRevisionRecord {
                 attributes_revision_no: AttributeRevisionNo(2),
                 attributes,
                 ..
-            }] if attributes.is_empty()
+            })] if attributes.is_empty()
         ),
         "only the cleared revision survives: {kept:?}"
     );

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -322,9 +322,9 @@ async fn segment_range_page_merges_base_and_delta_in_row_key_order() {
     let display_names = page
         .into_iter()
         .filter_map(|row| match row {
-            MetadataRow::DirentryBind { display_name, .. } => {
-                Some(display_name.as_str().to_owned())
-            }
+            MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
+                display_name, ..
+            }) => Some(display_name.as_str().to_owned()),
             _ => None,
         })
         .collect::<Vec<_>>();
@@ -426,7 +426,10 @@ async fn lookup_skips_segments_whose_filter_rules_the_name_out() {
     let docs_inode = docs_binds
         .iter()
         .find_map(|row| match row {
-            MetadataRow::DirentryBind { child_inode_id, .. } => Some(*child_inode_id),
+            MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
+                child_inode_id,
+                ..
+            }) => Some(*child_inode_id),
             _ => None,
         })
         .expect("docs directory bind");

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -348,7 +348,11 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
     );
     assert!(!receipts.is_empty());
     for row in &receipts {
-        if let MetadataRow::CommitReceipt { committed_seq, .. } = row {
+        if let MetadataRow::CommitReceipt(crate::metadata::CommitReceiptRecord {
+            committed_seq,
+            ..
+        }) = row
+        {
             assert!(
                 *committed_seq >= floor,
                 "receipt below floor survived: {committed_seq:?}"
@@ -357,7 +361,7 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
     }
     assert!(receipts.iter().any(|row| matches!(
         row,
-        MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq == floor
+        MetadataRow::CommitReceipt (crate::metadata::CommitReceiptRecord { committed_seq, .. }) if *committed_seq == floor
     )));
 
     let revisions = manifest_rows_for_family(
@@ -368,11 +372,11 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
     let checksum_two = Checksum::sha256(b"alpha two\n");
     assert!(revisions.iter().any(|row| matches!(
         row,
-        MetadataRow::FileRevision { content_ref, .. } if content_ref.checksum == checksum_one
+        MetadataRow::FileRevision (crate::metadata::RevisionRecord { content_ref, .. }) if content_ref.checksum == checksum_one
     )));
     assert!(revisions.iter().any(|row| matches!(
         row,
-        MetadataRow::FileRevision { content_ref, .. } if content_ref.checksum == checksum_two
+        MetadataRow::FileRevision (crate::metadata::RevisionRecord { content_ref, .. }) if content_ref.checksum == checksum_two
     )));
     let index_rows = manifest_rows_for_family(
         &materialized.metadata_state,
@@ -386,7 +390,7 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
     );
     assert!(!binds.iter().any(|row| matches!(
         row,
-        MetadataRow::DirentryBind { display_name, .. } if display_name.as_str() == "tmp.txt"
+        MetadataRow::DirentryBind (crate::metadata::DirentryBindRecord { display_name, .. }) if display_name.as_str() == "tmp.txt"
     )));
     let unbinds = manifest_rows_for_family(
         &materialized.metadata_state,
@@ -412,23 +416,27 @@ async fn a_base_rebuild_drops_what_the_floor_covers_and_keeps_what_it_does_not()
 #[test]
 fn drop_pass_keeps_the_floor_visible_binding_across_a_later_rename() {
     use std::collections::BTreeMap;
-    let bind = |seq: u64, delta: u32| MetadataRow::DirentryBind {
-        parent_inode_id: InodeId(1),
-        name_key: NameKey::parse("docs").expect("valid name key"),
-        display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
-        child_inode_id: InodeId(2),
-        bind_seq: ChangeSeq(seq),
-        bind_delta_index: delta,
+    let bind = |seq: u64, delta: u32| {
+        MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
+            parent_inode_id: InodeId(1),
+            name_key: NameKey::parse("docs").expect("valid name key"),
+            display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
+            child_inode_id: InodeId(2),
+            bind_seq: ChangeSeq(seq),
+            bind_delta_index: delta,
+        })
     };
-    let unbind = |bind_seq: u64, delta: u32, unbind_seq: u64| MetadataRow::DirentryUnbind {
-        parent_inode_id: InodeId(1),
-        name_key: NameKey::parse("docs").expect("valid name key"),
-        display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
-        child_inode_id: InodeId(2),
-        bind_seq: ChangeSeq(bind_seq),
-        bind_delta_index: delta,
-        unbind_seq: ChangeSeq(unbind_seq),
-        unbind_delta_index: 0,
+    let unbind = |bind_seq: u64, delta: u32, unbind_seq: u64| {
+        MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
+            parent_inode_id: InodeId(1),
+            name_key: NameKey::parse("docs").expect("valid name key"),
+            display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
+            child_inode_id: InodeId(2),
+            bind_seq: ChangeSeq(bind_seq),
+            bind_delta_index: delta,
+            unbind_seq: ChangeSeq(unbind_seq),
+            unbind_delta_index: 0,
+        })
     };
     let mut rows = BTreeMap::new();
     // bind at seq 1 is visible at the floor (1); the rename that supersedes
@@ -453,15 +461,17 @@ fn drop_pass_keeps_the_floor_visible_binding_across_a_later_rename() {
 #[test]
 fn drop_pass_resolves_same_seq_rebinds_by_delta_index() {
     use std::collections::BTreeMap;
-    let bind = |delta: u32| MetadataRow::DirentryBind {
-        parent_inode_id: InodeId(1),
-        name_key: NameKey::parse("docs").expect("valid name key"),
-        display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
-        child_inode_id: InodeId(2),
-        bind_seq: ChangeSeq(1),
-        bind_delta_index: delta,
+    let bind = |delta: u32| {
+        MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
+            parent_inode_id: InodeId(1),
+            name_key: NameKey::parse("docs").expect("valid name key"),
+            display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
+            child_inode_id: InodeId(2),
+            bind_seq: ChangeSeq(1),
+            bind_delta_index: delta,
+        })
     };
-    let unbind = MetadataRow::DirentryUnbind {
+    let unbind = MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
         parent_inode_id: InodeId(1),
         name_key: NameKey::parse("docs").expect("valid name key"),
         display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
@@ -470,7 +480,7 @@ fn drop_pass_resolves_same_seq_rebinds_by_delta_index() {
         bind_delta_index: 0,
         unbind_seq: ChangeSeq(1),
         unbind_delta_index: 1,
-    };
+    });
     let mut rows = BTreeMap::new();
     rows.insert(ApiMetadataRowFamily::DirentryBinds, vec![bind(0), bind(2)]);
     rows.insert(
@@ -491,10 +501,10 @@ fn drop_pass_resolves_same_seq_rebinds_by_delta_index() {
         assert_eq!(kept.len(), 1);
         assert!(matches!(
             kept[0],
-            MetadataRow::DirentryBind {
+            MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
                 bind_delta_index: 2,
                 ..
-            }
+            })
         ));
     }
     assert!(rows[&ApiMetadataRowFamily::DirentryUnbinds].is_empty());
@@ -503,13 +513,15 @@ fn drop_pass_resolves_same_seq_rebinds_by_delta_index() {
 #[test]
 fn drop_pass_refuses_superseded_bind_without_unbind() {
     use std::collections::BTreeMap;
-    let bind = |delta: u32| MetadataRow::DirentryBind {
-        parent_inode_id: InodeId(1),
-        name_key: NameKey::parse("docs").expect("valid name key"),
-        display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
-        child_inode_id: InodeId(2),
-        bind_seq: ChangeSeq(1),
-        bind_delta_index: delta,
+    let bind = |delta: u32| {
+        MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
+            parent_inode_id: InodeId(1),
+            name_key: NameKey::parse("docs").expect("valid name key"),
+            display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
+            child_inode_id: InodeId(2),
+            bind_seq: ChangeSeq(1),
+            bind_delta_index: delta,
+        })
     };
     let mut rows = BTreeMap::new();
     rows.insert(ApiMetadataRowFamily::DirentryBinds, vec![bind(0), bind(1)]);
@@ -544,7 +556,7 @@ async fn bounded_subset_rebuild_rejects_divergent_revision_index() {
     let (_, mut manifest, mut revision_index_rows) =
         revision_index_test_materialization(&store, &namespace_id, &context).await;
     let first = revision_index_rows.first_mut().expect("revision index row");
-    if let MetadataRow::FileRevision { content_ref, .. } = first {
+    if let MetadataRow::FileRevision(crate::metadata::RevisionRecord { content_ref, .. }) = first {
         content_ref.content_id = ContentId::generate();
     }
     rewrite_revision_index_segment(&store, &namespace_id, &mut manifest, revision_index_rows).await;
@@ -1070,7 +1082,7 @@ async fn manifest_rejects_a_revision_desc_index_that_disagrees_with_its_family()
             |rows| {
                 let extra = rows.first().expect("revision index row").clone();
                 rows.push(match extra {
-                    MetadataRow::FileRevision {
+                    MetadataRow::FileRevision(crate::metadata::RevisionRecord {
                         inode_id,
                         revision_no,
                         committed_seq,
@@ -1079,7 +1091,7 @@ async fn manifest_rejects_a_revision_desc_index_that_disagrees_with_its_family()
                         committed_by,
                         delta_index,
                         content_ref,
-                    } => MetadataRow::FileRevision {
+                    }) => MetadataRow::FileRevision(crate::metadata::RevisionRecord {
                         inode_id,
                         revision_no: loonfs_api::RevisionNo(revision_no.0 + 100),
                         committed_seq,
@@ -1088,7 +1100,7 @@ async fn manifest_rejects_a_revision_desc_index_that_disagrees_with_its_family()
                         committed_by,
                         delta_index,
                         content_ref,
-                    },
+                    }),
                     other => other,
                 });
             },
@@ -1098,7 +1110,11 @@ async fn manifest_rejects_a_revision_desc_index_that_disagrees_with_its_family()
             "changed content ref",
             |rows| {
                 let first = rows.first_mut().expect("revision index row");
-                if let MetadataRow::FileRevision { content_ref, .. } = first {
+                if let MetadataRow::FileRevision(crate::metadata::RevisionRecord {
+                    content_ref,
+                    ..
+                }) = first
+                {
                     content_ref.content_id = ContentId::generate();
                 }
             },

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -147,7 +147,7 @@ fn metadata_states_equivalent_ignoring_content_identity(
                 let rows = manifest_rows_for_family(state, family)
                     .into_iter()
                     .map(|row| match row {
-                        MetadataRow::FileRevision {
+                        MetadataRow::FileRevision(crate::metadata::RevisionRecord {
                             inode_id,
                             revision_no,
                             committed_seq,
@@ -156,7 +156,7 @@ fn metadata_states_equivalent_ignoring_content_identity(
                             committed_by,
                             delta_index,
                             content_ref,
-                        } => MetadataRow::FileRevision {
+                        }) => MetadataRow::FileRevision(crate::metadata::RevisionRecord {
                             inode_id,
                             revision_no,
                             committed_seq,
@@ -171,22 +171,22 @@ fn metadata_states_equivalent_ignoring_content_identity(
                                 .expect("placeholder content id"),
                                 ..content_ref
                             },
-                        },
-                        MetadataRow::CommitReceipt {
+                        }),
+                        MetadataRow::CommitReceipt(crate::metadata::CommitReceiptRecord {
                             commit_id,
                             committed_by,
                             semantic_commit_fingerprint: _,
                             committed_seq,
                             committed_at_ms,
                             message,
-                        } => MetadataRow::CommitReceipt {
+                        }) => MetadataRow::CommitReceipt(crate::metadata::CommitReceiptRecord {
                             commit_id,
                             committed_by,
                             semantic_commit_fingerprint: "<normalized>".to_owned(),
                             committed_seq,
                             committed_at_ms,
                             message,
-                        },
+                        }),
                         other => other,
                     })
                     .collect::<Vec<_>>();

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -415,11 +415,11 @@ async fn undelete_newest_deletion<S: ObjectStore + ?Sized>(
     let (root_inode_id, deletion_seq) = rows[&ApiMetadataRowFamily::ActiveDeletions]
         .iter()
         .filter_map(|row| match row {
-            MetadataRow::ActiveDeletion {
+            MetadataRow::ActiveDeletion(crate::metadata::ActiveDeletionRecord {
                 root_inode_id,
                 deletion_seq,
                 action: ActiveDeletionRowAction::Listed { .. },
-            } => Some((*root_inode_id, *deletion_seq)),
+            }) => Some((*root_inode_id, *deletion_seq)),
             _ => None,
         })
         .max_by_key(|(_, deletion_seq)| *deletion_seq)
@@ -1203,7 +1203,7 @@ async fn a_background_compaction_and_a_step_contained_merge_reach_the_same_rows(
     let reverse_rows_at_or_below_floor = before[&ApiMetadataRowFamily::DirentryChildBinds]
         .iter()
         .filter(|row| {
-            matches!(row, MetadataRow::DirentryBind { bind_seq, .. } if *bind_seq <= frozen_floor_seq)
+            matches!(row, MetadataRow::DirentryBind (crate::metadata::DirentryBindRecord { bind_seq, .. }) if *bind_seq <= frozen_floor_seq)
         })
         .count() as u64;
     assert!(
@@ -1760,24 +1760,28 @@ async fn install_synthetic_bindings_base(
         let scrambled = index.wrapping_mul(2_654_435_761) % count;
         let name = format!("g{scrambled:012}");
         let delta = u32::try_from(index).expect("test generation counts are small");
-        binds.push(MetadataRow::DirentryBind {
-            parent_inode_id: parent,
-            name_key: NameKey::parse(&name).expect("name key"),
-            display_name: loonfs_api::DisplayName::parse(&name).expect("display name"),
-            child_inode_id: InodeId(100_000 + index),
-            bind_seq: ChangeSeq(1),
-            bind_delta_index: delta,
-        });
-        unbinds.push(MetadataRow::DirentryUnbind {
-            parent_inode_id: parent,
-            name_key: NameKey::parse(&name).expect("name key"),
-            display_name: loonfs_api::DisplayName::parse(&name).expect("display name"),
-            child_inode_id: InodeId(100_000 + index),
-            bind_seq: ChangeSeq(1),
-            bind_delta_index: delta,
-            unbind_seq: ChangeSeq(2),
-            unbind_delta_index: delta,
-        });
+        binds.push(MetadataRow::DirentryBind(
+            crate::metadata::DirentryBindRecord {
+                parent_inode_id: parent,
+                name_key: NameKey::parse(&name).expect("name key"),
+                display_name: loonfs_api::DisplayName::parse(&name).expect("display name"),
+                child_inode_id: InodeId(100_000 + index),
+                bind_seq: ChangeSeq(1),
+                bind_delta_index: delta,
+            },
+        ));
+        unbinds.push(MetadataRow::DirentryUnbind(
+            crate::metadata::DirentryUnbindRecord {
+                parent_inode_id: parent,
+                name_key: NameKey::parse(&name).expect("name key"),
+                display_name: loonfs_api::DisplayName::parse(&name).expect("display name"),
+                child_inode_id: InodeId(100_000 + index),
+                bind_seq: ChangeSeq(1),
+                bind_delta_index: delta,
+                unbind_seq: ChangeSeq(2),
+                unbind_delta_index: delta,
+            },
+        ));
     }
 
     let mut manifest = load_current_manifest_segments(store, namespace_id)
@@ -2527,12 +2531,14 @@ async fn one_directory_far_past_the_row_budget_streams_a_row_at_a_time() {
     ] {
         for row in &before[&family] {
             match row {
-                MetadataRow::DirentryBind {
-                    parent_inode_id, ..
-                }
-                | MetadataRow::DirentryUnbind {
-                    parent_inode_id, ..
-                } => *rows_per_parent.entry(*parent_inode_id).or_default() += 1,
+                MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
+                    parent_inode_id,
+                    ..
+                })
+                | MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
+                    parent_inode_id,
+                    ..
+                }) => *rows_per_parent.entry(*parent_inode_id).or_default() += 1,
                 _ => {}
             }
         }
@@ -2701,7 +2707,7 @@ fn unbinds_at_or_below(
     rows[&ApiMetadataRowFamily::DirentryUnbinds]
         .iter()
         .filter(|row| {
-            matches!(row, MetadataRow::DirentryUnbind { unbind_seq, .. } if *unbind_seq <= floor_seq)
+            matches!(row, MetadataRow::DirentryUnbind (crate::metadata::DirentryUnbindRecord { unbind_seq, .. }) if *unbind_seq <= floor_seq)
         })
         .count()
 }

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -402,7 +402,11 @@ pub(super) async fn collect_referenced_content<S: ObjectStore + ?Sized>(
                 None => break,
             }
             for (_, row) in rows {
-                if let MetadataRow::FileRevision { content_ref, .. } = row {
+                if let MetadataRow::FileRevision(crate::metadata::RevisionRecord {
+                    content_ref,
+                    ..
+                }) = row
+                {
                     referenced.insert(content_ref.content_id);
                 }
             }

--- a/crates/loonfs-core/src/metadata/apply.rs
+++ b/crates/loonfs-core/src/metadata/apply.rs
@@ -3,7 +3,7 @@
 
 use super::{
     AttributesRevisionRecord, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
-    InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneAction, SubtreeTombstoneRecord,
+    InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneRecord, TombstoneRowAction,
 };
 use loonfs_api::wire::manifest::TombstoneGeneration;
 use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalDelta};
@@ -127,7 +127,7 @@ impl MetadataState {
                     commit_id: commit_id.clone(),
                     committed_at_ms,
                     committed_by: actor.clone(),
-                    revision_delta_index: *delta_index,
+                    delta_index: *delta_index,
                     content_ref: content_ref.clone(),
                 });
             }
@@ -145,7 +145,7 @@ impl MetadataState {
                     commit_id: commit_id.clone(),
                     deleted_at_ms: committed_at_ms,
                     deleted_by: actor.clone(),
-                    action: SubtreeTombstoneAction::Set {
+                    action: TombstoneRowAction::Set {
                         deleted_direntry: deleted_direntry.clone(),
                     },
                 });
@@ -164,7 +164,7 @@ impl MetadataState {
                     commit_id: commit_id.clone(),
                     deleted_at_ms: committed_at_ms,
                     deleted_by: actor.clone(),
-                    action: SubtreeTombstoneAction::Revoke { target: *target },
+                    action: TombstoneRowAction::Revoke { target: *target },
                 });
             }
             WalDelta::AppendAttributesRevision {

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -1,10 +1,10 @@
 //! At-head indexes over the in-memory metadata rows, maintained
 //! incrementally as deltas apply so head reads skip the row scans.
 
-use super::visibility::unbind_matches_binding;
+use super::visibility::{same_binding, unbind_matches_binding};
 use super::{
     AttributesRevisionRecord, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
-    InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneAction, SubtreeTombstoneRecord,
+    InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneRecord, TombstoneRowAction,
 };
 use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -70,7 +70,7 @@ impl MetadataIndexes {
             let Some(latest_child_bind) = latest_by_child.get(&bind.child_inode_id) else {
                 continue;
             };
-            if !bind.same_binding(latest_child_bind) {
+            if !same_binding(bind, latest_child_bind) {
                 continue;
             }
             indexes
@@ -144,7 +144,7 @@ impl MetadataIndexes {
         // a revoke as the newest record means no tombstone is active.
         self.tombstone_by_root
             .get(&root_inode_id)
-            .filter(|tombstone| matches!(tombstone.action, SubtreeTombstoneAction::Set { .. }))
+            .filter(|tombstone| matches!(tombstone.action, TombstoneRowAction::Set { .. }))
             .cloned()
     }
 
@@ -357,7 +357,7 @@ fn remove_active_parent_if_same(
 ) {
     if active_parent_by_child
         .get(&record.child_inode_id)
-        .is_some_and(|active| active.same_binding(record))
+        .is_some_and(|active| same_binding(active, record))
     {
         active_parent_by_child.remove(&record.child_inode_id);
     }
@@ -370,7 +370,7 @@ fn remove_active_child_if_same(
     let key = (record.parent_inode_id, record.name_key.clone());
     if active_child_by_parent_name
         .get(&key)
-        .is_some_and(|active| active.same_binding(record))
+        .is_some_and(|active| same_binding(active, record))
     {
         active_child_by_parent_name.remove(&key);
     }

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -18,18 +18,18 @@ mod view_session;
 mod visibility;
 
 pub use self::queries::{ResolvedVisiblePath, VisiblePathError};
-pub use self::rows::{
+pub use self::rows::MetadataState;
+pub use loonfs_api::wire::manifest::{
     AttributesRevisionRecord, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
-    InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneAction, SubtreeTombstoneRecord,
+    InodeRecord, RevisionRecord, SubtreeTombstoneRecord, TombstoneRowAction,
 };
 
 pub(crate) use self::durable_cache::DurableVisibilityCache;
 /// Newest-event-wins tombstone selection used by differential tests.
 #[cfg(test)]
 pub(crate) use self::rows::active_tombstone_from_records;
-pub(crate) use self::rows::content_ref_evidence_bytes;
 pub(crate) use self::rows::{
-    active_deletion_from_tombstone, ActiveDeletionAction, ActiveDeletionRecord, RecoverableDeletion,
+    active_deletion_from_tombstone, recoverable_deletion_from_active_record, RecoverableDeletion,
 };
 #[cfg(test)]
 pub(crate) use self::view::InMemoryMetadataView;
@@ -38,7 +38,8 @@ pub(crate) use self::view_session::{
     LeafRevisionPrefetch, MetadataViewSession, VisibleChildEntry,
     METADATA_VIEW_SESSION_COUNTER_FIELDS,
 };
-pub(crate) use self::visibility::{unbind_matches_binding, BindingIdentity};
+pub(crate) use self::visibility::{binding_generation, unbind_matches_binding, BindingIdentity};
+pub(crate) use loonfs_api::wire::manifest::ActiveDeletionRecord;
 
 #[cfg(test)]
 pub(crate) use self::rows::MetadataStateBuilder;

--- a/crates/loonfs-core/src/metadata/row_decode.rs
+++ b/crates/loonfs-core/src/metadata/row_decode.rs
@@ -6,11 +6,10 @@
 
 use crate::error::CoreError;
 use crate::metadata::{
-    ActiveDeletionAction, ActiveDeletionRecord, AttributesRevisionRecord, CommitReceiptRecord,
-    DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord, SubtreeTombstoneAction,
-    SubtreeTombstoneRecord,
+    ActiveDeletionRecord, AttributesRevisionRecord, CommitReceiptRecord, DirentryBindRecord,
+    DirentryUnbindRecord, InodeRecord, RevisionRecord, SubtreeTombstoneRecord,
 };
-use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow, TombstoneRowAction};
+use loonfs_api::wire::manifest::MetadataRow;
 
 /// The scanned segment can only hold `expected_kind` rows; the foreign row's
 /// self-keyed row key names its actual kind and identity.
@@ -23,21 +22,7 @@ fn foreign_row(expected_kind: &str, row: &MetadataRow) -> CoreError {
 
 pub(crate) fn inode_from_manifest_row(row: MetadataRow) -> Result<InodeRecord, CoreError> {
     match row {
-        MetadataRow::Inode {
-            inode_id,
-            inode_kind,
-            created_seq,
-            commit_id,
-            created_by,
-            created_at_ms,
-        } => Ok(InodeRecord {
-            inode_id,
-            inode_kind,
-            created_seq,
-            commit_id,
-            created_by,
-            created_at_ms,
-        }),
+        MetadataRow::Inode(record) => Ok(record),
         other => Err(foreign_row("inode", &other)),
     }
 }
@@ -46,21 +31,7 @@ pub(crate) fn direntry_bind_from_manifest_row(
     row: MetadataRow,
 ) -> Result<DirentryBindRecord, CoreError> {
     match row {
-        MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            display_name,
-            child_inode_id,
-            bind_seq,
-            bind_delta_index,
-        } => Ok(DirentryBindRecord {
-            parent_inode_id,
-            name_key,
-            display_name,
-            child_inode_id,
-            bind_seq,
-            bind_delta_index,
-        }),
+        MetadataRow::DirentryBind(record) => Ok(record),
         other => Err(foreign_row("direntry_bind", &other)),
     }
 }
@@ -69,60 +40,15 @@ pub(crate) fn direntry_unbind_from_manifest_row(
     row: MetadataRow,
 ) -> Result<DirentryUnbindRecord, CoreError> {
     match row {
-        MetadataRow::DirentryUnbind {
-            parent_inode_id,
-            name_key,
-            display_name,
-            child_inode_id,
-            bind_seq,
-            bind_delta_index,
-            unbind_seq,
-            unbind_delta_index,
-        } => Ok(DirentryUnbindRecord {
-            parent_inode_id,
-            name_key,
-            display_name,
-            child_inode_id,
-            bind_seq,
-            bind_delta_index,
-            unbind_seq,
-            unbind_delta_index,
-        }),
+        MetadataRow::DirentryUnbind(record) => Ok(record),
         other => Err(foreign_row("direntry_unbind", &other)),
     }
 }
 
 pub(crate) fn revision_from_manifest_row(row: MetadataRow) -> Result<RevisionRecord, CoreError> {
     match row {
-        MetadataRow::FileRevision {
-            inode_id,
-            revision_no,
-            committed_seq,
-            commit_id,
-            committed_at_ms,
-            committed_by,
-            delta_index,
-            content_ref,
-        } => Ok(RevisionRecord {
-            inode_id,
-            revision_no,
-            committed_seq,
-            commit_id,
-            committed_at_ms,
-            committed_by,
-            revision_delta_index: delta_index,
-            content_ref,
-        }),
+        MetadataRow::FileRevision(record) => Ok(record),
         other => Err(foreign_row("file_revision", &other)),
-    }
-}
-
-fn subtree_tombstone_action(action: TombstoneRowAction) -> SubtreeTombstoneAction {
-    match action {
-        TombstoneRowAction::Set { deleted_direntry } => {
-            SubtreeTombstoneAction::Set { deleted_direntry }
-        }
-        TombstoneRowAction::Revoke { target } => SubtreeTombstoneAction::Revoke { target },
     }
 }
 
@@ -130,21 +56,7 @@ pub(crate) fn tombstone_from_manifest_row(
     row: MetadataRow,
 ) -> Result<SubtreeTombstoneRecord, CoreError> {
     match row {
-        MetadataRow::Tombstone {
-            root_inode_id,
-            generation,
-            commit_id,
-            action,
-            deleted_at_ms,
-            deleted_by,
-        } => Ok(SubtreeTombstoneRecord {
-            root_inode_id,
-            generation,
-            commit_id,
-            deleted_at_ms,
-            deleted_by,
-            action: subtree_tombstone_action(action),
-        }),
+        MetadataRow::Tombstone(record) => Ok(record),
         other => Err(foreign_row("tombstone", &other)),
     }
 }
@@ -153,28 +65,7 @@ pub(crate) fn active_deletion_from_manifest_row(
     row: MetadataRow,
 ) -> Result<ActiveDeletionRecord, CoreError> {
     match row {
-        MetadataRow::ActiveDeletion {
-            root_inode_id,
-            deletion_seq,
-            action,
-        } => Ok(ActiveDeletionRecord {
-            root_inode_id,
-            deletion_seq,
-            action: match action {
-                ActiveDeletionRowAction::Listed {
-                    deleted_at_ms,
-                    deleted_by,
-                    deleted_direntry,
-                } => ActiveDeletionAction::Listed {
-                    deleted_at_ms,
-                    deleted_by,
-                    deleted_direntry,
-                },
-                ActiveDeletionRowAction::Removed { revocation_seq } => {
-                    ActiveDeletionAction::Removed { revocation_seq }
-                }
-            },
-        }),
+        MetadataRow::ActiveDeletion(record) => Ok(record),
         other => Err(foreign_row("active_deletion", &other)),
     }
 }
@@ -183,21 +74,7 @@ pub(crate) fn commit_receipt_from_manifest_row(
     row: MetadataRow,
 ) -> Result<CommitReceiptRecord, CoreError> {
     match row {
-        MetadataRow::CommitReceipt {
-            commit_id,
-            committed_by,
-            semantic_commit_fingerprint,
-            committed_seq,
-            committed_at_ms,
-            message,
-        } => Ok(CommitReceiptRecord {
-            commit_id,
-            committed_by,
-            semantic_commit_fingerprint,
-            committed_seq,
-            committed_at_ms,
-            message,
-        }),
+        MetadataRow::CommitReceipt(record) => Ok(record),
         other => Err(foreign_row("commit_receipt", &other)),
     }
 }
@@ -206,25 +83,7 @@ pub(crate) fn attributes_revision_from_manifest_row(
     row: MetadataRow,
 ) -> Result<AttributesRevisionRecord, CoreError> {
     match row {
-        MetadataRow::AttributesRevision {
-            inode_id,
-            attributes_revision_no,
-            committed_seq,
-            commit_id,
-            delta_index,
-            updated_by,
-            updated_at_ms,
-            attributes,
-        } => Ok(AttributesRevisionRecord {
-            inode_id,
-            attributes_revision_no,
-            committed_seq,
-            commit_id,
-            delta_index,
-            updated_by,
-            updated_at_ms,
-            attributes,
-        }),
+        MetadataRow::AttributesRevision(record) => Ok(record),
         other => Err(foreign_row("attributes_revision", &other)),
     }
 }
@@ -232,18 +91,18 @@ pub(crate) fn attributes_revision_from_manifest_row(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_api::wire::manifest::TombstoneGeneration;
+    use loonfs_api::wire::manifest::{TombstoneGeneration, TombstoneRowAction};
     use loonfs_api::{ChangeSeq, CommitId, InodeId};
 
     fn foreign() -> MetadataRow {
-        MetadataRow::Inode {
+        MetadataRow::Inode(InodeRecord {
             inode_id: InodeId(7),
             inode_kind: loonfs_api::InodeKind::File,
             created_seq: ChangeSeq(3),
             commit_id: CommitId::parse("c_foreign_inode").expect("commit id"),
             created_by: loonfs_api::ActorRef::loonfs_system(),
             created_at_ms: 4_000,
-        }
+        })
     }
 
     #[test]
@@ -263,7 +122,7 @@ mod tests {
         assert!(tombstone_from_manifest_row(foreign()).is_err());
         assert!(commit_receipt_from_manifest_row(foreign()).is_err());
         assert!(attributes_revision_from_manifest_row(foreign()).is_err());
-        let tombstone = MetadataRow::Tombstone {
+        let tombstone = MetadataRow::Tombstone(SubtreeTombstoneRecord {
             root_inode_id: InodeId(1),
             generation: TombstoneGeneration {
                 seq: ChangeSeq(1),
@@ -280,7 +139,7 @@ mod tests {
             },
             deleted_at_ms: 4_000,
             deleted_by: loonfs_api::ActorRef::loonfs_system(),
-        };
+        });
         assert!(inode_from_manifest_row(tombstone).is_err());
     }
 }

--- a/crates/loonfs-core/src/metadata/rows.rs
+++ b/crates/loonfs-core/src/metadata/rows.rs
@@ -1,16 +1,14 @@
-//! Metadata row records plus the append and accounting plumbing that keeps
-//! [`MetadataState`]'s derived indexes and decoded-size totals in step with
-//! its append-only rows.
+//! Metadata state plus the append and accounting logic that keeps its
+//! indexes and decoded-size totals in step with its rows.
 
 use super::indexes::MetadataIndexes;
-use crate::binding_generation::BindingGeneration;
-use loonfs_api::wire::manifest::{lookup_keys, DeletedDirentry, TombstoneGeneration};
-use loonfs_api::{
-    ActorRef, AttributeRevisionNo, Attributes, ChangeSeq, CommitId, ContentRef, DisplayName,
-    InodeId, InodeKind, NameKey, RevisionNo,
+use crate::checkpoint::DecodedRowWeight;
+use loonfs_api::wire::manifest::{
+    ActiveDeletionRecord, ActiveDeletionRowAction, AttributesRevisionRecord, CommitReceiptRecord,
+    DeletedDirentry, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
+    SubtreeTombstoneRecord, TombstoneRowAction,
 };
-use serde::{Deserialize, Serialize};
-use std::mem::size_of;
+use loonfs_api::{ActorRef, ChangeSeq, CommitId, InodeId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataState {
@@ -40,96 +38,6 @@ impl Default for MetadataState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct InodeRecord {
-    pub inode_id: InodeId,
-    pub inode_kind: InodeKind,
-    pub created_seq: ChangeSeq,
-    /// Commit ID associated with this row.
-    pub commit_id: CommitId,
-    pub created_by: ActorRef,
-    /// Time the inode was created, in Unix milliseconds. `created_seq`
-    /// determines order.
-    pub created_at_ms: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DirentryBindRecord {
-    pub parent_inode_id: InodeId,
-    pub name_key: NameKey,
-    pub display_name: DisplayName,
-    pub child_inode_id: InodeId,
-    pub bind_seq: ChangeSeq,
-    pub bind_delta_index: u32,
-}
-
-impl DirentryBindRecord {
-    pub(crate) fn generation(&self) -> BindingGeneration {
-        BindingGeneration {
-            bind_seq: self.bind_seq,
-            bind_delta_index: self.bind_delta_index,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DirentryUnbindRecord {
-    pub parent_inode_id: InodeId,
-    pub name_key: NameKey,
-    /// User-facing spelling the retired binding carried: while the unbind
-    /// row is retained, it is the durable home of a deleted name.
-    pub display_name: DisplayName,
-    pub child_inode_id: InodeId,
-    pub bind_seq: ChangeSeq,
-    pub bind_delta_index: u32,
-    pub unbind_seq: ChangeSeq,
-    pub unbind_delta_index: u32,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RevisionRecord {
-    pub inode_id: InodeId,
-    pub revision_no: RevisionNo,
-    pub committed_seq: ChangeSeq,
-    /// Commit ID associated with this row.
-    pub commit_id: CommitId,
-    /// Observational wall-clock stamp of the owning commit; never a
-    /// validity input — `committed_seq` is the order.
-    pub committed_at_ms: u64,
-    pub committed_by: ActorRef,
-    pub revision_delta_index: u32,
-    pub content_ref: ContentRef,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SubtreeTombstoneRecord {
-    pub root_inode_id: InodeId,
-    /// This event's own generation: the delete's committed position for a
-    /// `Set`, the undelete's for a `Revoke`.
-    pub generation: TombstoneGeneration,
-    /// Commit ID associated with this row.
-    pub commit_id: CommitId,
-    /// Wall-clock stamp of the recording commit.
-    pub deleted_at_ms: u64,
-    pub deleted_by: ActorRef,
-    /// Event action. The newest generation determines whether the deletion is
-    /// active.
-    pub action: SubtreeTombstoneAction,
-}
-
-/// The tombstone family's event vocabulary — an explicit state machine
-/// instead of a boolean, so every reader matches exhaustively and a revoke
-/// names the exact deletion generation it cancels.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum SubtreeTombstoneAction {
-    /// The subtree rooted here is deleted. The tombstone row is immortal, so
-    /// this is where the removed binding lives after unbind rows age out.
-    Set { deleted_direntry: DeletedDirentry },
-    /// The deletion recorded at `target` is revoked. Validation guarantees
-    /// the target was the active generation when the revoke committed.
-    Revoke { target: TombstoneGeneration },
-}
-
 /// The newest-event-wins active-tombstone rule, shared by every aggregation
 /// site: among records at or below `visible_seq`, the newest generation
 /// speaks for the root — a `Set` newest means that deletion is active, a
@@ -150,36 +58,7 @@ pub(crate) fn active_tombstone_from_records(
         .into_iter()
         .filter(|tombstone| tombstone.generation.seq <= visible_seq)
         .max_by_key(|tombstone| tombstone.generation)
-        .filter(|tombstone| matches!(tombstone.action, SubtreeTombstoneAction::Set { .. }))
-}
-
-/// One row of the derived `ActiveDeletions` family: the current-state view of
-/// a single deletion generation.
-///
-/// Nothing appends these — [`active_deletion_from_tombstone`] derives one from
-/// every tombstone event, so the family is a projection of the tombstone
-/// family and never a second source of truth.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ActiveDeletionRecord {
-    pub(crate) root_inode_id: InodeId,
-    /// The deletion's committed sequence. Together with `root_inode_id` this
-    /// is the handle `undelete` addresses and the trash entry renders.
-    pub(crate) deletion_seq: ChangeSeq,
-    pub(crate) action: ActiveDeletionAction,
-}
-
-/// Data stored for one active-deletion generation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ActiveDeletionAction {
-    /// The deletion is recoverable, and the trash lists it with these
-    /// details.
-    Listed {
-        deleted_at_ms: u64,
-        deleted_by: ActorRef,
-        deleted_direntry: DeletedDirentry,
-    },
-    /// An undelete cancelled the deletion, so the listing skips the key.
-    Removed { revocation_seq: ChangeSeq },
+        .filter(|tombstone| matches!(tombstone.action, TombstoneRowAction::Set { .. }))
 }
 
 /// Converts a tombstone event into its derived `ActiveDeletions` row. A `set`
@@ -195,56 +74,41 @@ pub(crate) fn active_deletion_from_tombstone(
     tombstone: &SubtreeTombstoneRecord,
 ) -> ActiveDeletionRecord {
     match &tombstone.action {
-        SubtreeTombstoneAction::Set { deleted_direntry } => ActiveDeletionRecord {
+        TombstoneRowAction::Set { deleted_direntry } => ActiveDeletionRecord {
             root_inode_id: tombstone.root_inode_id,
             deletion_seq: tombstone.generation.seq,
-            action: ActiveDeletionAction::Listed {
+            action: ActiveDeletionRowAction::Listed {
                 deleted_at_ms: tombstone.deleted_at_ms,
                 deleted_by: tombstone.deleted_by.clone(),
                 deleted_direntry: deleted_direntry.clone(),
             },
         },
-        SubtreeTombstoneAction::Revoke { target } => ActiveDeletionRecord {
+        TombstoneRowAction::Revoke { target } => ActiveDeletionRecord {
             root_inode_id: tombstone.root_inode_id,
             deletion_seq: target.seq,
-            action: ActiveDeletionAction::Removed {
+            action: ActiveDeletionRowAction::Removed {
                 revocation_seq: tombstone.generation.seq,
             },
         },
     }
 }
 
-impl ActiveDeletionRecord {
-    /// This row's durable key, which is also its position in the trash
-    /// listing's order.
-    pub(crate) fn row_key(&self) -> String {
-        lookup_keys::active_deletion_row_key(
-            self.deletion_seq,
-            self.root_inode_id,
-            match &self.action {
-                ActiveDeletionAction::Listed { .. } => lookup_keys::ACTIVE_DELETION_RANK_LISTED,
-                ActiveDeletionAction::Removed { .. } => lookup_keys::ACTIVE_DELETION_RANK_REMOVED,
-            },
-        )
-    }
-
-    /// The deletion this row lists, or `None` when the row is an undelete's
-    /// removal marker.
-    pub(crate) fn into_recoverable(self) -> Option<RecoverableDeletion> {
-        match self.action {
-            ActiveDeletionAction::Listed {
-                deleted_at_ms,
-                deleted_by,
-                deleted_direntry,
-            } => Some(RecoverableDeletion {
-                root_inode_id: self.root_inode_id,
-                deletion_seq: self.deletion_seq,
-                deleted_at_ms,
-                deleted_by,
-                deleted_direntry,
-            }),
-            ActiveDeletionAction::Removed { .. } => None,
-        }
+pub(crate) fn recoverable_deletion_from_active_record(
+    record: ActiveDeletionRecord,
+) -> Option<RecoverableDeletion> {
+    match record.action {
+        ActiveDeletionRowAction::Listed {
+            deleted_at_ms,
+            deleted_by,
+            deleted_direntry,
+        } => Some(RecoverableDeletion {
+            root_inode_id: record.root_inode_id,
+            deletion_seq: record.deletion_seq,
+            deleted_at_ms,
+            deleted_by,
+            deleted_direntry,
+        }),
+        ActiveDeletionRowAction::Removed { .. } => None,
     }
 }
 
@@ -257,42 +121,6 @@ pub(crate) struct RecoverableDeletion {
     pub(crate) deleted_by: ActorRef,
     /// The binding the delete removed and an in-place undelete restores.
     pub(crate) deleted_direntry: DeletedDirentry,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CommitReceiptRecord {
-    pub commit_id: CommitId,
-    pub committed_by: ActorRef,
-    pub semantic_commit_fingerprint: String,
-    pub committed_seq: ChangeSeq,
-    /// Observational wall-clock stamp of the commit; never a validity
-    /// input — `committed_seq` is the order.
-    pub committed_at_ms: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-}
-
-/// One inode's complete attribute map at one revision.
-///
-/// The record is whole state, so a reader takes the newest one for an inode
-/// and needs nothing older. An inode with no record is at revision 0 with an
-/// empty map, which is why nothing is written until a caller writes an
-/// attribute.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AttributesRevisionRecord {
-    pub inode_id: InodeId,
-    pub attributes_revision_no: AttributeRevisionNo,
-    pub committed_seq: ChangeSeq,
-    /// Commit ID associated with this row.
-    pub commit_id: CommitId,
-    pub delta_index: u32,
-    pub updated_by: ActorRef,
-    /// Time of the attribute update, in Unix milliseconds. `committed_seq`
-    /// determines order.
-    pub updated_at_ms: u64,
-    /// The inode's attributes after this update. An empty map is the cleared
-    /// state, not an absent record.
-    pub attributes: Attributes,
 }
 
 impl MetadataState {
@@ -384,43 +212,43 @@ impl MetadataState {
 
     pub(crate) fn push_inode_record(&mut self, record: InodeRecord) {
         self.indexes.record_inode(&record);
-        self.record_row_weight(inode_decoded_bytes(&record));
+        self.record_row_weight(record.decoded_weight());
         self.inodes.push(record);
     }
 
     pub(crate) fn push_direntry_bind_record(&mut self, record: DirentryBindRecord) {
         self.indexes.record_bind(&record);
-        self.record_row_weight(direntry_bind_decoded_bytes(&record));
+        self.record_row_weight(record.decoded_weight());
         self.direntry_binds.push(record);
     }
 
     pub(crate) fn push_direntry_unbind_record(&mut self, record: DirentryUnbindRecord) {
         self.indexes.record_unbind(&record);
-        self.record_row_weight(direntry_unbind_decoded_bytes(&record));
+        self.record_row_weight(record.decoded_weight());
         self.direntry_unbinds.push(record);
     }
 
     pub(crate) fn push_revision_record(&mut self, record: RevisionRecord) {
         self.indexes.record_revision(&record);
-        self.record_row_weight(revision_decoded_bytes(&record));
+        self.record_row_weight(record.decoded_weight());
         self.revisions.push(record);
     }
 
     pub(crate) fn push_subtree_tombstone_record(&mut self, record: SubtreeTombstoneRecord) {
         self.indexes.record_tombstone(&record);
-        self.record_row_weight(subtree_tombstone_decoded_bytes(&record));
+        self.record_row_weight(record.decoded_weight());
         self.subtree_tombstones.push(record);
     }
 
     pub(crate) fn push_commit_receipt_record(&mut self, record: CommitReceiptRecord) {
         self.indexes.record_commit_receipt(&record);
-        self.record_row_weight(commit_receipt_decoded_bytes(&record));
+        self.record_row_weight(record.decoded_weight());
         self.commit_receipts.push(record);
     }
 
     pub(crate) fn push_attributes_revision_record(&mut self, record: AttributesRevisionRecord) {
         self.indexes.record_attributes_revision(&record);
-        self.record_row_weight(attributes_revision_decoded_bytes(&record));
+        self.record_row_weight(record.decoded_weight());
         self.attributes_revisions.push(record);
     }
 
@@ -485,111 +313,17 @@ fn metadata_row_count(state: &MetadataState) -> usize {
 }
 
 fn metadata_decoded_bytes(state: &MetadataState) -> usize {
-    state
-        .inodes
-        .iter()
-        .map(inode_decoded_bytes)
-        .sum::<usize>()
-        .saturating_add(
-            state
-                .direntry_binds
-                .iter()
-                .map(direntry_bind_decoded_bytes)
-                .sum::<usize>(),
-        )
-        .saturating_add(
-            state
-                .direntry_unbinds
-                .iter()
-                .map(direntry_unbind_decoded_bytes)
-                .sum::<usize>(),
-        )
-        .saturating_add(
-            state
-                .revisions
-                .iter()
-                .map(revision_decoded_bytes)
-                .sum::<usize>(),
-        )
-        .saturating_add(
-            state
-                .subtree_tombstones
-                .iter()
-                .map(subtree_tombstone_decoded_bytes)
-                .sum::<usize>(),
-        )
-        .saturating_add(
-            state
-                .commit_receipts
-                .iter()
-                .map(commit_receipt_decoded_bytes)
-                .sum::<usize>(),
-        )
-        .saturating_add(
-            state
-                .attributes_revisions
-                .iter()
-                .map(attributes_revision_decoded_bytes)
-                .sum::<usize>(),
-        )
-}
-
-fn inode_decoded_bytes(record: &InodeRecord) -> usize {
-    size_of::<InodeRecord>()
-        + record.commit_id.as_str().len()
-        + actor_ref_decoded_bytes(&record.created_by)
-}
-
-fn subtree_tombstone_decoded_bytes(record: &SubtreeTombstoneRecord) -> usize {
-    size_of::<SubtreeTombstoneRecord>()
-        + record.commit_id.as_str().len()
-        + actor_ref_decoded_bytes(&record.deleted_by)
-}
-
-fn direntry_bind_decoded_bytes(record: &DirentryBindRecord) -> usize {
-    size_of::<DirentryBindRecord>()
-        + record.name_key.as_str().len()
-        + record.display_name.as_str().len()
-}
-
-fn direntry_unbind_decoded_bytes(record: &DirentryUnbindRecord) -> usize {
-    size_of::<DirentryUnbindRecord>() + record.name_key.as_str().len()
-}
-
-fn revision_decoded_bytes(record: &RevisionRecord) -> usize {
-    size_of::<RevisionRecord>()
-        + record.commit_id.as_str().len()
-        + actor_ref_decoded_bytes(&record.committed_by)
-        + content_ref_decoded_bytes(&record.content_ref)
-}
-
-fn commit_receipt_decoded_bytes(record: &CommitReceiptRecord) -> usize {
-    size_of::<CommitReceiptRecord>()
-        + record.commit_id.as_str().len()
-        + actor_ref_decoded_bytes(&record.committed_by)
-        + record.semantic_commit_fingerprint.len()
-        + record.message.as_ref().map_or(0, String::len)
-}
-
-/// The record's struct plus the key and value bytes its map owns. Attribute
-/// maps are caller-sized, so the map's own bytes are what this row weighs.
-fn attributes_revision_decoded_bytes(record: &AttributesRevisionRecord) -> usize {
-    size_of::<AttributesRevisionRecord>()
-        + record.commit_id.as_str().len()
-        + actor_ref_decoded_bytes(&record.updated_by)
-        + record.attributes.logical_bytes()
-}
-
-fn actor_ref_decoded_bytes(actor: &ActorRef) -> usize {
-    actor.kind.as_str().len() + actor.id.as_str().len()
-}
-
-fn content_ref_decoded_bytes(content_ref: &ContentRef) -> usize {
-    size_of::<ContentRef>() + content_ref_evidence_bytes(content_ref)
-}
-
-/// Heap bytes a content reference owns beyond its struct: the identity and
-/// the checksum strings.
-pub(crate) fn content_ref_evidence_bytes(content_ref: &ContentRef) -> usize {
-    content_ref.content_id.as_str().len() + content_ref.checksum.value.len()
+    fn total<R: DecodedRowWeight>(records: &[R]) -> usize {
+        records
+            .iter()
+            .map(DecodedRowWeight::decoded_weight)
+            .fold(0, usize::saturating_add)
+    }
+    total(&state.inodes)
+        .saturating_add(total(&state.direntry_binds))
+        .saturating_add(total(&state.direntry_unbinds))
+        .saturating_add(total(&state.revisions))
+        .saturating_add(total(&state.subtree_tombstones))
+        .saturating_add(total(&state.commit_receipts))
+        .saturating_add(total(&state.attributes_revisions))
 }

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -471,7 +471,7 @@ fn metadata_builder_tracks_the_highest_row_sequence() {
         commit_id: commit_id(2),
         committed_at_ms: 4_200,
         committed_by: actor(),
-        revision_delta_index: 0,
+        delta_index: 0,
         content_ref,
     });
     builder.push_revision(RevisionRecord {
@@ -481,7 +481,7 @@ fn metadata_builder_tracks_the_highest_row_sequence() {
         commit_id: commit_id(3),
         committed_at_ms: 4_200,
         committed_by: actor(),
-        revision_delta_index: 0,
+        delta_index: 0,
         content_ref: replacement_ref,
     });
     builder.push_commit_receipt(CommitReceiptRecord {

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -10,10 +10,10 @@ use super::visibility::{self, MetadataVisibilityReads};
 use crate::checkpoint::VerifiedMetadataSegments;
 use crate::error::CoreError;
 use crate::metadata::{
-    active_deletion_from_tombstone, unbind_matches_binding, ActiveDeletionRecord,
-    AttributesRevisionRecord, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
-    InodeRecord, MetadataState, RecoverableDeletion, ResolvedVisiblePath, RevisionRecord,
-    SubtreeTombstoneRecord,
+    active_deletion_from_tombstone, recoverable_deletion_from_active_record,
+    unbind_matches_binding, ActiveDeletionRecord, AttributesRevisionRecord, CommitReceiptRecord,
+    DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState, RecoverableDeletion,
+    ResolvedVisiblePath, RevisionRecord, SubtreeTombstoneRecord,
 };
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::manifest::lookup_keys;
@@ -875,7 +875,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             }
             last_row_key = Some(row_key);
             let generation = (record.deletion_seq, record.root_inode_id);
-            match record.into_recoverable() {
+            match recoverable_deletion_from_active_record(record) {
                 None => removed_generation = Some(generation),
                 Some(deletion) if removed_generation != Some(generation) => entries.push(deletion),
                 Some(_) => {}
@@ -1025,11 +1025,7 @@ fn attributes_order_key(
 }
 
 fn revision_order_key(record: &RevisionRecord) -> (RevisionNo, loonfs_api::ChangeSeq, u32) {
-    (
-        record.revision_no,
-        record.committed_seq,
-        record.revision_delta_index,
-    )
+    (record.revision_no, record.committed_seq, record.delta_index)
 }
 
 fn revision_is_after_position_desc(

--- a/crates/loonfs-core/src/metadata/view_session.rs
+++ b/crates/loonfs-core/src/metadata/view_session.rs
@@ -1017,13 +1017,5 @@ struct DirentryBindPageCandidate {
 }
 
 fn direntry_bind_row_key(record: &DirentryBindRecord) -> String {
-    MetadataRow::DirentryBind {
-        parent_inode_id: record.parent_inode_id,
-        name_key: record.name_key.clone(),
-        display_name: record.display_name.clone(),
-        child_inode_id: record.child_inode_id,
-        bind_seq: record.bind_seq,
-        bind_delta_index: record.bind_delta_index,
-    }
-    .row_key_for_family(MetadataRowFamily::DirentryBinds)
+    MetadataRow::DirentryBind(record.clone()).row_key_for_family(MetadataRowFamily::DirentryBinds)
 }

--- a/crates/loonfs-core/src/metadata/visibility.rs
+++ b/crates/loonfs-core/src/metadata/visibility.rs
@@ -9,6 +9,7 @@ use super::queries::{ResolvedVisiblePath, VisiblePathError};
 use super::{
     DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState, SubtreeTombstoneRecord,
 };
+use crate::binding_generation::BindingGeneration;
 use futures::FutureExt;
 use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, InodeKind, NameKey, ROOT_INODE_ID};
 use std::collections::BTreeSet;
@@ -53,10 +54,14 @@ impl<'a> From<&'a DirentryUnbindRecord> for BindingIdentity<'a> {
     }
 }
 
-impl DirentryBindRecord {
-    /// True iff `self` and `other` describe the same binding event.
-    pub(crate) fn same_binding(&self, other: &DirentryBindRecord) -> bool {
-        BindingIdentity::from(self) == BindingIdentity::from(other)
+pub(crate) fn same_binding(left: &DirentryBindRecord, right: &DirentryBindRecord) -> bool {
+    BindingIdentity::from(left) == BindingIdentity::from(right)
+}
+
+pub(crate) fn binding_generation(record: &DirentryBindRecord) -> BindingGeneration {
+    BindingGeneration {
+        bind_seq: record.bind_seq,
+        bind_delta_index: record.bind_delta_index,
     }
 }
 
@@ -291,7 +296,7 @@ pub(crate) async fn active_child_binding<R: MetadataVisibilityReads>(
         );
         return Ok(None);
     };
-    if !latest_binding.same_binding(&direntry) {
+    if !same_binding(&latest_binding, &direntry) {
         trace_absent_leg(
             AbsentVisibilityLeg::BindingSuperseded,
             parent_inode_id,
@@ -485,7 +490,7 @@ where
         current_absolute_path =
             join_display_path(&current_absolute_path, direntry.display_name.as_str());
         current_display_name = direntry.display_name.to_string();
-        current_binding_generation = Some(direntry.generation());
+        current_binding_generation = Some(binding_generation(&direntry));
     }
 
     let inode = reads

--- a/crates/loonfs-core/src/path/read/current_files.rs
+++ b/crates/loonfs-core/src/path/read/current_files.rs
@@ -4,7 +4,7 @@
 
 use super::materialized_view::LoadedMetadataView;
 use crate::error::{CoreError, Result};
-use crate::metadata::{DirentryBindRecord, MetadataViewSession, ResolvedVisiblePath};
+use crate::metadata::{binding_generation, MetadataViewSession, ResolvedVisiblePath};
 use loonfs_api::{AbsolutePath, InodeId, InodeKind, RevisionNo, ROOT_INODE_ID};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{HashMap, HashSet};
@@ -119,7 +119,7 @@ pub(crate) async fn resolve_visible_inode<S: ObjectStore + ?Sized>(
             .as_ref()
             .map(|binding| binding.display_name.to_string())
             .unwrap_or_default(),
-        binding_generation: current_binding.as_ref().map(DirentryBindRecord::generation),
+        binding_generation: current_binding.as_ref().map(binding_generation),
     }))
 }
 

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -10,8 +10,8 @@ use crate::checkpoint::{
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, MetadataViewError, Result};
 use crate::metadata::{
-    LeafRevisionPrefetch, MetadataState, MetadataView, MetadataViewSession, ResolvedVisiblePath,
-    RevisionRecord, VisibleChildEntry, METADATA_VIEW_SESSION_COUNTER_FIELDS,
+    binding_generation, LeafRevisionPrefetch, MetadataState, MetadataView, MetadataViewSession,
+    ResolvedVisiblePath, RevisionRecord, VisibleChildEntry, METADATA_VIEW_SESSION_COUNTER_FIELDS,
 };
 use crate::namespace::basis::MetadataBasis;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
@@ -556,7 +556,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                     inode_id,
                     last_revision_no: last.revision_no,
                     last_committed_seq: last.committed_seq,
-                    last_revision_delta_index: last.revision_delta_index,
+                    last_revision_delta_index: last.delta_index,
                 });
         let revisions = revision_records
             .into_iter()
@@ -898,7 +898,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 created_at_ms: child.inode.created_at_ms,
                 parent_inode_id: Some(child.binding.parent_inode_id),
                 display_name: child.binding.display_name.to_string(),
-                binding_generation: Some(child.binding.generation()),
+                binding_generation: Some(binding_generation(&child.binding)),
             },
             attributes,
         )

--- a/crates/loonfs-core/tests/it/differential.rs
+++ b/crates/loonfs-core/tests/it/differential.rs
@@ -7,7 +7,7 @@ use loonfs_api::{
     CommitId, ContentId, ContentRef, DisplayName, InodeId, InodeKind, NameKey, RevisionNo,
 };
 use loonfs_core::metadata::{
-    MetadataState as CoreMetadataState, SubtreeTombstoneAction as CoreTombstoneAction,
+    MetadataState as CoreMetadataState, TombstoneRowAction as CoreTombstoneAction,
 };
 use loonfs_model::metadata::{
     MetadataState as ModelMetadataState, SubtreeTombstoneAction as ModelTombstoneAction,
@@ -537,7 +537,7 @@ fn normalize_core(state: &CoreMetadataState) -> NormalizedMetadata {
                     revision.commit_id.clone(),
                     revision.committed_at_ms,
                     revision.committed_by.clone(),
-                    revision.revision_delta_index,
+                    revision.delta_index,
                     revision.content_ref.content_id.clone(),
                 )
             })


### PR DESCRIPTION
Defines each metadata row record once in loonfs-api and reuses those types in loonfs-core. This removes duplicate record types and field-by-field conversions, and gives the metadata block cache and WAL-tail cache one shared row-weight calculation.

The serialized JSON and CBOR row formats are unchanged, and the golden fixtures remain byte-for-byte identical. Cache accounting now includes actor and deleted-binding strings that were previously omitted.