### PR TITLE
perf(core): prefetch metadata and WAL data in parallel

### DIFF
--- a/crates/loonfs-core/src/block_cache.rs
+++ b/crates/loonfs-core/src/block_cache.rs
@@ -228,6 +228,25 @@ impl<K: Clone + Eq + Hash, V: DecodedBlock> DecodedBlockCache<K, V> {
         Some(block)
     }
 
+    /// Whether the cache holds `key`. Unlike `get`, this records no hit or
+    /// miss and does not touch the entry's recency.
+    pub(crate) fn contains_key(&self, key: &K) -> bool {
+        self.inner
+            .lock()
+            .expect("decoded block cache lock should not be poisoned")
+            .entries
+            .contains_key(key)
+    }
+
+    pub(crate) fn contains_key_matching(&self, matches: impl Fn(&K) -> bool) -> bool {
+        self.inner
+            .lock()
+            .expect("decoded block cache lock should not be poisoned")
+            .entries
+            .keys()
+            .any(matches)
+    }
+
     pub fn insert(&self, key: K, block: V) {
         if self.disabled() {
             return;

--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -13,12 +13,15 @@ use super::cache::{
 };
 use super::data_block_load::decoded_data_cache_block;
 use super::error::ManifestLoadError;
+use super::runs::{MetadataRunManifest, MAX_MATERIALIZED_TABLE_LOADS, OPEN_PREFETCH_ROW_FAMILIES};
 use super::stored_block_cache::{
     StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind,
 };
 use bytes::Bytes;
+use futures::StreamExt;
 use loonfs_api::wire::hex::hex_decode_bytes;
 use loonfs_api::wire::manifest::MetadataSegmentRef;
+use loonfs_api::wire::manifest::RunTier;
 use loonfs_api::wire::sst_blocks::{
     decode_data_block, decode_filter_block, decode_index_block, BlockHandle, SegmentFilter,
     SegmentIndexEntry, SstBlockCodecError,
@@ -26,6 +29,106 @@ use loonfs_api::wire::sst_blocks::{
 use loonfs_objectstore::keys::metadata_segment_object_key;
 use loonfs_objectstore::{ByteRange, ObjectStore};
 use std::sync::Arc;
+
+#[derive(Clone)]
+struct SegmentTailPrefetch {
+    descriptor: MetadataSegmentRef,
+    want: MetadataSegmentBlockKind,
+}
+
+fn select_segment_tail_prefetches(
+    segment_cache: &MetadataSegmentCache,
+    memo: &SessionBlockMemo,
+    runs: &[MetadataRunManifest],
+) -> Vec<SegmentTailPrefetch> {
+    let max_stored_bytes = u64::try_from(segment_cache.open_prefetch_max_stored_bytes())
+        .expect("a usize stored-byte budget should fit in u64");
+    let mut selected = Vec::new();
+    let mut selected_stored_bytes = 0_u64;
+    for family in OPEN_PREFETCH_ROW_FAMILIES {
+        for tier in [RunTier::Base, RunTier::Delta] {
+            for run in runs.iter().filter(|run| run.tier == tier) {
+                let Some(family_segments) = run
+                    .segments
+                    .iter()
+                    .find(|segments| segments.family == family)
+                else {
+                    continue;
+                };
+                for descriptor in &family_segments.segments {
+                    let (want, handle, stored_bytes) = if descriptor.filter_inline.is_some() {
+                        (
+                            MetadataSegmentBlockKind::Index,
+                            descriptor.index_block,
+                            u64::from(descriptor.index_block.stored_len),
+                        )
+                    } else {
+                        (
+                            MetadataSegmentBlockKind::Filter,
+                            descriptor.filter_block,
+                            u64::from(descriptor.filter_block.stored_len)
+                                + u64::from(descriptor.index_block.stored_len),
+                        )
+                    };
+                    let cache_key = segment_block_cache_key(descriptor, want, handle.offset);
+                    if memo.get(&cache_key).is_some() || segment_cache.contains(&cache_key) {
+                        continue;
+                    }
+                    let next_stored_bytes = selected_stored_bytes
+                        .checked_add(stored_bytes)
+                        .expect("selected segment tail bytes should fit in u64");
+                    if next_stored_bytes > max_stored_bytes {
+                        return selected;
+                    }
+                    selected_stored_bytes = next_stored_bytes;
+                    selected.push(SegmentTailPrefetch {
+                        descriptor: descriptor.clone(),
+                        want,
+                    });
+                }
+            }
+        }
+    }
+    selected
+}
+
+pub(super) async fn prefetch_segment_tails<S: ObjectStore + ?Sized>(
+    store: &S,
+    segment_cache: &MetadataSegmentCache,
+    memo: &SessionBlockMemo,
+    runs: &[MetadataRunManifest],
+) {
+    let selected = select_segment_tail_prefetches(segment_cache, memo, runs);
+    let mut failed_requests = 0_usize;
+    let mut first_error = None;
+    let results = futures::stream::iter(selected)
+        .map(|selected| async move {
+            load_and_publish_segment_sections(
+                store,
+                Some(segment_cache),
+                memo,
+                &selected.descriptor,
+                selected.want,
+            )
+            .await
+        })
+        .buffer_unordered(MAX_MATERIALIZED_TABLE_LOADS)
+        .collect::<Vec<_>>()
+        .await;
+    for result in results {
+        if let Err(error) = result {
+            failed_requests += 1;
+            first_error.get_or_insert_with(|| error.to_string());
+        }
+    }
+    if let Some(first_error) = first_error {
+        tracing::debug!(
+            failed_requests,
+            %first_error,
+            "metadata segment tail prefetch requests failed"
+        );
+    }
+}
 
 pub(super) fn segment_block_cache_key(
     descriptor: &MetadataSegmentRef,
@@ -512,4 +615,119 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
     };
     memo.record(&cache_key, &block);
     block.into_filter(&metadata_segment_object_key(descriptor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::cache::MetadataSegmentCacheConfig;
+    use crate::checkpoint::runs::MetadataFamilySegments;
+    use loonfs_api::wire::manifest::MetadataRowFamily;
+    use loonfs_api::{ChangeSeq, MetadataSegmentId, NamespaceId, RunNo};
+
+    fn descriptor(
+        id: u32,
+        family: MetadataRowFamily,
+        filter_stored_len: u32,
+        index_stored_len: u32,
+    ) -> MetadataSegmentRef {
+        MetadataSegmentRef {
+            owner_namespace_id: NamespaceId::parse("prefetch").expect("namespace id"),
+            segment_id: MetadataSegmentId::parse(format!("seg_{id:032x}")).expect("segment id"),
+            compaction_job_id: None,
+            family,
+            segment_index: 0,
+            row_count: 1,
+            min_row_key: "a".to_owned(),
+            max_row_key: "z".to_owned(),
+            index_block: BlockHandle {
+                offset: u64::from(filter_stored_len),
+                stored_len: index_stored_len,
+                decoded_len: index_stored_len,
+                crc32c: 0,
+            },
+            filter_block: BlockHandle {
+                offset: 0,
+                stored_len: filter_stored_len,
+                decoded_len: filter_stored_len,
+                crc32c: 0,
+            },
+            filter_inline: Some(String::new()),
+            object_checksum: format!("checksum-{id}"),
+        }
+    }
+
+    fn run(
+        run_no: u64,
+        tier: RunTier,
+        descriptors: Vec<MetadataSegmentRef>,
+    ) -> MetadataRunManifest {
+        let mut segments = Vec::new();
+        for descriptor in descriptors {
+            let family = descriptor.family;
+            segments.push(MetadataFamilySegments {
+                family,
+                segments: vec![descriptor],
+            });
+        }
+        MetadataRunManifest {
+            run_no: RunNo(run_no),
+            run_seq: ChangeSeq(run_no),
+            tier,
+            segments,
+        }
+    }
+
+    #[test]
+    fn segment_tail_selection_honors_priority_budget_and_memo_hits() {
+        let delta_bind = descriptor(1, MetadataRowFamily::DirentryBinds, 1, 4);
+        let base_bind = descriptor(2, MetadataRowFamily::DirentryBinds, 1, 3);
+        let inode = descriptor(3, MetadataRowFamily::Inodes, 1, 3);
+        let revision = descriptor(4, MetadataRowFamily::Revisions, 1, 1);
+        let runs = vec![
+            run(1, RunTier::Delta, vec![delta_bind]),
+            run(2, RunTier::Base, vec![base_bind.clone(), inode, revision]),
+        ];
+        let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
+            open_prefetch_max_stored_bytes: 7,
+            ..MetadataSegmentCacheConfig::default()
+        });
+        let memo = SessionBlockMemo::default();
+
+        let selected = select_segment_tail_prefetches(&cache, &memo, &runs);
+        assert_eq!(
+            selected
+                .iter()
+                .map(|selected| selected.descriptor.segment_id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "seg_00000000000000000000000000000002",
+                "seg_00000000000000000000000000000001",
+            ]
+        );
+
+        let base_bind_key = segment_block_cache_key(
+            &base_bind,
+            MetadataSegmentBlockKind::Index,
+            base_bind.index_block.offset,
+        );
+        memo.record(
+            &base_bind_key,
+            &DecodedMetadataSegmentBlock::Index {
+                entries: Arc::new(Vec::new()),
+                decoded_bytes: 0,
+            },
+        );
+        let selected = select_segment_tail_prefetches(&cache, &memo, &runs);
+        assert_eq!(
+            selected
+                .iter()
+                .map(|selected| selected.descriptor.segment_id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "seg_00000000000000000000000000000001",
+                "seg_00000000000000000000000000000003",
+            ]
+        );
+    }
 }

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -22,16 +22,21 @@ use std::sync::Arc;
 /// Default decoded-byte budget for metadata segment blocks. A value of zero
 /// disables the cache.
 pub(crate) const DEFAULT_METADATA_SEGMENT_CACHE_DECODED_BYTES: usize = 256 * 1024 * 1024;
+const DEFAULT_OPEN_PREFETCH_MAX_STORED_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetadataSegmentCacheConfig {
     pub max_decoded_bytes: usize,
+    /// Maximum stored bytes selected for the open-time segment-tail prefetch.
+    /// Zero disables the prefetch.
+    pub open_prefetch_max_stored_bytes: usize,
 }
 
 impl Default for MetadataSegmentCacheConfig {
     fn default() -> Self {
         Self {
             max_decoded_bytes: DEFAULT_METADATA_SEGMENT_CACHE_DECODED_BYTES,
+            open_prefetch_max_stored_bytes: DEFAULT_OPEN_PREFETCH_MAX_STORED_BYTES,
         }
     }
 }
@@ -63,6 +68,7 @@ pub(super) type DecodedMetadataSegmentBlock = DecodedSegmentBlock<
 
 pub struct MetadataSegmentCache {
     blocks: DecodedBlockCache<MetadataSegmentCacheKey, DecodedMetadataSegmentBlock>,
+    open_prefetch_max_stored_bytes: usize,
     stats: MetadataSegmentFilterStatsInner,
     observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
     /// Optional node-local cache for encoded blocks. Keeping it with the
@@ -75,6 +81,10 @@ impl std::fmt::Debug for MetadataSegmentCache {
         formatter
             .debug_struct("MetadataSegmentCache")
             .field("blocks", &self.blocks)
+            .field(
+                "open_prefetch_max_stored_bytes",
+                &self.open_prefetch_max_stored_bytes,
+            )
             .field("stats", &self.stats)
             .field("stored_block_cache", &self.stored_block_cache)
             .finish_non_exhaustive()
@@ -97,6 +107,7 @@ impl MetadataSegmentCache {
         stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
         observer: Option<Arc<dyn DecodedBlockCacheObserver>>,
     ) -> Self {
+        let open_prefetch_max_stored_bytes = config.open_prefetch_max_stored_bytes;
         Self {
             blocks: DecodedBlockCache::new(DecodedBlockCacheConfig {
                 max_decoded_bytes: config.max_decoded_bytes,
@@ -104,6 +115,7 @@ impl MetadataSegmentCache {
                 max_entries: None,
                 observer: observer.clone(),
             }),
+            open_prefetch_max_stored_bytes,
             stats: MetadataSegmentFilterStatsInner::default(),
             observer,
             stored_block_cache,
@@ -113,6 +125,11 @@ impl MetadataSegmentCache {
     /// Returns the node-local encoded-block cache, if one was configured.
     pub fn stored_block_cache(&self) -> Option<&Arc<dyn StoredMetadataBlockCache>> {
         self.stored_block_cache.as_ref()
+    }
+
+    /// Returns the stored-byte budget for open-time segment-tail prefetching.
+    pub fn open_prefetch_max_stored_bytes(&self) -> usize {
+        self.open_prefetch_max_stored_bytes
     }
 
     /// Resolves one block access through a single-flight cell.
@@ -158,6 +175,11 @@ impl MetadataSegmentCache {
 
     pub(super) fn get(&self, key: &MetadataSegmentCacheKey) -> Option<DecodedMetadataSegmentBlock> {
         self.blocks.get(key)
+    }
+
+    /// A probe that records no hit or miss, for deciding what to prefetch.
+    pub(super) fn contains(&self, key: &MetadataSegmentCacheKey) -> bool {
+        self.blocks.contains_key(key)
     }
 
     pub(super) fn insert(&self, key: MetadataSegmentCacheKey, block: DecodedMetadataSegmentBlock) {
@@ -283,6 +305,19 @@ impl WalTailProjectionCache {
         self.blocks.get(key)
     }
 
+    pub(crate) fn contains_head(
+        &self,
+        namespace_id: &NamespaceId,
+        head_seq: ChangeSeq,
+        head_etag: &str,
+    ) -> bool {
+        self.blocks.contains_key_matching(|key| {
+            &key.namespace_id == namespace_id
+                && key.head_seq == head_seq
+                && key.head_etag == head_etag
+        })
+    }
+
     pub fn insert(&self, key: WalTailProjectionCacheKey, rows: Arc<MetadataState>) {
         if self.config.max_entries == 0 {
             return;
@@ -400,6 +435,7 @@ mod tests {
     fn byte_budget_evicts_the_oldest_block() {
         let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
             max_decoded_bytes: 1000,
+            ..MetadataSegmentCacheConfig::default()
         });
         cache.insert(key("a"), block(600));
         cache.insert(key("b"), block(600));
@@ -415,6 +451,7 @@ mod tests {
     fn replacing_a_block_reaccounts_its_decoded_bytes() {
         let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
             max_decoded_bytes: 1000,
+            ..MetadataSegmentCacheConfig::default()
         });
         cache.insert(key("a"), block(600));
         cache.insert(key("a"), block(100));

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -257,6 +257,8 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
             visible_tip: head.visible_wal_tip.clone(),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: std::collections::HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &head.recent_segments,
         },
     )

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -86,6 +86,20 @@ pub(crate) use self::scan::{Readahead, VerifiedMetadataSegments};
 pub(crate) use self::snapshot::{extend_snapshot_expiry, release_snapshot};
 pub(crate) use self::streaming_compaction::run_metadata_compaction_job;
 
+pub(crate) async fn prefetch_verified_segment_tails<S: loonfs_objectstore::ObjectStore + ?Sized>(
+    store: &S,
+    segment_cache: &MetadataSegmentCache,
+    segments: &VerifiedMetadataSegments<'_, S>,
+) {
+    block_fetch::prefetch_segment_tails(
+        store,
+        segment_cache,
+        &segments.block_memo,
+        &segments.scan_runs,
+    )
+    .await;
+}
+
 fn checkpoint_summary(
     record: loonfs_api::wire::control::CheckpointRecordState,
 ) -> loonfs_api::Checkpoint {

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -32,18 +32,16 @@ pub(super) const CHECKPOINT_ROW_FAMILIES: [MetadataRowFamily; 10] = [
     MetadataRowFamily::Attributes,
 ];
 
-/// Path resolution families come first so open prefetching serves point lookups first.
-pub(super) const OPEN_PREFETCH_ROW_FAMILIES: [MetadataRowFamily; 10] = [
+/// The families the open-time tail wave fetches, path walk first. The other
+/// four families load lazily: reads touch them rarely, and every tail the
+/// wave fetches is paid by the read that opened the view.
+pub(super) const OPEN_PREFETCH_ROW_FAMILIES: [MetadataRowFamily; 6] = [
     MetadataRowFamily::DirentryBinds,
     MetadataRowFamily::Inodes,
     MetadataRowFamily::DirentryChildBinds,
     MetadataRowFamily::DirentryUnbinds,
     MetadataRowFamily::Revisions,
     MetadataRowFamily::RevisionsByInodeDesc,
-    MetadataRowFamily::Tombstones,
-    MetadataRowFamily::ActiveDeletions,
-    MetadataRowFamily::CommitReceipts,
-    MetadataRowFamily::Attributes,
 ];
 
 /// Metadata families merged together as one consistency unit.

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -16,9 +16,26 @@ pub(super) use loonfs_api::wire::sst_blocks::{
 
 pub(super) const MAX_MAINTENANCE_SEGMENT_IO: usize = 8;
 
+/// Segment tail and row-block fetches issued in one bounded wave.
+pub(super) const MAX_MATERIALIZED_TABLE_LOADS: usize = 16;
+
 pub(super) const CHECKPOINT_ROW_FAMILIES: [MetadataRowFamily; 10] = [
     MetadataRowFamily::Inodes,
     MetadataRowFamily::DirentryBinds,
+    MetadataRowFamily::DirentryChildBinds,
+    MetadataRowFamily::DirentryUnbinds,
+    MetadataRowFamily::Revisions,
+    MetadataRowFamily::RevisionsByInodeDesc,
+    MetadataRowFamily::Tombstones,
+    MetadataRowFamily::ActiveDeletions,
+    MetadataRowFamily::CommitReceipts,
+    MetadataRowFamily::Attributes,
+];
+
+/// Path resolution families come first so open prefetching serves point lookups first.
+pub(super) const OPEN_PREFETCH_ROW_FAMILIES: [MetadataRowFamily; 10] = [
+    MetadataRowFamily::DirentryBinds,
+    MetadataRowFamily::Inodes,
     MetadataRowFamily::DirentryChildBinds,
     MetadataRowFamily::DirentryUnbinds,
     MetadataRowFamily::Revisions,

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -7,7 +7,10 @@ use super::load::{
     load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter, SegmentKeyRangeBlocks,
     SessionBlockMemo,
 };
-use super::runs::{MetadataFamilySegments, MetadataRunManifest, CHECKPOINT_ROW_FAMILIES};
+use super::runs::{
+    MetadataFamilySegments, MetadataRunManifest, CHECKPOINT_ROW_FAMILIES,
+    MAX_MATERIALIZED_TABLE_LOADS,
+};
 #[cfg(test)]
 use crate::metadata::MetadataState;
 use futures::future::try_join_all;
@@ -18,11 +21,6 @@ use loonfs_api::wire::sst_blocks::{key_range_may_intersect, string_prefix_upper_
 use loonfs_api::ChangeSeq;
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
-
-/// Segment fetches issued per wave during a scan. Wide directories touch
-/// hundreds of segments per page; deeper waves amortize the per-wave await
-/// without unbounded fan-out.
-pub(super) const MAX_MATERIALIZED_TABLE_LOADS: usize = 16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Readahead {

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -281,6 +281,7 @@ pub(super) async fn merge_group_in_step<S: ObjectStore + ?Sized>(
 ) -> Result<MetadataMergeResult> {
     let probe_cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
         max_decoded_bytes: PROBE_CACHE_DECODED_BYTES,
+        open_prefetch_max_stored_bytes: 0,
     });
     let merge = GroupMerge::new(
         store,
@@ -322,6 +323,7 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
 ) -> Result<std::result::Result<MetadataMergeResult, MetadataCompactionJobOutcome>> {
     let probe_cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
         max_decoded_bytes: PROBE_CACHE_DECODED_BYTES,
+        open_prefetch_max_stored_bytes: 0,
     });
     let merge = GroupMerge::new(
         segments.store,

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -126,6 +126,7 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
 
     let degenerate = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
         max_decoded_bytes: 1,
+        ..MetadataSegmentCacheConfig::default()
     });
     let degenerate_segments = super::load_verified_manifest_segments(
         &store,

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -538,6 +538,8 @@ async fn collect_retained_wal<S: ObjectStore + ?Sized>(
             visible_tip: head.visible_wal_tip.clone(),
             stop_after_seq: None,
             max_segment_fetches: Some(usize::try_from(remaining).unwrap_or(usize::MAX)),
+            prefetched: std::collections::HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &head.recent_segments,
         },
     )

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -98,6 +98,8 @@ pub async fn load_namespace_diagnostics<S: ObjectStore + ?Sized>(
         visible_tip: loaded.head.visible_wal_tip.clone(),
         stop_after_seq: None,
         max_segment_fetches: None,
+        prefetched: std::collections::HashMap::new(),
+        speculative_requests: 0,
         recent_segments: &loaded.head.recent_segments,
     })
     .map_err(|error| {

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -4,8 +4,9 @@
 use super::current_files::resolve_visible_inode;
 use super::listing::{invalid_cursor, validate_cursor_head, validate_directory_cursor};
 use crate::checkpoint::{
-    head_from_manifest, load_basis_metadata_segments, MetadataSegmentCache,
-    VerifiedMetadataSegments, WalTailProjectionCache, WalTailProjectionCacheKey,
+    head_from_manifest, load_basis_metadata_segments, prefetch_verified_segment_tails,
+    MetadataSegmentCache, VerifiedMetadataSegments, WalTailProjectionCache,
+    WalTailProjectionCacheKey,
 };
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, MetadataViewError, Result};
@@ -20,7 +21,8 @@ use crate::namespace::control_snapshot::load_head_and_metadata_basis;
 use crate::path::mutation_path::{map_path_error_to_core, parse_absolute_path_for_core};
 use crate::storage::content::{content_object_key_for_ref, get_durable_content_bytes};
 use crate::wal::{
-    ensure_replayed_head_matches, load_wal_chain, project_validated_wal_tail, WalChainLoadRequest,
+    ensure_replayed_head_matches, load_wal_chain, prefetch_hinted_wal_segments,
+    project_validated_wal_tail, WalChainLoadRequest,
 };
 use loonfs_api::v0::DirectoryBinding;
 use loonfs_api::wire::control::HeadState;
@@ -183,14 +185,38 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         crate::namespace::control::ensure_namespace_live(&head)?;
         let catalog_entry = VerifiedNamespaceCatalogEntry::from_head(&head);
         let manifest_no = basis.manifest_no();
-        let loaded_basis = load_basis_metadata_segments(
+        let basis_head_seq = basis
+            .manifest()
+            .map_or(ChangeSeq(0), |manifest| manifest.manifest_head_seq);
+        let tail_projection_cached = load_context.tail_cache.is_some_and(|cache| {
+            cache.contains_head(namespace_id, head.seq, load_context.head_etag)
+        });
+        let speculative_wal_prefetch = async {
+            if head.seq > basis_head_seq && !tail_projection_cached {
+                if let Some(tip) = head.visible_wal_tip.as_ref() {
+                    return prefetch_hinted_wal_segments(
+                        store,
+                        namespace_id,
+                        tip,
+                        &head.recent_segments,
+                        head.seq,
+                        None,
+                    )
+                    .await;
+                }
+            }
+            (HashMap::new(), 0)
+        };
+        let load_basis = load_basis_metadata_segments(
             store,
             load_context.segment_cache,
             namespace_id,
             basis,
             head.created_at_ms,
-        )
-        .await?;
+        );
+        let (loaded_basis, (prefetched, speculative_requests)) =
+            futures::join!(load_basis, speculative_wal_prefetch);
+        let loaded_basis = loaded_basis?;
         let segments = loaded_basis.segments;
         let manifest_head = head_from_manifest(&head, segments.manifest());
         let anchor = ReadAnchor {
@@ -207,6 +233,12 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         };
         if let Some(cache) = load_context.tail_cache {
             if let Some(wal_tail_rows) = cache.get(&cache_key) {
+                if let Some(segment_cache) = load_context
+                    .segment_cache
+                    .filter(|cache| cache.open_prefetch_max_stored_bytes() != 0)
+                {
+                    prefetch_verified_segment_tails(store, segment_cache, &segments).await;
+                }
                 return Ok(Self {
                     namespace_id: namespace_id.clone(),
                     content_store_id: catalog_entry.content_store_id().clone(),
@@ -217,7 +249,15 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 });
             }
         }
-        let wal_chain = load_wal_chain(
+        let tail_prefetch = async {
+            if let Some(segment_cache) = load_context
+                .segment_cache
+                .filter(|cache| cache.open_prefetch_max_stored_bytes() != 0)
+            {
+                prefetch_verified_segment_tails(store, segment_cache, &segments).await;
+            }
+        };
+        let wal_chain_load = load_wal_chain(
             store,
             WalChainLoadRequest {
                 namespace_id,
@@ -226,14 +266,17 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 visible_tip: head.visible_wal_tip.clone(),
                 stop_after_seq: None,
                 max_segment_fetches: None,
+                prefetched,
+                speculative_requests,
                 recent_segments: &head.recent_segments,
             },
-        )
-        .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
-        })?
-        .into_complete();
+        );
+        let ((), wal_chain) = futures::join!(tail_prefetch, wal_chain_load);
+        let wal_chain = wal_chain
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
+            })?
+            .into_complete();
         let replayed = {
             let _span =
                 tracing::debug_span!("loonfs.phase", phase = "project_metadata_state").entered();

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -54,6 +54,8 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
             visible_tip: head.visible_wal_tip.clone(),
             stop_after_seq: Some(after_seq),
             max_segment_fetches: None,
+            prefetched: std::collections::HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &head.recent_segments,
         },
     )

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -230,6 +230,8 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
             visible_tip: head.visible_wal_tip.clone(),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: std::collections::HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &head.recent_segments,
         },
     )

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -1,11 +1,13 @@
 //! WAL segment and chain framing types, shared by the writer, reader, and
 //! replay paths.
 
+use bytes::Bytes;
 use loonfs_api::wire::control::{HeadState, WalSegmentPointer};
 use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalSegmentEnvelope};
 use loonfs_api::{ChangeSeq, CommitId, NamespaceId, WriterEpoch};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::collections::HashMap;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,6 +65,9 @@ pub(crate) struct WalChainLoadRequest<'a> {
     pub(crate) visible_tip: Option<WalSegmentPointer>,
     pub(crate) stop_after_seq: Option<ChangeSeq>,
     pub(crate) max_segment_fetches: Option<usize>,
+    /// These bodies were fetched speculatively by the caller and already cost its fetch budget.
+    pub(crate) prefetched: HashMap<String, Bytes>,
+    pub(crate) speculative_requests: usize,
     /// The head's `recent_segments` accelerator, used only to prefetch the
     /// replay gap concurrently. Chain links stay the sole history
     /// authority: wrong or missing hints cost a fallback fetch, never

--- a/crates/loonfs-core/src/wal/mod.rs
+++ b/crates/loonfs-core/src/wal/mod.rs
@@ -10,7 +10,9 @@ pub(crate) use self::frame::{
     DecodedWalRecord, PreparedWalSegment, ReplayedWalTail, ValidatedWalChain, ValidatedWalSegment,
     WalChainLoadError, WalChainLoadRequest, WalSegmentError,
 };
-pub(crate) use self::reader::{count_visible_wal_tail_segments, load_wal_chain, WalChainLoad};
+pub(crate) use self::reader::{
+    count_visible_wal_tail_segments, load_wal_chain, prefetch_hinted_wal_segments, WalChainLoad,
+};
 pub(crate) use self::replay::{ensure_replayed_head_matches, project_validated_wal_tail};
 pub(crate) use self::writer::prepare_wal_segment;
 

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -65,6 +65,23 @@ fn hints_in_gap(
         .collect()
 }
 
+pub(crate) async fn prefetch_hinted_wal_segments<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    tip: &WalSegmentPointer,
+    hints: &[WalSegmentPointer],
+    head_seq: ChangeSeq,
+    max_segment_fetches: Option<usize>,
+) -> (HashMap<String, Bytes>, usize) {
+    let in_gap = hints_in_gap(namespace_id, tip, hints, ChangeSeq(0), head_seq);
+    let request_count = max_segment_fetches
+        .unwrap_or(RECENT_SEGMENT_PREFETCH_CONCURRENCY)
+        .min(RECENT_SEGMENT_PREFETCH_CONCURRENCY)
+        .min(in_gap.len());
+    let prefetched = prefetch_recent_segments(store, namespace_id, &in_gap[..request_count]).await;
+    (prefetched, request_count)
+}
+
 /// Concurrently fetches hinted WAL segments in the replay range.
 ///
 /// A miss or failed prefetch does not fail the load; the normal chain walk
@@ -157,9 +174,9 @@ impl WalChainLoad {
 )]
 pub(crate) async fn load_wal_chain<S: ObjectStore + ?Sized>(
     store: &S,
-    request: WalChainLoadRequest<'_>,
+    mut request: WalChainLoadRequest<'_>,
 ) -> Result<WalChainLoad, WalChainLoadError> {
-    let walked = walk_chain(store, &request).await?;
+    let walked = walk_chain(store, &mut request).await?;
     if walked.limit_reached {
         Ok(WalChainLoad::LimitReached {
             requests_issued: walked.fetches,
@@ -176,12 +193,13 @@ pub(crate) async fn load_wal_chain<S: ObjectStore + ?Sized>(
 /// limiting requests for segment bodies.
 async fn walk_chain<S: ObjectStore + ?Sized>(
     store: &S,
-    request: &WalChainLoadRequest<'_>,
+    request: &mut WalChainLoadRequest<'_>,
 ) -> Result<WalkedChain, WalChainLoadError> {
+    let mut fetches = request.speculative_requests;
     let Some((mut pointer, stop_after_seq)) = request.tip_and_stop()? else {
         return Ok(WalkedChain {
             segments: Vec::new(),
-            fetches: 0,
+            fetches,
             limit_reached: false,
         });
     };
@@ -192,19 +210,33 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
         stop_after_seq,
         request.head_seq,
     );
-    // `fetches` counts every segment-body request, including prefetches, and
-    // never exceeds `max_segment_fetches`. Prefetch consumes its share first;
-    // the chain walk uses the remaining budget. Because hints are ordered from
-    // newest to oldest, a limited prefetch covers the segments nearest the tip.
-    let prefetched_hints = request
-        .max_segment_fetches
-        .map_or(in_gap.len(), |limit| in_gap.len().min(limit));
-    let mut fetches = prefetched_hints;
-    let mut prefetched = if prefetched_hints == 0 {
-        HashMap::new()
-    } else {
-        prefetch_recent_segments(store, request.namespace_id, &in_gap[..prefetched_hints]).await
-    };
+    let in_gap_set = in_gap.iter().collect::<HashSet<_>>();
+    let mut prefetched = std::mem::take(&mut request.prefetched);
+    prefetched.retain(|object_key, _| in_gap_set.contains(object_key));
+    let missing_hints = in_gap
+        .iter()
+        .filter(|object_key| !prefetched.contains_key(*object_key))
+        .collect::<Vec<_>>();
+    // `fetches` counts every segment-body request, including speculative and
+    // local prefetches, and never exceeds `max_segment_fetches`. Prefetch
+    // consumes its share first; the chain walk uses the remaining budget.
+    // Because hints are ordered from newest to oldest, a limited prefetch
+    // covers the segments nearest the tip.
+    let remaining_fetches = request.max_segment_fetches.map_or(usize::MAX, |limit| {
+        limit
+            .checked_sub(fetches)
+            .expect("speculative WAL requests should fit the caller's fetch limit")
+    });
+    let prefetched_hints = missing_hints.len().min(remaining_fetches);
+    fetches += prefetched_hints;
+    if prefetched_hints != 0 {
+        let object_keys = missing_hints[..prefetched_hints]
+            .iter()
+            .map(|object_key| (*object_key).clone())
+            .collect::<Vec<_>>();
+        prefetched
+            .extend(prefetch_recent_segments(store, request.namespace_id, &object_keys).await);
+    }
     let mut reversed = Vec::new();
     loop {
         if pointer.end_seq <= stop_after_seq {

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -19,6 +19,7 @@ use loonfs_test_support::stores::{
     ConcurrencyWatchStore, FailStore, InjectedError, KeyPredicate, OperationClass, RecordingStore,
 };
 use std::borrow::Cow;
+use std::collections::HashMap;
 use tempfile::tempdir;
 
 async fn load_complete_wal_chain<S: ObjectStore + ?Sized>(
@@ -154,6 +155,8 @@ async fn validated_wal_chain_loads_visible_segments_in_ascending_order() {
             visible_tip: Some(segment.envelope.pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &[],
         },
     )
@@ -317,6 +320,8 @@ async fn validated_wal_chain_can_load_cursor_suffix_without_full_base() {
             visible_tip: Some(second.envelope.pointer()),
             stop_after_seq: Some(ChangeSeq(1)),
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &[],
         },
     )
@@ -352,6 +357,8 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
             visible_tip: Some(segment.envelope.pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &[],
         },
     )
@@ -495,6 +502,8 @@ async fn assert_wal_chain_corruption_rejected(
             visible_tip: Some(pointer),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &[],
         },
     )
@@ -536,6 +545,8 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
             visible_tip: Some(second.envelope.pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &[],
         },
     )
@@ -553,6 +564,8 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
             visible_tip: Some(second.envelope.pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &accurate,
         },
     )
@@ -584,6 +597,8 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
             visible_tip: Some(second.envelope.pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &garbage,
         },
     )
@@ -638,6 +653,8 @@ async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
             visible_tip: Some(tip.clone()),
             stop_after_seq: None,
             max_segment_fetches: Some(2),
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &[],
         },
     )
@@ -669,6 +686,8 @@ async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
             visible_tip: Some(tip.clone()),
             stop_after_seq: None,
             max_segment_fetches: Some(2),
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &newest_first[1..],
         },
     )
@@ -683,6 +702,45 @@ async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
         2,
         "the prefetch issued the requests the limit allows, not none and not five"
     );
+}
+
+#[tokio::test]
+async fn speculative_requests_count_against_the_chain_fetch_limit() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let pointers = write_linked_chain(&inner, &namespace_id, 3).await;
+    let tip = pointers.last().expect("a chain was written").clone();
+    let tip_key = wal_segment(&namespace_id, &tip.segment_id);
+    let tip_bytes = inner
+        .get(&tip_key, None)
+        .await
+        .expect("read speculative body")
+        .expect("speculative body exists");
+    let store = RecordingStore::new(inner, KeyPredicate::any());
+
+    let loaded = load_wal_chain(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(tip),
+            stop_after_seq: None,
+            max_segment_fetches: Some(2),
+            prefetched: HashMap::from([(tip_key, tip_bytes)]),
+            speculative_requests: 2,
+            recent_segments: &[],
+        },
+    )
+    .await
+    .expect("bounded chain load");
+
+    match loaded {
+        WalChainLoad::Complete { .. } => panic!("two requests do not cover three segments"),
+        WalChainLoad::LimitReached { requests_issued } => assert_eq!(requests_issued, 2),
+    }
+    assert_eq!(store.count(OperationClass::Get), 0);
 }
 
 #[tokio::test]
@@ -702,6 +760,8 @@ async fn a_limit_that_covers_the_chain_loads_all_of_it() {
         visible_tip: Some(tip.clone()),
         stop_after_seq: None,
         max_segment_fetches,
+        prefetched: HashMap::new(),
+        speculative_requests: 0,
         recent_segments: recent,
     };
     let unbounded = load_complete_wal_chain(&store, request(&[], None))
@@ -758,6 +818,8 @@ async fn a_failed_prefetch_costs_its_own_request_and_the_walk_loads_the_chain() 
             visible_tip: Some(tip),
             stop_after_seq: None,
             max_segment_fetches: Some(16),
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &newest_first[1..],
         },
     )
@@ -814,6 +876,8 @@ async fn failed_prefetch_requests_count_against_the_limit() {
             visible_tip: Some(tip),
             stop_after_seq: None,
             max_segment_fetches: Some(3),
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &newest_first[1..],
         },
     )
@@ -945,6 +1009,8 @@ fn tail_count_request<'a>(
         visible_tip: hints.first().cloned(),
         stop_after_seq: None,
         max_segment_fetches: None,
+        prefetched: HashMap::new(),
+        speculative_requests: 0,
         recent_segments: hints.get(1..).unwrap_or_default(),
     }
 }
@@ -997,6 +1063,8 @@ fn tail_count_at_genesis_is_zero_without_tip_or_hints() {
         visible_tip: None,
         stop_after_seq: None,
         max_segment_fetches: None,
+        prefetched: HashMap::new(),
+        speculative_requests: 0,
         recent_segments: &[],
     })
     .expect("count genesis tail");
@@ -1098,6 +1166,8 @@ async fn chain_load_walks_predecessor_links_past_the_hinted_window() {
             visible_tip: Some(pointers[0].clone()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &short_window[1..],
         },
     )
@@ -1135,6 +1205,8 @@ async fn boundary_length_replay_fetches_every_segment_once_in_bounded_waves() {
             visible_tip: Some(hints[0].clone()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &hints[1..],
         },
     )
@@ -1172,6 +1244,8 @@ async fn prefetch_fetches_only_the_segments_the_gap_intersects() {
             visible_tip: Some(hints[0].clone()),
             stop_after_seq: Some(ChangeSeq(3)),
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &hints[1..],
         },
     )
@@ -1221,6 +1295,8 @@ async fn a_corrupt_segment_inside_the_hinted_set_is_still_rejected() {
             visible_tip: Some(hints[0].clone()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &hints[1..],
         },
     )
@@ -1235,6 +1311,8 @@ async fn a_corrupt_segment_inside_the_hinted_set_is_still_rejected() {
             visible_tip: Some(hints[0].clone()),
             stop_after_seq: None,
             max_segment_fetches: None,
+            prefetched: HashMap::new(),
+            speculative_requests: 0,
             recent_segments: &[],
         },
     )

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -72,6 +72,8 @@ writer_id = "loonfs-server-local"
 #max_cached_wal_tail_projection_decoded_bytes = 268435456
 # Decoded-byte budget for the metadata segment cache; unlimited by default.
 #metadata_segment_cache_max_decoded_bytes = 268435456
+# Stored-byte budget for fetching metadata segment tails when a view opens.
+#metadata_segment_cache_open_prefetch_max_stored_bytes = 16777216
 
 # Optional node-local cache of encoded metadata blocks, on this machine's own
 # disk. Omit the table and there is none: every metadata block the decoded

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -241,6 +241,7 @@ pub struct RuntimeCacheConfigOverrides {
     pub max_cached_wal_tail_projection_rows: Option<usize>,
     pub max_cached_wal_tail_projection_decoded_bytes: Option<usize>,
     pub metadata_segment_cache_max_decoded_bytes: Option<usize>,
+    pub metadata_segment_cache_open_prefetch_max_stored_bytes: Option<usize>,
 }
 
 /// Controls whether this server schedules maintenance automatically.
@@ -403,6 +404,12 @@ impl ServerConfig {
         }
         if let Some(value) = self.runtime_cache.metadata_segment_cache_max_decoded_bytes {
             config.metadata_segment_cache.max_decoded_bytes = value;
+        }
+        if let Some(value) = self
+            .runtime_cache
+            .metadata_segment_cache_open_prefetch_max_stored_bytes
+        {
+            config.metadata_segment_cache.open_prefetch_max_stored_bytes = value;
         }
         config
     }
@@ -1562,6 +1569,7 @@ writer_id = "loonfs-server"
 max_cached_namespaces = 2
 max_cached_wal_tail_projection_rows = 10
 max_cached_wal_tail_projection_decoded_bytes = 4096
+metadata_segment_cache_open_prefetch_max_stored_bytes = 8192
 
 [store]
 kind = "local-fs"
@@ -1575,6 +1583,10 @@ root = "/tmp/loonfs-server"
         assert_eq!(config.max_cached_namespaces, 2);
         assert_eq!(config.max_cached_wal_tail_projection_rows, 10);
         assert_eq!(config.max_cached_wal_tail_projection_decoded_bytes, 4096);
+        assert_eq!(
+            config.metadata_segment_cache.open_prefetch_max_stored_bytes,
+            8192
+        );
     }
 
     #[test]
@@ -1590,6 +1602,7 @@ max_cached_namespaces = 0
 max_cached_wal_tail_projection_rows = 0
 max_cached_wal_tail_projection_decoded_bytes = 0
 metadata_segment_cache_max_decoded_bytes = 0
+metadata_segment_cache_open_prefetch_max_stored_bytes = 0
 
 [store]
 kind = "local-fs"

--- a/crates/loonfs-server/tests/it/local_cache.rs
+++ b/crates/loonfs-server/tests/it/local_cache.rs
@@ -4,7 +4,7 @@ use crate::common::http_split_support::*;
 use crate::common::{collect_path_entries, scrape, series, start_graceful_server};
 use loonfs_api::CreateCheckpointRequest;
 use loonfs_client::NamespacePath;
-use loonfs_server::{LocalCacheConfig, MaintenanceMode, ServerConfig};
+use loonfs_server::{LocalCacheConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig};
 use loonfs_test_support::ids::namespace_id;
 use std::path::Path;
 use tempfile::tempdir;
@@ -35,6 +35,10 @@ fn test_config_with_local_cache(
 ) -> ServerConfig {
     ServerConfig {
         maintenance: MaintenanceMode::Manual,
+        runtime_cache: RuntimeCacheConfigOverrides {
+            metadata_segment_cache_open_prefetch_max_stored_bytes: Some(0),
+            ..RuntimeCacheConfigOverrides::default()
+        },
         local_cache: Some(LocalCacheConfig {
             path: cache_root.display().to_string(),
             memory_bytes: 4 * 1024 * 1024,

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -74,6 +74,7 @@ impl RuntimeCacheConfig {
             max_cached_wal_tail_projection_decoded_bytes: 0,
             metadata_segment_cache: MetadataSegmentCacheConfig {
                 max_decoded_bytes: 0,
+                open_prefetch_max_stored_bytes: 0,
             },
         }
     }

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -744,7 +744,13 @@ fn an_installed_stored_block_cache_is_filled_and_then_serves_a_later_runtime() {
 
     let calls_before = stored_blocks.call_count();
     let reader = open_runtime_with(shared_store, "stored-block-reader", |builder| {
-        builder.stored_metadata_block_cache(stored_blocks.clone())
+        let mut runtime_cache = RuntimeCacheConfig::default();
+        runtime_cache
+            .metadata_segment_cache
+            .open_prefetch_max_stored_bytes = 0;
+        builder
+            .runtime_cache(runtime_cache)
+            .stored_metadata_block_cache(stored_blocks.clone())
     });
     let entries = reader
         .list_path_blocking(&namespace_id, "/docs")

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -11,7 +11,7 @@
 
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenancePlan,
-    MetadataMaintenanceOptions, NamespaceId, PutFileOptions,
+    MetadataMaintenanceOptions, NamespaceId, PutFileOptions, RuntimeCacheConfig,
 };
 use loonfs_api::wire::manifest::{decode_namespace_manifest_json, MetadataRowFamily};
 use loonfs_api::AbsolutePath;
@@ -205,7 +205,12 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .collect();
 
     // The measured operation: first stat on a fresh handle, nothing warm.
+    let mut runtime_cache = RuntimeCacheConfig::default();
+    runtime_cache
+        .metadata_segment_cache
+        .open_prefetch_max_stored_bytes = 0;
     let reader = FsReader::builder_with_store(store.clone())
+        .runtime_cache(runtime_cache)
         .build()
         .await
         .expect("build reader");

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -1,24 +1,27 @@
-//! Diagnostic (ignored): per-section request accounting for the warm-ops
-//! benchmark shape. Builds a bench-like namespace, then runs each warm
-//! phase on a fresh handle while classifying every store GET — by object
-//! class, and for metadata segments by section (index / filter / data),
-//! family, and run tier, using the live manifest's own descriptors.
+//! Request accounting for metadata and WAL prefetch behavior.
 //!
 //! Run with:
 //!   cargo test -p loonfs --test it request_accounting -- --ignored --nocapture
 
 use loonfs::{
-    CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenancePlan,
+    CreateNamespaceOptions, ErrorCode, FsAdmin, FsReader, FsWriter, MaintenancePlan,
     MetadataMaintenanceOptions, NamespaceId, PageRequest, PaginationPolicy, PutFileOptions,
-    SharedObjectStore,
+    RuntimeCacheConfig, SharedObjectStore,
 };
 use loonfs_api::AbsolutePath;
 
-use loonfs_api::wire::manifest::{decode_namespace_manifest_json, RunTier};
-use loonfs_objectstore::keys::{metadata_manifest_object, metadata_segment_object_key};
+use loonfs_api::wire::manifest::{
+    decode_namespace_manifest_json, MetadataRowFamily, NamespaceManifestEnvelope, RunTier,
+};
+use loonfs_objectstore::keys::{
+    metadata_manifest_object, metadata_segment_object_key, wal_segment_prefix,
+};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_test_support::stores::{KeyPredicate, RecordedGet, RecordingStore};
-use std::collections::BTreeMap;
+use loonfs_test_support::stores::{
+    BlockingStore, ConcurrencyWatchStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+    RecordedGet, RecordingStore,
+};
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -116,6 +119,271 @@ async fn publish_candidates(
     for outcome in futures::future::join_all(submissions).await {
         outcome.expect("publish batch member");
     }
+}
+
+async fn build_folded_namespace(
+    root: &std::path::Path,
+    namespace_id: &NamespaceId,
+) -> NamespaceManifestEnvelope {
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(root).expect("create local-fs store"));
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("open-prefetch-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("open-prefetch-admin")
+        .build()
+        .await
+        .expect("build admin");
+    writer
+        .create_namespace(namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .put_file_bytes(
+            namespace_id,
+            "/docs/file.txt",
+            b"file",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("put file");
+    admin.flush_wal(namespace_id).await.expect("flush WAL");
+
+    let root = loonfs_core::control::load_namespace_metadata_root_control(&store, namespace_id)
+        .await
+        .expect("load metadata root");
+    let manifest_key =
+        metadata_manifest_object(namespace_id, &root.state.manifest.manifest_object_id);
+    let manifest_bytes = store
+        .get(&manifest_key, None)
+        .await
+        .expect("read manifest")
+        .expect("manifest exists");
+    decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest")
+}
+
+fn manifest_segment_keys(manifest: &NamespaceManifestEnvelope) -> BTreeSet<String> {
+    manifest
+        .payload
+        .runs
+        .iter()
+        .flat_map(|run| &run.segments)
+        .map(metadata_segment_object_key)
+        .collect()
+}
+
+#[tokio::test]
+async fn open_prefetches_segment_tails_in_one_wave_and_zero_disables_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("open-prefetch").expect("valid namespace id");
+    let manifest = build_folded_namespace(temp_dir.path(), &namespace_id).await;
+    let families = manifest
+        .payload
+        .runs
+        .iter()
+        .flat_map(|run| &run.segments)
+        .map(|descriptor| descriptor.family)
+        .collect::<BTreeSet<_>>();
+    for family in [
+        MetadataRowFamily::Inodes,
+        MetadataRowFamily::DirentryBinds,
+        MetadataRowFamily::Revisions,
+    ] {
+        assert!(families.contains(&family));
+    }
+    let segment_keys = manifest_segment_keys(&manifest);
+    assert!(segment_keys.len() > 1);
+
+    let recording = RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("open local-fs store"),
+        KeyPredicate::any(),
+    );
+    let watched = Arc::new(ConcurrencyWatchStore::new(
+        recording,
+        KeyPredicate::metadata_segment(),
+    ));
+    let store: SharedObjectStore = watched.clone();
+    let reader = FsReader::builder_with_store(store)
+        .build()
+        .await
+        .expect("build reader");
+    let error = reader
+        .get_path_entry(&namespace_id, "relative", Default::default())
+        .await
+        .expect_err("relative path is invalid");
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
+    let open_gets = watched.inner().take_gets();
+    let open_segment_gets = open_gets
+        .iter()
+        .filter(|(key, _)| segment_keys.contains(key))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(open_segment_gets.len(), segment_keys.len());
+    assert_eq!(
+        open_segment_gets
+            .iter()
+            .map(|(key, _)| key)
+            .collect::<BTreeSet<_>>(),
+        segment_keys.iter().collect::<BTreeSet<_>>()
+    );
+    assert!(watched.reads().peak_in_flight > 1);
+
+    reader
+        .get_path_entry(&namespace_id, "/docs/file.txt", Default::default())
+        .await
+        .expect("stat file");
+    let stat_segment_gets = watched
+        .inner()
+        .take_gets()
+        .into_iter()
+        .filter(|(key, _)| segment_keys.contains(key))
+        .collect::<Vec<_>>();
+    assert!(stat_segment_gets.len() <= 2);
+    for tail_get in open_segment_gets {
+        assert!(!stat_segment_gets.contains(&tail_get));
+    }
+
+    let recording = RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("open local-fs store"),
+        KeyPredicate::any(),
+    );
+    let recording = Arc::new(recording);
+    let store: SharedObjectStore = recording.clone();
+    let mut runtime_cache = RuntimeCacheConfig::default();
+    runtime_cache
+        .metadata_segment_cache
+        .open_prefetch_max_stored_bytes = 0;
+    let reader = FsReader::builder_with_store(store)
+        .runtime_cache(runtime_cache)
+        .build()
+        .await
+        .expect("build reader");
+    let error = reader
+        .get_path_entry(&namespace_id, "relative", Default::default())
+        .await
+        .expect_err("relative path is invalid");
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
+    assert!(recording
+        .take_gets()
+        .iter()
+        .all(|(key, _)| !segment_keys.contains(key)));
+
+    reader
+        .get_path_entry(&namespace_id, "/docs/file.txt", Default::default())
+        .await
+        .expect("stat file");
+    assert!(recording
+        .take_gets()
+        .iter()
+        .any(|(key, _)| segment_keys.contains(key)));
+}
+
+#[tokio::test]
+async fn segment_tail_prefetch_failures_do_not_fail_open() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("prefetch-failure").expect("valid namespace id");
+    let manifest = build_folded_namespace(temp_dir.path(), &namespace_id).await;
+    let segment_count = manifest_segment_keys(&manifest).len();
+    let failing = Arc::new(FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("open local-fs store"),
+        KeyPredicate::metadata_segment(),
+        OperationClass::Get,
+        InjectedError::Transport("segment read failed".to_owned()),
+    ));
+    failing.fail_all();
+    let store: SharedObjectStore = failing.clone();
+    let reader = FsReader::builder_with_store(store)
+        .build()
+        .await
+        .expect("build reader");
+
+    let error = reader
+        .get_path_entry(&namespace_id, "relative", Default::default())
+        .await
+        .expect_err("relative path is invalid after open");
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
+    assert_eq!(failing.attempts(), segment_count);
+
+    let error = reader
+        .get_path_entry(&namespace_id, "/docs/file.txt", Default::default())
+        .await
+        .expect_err("the lookup reports the segment failure");
+    assert_eq!(error.code(), ErrorCode::ServerError);
+    assert!(failing.attempts() > segment_count);
+}
+
+#[tokio::test]
+async fn hinted_wal_prefetch_starts_while_the_manifest_is_blocked() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("wal-prefetch").expect("valid namespace id");
+    build_folded_namespace(temp_dir.path(), &namespace_id).await;
+    let setup_store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("open local-fs store"));
+    let writer = FsWriter::builder_with_store(setup_store.clone())
+        .writer_id("wal-prefetch-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    for index in 0..3 {
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/docs/tail-{index}.txt"),
+                b"tail",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("put tail file");
+    }
+    let head = loonfs_core::control::load_namespace_head_control(&setup_store, &namespace_id)
+        .await
+        .expect("load namespace head");
+    assert!(!head.state.recent_segments.is_empty());
+    let root =
+        loonfs_core::control::load_namespace_metadata_root_control(&setup_store, &namespace_id)
+            .await
+            .expect("load metadata root");
+    let manifest_key =
+        metadata_manifest_object(&namespace_id, &root.state.manifest.manifest_object_id);
+    drop(writer);
+    drop(setup_store);
+
+    let blocking = BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("open local-fs store"),
+        KeyPredicate::exact(manifest_key),
+        OperationClass::Get,
+    );
+    let watched = Arc::new(ConcurrencyWatchStore::new(
+        blocking,
+        KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
+    ));
+    let store: SharedObjectStore = watched.clone();
+    let reader = FsReader::builder_with_store(store)
+        .build()
+        .await
+        .expect("build reader");
+    watched.inner().arm();
+    let open = tokio::spawn({
+        let namespace_id = namespace_id.clone();
+        async move {
+            reader
+                .get_path_entry(&namespace_id, "relative", Default::default())
+                .await
+        }
+    });
+    watched.inner().wait_until_blocked().await;
+    assert!(watched.reads().total > 0);
+    watched.inner().release();
+    let error = open
+        .await
+        .expect("join open")
+        .expect_err("relative path is invalid");
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
 }
 
 #[allow(clippy::print_stdout)]

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -166,12 +166,26 @@ async fn build_folded_namespace(
     decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest")
 }
 
-fn manifest_segment_keys(manifest: &NamespaceManifestEnvelope) -> BTreeSet<String> {
+/// The families the open-time tail wave covers; the rest load lazily.
+const OPEN_PREFETCH_FAMILIES: [MetadataRowFamily; 6] = [
+    MetadataRowFamily::DirentryBinds,
+    MetadataRowFamily::Inodes,
+    MetadataRowFamily::DirentryChildBinds,
+    MetadataRowFamily::DirentryUnbinds,
+    MetadataRowFamily::Revisions,
+    MetadataRowFamily::RevisionsByInodeDesc,
+];
+
+fn manifest_segment_keys(
+    manifest: &NamespaceManifestEnvelope,
+    prefetched: bool,
+) -> BTreeSet<String> {
     manifest
         .payload
         .runs
         .iter()
         .flat_map(|run| &run.segments)
+        .filter(|descriptor| OPEN_PREFETCH_FAMILIES.contains(&descriptor.family) == prefetched)
         .map(metadata_segment_object_key)
         .collect()
 }
@@ -195,8 +209,10 @@ async fn open_prefetches_segment_tails_in_one_wave_and_zero_disables_it() {
     ] {
         assert!(families.contains(&family));
     }
-    let segment_keys = manifest_segment_keys(&manifest);
+    let segment_keys = manifest_segment_keys(&manifest, true);
+    let lazy_keys = manifest_segment_keys(&manifest, false);
     assert!(segment_keys.len() > 1);
+    assert!(!lazy_keys.is_empty());
 
     let recording = RecordingStore::new(
         LocalFsStore::new(temp_dir.path()).expect("open local-fs store"),
@@ -223,6 +239,7 @@ async fn open_prefetches_segment_tails_in_one_wave_and_zero_disables_it() {
         .cloned()
         .collect::<Vec<_>>();
     assert_eq!(open_segment_gets.len(), segment_keys.len());
+    assert!(open_gets.iter().all(|(key, _)| !lazy_keys.contains(key)));
     assert_eq!(
         open_segment_gets
             .iter()
@@ -287,7 +304,7 @@ async fn segment_tail_prefetch_failures_do_not_fail_open() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("prefetch-failure").expect("valid namespace id");
     let manifest = build_folded_namespace(temp_dir.path(), &namespace_id).await;
-    let segment_count = manifest_segment_keys(&manifest).len();
+    let segment_count = manifest_segment_keys(&manifest, true).len();
     let failing = Arc::new(FailStore::new(
         LocalFsStore::new(temp_dir.path()).expect("open local-fs store"),
         KeyPredicate::metadata_segment(),


### PR DESCRIPTION
A cold read runs several dependent round trips before it can touch a data block: the manifest GET, then the WAL chain, then one filter-and-index tail fetch per segment the first time a lookup touches that segment. This change moves the tail fetches into one bounded parallel wave at open, overlapped with the WAL chain load, and starts the hinted WAL segment prefetch before the manifest GET completes instead of after it. What a read returns does not change; only when the bytes are fetched does.

The tail wave covers only the six path-walk families (directory binds, inodes, child binds, unbinds, revisions, revisions by inode), in that order, base runs before delta runs; tombstones, active deletions, commit receipts, and attributes keep loading lazily. It skips tails already in the decoded cache or the session memo, and stops at a stored-byte budget computed before any request is issued. The budget is `MetadataSegmentCacheConfig::open_prefetch_max_stored_bytes`, 16 MiB by default and zero to disable, exposed on the server as `metadata_segment_cache_open_prefetch_max_stored_bytes`. At most sixteen tail fetches are in flight. A failed tail fetch is logged at debug level and does not fail the open; the lazy path loads it later and reports any real error then.

The WAL side adds `prefetched` bodies and a `speculative_requests` count to `WalChainLoadRequest`. When the head has a visible tail above the basis and the tail projection cache does not already hold this head, the open fetches up to thirty-two hinted segments concurrently with the manifest GET. The chain walk drops any speculative body at or below the stop sequence once the manifest is known, fetches only the hinted segments the speculation did not cover, and counts every speculative request against the caller's fetch limit, so `requests_issued` never exceeds it.

Behavior a reviewer should know about: a normal open now issues up to 16 MiB of segment tail reads that used to be paid lazily by the first lookups, so per-open request counts rise and per-lookup counts fall. Maintenance reads pass no segment cache and are unaffected. Compaction probe caches set the budget to zero. Three existing tests that pin the lazy request shape (cold stat, stored-block cache fill, server local cache) set the budget to zero so they keep pinning it. New tests pin the wave (tails fetched in one wave at open, a following stat fetches no tail), the budget and family order on a synthetic run list, advisory failure, the WAL reads starting while the manifest read is blocked, and the fetch-limit accounting with speculative bodies. No wire shape, error code, or durable format changes.

Bench results are in the follow-up comments: one s3-10k run of the first shape, then the series after the family restriction.
