### PR TITLE
perf(runtime): skip head checks on continuation pages

### DIFF
--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -1,13 +1,15 @@
 //! Runtime caches for control-object reads and WAL-tail projections.
 //! This module also defines the cache-management methods on [`ReadCore`].
 //!
-//! Every cache revalidates against durable state before its contents are
-//! used; nothing here weakens read-after-write consistency.
+//! Namespace anchors can satisfy cursor continuations without revalidation;
+//! other cached control reads revalidate against durable state.
 
 use crate::fs::{should_invalidate_after_result, ReadCore};
 use crate::metrics::RuntimeInstruments;
 use crate::trace::phase_span;
-use crate::{CheckpointId, CommitResponse, CoreError, NamespaceId, Recency, RuntimeCacheConfig};
+use crate::{
+    ChangeSeq, CheckpointId, CommitResponse, CoreError, NamespaceId, Recency, RuntimeCacheConfig,
+};
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
 use loonfs_core::cache::{MetadataSegmentCacheStats, WalTailProjectionCacheStats};
@@ -217,9 +219,12 @@ fn namespace_slot_is_live(
 }
 
 impl ReadCore {
+    /// Reuses the cached anchor when a cursor's head seq is at or below the cached head seq.
+    /// Revalidates every other cached anchor against the store.
     pub(crate) async fn load_namespace_head_cached(
         &self,
         namespace_id: &NamespaceId,
+        min_head_seq: Option<ChangeSeq>,
     ) -> std::result::Result<CachedNamespaceAnchor, ControlObjectLoadError> {
         let cache_config = &self.inner.config.runtime_cache;
         if !self.control_cache_enabled() {
@@ -233,6 +238,9 @@ impl ReadCore {
             .control_cache()
             .cached_namespace_head(namespace_id);
         if let Some(head) = cached {
+            if min_head_seq.is_some_and(|min| head.head.state.seq >= min) {
+                return Ok(head);
+            }
             match self
                 .cached_control_identity_matches(&wal_head(namespace_id), &head.head.etag)
                 .await
@@ -274,8 +282,9 @@ impl ReadCore {
     pub(crate) async fn head_for_metadata_read(
         &self,
         namespace_id: &NamespaceId,
+        min_head_seq: Option<ChangeSeq>,
     ) -> Result<CachedNamespaceAnchor> {
-        self.load_namespace_head_cached(namespace_id)
+        self.load_namespace_head_cached(namespace_id, min_head_seq)
             .await
             .map_err(|error| {
                 RuntimeError::Core(CoreError::MetadataProjection(
@@ -342,11 +351,14 @@ impl ReadCore {
     pub(crate) async fn pinned_read(
         &self,
         namespace_id: &NamespaceId,
+        min_head_seq: Option<ChangeSeq>,
     ) -> Result<(
         loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
-        let anchor = self.head_for_metadata_read(namespace_id).await?;
+        let anchor = self
+            .head_for_metadata_read(namespace_id, min_head_seq)
+            .await?;
         let read_context = self.runtime_read_context(&anchor);
         Ok((self.reader_engine(namespace_id), read_context))
     }
@@ -360,7 +372,7 @@ impl ReadCore {
         loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
-        let live = self.head_for_metadata_read(namespace_id).await?;
+        let live = self.head_for_metadata_read(namespace_id, None).await?;
         let pinned = load_checkpoint_read_basis(
             self.store(),
             Some(self.inner.metadata_segment_cache.as_ref()),
@@ -381,7 +393,7 @@ impl ReadCore {
         loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
-        let live = self.head_for_metadata_read(namespace_id).await?;
+        let live = self.head_for_metadata_read(namespace_id, None).await?;
         let pinned = load_snapshot_read_basis(
             self.store(),
             Some(self.inner.metadata_segment_cache.as_ref()),
@@ -415,11 +427,12 @@ impl ReadCore {
     pub(crate) async fn pinned_metadata_read(
         &self,
         namespace_id: &NamespaceId,
+        min_head_seq: Option<ChangeSeq>,
     ) -> Result<(
         loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
-        let pinned = self.pinned_read(namespace_id).await?;
+        let pinned = self.pinned_read(namespace_id, min_head_seq).await?;
         self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(pinned)
     }
@@ -429,8 +442,11 @@ impl ReadCore {
     pub(crate) async fn load_namespace_catalog_cached(
         &self,
         namespace_id: &NamespaceId,
+        min_head_seq: Option<ChangeSeq>,
     ) -> Result<VerifiedNamespaceCatalogEntry> {
-        let anchor = self.head_for_metadata_read(namespace_id).await?;
+        let anchor = self
+            .head_for_metadata_read(namespace_id, min_head_seq)
+            .await?;
         Ok(VerifiedNamespaceCatalogEntry::from_head(&anchor.head.state))
     }
 
@@ -446,10 +462,8 @@ impl ReadCore {
             .invalidate_namespace(namespace_id);
     }
 
-    /// Seeds the read caches with the state one landed publish produced:
-    /// the head anchor and the projected WAL tail. Safe by construction —
-    /// the anchor is etag-revalidated against the store on every read, so a
-    /// wrong seed degrades to today's reload instead of a wrong read.
+    /// Seeds the read caches with the head anchor and WAL-tail projection from
+    /// one landed publish.
     pub(crate) fn seed_namespace_read_cache(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -247,7 +247,7 @@ impl FsReader {
     )]
     pub async fn pin_namespace(&self, namespace_id: &NamespaceId) -> Result<FsReadSnapshot> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         Ok(self.read_snapshot(engine, context, None))
     }
 
@@ -356,7 +356,7 @@ impl FsReader {
         )?;
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let entry = engine
             .resolve_path(absolute_path, options, &read_context)
             .await?;
@@ -386,7 +386,7 @@ impl FsReader {
     ) -> Result<PathEntry> {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let entry = engine.stat_inode(inode_id, options, &read_context).await?;
         tracing::Span::current().record("cache_path", crate::trace::CACHE_MATERIALIZED_SEGMENTS);
         Ok(entry)
@@ -470,7 +470,13 @@ impl FsReader {
     ) -> Result<(ListPathEntriesResponse, Option<DirectoryPageCursor>)> {
         let listed_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(
+                namespace_id,
+                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+            )
+            .await?;
         let page = engine
             .list_path_page(listed_path.as_str(), request, options, &read_context)
             .await?;
@@ -544,7 +550,13 @@ impl FsReader {
     ) -> Result<ListInodeChildrenResponse> {
         reject_snapshot_bound_directory_cursor(request.cursor.as_ref())?;
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(
+                namespace_id,
+                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+            )
+            .await?;
         let page = engine
             .list_inode_children_page(inode_id, request, options, &read_context)
             .await?;
@@ -579,7 +591,7 @@ impl FsReader {
         absolute_path: &str,
     ) -> Result<FileBytes> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let read = engine
             .get_file(
                 absolute_path,
@@ -620,7 +632,7 @@ impl FsReader {
         options: ReadFileStreamOptions,
     ) -> Result<FileContentStream<SharedObjectStore>> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let stream = engine
             .read_file_stream(
                 absolute_path,
@@ -660,7 +672,7 @@ impl FsReader {
         revision_no: Option<RevisionNo>,
     ) -> Result<DirectDownloadTarget> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let target = engine
             .direct_download_target(absolute_path, revision_no, &read_context)
             .await?;
@@ -688,7 +700,7 @@ impl FsReader {
         revision_no: RevisionNo,
     ) -> Result<DirectDownloadByInodeTarget> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let target = engine
             .direct_download_target_by_inode(inode_id, revision_no, &read_context)
             .await?;
@@ -719,7 +731,7 @@ impl FsReader {
         request: PageRequest<CheckpointFilesPageCursor>,
     ) -> Result<CheckpointFilesPage> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_read(namespace_id, None).await?;
         Ok(engine
             .list_checkpoint_files_page(checkpoint_id, request, &read_context)
             .await?)
@@ -751,7 +763,7 @@ impl FsReader {
         inode_ids: &[InodeId],
     ) -> Result<Vec<CurrentFileState>> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let states = engine
             .resolve_current_files(inode_ids, &read_context)
             .await?;
@@ -786,7 +798,7 @@ impl FsReader {
         max_bytes: u64,
     ) -> Result<Vec<u8>> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_read(namespace_id, None).await?;
         Ok(engine
             .read_content_ref(content_ref, max_bytes, &read_context)
             .await?)
@@ -814,7 +826,13 @@ impl FsReader {
         request: PageRequest<loonfs_api::TrashPageCursor>,
     ) -> Result<loonfs_api::ListTrashResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(
+                namespace_id,
+                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+            )
+            .await?;
         let page = engine.list_trash_page(request, &read_context).await?;
         let next_cursor = encode_next_cursor(page.next_cursor.as_ref())?;
         Ok(loonfs_api::ListTrashResponse {
@@ -868,7 +886,13 @@ impl FsReader {
         self.core.record_trace_context(&tracing::Span::current());
         let absolute_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(
+                namespace_id,
+                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+            )
+            .await?;
         let fallback_inode_id = request.cursor.as_ref().map(|cursor| cursor.inode_id);
         let page = engine
             .list_file_revisions_page(absolute_path.as_str(), request, &read_context)
@@ -929,7 +953,13 @@ impl FsReader {
         request: PageRequest<FileRevisionsPageCursor>,
     ) -> Result<ListFileRevisionsResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(
+                namespace_id,
+                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+            )
+            .await?;
         let page = engine
             .list_file_revisions_for_inode_page(inode_id, request, &read_context)
             .await?;
@@ -988,7 +1018,7 @@ impl FsReader {
         revision_no: RevisionNo,
     ) -> Result<FileBytes> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let read = engine
             .get_file_revision(
                 absolute_path,
@@ -1021,7 +1051,7 @@ impl FsReader {
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
         let bytes = engine
             .get_file_revision_for_inode(
                 inode_id,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -538,7 +538,9 @@ impl FsWriter {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<loonfs_core::control::VerifiedNamespaceCatalogEntry> {
-        self.core.load_namespace_catalog_cached(namespace_id).await
+        self.core
+            .load_namespace_catalog_cached(namespace_id, None)
+            .await
     }
 
     /// Creates a directory at an absolute path.

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -1,14 +1,10 @@
-//! Diagnostic (ignored): per-section request accounting for the warm-ops
-//! benchmark shape. Builds a bench-like namespace, then runs each warm
-//! phase on a fresh handle while classifying every store GET — by object
-//! class, and for metadata segments by section (index / filter / data),
-//! family, and run tier, using the live manifest's own descriptors.
+//! Request accounting for cached reads and the ignored warm-ops diagnostic.
 //!
 //! Run with:
 //!   cargo test -p loonfs --test it request_accounting -- --ignored --nocapture
 
 use loonfs::{
-    CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenancePlan,
+    CreateDirectoryOptions, CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenancePlan,
     MetadataMaintenanceOptions, NamespaceId, PageRequest, PaginationPolicy, PutFileOptions,
     SharedObjectStore,
 };
@@ -17,7 +13,7 @@ use loonfs_api::AbsolutePath;
 use loonfs_api::wire::manifest::{decode_namespace_manifest_json, RunTier};
 use loonfs_objectstore::keys::{metadata_manifest_object, metadata_segment_object_key};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_test_support::stores::{KeyPredicate, RecordedGet, RecordingStore};
+use loonfs_test_support::stores::{KeyPredicate, OperationClass, RecordedGet, RecordingStore};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -116,6 +112,132 @@ async fn publish_candidates(
     for outcome in futures::future::join_all(submissions).await {
         outcome.expect("publish batch member");
     }
+}
+
+#[tokio::test]
+async fn continuation_pages_reuse_the_cached_anchor() {
+    let temp_dir = tempdir().expect("tempdir");
+    let log = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let store: SharedObjectStore = log.clone();
+    let namespace_id = NamespaceId::parse("continuation-anchor").expect("valid namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("continuation-anchor-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for path in ["/b", "/c", "/d"] {
+        writer
+            .create_directory(
+                &namespace_id,
+                path,
+                CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("create directory");
+    }
+    let reader = writer.reader();
+    let limit = PaginationPolicy::default()
+        .resolve_limit(Some(1))
+        .expect("valid limit");
+
+    log.reset();
+    let first = reader
+        .list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit,
+                cursor: None,
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list first page");
+    assert_eq!(log.count(OperationClass::Head), 1);
+
+    log.reset();
+    let second_cursor: loonfs_api::DirectoryPageCursor = loonfs_api::decode_cursor(
+        first
+            .next_cursor
+            .as_deref()
+            .expect("first page has a cursor"),
+    )
+    .expect("decode second-page cursor");
+    let second = reader
+        .list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit,
+                cursor: Some(second_cursor),
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list second page");
+    let third_cursor: loonfs_api::DirectoryPageCursor = loonfs_api::decode_cursor(
+        second
+            .next_cursor
+            .as_deref()
+            .expect("second page has a cursor"),
+    )
+    .expect("decode third-page cursor");
+    reader
+        .list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit,
+                cursor: Some(third_cursor),
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list third page");
+    assert_eq!(log.count(OperationClass::Head), 0);
+
+    let second_writer = FsWriter::builder_with_store(store)
+        .writer_id("continuation-anchor-second-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build second writer");
+    second_writer
+        .create_directory(
+            &namespace_id,
+            "/a",
+            CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("advance head");
+    log.reset();
+    let fresh = reader
+        .list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit,
+                cursor: None,
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list fresh first page");
+    assert_eq!(
+        (
+            log.count(OperationClass::Head),
+            fresh.entries.first().map(|entry| entry.path.as_str()),
+        ),
+        (1, Some("/a")),
+    );
 }
 
 #[allow(clippy::print_stdout)]


### PR DESCRIPTION
Continuation pages now reuse a cached namespace head when it is at least as new as the cursor. This removes the HEAD request from later pages in directory, trash, and revision listings. First pages and unrelated reads still revalidate the cached head.

A continuation can remain on the cached head after another process commits; a new first page revalidates and sees the commit. Snapshot and checkpoint reads, grep, wire formats, error codes, and durable data are unchanged.