### PR TITLE
refactor(core): consolidate block caches and metadata reads

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -614,6 +614,11 @@ pub mod lookup_keys {
     pub(super) const COMMIT_RECEIPT_ROW_PREFIX: &str = "commit-receipt-";
     pub(super) const ATTRIBUTE_ROW_PREFIX: &str = "attribute-";
 
+    /// Builds the exclusive lower bound after `row_key`.
+    pub fn after_row_key(row_key: &str) -> String {
+        format!("{row_key}\0")
+    }
+
     /// Builds an inode row key.
     pub fn inode_key(inode_id: InodeId) -> String {
         format!("{INODE_ROW_PREFIX}{:020}", inode_id.0)
@@ -621,7 +626,7 @@ pub mod lookup_keys {
 
     /// Builds a scan bound immediately after an inode row.
     pub fn inode_key_after(inode_id: InodeId) -> String {
-        format!("{}\0", inode_key(inode_id))
+        after_row_key(&inode_key(inode_id))
     }
 
     /// Builds the prefix for directory bindings under one parent.
@@ -783,10 +788,11 @@ pub mod lookup_keys {
 
     /// Builds a trash scan bound after one deletion generation.
     pub fn active_deletion_key_after(deletion_seq: ChangeSeq, root_inode_id: InodeId) -> String {
-        format!(
-            "{}\0",
-            active_deletion_row_key(deletion_seq, root_inode_id, ACTIVE_DELETION_RANK_LISTED)
-        )
+        after_row_key(&active_deletion_row_key(
+            deletion_seq,
+            root_inode_id,
+            ACTIVE_DELETION_RANK_LISTED,
+        ))
     }
 
     /// Builds the Bloom filter probe for one commit ID.

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -9,7 +9,9 @@ use crate::config::{
 };
 use crate::error::CliError;
 use crate::profiles::default_namespace;
-use loonfs::{FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreKind};
+use loonfs::{
+    DecodedBlockCacheConfig, FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreKind,
+};
 use loonfs_api::{ActorId, ActorKind, ActorRef, NamespaceId, SecretString};
 use loonfs_client::Client;
 use loonfs_grep::{GrepBlockCache, GrepService, DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES};
@@ -232,15 +234,16 @@ impl EmbeddedTarget {
             .build()
             .await
             .map_err(map_runtime_error)?;
-        let grep_block_cache =
-            Arc::new(GrepBlockCache::new(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES));
+        let grep_block_cache = Arc::new(GrepBlockCache::new(
+            DecodedBlockCacheConfig::with_max_decoded_bytes(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES),
+        ));
         let backend = EmbeddedBackend {
             writer,
             reader,
             admin,
             // Embedded mode composes grep itself: the runtime handles above
             // know nothing about it.
-            grep: GrepService::with_block_cache(Arc::clone(&grep_block_cache)),
+            grep: GrepService::new(Arc::clone(&grep_block_cache)),
             grep_block_cache,
         };
         Ok(Self { backend })

--- a/crates/loonfs-core/src/block_cache.rs
+++ b/crates/loonfs-core/src/block_cache.rs
@@ -1,42 +1,100 @@
 //! Shared cache for decoded immutable objects.
 
+use crate::checkpoint::ManifestLoadError;
 use crate::recency::Recency;
+use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::OnceCell;
 
-/// A value whose decoded size counts against the cache budget.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DecodedBlockWeight {
+    pub bytes: usize,
+    pub rows: usize,
+}
+
+impl DecodedBlockWeight {
+    fn saturating_add(self, other: Self) -> Self {
+        Self {
+            bytes: self.bytes.saturating_add(other.bytes),
+            rows: self.rows.saturating_add(other.rows),
+        }
+    }
+
+    fn saturating_sub(self, other: Self) -> Self {
+        Self {
+            bytes: self.bytes.saturating_sub(other.bytes),
+            rows: self.rows.saturating_sub(other.rows),
+        }
+    }
+}
+
 pub trait DecodedBlock: Clone {
-    /// Bytes this value occupies in its decoded form.
-    fn decoded_bytes(&self) -> usize;
+    fn weight(&self) -> DecodedBlockWeight;
 }
 
 /// Receives decoded-block cache events for metrics.
 pub trait DecodedBlockCacheObserver: Send + Sync + 'static {
-    fn hit(&self);
-    fn miss(&self);
-    fn insert(&self);
-    fn evict(&self);
+    fn hit(&self) {}
+    fn miss(&self) {}
+    fn insert(&self) {}
+    fn evict(&self, _weight: DecodedBlockWeight) {}
+    fn reject(&self, _weight: DecodedBlockWeight) {}
+    fn retained(&self, _weight: DecodedBlockWeight) {}
+    fn filter_skip(&self) {}
+    fn filter_false_positive(&self) {}
 }
 
-/// Cumulative cache activity.
+#[derive(Clone)]
+pub struct DecodedBlockCacheConfig {
+    pub max_decoded_bytes: usize,
+    pub max_rows: Option<usize>,
+    pub max_entries: Option<usize>,
+    pub observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
+}
+
+impl std::fmt::Debug for DecodedBlockCacheConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DecodedBlockCacheConfig")
+            .field("max_decoded_bytes", &self.max_decoded_bytes)
+            .field("max_rows", &self.max_rows)
+            .field("max_entries", &self.max_entries)
+            .field("observer", &self.observer.as_ref().map(|_| "configured"))
+            .finish()
+    }
+}
+
+impl DecodedBlockCacheConfig {
+    /// A byte-bounded cache with no row bound, no entry bound, and no observer.
+    pub fn with_max_decoded_bytes(max_decoded_bytes: usize) -> Self {
+        Self {
+            max_decoded_bytes,
+            max_rows: None,
+            max_entries: None,
+            observer: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DecodedBlockCacheStats {
     pub hits: usize,
     pub misses: usize,
     pub inserts: usize,
     pub evictions: usize,
+    pub evicted_rows: usize,
+    pub evicted_decoded_bytes: usize,
+    pub cached_rows: usize,
+    pub cached_decoded_bytes: usize,
 }
 
-/// A byte-bounded cache with recency eviction and one in-flight load per key.
-/// A budget of zero disables the cache.
 pub struct DecodedBlockCache<K, V> {
-    max_decoded_bytes: usize,
+    config: DecodedBlockCacheConfig,
     inner: Mutex<Inner<K, V>>,
     stats: StatsInner,
-    observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
     in_flight: Mutex<HashMap<K, Arc<OnceCell<V>>>>,
 }
 
@@ -44,7 +102,7 @@ impl<K: std::fmt::Debug, V: std::fmt::Debug> std::fmt::Debug for DecodedBlockCac
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("DecodedBlockCache")
-            .field("max_decoded_bytes", &self.max_decoded_bytes)
+            .field("config", &self.config)
             .field("inner", &self.inner)
             .field("stats", &self.stats)
             .field("in_flight", &self.in_flight)
@@ -56,13 +114,12 @@ impl<K: std::fmt::Debug, V: std::fmt::Debug> std::fmt::Debug for DecodedBlockCac
 struct Inner<K, V> {
     entries: HashMap<K, CacheSlot<V>>,
     order: Recency<K>,
-    decoded_bytes: usize,
+    weight: DecodedBlockWeight,
 }
 
 #[derive(Debug)]
 struct CacheSlot<V> {
     block: V,
-    /// The entry's current recency stamp.
     last_touch: u64,
 }
 
@@ -72,28 +129,20 @@ struct StatsInner {
     misses: AtomicUsize,
     inserts: AtomicUsize,
     evictions: AtomicUsize,
+    evicted_rows: AtomicUsize,
+    evicted_decoded_bytes: AtomicUsize,
 }
 
 impl<K: Clone + Eq + Hash, V: DecodedBlock> DecodedBlockCache<K, V> {
-    /// Creates a cache with the supplied decoded-byte budget.
-    pub fn new(max_decoded_bytes: usize) -> Self {
-        Self::with_observer(max_decoded_bytes, None)
-    }
-
-    /// Creates a cache that reports activity to the optional `observer`.
-    pub fn with_observer(
-        max_decoded_bytes: usize,
-        observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
-    ) -> Self {
+    pub fn new(config: DecodedBlockCacheConfig) -> Self {
         Self {
-            max_decoded_bytes,
+            config,
             inner: Mutex::new(Inner {
                 entries: HashMap::new(),
                 order: Recency::default(),
-                decoded_bytes: 0,
+                weight: DecodedBlockWeight::default(),
             }),
             stats: StatsInner::default(),
-            observer,
             in_flight: Mutex::new(HashMap::new()),
         }
     }
@@ -139,18 +188,25 @@ impl<K: Clone + Eq + Hash, V: DecodedBlock> DecodedBlockCache<K, V> {
         result
     }
 
-    /// Returns cumulative hit, miss, insert, and eviction counters.
     pub fn stats(&self) -> DecodedBlockCacheStats {
+        let inner = self
+            .inner
+            .lock()
+            .expect("decoded block cache lock should not be poisoned");
         DecodedBlockCacheStats {
             hits: self.stats.hits.load(Ordering::SeqCst),
             misses: self.stats.misses.load(Ordering::SeqCst),
             inserts: self.stats.inserts.load(Ordering::SeqCst),
             evictions: self.stats.evictions.load(Ordering::SeqCst),
+            evicted_rows: self.stats.evicted_rows.load(Ordering::SeqCst),
+            evicted_decoded_bytes: self.stats.evicted_decoded_bytes.load(Ordering::SeqCst),
+            cached_rows: inner.weight.rows,
+            cached_decoded_bytes: inner.weight.bytes,
         }
     }
 
     pub fn get(&self, key: &K) -> Option<V> {
-        if self.max_decoded_bytes == 0 {
+        if self.disabled() {
             return None;
         }
         let mut inner = self
@@ -159,28 +215,28 @@ impl<K: Clone + Eq + Hash, V: DecodedBlock> DecodedBlockCache<K, V> {
             .expect("decoded block cache lock should not be poisoned");
         let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
             self.stats.misses.fetch_add(1, Ordering::SeqCst);
-            if let Some(observer) = &self.observer {
+            if let Some(observer) = &self.config.observer {
                 observer.miss();
             }
             return None;
         };
         inner.touch(key);
         self.stats.hits.fetch_add(1, Ordering::SeqCst);
-        if let Some(observer) = &self.observer {
+        if let Some(observer) = &self.config.observer {
             observer.hit();
         }
         Some(block)
     }
 
     pub fn insert(&self, key: K, block: V) {
-        if self.max_decoded_bytes == 0 {
+        if self.disabled() {
             return;
         }
         let mut inner = self
             .inner
             .lock()
             .expect("decoded block cache lock should not be poisoned");
-        let decoded_bytes = block.decoded_bytes();
+        let weight = block.weight();
         if let Some(previous) = inner.entries.insert(
             key.clone(),
             CacheSlot {
@@ -188,33 +244,83 @@ impl<K: Clone + Eq + Hash, V: DecodedBlock> DecodedBlockCache<K, V> {
                 last_touch: 0,
             },
         ) {
-            inner.decoded_bytes = inner
-                .decoded_bytes
-                .saturating_sub(previous.block.decoded_bytes());
+            inner.weight = inner.weight.saturating_sub(previous.block.weight());
         }
-        inner.decoded_bytes = inner.decoded_bytes.saturating_add(decoded_bytes);
+        inner.weight = inner.weight.saturating_add(weight);
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
-        if let Some(observer) = &self.observer {
+        if let Some(observer) = &self.config.observer {
             observer.insert();
         }
-        let Inner {
-            entries,
-            order,
-            decoded_bytes,
-        } = &mut *inner;
-        while *decoded_bytes > self.max_decoded_bytes {
+        self.evict_over_budget(&mut inner);
+        self.record_retained(inner.weight);
+    }
+
+    pub fn invalidate(&self, matches: impl Fn(&K) -> bool) {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("decoded block cache lock should not be poisoned");
+        let keys = inner
+            .entries
+            .keys()
+            .filter(|key| matches(key))
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in keys {
+            if let Some(slot) = inner.entries.remove(&key) {
+                let weight = slot.block.weight();
+                inner.weight = inner.weight.saturating_sub(weight);
+                self.record_eviction(weight);
+            }
+        }
+        self.record_retained(inner.weight);
+    }
+
+    fn disabled(&self) -> bool {
+        self.config.max_decoded_bytes == 0 || self.config.max_entries == Some(0)
+    }
+
+    fn evict_over_budget(&self, inner: &mut Inner<K, V>) {
+        while inner.weight.bytes > self.config.max_decoded_bytes
+            || self
+                .config
+                .max_rows
+                .is_some_and(|max_rows| inner.weight.rows > max_rows)
+            || self
+                .config
+                .max_entries
+                .is_some_and(|max_entries| inner.entries.len() > max_entries)
+        {
+            let Inner { entries, order, .. } = &mut *inner;
             let Some(candidate) = order.pop_oldest(|key, stamp| slot_is_live(entries, key, stamp))
             else {
                 break;
             };
             if let Some(slot) = entries.remove(&candidate) {
-                *decoded_bytes = decoded_bytes.saturating_sub(slot.block.decoded_bytes());
-                self.stats.evictions.fetch_add(1, Ordering::SeqCst);
-                if let Some(observer) = &self.observer {
-                    observer.evict();
-                }
+                let weight = slot.block.weight();
+                inner.weight = inner.weight.saturating_sub(weight);
+                self.record_eviction(weight);
             }
+        }
+    }
+
+    fn record_eviction(&self, weight: DecodedBlockWeight) {
+        self.stats.evictions.fetch_add(1, Ordering::SeqCst);
+        self.stats
+            .evicted_rows
+            .fetch_add(weight.rows, Ordering::SeqCst);
+        self.stats
+            .evicted_decoded_bytes
+            .fetch_add(weight.bytes, Ordering::SeqCst);
+        if let Some(observer) = &self.config.observer {
+            observer.evict(weight);
+        }
+    }
+
+    fn record_retained(&self, weight: DecodedBlockWeight) {
+        if let Some(observer) = &self.config.observer {
+            observer.retained(weight);
         }
     }
 }
@@ -238,22 +344,143 @@ fn slot_is_live<K: Eq + Hash, V>(entries: &HashMap<K, CacheSlot<V>>, key: &K, st
         .is_some_and(|slot| slot.last_touch == stamp)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SegmentBlockKind {
+    Index,
+    Filter,
+    Data,
+    Manifest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SegmentCacheKey {
+    /// The immutable checksum or object key that identifies the cached object.
+    pub identity: String,
+    pub block_kind: SegmentBlockKind,
+    pub block_offset: u64,
+}
+
+#[derive(Debug, Clone)]
+pub enum DecodedSegmentBlock<Row, Manifest> {
+    Index {
+        entries: Arc<Vec<SegmentIndexEntry>>,
+        decoded_bytes: usize,
+    },
+    Filter {
+        filter: Arc<SegmentFilter>,
+        decoded_bytes: usize,
+    },
+    Data {
+        block: Arc<DecodedDataBlock<Row>>,
+        decoded_bytes: usize,
+    },
+    Manifest {
+        manifest: Manifest,
+        decoded_bytes: usize,
+    },
+}
+
+impl<Row: Clone, Manifest: Clone> DecodedBlock for DecodedSegmentBlock<Row, Manifest> {
+    fn weight(&self) -> DecodedBlockWeight {
+        let bytes = match self {
+            Self::Index { decoded_bytes, .. }
+            | Self::Filter { decoded_bytes, .. }
+            | Self::Data { decoded_bytes, .. }
+            | Self::Manifest { decoded_bytes, .. } => *decoded_bytes,
+        };
+        DecodedBlockWeight { bytes, rows: 0 }
+    }
+}
+
+impl<Row, Manifest> DecodedSegmentBlock<Row, Manifest> {
+    pub fn index(self) -> Option<Arc<Vec<SegmentIndexEntry>>> {
+        match self {
+            Self::Index { entries, .. } => Some(entries),
+            Self::Filter { .. } | Self::Data { .. } | Self::Manifest { .. } => None,
+        }
+    }
+
+    pub fn filter(self) -> Option<Arc<SegmentFilter>> {
+        match self {
+            Self::Filter { filter, .. } => Some(filter),
+            Self::Index { .. } | Self::Data { .. } | Self::Manifest { .. } => None,
+        }
+    }
+
+    pub fn data(self) -> Option<Arc<DecodedDataBlock<Row>>> {
+        match self {
+            Self::Data { block, .. } => Some(block),
+            Self::Index { .. } | Self::Filter { .. } | Self::Manifest { .. } => None,
+        }
+    }
+
+    pub(crate) fn into_index(
+        self,
+        object_key: &str,
+    ) -> Result<Arc<Vec<SegmentIndexEntry>>, ManifestLoadError> {
+        match self {
+            Self::Index { entries, .. } => Ok(entries),
+            _ => Err(wrong_kind(object_key, "non-index block for an index key")),
+        }
+    }
+
+    pub(crate) fn into_filter(
+        self,
+        object_key: &str,
+    ) -> Result<Arc<SegmentFilter>, ManifestLoadError> {
+        match self {
+            Self::Filter { filter, .. } => Ok(filter),
+            _ => Err(wrong_kind(object_key, "non-filter block")),
+        }
+    }
+
+    pub(crate) fn into_data(
+        self,
+        object_key: &str,
+    ) -> Result<Arc<DecodedDataBlock<Row>>, ManifestLoadError> {
+        match self {
+            Self::Data { block, .. } => Ok(block),
+            _ => Err(wrong_kind(object_key, "non-data block for a data key")),
+        }
+    }
+
+    pub(crate) fn into_manifest(self, object_key: &str) -> Result<Manifest, ManifestLoadError> {
+        match self {
+            Self::Manifest { manifest, .. } => Ok(manifest),
+            _ => Err(wrong_kind(
+                object_key,
+                "non-manifest entry for a manifest key",
+            )),
+        }
+    }
+}
+
+fn wrong_kind(object_key: &str, message: &str) -> ManifestLoadError {
+    ManifestLoadError::SegmentCodec {
+        object_key: object_key.to_owned(),
+        message: format!("cache returned a {message}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{DecodedBlock, DecodedBlockCache};
+    use super::{DecodedBlock, DecodedBlockCache, DecodedBlockCacheConfig, DecodedBlockWeight};
 
     #[derive(Clone)]
     struct Block(usize);
 
     impl DecodedBlock for Block {
-        fn decoded_bytes(&self) -> usize {
-            self.0
+        fn weight(&self) -> DecodedBlockWeight {
+            DecodedBlockWeight {
+                bytes: self.0,
+                rows: 0,
+            }
         }
     }
 
     #[test]
     fn recency_queue_stays_bounded_under_repeated_hits() {
-        let cache = DecodedBlockCache::new(10_000);
+        let cache = DecodedBlockCache::new(DecodedBlockCacheConfig::with_max_decoded_bytes(10_000));
         for index in 0..8 {
             cache.insert(format!("k{index}"), Block(10));
         }

--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -441,15 +441,7 @@ async fn load_segment_index_inner<S: ObjectStore + ?Sized>(
         None => fetch().await?,
     };
     memo.record(&cache_key, &block);
-    match block {
-        DecodedMetadataSegmentBlock::Index { entries, .. } => Ok(entries),
-        DecodedMetadataSegmentBlock::Filter { .. }
-        | DecodedMetadataSegmentBlock::Data { .. }
-        | DecodedMetadataSegmentBlock::Manifest { .. } => Err(segment_codec_error(
-            &metadata_segment_object_key(descriptor),
-            "cache returned a non-index block for an index key",
-        )),
-    }
+    block.into_index(&metadata_segment_object_key(descriptor))
 }
 
 /// Loads a segment's bloom filter block: the cheap pre-index check a lookup
@@ -519,13 +511,5 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
         None => fetch().await?,
     };
     memo.record(&cache_key, &block);
-    match block {
-        DecodedMetadataSegmentBlock::Filter { filter, .. } => Ok(filter),
-        DecodedMetadataSegmentBlock::Index { .. }
-        | DecodedMetadataSegmentBlock::Data { .. }
-        | DecodedMetadataSegmentBlock::Manifest { .. } => Err(segment_codec_error(
-            &metadata_segment_object_key(descriptor),
-            "cache returned a non-filter block",
-        )),
-    }
+    block.into_filter(&metadata_segment_object_key(descriptor))
 }

--- a/crates/loonfs-core/src/checkpoint/block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/block_load.rs
@@ -67,11 +67,7 @@ impl SegmentKeyRangeBlocks {
     }
 }
 
-/// Per-view memo of decoded blocks. Index, filter, and manifest entries stay
-/// for the view's lifetime, while data entries have a decoded-byte budget and
-/// leave in insertion order. This is a dedupe map, not an owner:
-/// [`SegmentKeyRangeBlocks`] holds its own block [`Arc`]s, so eviction cannot
-/// invalidate borrowed rows. Its worst case is one extra shared-cache lookup.
+/// This memo stays separate because it uses FIFO eviction for one operation.
 #[derive(Debug, Default)]
 pub(super) struct SessionBlockMemo {
     inner: Mutex<SessionBlockMemoInner>,
@@ -119,7 +115,7 @@ impl SessionBlockMemo {
         if let Some(previous) = previous {
             inner.data_decoded_bytes = inner
                 .data_decoded_bytes
-                .saturating_sub(previous.decoded_bytes());
+                .saturating_sub(previous.weight().bytes);
         } else {
             inner.data_insertion_order.push_back(cache_key);
         }
@@ -135,7 +131,7 @@ impl SessionBlockMemo {
                 .expect("session block memo queue and map should stay one-to-one");
             inner.data_decoded_bytes = inner
                 .data_decoded_bytes
-                .saturating_sub(evicted.decoded_bytes());
+                .saturating_sub(evicted.weight().bytes);
         }
     }
 }
@@ -244,8 +240,10 @@ mod tests {
     fn manifest_block() -> DecodedMetadataSegmentBlock {
         let namespace_id = NamespaceId::parse("memo").expect("namespace id");
         DecodedMetadataSegmentBlock::Manifest {
-            manifest: Arc::new(genesis_basis_manifest(&namespace_id)),
-            scan_runs: Arc::new(Vec::new()),
+            manifest: (
+                Arc::new(genesis_basis_manifest(&namespace_id)),
+                Arc::new(Vec::new()),
+            ),
             decoded_bytes: 1,
         }
     }

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -7,16 +7,17 @@
 
 use super::runs::MetadataRunManifest;
 use super::stored_block_cache::StoredMetadataBlockCache;
-use crate::block_cache::{DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver};
+use crate::block_cache::{
+    DecodedBlock, DecodedBlockCache, DecodedBlockCacheConfig, DecodedBlockCacheObserver,
+    DecodedBlockWeight, DecodedSegmentBlock, SegmentBlockKind, SegmentCacheKey,
+};
 use crate::metadata::MetadataState;
-use crate::recency::Recency;
+use loonfs_api::wire::manifest::MetadataRow;
 use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
-use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use loonfs_api::{ChangeSeq, ManifestNo, NamespaceId};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// Default decoded-byte budget for metadata segment blocks. A value of zero
 /// disables the cache.
@@ -50,77 +51,20 @@ pub struct MetadataSegmentCacheStats {
     pub filter_false_positives: usize,
 }
 
-/// Receives metadata segment cache events for metrics.
-pub trait MetadataSegmentCacheObserver: Send + Sync + 'static {
-    fn hit(&self);
-    fn miss(&self);
-    fn insert(&self);
-    fn evict(&self);
-    fn filter_skip(&self);
-    fn filter_false_positive(&self);
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(super) enum MetadataSegmentBlockKind {
-    Index,
-    Filter,
-    Data,
-    Manifest,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(super) struct MetadataSegmentCacheKey {
-    /// The cached object's identity: a segment's object checksum for block
-    /// entries, or the manifest object key for manifest entries — both
-    /// immutable, so entries can never go stale.
-    pub(super) identity: String,
-    pub(super) block_kind: MetadataSegmentBlockKind,
-    pub(super) block_offset: u64,
-}
-
-/// One decoded, verified object the cache holds: a CRC-checked segment
-/// section (index, filter, or data) or a validated namespace manifest.
-/// Everything shares the cache and its byte budget; the key's `block_kind`
-/// and `block_offset` make collisions between kinds impossible. Data blocks
-/// hold metadata rows.
-#[derive(Debug, Clone)]
-pub(super) enum DecodedMetadataSegmentBlock {
-    Index {
-        entries: Arc<Vec<SegmentIndexEntry>>,
-        decoded_bytes: usize,
-    },
-    Filter {
-        filter: Arc<SegmentFilter>,
-        decoded_bytes: usize,
-    },
-    Data {
-        block: Arc<DecodedDataBlock>,
-        decoded_bytes: usize,
-    },
-    Manifest {
-        manifest: Arc<NamespaceManifestEnvelope>,
-        /// The manifest's `segments` grouped in scan order during validation.
-        /// Reusing this list avoids rebuilding it for every page.
-        scan_runs: Arc<Vec<MetadataRunManifest>>,
-        decoded_bytes: usize,
-    },
-}
-
-impl DecodedBlock for DecodedMetadataSegmentBlock {
-    fn decoded_bytes(&self) -> usize {
-        match self {
-            Self::Index { decoded_bytes, .. }
-            | Self::Filter { decoded_bytes, .. }
-            | Self::Data { decoded_bytes, .. }
-            | Self::Manifest { decoded_bytes, .. } => *decoded_bytes,
-        }
-    }
-}
+pub(super) type MetadataSegmentBlockKind = SegmentBlockKind;
+pub(super) type MetadataSegmentCacheKey = SegmentCacheKey;
+pub(super) type DecodedMetadataSegmentBlock = DecodedSegmentBlock<
+    MetadataRow,
+    (
+        Arc<NamespaceManifestEnvelope>,
+        Arc<Vec<MetadataRunManifest>>,
+    ),
+>;
 
 pub struct MetadataSegmentCache {
     blocks: DecodedBlockCache<MetadataSegmentCacheKey, DecodedMetadataSegmentBlock>,
     stats: MetadataSegmentFilterStatsInner,
-    observer: Option<Arc<dyn MetadataSegmentCacheObserver>>,
+    observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
     /// Optional node-local cache for encoded blocks. Keeping it with the
     /// decoded cache ensures callers use both cache tiers or neither tier.
     stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
@@ -143,42 +87,23 @@ struct MetadataSegmentFilterStatsInner {
     filter_false_positives: AtomicUsize,
 }
 
-struct MetadataSegmentCacheEvents(Arc<dyn MetadataSegmentCacheObserver>);
-
-impl DecodedBlockCacheObserver for MetadataSegmentCacheEvents {
-    fn hit(&self) {
-        self.0.hit();
-    }
-
-    fn miss(&self) {
-        self.0.miss();
-    }
-
-    fn insert(&self) {
-        self.0.insert();
-    }
-
-    fn evict(&self) {
-        self.0.evict();
-    }
-}
-
 impl MetadataSegmentCache {
     pub fn new(config: MetadataSegmentCacheConfig) -> Self {
         Self::with_stored_block_cache_and_observer(config, None, None)
     }
 
-    /// Creates a cache that reports activity to the optional `observer`.
     pub fn with_stored_block_cache_and_observer(
         config: MetadataSegmentCacheConfig,
         stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
-        observer: Option<Arc<dyn MetadataSegmentCacheObserver>>,
+        observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
     ) -> Self {
-        let block_observer = observer.clone().map(|observer| {
-            Arc::new(MetadataSegmentCacheEvents(observer)) as Arc<dyn DecodedBlockCacheObserver>
-        });
         Self {
-            blocks: DecodedBlockCache::with_observer(config.max_decoded_bytes, block_observer),
+            blocks: DecodedBlockCache::new(DecodedBlockCacheConfig {
+                max_decoded_bytes: config.max_decoded_bytes,
+                max_rows: None,
+                max_entries: None,
+                observer: observer.clone(),
+            }),
             stats: MetadataSegmentFilterStatsInner::default(),
             observer,
             stored_block_cache,
@@ -269,16 +194,6 @@ pub struct WalTailProjectionCacheStats {
     pub cached_decoded_bytes: usize,
 }
 
-/// Receives WAL-tail projection cache events so they can be recorded as metrics.
-pub trait WalTailProjectionCacheObserver: Send + Sync + 'static {
-    fn hit(&self);
-    fn miss(&self);
-    fn insert(&self);
-    fn evict(&self, rows: usize, decoded_bytes: usize);
-    fn reject(&self, rows: usize, decoded_bytes: usize);
-    fn retained(&self, rows: usize, decoded_bytes: usize);
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WalTailProjectionCacheKey {
     pub namespace_id: NamespaceId,
@@ -288,16 +203,20 @@ pub struct WalTailProjectionCacheKey {
     pub head_etag: String,
 }
 
-/// Returns the row count and decoded size charged to the cache budgets.
-fn projection_weight(rows: &MetadataState) -> (usize, usize) {
-    (rows.row_count(), rows.decoded_bytes())
+impl DecodedBlock for Arc<MetadataState> {
+    fn weight(&self) -> DecodedBlockWeight {
+        DecodedBlockWeight {
+            bytes: self.decoded_bytes(),
+            rows: self.row_count(),
+        }
+    }
 }
 
 pub struct WalTailProjectionCache {
     config: WalTailProjectionCacheConfig,
-    inner: Mutex<WalTailProjectionCacheInner>,
-    stats: WalTailProjectionCacheStatsInner,
-    observer: Option<Arc<dyn WalTailProjectionCacheObserver>>,
+    observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
+    blocks: DecodedBlockCache<WalTailProjectionCacheKey, Arc<MetadataState>>,
+    rejection_stats: WalTailProjectionCacheRejectionStats,
 }
 
 impl std::fmt::Debug for WalTailProjectionCache {
@@ -305,226 +224,92 @@ impl std::fmt::Debug for WalTailProjectionCache {
         formatter
             .debug_struct("WalTailProjectionCache")
             .field("config", &self.config)
-            .field("inner", &self.inner)
-            .field("stats", &self.stats)
+            .field("blocks", &self.blocks)
+            .field("rejection_stats", &self.rejection_stats)
             .finish_non_exhaustive()
     }
 }
 
 #[derive(Debug, Default)]
-struct WalTailProjectionCacheInner {
-    entries: HashMap<WalTailProjectionCacheKey, WalTailProjectionCacheSlot>,
-    order: Recency<WalTailProjectionCacheKey>,
-    cached_rows: usize,
-    cached_decoded_bytes: usize,
-}
-
-#[derive(Debug)]
-struct WalTailProjectionCacheSlot {
-    rows: Arc<MetadataState>,
-    /// Recency stamp assigned on the most recent access. Recency records with
-    /// an older stamp for this key are ignored.
-    last_touch: u64,
-}
-
-#[derive(Debug, Default)]
-struct WalTailProjectionCacheStatsInner {
-    hits: AtomicUsize,
-    misses: AtomicUsize,
-    inserts: AtomicUsize,
-    evictions: AtomicUsize,
-    evicted_rows: AtomicUsize,
-    evicted_decoded_bytes: AtomicUsize,
+struct WalTailProjectionCacheRejectionStats {
     uncacheable_count: AtomicUsize,
     uncacheable_rows: AtomicUsize,
     uncacheable_decoded_bytes: AtomicUsize,
 }
 
 impl WalTailProjectionCache {
-    pub fn new(config: WalTailProjectionCacheConfig) -> Self {
-        Self::with_observer(config, None)
-    }
-
-    /// Creates a cache that reports activity to the optional `observer`.
-    pub fn with_observer(
+    pub fn new(
         config: WalTailProjectionCacheConfig,
-        observer: Option<Arc<dyn WalTailProjectionCacheObserver>>,
+        observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
     ) -> Self {
+        let blocks = DecodedBlockCache::new(DecodedBlockCacheConfig {
+            max_decoded_bytes: config.max_decoded_bytes,
+            max_rows: Some(config.max_rows),
+            max_entries: Some(config.max_entries),
+            observer: observer.clone(),
+        });
         Self {
             config,
-            inner: Mutex::new(WalTailProjectionCacheInner::default()),
-            stats: WalTailProjectionCacheStatsInner::default(),
             observer,
+            blocks,
+            rejection_stats: WalTailProjectionCacheRejectionStats::default(),
         }
     }
 
     pub fn stats(&self) -> WalTailProjectionCacheStats {
-        let inner = self
-            .inner
-            .lock()
-            .expect("wal tail projection cache lock should not be poisoned");
+        let blocks = self.blocks.stats();
         WalTailProjectionCacheStats {
-            hits: self.stats.hits.load(Ordering::SeqCst),
-            misses: self.stats.misses.load(Ordering::SeqCst),
-            inserts: self.stats.inserts.load(Ordering::SeqCst),
-            evictions: self.stats.evictions.load(Ordering::SeqCst),
-            evicted_rows: self.stats.evicted_rows.load(Ordering::SeqCst),
-            evicted_decoded_bytes: self.stats.evicted_decoded_bytes.load(Ordering::SeqCst),
-            uncacheable_count: self.stats.uncacheable_count.load(Ordering::SeqCst),
-            uncacheable_rows: self.stats.uncacheable_rows.load(Ordering::SeqCst),
-            uncacheable_decoded_bytes: self.stats.uncacheable_decoded_bytes.load(Ordering::SeqCst),
-            cached_rows: inner.cached_rows,
-            cached_decoded_bytes: inner.cached_decoded_bytes,
+            hits: blocks.hits,
+            misses: blocks.misses,
+            inserts: blocks.inserts,
+            evictions: blocks.evictions,
+            evicted_rows: blocks.evicted_rows,
+            evicted_decoded_bytes: blocks.evicted_decoded_bytes,
+            uncacheable_count: self
+                .rejection_stats
+                .uncacheable_count
+                .load(Ordering::SeqCst),
+            uncacheable_rows: self.rejection_stats.uncacheable_rows.load(Ordering::SeqCst),
+            uncacheable_decoded_bytes: self
+                .rejection_stats
+                .uncacheable_decoded_bytes
+                .load(Ordering::SeqCst),
+            cached_rows: blocks.cached_rows,
+            cached_decoded_bytes: blocks.cached_decoded_bytes,
         }
     }
 
     pub fn get(&self, key: &WalTailProjectionCacheKey) -> Option<Arc<MetadataState>> {
-        if self.config.max_entries == 0 {
-            return None;
-        }
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("wal tail projection cache lock should not be poisoned");
-        let Some(rows) = inner.entries.get(key).map(|slot| Arc::clone(&slot.rows)) else {
-            self.stats.misses.fetch_add(1, Ordering::SeqCst);
-            if let Some(observer) = &self.observer {
-                observer.miss();
-            }
-            return None;
-        };
-        inner.touch(key);
-        self.stats.hits.fetch_add(1, Ordering::SeqCst);
-        if let Some(observer) = &self.observer {
-            observer.hit();
-        }
-        Some(rows)
+        self.blocks.get(key)
     }
 
     pub fn insert(&self, key: WalTailProjectionCacheKey, rows: Arc<MetadataState>) {
         if self.config.max_entries == 0 {
             return;
         }
-        let (row_count, decoded_bytes) = projection_weight(&rows);
-        if row_count > self.config.max_rows || decoded_bytes > self.config.max_decoded_bytes {
-            self.stats.uncacheable_count.fetch_add(1, Ordering::SeqCst);
-            self.stats
+        let weight = rows.weight();
+        if weight.rows > self.config.max_rows || weight.bytes > self.config.max_decoded_bytes {
+            self.rejection_stats
+                .uncacheable_count
+                .fetch_add(1, Ordering::SeqCst);
+            self.rejection_stats
                 .uncacheable_rows
-                .fetch_add(row_count, Ordering::SeqCst);
-            self.stats
+                .fetch_add(weight.rows, Ordering::SeqCst);
+            self.rejection_stats
                 .uncacheable_decoded_bytes
-                .fetch_add(decoded_bytes, Ordering::SeqCst);
+                .fetch_add(weight.bytes, Ordering::SeqCst);
             if let Some(observer) = &self.observer {
-                observer.reject(row_count, decoded_bytes);
+                observer.reject(weight);
             }
             return;
         }
-
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("wal tail projection cache lock should not be poisoned");
-        if let Some(previous) = inner.entries.insert(
-            key.clone(),
-            WalTailProjectionCacheSlot {
-                rows,
-                last_touch: 0,
-            },
-        ) {
-            let (previous_rows, previous_bytes) = projection_weight(&previous.rows);
-            inner.cached_rows = inner.cached_rows.saturating_sub(previous_rows);
-            inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(previous_bytes);
-        }
-        inner.cached_rows = inner.cached_rows.saturating_add(row_count);
-        inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_add(decoded_bytes);
-        inner.touch(&key);
-        self.stats.inserts.fetch_add(1, Ordering::SeqCst);
-        if let Some(observer) = &self.observer {
-            observer.insert();
-        }
-
-        while inner.entries.len() > self.config.max_entries
-            || inner.cached_rows > self.config.max_rows
-            || inner.cached_decoded_bytes > self.config.max_decoded_bytes
-        {
-            let WalTailProjectionCacheInner { entries, order, .. } = &mut *inner;
-            let Some(evicted) = order
-                .pop_oldest(|key, stamp| wal_tail_projection_slot_is_live(entries, key, stamp))
-            else {
-                break;
-            };
-            if let Some(previous) = entries.remove(&evicted) {
-                let (rows, bytes) = projection_weight(&previous.rows);
-                inner.cached_rows = inner.cached_rows.saturating_sub(rows);
-                inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(bytes);
-                self.stats.evictions.fetch_add(1, Ordering::SeqCst);
-                self.stats.evicted_rows.fetch_add(rows, Ordering::SeqCst);
-                self.stats
-                    .evicted_decoded_bytes
-                    .fetch_add(bytes, Ordering::SeqCst);
-                if let Some(observer) = &self.observer {
-                    observer.evict(rows, bytes);
-                }
-            }
-        }
-        if let Some(observer) = &self.observer {
-            observer.retained(inner.cached_rows, inner.cached_decoded_bytes);
-        }
+        self.blocks.insert(key, rows);
     }
 
     pub fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("wal tail projection cache lock should not be poisoned");
-        let keys = inner
-            .entries
-            .keys()
-            .filter(|key| &key.namespace_id == namespace_id)
-            .cloned()
-            .collect::<Vec<_>>();
-        for key in keys {
-            if let Some(previous) = inner.entries.remove(&key) {
-                let (rows, bytes) = projection_weight(&previous.rows);
-                inner.cached_rows = inner.cached_rows.saturating_sub(rows);
-                inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(bytes);
-                self.stats.evictions.fetch_add(1, Ordering::SeqCst);
-                self.stats.evicted_rows.fetch_add(rows, Ordering::SeqCst);
-                self.stats
-                    .evicted_decoded_bytes
-                    .fetch_add(bytes, Ordering::SeqCst);
-                if let Some(observer) = &self.observer {
-                    observer.evict(rows, bytes);
-                }
-            }
-        }
-        if let Some(observer) = &self.observer {
-            observer.retained(inner.cached_rows, inner.cached_decoded_bytes);
-        }
+        self.blocks
+            .invalidate(|key| &key.namespace_id == namespace_id);
     }
-}
-
-impl WalTailProjectionCacheInner {
-    fn touch(&mut self, key: &WalTailProjectionCacheKey) {
-        let stamp = self.order.touch(key);
-        if let Some(slot) = self.entries.get_mut(key) {
-            slot.last_touch = stamp;
-        }
-        let entries = &self.entries;
-        self.order.compact(entries.len(), |key, stamp| {
-            wal_tail_projection_slot_is_live(entries, key, stamp)
-        });
-    }
-}
-
-fn wal_tail_projection_slot_is_live(
-    entries: &HashMap<WalTailProjectionCacheKey, WalTailProjectionCacheSlot>,
-    key: &WalTailProjectionCacheKey,
-    stamp: u64,
-) -> bool {
-    entries
-        .get(key)
-        .is_some_and(|slot| slot.last_touch == stamp)
 }
 
 #[cfg(test)]
@@ -560,11 +345,14 @@ mod tests {
 
     #[test]
     fn row_attribution_and_timestamps_never_enter_projection_cache_keys() {
-        let cache = WalTailProjectionCache::new(WalTailProjectionCacheConfig {
-            max_entries: 1,
-            max_rows: 10,
-            max_decoded_bytes: 16 * 1024,
-        });
+        let cache = WalTailProjectionCache::new(
+            WalTailProjectionCacheConfig {
+                max_entries: 1,
+                max_rows: 10,
+                max_decoded_bytes: 16 * 1024,
+            },
+            None,
+        );
         let key = WalTailProjectionCacheKey {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
             manifest_no: ManifestNo(7),

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -76,15 +76,7 @@ pub(super) async fn load_segment_data_block<S: ObjectStore + ?Sized>(
         None => fetch().await?,
     };
     memo.record(&cache_key, &block);
-    match block {
-        DecodedMetadataSegmentBlock::Data { block, .. } => Ok(block),
-        DecodedMetadataSegmentBlock::Index { .. }
-        | DecodedMetadataSegmentBlock::Filter { .. }
-        | DecodedMetadataSegmentBlock::Manifest { .. } => Err(segment_codec_error(
-            &metadata_segment_object_key(descriptor),
-            "cache returned a non-data block for a data key",
-        )),
-    }
+    block.into_data(&metadata_segment_object_key(descriptor))
 }
 
 pub(super) fn decoded_data_cache_block(block: DecodedDataBlock) -> DecodedMetadataSegmentBlock {

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -88,7 +88,7 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
         let family_exhausted = rows.len() < wave_rows;
         // Resume after the last scanned row, including rows filtered out below.
         match rows.last() {
-            Some((row_key, _)) => lower_bound = format!("{row_key}\0"),
+            Some((row_key, _)) => lower_bound = lookup_keys::after_row_key(row_key),
             None => break,
         }
         let inode_rows = rows

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -4,7 +4,6 @@
 //! fetching row data. Other checkpoint modules load blocks. Full
 //! materialization is available only in tests.
 
-use super::block_fetch::segment_codec_error;
 pub(super) use super::block_load::SessionBlockMemo;
 use super::cache::{
     DecodedMetadataSegmentBlock, MetadataSegmentBlockKind, MetadataSegmentCache,
@@ -263,8 +262,7 @@ pub(crate) async fn load_verified_manifest_segments<'a, S: ObjectStore + ?Sized>
         validate_manifest(&manifest_key, &manifest.payload)?;
         let scan_runs = Arc::new(runs_in_reorganization_order(&manifest.payload));
         Ok(DecodedMetadataSegmentBlock::Manifest {
-            manifest: Arc::new(manifest),
-            scan_runs,
+            manifest: (Arc::new(manifest), scan_runs),
             // The entry retains the envelope plus its scan-ordered run list.
             decoded_bytes: manifest_bytes.len().saturating_mul(2),
         })
@@ -280,21 +278,7 @@ pub(crate) async fn load_verified_manifest_segments<'a, S: ObjectStore + ?Sized>
         }
         None => fetch().await?,
     };
-    let (manifest, scan_runs) = match decoded {
-        DecodedMetadataSegmentBlock::Manifest {
-            manifest,
-            scan_runs,
-            ..
-        } => (manifest, scan_runs),
-        DecodedMetadataSegmentBlock::Index { .. }
-        | DecodedMetadataSegmentBlock::Filter { .. }
-        | DecodedMetadataSegmentBlock::Data { .. } => {
-            return Err(segment_codec_error(
-                &manifest_key,
-                "cache returned a non-manifest entry for a manifest key",
-            ));
-        }
-    };
+    let (manifest, scan_runs) = decoded.into_manifest(&manifest_key)?;
     let segments = VerifiedMetadataSegments {
         store,
         segment_cache,

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -38,10 +38,10 @@ mod validate;
 
 pub use self::build::write_segments_in_waves;
 pub use self::cache::{
-    MetadataSegmentCache, MetadataSegmentCacheConfig, MetadataSegmentCacheObserver,
-    MetadataSegmentCacheStats, WalTailProjectionCache, WalTailProjectionCacheConfig,
-    WalTailProjectionCacheKey, WalTailProjectionCacheObserver, WalTailProjectionCacheStats,
-    DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+    MetadataSegmentCache, MetadataSegmentCacheConfig, MetadataSegmentCacheStats,
+    WalTailProjectionCache, WalTailProjectionCacheConfig, WalTailProjectionCacheKey,
+    WalTailProjectionCacheStats, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
 pub use self::compaction_merge::{
     refill_iterators, select_next_iterator, SegmentBlockLoader, SegmentRowIterator,

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -634,7 +634,7 @@ async fn validate_source_binding<S: ObjectStore + ?Sized>(
     };
     let expected_identity = BindingIdentity {
         parent_inode_id: expected.parent_inode_id,
-        name_key: &expected.name_key,
+        name_key: expected.name_key.clone(),
         child_inode_id: expected.child_inode_id,
         bind_seq: expected.bind_seq,
         bind_delta_index: expected.bind_delta_index,

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -98,17 +98,19 @@ pub mod time;
 /// runtime owns these caches and their statistics.
 pub mod cache {
     pub use crate::block_cache::{
-        DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver, DecodedBlockCacheStats,
+        DecodedBlock, DecodedBlockCache, DecodedBlockCacheConfig, DecodedBlockCacheObserver,
+        DecodedBlockCacheStats, DecodedBlockWeight, DecodedSegmentBlock, SegmentBlockKind,
+        SegmentCacheKey,
     };
     pub use crate::recency::Recency;
 
     pub use crate::checkpoint::{
         ManifestLoadError, ManifestLoadFailureClass, MetadataSegmentCache,
-        MetadataSegmentCacheConfig, MetadataSegmentCacheObserver, MetadataSegmentCacheStats,
-        StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
-        StoredMetadataBlockKind, WalTailProjectionCache, WalTailProjectionCacheConfig,
-        WalTailProjectionCacheKey, WalTailProjectionCacheObserver, WalTailProjectionCacheStats,
-        DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+        MetadataSegmentCacheConfig, MetadataSegmentCacheStats, StoredMetadataBlockCache,
+        StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey, StoredMetadataBlockKind,
+        WalTailProjectionCache, WalTailProjectionCacheConfig, WalTailProjectionCacheKey,
+        WalTailProjectionCacheStats, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+        DEFAULT_WAL_TAIL_PROJECTION_ROWS,
     };
     pub use crate::namespace::status::{
         load_deleted_namespace_diagnostics, load_namespace, load_namespace_diagnostics,

--- a/crates/loonfs-core/src/metadata/durable_cache.rs
+++ b/crates/loonfs-core/src/metadata/durable_cache.rs
@@ -2,6 +2,7 @@
 //! lookups shared across a publish batch's candidates, plus the cache key
 //! types and the shared-row handle its hits return.
 
+use super::visibility::BindingIdentity;
 use super::{DirentryBindRecord, DirentryUnbindRecord, InodeRecord, SubtreeTombstoneRecord};
 use loonfs_api::{InodeId, NameKey};
 use std::collections::HashMap;
@@ -25,7 +26,7 @@ pub(super) struct DurableVisibilityCacheInner {
     pub(super) inodes: HashMap<InodeId, Option<InodeRecord>>,
     pub(super) binds_for_parent_name: HashMap<ParentNameCacheKey, Arc<Vec<DirentryBindRecord>>>,
     pub(super) binds_for_child: HashMap<InodeId, Arc<Vec<DirentryBindRecord>>>,
-    pub(super) unbinds_for_binding: HashMap<BindingCacheKey, Arc<Vec<DirentryUnbindRecord>>>,
+    pub(super) unbinds_for_binding: HashMap<BindingIdentity, Arc<Vec<DirentryUnbindRecord>>>,
     pub(super) tombstones_for_root: HashMap<InodeId, Arc<Vec<SubtreeTombstoneRecord>>>,
     hits: u64,
     misses: u64,
@@ -100,39 +101,4 @@ impl DurableVisibilityCache {
 pub(super) struct ParentNameCacheKey {
     pub(super) parent_inode_id: InodeId,
     pub(super) name_key: NameKey,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(super) struct BindingCacheKey {
-    pub(super) parent_inode_id: InodeId,
-    pub(super) name_key: NameKey,
-    child_inode_id: InodeId,
-    bind_seq: loonfs_api::ChangeSeq,
-    bind_delta_index: u32,
-}
-
-impl From<&DirentryBindRecord> for BindingCacheKey {
-    fn from(record: &DirentryBindRecord) -> Self {
-        Self {
-            parent_inode_id: record.parent_inode_id,
-            name_key: record.name_key.clone(),
-            child_inode_id: record.child_inode_id,
-            bind_seq: record.bind_seq,
-            bind_delta_index: record.bind_delta_index,
-        }
-    }
-}
-
-/// An unbind carries the identity of the binding event it revokes, so it
-/// keys the same cache slot as that binding.
-impl From<&DirentryUnbindRecord> for BindingCacheKey {
-    fn from(record: &DirentryUnbindRecord) -> Self {
-        Self {
-            parent_inode_id: record.parent_inode_id,
-            name_key: record.name_key.clone(),
-            child_inode_id: record.child_inode_id,
-            bind_seq: record.bind_seq,
-            bind_delta_index: record.bind_delta_index,
-        }
-    }
 }

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -1,25 +1,25 @@
 //! At-head indexes over the in-memory metadata rows, maintained
 //! incrementally as deltas apply so head reads skip the row scans.
 
-use super::visibility::{same_binding, unbind_matches_binding};
+use super::visibility::{same_binding, unbind_matches_binding, BindingIdentity};
 use super::{
     AttributesRevisionRecord, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
     InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneRecord, TombstoneRowAction,
 };
 use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct MetadataIndexes {
     indexed_seq: ChangeSeq,
     inode_by_id: HashMap<InodeId, InodeRecord>,
-    active_child_by_parent_name: BTreeMap<(InodeId, NameKey), DirentryBindRecord>,
+    active_child_by_parent_name: HashMap<(InodeId, NameKey), DirentryBindRecord>,
     /// Latest bind ever recorded per (parent, name), kept even after the
     /// binding is unbound. Tombstone-ancestry checks need to see dead
     /// bindings, which the active map deliberately drops.
     latest_bind_by_parent_name: HashMap<(InodeId, NameKey), DirentryBindRecord>,
     active_parent_by_child: HashMap<InodeId, DirentryBindRecord>,
-    unbound_binding_keys: HashSet<BindingKey>,
+    unbound_binding_keys: HashSet<BindingIdentity>,
     tombstone_by_root: HashMap<InodeId, SubtreeTombstoneRecord>,
     commit_receipt_by_id: HashMap<CommitId, CommitReceiptRecord>,
 }
@@ -29,7 +29,7 @@ impl Default for MetadataIndexes {
         Self {
             indexed_seq: ChangeSeq(0),
             inode_by_id: HashMap::new(),
-            active_child_by_parent_name: BTreeMap::new(),
+            active_child_by_parent_name: HashMap::new(),
             latest_bind_by_parent_name: HashMap::new(),
             active_parent_by_child: HashMap::new(),
             unbound_binding_keys: HashSet::new(),
@@ -51,12 +51,18 @@ impl MetadataIndexes {
         let mut latest_by_child = HashMap::<InodeId, DirentryBindRecord>::new();
         for bind in &state.direntry_binds {
             indexes.indexed_seq = indexes.indexed_seq.max(bind.bind_seq);
-            replace_if_newer_bind(
+            replace_if_newer(
                 &mut latest_by_parent_name,
                 (bind.parent_inode_id, bind.name_key.clone()),
                 bind.clone(),
+                bind_order_key,
             );
-            replace_if_newer_bind(&mut latest_by_child, bind.child_inode_id, bind.clone());
+            replace_if_newer(
+                &mut latest_by_child,
+                bind.child_inode_id,
+                bind.clone(),
+                bind_order_key,
+            );
         }
 
         for unbind in &state.direntry_unbinds {
@@ -154,7 +160,7 @@ impl MetadataIndexes {
 
     pub(super) fn is_unbound(&self, record: &DirentryBindRecord) -> bool {
         self.unbound_binding_keys
-            .contains(&BindingKey::from_bind(record))
+            .contains(&BindingIdentity::from(record))
     }
 
     pub(super) fn record_inode(&mut self, record: &InodeRecord) {
@@ -191,23 +197,32 @@ impl MetadataIndexes {
                 .is_none_or(|existing| bind_order_key(record) >= bind_order_key(existing)),
             "binds for one (parent, name) must be recorded in append order"
         );
-        replace_if_newer_bind(
+        replace_if_newer(
             &mut self.latest_bind_by_parent_name,
             parent_name_key.clone(),
             record.clone(),
+            bind_order_key,
         );
 
         if let Some(previous_child_at_name) =
             self.active_child_by_parent_name.remove(&parent_name_key)
         {
-            remove_active_parent_if_same(&mut self.active_parent_by_child, &previous_child_at_name);
+            remove_if_same_binding(
+                &mut self.active_parent_by_child,
+                previous_child_at_name.child_inode_id,
+                &previous_child_at_name,
+            );
         }
 
         if let Some(previous_parent_for_child) =
             self.active_parent_by_child.remove(&record.child_inode_id)
         {
-            remove_active_child_if_same(
+            remove_if_same_binding(
                 &mut self.active_child_by_parent_name,
+                (
+                    previous_parent_for_child.parent_inode_id,
+                    previous_parent_for_child.name_key.clone(),
+                ),
                 &previous_parent_for_child,
             );
         }
@@ -223,7 +238,7 @@ impl MetadataIndexes {
     pub(super) fn record_unbind(&mut self, record: &DirentryUnbindRecord) {
         self.indexed_seq = self.indexed_seq.max(record.unbind_seq);
         self.unbound_binding_keys
-            .insert(BindingKey::from_unbind(record));
+            .insert(BindingIdentity::from(record));
 
         let parent_name_key = (record.parent_inode_id, record.name_key.clone());
         if self
@@ -251,19 +266,21 @@ impl MetadataIndexes {
 
     pub(super) fn record_tombstone(&mut self, record: &SubtreeTombstoneRecord) {
         self.indexed_seq = self.indexed_seq.max(record.generation.seq);
-        replace_if_newer_tombstone(
+        replace_if_newer(
             &mut self.tombstone_by_root,
             record.root_inode_id,
             record.clone(),
+            tombstone_order_key,
         );
     }
 
     pub(super) fn record_commit_receipt(&mut self, record: &CommitReceiptRecord) {
         self.indexed_seq = self.indexed_seq.max(record.committed_seq);
-        replace_if_newer_receipt(
+        replace_if_newer(
             &mut self.commit_receipt_by_id,
             record.commit_id.clone(),
             record.clone(),
+            |receipt| receipt.committed_seq,
         );
     }
 
@@ -275,104 +292,31 @@ impl MetadataIndexes {
     }
 }
 
-/// Owned hash-key twin of [`super::visibility::BindingIdentity`]: the same
-/// five identity fields, owned so unbound binding events can live in a
-/// `HashSet`. Not a comparison rule of its own — membership tests through it
-/// are identity comparisons by construction.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct BindingKey {
-    parent_inode_id: InodeId,
-    name_key: NameKey,
-    child_inode_id: InodeId,
-    bind_seq: ChangeSeq,
-    bind_delta_index: u32,
-}
-
-impl BindingKey {
-    fn from_bind(record: &DirentryBindRecord) -> Self {
-        Self {
-            parent_inode_id: record.parent_inode_id,
-            name_key: record.name_key.clone(),
-            child_inode_id: record.child_inode_id,
-            bind_seq: record.bind_seq,
-            bind_delta_index: record.bind_delta_index,
-        }
-    }
-
-    fn from_unbind(record: &DirentryUnbindRecord) -> Self {
-        Self {
-            parent_inode_id: record.parent_inode_id,
-            name_key: record.name_key.clone(),
-            child_inode_id: record.child_inode_id,
-            bind_seq: record.bind_seq,
-            bind_delta_index: record.bind_delta_index,
-        }
-    }
-}
-
-fn replace_if_newer_bind<K>(
-    map: &mut HashMap<K, DirentryBindRecord>,
-    key: K,
-    record: DirentryBindRecord,
-) where
+fn replace_if_newer<K, V, O>(map: &mut HashMap<K, V>, key: K, value: V, order: impl Fn(&V) -> O)
+where
     K: Eq + std::hash::Hash,
+    O: Ord,
 {
     let should_replace = map
         .get(&key)
-        .is_none_or(|existing| bind_order_key(&record) > bind_order_key(existing));
+        .is_none_or(|existing| order(&value) > order(existing));
     if should_replace {
-        map.insert(key, record);
+        map.insert(key, value);
     }
 }
 
-fn replace_if_newer_receipt(
-    map: &mut HashMap<CommitId, CommitReceiptRecord>,
-    key: CommitId,
-    record: CommitReceiptRecord,
-) {
-    let should_replace = map
-        .get(&key)
-        .is_none_or(|existing| record.committed_seq > existing.committed_seq);
-    if should_replace {
-        map.insert(key, record);
-    }
-}
-
-fn replace_if_newer_tombstone(
-    map: &mut HashMap<InodeId, SubtreeTombstoneRecord>,
-    key: InodeId,
-    record: SubtreeTombstoneRecord,
-) {
-    let should_replace = map
-        .get(&key)
-        .is_none_or(|existing| tombstone_order_key(&record) > tombstone_order_key(existing));
-    if should_replace {
-        map.insert(key, record);
-    }
-}
-
-fn remove_active_parent_if_same(
-    active_parent_by_child: &mut HashMap<InodeId, DirentryBindRecord>,
+fn remove_if_same_binding<K>(
+    map: &mut HashMap<K, DirentryBindRecord>,
+    key: K,
     record: &DirentryBindRecord,
-) {
-    if active_parent_by_child
-        .get(&record.child_inode_id)
-        .is_some_and(|active| same_binding(active, record))
-    {
-        active_parent_by_child.remove(&record.child_inode_id);
-    }
-}
-
-fn remove_active_child_if_same(
-    active_child_by_parent_name: &mut BTreeMap<(InodeId, NameKey), DirentryBindRecord>,
-    record: &DirentryBindRecord,
-) {
-    let key = (record.parent_inode_id, record.name_key.clone());
-    if active_child_by_parent_name
+) where
+    K: Eq + std::hash::Hash,
+{
+    if map
         .get(&key)
         .is_some_and(|active| same_binding(active, record))
     {
-        active_child_by_parent_name.remove(&key);
+        map.remove(&key);
     }
 }
 

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -51,7 +51,7 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
 ) -> Result<Vec<ManifestDirentryBindCandidate>> {
     let parent_prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
     let lower_bound = if let Some(row_key) = start_after_row_key {
-        resume_after_row_key(row_key)
+        lookup_keys::after_row_key(row_key)
     } else if let Some(name_key) = start_after_name_key {
         let exact_name_prefix = lookup_keys::direntry_bind_prefix(parent_inode_id, name_key);
         string_prefix_upper_bound(&exact_name_prefix).unwrap_or(exact_name_prefix)
@@ -190,7 +190,7 @@ pub(super) async fn direntry_unbinds_for_parent_name_range<S: ObjectStore + ?Siz
         let Some(last_row_key) = last_row_key else {
             break;
         };
-        lower_bound = resume_after_row_key(&last_row_key);
+        lower_bound = lookup_keys::after_row_key(&last_row_key);
     }
     Ok(unbinds)
 }
@@ -231,8 +231,8 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
     revision_no: RevisionNo,
 ) -> Result<Option<RevisionRecord>> {
-    let exact_prefix = revision_by_inode_desc_exact_revision_prefix(inode_id, revision_no);
-    let filter_probe = revision_by_inode_desc_filter_probe(inode_id);
+    let exact_prefix = lookup_keys::revision_by_inode_desc_revision_prefix(inode_id, revision_no);
+    let filter_probe = lookup_keys::revision_by_inode_desc_probe(inode_id);
     segments
         .scan_range_page_for_lookup(
             MetadataRowFamily::RevisionsByInodeDesc,
@@ -258,10 +258,17 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
     if limit == 0 {
         return Ok(Vec::new());
     }
-    let inode_prefix = revision_by_inode_desc_inode_prefix(inode_id);
-    let filter_probe = revision_by_inode_desc_filter_probe(inode_id);
+    let inode_prefix = lookup_keys::revision_by_inode_desc_prefix(inode_id);
+    let filter_probe = lookup_keys::revision_by_inode_desc_probe(inode_id);
     let lower_bound = start_after
-        .map(|position| resume_after_row_key(&revision_by_inode_desc_row_key(inode_id, position)))
+        .map(|position| {
+            lookup_keys::after_row_key(&lookup_keys::revision_by_inode_desc_row_key(
+                inode_id,
+                position.revision_no,
+                position.committed_seq,
+                position.revision_delta_index,
+            ))
+        })
         .unwrap_or_else(|| inode_prefix.clone());
     segments
         .scan_range_page_for_lookup(
@@ -393,37 +400,6 @@ pub(super) async fn attributes_for_inode<S: ObjectStore + ?Sized>(
         let Some(last_row_key) = last_row_key else {
             return Ok(None);
         };
-        lower_bound = resume_after_row_key(&last_row_key);
+        lower_bound = lookup_keys::after_row_key(&last_row_key);
     }
-}
-
-fn resume_after_row_key(row_key: &str) -> String {
-    let mut lower_bound = String::with_capacity(row_key.len() + 1);
-    lower_bound.push_str(row_key);
-    lower_bound.push('\0');
-    lower_bound
-}
-
-fn revision_by_inode_desc_inode_prefix(inode_id: InodeId) -> String {
-    lookup_keys::revision_by_inode_desc_prefix(inode_id)
-}
-
-fn revision_by_inode_desc_filter_probe(inode_id: InodeId) -> String {
-    lookup_keys::revision_by_inode_desc_probe(inode_id)
-}
-
-fn revision_by_inode_desc_exact_revision_prefix(
-    inode_id: InodeId,
-    revision_no: RevisionNo,
-) -> String {
-    lookup_keys::revision_by_inode_desc_revision_prefix(inode_id, revision_no)
-}
-
-fn revision_by_inode_desc_row_key(inode_id: InodeId, position: RevisionPagePosition) -> String {
-    lookup_keys::revision_by_inode_desc_row_key(
-        inode_id,
-        position.revision_no,
-        position.committed_seq,
-        position.revision_delta_index,
-    )
 }

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -33,7 +33,7 @@ pub(crate) use self::rows::{
 };
 #[cfg(test)]
 pub(crate) use self::view::InMemoryMetadataView;
-pub(crate) use self::view::MetadataView;
+pub(crate) use self::view::{AttributesProjection, MetadataView};
 pub(crate) use self::view_session::{
     LeafRevisionPrefetch, MetadataViewSession, VisibleChildEntry,
     METADATA_VIEW_SESSION_COUNTER_FIELDS,

--- a/crates/loonfs-core/src/metadata/queries.rs
+++ b/crates/loonfs-core/src/metadata/queries.rs
@@ -1,13 +1,13 @@
 //! Seq-gated reads over [`MetadataState`]: record lookups, visibility
 //! checks, and path resolution.
 //!
-//! Every seq-parameterized query routes to its `*_at_head` twin once
-//! `base_seq` reaches [`MetadataState::indexed_seq`], and to a historical
-//! row scan below it. The composite visibility decisions themselves live in
-//! [`super::visibility`]; this module only chooses which storage arm
-//! (historical scan or at-head index) answers the primitive lookups.
+//! Primitive reads use indexes at or above [`MetadataState::indexed_seq`]
+//! and scan historical rows below it. Composite visibility decisions live in
+//! [`super::visibility`].
 
-use super::visibility::{self, resolve_in_memory_read, unbind_matches_binding};
+use super::visibility::{
+    self, resolve_in_memory_read, unbind_matches_binding, MetadataVisibilityReads,
+};
 use super::{DirentryBindRecord, InodeRecord, MetadataState, SubtreeTombstoneRecord};
 use crate::binding_generation::BindingGeneration;
 use loonfs_api::{AbsolutePath, ActorRef, ChangeSeq, InodeId, InodeKind, NameKey};
@@ -45,17 +45,14 @@ pub enum VisiblePathError {
 
 impl MetadataState {
     pub fn inode_at_seq(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.inode_at_head(inode_id);
-        }
-        self.inode_at_seq_scan(inode_id, base_seq)
+        read_now(self.reads_at_seq(base_seq).find_inode(inode_id))
     }
 
-    pub(crate) fn inode_at_head(&self, inode_id: InodeId) -> Option<InodeRecord> {
-        self.indexes.inode(inode_id)
-    }
-
-    fn inode_at_seq_scan(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
+    pub(super) fn inode_at_seq_scan(
+        &self,
+        inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> Option<InodeRecord> {
         self.inodes
             .iter()
             .find(|inode| inode.inode_id == inode_id && inode.created_seq <= base_seq)
@@ -64,19 +61,20 @@ impl MetadataState {
 
     /// Latest bind for `(parent, name)` at or before `base_seq`, regardless
     /// of whether it has since been unbound.
+    #[cfg(test)]
     pub(crate) fn bound_child_at_seq(
         &self,
         parent_inode_id: InodeId,
         name_key: &NameKey,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.indexes.latest_bind(parent_inode_id, name_key);
-        }
-        self.bound_child_at_seq_scan(parent_inode_id, name_key, base_seq)
+        read_now(
+            self.reads_at_seq(base_seq)
+                .find_latest_bound_child(parent_inode_id, name_key),
+        )
     }
 
-    fn bound_child_at_seq_scan(
+    pub(super) fn bound_child_at_seq_scan(
         &self,
         parent_inode_id: InodeId,
         name_key: &NameKey,
@@ -98,20 +96,10 @@ impl MetadataState {
         child_inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.current_parent_binding_for_child_at_head(child_inode_id);
-        }
-        read_now(visibility::current_parent_binding_for_child(
-            &mut self.reads_at_seq(base_seq),
-            child_inode_id,
-        ))
-    }
-
-    pub(crate) fn current_parent_binding_for_child_at_head(
-        &self,
-        child_inode_id: InodeId,
-    ) -> Option<DirentryBindRecord> {
-        self.indexes.active_parent_for_child(child_inode_id)
+        read_now(
+            self.reads_at_seq(base_seq)
+                .current_parent_binding_for_child(child_inode_id),
+        )
     }
 
     pub fn active_subtree_tombstone(
@@ -119,20 +107,13 @@ impl MetadataState {
         root_inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<SubtreeTombstoneRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.active_subtree_tombstone_at_head(root_inode_id);
-        }
-        self.active_subtree_tombstone_scan(root_inode_id, base_seq)
+        read_now(
+            self.reads_at_seq(base_seq)
+                .find_active_subtree_tombstone(root_inode_id),
+        )
     }
 
-    pub(crate) fn active_subtree_tombstone_at_head(
-        &self,
-        root_inode_id: InodeId,
-    ) -> Option<SubtreeTombstoneRecord> {
-        self.indexes.active_tombstone(root_inode_id)
-    }
-
-    fn active_subtree_tombstone_scan(
+    pub(super) fn active_subtree_tombstone_scan(
         &self,
         root_inode_id: InodeId,
         base_seq: ChangeSeq,
@@ -151,38 +132,15 @@ impl MetadataState {
         inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<SubtreeTombstoneRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.covering_subtree_tombstone_at_head(inode_id);
-        }
         read_now(visibility::covering_subtree_tombstone(
             &mut self.reads_at_seq(base_seq),
-            inode_id,
-        ))
-    }
-
-    pub(crate) fn covering_subtree_tombstone_at_head(
-        &self,
-        inode_id: InodeId,
-    ) -> Option<SubtreeTombstoneRecord> {
-        read_now(visibility::covering_subtree_tombstone(
-            &mut self.reads_at_head(),
             inode_id,
         ))
     }
 
     pub fn visible_inode(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.visible_inode_at_head(inode_id);
-        }
         read_now(visibility::visible_inode(
             &mut self.reads_at_seq(base_seq),
-            inode_id,
-        ))
-    }
-
-    pub(crate) fn visible_inode_at_head(&self, inode_id: InodeId) -> Option<InodeRecord> {
-        read_now(visibility::visible_inode(
-            &mut self.reads_at_head(),
             inode_id,
         ))
     }
@@ -193,23 +151,8 @@ impl MetadataState {
         name_key: &NameKey,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.visible_child_at_head(parent_inode_id, name_key);
-        }
         read_now(visibility::visible_child(
             &mut self.reads_at_seq(base_seq),
-            parent_inode_id,
-            name_key,
-        ))
-    }
-
-    pub(crate) fn visible_child_at_head(
-        &self,
-        parent_inode_id: InodeId,
-        name_key: &NameKey,
-    ) -> Option<DirentryBindRecord> {
-        read_now(visibility::visible_child(
-            &mut self.reads_at_head(),
             parent_inode_id,
             name_key,
         ))
@@ -240,22 +183,16 @@ impl MetadataState {
             .cloned()
     }
 
+    #[cfg(test)]
     pub(crate) fn is_direntry_unbound_at_seq(
         &self,
         direntry: &DirentryBindRecord,
         base_seq: ChangeSeq,
     ) -> bool {
-        if base_seq >= self.indexed_seq() {
-            return self.is_direntry_unbound_at_head(direntry);
-        }
-        self.is_direntry_unbound_at_seq_scan(direntry, base_seq)
+        read_now(self.reads_at_seq(base_seq).is_binding_unbound(direntry))
     }
 
-    pub(crate) fn is_direntry_unbound_at_head(&self, direntry: &DirentryBindRecord) -> bool {
-        self.indexes.is_unbound(direntry)
-    }
-
-    fn is_direntry_unbound_at_seq_scan(
+    pub(super) fn is_direntry_unbound_at_seq_scan(
         &self,
         direntry: &DirentryBindRecord,
         base_seq: ChangeSeq,
@@ -271,23 +208,8 @@ impl MetadataState {
         new_parent_inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> bool {
-        if base_seq >= self.indexed_seq() {
-            return self.would_create_directory_cycle_at_head(inode_id, new_parent_inode_id);
-        }
         read_now(visibility::would_create_directory_cycle(
             &mut self.reads_at_seq(base_seq),
-            inode_id,
-            new_parent_inode_id,
-        ))
-    }
-
-    pub(crate) fn would_create_directory_cycle_at_head(
-        &self,
-        inode_id: InodeId,
-        new_parent_inode_id: InodeId,
-    ) -> bool {
-        read_now(visibility::would_create_directory_cycle(
-            &mut self.reads_at_head(),
             inode_id,
             new_parent_inode_id,
         ))

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -206,17 +206,19 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
     );
 
     assert_eq!(metadata_state.indexed_seq(), ChangeSeq(2));
-    assert!(metadata_state.inode_at_head(InodeId(2)).is_some());
+    assert!(metadata_state
+        .inode_at_seq(InodeId(2), metadata_state.indexed_seq())
+        .is_some());
     assert_eq!(
         metadata_state
-            .visible_child_at_head(InodeId(1), &name_key("docs"))
+            .visible_child(InodeId(1), &name_key("docs"), metadata_state.indexed_seq(),)
             .expect("docs visible")
             .child_inode_id,
         InodeId(2)
     );
     assert_eq!(
         metadata_state
-            .current_parent_binding_for_child_at_head(InodeId(2))
+            .current_parent_binding_for_child(InodeId(2), metadata_state.indexed_seq())
             .expect("parent binding")
             .parent_inode_id,
         InodeId(1)
@@ -238,10 +240,10 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
         }],
     );
     assert!(metadata_state
-        .visible_child_at_head(InodeId(1), &name_key("docs"))
+        .visible_child(InodeId(1), &name_key("docs"), metadata_state.indexed_seq(),)
         .is_none());
     assert!(metadata_state
-        .current_parent_binding_for_child_at_head(InodeId(2))
+        .current_parent_binding_for_child(InodeId(2), metadata_state.indexed_seq())
         .is_none());
 
     let metadata_state = metadata_state.apply_committed_wal_deltas(
@@ -258,11 +260,15 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
         }],
     );
     assert!(metadata_state
-        .visible_child_at_head(InodeId(1), &name_key("docs"))
+        .visible_child(InodeId(1), &name_key("docs"), metadata_state.indexed_seq(),)
         .is_none());
     assert_eq!(
         metadata_state
-            .visible_child_at_head(InodeId(1), &name_key("renamed"))
+            .visible_child(
+                InodeId(1),
+                &name_key("renamed"),
+                metadata_state.indexed_seq(),
+            )
             .expect("renamed visible")
             .child_inode_id,
         InodeId(2)
@@ -280,11 +286,15 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
         }],
     );
     assert!(metadata_state
-        .visible_child_at_head(InodeId(1), &name_key("renamed"))
+        .visible_child(
+            InodeId(1),
+            &name_key("renamed"),
+            metadata_state.indexed_seq(),
+        )
         .is_none());
     assert_eq!(
         metadata_state
-            .covering_subtree_tombstone_at_head(InodeId(3))
+            .covering_subtree_tombstone(InodeId(3), metadata_state.indexed_seq())
             .expect("descendant tombstone")
             .root_inode_id,
         InodeId(2)
@@ -347,13 +357,17 @@ fn stale_binding_is_not_active_after_newer_bind_claims_same_name() {
 
     assert_eq!(
         metadata_state
-            .visible_child_at_head(InodeId(1), &name_key("report"))
+            .visible_child(
+                InodeId(1),
+                &name_key("report"),
+                metadata_state.indexed_seq(),
+            )
             .expect("latest child")
             .child_inode_id,
         InodeId(3)
     );
     assert!(metadata_state
-        .current_parent_binding_for_child_at_head(InodeId(2))
+        .current_parent_binding_for_child(InodeId(2), metadata_state.indexed_seq())
         .is_none());
 }
 
@@ -853,15 +867,15 @@ fn queries_above_indexed_seq_match_at_head_results() {
     );
     assert_eq!(
         state.visible_child(InodeId(1), &name_key("contested"), beyond_head),
-        state.visible_child_at_head(InodeId(1), &name_key("contested")),
+        state.visible_child(InodeId(1), &name_key("contested"), state.indexed_seq(),),
     );
     assert_eq!(
         state.current_parent_binding_for_child(InodeId(2), beyond_head),
-        state.current_parent_binding_for_child_at_head(InodeId(2)),
+        state.current_parent_binding_for_child(InodeId(2), state.indexed_seq()),
     );
     assert_eq!(
         state.visible_inode(InodeId(3), beyond_head),
-        state.visible_inode_at_head(InodeId(3)),
+        state.visible_inode(InodeId(3), state.indexed_seq()),
     );
 }
 

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -2,11 +2,11 @@
 //! merged with the WAL tail, plus the caching session wide reads use.
 
 use super::durable_cache::{
-    BindingCacheKey, DurableVisibilityCache, ParentNameCacheKey, SharedRows,
+    DurableVisibilityCache, DurableVisibilityCacheInner, ParentNameCacheKey, SharedRows,
 };
 use super::manifest_index;
-use super::view_session::LeafRevisionPrefetch;
-use super::visibility::{self, MetadataVisibilityReads};
+use super::view_session::{latest_visible_bind, LeafRevisionPrefetch};
+use super::visibility::{self, BindingIdentity, MetadataVisibilityReads};
 use crate::checkpoint::VerifiedMetadataSegments;
 use crate::error::CoreError;
 use crate::metadata::{
@@ -25,7 +25,9 @@ use loonfs_api::{
 #[cfg(test)]
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 pub(super) const DIRECTORY_PAGE_RAW_SCAN_LIMIT: usize = 64;
@@ -58,15 +60,10 @@ impl ActiveDeletionScan {
         if page.len() < requested {
             self.exhausted = true;
         } else if let Some((last_row_key, _)) = page.last() {
-            self.lower_bound = format!("{last_row_key}\0");
+            self.lower_bound = lookup_keys::after_row_key(last_row_key);
         }
         self.buffered.extend(page);
     }
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct MetadataSnapshot {
-    visible_seq: ChangeSeq,
 }
 
 pub(crate) struct MetadataSourceStack<'a, 'store, S: ObjectStore + ?Sized> {
@@ -78,8 +75,16 @@ pub(crate) struct MetadataSourceStack<'a, 'store, S: ObjectStore + ?Sized> {
 }
 
 pub(crate) struct MetadataView<'a, 'store, S: ObjectStore + ?Sized> {
-    snapshot: MetadataSnapshot,
+    visible_seq: ChangeSeq,
     sources: MetadataSourceStack<'a, 'store, S>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AttributesProjection {
+    pub(crate) revision_no: AttributeRevisionNo,
+    pub(crate) attributes: Attributes,
+    pub(crate) updated_by: Option<loonfs_api::ActorRef>,
+    pub(crate) updated_at_ms: Option<u64>,
 }
 
 #[cfg(test)]
@@ -109,7 +114,7 @@ impl<'a> InMemoryMetadataView<'a> {
         visible_seq: ChangeSeq,
     ) -> Self {
         Self {
-            snapshot: MetadataSnapshot { visible_seq },
+            visible_seq,
             sources: MetadataSourceStack {
                 overlay,
                 batch_accepted: None,
@@ -128,9 +133,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         wal_tail_rows: &'a MetadataState,
     ) -> Self {
         Self {
-            snapshot: MetadataSnapshot {
-                visible_seq: head.seq,
-            },
+            visible_seq: head.seq,
             sources: MetadataSourceStack {
                 overlay: None,
                 batch_accepted: None,
@@ -151,9 +154,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         materialized_seq: ChangeSeq,
     ) -> Self {
         Self {
-            snapshot: MetadataSnapshot {
-                visible_seq: materialized_seq,
-            },
+            visible_seq: materialized_seq,
             sources: MetadataSourceStack {
                 overlay: None,
                 batch_accepted: None,
@@ -171,7 +172,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         visible_seq: ChangeSeq,
     ) -> MetadataView<'view, 'store, S> {
         MetadataView {
-            snapshot: MetadataSnapshot { visible_seq },
+            visible_seq,
             sources: MetadataSourceStack {
                 overlay: Some(overlay),
                 batch_accepted: Some(batch_accepted),
@@ -183,7 +184,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     }
 
     pub(super) fn visible_seq(&self) -> ChangeSeq {
-        self.snapshot.visible_seq
+        self.visible_seq
     }
 
     /// Attaches a cache for durable lookups performed during one batch.
@@ -221,6 +222,43 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
 
     pub(super) fn manifest_segments(&self) -> Option<&'a VerifiedMetadataSegments<'store, S>> {
         self.sources.manifest
+    }
+
+    async fn shared_rows<T, K>(
+        &self,
+        select_map: fn(&mut DurableVisibilityCacheInner) -> &mut HashMap<K, Arc<Vec<T>>>,
+        key: K,
+        fetch: Pin<Box<dyn Future<Output = Result<Vec<T>, CoreError>> + Send + '_>>,
+        rows_of: fn(&MetadataState) -> &[T],
+        matches: impl Fn(&T) -> bool,
+    ) -> Result<SharedRows<T>, CoreError>
+    where
+        T: Clone,
+        K: Clone + Eq + std::hash::Hash,
+    {
+        let durable = if let Some(cached) = self
+            .sources
+            .durable_cache
+            .and_then(|cache| cache.get(select_map, &key))
+        {
+            cached
+        } else {
+            let mut durable = fetch.await?;
+            durable.extend(
+                self.durable_row_states()
+                    .flat_map(|state| rows_of(state).iter().filter(|row| matches(row)).cloned()),
+            );
+            let durable = Arc::new(durable);
+            if let Some(cache) = self.sources.durable_cache {
+                cache.insert(select_map, key, Arc::clone(&durable));
+            }
+            durable
+        };
+        let overlay = self
+            .overlay_states()
+            .flat_map(|state| rows_of(state).iter().filter(|row| matches(row)).cloned())
+            .collect();
+        Ok(SharedRows { durable, overlay })
     }
 }
 
@@ -445,27 +483,22 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     pub(crate) async fn attributes_projection_at_visible_seq(
         &self,
         inode_id: InodeId,
-    ) -> Result<
-        (
-            AttributeRevisionNo,
-            Attributes,
-            Option<loonfs_api::ActorRef>,
-            Option<u64>,
-        ),
-        CoreError,
-    > {
+    ) -> Result<AttributesProjection, CoreError> {
         Ok(self
             .latest_attributes_revision(inode_id)
             .await?
-            .map(|record| {
-                (
-                    record.attributes_revision_no,
-                    record.attributes,
-                    Some(record.updated_by),
-                    Some(record.updated_at_ms),
-                )
+            .map(|record| AttributesProjection {
+                revision_no: record.attributes_revision_no,
+                attributes: record.attributes,
+                updated_by: Some(record.updated_by),
+                updated_at_ms: Some(record.updated_at_ms),
             })
-            .unwrap_or_else(|| (AttributeRevisionNo(0), Attributes::default(), None, None)))
+            .unwrap_or_else(|| AttributesProjection {
+                revision_no: AttributeRevisionNo(0),
+                attributes: Attributes::default(),
+                updated_by: None,
+                updated_at_ms: None,
+            }))
     }
 
     pub(crate) async fn find_commit_receipt(
@@ -509,11 +542,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         child_inode_id: InodeId,
     ) -> Result<Option<DirentryBindRecord>, CoreError> {
         let bindings = self.direntry_binds_for_child(child_inode_id).await?;
-        let latest = bindings
-            .iter()
-            .filter(|direntry| direntry.bind_seq <= self.visible_seq())
-            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-            .cloned();
+        let latest = latest_visible_bind(bindings.iter(), self.visible_seq());
         Ok(latest)
     }
 
@@ -541,11 +570,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         let bindings = self
             .direntry_binds_for_parent_name(parent_inode_id, name_key)
             .await?;
-        let latest = bindings
-            .iter()
-            .filter(|direntry| direntry.bind_seq <= self.visible_seq())
-            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-            .cloned();
+        let latest = latest_visible_bind(bindings.iter(), self.visible_seq());
         Ok(latest)
     }
 
@@ -581,146 +606,68 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             parent_inode_id,
             name_key: name_key.clone(),
         };
-        let durable = if let Some(cached) = self
-            .sources
-            .durable_cache
-            .and_then(|cache| cache.get(|inner| &mut inner.binds_for_parent_name, &cache_key))
-        {
-            cached
-        } else {
-            let mut durable = if let Some(segments) = self.manifest_segments() {
-                manifest_index::direntry_binds_for_parent_name(segments, parent_inode_id, name_key)
-                    .await?
-            } else {
-                Vec::new()
-            };
-            durable.extend(self.durable_row_states().flat_map(|state| {
-                state
-                    .direntry_binds()
-                    .iter()
-                    .filter(move |direntry| {
-                        direntry.parent_inode_id == parent_inode_id
-                            && direntry.name_key == *name_key
-                    })
-                    .cloned()
-            }));
-            let durable = Arc::new(durable);
-            if let Some(cache) = self.sources.durable_cache {
-                cache.insert(
-                    |inner| &mut inner.binds_for_parent_name,
-                    cache_key,
-                    Arc::clone(&durable),
-                );
-            }
-            durable
-        };
-        let overlay = self
-            .overlay_states()
-            .flat_map(|state| {
-                state
-                    .direntry_binds()
-                    .iter()
-                    .filter(move |direntry| {
-                        direntry.parent_inode_id == parent_inode_id
-                            && direntry.name_key == *name_key
-                    })
-                    .cloned()
-            })
-            .collect();
-        Ok(SharedRows { durable, overlay })
+        self.shared_rows(
+            |inner| &mut inner.binds_for_parent_name,
+            cache_key,
+            Box::pin(async {
+                if let Some(segments) = self.manifest_segments() {
+                    manifest_index::direntry_binds_for_parent_name(
+                        segments,
+                        parent_inode_id,
+                        name_key,
+                    )
+                    .await
+                } else {
+                    Ok(Vec::new())
+                }
+            }),
+            MetadataState::direntry_binds,
+            |direntry| {
+                direntry.parent_inode_id == parent_inode_id && direntry.name_key == *name_key
+            },
+        )
+        .await
     }
 
     pub(super) async fn direntry_binds_for_child(
         &self,
         child_inode_id: InodeId,
     ) -> Result<SharedRows<DirentryBindRecord>, CoreError> {
-        let durable = if let Some(cached) = self
-            .sources
-            .durable_cache
-            .and_then(|cache| cache.get(|inner| &mut inner.binds_for_child, &child_inode_id))
-        {
-            cached
-        } else {
-            let mut durable = if let Some(segments) = self.manifest_segments() {
-                manifest_index::direntry_binds_for_child(segments, child_inode_id).await?
-            } else {
-                Vec::new()
-            };
-            durable.extend(self.durable_row_states().flat_map(|state| {
-                state
-                    .direntry_binds()
-                    .iter()
-                    .filter(move |direntry| direntry.child_inode_id == child_inode_id)
-                    .cloned()
-            }));
-            let durable = Arc::new(durable);
-            if let Some(cache) = self.sources.durable_cache {
-                cache.insert(
-                    |inner| &mut inner.binds_for_child,
-                    child_inode_id,
-                    Arc::clone(&durable),
-                );
-            }
-            durable
-        };
-        let overlay = self
-            .overlay_states()
-            .flat_map(|state| {
-                state
-                    .direntry_binds()
-                    .iter()
-                    .filter(move |direntry| direntry.child_inode_id == child_inode_id)
-                    .cloned()
-            })
-            .collect();
-        Ok(SharedRows { durable, overlay })
+        self.shared_rows(
+            |inner| &mut inner.binds_for_child,
+            child_inode_id,
+            Box::pin(async {
+                if let Some(segments) = self.manifest_segments() {
+                    manifest_index::direntry_binds_for_child(segments, child_inode_id).await
+                } else {
+                    Ok(Vec::new())
+                }
+            }),
+            MetadataState::direntry_binds,
+            |direntry| direntry.child_inode_id == child_inode_id,
+        )
+        .await
     }
 
     pub(super) async fn direntry_unbinds_for_binding(
         &self,
         direntry: &DirentryBindRecord,
     ) -> Result<SharedRows<DirentryUnbindRecord>, CoreError> {
-        let cache_key = BindingCacheKey::from(direntry);
-        let durable = if let Some(cached) = self
-            .sources
-            .durable_cache
-            .and_then(|cache| cache.get(|inner| &mut inner.unbinds_for_binding, &cache_key))
-        {
-            cached
-        } else {
-            let mut durable = if let Some(segments) = self.manifest_segments() {
-                manifest_index::direntry_unbinds_for_binding(segments, direntry).await?
-            } else {
-                Vec::new()
-            };
-            durable.extend(self.durable_row_states().flat_map(|state| {
-                state
-                    .direntry_unbinds()
-                    .iter()
-                    .filter(move |unbind| unbind_matches_binding(unbind, direntry))
-                    .cloned()
-            }));
-            let durable = Arc::new(durable);
-            if let Some(cache) = self.sources.durable_cache {
-                cache.insert(
-                    |inner| &mut inner.unbinds_for_binding,
-                    cache_key,
-                    Arc::clone(&durable),
-                );
-            }
-            durable
-        };
-        let overlay = self
-            .overlay_states()
-            .flat_map(|state| {
-                state
-                    .direntry_unbinds()
-                    .iter()
-                    .filter(move |unbind| unbind_matches_binding(unbind, direntry))
-                    .cloned()
-            })
-            .collect();
-        Ok(SharedRows { durable, overlay })
+        let cache_key = BindingIdentity::from(direntry);
+        self.shared_rows(
+            |inner| &mut inner.unbinds_for_binding,
+            cache_key,
+            Box::pin(async {
+                if let Some(segments) = self.manifest_segments() {
+                    manifest_index::direntry_unbinds_for_binding(segments, direntry).await
+                } else {
+                    Ok(Vec::new())
+                }
+            }),
+            MetadataState::direntry_unbinds,
+            |unbind| unbind_matches_binding(unbind, direntry),
+        )
+        .await
     }
 
     fn row_latest_revision_for_inode(&self, inode_id: InodeId) -> Option<RevisionRecord> {
@@ -888,46 +835,20 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         &self,
         root_inode_id: InodeId,
     ) -> Result<SharedRows<SubtreeTombstoneRecord>, CoreError> {
-        let durable = if let Some(cached) = self
-            .sources
-            .durable_cache
-            .and_then(|cache| cache.get(|inner| &mut inner.tombstones_for_root, &root_inode_id))
-        {
-            cached
-        } else {
-            let mut durable = if let Some(segments) = self.manifest_segments() {
-                manifest_index::tombstones_for_root(segments, root_inode_id).await?
-            } else {
-                Vec::new()
-            };
-            durable.extend(self.durable_row_states().flat_map(|state| {
-                state
-                    .subtree_tombstones()
-                    .iter()
-                    .filter(move |tombstone| tombstone.root_inode_id == root_inode_id)
-                    .cloned()
-            }));
-            let durable = Arc::new(durable);
-            if let Some(cache) = self.sources.durable_cache {
-                cache.insert(
-                    |inner| &mut inner.tombstones_for_root,
-                    root_inode_id,
-                    Arc::clone(&durable),
-                );
-            }
-            durable
-        };
-        let overlay = self
-            .overlay_states()
-            .flat_map(|state| {
-                state
-                    .subtree_tombstones()
-                    .iter()
-                    .filter(move |tombstone| tombstone.root_inode_id == root_inode_id)
-                    .cloned()
-            })
-            .collect();
-        Ok(SharedRows { durable, overlay })
+        self.shared_rows(
+            |inner| &mut inner.tombstones_for_root,
+            root_inode_id,
+            Box::pin(async {
+                if let Some(segments) = self.manifest_segments() {
+                    manifest_index::tombstones_for_root(segments, root_inode_id).await
+                } else {
+                    Ok(Vec::new())
+                }
+            }),
+            MetadataState::subtree_tombstones,
+            |tombstone| tombstone.root_inode_id == root_inode_id,
+        )
+        .await
     }
 
     /// Every unbind for `parent_inode_id` with a name key in

--- a/crates/loonfs-core/src/metadata/view_session.rs
+++ b/crates/loonfs-core/src/metadata/view_session.rs
@@ -8,22 +8,83 @@
 //! [`super::visibility`] rule bodies; the session only memoizes their
 //! primitive inputs.
 
-use super::durable_cache::{BindingCacheKey, ParentNameCacheKey};
+use super::durable_cache::ParentNameCacheKey;
 use super::manifest_index;
 use super::view::DIRECTORY_PAGE_RAW_SCAN_LIMIT;
-use super::visibility::{self, MetadataVisibilityReads};
+use super::visibility::{self, BindingIdentity, MetadataVisibilityReads};
 use super::{
-    DirentryBindRecord, InodeRecord, MetadataView, RecoverableDeletion, ResolvedVisiblePath,
-    RevisionRecord, SubtreeTombstoneRecord,
+    AttributesProjection, DirentryBindRecord, InodeRecord, MetadataView, RecoverableDeletion,
+    ResolvedVisiblePath, RevisionRecord, SubtreeTombstoneRecord,
 };
 use crate::error::CoreError;
-use loonfs_api::wire::manifest::{MetadataRow, MetadataRowFamily};
-use loonfs_api::{
-    AbsolutePath, AttributeRevisionNo, Attributes, ChangeSeq, InodeId, InodeKind, NameKey,
-    ROOT_INODE_ID,
-};
+use loonfs_api::wire::manifest::lookup_keys;
+use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, InodeKind, NameKey, ROOT_INODE_ID};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{HashMap, HashSet, VecDeque};
+
+pub(super) fn latest_visible_bind<'a>(
+    rows: impl Iterator<Item = &'a DirentryBindRecord>,
+    visible_seq: ChangeSeq,
+) -> Option<DirentryBindRecord> {
+    rows.filter(|direntry| direntry.bind_seq <= visible_seq)
+        .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
+        .cloned()
+}
+
+async fn fetch_inode_at_seq<S: ObjectStore + ?Sized>(
+    base: &MetadataView<'_, '_, S>,
+    inode_id: InodeId,
+) -> Result<Option<InodeRecord>, CoreError> {
+    base.inode_at_seq(inode_id).await
+}
+
+async fn fetch_active_subtree_tombstone<S: ObjectStore + ?Sized>(
+    base: &MetadataView<'_, '_, S>,
+    root_inode_id: InodeId,
+) -> Result<Option<SubtreeTombstoneRecord>, CoreError> {
+    let tombstones = base.tombstones_for_root(root_inode_id).await?;
+    Ok(super::rows::active_tombstone_from_records(
+        tombstones.iter().cloned(),
+        base.visible_seq(),
+    ))
+}
+
+async fn fetch_latest_parent_binding_for_child<S: ObjectStore + ?Sized>(
+    base: &MetadataView<'_, '_, S>,
+    child_inode_id: InodeId,
+) -> Result<Option<DirentryBindRecord>, CoreError> {
+    let bindings = base.direntry_binds_for_child(child_inode_id).await?;
+    Ok(latest_visible_bind(bindings.iter(), base.visible_seq()))
+}
+
+async fn fetch_is_direntry_unbound<S: ObjectStore + ?Sized>(
+    base: &MetadataView<'_, '_, S>,
+    direntry: &DirentryBindRecord,
+) -> Result<bool, CoreError> {
+    let unbinds = base.direntry_unbinds_for_binding(direntry).await?;
+    let unbound = unbinds
+        .iter()
+        .any(|unbind| unbind.unbind_seq <= base.visible_seq());
+    Ok(unbound)
+}
+
+async fn fetch_bound_child<S: ObjectStore + ?Sized>(
+    base: &MetadataView<'_, '_, S>,
+    parent_inode_id: InodeId,
+    name_key: &NameKey,
+) -> Result<Option<DirentryBindRecord>, CoreError> {
+    let bindings = base
+        .direntry_binds_for_parent_name(parent_inode_id, name_key)
+        .await?;
+    Ok(latest_visible_bind(bindings.iter(), base.visible_seq()))
+}
+
+async fn fetch_latest_revision_head_of_visible<S: ObjectStore + ?Sized>(
+    base: &MetadataView<'_, '_, S>,
+    inode_id: InodeId,
+) -> Result<Option<RevisionRecord>, CoreError> {
+    base.latest_revision_record(inode_id).await
+}
 
 impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     /// Opens a fresh session over this view; the view is `Copy`, so the
@@ -46,7 +107,12 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                         .is_none_or(|last_name_key| direntry.name_key.as_str() > last_name_key)
             })
             .map(|record| DirentryBindPageCandidate {
-                row_key: direntry_bind_row_key(record),
+                row_key: lookup_keys::direntry_bind_row_key(
+                    record.parent_inode_id,
+                    record.name_key.as_str(),
+                    record.bind_seq,
+                    record.bind_delta_index,
+                ),
                 record: record.clone(),
             })
             .collect::<Vec<_>>();
@@ -83,39 +149,52 @@ pub(crate) struct MetadataViewSessionCounters {
     pub(crate) list_preload_child_lookups: u64,
 }
 
-pub(crate) const METADATA_VIEW_SESSION_COUNTER_FIELDS: [&str; 12] = [
-    "list_page_visible_child_calls",
-    "list_page_visible_inode_calls",
-    "list_page_current_parent_binding_calls",
-    "list_page_covering_tombstone_calls",
-    "list_page_latest_revision_calls",
-    "list_page_latest_attributes_calls",
-    "list_page_direntry_child_scan_calls",
-    "list_page_scan_prefix_calls",
-    "list_page_scan_range_page_calls",
-    "list_page_preload_unbind_range_scans",
-    "list_page_preload_child_lookups",
-    "list_page_preload_attribute_lookups",
+pub(crate) type MetadataViewSessionCounterField =
+    (&'static str, fn(&MetadataViewSessionCounters) -> u64);
+
+pub(crate) const METADATA_VIEW_SESSION_COUNTER_FIELDS: [MetadataViewSessionCounterField; 12] = [
+    ("list_page_visible_child_calls", |counters| {
+        counters.visible_child_calls
+    }),
+    ("list_page_visible_inode_calls", |counters| {
+        counters.visible_inode_calls
+    }),
+    ("list_page_current_parent_binding_calls", |counters| {
+        counters.current_parent_binding_calls
+    }),
+    ("list_page_covering_tombstone_calls", |counters| {
+        counters.covering_tombstone_calls
+    }),
+    ("list_page_latest_revision_calls", |counters| {
+        counters.latest_revision_calls
+    }),
+    ("list_page_latest_attributes_calls", |counters| {
+        counters.latest_attributes_calls
+    }),
+    ("list_page_direntry_child_scan_calls", |counters| {
+        counters.direntry_child_scan_calls
+    }),
+    ("list_page_scan_prefix_calls", |counters| {
+        counters.scan_prefix_calls
+    }),
+    ("list_page_scan_range_page_calls", |counters| {
+        counters.scan_range_page_calls
+    }),
+    ("list_page_preload_unbind_range_scans", |counters| {
+        counters.list_preload_unbind_range_scans
+    }),
+    ("list_page_preload_child_lookups", |counters| {
+        counters.list_preload_child_lookups
+    }),
+    ("list_page_preload_attribute_lookups", |counters| {
+        counters.preload_attribute_lookups
+    }),
 ];
 
 impl MetadataViewSessionCounters {
     pub(crate) fn record_on(self, span: &tracing::Span) {
-        let values = [
-            self.visible_child_calls,
-            self.visible_inode_calls,
-            self.current_parent_binding_calls,
-            self.covering_tombstone_calls,
-            self.latest_revision_calls,
-            self.latest_attributes_calls,
-            self.direntry_child_scan_calls,
-            self.scan_prefix_calls,
-            self.scan_range_page_calls,
-            self.list_preload_unbind_range_scans,
-            self.list_preload_child_lookups,
-            self.preload_attribute_lookups,
-        ];
-        for (field, value) in METADATA_VIEW_SESSION_COUNTER_FIELDS.iter().zip(values) {
-            span.record(*field, value);
+        for (field, value) in METADATA_VIEW_SESSION_COUNTER_FIELDS {
+            span.record(field, value(&self));
         }
     }
 }
@@ -129,18 +208,10 @@ pub(crate) struct MetadataViewSession<'a, 'store, S: ObjectStore + ?Sized> {
     current_parent_binding_cache: HashMap<InodeId, Option<DirentryBindRecord>>,
     latest_parent_binding_cache: HashMap<InodeId, Option<DirentryBindRecord>>,
     latest_revision_head_cache: HashMap<InodeId, Option<RevisionRecord>>,
-    attributes_cache: HashMap<
-        InodeId,
-        (
-            AttributeRevisionNo,
-            Attributes,
-            Option<loonfs_api::ActorRef>,
-            Option<u64>,
-        ),
-    >,
+    attributes_cache: HashMap<InodeId, AttributesProjection>,
     active_tombstone_cache: HashMap<InodeId, Option<SubtreeTombstoneRecord>>,
     covering_tombstone_cache: HashMap<InodeId, Option<SubtreeTombstoneRecord>>,
-    unbind_cache: HashMap<BindingCacheKey, bool>,
+    unbind_cache: HashMap<BindingIdentity, bool>,
     counters: MetadataViewSessionCounters,
 }
 
@@ -164,6 +235,52 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
 
     pub(crate) fn counters(&self) -> MetadataViewSessionCounters {
         self.counters
+    }
+
+    fn cached_inode_at_seq(&self, inode_id: InodeId) -> Option<Option<InodeRecord>> {
+        self.inode_at_seq_cache.get(&inode_id).cloned()
+    }
+
+    fn cached_active_subtree_tombstone(
+        &self,
+        root_inode_id: InodeId,
+    ) -> Option<Option<SubtreeTombstoneRecord>> {
+        self.active_tombstone_cache.get(&root_inode_id).cloned()
+    }
+
+    fn cached_latest_parent_binding_for_child(
+        &self,
+        child_inode_id: InodeId,
+    ) -> Option<Option<DirentryBindRecord>> {
+        self.latest_parent_binding_cache
+            .get(&child_inode_id)
+            .cloned()
+    }
+
+    fn cached_is_direntry_unbound(&self, direntry: &DirentryBindRecord) -> Option<bool> {
+        self.unbind_cache
+            .get(&BindingIdentity::from(direntry))
+            .copied()
+    }
+
+    fn cached_bound_child(
+        &self,
+        parent_inode_id: InodeId,
+        name_key: &NameKey,
+    ) -> Option<Option<DirentryBindRecord>> {
+        self.bound_child_cache
+            .get(&ParentNameCacheKey {
+                parent_inode_id,
+                name_key: name_key.clone(),
+            })
+            .cloned()
+    }
+
+    fn cached_latest_revision_head_of_visible(
+        &self,
+        inode_id: InodeId,
+    ) -> Option<Option<RevisionRecord>> {
+        self.latest_revision_head_cache.get(&inode_id).cloned()
     }
 
     pub(crate) async fn visible_children_page_by_name_key(
@@ -332,12 +449,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         let visible_seq = self.base.visible_seq();
         let mut latest_binds = Vec::with_capacity(groups.len());
         for group in groups {
-            let latest = group
-                .rows
-                .iter()
-                .filter(|direntry| direntry.bind_seq <= visible_seq)
-                .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-                .cloned();
+            let latest = latest_visible_bind(group.rows.iter(), visible_seq);
             self.bound_child_cache.insert(
                 ParentNameCacheKey {
                     parent_inode_id,
@@ -365,13 +477,13 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                 &last_group.name_key,
             )
             .await?;
-        let unbound_identities: HashSet<BindingCacheKey> = unbinds
+        let unbound_identities: HashSet<BindingIdentity> = unbinds
             .iter()
             .filter(|unbind| unbind.unbind_seq <= visible_seq)
-            .map(BindingCacheKey::from)
+            .map(BindingIdentity::from)
             .collect();
         for direntry in &latest_binds {
-            let cache_key = BindingCacheKey::from(direntry);
+            let cache_key = BindingIdentity::from(direntry);
             let unbound = unbound_identities.contains(&cache_key);
             self.unbind_cache.insert(cache_key, unbound);
         }
@@ -398,7 +510,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                     && latest_binding.name_key.as_str() >= first_group.name_key.as_str()
                     && latest_binding.name_key.as_str() <= last_group.name_key.as_str()
                 {
-                    let cache_key = BindingCacheKey::from(latest_binding);
+                    let cache_key = BindingIdentity::from(latest_binding);
                     let unbound = unbound_identities.contains(&cache_key);
                     self.unbind_cache.entry(cache_key).or_insert(unbound);
                 }
@@ -445,11 +557,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
 
         for (inode_id, inode, bindings, tombstones) in lookups {
             self.inode_at_seq_cache.insert(inode_id, inode);
-            let latest_binding = bindings
-                .iter()
-                .filter(|direntry| direntry.bind_seq <= visible_seq)
-                .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-                .cloned();
+            let latest_binding = latest_visible_bind(bindings.iter(), visible_seq);
             self.latest_parent_binding_cache
                 .insert(inode_id, latest_binding);
             let active_tombstone =
@@ -493,7 +601,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         absolute_path: &AbsolutePath,
         prefetch_leaf_revision: LeafRevisionPrefetch,
     ) -> Result<(), CoreError> {
-        let visible_seq = self.base.visible_seq();
         let component_name_keys: Vec<NameKey> = absolute_path
             .components()
             .iter()
@@ -513,57 +620,31 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             let base = &self.base;
             let (inode, tombstone, parent_binding, unbind, bound_child, revision) = futures::try_join!(
                 async {
-                    match self.inode_at_seq_cache.get(&current_inode_id).cloned() {
+                    match self.cached_inode_at_seq(current_inode_id) {
                         Some(inode) => Ok(inode),
-                        None => base.inode_at_seq(current_inode_id).await,
+                        None => fetch_inode_at_seq(base, current_inode_id).await,
                     }
                 },
                 async {
-                    match self.active_tombstone_cache.get(&current_inode_id).cloned() {
+                    match self.cached_active_subtree_tombstone(current_inode_id) {
                         Some(tombstone) => Ok(tombstone),
-                        None => base
-                            .tombstones_for_root(current_inode_id)
-                            .await
-                            .map(|rows| {
-                                super::rows::active_tombstone_from_records(
-                                    rows.iter().cloned(),
-                                    visible_seq,
-                                )
-                            }),
+                        None => fetch_active_subtree_tombstone(base, current_inode_id).await,
                     }
                 },
                 async {
-                    match self
-                        .latest_parent_binding_cache
-                        .get(&current_inode_id)
-                        .cloned()
-                    {
+                    match self.cached_latest_parent_binding_for_child(current_inode_id) {
                         Some(binding) => Ok(binding),
-                        None => base
-                            .direntry_binds_for_child(current_inode_id)
-                            .await
-                            .map(|rows| {
-                                rows.iter()
-                                    .filter(|direntry| direntry.bind_seq <= visible_seq)
-                                    .max_by_key(|direntry| {
-                                        (direntry.bind_seq, direntry.bind_delta_index)
-                                    })
-                                    .cloned()
-                            }),
+                        None => fetch_latest_parent_binding_for_child(base, current_inode_id).await,
                     }
                 },
                 async {
                     let Some(binding) = &arrived_by_binding else {
                         return Ok(None);
                     };
-                    let cache_key = BindingCacheKey::from(binding);
-                    let unbound = match self.unbind_cache.get(&cache_key).copied() {
+                    let cache_key = BindingIdentity::from(binding);
+                    let unbound = match self.cached_is_direntry_unbound(binding) {
                         Some(unbound) => unbound,
-                        None => base
-                            .direntry_unbinds_for_binding(binding)
-                            .await?
-                            .iter()
-                            .any(|unbind| unbind.unbind_seq <= visible_seq),
+                        None => fetch_is_direntry_unbound(base, binding).await?,
                     };
                     Ok(Some((cache_key, unbound)))
                 },
@@ -575,15 +656,9 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                         parent_inode_id: current_inode_id,
                         name_key: name_key.clone(),
                     };
-                    let binding = match self.bound_child_cache.get(&cache_key).cloned() {
+                    let binding = match self.cached_bound_child(current_inode_id, name_key) {
                         Some(binding) => binding,
-                        None => base
-                            .direntry_binds_for_parent_name(current_inode_id, name_key)
-                            .await?
-                            .iter()
-                            .filter(|direntry| direntry.bind_seq <= visible_seq)
-                            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-                            .cloned(),
+                        None => fetch_bound_child(base, current_inode_id, name_key).await?,
                     };
                     Ok(Some((cache_key, binding)))
                 },
@@ -591,13 +666,9 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                     if !prefetch_revision {
                         return Ok(None);
                     }
-                    match self
-                        .latest_revision_head_cache
-                        .get(&current_inode_id)
-                        .cloned()
-                    {
+                    match self.cached_latest_revision_head_of_visible(current_inode_id) {
                         Some(revision) => Ok(revision),
-                        None => base.latest_revision_record(current_inode_id).await,
+                        None => fetch_latest_revision_head_of_visible(base, current_inode_id).await,
                     }
                 },
             )?;
@@ -643,7 +714,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     }
 
     /// Returns the inode when it is visible in this session's snapshot.
-    ///
     pub(crate) async fn visible_inode(
         &mut self,
         inode_id: InodeId,
@@ -662,10 +732,10 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         &mut self,
         inode_id: InodeId,
     ) -> Result<Option<InodeRecord>, CoreError> {
-        if let Some(cached) = self.inode_at_seq_cache.get(&inode_id).cloned() {
+        if let Some(cached) = self.cached_inode_at_seq(inode_id) {
             return Ok(cached);
         }
-        let inode = self.base.inode_at_seq(inode_id).await?;
+        let inode = fetch_inode_at_seq(&self.base, inode_id).await?;
         self.inode_at_seq_cache.insert(inode_id, inode.clone());
         Ok(inode)
     }
@@ -676,16 +746,15 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     /// full child-binds scan and tombstone probe per entry on a wide listing,
     /// and it cannot disagree with the enumeration that admitted the entry
     /// at the same seq.
-    ///
     pub(crate) async fn latest_revision_head_of_visible(
         &mut self,
         inode_id: InodeId,
     ) -> Result<Option<RevisionRecord>, CoreError> {
         self.counters.latest_revision_calls = self.counters.latest_revision_calls.saturating_add(1);
-        if let Some(cached) = self.latest_revision_head_cache.get(&inode_id).cloned() {
+        if let Some(cached) = self.cached_latest_revision_head_of_visible(inode_id) {
             return Ok(cached);
         }
-        let revision = self.base.latest_revision_record(inode_id).await?;
+        let revision = fetch_latest_revision_head_of_visible(&self.base, inode_id).await?;
         self.latest_revision_head_cache
             .insert(inode_id, revision.clone());
         Ok(revision)
@@ -703,15 +772,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     pub(crate) async fn attributes_of_visible(
         &mut self,
         inode_id: InodeId,
-    ) -> Result<
-        (
-            AttributeRevisionNo,
-            Attributes,
-            Option<loonfs_api::ActorRef>,
-            Option<u64>,
-        ),
-        CoreError,
-    > {
+    ) -> Result<AttributesProjection, CoreError> {
         self.counters.latest_attributes_calls =
             self.counters.latest_attributes_calls.saturating_add(1);
         if let Some(cached) = self.attributes_cache.get(&inode_id).cloned() {
@@ -777,7 +838,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     }
 
     /// Returns the child's active parent binding at the visible sequence.
-    ///
     pub(crate) async fn current_parent_binding_for_child(
         &mut self,
         child_inode_id: InodeId,
@@ -806,22 +866,13 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         &mut self,
         child_inode_id: InodeId,
     ) -> Result<Option<DirentryBindRecord>, CoreError> {
-        if let Some(cached) = self
-            .latest_parent_binding_cache
-            .get(&child_inode_id)
-            .cloned()
-        {
+        if let Some(cached) = self.cached_latest_parent_binding_for_child(child_inode_id) {
             return Ok(cached);
         }
         self.counters.direntry_child_scan_calls =
             self.counters.direntry_child_scan_calls.saturating_add(1);
         self.counters.scan_prefix_calls = self.counters.scan_prefix_calls.saturating_add(1);
-        let bindings = self.base.direntry_binds_for_child(child_inode_id).await?;
-        let latest = bindings
-            .iter()
-            .filter(|direntry| direntry.bind_seq <= self.base.visible_seq())
-            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-            .cloned();
+        let latest = fetch_latest_parent_binding_for_child(&self.base, child_inode_id).await?;
         self.latest_parent_binding_cache
             .insert(child_inode_id, latest.clone());
         Ok(latest)
@@ -858,15 +909,11 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         &mut self,
         root_inode_id: InodeId,
     ) -> Result<Option<SubtreeTombstoneRecord>, CoreError> {
-        if let Some(cached) = self.active_tombstone_cache.get(&root_inode_id).cloned() {
+        if let Some(cached) = self.cached_active_subtree_tombstone(root_inode_id) {
             return Ok(cached);
         }
         self.counters.scan_prefix_calls = self.counters.scan_prefix_calls.saturating_add(1);
-        let tombstones = self.base.tombstones_for_root(root_inode_id).await?;
-        let tombstone = super::rows::active_tombstone_from_records(
-            tombstones.iter().cloned(),
-            self.base.visible_seq(),
-        );
+        let tombstone = fetch_active_subtree_tombstone(&self.base, root_inode_id).await?;
         self.active_tombstone_cache
             .insert(root_inode_id, tombstone.clone());
         Ok(tombstone)
@@ -881,19 +928,11 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             parent_inode_id,
             name_key: name_key.clone(),
         };
-        if let Some(cached) = self.bound_child_cache.get(&cache_key).cloned() {
+        if let Some(cached) = self.cached_bound_child(parent_inode_id, name_key) {
             return Ok(cached);
         }
         self.counters.scan_prefix_calls = self.counters.scan_prefix_calls.saturating_add(1);
-        let bindings = self
-            .base
-            .direntry_binds_for_parent_name(parent_inode_id, name_key)
-            .await?;
-        let binding = bindings
-            .iter()
-            .filter(|direntry| direntry.bind_seq <= self.base.visible_seq())
-            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-            .cloned();
+        let binding = fetch_bound_child(&self.base, parent_inode_id, name_key).await?;
         self.bound_child_cache.insert(cache_key, binding.clone());
         Ok(binding)
     }
@@ -902,15 +941,12 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         &mut self,
         direntry: &DirentryBindRecord,
     ) -> Result<bool, CoreError> {
-        let cache_key = BindingCacheKey::from(direntry);
-        if let Some(cached) = self.unbind_cache.get(&cache_key).copied() {
+        let cache_key = BindingIdentity::from(direntry);
+        if let Some(cached) = self.cached_is_direntry_unbound(direntry) {
             return Ok(cached);
         }
         self.counters.scan_prefix_calls = self.counters.scan_prefix_calls.saturating_add(1);
-        let unbinds = self.base.direntry_unbinds_for_binding(direntry).await?;
-        let unbound = unbinds
-            .iter()
-            .any(|unbind| unbind.unbind_seq <= self.base.visible_seq());
+        let unbound = fetch_is_direntry_unbound(&self.base, direntry).await?;
         self.unbind_cache.insert(cache_key, unbound);
         Ok(unbound)
     }
@@ -1014,8 +1050,4 @@ struct DirentryBindNameGroup {
 struct DirentryBindPageCandidate {
     row_key: String,
     record: DirentryBindRecord,
-}
-
-fn direntry_bind_row_key(record: &DirentryBindRecord) -> String {
-    MetadataRow::DirentryBind(record.clone()).row_key_for_family(MetadataRowFamily::DirentryBinds)
 }

--- a/crates/loonfs-core/src/metadata/visibility.rs
+++ b/crates/loonfs-core/src/metadata/visibility.rs
@@ -21,20 +21,20 @@ use std::future::Future;
 /// Unbind records carry the identity of the bind they revoke, so an unbind
 /// matches a bind through the same comparison. `display_name` is
 /// presentation, not identity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct BindingIdentity<'a> {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct BindingIdentity {
     pub(crate) parent_inode_id: InodeId,
-    pub(crate) name_key: &'a NameKey,
+    pub(crate) name_key: NameKey,
     pub(crate) child_inode_id: InodeId,
     pub(crate) bind_seq: ChangeSeq,
     pub(crate) bind_delta_index: u32,
 }
 
-impl<'a> From<&'a DirentryBindRecord> for BindingIdentity<'a> {
-    fn from(record: &'a DirentryBindRecord) -> Self {
+impl From<&DirentryBindRecord> for BindingIdentity {
+    fn from(record: &DirentryBindRecord) -> Self {
         Self {
             parent_inode_id: record.parent_inode_id,
-            name_key: &record.name_key,
+            name_key: record.name_key.clone(),
             child_inode_id: record.child_inode_id,
             bind_seq: record.bind_seq,
             bind_delta_index: record.bind_delta_index,
@@ -42,11 +42,11 @@ impl<'a> From<&'a DirentryBindRecord> for BindingIdentity<'a> {
     }
 }
 
-impl<'a> From<&'a DirentryUnbindRecord> for BindingIdentity<'a> {
-    fn from(record: &'a DirentryUnbindRecord) -> Self {
+impl From<&DirentryUnbindRecord> for BindingIdentity {
+    fn from(record: &DirentryUnbindRecord) -> Self {
         Self {
             parent_inode_id: record.parent_inode_id,
-            name_key: &record.name_key,
+            name_key: record.name_key.clone(),
             child_inode_id: record.child_inode_id,
             bind_seq: record.bind_seq,
             bind_delta_index: record.bind_delta_index,
@@ -532,47 +532,30 @@ pub(crate) fn resolve_in_memory_read<T>(future: impl Future<Output = T>) -> T {
         .expect("in-memory metadata visibility reads should never await")
 }
 
-/// [`MetadataState`] reads scoped to `base_seq`: each lookup scans rows at
-/// or below that seq.
-///
-/// The composite overrides route back through the seq-gated
-/// [`MetadataState`] composites so that reads at or above the indexed seq
-/// keep their at-head index fast paths. This matters for
-/// [`resolve_visible_path`], which is not itself seq-gated and resolves
-/// most paths at head.
-pub(super) struct MetadataStateAtSeqReads<'a> {
+/// [`MetadataState`] reads scoped to `base_seq`.
+pub(super) struct MetadataStateReads<'a> {
     state: &'a MetadataState,
     base_seq: ChangeSeq,
 }
 
-/// [`MetadataState`] reads answered by the at-head indexes.
-///
-/// The composite overrides reuse the index materializations
-/// (`visible_*_at_head`, `current_parent_binding_for_child_at_head`); the
-/// ancestor-walk composites are NOT overridden, so both walk rules run their
-/// canonical bodies over these index-backed steps.
-pub(super) struct MetadataStateAtHeadReads<'a> {
-    state: &'a MetadataState,
-}
-
 impl MetadataState {
-    pub(super) fn reads_at_seq(&self, base_seq: ChangeSeq) -> MetadataStateAtSeqReads<'_> {
-        MetadataStateAtSeqReads {
+    pub(super) fn reads_at_seq(&self, base_seq: ChangeSeq) -> MetadataStateReads<'_> {
+        MetadataStateReads {
             state: self,
             base_seq,
         }
     }
-
-    pub(super) fn reads_at_head(&self) -> MetadataStateAtHeadReads<'_> {
-        MetadataStateAtHeadReads { state: self }
-    }
 }
 
-impl MetadataVisibilityReads for MetadataStateAtSeqReads<'_> {
+impl MetadataVisibilityReads for MetadataStateReads<'_> {
     type Error = VisiblePathError;
 
     async fn find_inode(&mut self, inode_id: InodeId) -> Result<Option<InodeRecord>, Self::Error> {
-        Ok(self.state.inode_at_seq(inode_id, self.base_seq))
+        Ok(if self.base_seq >= self.state.indexed_seq() {
+            self.state.indexes.inode(inode_id)
+        } else {
+            self.state.inode_at_seq_scan(inode_id, self.base_seq)
+        })
     }
 
     async fn find_latest_bound_child(
@@ -580,121 +563,56 @@ impl MetadataVisibilityReads for MetadataStateAtSeqReads<'_> {
         parent_inode_id: InodeId,
         name_key: &NameKey,
     ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        Ok(self
-            .state
-            .bound_child_at_seq(parent_inode_id, name_key, self.base_seq))
+        Ok(if self.base_seq >= self.state.indexed_seq() {
+            self.state.indexes.latest_bind(parent_inode_id, name_key)
+        } else {
+            self.state
+                .bound_child_at_seq_scan(parent_inode_id, name_key, self.base_seq)
+        })
     }
 
     async fn find_latest_parent_binding_for_child(
         &mut self,
         child_inode_id: InodeId,
     ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        Ok(self
-            .state
-            .latest_parent_binding_for_child_at_seq(child_inode_id, self.base_seq))
+        Ok(self.state.latest_parent_binding_for_child_at_seq(
+            child_inode_id,
+            self.base_seq.min(self.state.indexed_seq()),
+        ))
     }
 
     async fn find_active_subtree_tombstone(
         &mut self,
         root_inode_id: InodeId,
     ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
-        Ok(self
-            .state
-            .active_subtree_tombstone(root_inode_id, self.base_seq))
+        Ok(if self.base_seq >= self.state.indexed_seq() {
+            self.state.indexes.active_tombstone(root_inode_id)
+        } else {
+            self.state
+                .active_subtree_tombstone_scan(root_inode_id, self.base_seq)
+        })
     }
 
     async fn is_binding_unbound(
         &mut self,
         direntry: &DirentryBindRecord,
     ) -> Result<bool, Self::Error> {
-        Ok(self
-            .state
-            .is_direntry_unbound_at_seq(direntry, self.base_seq))
+        Ok(if self.base_seq >= self.state.indexed_seq() {
+            self.state.indexes.is_unbound(direntry)
+        } else {
+            self.state
+                .is_direntry_unbound_at_seq_scan(direntry, self.base_seq)
+        })
     }
 
     async fn current_parent_binding_for_child(
         &mut self,
         child_inode_id: InodeId,
     ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        Ok(self
-            .state
-            .current_parent_binding_for_child(child_inode_id, self.base_seq))
-    }
-
-    async fn covering_subtree_tombstone(
-        &mut self,
-        inode_id: InodeId,
-    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
-        Ok(self
-            .state
-            .covering_subtree_tombstone(inode_id, self.base_seq))
-    }
-
-    async fn visible_inode(
-        &mut self,
-        inode_id: InodeId,
-    ) -> Result<Option<InodeRecord>, Self::Error> {
-        Ok(self.state.visible_inode(inode_id, self.base_seq))
-    }
-
-    async fn visible_child(
-        &mut self,
-        parent_inode_id: InodeId,
-        name_key: &NameKey,
-    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        Ok(self
-            .state
-            .visible_child(parent_inode_id, name_key, self.base_seq))
-    }
-}
-
-impl MetadataVisibilityReads for MetadataStateAtHeadReads<'_> {
-    type Error = VisiblePathError;
-
-    async fn find_inode(&mut self, inode_id: InodeId) -> Result<Option<InodeRecord>, Self::Error> {
-        Ok(self.state.inode_at_head(inode_id))
-    }
-
-    async fn find_latest_bound_child(
-        &mut self,
-        parent_inode_id: InodeId,
-        name_key: &NameKey,
-    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        Ok(self.state.indexes.latest_bind(parent_inode_id, name_key))
-    }
-
-    async fn find_latest_parent_binding_for_child(
-        &mut self,
-        child_inode_id: InodeId,
-    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        // At head every row is at or below the indexed seq, so the seq-scan
-        // with `indexed_seq` as the bound is the honest latest-overall scan.
-        Ok(self
-            .state
-            .latest_parent_binding_for_child_at_seq(child_inode_id, self.state.indexed_seq()))
-    }
-
-    async fn find_active_subtree_tombstone(
-        &mut self,
-        root_inode_id: InodeId,
-    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
-        Ok(self.state.active_subtree_tombstone_at_head(root_inode_id))
-    }
-
-    async fn is_binding_unbound(
-        &mut self,
-        direntry: &DirentryBindRecord,
-    ) -> Result<bool, Self::Error> {
-        Ok(self.state.is_direntry_unbound_at_head(direntry))
-    }
-
-    async fn current_parent_binding_for_child(
-        &mut self,
-        child_inode_id: InodeId,
-    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        Ok(self
-            .state
-            .current_parent_binding_for_child_at_head(child_inode_id))
+        if self.base_seq >= self.state.indexed_seq() {
+            return Ok(self.state.indexes.active_parent_for_child(child_inode_id));
+        }
+        current_parent_binding_for_child(self, child_inode_id).await
     }
 
     async fn active_child_binding(
@@ -702,21 +620,9 @@ impl MetadataVisibilityReads for MetadataStateAtHeadReads<'_> {
         parent_inode_id: InodeId,
         name_key: &NameKey,
     ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        Ok(self.state.indexes.active_child(parent_inode_id, name_key))
-    }
-
-    async fn visible_inode(
-        &mut self,
-        inode_id: InodeId,
-    ) -> Result<Option<InodeRecord>, Self::Error> {
-        Ok(self.state.visible_inode_at_head(inode_id))
-    }
-
-    async fn visible_child(
-        &mut self,
-        parent_inode_id: InodeId,
-        name_key: &NameKey,
-    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
-        Ok(self.state.visible_child_at_head(parent_inode_id, name_key))
+        if self.base_seq >= self.state.indexed_seq() {
+            return Ok(self.state.indexes.active_child(parent_inode_id, name_key));
+        }
+        active_child_binding(self, parent_inode_id, name_key).await
     }
 }

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -748,18 +748,18 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             "loonfs.phase",
             phase = "list_page_build_entries",
             list_page_children_returned = children.len() as u64,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[0] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[1] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[2] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[3] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[4] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[5] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[6] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[7] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[8] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[9] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[10] } = tracing::field::Empty,
-            { METADATA_VIEW_SESSION_COUNTER_FIELDS[11] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[0].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[1].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[2].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[3].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[4].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[5].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[6].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[7].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[8].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[9].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[10].0 } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[11].0 } = tracing::field::Empty,
         );
         let entries = async {
             // A projected page reads every child's attributes as one wave,
@@ -825,13 +825,12 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         // as a file; only the projection decides whether the read happens.
         let attributes = match attributes {
             AttributeInclusion::Include => {
-                let (revision_no, attributes, updated_by, updated_at_ms) =
-                    session.attributes_of_visible(resolved.inode_id).await?;
+                let projection = session.attributes_of_visible(resolved.inode_id).await?;
                 Some(AttributesProjection {
-                    attributes_revision_no: revision_no,
-                    attributes_updated_by: updated_by,
-                    attributes_updated_at_ms: updated_at_ms,
-                    attributes,
+                    attributes_revision_no: projection.revision_no,
+                    attributes_updated_by: projection.updated_by,
+                    attributes_updated_at_ms: projection.updated_at_ms,
+                    attributes: projection.attributes,
                 })
             }
             AttributeInclusion::Omit => None,

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -217,7 +217,7 @@ fn canonical_replay_advances_head_and_applies_metadata_rows() {
     assert_eq!(replayed.resulting_head.next_inode_id, InodeId(3));
     assert!(replayed
         .resulting_metadata_state
-        .inode_at_head(InodeId(2))
+        .inode_at_seq(InodeId(2), replayed.resulting_metadata_state.indexed_seq())
         .is_some());
     assert!(replayed
         .resulting_metadata_state

--- a/crates/loonfs-core/tests/it/common/mod.rs
+++ b/crates/loonfs-core/tests/it/common/mod.rs
@@ -43,11 +43,14 @@ pub(crate) async fn read_context<S: ObjectStore + ?Sized>(
         segment_cache: Arc::new(MetadataSegmentCache::new(
             MetadataSegmentCacheConfig::default(),
         )),
-        tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
-            max_entries: 4,
-            max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
-            max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-        })),
+        tail_cache: Arc::new(WalTailProjectionCache::new(
+            WalTailProjectionCacheConfig {
+                max_entries: 4,
+                max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+                max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+            },
+            None,
+        )),
     }
 }
 

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -3,90 +3,23 @@
 use crate::codec::IndexRow;
 use crate::root::GrepManifestState;
 use loonfs::metrics::{CounterHandle, MetricsRecorder, RESULT_HIT, RESULT_MISS};
-use loonfs::{DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver};
-use loonfs_api::wire::sst_blocks::{
-    DecodedDataBlock, SegmentFilter, SegmentIndexEntry, DEFAULT_TARGET_BLOCK_BYTES,
+use loonfs::{
+    DecodedBlockCache, DecodedBlockCacheConfig, DecodedBlockCacheObserver, DecodedBlockWeight,
+    DecodedSegmentBlock, SegmentBlockKind, SegmentCacheKey,
 };
+use loonfs_api::wire::sst_blocks::DEFAULT_TARGET_BLOCK_BYTES;
 use std::sync::Arc;
 
 /// Default decoded-byte budget for cached grep manifests and segment blocks.
 pub const DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES: usize = 4_096 * DEFAULT_TARGET_BLOCK_BYTES;
 
 /// Grep's cache for decoded manifests and segment blocks.
-pub type GrepBlockCache = DecodedBlockCache<GrepBlockCacheKey, DecodedGrepBlock>;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum GrepBlockKind {
-    Manifest,
-    Filter,
-    Index,
-    Data,
-}
-
-/// Identifies a cached grep block.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct GrepBlockCacheKey {
-    /// Immutable cache identity. Manifest entries use `payload_checksum`;
-    /// segment blocks use `object_checksum`.
-    pub(crate) identity: String,
-    pub(crate) block_kind: GrepBlockKind,
-    pub(crate) block_offset: u64,
-}
+pub type GrepBlockCache = DecodedBlockCache<SegmentCacheKey, DecodedGrepBlock>;
 
 /// A decoded grep block.
-#[derive(Debug, Clone)]
-pub enum DecodedGrepBlock {
-    Manifest {
-        state: Arc<GrepManifestState>,
-        decoded_bytes: usize,
-    },
-    Filter {
-        filter: Arc<SegmentFilter>,
-        decoded_bytes: usize,
-    },
-    Index {
-        entries: Arc<Vec<SegmentIndexEntry>>,
-        decoded_bytes: usize,
-    },
-    Data {
-        block: Arc<DecodedDataBlock<IndexRow>>,
-        decoded_bytes: usize,
-    },
-}
-
-impl DecodedGrepBlock {
-    pub(crate) fn filter(self) -> Option<Arc<SegmentFilter>> {
-        match self {
-            Self::Filter { filter, .. } => Some(filter),
-            Self::Manifest { .. } | Self::Index { .. } | Self::Data { .. } => None,
-        }
-    }
-
-    pub(crate) fn index(self) -> Option<Arc<Vec<SegmentIndexEntry>>> {
-        match self {
-            Self::Index { entries, .. } => Some(entries),
-            Self::Manifest { .. } | Self::Filter { .. } | Self::Data { .. } => None,
-        }
-    }
-
-    pub(crate) fn data(self) -> Option<Arc<DecodedDataBlock<IndexRow>>> {
-        match self {
-            Self::Data { block, .. } => Some(block),
-            Self::Manifest { .. } | Self::Filter { .. } | Self::Index { .. } => None,
-        }
-    }
-}
-
-impl DecodedBlock for DecodedGrepBlock {
-    fn decoded_bytes(&self) -> usize {
-        match self {
-            Self::Manifest { decoded_bytes, .. }
-            | Self::Filter { decoded_bytes, .. }
-            | Self::Index { decoded_bytes, .. }
-            | Self::Data { decoded_bytes, .. } => *decoded_bytes,
-        }
-    }
-}
+pub type DecodedGrepBlock = DecodedSegmentBlock<IndexRow, Arc<GrepManifestState>>;
+pub(crate) type GrepBlockKind = SegmentBlockKind;
+pub type GrepBlockCacheKey = SegmentCacheKey;
 
 struct GrepBlockCacheMetrics {
     hits: Arc<dyn CounterHandle>,
@@ -126,10 +59,10 @@ pub fn new_grep_block_cache(
     max_decoded_bytes: usize,
     recorder: &dyn MetricsRecorder,
 ) -> GrepBlockCache {
-    GrepBlockCache::with_observer(
-        max_decoded_bytes,
-        Some(Arc::new(GrepBlockCacheMetrics::register(recorder))),
-    )
+    GrepBlockCache::new(DecodedBlockCacheConfig {
+        observer: Some(Arc::new(GrepBlockCacheMetrics::register(recorder))),
+        ..DecodedBlockCacheConfig::with_max_decoded_bytes(max_decoded_bytes)
+    })
 }
 
 impl DecodedBlockCacheObserver for GrepBlockCacheMetrics {
@@ -145,7 +78,7 @@ impl DecodedBlockCacheObserver for GrepBlockCacheMetrics {
         self.inserts.increment(1);
     }
 
-    fn evict(&self) {
+    fn evict(&self, _weight: DecodedBlockWeight) {
         self.evictions.increment(1);
     }
 }
@@ -196,10 +129,10 @@ mod tests {
     #[test]
     fn cache_activity_reaches_the_metrics_recorder() {
         let recorder = DefaultMetricsRecorder::new();
-        let cache = GrepBlockCache::with_observer(
-            1_000,
-            Some(Arc::new(GrepBlockCacheMetrics::register(&recorder))),
-        );
+        let cache = GrepBlockCache::new(loonfs::DecodedBlockCacheConfig {
+            observer: Some(Arc::new(GrepBlockCacheMetrics::register(&recorder))),
+            ..loonfs::DecodedBlockCacheConfig::with_max_decoded_bytes(1_000)
+        });
         cache.insert(key("a"), block(600));
         cache.insert(key("b"), block(600));
         assert!(cache.get(&key("a")).is_none());
@@ -234,7 +167,9 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_loads_of_one_key_run_one_underlying_load() {
-        let cache = GrepBlockCache::new(1_000);
+        let cache = GrepBlockCache::new(loonfs::DecodedBlockCacheConfig::with_max_decoded_bytes(
+            1_000,
+        ));
         let loads = AtomicUsize::new(0);
         let cache_key = key("a");
         let first = cache.get_or_load(&cache_key, || async {

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -83,15 +83,8 @@ struct MaterializedGrepIndexSnapshot {
 }
 
 impl GrepService {
-    /// Creates a service with a fresh default-sized block cache.
-    pub fn new() -> Self {
-        Self::with_block_cache(Arc::new(GrepBlockCache::new(
-            DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
-        )))
-    }
-
     /// Creates a service over a host-composed process-wide grep block cache.
-    pub fn with_block_cache(block_cache: Arc<GrepBlockCache>) -> Self {
+    pub fn new(block_cache: Arc<GrepBlockCache>) -> Self {
         Self { block_cache }
     }
 
@@ -137,13 +130,13 @@ impl GrepService {
                     .len()
                     .saturating_mul(2);
                 Ok(DecodedGrepBlock::Manifest {
-                    state,
+                    manifest: state,
                     decoded_bytes,
                 })
             })
             .await
         {
-            Ok(DecodedGrepBlock::Manifest { state, .. }) => state,
+            Ok(DecodedGrepBlock::Manifest { manifest, .. }) => manifest,
             Ok(
                 DecodedGrepBlock::Filter { .. }
                 | DecodedGrepBlock::Index { .. }
@@ -334,7 +327,11 @@ fn materialized_snapshot_from_state(
 
 impl Default for GrepService {
     fn default() -> Self {
-        Self::new()
+        Self::new(Arc::new(GrepBlockCache::new(
+            loonfs::DecodedBlockCacheConfig::with_max_decoded_bytes(
+                DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
+            ),
+        )))
     }
 }
 

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -232,7 +232,11 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             store,
             reader,
             admin,
-            Arc::new(GrepBlockCache::new(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES)),
+            Arc::new(GrepBlockCache::new(
+                loonfs::DecodedBlockCacheConfig::with_max_decoded_bytes(
+                    DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
+                ),
+            )),
         )
     }
 

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -40,12 +40,16 @@ impl GrepHost {
             .build()
             .await
             .expect("build admin");
-        let block_cache = Arc::new(GrepBlockCache::new(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES));
+        let block_cache = Arc::new(GrepBlockCache::new(
+            loonfs::DecodedBlockCacheConfig::with_max_decoded_bytes(
+                DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
+            ),
+        ));
         Self {
             store: store.clone(),
             reader: reader.clone(),
             admin: admin.clone(),
-            service: GrepService::with_block_cache(Arc::clone(&block_cache)),
+            service: GrepService::new(Arc::clone(&block_cache)),
             worker: GrepWorker::with_block_cache(
                 store.clone(),
                 reader,

--- a/crates/loonfs-grep/tests/it/grep_service_differential.rs
+++ b/crates/loonfs-grep/tests/it/grep_service_differential.rs
@@ -50,7 +50,7 @@ impl ServiceHarness {
             store,
             namespace_id,
             reader,
-            service: GrepService::new(),
+            service: GrepService::default(),
         }
     }
 

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -103,7 +103,7 @@ async fn new_query_page(
         .await
         .expect("new query reader");
     grep_with(
-        &GrepService::new(),
+        &GrepService::default(),
         &reader,
         store,
         namespace_id,

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -300,7 +300,7 @@ pub async fn app(
         .grep
         .mode
         .serves_grep()
-        .then(|| Arc::new(GrepService::with_block_cache(Arc::clone(&grep_block_cache))));
+        .then(|| Arc::new(GrepService::new(Arc::clone(&grep_block_cache))));
     let grep_maintenance = if maintains_grep_index {
         let grep_worker = grep_worker
             .as_ref()

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -144,7 +144,7 @@ impl ReadCore {
                 instruments.metadata_segment_cache_observer(),
             ))
         });
-        let wal_tail_projection_cache = Arc::new(WalTailProjectionCache::with_observer(
+        let wal_tail_projection_cache = Arc::new(WalTailProjectionCache::new(
             WalTailProjectionCacheConfig {
                 max_entries: config.runtime_cache.max_cached_namespaces,
                 max_rows: config.runtime_cache.max_cached_wal_tail_projection_rows,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -94,8 +94,9 @@ pub use loonfs_api::{
     PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::{
-    DecodedBlock, DecodedBlockCache, DecodedBlockCacheObserver, DecodedBlockCacheStats,
-    MetadataSegmentCacheConfig, Recency, StoredMetadataBlockCache,
+    DecodedBlock, DecodedBlockCache, DecodedBlockCacheConfig, DecodedBlockCacheObserver,
+    DecodedBlockCacheStats, DecodedBlockWeight, DecodedSegmentBlock, MetadataSegmentCacheConfig,
+    Recency, SegmentBlockKind, SegmentCacheKey, StoredMetadataBlockCache,
     StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey, StoredMetadataBlockKind,
 };
 pub use loonfs_core::limits::{

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -14,7 +14,7 @@ use crate::metrics::{
 use crate::{
     GcResponse, MaintenanceJobId, MaintenanceStepConclusion, MetadataCompactionJobOutcome,
 };
-use loonfs_core::cache::{MetadataSegmentCacheObserver, WalTailProjectionCacheObserver};
+use loonfs_core::cache::{DecodedBlockCacheObserver, DecodedBlockWeight};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -213,7 +213,7 @@ impl RuntimeInstruments {
     /// Returns the metadata-segment cache metrics observer, if metrics are enabled.
     pub(crate) fn metadata_segment_cache_observer(
         &self,
-    ) -> Option<Arc<dyn MetadataSegmentCacheObserver>> {
+    ) -> Option<Arc<dyn DecodedBlockCacheObserver>> {
         let observer = Arc::clone(&self.installed.as_ref()?.cache.metadata_segment);
         Some(observer)
     }
@@ -221,7 +221,7 @@ impl RuntimeInstruments {
     /// Returns the WAL-tail projection cache metrics observer, if metrics are enabled.
     pub(crate) fn wal_tail_projection_cache_observer(
         &self,
-    ) -> Option<Arc<dyn WalTailProjectionCacheObserver>> {
+    ) -> Option<Arc<dyn DecodedBlockCacheObserver>> {
         let observer = Arc::clone(&self.installed.as_ref()?.cache.wal_tail_projection);
         Some(observer)
     }
@@ -716,7 +716,7 @@ impl MetadataSegmentCacheInstruments {
     }
 }
 
-impl MetadataSegmentCacheObserver for MetadataSegmentCacheInstruments {
+impl DecodedBlockCacheObserver for MetadataSegmentCacheInstruments {
     fn hit(&self) {
         self.hits.increment(1);
     }
@@ -729,7 +729,7 @@ impl MetadataSegmentCacheObserver for MetadataSegmentCacheInstruments {
         self.inserts.increment(1);
     }
 
-    fn evict(&self) {
+    fn evict(&self, _weight: DecodedBlockWeight) {
         self.evictions.increment(1);
     }
 
@@ -803,7 +803,7 @@ impl WalTailProjectionCacheInstruments {
     }
 }
 
-impl WalTailProjectionCacheObserver for WalTailProjectionCacheInstruments {
+impl DecodedBlockCacheObserver for WalTailProjectionCacheInstruments {
     fn hit(&self) {
         self.hits.increment(1);
     }
@@ -816,23 +816,23 @@ impl WalTailProjectionCacheObserver for WalTailProjectionCacheInstruments {
         self.inserts.increment(1);
     }
 
-    fn evict(&self, rows: usize, decoded_bytes: usize) {
+    fn evict(&self, weight: DecodedBlockWeight) {
         self.evictions.increment(1);
-        self.evicted_rows.increment(metric_count(rows));
+        self.evicted_rows.increment(metric_count(weight.rows));
         self.evicted_decoded_bytes
-            .increment(metric_count(decoded_bytes));
+            .increment(metric_count(weight.bytes));
     }
 
-    fn reject(&self, rows: usize, decoded_bytes: usize) {
+    fn reject(&self, weight: DecodedBlockWeight) {
         self.rejections.increment(1);
-        self.rejected_rows.increment(metric_count(rows));
+        self.rejected_rows.increment(metric_count(weight.rows));
         self.rejected_decoded_bytes
-            .increment(metric_count(decoded_bytes));
+            .increment(metric_count(weight.bytes));
     }
 
-    fn retained(&self, rows: usize, decoded_bytes: usize) {
-        self.retained_rows.set(metric_level(rows));
-        self.retained_decoded_bytes.set(metric_level(decoded_bytes));
+    fn retained(&self, weight: DecodedBlockWeight) {
+        self.retained_rows.set(metric_level(weight.rows));
+        self.retained_decoded_bytes.set(metric_level(weight.bytes));
     }
 }
 
@@ -1078,7 +1078,7 @@ mod tests {
         metadata.hit();
         metadata.miss();
         metadata.insert();
-        metadata.evict();
+        metadata.evict(DecodedBlockWeight::default());
         metadata.filter_skip();
         metadata.filter_false_positive();
 
@@ -1088,9 +1088,15 @@ mod tests {
         wal.hit();
         wal.miss();
         wal.insert();
-        wal.evict(7, 70);
-        wal.reject(11, 110);
-        wal.retained(13, 130);
+        wal.evict(DecodedBlockWeight { rows: 7, bytes: 70 });
+        wal.reject(DecodedBlockWeight {
+            rows: 11,
+            bytes: 110,
+        });
+        wal.retained(DecodedBlockWeight {
+            rows: 13,
+            bytes: 130,
+        });
 
         let snapshot = recorder.snapshot();
         for (name, labels, value) in [


### PR DESCRIPTION
This consolidates the metadata and grep block caches around one decoded-block cache. The shared cache supports byte, row, and entry limits and reports cache activity through one observer interface. The metadata cache, grep cache, and WAL-tail projection cache keep their existing limits and metrics while sharing eviction and accounting code.

It also removes duplicated metadata read logic. In-memory reads now choose between indexes and historical scans in one place, manifest-backed views share durable-row loading, and read sessions reuse the same helpers for visibility, revision, and attribute lookups. The Rust cache and grep service constructors now take their configuration or cache dependencies directly, but wire formats, stored data, error codes, and error messages are unchanged.