### PR TITLE
perf(core): validate content size with the first ranged read

### DIFF
--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -109,7 +109,6 @@ pub(crate) async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     content_ref: &ContentRef,
 ) -> Result<(), DurableContentValidationError> {
     let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
-    validate_content_size(store, &object_key, content_ref).await?;
     let bytes = load_required_object(store, &object_key).await?;
     validate_loaded_content_bytes(object_key, content_ref, &bytes)
 }
@@ -169,7 +168,7 @@ pub fn prepare_stored_content(
 /// Fully validates an existing durable content reference for publication.
 ///
 /// The verified catalog selects the store to validate. This performs one
-/// object HEAD followed by one full GET and checksum check.
+/// full GET and checksum check.
 #[cfg(any(test, feature = "test-support"))]
 pub async fn prepare_existing_content_ref<S: ObjectStore + ?Sized>(
     store: &S,
@@ -301,6 +300,8 @@ pub struct FileContentStream<S> {
     chunk_bytes: NonZeroU64,
     /// Start offset of the next ranged read.
     next_offset: u64,
+    /// Whether the next ranged read must also validate the object's size.
+    first_fetch: bool,
     /// Offset where this stream started.
     resumed_from: u64,
     /// Number of bytes before `resumed_from` included in the checksum.
@@ -364,7 +365,6 @@ impl<S: ObjectStore> FileContentStream<S> {
         start_offset: u64,
     ) -> Result<Self, DurableContentValidationError> {
         let object_key = content_object_key_for_ref(content_store_id, &content_ref)?;
-        validate_content_size(&store, &object_key, &content_ref).await?;
         let expected = content_ref.checksum.clone();
         let digest = StreamingChecksum::for_algorithm(expected.algorithm);
         Ok(Self {
@@ -374,6 +374,7 @@ impl<S: ObjectStore> FileContentStream<S> {
             content_ref,
             chunk_bytes,
             next_offset: start_offset,
+            first_fetch: true,
             resumed_from: start_offset,
             prefix_folded: 0,
             digest,
@@ -447,35 +448,78 @@ impl<S: ObjectStore> FileContentStream<S> {
     async fn next_verified_chunk(
         &mut self,
     ) -> Result<Option<Bytes>, DurableContentValidationError> {
-        if self.next_offset == self.content_ref.size_bytes {
+        if let Some(Err(error)) = &self.completion {
+            return Err(error.clone());
+        }
+        if !self.first_fetch && self.next_offset == self.content_ref.size_bytes {
             return self.completion().map(|()| None);
         }
         let end_exclusive = self
             .next_offset
             .saturating_add(self.chunk_bytes.get())
             .min(self.content_ref.size_bytes);
-        let bytes = match self
-            .store
-            .get(
-                &self.object_key,
-                Some(ByteRange {
-                    start_inclusive: self.next_offset,
-                    end_exclusive,
-                }),
-            )
-            .await
-        {
-            Ok(Some(bytes)) => bytes,
-            Ok(None) => {
-                return Err(DurableContentValidationError::MissingContentObject {
+        let range = ByteRange {
+            start_inclusive: self.next_offset,
+            end_exclusive,
+        };
+        let bytes = if self.first_fetch {
+            self.first_fetch = false;
+            let body = match self
+                .store
+                .get_range_with_metadata(&self.object_key, range)
+                .await
+            {
+                Ok(Some(body)) => body,
+                Ok(None) => {
+                    let error = DurableContentValidationError::MissingContentObject {
+                        object_key: self.object_key.clone(),
+                    };
+                    self.completion = Some(Err(error.clone()));
+                    return Err(error);
+                }
+                Err(err) => {
+                    let error = DurableContentValidationError::Store {
+                        object_key: self.object_key.clone(),
+                        message: err.public_message().into_owned(),
+                    };
+                    self.completion = Some(Err(error.clone()));
+                    return Err(error);
+                }
+            };
+            if body.metadata.size_bytes != self.content_ref.size_bytes {
+                let error = DurableContentValidationError::ContentLengthMismatch {
                     object_key: self.object_key.clone(),
-                })
+                    expected: self.content_ref.size_bytes,
+                    actual: body.metadata.size_bytes,
+                };
+                self.completion = Some(Err(error.clone()));
+                return Err(error);
             }
-            Err(err) => {
-                return Err(DurableContentValidationError::Store {
-                    object_key: self.object_key.clone(),
-                    message: err.public_message().into_owned(),
-                })
+            Bytes::from(body.bytes)
+        } else {
+            match self
+                .store
+                .get(
+                    &self.object_key,
+                    Some(ByteRange {
+                        start_inclusive: self.next_offset,
+                        end_exclusive,
+                    }),
+                )
+                .await
+            {
+                Ok(Some(bytes)) => bytes,
+                Ok(None) => {
+                    return Err(DurableContentValidationError::MissingContentObject {
+                        object_key: self.object_key.clone(),
+                    });
+                }
+                Err(err) => {
+                    return Err(DurableContentValidationError::Store {
+                        object_key: self.object_key.clone(),
+                        message: err.public_message().into_owned(),
+                    });
+                }
             }
         };
         // A range ending past the object is truncated, so a short answer is
@@ -489,6 +533,9 @@ impl<S: ObjectStore> FileContentStream<S> {
         }
         self.digest.update(&bytes);
         self.next_offset += bytes.len() as u64;
+        if bytes.is_empty() {
+            return self.completion().map(|()| None);
+        }
         Ok(Some(bytes))
     }
 
@@ -500,8 +547,8 @@ impl<S: ObjectStore> FileContentStream<S> {
     /// for past the declared size, so reaching this point *is* having folded
     /// exactly `size_bytes` — the resumed head start, which the first
     /// [`Self::next_chunk`] refuses to start without, plus everything
-    /// fetched from it to the end. The object's own length was checked
-    /// against the reference by the head request [`Self::open`] made.
+    /// fetched from it to the end. The first ranged read checked the object's
+    /// own length against the reference before returning bytes.
     fn completion(&mut self) -> Result<(), DurableContentValidationError> {
         let verdict = match self.completion.take() {
             Some(verdict) => verdict,
@@ -594,39 +641,6 @@ fn validate_loaded_content_bytes(
 
 fn describe_checksum(checksum: &Checksum) -> String {
     format!("{}:{}", checksum.algorithm, checksum.value)
-}
-
-/// Existence and size from one HEAD, used as cheap prevalidation before the
-/// authoritative read-and-hash: a wrong-sized object fails without being
-/// downloaded.
-async fn validate_content_size<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    content_ref: &ContentRef,
-) -> Result<(), DurableContentValidationError> {
-    let metadata = match store.head(object_key).await {
-        Ok(Some(metadata)) => metadata,
-        Ok(None) => {
-            return Err(DurableContentValidationError::MissingContentObject {
-                object_key: object_key.to_owned(),
-            })
-        }
-        Err(err) => {
-            return Err(DurableContentValidationError::Store {
-                object_key: object_key.to_owned(),
-                message: err.public_message().into_owned(),
-            })
-        }
-    };
-
-    if metadata.size_bytes != content_ref.size_bytes {
-        return Err(DurableContentValidationError::ContentLengthMismatch {
-            object_key: object_key.to_owned(),
-            expected: content_ref.size_bytes,
-            actual: metadata.size_bytes,
-        });
-    }
-    Ok(())
 }
 
 /// Plants durable content under a fresh identity, resolving the namespace's
@@ -1159,6 +1173,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_one_chunk_stream_read_uses_one_byte_read_and_no_head() {
+        let (_temp_dir, inner, content_store_id) = test_store();
+        let store = RecordingStore::new(inner, KeyPredicate::content_blob());
+        let bytes = payload(TEST_CHUNK_BYTES as usize - 1);
+        let content_ref = content_ref(&bytes);
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+
+        store.reset();
+        let mut stream = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect("open stream");
+        assert_eq!(
+            stream.next_chunk().await.expect("chunk"),
+            Some(Bytes::from(bytes.clone()))
+        );
+        assert!(stream.next_chunk().await.expect("verified end").is_none());
+
+        let counts = store.counts();
+        assert_eq!(counts.heads, 0);
+        assert_eq!(counts.gets, 1);
+        assert_eq!(counts.read_bytes, bytes.len() as u64);
+    }
+
+    #[tokio::test]
     async fn a_finished_stream_repeats_its_verdict() {
         let (_temp_dir, store, content_store_id) = test_store();
         let bytes = payload(TEST_CHUNK_BYTES as usize + 3);
@@ -1356,7 +1394,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_streamed_read_of_an_empty_object_verifies_without_fetching() {
+    async fn an_empty_stream_read_checks_size_with_one_empty_range() {
         let (_temp_dir, inner, content_store_id) = test_store();
         let store = RecordingStore::new(inner, KeyPredicate::content_blob());
         let content_ref = content_ref(b"");
@@ -1367,11 +1405,10 @@ mod tests {
             .await
             .expect("open stream");
         assert!(stream.next_chunk().await.expect("verified end").is_none());
-        assert_eq!(
-            store.count(OperationClass::Read),
-            0,
-            "an empty object needs no ranged read"
-        );
+        let counts = store.counts();
+        assert_eq!(counts.heads, 0);
+        assert_eq!(counts.gets, 1);
+        assert_eq!(counts.read_bytes, 0);
     }
 
     #[tokio::test]
@@ -1526,11 +1563,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_streamed_read_reports_a_missing_object_when_it_opens() {
+    async fn a_streamed_read_reports_a_missing_object_when_first_fetched() {
         let (_temp_dir, store, content_store_id) = test_store();
         let content_ref = content_ref(b"never stored");
 
-        let err = open_stream(&store, &content_store_id, &content_ref)
+        let mut stream = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect("open stream");
+        let err = stream
+            .next_verified_chunk()
             .await
             .expect_err("missing object");
         assert!(matches!(
@@ -1541,19 +1582,32 @@ mod tests {
 
     #[tokio::test]
     async fn a_streamed_read_rejects_an_object_of_the_wrong_length() {
-        let (_temp_dir, store, content_store_id) = test_store();
+        let (_temp_dir, inner, content_store_id) = test_store();
+        let store = RecordingStore::new(inner, KeyPredicate::content_blob());
         let bytes = payload(TEST_CHUNK_BYTES as usize + 1);
         let mut content_ref = content_ref(&bytes);
         put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
         content_ref.size_bytes += 1;
 
-        let err = open_stream(&store, &content_store_id, &content_ref)
+        store.reset();
+        let mut stream = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect("open stream");
+        let err = stream
+            .next_verified_chunk()
             .await
             .expect_err("length mismatch");
         assert!(matches!(
             err,
             DurableContentValidationError::ContentLengthMismatch { .. }
         ));
+        assert!(matches!(
+            stream.next_verified_chunk().await,
+            Err(DurableContentValidationError::ContentLengthMismatch { .. })
+        ));
+        let counts = store.counts();
+        assert_eq!(counts.heads, 0);
+        assert_eq!(counts.gets, 1);
     }
 
     fn test_store() -> (tempfile::TempDir, LocalFsStore, ContentStoreId) {

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -361,6 +361,51 @@ impl LocalFsStore {
         Ok(Some(ObjectBody { metadata, bytes }))
     }
 
+    async fn get_range_with_metadata_object(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>> {
+        let path = self.resolve_key(key)?;
+        let invalid_range = || ObjectStoreError::InvalidRange {
+            object_key: key.to_owned(),
+        };
+        if range.end_exclusive < range.start_inclusive {
+            return Err(invalid_range());
+        }
+        let mut file = match File::open(&path).await {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(io_error(key, err)),
+        };
+        let fs_metadata = file.metadata().await.map_err(|err| io_error(key, err))?;
+        if range.start_inclusive > fs_metadata.len() {
+            return Err(invalid_range());
+        }
+
+        let end_exclusive = range.end_exclusive.min(fs_metadata.len());
+        file.seek(SeekFrom::Start(range.start_inclusive))
+            .await
+            .map_err(|err| io_error(key, err))?;
+        let mut bytes = Vec::new();
+        (&mut file)
+            .take(end_exclusive - range.start_inclusive)
+            .read_to_end(&mut bytes)
+            .await
+            .map_err(|err| io_error(key, err))?;
+
+        file.seek(SeekFrom::Start(0))
+            .await
+            .map_err(|err| io_error(key, err))?;
+        let mut content_bytes = Vec::new();
+        file.read_to_end(&mut content_bytes)
+            .await
+            .map_err(|err| io_error(key, err))?;
+        let content_digest = sha256_digest(&content_bytes);
+        let metadata = Self::metadata_from_fs_metadata(key, &fs_metadata, &content_digest, &path)?;
+        Ok(Some(ObjectBody { metadata, bytes }))
+    }
+
     /// Reads the whole object, or exactly one range of it.
     ///
     /// A ranged read seeks to its start and reads only its length, so it
@@ -506,6 +551,15 @@ impl ObjectStore for LocalFsStore {
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         self.get_with_metadata_object(&self.scoped(key)?).await
+    }
+
+    async fn get_range_with_metadata(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>> {
+        self.get_range_with_metadata_object(&self.scoped(key)?, range)
+            .await
     }
 
     async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
@@ -935,6 +989,13 @@ mod tests {
             store.get(&key, range(4, 7)).await.expect("middle range"),
             Some(Bytes::from_static(b"456"))
         );
+        let body = store
+            .get_range_with_metadata(&key, range(4, 7).expect("range"))
+            .await
+            .expect("middle range with metadata")
+            .expect("object exists");
+        assert_eq!(body.bytes, b"456");
+        assert_eq!(body.metadata.size_bytes, payload.len() as u64);
         assert_eq!(
             store
                 .get(&key, range(7, 99))
@@ -966,6 +1027,16 @@ mod tests {
             )
             .await
             .expect("a ranged read of a missing object is absent, not an error")
+            .is_none());
+        assert!(store
+            .get_range_with_metadata(
+                &wal_head(
+                    &loonfs_api::NamespaceId::parse("ns-missing").expect("valid namespace id")
+                ),
+                range(0, 4).expect("range")
+            )
+            .await
+            .expect("a ranged metadata read of a missing object is absent, not an error")
             .is_none());
     }
 

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -127,7 +127,7 @@ impl LocalFsStore {
             return Ok(None);
         };
         let content_digest = sha256_digest(&content_bytes);
-        Self::metadata_from_fs_metadata(key, &metadata, &content_digest, path).map(Some)
+        Self::metadata_from_fs_metadata(key, &metadata, Some(&content_digest), path).map(Some)
     }
 
     /// Reads the object's bytes for the digest, answering `None` when the
@@ -146,7 +146,7 @@ impl LocalFsStore {
     fn metadata_from_fs_metadata(
         key: &str,
         metadata: &std::fs::Metadata,
-        content_digest: &str,
+        content_digest: Option<&str>,
         path: &Path,
     ) -> Result<ObjectMetadata> {
         if !metadata.is_file() {
@@ -162,7 +162,7 @@ impl LocalFsStore {
             .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
             .and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok());
         Ok(ObjectMetadata {
-            etag: Some(format!("local-fs-v1:{content_digest}")),
+            etag: content_digest.map(|digest| format!("local-fs-v1:{digest}")),
             version: None,
             size_bytes: metadata.len(),
             last_modified_ms,
@@ -357,7 +357,8 @@ impl LocalFsStore {
             .map_err(|err| io_error(key, err))?;
 
         let content_digest = sha256_digest(&bytes);
-        let metadata = Self::metadata_from_fs_metadata(key, &fs_metadata, &content_digest, &path)?;
+        let metadata =
+            Self::metadata_from_fs_metadata(key, &fs_metadata, Some(&content_digest), &path)?;
         Ok(Some(ObjectBody { metadata, bytes }))
     }
 
@@ -393,16 +394,10 @@ impl LocalFsStore {
             .read_to_end(&mut bytes)
             .await
             .map_err(|err| io_error(key, err))?;
-
-        file.seek(SeekFrom::Start(0))
-            .await
-            .map_err(|err| io_error(key, err))?;
-        let mut content_bytes = Vec::new();
-        file.read_to_end(&mut content_bytes)
-            .await
-            .map_err(|err| io_error(key, err))?;
-        let content_digest = sha256_digest(&content_bytes);
-        let metadata = Self::metadata_from_fs_metadata(key, &fs_metadata, &content_digest, &path)?;
+        // The etag here is a digest of the whole object, and computing it
+        // would read every byte a ranged read exists to skip; the range
+        // carries no identity.
+        let metadata = Self::metadata_from_fs_metadata(key, &fs_metadata, None, &path)?;
         Ok(Some(ObjectBody { metadata, bytes }))
     }
 
@@ -501,7 +496,7 @@ impl LocalFsStore {
             }
             Err(err) => return Err(io_error(key, err)),
         };
-        Self::metadata_from_fs_metadata(key, &metadata, &content_digest, &path)
+        Self::metadata_from_fs_metadata(key, &metadata, Some(&content_digest), &path)
     }
 
     async fn delete_object(&self, key: &str) -> Result<()> {
@@ -996,6 +991,7 @@ mod tests {
             .expect("object exists");
         assert_eq!(body.bytes, b"456");
         assert_eq!(body.metadata.size_bytes, payload.len() as u64);
+        assert_eq!(body.metadata.etag, None, "a ranged read carries no digest");
         assert_eq!(
             store
                 .get(&key, range(7, 99))

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -469,6 +469,18 @@ where
         result
     }
 
+    async fn get_range_with_metadata(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>> {
+        let start = sample_clock();
+        let (result, attempts) =
+            counting_attempts(self.inner.get_range_with_metadata(key, range.clone())).await;
+        self.record_range_with_metadata(key, &range, start.elapsed(), attempts, &result);
+        result
+    }
+
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         let start = sample_clock();
         let (result, attempts) = counting_attempts(self.inner.get_with_metadata(key)).await;
@@ -620,6 +632,30 @@ impl<S> InstrumentedObjectStore<S> {
             .ok()
             .and_then(|body| body.as_ref().map(|body| body.bytes.len() as u64));
         sample.range_class = Some(RangeClass::FullObject);
+        self.record(sample);
+    }
+
+    fn record_range_with_metadata(
+        &self,
+        key: &str,
+        range: &ByteRange,
+        elapsed: Duration,
+        attempts: u32,
+        result: &Result<Option<ObjectBody>>,
+    ) {
+        let mut sample = ObjectStoreMetricSample::new(
+            ObjectStoreOperation::Get,
+            key,
+            elapsed,
+            attempts,
+            classify_optional_result(result),
+            self.store_kind.clone(),
+        );
+        sample.bytes_out = result
+            .as_ref()
+            .ok()
+            .and_then(|body| body.as_ref().map(|body| body.bytes.len() as u64));
+        sample.range_class = Some(classify_range(Some(range)));
         self.record(sample);
     }
 

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -20,7 +20,7 @@ pub type SharedObjectStore = Arc<dyn ObjectStore>;
 /// implementation cleans up whatever it had started.
 pub type ByteStream = BoxStream<'static, Result<Bytes>>;
 
-/// Metadata returned by a successful `head`, full-object `get`, or `put` call.
+/// Metadata returned by a successful metadata read, content read, or `put` call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectMetadata {
     /// Opaque compare token for one object version.
@@ -82,12 +82,12 @@ pub enum MultipartCompletion {
     UnknownUpload,
 }
 
-/// Full object bytes returned with metadata from the same read operation.
+/// Object bytes returned with associated metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectBody {
-    /// Identity, size, and modification metadata observed with these exact bytes.
+    /// Identity, whole-object size, and modification metadata for the object.
     pub metadata: ObjectMetadata,
-    /// Complete object payload from the same read as `metadata`.
+    /// Complete or ranged object payload.
     pub bytes: Vec<u8>,
 }
 
@@ -442,6 +442,26 @@ pub trait ObjectStore: Send + Sync + Debug {
     /// failures are returned as [`ObjectStoreError`].
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>>;
 
+    /// Reads one byte range together with the object's metadata.
+    ///
+    /// `metadata.size_bytes` is the whole object's size, not the range's.
+    async fn get_range_with_metadata(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>> {
+        let Some(metadata) = self.head(key).await? else {
+            return Ok(None);
+        };
+        let Some(bytes) = self.get(key, Some(range)).await? else {
+            return Ok(None);
+        };
+        Ok(Some(ObjectBody {
+            metadata,
+            bytes: bytes.to_vec(),
+        }))
+    }
+
     /// Reads a full object or one half-open byte range, returning `None` when absent.
     ///
     /// A range ending beyond the object is truncated; a descending range or
@@ -597,6 +617,14 @@ impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
         self.as_ref().get_with_metadata(key).await
     }
 
+    async fn get_range_with_metadata(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>> {
+        self.as_ref().get_range_with_metadata(key, range).await
+    }
+
     async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         self.as_ref().get(key, range).await
     }
@@ -691,6 +719,14 @@ impl<T: ObjectStore + ?Sized> ObjectStore for &T {
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         (*self).get_with_metadata(key).await
+    }
+
+    async fn get_range_with_metadata(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>> {
+        (*self).get_range_with_metadata(key, range).await
     }
 
     async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -445,6 +445,8 @@ pub trait ObjectStore: Send + Sync + Debug {
     /// Reads one byte range together with the object's metadata.
     ///
     /// `metadata.size_bytes` is the whole object's size, not the range's.
+    /// A store may leave `metadata.etag` absent when naming the object's
+    /// identity would cost reading the whole object.
     async fn get_range_with_metadata(
         &self,
         key: &str,

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -336,12 +336,70 @@ impl ProviderObjectStore {
             ..Default::default()
         };
         match self.inner.get_opts(path, options).await {
-            Ok(result) => match result.bytes().await {
-                Ok(bytes) => RangedGet::Bytes(bytes),
-                Err(err) => RangedGet::Refused(err),
-            },
+            Ok(result) => {
+                let metadata = self.metadata_from_meta(result.meta.clone());
+                match result.bytes().await {
+                    Ok(bytes) => RangedGet::Object(RangedObject { metadata, bytes }),
+                    Err(err) => RangedGet::Refused(err),
+                }
+            }
             Err(err) if provider_not_found(&err) => RangedGet::NotFound,
             Err(err) => RangedGet::Refused(err),
+        }
+    }
+
+    async fn get_range_object(&self, key: &str, range: ByteRange) -> Result<Option<RangedObject>> {
+        let path = self.to_path(key)?;
+        if range.end_exclusive < range.start_inclusive {
+            return Err(ObjectStoreError::InvalidRange {
+                object_key: key.to_owned(),
+            });
+        }
+        if range.end_exclusive == range.start_inclusive {
+            return match self.head(key).await? {
+                None => Ok(None),
+                Some(metadata) if range.start_inclusive > metadata.size_bytes => {
+                    Err(ObjectStoreError::InvalidRange {
+                        object_key: key.to_owned(),
+                    })
+                }
+                Some(metadata) => Ok(Some(RangedObject {
+                    metadata,
+                    bytes: Bytes::new(),
+                })),
+            };
+        }
+        match self
+            .ranged_get(&path, range.start_inclusive, range.end_exclusive)
+            .await
+        {
+            RangedGet::Object(object) => Ok(Some(object)),
+            RangedGet::NotFound => Ok(None),
+            RangedGet::Refused(err) => match self.head(key).await? {
+                None => Ok(None),
+                Some(metadata) if range.start_inclusive > metadata.size_bytes => {
+                    Err(ObjectStoreError::InvalidRange {
+                        object_key: key.to_owned(),
+                    })
+                }
+                Some(metadata) if range.start_inclusive == metadata.size_bytes => {
+                    Ok(Some(RangedObject {
+                        metadata,
+                        bytes: Bytes::new(),
+                    }))
+                }
+                Some(metadata) if range.end_exclusive > metadata.size_bytes => {
+                    match self
+                        .ranged_get(&path, range.start_inclusive, metadata.size_bytes)
+                        .await
+                    {
+                        RangedGet::Object(object) => Ok(Some(object)),
+                        RangedGet::NotFound => Ok(None),
+                        RangedGet::Refused(err) => Err(map_provider_error(key, err)),
+                    }
+                }
+                Some(_) => Err(map_provider_error(key, err)),
+            },
         }
     }
 
@@ -855,6 +913,20 @@ impl ObjectStore for ProviderObjectStore {
         }
     }
 
+    async fn get_range_with_metadata(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>> {
+        Ok(self
+            .get_range_object(key, range)
+            .await?
+            .map(|object| ObjectBody {
+                metadata: object.metadata,
+                bytes: object.bytes.to_vec(),
+            }))
+    }
+
     /// Bounded reads issue the ranged GET directly — one round trip, not a
     /// sizing HEAD plus a GET — and pay a single HEAD only on the failure
     /// path, to decide whether the range or the transport was the problem.
@@ -864,8 +936,8 @@ impl ObjectStore for ProviderObjectStore {
     /// object clamps, `start == size` reads empty, and `start > size` is
     /// `InvalidRange`.
     async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
-        let path = self.to_path(key)?;
         let Some(range) = range else {
+            let path = self.to_path(key)?;
             return match self.inner.get(&path).await {
                 Ok(result) => result
                     .bytes()
@@ -876,59 +948,10 @@ impl ObjectStore for ProviderObjectStore {
                 Err(err) => Err(map_provider_error(key, err)),
             };
         };
-        if range.end_exclusive < range.start_inclusive {
-            return Err(ObjectStoreError::InvalidRange {
-                object_key: key.to_owned(),
-            });
-        }
-        if range.end_exclusive == range.start_inclusive {
-            // A zero-length request needs no bytes; existence and size
-            // alone answer it.
-            return match self.head(key).await? {
-                None => Ok(None),
-                Some(metadata) if range.start_inclusive > metadata.size_bytes => {
-                    Err(ObjectStoreError::InvalidRange {
-                        object_key: key.to_owned(),
-                    })
-                }
-                Some(_) => Ok(Some(Bytes::new())),
-            };
-        }
-        match self
-            .ranged_get(&path, range.start_inclusive, range.end_exclusive)
-            .await
-        {
-            RangedGet::Bytes(bytes) => Ok(Some(bytes)),
-            RangedGet::NotFound => Ok(None),
-            RangedGet::Refused(err) => {
-                // The provider refused; one HEAD decides whether the range
-                // was the problem, matching the reference semantics.
-                match self.head(key).await? {
-                    None => Ok(None),
-                    Some(metadata) if range.start_inclusive > metadata.size_bytes => {
-                        Err(ObjectStoreError::InvalidRange {
-                            object_key: key.to_owned(),
-                        })
-                    }
-                    Some(metadata) if range.start_inclusive == metadata.size_bytes => {
-                        Ok(Some(Bytes::new()))
-                    }
-                    Some(metadata) if range.end_exclusive > metadata.size_bytes => {
-                        // A strict provider rejected the over-long end
-                        // instead of clamping; clamp and retry once.
-                        match self
-                            .ranged_get(&path, range.start_inclusive, metadata.size_bytes)
-                            .await
-                        {
-                            RangedGet::Bytes(bytes) => Ok(Some(bytes)),
-                            RangedGet::NotFound => Ok(None),
-                            RangedGet::Refused(err) => Err(map_provider_error(key, err)),
-                        }
-                    }
-                    Some(_) => Err(map_provider_error(key, err)),
-                }
-            }
-        }
+        Ok(self
+            .get_range_object(key, range)
+            .await?
+            .map(|object| object.bytes))
     }
 
     async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
@@ -1123,9 +1146,14 @@ fn last_modified_ms(timestamp_millis: i64) -> Option<u64> {
 }
 
 enum RangedGet {
-    Bytes(Bytes),
+    Object(RangedObject),
     NotFound,
     Refused(provider_store::Error),
+}
+
+struct RangedObject {
+    metadata: ObjectMetadata,
+    bytes: Bytes,
 }
 
 fn provider_not_found(err: &provider_store::Error) -> bool {
@@ -1425,6 +1453,13 @@ mod tests {
             store.get(key, range(2, 6)).await.expect("bounded"),
             Some(Bytes::from_static(b"2345"))
         );
+        let body = store
+            .get_range_with_metadata(key, range(2, 6).expect("range"))
+            .await
+            .expect("bounded with metadata")
+            .expect("object exists");
+        assert_eq!(body.bytes, b"2345");
+        assert_eq!(body.metadata.size_bytes, 10);
         // An end past the object clamps.
         assert_eq!(
             store.get(key, range(6, 99)).await.expect("clamped"),
@@ -1456,6 +1491,13 @@ mod tests {
         let missing = "namespaces/demo/metadata/segments/seg_missing.sst.zst";
         assert_eq!(
             store.get(missing, range(0, 4)).await.expect("missing"),
+            None
+        );
+        assert_eq!(
+            store
+                .get_range_with_metadata(missing, range(0, 4).expect("range"))
+                .await
+                .expect("missing with metadata"),
             None
         );
         assert_eq!(

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -178,6 +178,23 @@ async fn records_get_success_bytes_out() {
     assert_eq!(sample.bytes_out, Some(3));
     assert_eq!(sample.key_class, KeyClass::Content);
     assert_eq!(sample.range_class, Some(RangeClass::Bounded));
+
+    let body = store
+        .get_range_with_metadata(
+            "content-stores/cs_abc/objects/ab/cd/con_abcdef0123456789abcdef0123456789",
+            ByteRange {
+                start_inclusive: 2,
+                end_exclusive: 4,
+            },
+        )
+        .await
+        .expect("get object with metadata")
+        .expect("object exists");
+    assert_eq!(body.bytes, b"cd");
+    let sample = recorder.samples().pop().expect("ranged metadata sample");
+    assert_eq!(sample.operation, ObjectStoreOperation::Get);
+    assert_eq!(sample.bytes_out, Some(2));
+    assert_eq!(sample.range_class, Some(RangeClass::Bounded));
 }
 
 #[tokio::test]

--- a/crates/loonfs-sim/src/fault_store.rs
+++ b/crates/loonfs-sim/src/fault_store.rs
@@ -298,6 +298,71 @@ where
         }
     }
 
+    async fn get_range_with_metadata(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let op = self.next_object_op(ObjectOperationKind::Get, key);
+        let scheduled = self.scheduled_fault(&op);
+        match scheduled.as_ref().map(|fault| &fault.fault) {
+            Some(ObjectStoreFault::GetReturnsStaleValue) => {
+                if let Some(mut body) = self.stale_value(key) {
+                    body.bytes = apply_range(key, body.bytes, Some(range))?.to_vec();
+                    self.push_trace(
+                        op,
+                        "get_range_with_metadata_stale_value",
+                        Some(ObjectStoreFault::GetReturnsStaleValue),
+                        SimEventResult::Ok,
+                    );
+                    return Ok(Some(body));
+                }
+                let result = self.inner.get_range_with_metadata(key, range).await;
+                self.push_trace(
+                    op,
+                    "get_range_with_metadata_stale_value_skipped",
+                    Some(ObjectStoreFault::GetReturnsStaleValue),
+                    SimEventResult::Skipped {
+                        reason: "no_stale_value_recorded".to_owned(),
+                    },
+                );
+                result
+            }
+            Some(ObjectStoreFault::CorruptObjectBytes) => {
+                let mut result = self.inner.get_range_with_metadata(key, range).await;
+                if let Ok(Some(body)) = &mut result {
+                    if let Some(first) = body.bytes.first_mut() {
+                        *first ^= 0x01;
+                    }
+                }
+                self.push_trace(
+                    op,
+                    "get_range_with_metadata_corrupt_bytes",
+                    Some(ObjectStoreFault::CorruptObjectBytes),
+                    result_class(&result),
+                );
+                result
+            }
+            Some(incompatible) => {
+                let result = self.inner.get_range_with_metadata(key, range).await;
+                self.push_trace(
+                    op,
+                    "get_range_with_metadata_fault_skipped",
+                    Some(incompatible.clone()),
+                    SimEventResult::Skipped {
+                        reason: "fault_not_applicable_to_operation".to_owned(),
+                    },
+                );
+                result
+            }
+            None => {
+                let result = self.inner.get_range_with_metadata(key, range).await;
+                self.push_trace(op, "get_range_with_metadata", None, result_class(&result));
+                result
+            }
+        }
+    }
+
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
         let op = self.next_object_op(ObjectOperationKind::Get, key);
         let scheduled = self.scheduled_fault(&op);

--- a/crates/loonfs-test-support/src/stores/delegate.rs
+++ b/crates/loonfs-test-support/src/stores/delegate.rs
@@ -16,6 +16,7 @@ macro_rules! delegate_object_store {
             complete_multipart_upload,
             abort_multipart_upload,
             get_with_metadata,
+            get_range_with_metadata,
             get,
             put,
             put_streamed,
@@ -37,6 +38,7 @@ macro_rules! delegate_object_store {
             complete_multipart_upload,
             abort_multipart_upload,
             get_with_metadata,
+            get_range_with_metadata,
             put,
             put_streamed,
             put_overwrite,
@@ -57,6 +59,7 @@ macro_rules! delegate_object_store {
             complete_multipart_upload,
             abort_multipart_upload,
             get_with_metadata,
+            get_range_with_metadata,
             get,
             delete,
             list_prefix_stream,
@@ -71,6 +74,7 @@ macro_rules! delegate_object_store {
             complete_multipart_upload,
             abort_multipart_upload,
             get_with_metadata,
+            get_range_with_metadata,
             get,
             put,
             put_streamed,
@@ -235,6 +239,30 @@ macro_rules! __delegate_object_store_method {
             Self: 'future,
         {
             ::std::boxed::Box::pin(async move { $inner.get_with_metadata(key).await })
+        }
+    };
+    (get_range_with_metadata, $receiver:ident, $inner:expr) => {
+        fn get_range_with_metadata<'store, 'key, 'future>(
+            &'store $receiver,
+            key: &'key str,
+            range: ::loonfs_objectstore::ByteRange,
+        ) -> ::core::pin::Pin<::std::boxed::Box<
+            dyn ::core::future::Future<
+                    Output = Result<
+                        Option<::loonfs_objectstore::ObjectBody>,
+                        ::loonfs_objectstore::ObjectStoreError,
+                    >,
+                > + Send
+                + 'future,
+        >>
+        where
+            'store: 'future,
+            'key: 'future,
+            Self: 'future,
+        {
+            ::std::boxed::Box::pin(async move {
+                $inner.get_range_with_metadata(key, range).await
+            })
         }
     };
     (get, $receiver:ident, $inner:expr) => {

--- a/crates/loonfs-test-support/src/stores/intercept_store.rs
+++ b/crates/loonfs-test-support/src/stores/intercept_store.rs
@@ -180,6 +180,30 @@ impl<S: ObjectStore + 'static, I: Interceptor + 'static> ObjectStore for Interce
         Self::finish(&self.interceptor, &context, intercept, result, outcome)
     }
 
+    async fn get_range_with_metadata(
+        &self,
+        key: &str,
+        range: ByteRange,
+    ) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let context = OperationContext::new(
+            key,
+            OperationKind::Get {
+                range: Some(&range),
+            },
+        );
+        let intercept = match self.interceptor.before(&context).await {
+            Intercept::FailBefore(error) => return Err(error),
+            intercept => intercept,
+        };
+        let result = self.inner.get_range_with_metadata(key, range.clone()).await;
+        let outcome = match &result {
+            Ok(Some(body)) => Outcome::Bytes(body.bytes.len()),
+            Ok(None) => Outcome::Bytes(0),
+            Err(_) => Outcome::Failure,
+        };
+        Self::finish(&self.interceptor, &context, intercept, result, outcome)
+    }
+
     async fn get(
         &self,
         key: &str,

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -188,7 +188,7 @@ async fn bind_namespace_to_content_store(
         .expect("rebind the namespace head to the shared content store");
 }
 
-/// Full external preparation performs one content HEAD and one full GET.
+/// Full external preparation performs one full content GET.
 async fn prepare_content(
     store: &SharedObjectStore,
     namespace_id: &NamespaceId,
@@ -265,7 +265,7 @@ async fn put_file_content_ref_validates_content_before_publication() {
         .await
         .expect("publish content ref");
 
-    assert_content_counts(harness.recording.snapshot(), 1, 1, 1, bytes.len());
+    assert_content_counts(harness.recording.snapshot(), 0, 1, 1, bytes.len());
 }
 
 #[tokio::test]
@@ -519,7 +519,7 @@ async fn prepare_content_ref_reads_large_sources_in_bounded_ranges() {
         prepared.content_ref().checksum,
         loonfs_api::Checksum::sha256(&bytes)
     );
-    assert_content_counts(harness.recording.snapshot(), 1, 2, 1, bytes.len());
+    assert_content_counts(harness.recording.snapshot(), 0, 2, 1, bytes.len());
 }
 
 #[tokio::test]
@@ -542,7 +542,7 @@ async fn prepare_content_ref_reads_once_and_prepared_publication_reads_nothing()
     );
     assert_eq!(prepared.content_ref().checksum, content_ref.checksum);
     assert_eq!(prepared.content_ref().size_bytes, content_ref.size_bytes);
-    assert_content_counts(harness.recording.snapshot(), 1, 1, 1, bytes.len());
+    assert_content_counts(harness.recording.snapshot(), 0, 1, 1, bytes.len());
     harness.recording.reset();
 
     harness

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -268,8 +268,8 @@ The content model has six rules.
    comes from `ContentRef`, not from the checksum algorithm.
 6. **Every read verifies the checksum.** The reader computes the algorithm in
    `content_ref.checksum` over the complete file. If it cannot compute that
-   algorithm, the read fails. A HEAD request may check existence and size
-   before downloading the object.
+   algorithm, the read fails. The first ranged read checks the object's
+   existence and size before any bytes are verified.
 
 ##### Checksum format
 


### PR DESCRIPTION
Content streams now validate object existence and size with their first ranged read instead of issuing a separate HEAD request. Provider-backed stores return the range and whole-object size in one request. The trait default keeps other stores compatible by using HEAD followed by a ranged GET.

Missing objects and size mismatches are now reported when the first chunk is requested rather than when the stream is opened. Full content-reference validation also removes a redundant HEAD because the following full GET validates the length and checksum. HTTP and CLI behavior, wire formats, error codes, and durable data are unchanged.