### PR TITLE
perf(runtime): add optional bounded-staleness reads

### DIFF
--- a/crates/loonfs-client/tests/snapshots.rs
+++ b/crates/loonfs-client/tests/snapshots.rs
@@ -5,8 +5,8 @@ use loonfs_client::{
     Client, ClientConfig, NamespacePath, PutFileOptions, ReadFileOptions, StatPathOptions,
 };
 use loonfs_server::{
-    app, AppOptions, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig,
-    StoreConfig,
+    app, AppOptions, GrepConfig, MaintenanceMode, ReadConsistencyConfig,
+    RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
 };
 use tempfile::TempDir;
 
@@ -30,6 +30,7 @@ async fn start_server(name: &str) -> TestServer {
         content_token_secret: "test-content-token-secret".into(),
         writer_id: name.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        read_consistency: ReadConsistencyConfig::default(),
         local_cache: None,
         grep: GrepConfig::default(),
         maintenance: MaintenanceMode::Automatic,

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -73,6 +73,13 @@ writer_id = "loonfs-server-local"
 # Decoded-byte budget for the metadata segment cache; unlimited by default.
 #metadata_segment_cache_max_decoded_bytes = 268435456
 
+# Optional reader anchor staleness window in milliseconds. A read may serve a
+# head up to this old; a write through this server is visible to its own reads
+# immediately because publishing seeds the anchor. The default is strong
+# consistency, which revalidates the cached anchor for every read.
+#[read_consistency]
+#bounded_staleness_ms = 500
+
 # Optional node-local cache of encoded metadata blocks, on this machine's own
 # disk. Omit the table and there is none: every metadata block the decoded
 # cache misses is read from object storage.

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -2,7 +2,7 @@
 //! store, and runtime cache overrides.
 
 use crate::local_cache::{DISK_BLOCK_BYTES, MIN_DISK_BYTES};
-use loonfs::RuntimeCacheConfig;
+use loonfs::{ReadConsistency, RuntimeCacheConfig};
 use loonfs_api::env::{AUTH_TOKEN_ENV, CONTENT_TOKEN_SECRET_ENV};
 use loonfs_api::SecretString;
 use loonfs_grep::GrepWorkerConfig;
@@ -12,6 +12,7 @@ use std::env;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::Path;
+use std::time::Duration;
 use thiserror::Error;
 
 pub use loonfs_objectstore::StoreConfig;
@@ -44,6 +45,8 @@ pub struct ServerConfig {
     pub writer_id: String,
     #[serde(default)]
     pub runtime_cache: RuntimeCacheConfigOverrides,
+    #[serde(default)]
+    pub read_consistency: ReadConsistencyConfig,
     /// The node-local cache of encoded metadata blocks, if this deployment
     /// keeps one. Absent means no local cache: every metadata block read
     /// that misses the decoded cache goes to object storage, which is the
@@ -243,6 +246,12 @@ pub struct RuntimeCacheConfigOverrides {
     pub metadata_segment_cache_max_decoded_bytes: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReadConsistencyConfig {
+    pub bounded_staleness_ms: Option<u64>,
+}
+
 /// Controls whether this server schedules maintenance automatically.
 ///
 /// `automatic` schedules metadata, garbage collection, and enabled grep
@@ -405,6 +414,14 @@ impl ServerConfig {
             config.metadata_segment_cache.max_decoded_bytes = value;
         }
         config
+    }
+
+    /// Resolves the reader consistency selected by this server.
+    pub fn read_consistency(&self) -> ReadConsistency {
+        match self.read_consistency.bounded_staleness_ms {
+            Some(window_ms) => ReadConsistency::BoundedStaleness(Duration::from_millis(window_ms)),
+            None => ReadConsistency::Strong,
+        }
     }
 
     /// Builds the object store selected by this server configuration.
@@ -637,6 +654,7 @@ mod tests {
     };
     use loonfs_test_support::EnvGuard;
     use std::fs;
+    use std::time::Duration;
     use tempfile::tempdir;
 
     const AZURITE_ACCOUNT_KEY: &str =
@@ -1548,6 +1566,43 @@ root = "/tmp/loonfs-server"
             config.runtime_cache_config(),
             loonfs::RuntimeCacheConfig::default()
         );
+    }
+
+    #[test]
+    fn read_consistency_reaches_the_writer_setting_and_defaults_to_strong() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[read_consistency]
+bounded_staleness_ms = 500
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let config = load_server_config(&path).expect("load bounded staleness config");
+        assert_eq!(
+            config.read_consistency(),
+            loonfs::ReadConsistency::BoundedStaleness(Duration::from_millis(500))
+        );
+
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let config = load_server_config(&path).expect("load strong config");
+        assert_eq!(config.read_consistency(), loonfs::ReadConsistency::Strong);
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -403,6 +403,7 @@ pub(super) async fn build_handles(
         .max_read_content_bytes(config.max_download_bytes)
         .max_concurrent_maintenance(config.max_concurrent_maintenance)
         .runtime_cache(config.runtime_cache_config())
+        .read_consistency(config.read_consistency())
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind)
         .metrics_recorder(metrics.recorder());

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -7,7 +7,7 @@ use super::{
     app, build_handles, request_log_severity, AppOptions, AppState, RequestLogSeverity,
     SharedObjectStore,
 };
-use crate::config::RuntimeCacheConfigOverrides;
+use crate::config::{ReadConsistencyConfig, RuntimeCacheConfigOverrides};
 use crate::{ServerConfig, StoreConfig};
 use async_trait::async_trait;
 use axum::body::Bytes;
@@ -3519,6 +3519,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         content_token_secret: "test-content-token-secret".into(),
         writer_id: writer_id.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        read_consistency: ReadConsistencyConfig::default(),
         local_cache: None,
         grep: crate::config::GrepConfig {
             mode: crate::config::GrepMode::ServeAndMaintain,

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -12,8 +12,8 @@ mod trace;
 
 pub use config::{
     load_server_config, parse_server_config, GrepConfig, GrepMode, LocalCacheConfig,
-    MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig,
-    TlsServerConfig,
+    MaintenanceMode, ReadConsistencyConfig, RuntimeCacheConfigOverrides, ServerConfig,
+    ServerConfigError, StoreConfig, TlsServerConfig,
 };
 #[cfg(feature = "openapi")]
 pub use http::openapi_document;

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -11,7 +11,8 @@ use loonfs_api::{ListCheckpointsResponse, ListPathEntriesResponse, NamespaceId};
 use loonfs_client::{Client, ClientConfig, ListPathEntriesOptions, NamespacePath};
 use loonfs_server::{
     app, serve_with_shutdown, AppOptions, GrepConfig, GrepMode, MaintenanceMode,
-    RuntimeCacheConfigOverrides, ServeError, ServerConfig, StoreConfig, TlsServerConfig,
+    ReadConsistencyConfig, RuntimeCacheConfigOverrides, ServeError, ServerConfig, StoreConfig,
+    TlsServerConfig,
 };
 use loonfs_test_support::http::raw_agent;
 use std::collections::BTreeMap;
@@ -304,6 +305,7 @@ pub(crate) fn test_config(
         content_token_secret: content_token_secret.into(),
         writer_id: writer_id.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        read_consistency: ReadConsistencyConfig::default(),
         local_cache: None,
         grep: GrepConfig {
             mode: GrepMode::ServeAndMaintain,

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -18,8 +18,8 @@ use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker, GREP_INDEX
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
 use loonfs_server::{
-    app, AppOptions, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides,
-    ServerConfig, StoreConfig,
+    app, AppOptions, GrepConfig, GrepMode, MaintenanceMode, ReadConsistencyConfig,
+    RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
 };
 use serde::de::DeserializeOwned;
 use std::num::NonZeroUsize;
@@ -679,6 +679,7 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
         content_token_secret: "test-content-token-secret".into(),
         writer_id: format!("grep-mode-{mode:?}"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        read_consistency: ReadConsistencyConfig::default(),
         local_cache: None,
         grep: GrepConfig {
             mode,

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -8,7 +8,8 @@ use crate::fs::{should_invalidate_after_result, ReadCore};
 use crate::metrics::RuntimeInstruments;
 use crate::trace::phase_span;
 use crate::{
-    ChangeSeq, CheckpointId, CommitResponse, CoreError, NamespaceId, Recency, RuntimeCacheConfig,
+    ChangeSeq, CheckpointId, CommitResponse, CoreError, NamespaceId, ReadConsistency, Recency,
+    RuntimeCacheConfig,
 };
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
@@ -44,6 +45,19 @@ pub(crate) struct CachedControl<T> {
 pub(crate) struct CachedNamespaceAnchor {
     pub(crate) head: CachedControl<HeadState>,
     pub(crate) basis: MetadataBasis,
+    pub(crate) validated_at: tokio::time::Instant,
+}
+
+pub(crate) enum AnchorReuse {
+    /// Revalidate the cached anchor against the store before using it.
+    Revalidate,
+    /// Reuse the cached anchor when its head seq is at or above this seq.
+    /// A lower cached seq means the head has moved past the anchor, so the
+    /// anchor is revalidated whatever the configured consistency says.
+    AtLeast(ChangeSeq),
+    /// Reuse the cached anchor when the configured `ReadConsistency`
+    /// allows it; otherwise revalidate.
+    Configured,
 }
 
 /// Snapshot of runtime cache counters.
@@ -219,12 +233,11 @@ fn namespace_slot_is_live(
 }
 
 impl ReadCore {
-    /// Reuses the cached anchor when a cursor's head seq is at or below the cached head seq.
-    /// Revalidates every other cached anchor against the store.
+    /// Reuses or revalidates a cached namespace anchor as requested.
     pub(crate) async fn load_namespace_head_cached(
         &self,
         namespace_id: &NamespaceId,
-        min_head_seq: Option<ChangeSeq>,
+        anchor_reuse: AnchorReuse,
     ) -> std::result::Result<CachedNamespaceAnchor, ControlObjectLoadError> {
         let cache_config = &self.inner.config.runtime_cache;
         if !self.control_cache_enabled() {
@@ -238,14 +251,34 @@ impl ReadCore {
             .control_cache()
             .cached_namespace_head(namespace_id);
         if let Some(head) = cached {
-            if min_head_seq.is_some_and(|min| head.head.state.seq >= min) {
+            let reuse = match anchor_reuse {
+                AnchorReuse::AtLeast(seq) => head.head.state.seq >= seq,
+                AnchorReuse::Configured => matches!(
+                    &self.inner.config.read_consistency,
+                    ReadConsistency::BoundedStaleness(window)
+                        if head.validated_at.elapsed() < *window
+                ),
+                AnchorReuse::Revalidate => false,
+            };
+            if reuse {
                 return Ok(head);
             }
             match self
                 .cached_control_identity_matches(&wal_head(namespace_id), &head.head.etag)
                 .await
             {
-                Ok(true) => return Ok(head),
+                Ok(true) => {
+                    let head = CachedNamespaceAnchor {
+                        validated_at: anchor_clock(),
+                        ..head
+                    };
+                    self.inner.control_cache().insert_namespace_head(
+                        namespace_id,
+                        head.clone(),
+                        cache_config.max_cached_namespaces,
+                    );
+                    return Ok(head);
+                }
                 Ok(false) => self
                     .inner
                     .control_cache()
@@ -282,9 +315,9 @@ impl ReadCore {
     pub(crate) async fn head_for_metadata_read(
         &self,
         namespace_id: &NamespaceId,
-        min_head_seq: Option<ChangeSeq>,
+        anchor_reuse: AnchorReuse,
     ) -> Result<CachedNamespaceAnchor> {
-        self.load_namespace_head_cached(namespace_id, min_head_seq)
+        self.load_namespace_head_cached(namespace_id, anchor_reuse)
             .await
             .map_err(|error| {
                 RuntimeError::Core(CoreError::MetadataProjection(
@@ -351,13 +384,13 @@ impl ReadCore {
     pub(crate) async fn pinned_read(
         &self,
         namespace_id: &NamespaceId,
-        min_head_seq: Option<ChangeSeq>,
+        anchor_reuse: AnchorReuse,
     ) -> Result<(
         loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
         let anchor = self
-            .head_for_metadata_read(namespace_id, min_head_seq)
+            .head_for_metadata_read(namespace_id, anchor_reuse)
             .await?;
         let read_context = self.runtime_read_context(&anchor);
         Ok((self.reader_engine(namespace_id), read_context))
@@ -372,7 +405,9 @@ impl ReadCore {
         loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
-        let live = self.head_for_metadata_read(namespace_id, None).await?;
+        let live = self
+            .head_for_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let pinned = load_checkpoint_read_basis(
             self.store(),
             Some(self.inner.metadata_segment_cache.as_ref()),
@@ -393,7 +428,9 @@ impl ReadCore {
         loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
-        let live = self.head_for_metadata_read(namespace_id, None).await?;
+        let live = self
+            .head_for_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let pinned = load_snapshot_read_basis(
             self.store(),
             Some(self.inner.metadata_segment_cache.as_ref()),
@@ -419,6 +456,7 @@ impl ReadCore {
                 state: pinned.head,
             },
             basis: pinned.basis,
+            validated_at: anchor_clock(),
         });
         (self.reader_engine(namespace_id), read_context)
     }
@@ -427,12 +465,12 @@ impl ReadCore {
     pub(crate) async fn pinned_metadata_read(
         &self,
         namespace_id: &NamespaceId,
-        min_head_seq: Option<ChangeSeq>,
+        anchor_reuse: AnchorReuse,
     ) -> Result<(
         loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
-        let pinned = self.pinned_read(namespace_id, min_head_seq).await?;
+        let pinned = self.pinned_read(namespace_id, anchor_reuse).await?;
         self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(pinned)
     }
@@ -442,10 +480,10 @@ impl ReadCore {
     pub(crate) async fn load_namespace_catalog_cached(
         &self,
         namespace_id: &NamespaceId,
-        min_head_seq: Option<ChangeSeq>,
+        anchor_reuse: AnchorReuse,
     ) -> Result<VerifiedNamespaceCatalogEntry> {
         let anchor = self
-            .head_for_metadata_read(namespace_id, min_head_seq)
+            .head_for_metadata_read(namespace_id, anchor_reuse)
             .await?;
         Ok(VerifiedNamespaceCatalogEntry::from_head(&anchor.head.state))
     }
@@ -483,6 +521,7 @@ impl ReadCore {
                     state: state.head,
                 },
                 basis: state.basis,
+                validated_at: anchor_clock(),
             },
             max_cached_namespaces,
         );
@@ -536,5 +575,13 @@ fn cached_anchor(
             state: head.state,
         },
         basis,
+        validated_at: anchor_clock(),
     }
+}
+
+#[allow(clippy::disallowed_methods)]
+// Anchor age is measured here and nowhere else; it decides when to look
+// at the store again, never what the store holds.
+fn anchor_clock() -> tokio::time::Instant {
+    tokio::time::Instant::now()
 }

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -2,6 +2,7 @@
 
 use crate::trace::{TraceMode, TraceStoreKind};
 use crate::MetadataSegmentCacheConfig;
+use std::time::Duration;
 
 /// Default maximum namespaces retained in runtime caches.
 pub(crate) const DEFAULT_MAX_CACHED_NAMESPACES: usize = 64;
@@ -35,10 +36,26 @@ pub(crate) struct ReadConfig {
     pub max_read_content_bytes: Option<u64>,
     /// Cache configuration.
     pub runtime_cache: RuntimeCacheConfig,
+    /// Cached namespace anchor consistency.
+    pub read_consistency: ReadConsistency,
     /// Tracing mode label.
     pub trace_mode: TraceMode,
     /// Object-store kind label used by tracing.
     pub trace_store_kind: TraceStoreKind,
+}
+
+/// Controls how [`FsReader`](crate::FsReader) revalidates cached namespace
+/// anchors.
+///
+/// When [`RuntimeCacheConfig::max_cached_namespaces`] is zero, no anchor is
+/// cached, so every read loads fresh state regardless of this setting.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ReadConsistency {
+    /// Every read revalidates its cached anchor against the store.
+    #[default]
+    Strong,
+    /// A read may reuse an anchor validated within this window.
+    BoundedStaleness(Duration),
 }
 
 /// Cache configuration for the embedded runtime. Every cache disables the

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -1,6 +1,7 @@
 //! Read-only namespace and filesystem operations for [`FsReader`].
 
 use super::core::{encode_next_cursor, file_revisions_page_response};
+use crate::cache::AnchorReuse;
 use crate::downloads::{DirectDownloadByInodeTarget, DirectDownloadTarget};
 use crate::FsReader;
 use crate::Result;
@@ -211,6 +212,13 @@ fn pager_request<C: PageCursor>(
     Ok(PageRequest { limit, cursor })
 }
 
+fn anchor_reuse_for_cursor(head_seq: Option<ChangeSeq>) -> AnchorReuse {
+    match head_seq {
+        Some(head_seq) => AnchorReuse::AtLeast(head_seq),
+        None => AnchorReuse::Configured,
+    }
+}
+
 impl FsReader {
     fn read_snapshot(
         &self,
@@ -231,7 +239,8 @@ impl FsReader {
     /// The returned snapshot keeps path lookup, directory listing, inode
     /// resolution, and content selection on the same head even if commits
     /// publish concurrently. It is intended to be short-lived for one
-    /// request or unit of work.
+    /// request or unit of work. With bounded staleness, it may start at a
+    /// head up to the configured window old.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.pin_namespace",
@@ -247,7 +256,10 @@ impl FsReader {
     )]
     pub async fn pin_namespace(&self, namespace_id: &NamespaceId) -> Result<FsReadSnapshot> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         Ok(self.read_snapshot(engine, context, None))
     }
 
@@ -356,7 +368,10 @@ impl FsReader {
         )?;
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let entry = engine
             .resolve_path(absolute_path, options, &read_context)
             .await?;
@@ -386,7 +401,10 @@ impl FsReader {
     ) -> Result<PathEntry> {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let entry = engine.stat_inode(inode_id, options, &read_context).await?;
         tracing::Span::current().record("cache_path", crate::trace::CACHE_MATERIALIZED_SEGMENTS);
         Ok(entry)
@@ -474,7 +492,7 @@ impl FsReader {
             .core
             .pinned_metadata_read(
                 namespace_id,
-                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+                anchor_reuse_for_cursor(request.cursor.as_ref().map(|cursor| cursor.head_seq)),
             )
             .await?;
         let page = engine
@@ -554,7 +572,7 @@ impl FsReader {
             .core
             .pinned_metadata_read(
                 namespace_id,
-                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+                anchor_reuse_for_cursor(request.cursor.as_ref().map(|cursor| cursor.head_seq)),
             )
             .await?;
         let page = engine
@@ -591,7 +609,10 @@ impl FsReader {
         absolute_path: &str,
     ) -> Result<FileBytes> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let read = engine
             .get_file(
                 absolute_path,
@@ -632,7 +653,10 @@ impl FsReader {
         options: ReadFileStreamOptions,
     ) -> Result<FileContentStream<SharedObjectStore>> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let stream = engine
             .read_file_stream(
                 absolute_path,
@@ -672,7 +696,10 @@ impl FsReader {
         revision_no: Option<RevisionNo>,
     ) -> Result<DirectDownloadTarget> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let target = engine
             .direct_download_target(absolute_path, revision_no, &read_context)
             .await?;
@@ -700,7 +727,10 @@ impl FsReader {
         revision_no: RevisionNo,
     ) -> Result<DirectDownloadByInodeTarget> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let target = engine
             .direct_download_target_by_inode(inode_id, revision_no, &read_context)
             .await?;
@@ -731,7 +761,10 @@ impl FsReader {
         request: PageRequest<CheckpointFilesPageCursor>,
     ) -> Result<CheckpointFilesPage> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         Ok(engine
             .list_checkpoint_files_page(checkpoint_id, request, &read_context)
             .await?)
@@ -763,7 +796,10 @@ impl FsReader {
         inode_ids: &[InodeId],
     ) -> Result<Vec<CurrentFileState>> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let states = engine
             .resolve_current_files(inode_ids, &read_context)
             .await?;
@@ -798,7 +834,10 @@ impl FsReader {
         max_bytes: u64,
     ) -> Result<Vec<u8>> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         Ok(engine
             .read_content_ref(content_ref, max_bytes, &read_context)
             .await?)
@@ -830,7 +869,7 @@ impl FsReader {
             .core
             .pinned_metadata_read(
                 namespace_id,
-                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+                anchor_reuse_for_cursor(request.cursor.as_ref().map(|cursor| cursor.head_seq)),
             )
             .await?;
         let page = engine.list_trash_page(request, &read_context).await?;
@@ -890,7 +929,7 @@ impl FsReader {
             .core
             .pinned_metadata_read(
                 namespace_id,
-                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+                anchor_reuse_for_cursor(request.cursor.as_ref().map(|cursor| cursor.head_seq)),
             )
             .await?;
         let fallback_inode_id = request.cursor.as_ref().map(|cursor| cursor.inode_id);
@@ -957,7 +996,7 @@ impl FsReader {
             .core
             .pinned_metadata_read(
                 namespace_id,
-                request.cursor.as_ref().map(|cursor| cursor.head_seq),
+                anchor_reuse_for_cursor(request.cursor.as_ref().map(|cursor| cursor.head_seq)),
             )
             .await?;
         let page = engine
@@ -1018,7 +1057,10 @@ impl FsReader {
         revision_no: RevisionNo,
     ) -> Result<FileBytes> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let read = engine
             .get_file_revision(
                 absolute_path,
@@ -1051,7 +1093,10 @@ impl FsReader {
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>> {
         self.core.record_trace_context(&tracing::Span::current());
-        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id, None).await?;
+        let (engine, read_context) = self
+            .core
+            .pinned_metadata_read(namespace_id, AnchorReuse::Configured)
+            .await?;
         let bytes = engine
             .get_file_revision_for_inode(
                 inode_id,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -1,6 +1,7 @@
 //! [`FsWriter`]'s path mutations, commits, and the publication pipeline.
 
 use super::core::{ReadCore, WriterBits};
+use crate::cache::AnchorReuse;
 use crate::maintenance_runner::NamespacePublication;
 use crate::publish::{CommitCandidate, CommitRequest, FilesystemOperation, PreparedContent};
 use crate::trace::phase_span;
@@ -539,7 +540,7 @@ impl FsWriter {
         namespace_id: &NamespaceId,
     ) -> Result<loonfs_core::control::VerifiedNamespaceCatalogEntry> {
         self.core
-            .load_namespace_catalog_cached(namespace_id, None)
+            .load_namespace_catalog_cached(namespace_id, AnchorReuse::Revalidate)
             .await
     }
 

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -7,8 +7,8 @@ use crate::metrics::{
     fan_out_object_store_recorder, MetricsRecorder, ObjectStoreMetricsRecorder, RuntimeInstruments,
 };
 use crate::{
-    Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
-    TraceStoreKind,
+    ReadConsistency, Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig,
+    TraceMode, TraceStoreKind,
 };
 use loonfs_core::cache::{MetadataSegmentCache, StoredMetadataBlockCache};
 use loonfs_objectstore::metrics::InstrumentedObjectStore;
@@ -29,6 +29,7 @@ pub(super) struct HandleBuilderCore {
     pub(super) source: StoreSource,
     pub(super) max_read_content_bytes: Option<u64>,
     pub(super) runtime_cache: RuntimeCacheConfig,
+    pub(super) read_consistency: ReadConsistency,
     /// An existing decoded-block cache to share instead of sizing a fresh
     /// one from `runtime_cache`; see [`ReadCore::open`].
     pub(super) shared_metadata_segment_cache: Option<Arc<MetadataSegmentCache>>,
@@ -55,6 +56,7 @@ impl HandleBuilderCore {
             source,
             max_read_content_bytes: None,
             runtime_cache: RuntimeCacheConfig::default(),
+            read_consistency: ReadConsistency::default(),
             shared_metadata_segment_cache: None,
             stored_metadata_block_cache: None,
             trace_mode: TraceMode::Embedded,
@@ -99,6 +101,7 @@ impl HandleBuilderCore {
             ReadConfig {
                 max_read_content_bytes: self.max_read_content_bytes,
                 runtime_cache: self.runtime_cache,
+                read_consistency: self.read_consistency,
                 trace_mode: self.trace_mode,
                 trace_store_kind,
             },

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -4,8 +4,8 @@ use super::HandleBuilderCore;
 use crate::fs::ReadCore;
 use crate::metrics::{MetricsRecorder, ObjectStoreMetricsRecorder};
 use crate::{
-    CapabilityDocument, Result, RuntimeCacheConfig, RuntimeCacheStats, SharedObjectStore,
-    StoreConfig, TraceMode, TraceStoreKind,
+    CapabilityDocument, ReadConsistency, Result, RuntimeCacheConfig, RuntimeCacheStats,
+    SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
 use std::sync::Arc;
 
@@ -13,8 +13,8 @@ use std::sync::Arc;
 ///
 /// `FsReader` reads namespace state, paths, content, revisions, and the change
 /// feed. It has no writer identity or session, cannot publish changes, and
-/// does not schedule maintenance. Reads check cached control state against
-/// durable state, so a standalone reader does not need writer coordination.
+/// does not schedule maintenance. Reads follow the configured consistency
+/// policy, which revalidates cached control state by default.
 ///
 /// The handle is runtime-bound: open it with `build().await` inside the
 /// Tokio runtime that will drive its reads. `FsReader` is cheap to clone.
@@ -72,6 +72,12 @@ impl FsReaderBuilder {
     /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.core.runtime_cache = runtime_cache;
+        self
+    }
+
+    /// Sets how reads revalidate cached namespace anchors.
+    pub fn read_consistency(mut self, read_consistency: ReadConsistency) -> Self {
+        self.core.read_consistency = read_consistency;
         self
     }
 

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -7,8 +7,8 @@ use crate::metrics::{MetricsRecorder, ObjectStoreMetricsRecorder};
 use crate::publisher::{NamespaceAdvanceHint, NamespaceAdvanceObserver, PublisherRegistry};
 use crate::{
     CapabilityDocument, FsBackgroundWork, MaintenanceHandle, MaintenanceJob, MaintenanceJobId,
-    Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig,
-    TraceMode, TraceStoreKind,
+    ReadConsistency, Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError,
+    SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
 use loonfs_core::cache::{MetadataSegmentCache, StoredMetadataBlockCache};
 use std::num::NonZeroUsize;
@@ -302,6 +302,13 @@ impl FsWriterBuilder {
     /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.core.runtime_cache = runtime_cache;
+        self
+    }
+
+    /// Sets consistency for reads through readers derived from this writer.
+    /// The writer's mutation paths always revalidate cached anchors.
+    pub fn read_consistency(mut self, read_consistency: ReadConsistency) -> Self {
+        self.core.read_consistency = read_consistency;
         self
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -191,7 +191,7 @@ pub use loonfs_objectstore::{
 };
 
 pub use cache::RuntimeCacheStats;
-pub use config::{RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE};
+pub use config::{ReadConsistency, RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE};
 pub use fs::{
     ChangesPager, CheckpointsPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager,
     MetadataCompactionOutcome, PathEntriesPager, TrashPager,

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -169,6 +169,7 @@ fn test_read_core(store: SharedStore) -> ReadCore {
         ReadConfig {
             max_read_content_bytes: None,
             runtime_cache: RuntimeCacheConfig::default(),
+            read_consistency: crate::ReadConsistency::Strong,
             trace_mode: TraceMode::Remote,
             trace_store_kind: TraceStoreKind::LocalFs,
         },

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -6,7 +6,7 @@
 use loonfs::{
     CreateDirectoryOptions, CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenancePlan,
     MetadataMaintenanceOptions, NamespaceId, PageRequest, PaginationPolicy, PutFileOptions,
-    SharedObjectStore,
+    ReadConsistency, SharedObjectStore,
 };
 use loonfs_api::AbsolutePath;
 
@@ -14,8 +14,9 @@ use loonfs_api::wire::manifest::{decode_namespace_manifest_json, RunTier};
 use loonfs_objectstore::keys::{metadata_manifest_object, metadata_segment_object_key};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::stores::{KeyPredicate, OperationClass, RecordedGet, RecordingStore};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use std::time::Duration;
 use tempfile::tempdir;
 
 const FILES: usize = 10_000;
@@ -238,6 +239,311 @@ async fn continuation_pages_reuse_the_cached_anchor() {
         ),
         (1, Some("/a")),
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn bounded_staleness_revalidates_once_per_window_and_delays_external_writes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let log = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let store: SharedObjectStore = log.clone();
+    let namespace_id = NamespaceId::parse("bounded-reader").expect("valid namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("bounded-reader-setup")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build setup writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .create_directory(
+            &namespace_id,
+            "/old",
+            CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create old directory");
+
+    let window = Duration::from_millis(500);
+    let reader = FsReader::builder_with_store(store.clone())
+        .read_consistency(ReadConsistency::BoundedStaleness(window))
+        .build()
+        .await
+        .expect("build bounded reader");
+    reader
+        .get_path_entry(&namespace_id, "/", Default::default())
+        .await
+        .expect("warm reader anchor");
+
+    tokio::time::advance(window + Duration::from_millis(1)).await;
+    log.reset();
+    for _ in 0..2 {
+        reader
+            .get_path_entry(&namespace_id, "/", Default::default())
+            .await
+            .expect("stat inside window");
+    }
+    assert_eq!(log.count(OperationClass::Head), 1);
+
+    tokio::time::advance(window + Duration::from_millis(1)).await;
+    reader
+        .get_path_entry(&namespace_id, "/", Default::default())
+        .await
+        .expect("stat after window");
+    assert_eq!(log.count(OperationClass::Head), 2);
+
+    let second_writer = FsWriter::builder_with_store(store)
+        .writer_id("bounded-reader-external")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build external writer");
+    second_writer
+        .create_directory(
+            &namespace_id,
+            "/new",
+            CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create new directory");
+
+    let limit = PaginationPolicy::default()
+        .resolve_limit(Some(10))
+        .expect("valid limit");
+    log.reset();
+    let stale = reader
+        .list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit,
+                cursor: None,
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list inside window");
+    assert_eq!(
+        stale
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["/old"]),
+    );
+    assert_eq!(log.count(OperationClass::Head), 0);
+
+    tokio::time::advance(window + Duration::from_millis(1)).await;
+    let fresh = reader
+        .list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit,
+                cursor: None,
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list after window");
+    assert_eq!(
+        fresh
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["/new", "/old"]),
+    );
+    assert_eq!(log.count(OperationClass::Head), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_cursor_ahead_of_a_bounded_anchor_revalidates_inside_the_window() {
+    let temp_dir = tempdir().expect("tempdir");
+    let log = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let store: SharedObjectStore = log.clone();
+    let namespace_id = NamespaceId::parse("bounded-cursor").expect("valid namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("bounded-cursor-setup")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build setup writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for path in ["/b", "/c"] {
+        writer
+            .create_directory(
+                &namespace_id,
+                path,
+                CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("create directory");
+    }
+    let bounded = FsReader::builder_with_store(store.clone())
+        .read_consistency(ReadConsistency::BoundedStaleness(Duration::from_millis(
+            500,
+        )))
+        .build()
+        .await
+        .expect("build bounded reader");
+    bounded
+        .get_path_entry(&namespace_id, "/", Default::default())
+        .await
+        .expect("warm the bounded anchor");
+
+    writer
+        .create_directory(
+            &namespace_id,
+            "/a",
+            CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("advance the head past the bounded anchor");
+    let limit = PaginationPolicy::default()
+        .resolve_limit(Some(1))
+        .expect("valid limit");
+    let first = FsReader::builder_with_store(store)
+        .build()
+        .await
+        .expect("build strong reader")
+        .list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit,
+                cursor: None,
+            },
+            Default::default(),
+        )
+        .await
+        .expect("list the first page at the new head");
+    let cursor: loonfs_api::DirectoryPageCursor = loonfs_api::decode_cursor(
+        first
+            .next_cursor
+            .as_deref()
+            .expect("first page has a cursor"),
+    )
+    .expect("decode the cursor");
+
+    log.reset();
+    let second = bounded
+        .list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit,
+                cursor: Some(cursor),
+            },
+            Default::default(),
+        )
+        .await
+        .expect("a cursor ahead of the cached anchor is served, not rejected");
+    assert_eq!(
+        (
+            log.count(OperationClass::Head),
+            second.entries.first().map(|entry| entry.path.as_str()),
+        ),
+        (1, Some("/b")),
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn strong_consistency_revalidates_every_stat_by_default() {
+    let temp_dir = tempdir().expect("tempdir");
+    let log = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let store: SharedObjectStore = log.clone();
+    let namespace_id = NamespaceId::parse("strong-reader").expect("valid namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("strong-reader-setup")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build setup writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    let reader = FsReader::builder_with_store(store)
+        .build()
+        .await
+        .expect("build strong reader");
+    reader
+        .get_path_entry(&namespace_id, "/", Default::default())
+        .await
+        .expect("warm reader anchor");
+
+    log.reset();
+    for _ in 0..2 {
+        reader
+            .get_path_entry(&namespace_id, "/", Default::default())
+            .await
+            .expect("stat inside window");
+    }
+    assert_eq!(log.count(OperationClass::Head), 2);
+
+    tokio::time::advance(Duration::from_millis(501)).await;
+    reader
+        .get_path_entry(&namespace_id, "/", Default::default())
+        .await
+        .expect("stat after window");
+    assert_eq!(log.count(OperationClass::Head), 3);
+}
+
+#[tokio::test(start_paused = true)]
+async fn writer_seeded_anchor_is_immediately_visible_without_revalidation() {
+    let temp_dir = tempdir().expect("tempdir");
+    let log = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let store: SharedObjectStore = log.clone();
+    let namespace_id = NamespaceId::parse("seeded-bounded-reader").expect("valid namespace id");
+    let writer = FsWriter::builder_with_store(store)
+        .writer_id("seeded-bounded-reader-writer")
+        .min_publish_interval_ms(0)
+        .read_consistency(ReadConsistency::BoundedStaleness(Duration::from_millis(
+            500,
+        )))
+        .build()
+        .await
+        .expect("build writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .create_directory(
+            &namespace_id,
+            "/new",
+            CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create directory");
+
+    log.reset();
+    let entry = writer
+        .reader()
+        .get_path_entry(&namespace_id, "/new", Default::default())
+        .await
+        .expect("read seeded directory");
+    assert_eq!(entry.path.as_str(), "/new");
+    assert_eq!(log.count(OperationClass::Head), 0);
 }
 
 #[allow(clippy::print_stdout)]


### PR DESCRIPTION
Readers can now opt into bounded-staleness caching. Strong consistency remains the default. With bounded staleness, a reader may reuse a namespace head validated within the configured window and avoid a HEAD request.

Writes made through the same process update its cache immediately. Writes from another process may remain invisible until the window expires, and a snapshot created during that time may start from the older head. Disabling the control cache still forces fresh reads. The server exposes the option as bounded_staleness_ms; omitting it keeps strong consistency. Wire formats, error codes, and durable data are unchanged.