### PR TITLE
feat(core): fold WAL tails during writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
  "loonfs",
  "loonfs-api",
  "loonfs-client",
+ "loonfs-core",
  "loonfs-grep",
  "loonfs-objectstore",
  "loonfs-test-support",

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -39,6 +39,7 @@ walkdir.workspace = true
 [dev-dependencies]
 ureq.workspace = true
 insta = { version = "1.39", features = ["json"] }
+loonfs-core = { workspace = true, features = ["test-support"] }
 # The store wrappers that make "this transfer never held the file" a
 # checkable claim rather than a comment.
 loonfs-test-support.workspace = true

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -1062,10 +1062,11 @@ mod tests {
         RuntimeError, SharedObjectStore, StatPathOptions,
     };
     use loonfs_api::{
-        ChangeSeq, CreateCheckpointRequest, DestinationBehavior, ErrorCode, InodeId, NamespaceId,
-        RevisionNo,
+        ChangeSeq, CreateCheckpointRequest, ErrorCode, InodeId, NamespaceId, RevisionNo,
     };
     use loonfs_client::NamespacePath;
+    use loonfs_core::test_support::append_wal_segments;
+    use loonfs_core::MutationContext;
     use tempfile::tempdir;
 
     fn namespace_id(value: &str) -> NamespaceId {
@@ -1090,12 +1091,8 @@ mod tests {
         ]
     }
 
-    /// Leaves a namespace with a metadata backlog no scheduler will touch:
-    /// a `ManualOnly` writer publishes past the WAL-tail checkpoint
-    /// threshold, which is exactly the state a cold namespace is in when the
-    /// process that wrote it went away.
     async fn seed_wal_backlog(store: &SharedObjectStore, namespace_id: &NamespaceId) {
-        const PUBLISHES_PAST_THE_CHECKPOINT_THRESHOLD: usize = 34;
+        const PUBLISHES_PAST_THE_CHECKPOINT_THRESHOLD: u64 = 34;
         let writer = FsWriter::builder_with_store(store.clone())
             .writer_id(format!("{namespace_id}-backlog"))
             .background_work(FsBackgroundWork::ManualOnly)
@@ -1107,17 +1104,18 @@ mod tests {
             .create_namespace(namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("create namespace");
-        for index in 0..PUBLISHES_PAST_THE_CHECKPOINT_THRESHOLD {
-            writer
-                .put_file_bytes(
-                    namespace_id,
-                    &format!("/notes/note-{index}.txt"),
-                    b"assigned needle\n",
-                    PutFileOptions::new(loonfs_test_support::test_actor()),
-                )
-                .await
-                .unwrap_or_else(|error| panic!("seed put {index} failed: {error}"));
-        }
+        append_wal_segments(
+            store.as_ref(),
+            namespace_id,
+            PUBLISHES_PAST_THE_CHECKPOINT_THRESHOLD,
+            &MutationContext {
+                writer_id: loonfs_api::WriterId::parse(format!("{namespace_id}-tail"))
+                    .expect("writer id"),
+                now_ms: 1_000,
+            },
+        )
+        .await
+        .expect("seed WAL backlog");
     }
 
     fn local_store(temp_dir: &std::path::Path) -> (StoreConfig, SharedObjectStore) {
@@ -1523,14 +1521,11 @@ mod tests {
             key_prefix: None,
         };
 
-        // Accumulate WAL debt the way pre-fix builds did: a ManualOnly
-        // writer publishes until the backpressure gate refuses the next
-        // publish outright.
         let store = store_config
             .configured_object_store()
             .expect("configure store")
             .into_shared();
-        let writer = FsWriter::builder_with_store(store)
+        let writer = FsWriter::builder_with_store(store.clone())
             .writer_id("debt-builder")
             .background_work(FsBackgroundWork::ManualOnly)
             .min_publish_interval_ms(0)
@@ -1542,39 +1537,18 @@ mod tests {
             .create_namespace(&namespace, CreateNamespaceOptions::default())
             .await
             .expect("create namespace");
-        let mut stalled = false;
-        for index in 0..200 {
-            let result =
-                writer
-                    .put_file_bytes(
-                        &namespace,
-                        &format!("/files/f{index}.txt"),
-                        b"payload",
-                        PutFileOptions {
-                            behavior: DestinationBehavior::NoReplace,
-                            commit: loonfs_client::CommitOptions::new(
-                                loonfs_test_support::test_actor(),
-                            ),
-                            expected_inode_id: None,
-                            expected_revision_no: None,
-                        },
-                    )
-                    .await;
-            match result {
-                Ok(_) => {}
-                Err(RuntimeError::Core(error))
-                    if matches!(error.code(), ErrorCode::MaintenanceRequired) =>
-                {
-                    stalled = true;
-                    break;
-                }
-                Err(error) => panic!("unexpected stall error: {error}"),
-            }
-        }
-        assert!(stalled, "ManualOnly writer never hit the backpressure cap");
+        append_wal_segments(
+            store.as_ref(),
+            &namespace,
+            loonfs_core::limits::MAX_UNFLUSHED_WAL_SEGMENTS,
+            &MutationContext {
+                writer_id: loonfs_api::WriterId::parse("debt-builder").expect("writer id"),
+                now_ms: 1_000,
+            },
+        )
+        .await
+        .expect("seed WAL debt at the write-stop bound");
 
-        // The embedded backend digs itself out: the gated publish schedules
-        // its own step, the backend settles it and resubmits.
         let target = EmbeddedTarget::new(&store_config, None)
             .await
             .expect("build embedded target");

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -24,7 +24,8 @@ use crate::error::Result;
 use crate::limits::METADATA_PUBLICATION_BUDGET_MS;
 use crate::metadata::MetadataState;
 use crate::namespace::basis::MetadataBasis;
-use crate::namespace::control_snapshot::load_control_snapshot;
+use crate::namespace::control_snapshot::{load_control_snapshot, resolve_retention_floor_seq};
+use crate::protocol::{PublishMetadataView, PublishTailProjection};
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use crate::wal::{
     ensure_replayed_head_matches, load_wal_chain, project_validated_wal_tail, WalChainLoadRequest,
@@ -38,6 +39,7 @@ use loonfs_api::{
     NamespaceId, RunNo, MAX_PUBLIC_INTEGER,
 };
 use loonfs_objectstore::ObjectStore;
+use std::sync::Arc;
 use tracing::Instrument;
 
 /// Manifest that covers the head after a flush attempt.
@@ -91,13 +93,9 @@ pub(super) async fn flush_wal_with_timer<S: ObjectStore + ?Sized>(
         || async move {
             Result::Ok(
                 match try_flush_wal(store, namespace_id, context, timer).await? {
-                    TryFlushWal::Settled(basis) => CasAttempt::Settled(FlushWalResponse {
-                        namespace_id: namespace_id.clone(),
-                        target_head_seq: basis.target_head_seq,
-                        manifest_no: basis.root_after_manifest_no,
-                        manifest_head_seq: basis.root_after_head_seq,
-                        outcome: basis.outcome,
-                    }),
+                    TryFlushWal::Settled(basis) => {
+                        CasAttempt::Settled(flush_wal_response(namespace_id, *basis))
+                    }
                     TryFlushWal::RaceLost => CasAttempt::Contended(CoreError::HeadPublish(
                         CommitHeadPublishError::StaleHead,
                     )),
@@ -121,13 +119,23 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     timer: &dyn MonotonicTimer,
 ) -> Result<TryFlushWal> {
-    let publication_started_ms = timer.monotonic_now_ms();
     let projection = load_root_projection(store, namespace_id)
         .instrument(tracing::debug_span!(
             "loonfs.phase",
             phase = "scan_namespace_state"
         ))
         .await?;
+    try_flush_wal_projection(store, namespace_id, &projection, context, timer).await
+}
+
+async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    projection: &RootProjection<'_, S>,
+    context: &MutationContext,
+    timer: &dyn MonotonicTimer,
+) -> Result<TryFlushWal> {
+    let publication_started_ms = timer.monotonic_now_ms();
     let head_seq = projection.head.seq;
     let basis_manifest_no = projection.basis.manifest_no();
     // Only a manifest this namespace published can already cover the head.
@@ -156,7 +164,7 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
     let manifest = build_namespace_manifest_for_projection(
         store,
         namespace_id,
-        &projection,
+        projection,
         manifest_no,
         ManifestObjectId::generate(manifest_no),
     )
@@ -217,14 +225,68 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
     })))
 }
 
+pub(crate) async fn fold_publish_tail_projection<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    publish_view: &PublishMetadataView<'_, S>,
+    projection: &PublishTailProjection,
+    context: &MutationContext,
+    timer: &dyn MonotonicTimer,
+) -> Result<FlushWalResponse> {
+    let floor_seq = match publish_view.retention_floor_seq() {
+        Some(floor_seq) => floor_seq,
+        None => resolve_retention_floor_seq(store, publish_view.head())
+            .await
+            .map_err(CoreError::ControlObjectLoad)?,
+    };
+    let root_projection = RootProjection {
+        head: publish_view.head().clone(),
+        basis: projection.basis().clone(),
+        floor_seq,
+        manifest_segments: ProjectionManifestSegments::Borrowed(publish_view.manifest_segments()),
+        tail_state: Arc::clone(&projection.tail_state),
+    };
+    // A fold publishes metadata without updating the namespace head.
+    match try_flush_wal_projection(store, namespace_id, &root_projection, context, timer).await? {
+        TryFlushWal::Settled(basis) => Ok(flush_wal_response(namespace_id, *basis)),
+        TryFlushWal::RaceLost => flush_wal(store, namespace_id, context).await,
+    }
+}
+
+fn flush_wal_response(namespace_id: &NamespaceId, basis: FlushedBasis) -> FlushWalResponse {
+    FlushWalResponse {
+        namespace_id: namespace_id.clone(),
+        target_head_seq: basis.target_head_seq,
+        manifest_no: basis.root_after_manifest_no,
+        manifest_head_seq: basis.root_after_head_seq,
+        outcome: basis.outcome,
+    }
+}
+
+pub(super) enum ProjectionManifestSegments<'a, S: ObjectStore + ?Sized> {
+    Loaded(VerifiedMetadataSegments<'a, S>),
+    Borrowed(&'a VerifiedMetadataSegments<'a, S>),
+}
+
+impl<'a, S: ObjectStore + ?Sized> std::ops::Deref for ProjectionManifestSegments<'a, S> {
+    type Target = VerifiedMetadataSegments<'a, S>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Loaded(segments) => segments,
+            Self::Borrowed(segments) => segments,
+        }
+    }
+}
+
 pub(super) struct RootProjection<'a, S: ObjectStore + ?Sized> {
     pub(super) head: HeadState,
     pub(super) basis: MetadataBasis,
     pub(super) floor_seq: ChangeSeq,
-    pub(super) manifest_segments: VerifiedMetadataSegments<'a, S>,
+    pub(super) manifest_segments: ProjectionManifestSegments<'a, S>,
     /// Rows that are not in any segment yet: the genesis root inode when the
     /// basis is genesis, plus the replayed WAL tail.
-    pub(super) tail_state: MetadataState,
+    pub(super) tail_state: Arc<MetadataState>,
 }
 
 pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
@@ -282,8 +344,8 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
         head,
         basis,
         floor_seq,
-        manifest_segments,
-        tail_state: replayed.resulting_metadata_state,
+        manifest_segments: ProjectionManifestSegments::Loaded(manifest_segments),
+        tail_state: Arc::new(replayed.resulting_metadata_state),
     })
 }
 

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -69,7 +69,7 @@ pub(crate) use self::compaction_lease::{claim_compaction_prefix, CompactionPrefi
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::data_block_load::DecodedRowWeight;
 pub(crate) use self::files::list_checkpoint_files_page;
-pub(crate) use self::flush::flush_wal;
+pub(crate) use self::flush::{flush_wal, fold_publish_tail_projection};
 pub(crate) use self::list::list_checkpoints_page;
 pub(crate) use self::load::{
     head_from_manifest, load_basis_metadata_segments, load_namespace_manifest_envelope,

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -3,6 +3,89 @@
 use super::*;
 
 #[tokio::test]
+async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("publish-fold").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    crate::test_support::append_wal_segments(&store, &namespace_id, 3, &context)
+        .await
+        .expect("build WAL tail");
+    let expected_tail = Arc::clone(
+        &flush::load_root_projection(&store, &namespace_id)
+            .await
+            .expect("load store projection")
+            .tail_state,
+    );
+    let head = load_head_object(&store, &namespace_id)
+        .await
+        .expect("load head");
+    let acquired_writer = loonfs_api::wire::control::AcquiredWriter {
+        writer_id: context.writer_id.to_string(),
+        writer_epoch: head.state.writer_epoch,
+    };
+    let (publish_view, projection) = crate::protocol::load_publish_metadata_view(
+        &store,
+        None,
+        &namespace_id,
+        acquired_writer,
+        None,
+        &PublishTailOptions::default(),
+    )
+    .await
+    .expect("load publish projection");
+
+    let response = flush::fold_publish_tail_projection(
+        &store,
+        &namespace_id,
+        &publish_view,
+        &projection,
+        &context,
+        &crate::time::StdMonotonicTimer::default(),
+    )
+    .await
+    .expect("fold publish projection");
+    assert_eq!(response.outcome, loonfs_api::FlushWalOutcome::Published);
+    let materialized =
+        load_manifest_materialization_for_inspection(&store, &namespace_id, response.manifest_no)
+            .await
+            .expect("load folded manifest");
+    let delta = materialized
+        .manifest
+        .payload
+        .runs
+        .last()
+        .expect("folded manifest has a delta run");
+    assert_eq!(delta.tier, RunTier::Delta);
+    let delta_manifest = runs_in_materialization_order(&materialized.manifest.payload)
+        .into_iter()
+        .find(|run| run.run_no == delta.run_no)
+        .expect("folded delta run is valid");
+    let manifest_key = metadata_manifest_object(
+        &namespace_id,
+        &materialized.manifest.payload.manifest_object_id,
+    );
+    let mut actual_tail = MetadataStateBuilder::default();
+    inspection_materialization::append_manifest_segments_to_metadata(
+        &store,
+        &namespace_id,
+        &manifest_key,
+        delta_manifest.run_seq,
+        &delta_manifest.segments,
+        &mut actual_tail,
+    )
+    .await
+    .expect("load delta run");
+    assert!(metadata_states_equivalent(
+        &expected_tail,
+        &actual_tail.finish()
+    ));
+}
+
+#[tokio::test]
 async fn manifest_round_trip_uses_manifest_materialization_for_mixed_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -2,7 +2,7 @@
 //! candidates as one WAL segment and one head compare-and-swap, then returns
 //! one result per candidate.
 
-use crate::checkpoint::MetadataSegmentCache;
+use crate::checkpoint::{fold_publish_tail_projection, MetadataSegmentCache};
 use crate::commit::CommitFingerprint;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataViewError, Result, WriterFence};
@@ -22,8 +22,10 @@ use loonfs_api::wire::control::{AcquiredWriter, HeadState};
 use loonfs_api::{ChangeSeq, CommitId, ContentId, DeleteNamespaceResponse, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashSet;
+use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
+use tracing::Instrument;
 
 /// One namespace mutation together with the result of preparing any content
 /// it references.
@@ -166,6 +168,8 @@ impl CommitCandidate {
 #[derive(Debug, Clone)]
 pub struct NamespaceCommitEnginePublishResult {
     pub results: Vec<Result<ApiCommitResponse>>,
+    /// Whether this publish first folded the WAL tail into a manifest.
+    pub folded: bool,
     /// WAL tail length observed by this publish, for opportunistic
     /// maintenance scheduling. Zero when no projection was loaded.
     pub wal_tail_segments: u64,
@@ -214,6 +218,7 @@ pub type SharedWriterSessionState = Arc<Mutex<WriterSessionState>>;
 pub struct NamespaceCommitEngine {
     namespace_id: NamespaceId,
     publish_tail_projection: Option<PublishTailProjection>,
+    fold_wal_tail_at: Option<NonZeroU64>,
     /// This session's epoch and fencing for the namespace; see
     /// [`WriterSessionState`].
     session: SharedWriterSessionState,
@@ -230,6 +235,7 @@ impl NamespaceCommitEngine {
         Self {
             namespace_id,
             publish_tail_projection: None,
+            fold_wal_tail_at: None,
             session: SharedWriterSessionState::default(),
             timer: Arc::new(StdMonotonicTimer::default()),
             segment_cache: None,
@@ -240,6 +246,12 @@ impl NamespaceCommitEngine {
     /// persist across engine instances.
     pub fn writer_session(mut self, session: SharedWriterSessionState) -> Self {
         self.session = session;
+        self
+    }
+
+    /// Folds the WAL tail before a publish that observes this many segments.
+    pub fn fold_wal_tail_at(mut self, threshold: Option<NonZeroU64>) -> Self {
+        self.fold_wal_tail_at = threshold;
         self
     }
 
@@ -342,9 +354,40 @@ impl NamespaceCommitEngine {
         context: &MutationContext,
         tail_options: &PublishTailOptions,
     ) -> NamespaceCommitEnginePublishResult {
+        Box::pin(self.publish_batch_inner(store, candidates, context, tail_options, None)).await
+    }
+
+    /// Publishes a batch and instruments any configured WAL fold with `fold_span`.
+    pub async fn publish_batch_with_fold_span<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        candidates: Vec<CommitCandidate>,
+        context: &MutationContext,
+        tail_options: &PublishTailOptions,
+        fold_span: tracing::Span,
+    ) -> NamespaceCommitEnginePublishResult {
+        Box::pin(self.publish_batch_inner(
+            store,
+            candidates,
+            context,
+            tail_options,
+            Some(fold_span),
+        ))
+        .await
+    }
+
+    async fn publish_batch_inner<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        candidates: Vec<CommitCandidate>,
+        context: &MutationContext,
+        tail_options: &PublishTailOptions,
+        fold_span: Option<tracing::Span>,
+    ) -> NamespaceCommitEnginePublishResult {
         if candidates.is_empty() {
             return NamespaceCommitEnginePublishResult {
                 results: Vec::new(),
+                folded: false,
                 wal_tail_segments: 0,
                 resulting_read_state: None,
             };
@@ -356,17 +399,18 @@ impl NamespaceCommitEngine {
             Err(error) => {
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, error),
+                    folded: false,
                     wal_tail_segments: 0,
                     resulting_read_state: None,
                 };
             }
         };
 
-        let (publish_view, projection) = match load_publish_metadata_view(
+        let (mut publish_view, mut projection) = match load_publish_metadata_view(
             store,
             self.segment_cache.as_deref(),
             &self.namespace_id,
-            acquired_writer,
+            acquired_writer.clone(),
             self.publish_tail_projection.as_ref(),
             tail_options,
         )
@@ -380,11 +424,75 @@ impl NamespaceCommitEngine {
                 }
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, error),
+                    folded: false,
                     wal_tail_segments: 0,
                     resulting_read_state: None,
                 };
             }
         };
+
+        let mut folded = false;
+        if self
+            .fold_wal_tail_at
+            .is_some_and(|threshold| projection.wal_tail_segments >= threshold.get())
+        {
+            let wal_tail_segments = projection.wal_tail_segments;
+            let fold = fold_publish_tail_projection(
+                store,
+                &self.namespace_id,
+                &publish_view,
+                &projection,
+                context,
+                self.timer.as_ref(),
+            );
+            let fold = match fold_span {
+                Some(fold_span) => fold.instrument(fold_span).await,
+                None => fold.await,
+            };
+            match fold {
+                Ok(_) => {
+                    drop(publish_view);
+                    drop(projection);
+                    self.invalidate_projection();
+                    folded = true;
+                    match load_publish_metadata_view(
+                        store,
+                        self.segment_cache.as_deref(),
+                        &self.namespace_id,
+                        acquired_writer,
+                        None,
+                        tail_options,
+                    )
+                    .await
+                    {
+                        Ok((fresh_view, fresh_projection)) => {
+                            publish_view = fresh_view;
+                            projection = fresh_projection;
+                        }
+                        Err(error) => {
+                            if let CoreError::WriterFenced(fence) = &error {
+                                *self.lock_session() = WriterSessionState::Fenced(fence.clone());
+                            }
+                            return NamespaceCommitEnginePublishResult {
+                                results: repeated_error(candidate_count, error),
+                                folded,
+                                wal_tail_segments: 0,
+                                resulting_read_state: None,
+                            };
+                        }
+                    }
+                }
+                Err(error) => {
+                    // A failed fold does not fail the publish.
+                    tracing::info!(
+                        namespace_id = %self.namespace_id,
+                        wal_tail_segments,
+                        error = %error.message(),
+                        "WAL-tail fold failed; continuing the publish"
+                    );
+                }
+            }
+        }
 
         let reject_writes_at_segments = crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS;
         // `wal_tail_segments` is the tail this publish would extend, so
@@ -400,6 +508,7 @@ impl NamespaceCommitEngine {
             };
             return NamespaceCommitEnginePublishResult {
                 results: repeated_error(candidate_count, CoreError::from(error)),
+                folded,
                 wal_tail_segments,
                 resulting_read_state: None,
             };
@@ -436,6 +545,7 @@ impl NamespaceCommitEngine {
         };
         NamespaceCommitEnginePublishResult {
             results: published.results,
+            folded,
             wal_tail_segments,
             resulting_read_state,
         }

--- a/crates/loonfs-core/src/namespace/control_snapshot.rs
+++ b/crates/loonfs-core/src/namespace/control_snapshot.rs
@@ -29,6 +29,7 @@ impl NamespaceControlSnapshot {
 pub(crate) struct LoadedNamespaceBasis {
     pub(crate) head: LoadedHeadObject,
     pub(crate) basis: MetadataBasis,
+    pub(crate) retention_floor_seq: Option<ChangeSeq>,
 }
 
 /// Reads a consistent head and retention floor without reading the root.
@@ -80,6 +81,7 @@ pub(crate) async fn load_head_and_metadata_basis<S: ObjectStore + ?Sized>(
     let root = reads.root.into_loaded();
     Ok(LoadedNamespaceBasis {
         basis: basis_of(&head.state, root.as_ref()),
+        retention_floor_seq: reads.floor_seq,
         head,
     })
 }

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -12,7 +12,9 @@ pub(crate) use self::batch::{
     publish_namespace_commits_batch_against_publish_view, PublishViewEffect,
 };
 pub(crate) use self::changes::list_changes_after;
-pub(crate) use self::publish_view::{load_publish_metadata_view, PublishTailProjection};
+pub(crate) use self::publish_view::{
+    load_publish_metadata_view, PublishMetadataView, PublishTailProjection,
+};
 pub use self::publish_view::{PublishTailOptions, PublishTailWeight};
 pub(crate) use self::uploads::{
     abort_upload, begin_direct_multipart_upload_target, begin_direct_put_upload_target,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -32,6 +32,7 @@ pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     pub(super) acquired_writer: AcquiredWriter,
     manifest_segments: VerifiedMetadataSegments<'a, S>,
     tail_state: Arc<MetadataState>,
+    retention_floor_seq: Option<ChangeSeq>,
 }
 
 impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
@@ -41,6 +42,18 @@ impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
 
     pub(crate) fn content_store_id(&self) -> &ContentStoreId {
         &self.content_store_id
+    }
+
+    pub(crate) fn head(&self) -> &HeadState {
+        &self.head
+    }
+
+    pub(crate) fn manifest_segments(&self) -> &VerifiedMetadataSegments<'_, S> {
+        &self.manifest_segments
+    }
+
+    pub(crate) fn retention_floor_seq(&self) -> Option<ChangeSeq> {
+        self.retention_floor_seq
     }
 
     pub(super) async fn find_commit_receipt(
@@ -161,6 +174,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     let loaded = load_head_and_metadata_basis(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
+    let retention_floor_seq = loaded.retention_floor_seq;
     let head_etag = loaded.head.etag;
     let head = loaded.head.state;
     if head.status.is_deleted() {
@@ -209,6 +223,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
             acquired_writer,
             manifest_segments,
             tail_state,
+            retention_floor_seq,
         },
         projection,
     ))

--- a/crates/loonfs-core/src/test_support.rs
+++ b/crates/loonfs-core/src/test_support.rs
@@ -15,6 +15,52 @@ use bytes::Bytes;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+/// Appends one small commit per WAL segment without folding the tail.
+#[cfg(any(test, feature = "test-support"))]
+pub async fn append_wal_segments<S: loonfs_objectstore::ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &loonfs_api::NamespaceId,
+    count: u64,
+    context: &crate::MutationContext,
+) -> crate::error::Result<()> {
+    let mut engine = crate::publish::NamespaceCommitEngine::new(namespace_id.clone());
+    for _ in 0..count {
+        let commit_id = loonfs_api::CommitId::generate();
+        let path =
+            loonfs_api::AbsolutePath::parse(format!("/wal-tail-{commit_id}")).map_err(|error| {
+                crate::error::CoreError::Internal(format!("test WAL-tail path: {error}"))
+            })?;
+        let request = crate::publish::CommitRequest::single(
+            commit_id,
+            loonfs_api::ActorRef::loonfs_system(),
+            None,
+            crate::publish::FilesystemOperation::CreateDirectory {
+                path,
+                parents: false,
+            },
+        );
+        let mut results = engine
+            .publish_batch(
+                store,
+                vec![crate::publish::CommitCandidate::new(request)],
+                context,
+                &crate::publish::PublishTailOptions::default(),
+            )
+            .await
+            .results;
+        if results.len() != 1 {
+            return Err(crate::error::CoreError::Internal(format!(
+                "test WAL-tail publish returned {count} results for one candidate",
+                count = results.len(),
+            )));
+        }
+        results
+            .pop()
+            .expect("single-candidate test publish should hold one result")?;
+    }
+    Ok(())
+}
+
 /// A call recorded by [`RecordingStoredMetadataBlockCache`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecordedStoredMetadataBlockCall {

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -946,8 +946,15 @@ pub(crate) async fn publish_batch_with_engine(
     // Boxing erases the engine's deeply nested publish future; without
     // it, callers awaiting a put or commit (CLI, server, embedding
     // crates) exceed rustc's type-recursion depth.
-    let mut publish =
-        Box::pin(engine.publish_batch(&store, candidates, &context, &tail_options)).await;
+    let fold_span = phase_span!(core, "wal_fold", namespace_id);
+    let mut publish = Box::pin(engine.publish_batch_with_fold_span(
+        &store,
+        candidates,
+        &context,
+        &tail_options,
+        fold_span,
+    ))
+    .await;
     if !core.control_cache_enabled() {
         // Diagnostic mode: the publisher's engine outlives the publish
         // even with caches off, so drop the tail projection it just
@@ -971,6 +978,10 @@ pub(crate) async fn publish_batch_with_engine(
         }
     }
     let wal_tail_segments = publish.wal_tail_segments;
+    let folded = publish.folded;
+    if folded {
+        core.instruments().publisher_wal_fold();
+    }
     let results = publish
         .results
         .into_iter()
@@ -980,6 +991,7 @@ pub(crate) async fn publish_batch_with_engine(
         namespace_id,
         &NamespacePublication {
             committed_through_seq: highest_committed_seq(&results),
+            folded,
             wal_tail_segments,
         },
     );

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -155,6 +155,8 @@ impl MaintenanceStepReport {
 pub struct NamespacePublication {
     /// Highest sequence committed by the attempt, if any.
     pub committed_through_seq: Option<ChangeSeq>,
+    /// Whether the publish first folded the WAL tail into a manifest.
+    pub folded: bool,
     /// Visible WAL-tail length, or zero if the attempt did not read it.
     pub wal_tail_segments: u64,
 }

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -106,7 +106,7 @@ impl MaintenanceJob for MetadataJob {
     }
 
     fn should_nudge_after_publication(&self, publication: &NamespacePublication) -> bool {
-        self.options.flush_is_due(publication.wal_tail_segments)
+        publication.folded || self.options.flush_is_due(publication.wal_tail_segments)
     }
 
     /// Carries no continuation: what is left to flush or fold is what the

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -608,6 +608,7 @@ async fn a_publication_nudges_only_the_jobs_it_concerns() {
         &namespace_id,
         &NamespacePublication {
             committed_through_seq: None,
+            folded: false,
             wal_tail_segments: 4,
         },
     );
@@ -621,6 +622,7 @@ async fn a_publication_nudges_only_the_jobs_it_concerns() {
         &namespace_id,
         &NamespacePublication {
             committed_through_seq: Some(ChangeSeq(7)),
+            folded: false,
             wal_tail_segments: 5,
         },
     );

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -390,6 +390,14 @@ impl RuntimeInstruments {
         installed.publisher.batch_size.record(batch_size as f64);
     }
 
+    /// Reports one WAL-tail fold on the publication path.
+    pub(crate) fn publisher_wal_fold(&self) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed.publisher.wal_folds.increment(1);
+    }
+
     /// Reports one publication result delivered to its caller.
     pub(crate) fn publisher_publish(&self, outcome: PublishOutcome) {
         let Some(installed) = &self.installed else {
@@ -918,6 +926,7 @@ impl CompactionInstruments {
 /// construction, so all of them register once.
 struct PublisherInstruments {
     batches: Arc<dyn CounterHandle>,
+    wal_folds: Arc<dyn CounterHandle>,
     batch_size: Arc<dyn HistogramHandle>,
     queue_depth: Arc<dyn GaugeHandle>,
     retained_projections: Arc<dyn GaugeHandle>,
@@ -931,6 +940,11 @@ impl PublisherInstruments {
             batches: recorder.register_counter(
                 "loonfs.publisher.batches",
                 "Mutation batches taken for publication",
+                &[],
+            ),
+            wal_folds: recorder.register_counter(
+                "loonfs.publisher.wal_folds",
+                "WAL tails folded on the publication path",
                 &[],
             ),
             batch_size: recorder.register_histogram(
@@ -1313,6 +1327,7 @@ mod tests {
         assert!(fan_out_object_store_recorder(None, instruments.object_store_recorder()).is_none());
 
         instruments.publisher_batch(4);
+        instruments.publisher_wal_fold();
         instruments.publisher_publish(PublishOutcome::Ok);
         instruments.maintenance_step(MaintenanceJobId::GC, MaintenanceStepConclusion::Idle, 1, 2);
     }

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -20,7 +20,7 @@ use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::{ChangeSeq, CommitId, NamespaceId};
 use loonfs_core::cache::Recency;
 use loonfs_core::commit::{CommitFingerprint, CommitHeadPublishError};
-use loonfs_core::limits::CONTENTION_RETRY_LIMIT;
+use loonfs_core::limits::{CHECKPOINT_AT_WAL_SEGMENTS, CONTENTION_RETRY_LIMIT};
 use loonfs_core::publish::{NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState};
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::collections::{HashMap, VecDeque};
@@ -980,6 +980,7 @@ impl NamespacePublisher {
             NamespaceCommitEngine::new(self.namespace_id.clone())
                 .segment_cache(self.read_core.metadata_segment_cache())
                 .writer_session(Arc::clone(&slot.session))
+                .fold_wal_tail_at(std::num::NonZeroU64::new(CHECKPOINT_AT_WAL_SEGMENTS))
         })
     }
 

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -14,12 +14,17 @@ use loonfs::{
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_core::control::load_namespace_metadata_root_control;
+use loonfs_core::test_support::append_wal_segments;
+use loonfs_core::MutationContext;
 use loonfs_objectstore::keys::metadata_manifest_object;
+use loonfs_objectstore::layout::DurableObjectFamily;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
-use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
+use loonfs_test_support::stores::{
+    BlockingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+};
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -56,254 +61,40 @@ async fn writer(root: &Path, background_work: FsBackgroundWork) -> FsWriter {
         .expect("build writer")
 }
 
-async fn fill_wal_tail_past_threshold(writer: &FsWriter, namespace_id: &NamespaceId) {
-    for round in 0..writes_past_wal_tail_threshold() {
-        writer
-            .put_file_bytes(
-                namespace_id,
-                &format!("/docs/file-{round}.txt"),
-                b"body",
-                PutFileOptions::new(loonfs_test_support::test_actor()),
-            )
-            .await
-            .expect("put file");
-    }
+async fn fill_wal_tail_past_threshold<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) {
+    append_wal_segments(
+        store,
+        namespace_id,
+        wal_tail_segment_count_past_threshold(),
+        &MutationContext {
+            writer_id: loonfs_api::WriterId::parse("wal-tail-test-writer").expect("writer id"),
+            now_ms: 1_000,
+        },
+    )
+    .await
+    .expect("fill WAL tail past threshold");
 }
 
 /// Leaves the tail exactly at the write-stop bound: every write here is
 /// admitted, and the next one is not.
-async fn fill_wal_tail_to_write_stop(writer: &FsWriter, namespace_id: &NamespaceId) {
-    let writes = u32::try_from(loonfs_core::limits::MAX_UNFLUSHED_WAL_SEGMENTS)
-        .expect("the WAL write-stop bound should fit in u32");
-    for round in 0..writes {
-        writer
-            .put_file_bytes(
-                namespace_id,
-                &format!("/write-stop/file-{round}.txt"),
-                b"body",
-                PutFileOptions::new(loonfs_test_support::test_actor()),
-            )
-            .await
-            .expect("put file up to the write-stop boundary");
-    }
-}
-
-#[test]
-fn a_threshold_crossing_during_an_active_step_still_bounds_the_tail() {
-    // The interleaving behind the CI failures on the extraction stack: the
-    // first crossing's step is mid-run when more publishes cross the
-    // threshold. Their requests must defer and rerun the step — dropping
-    // them leaves the tail unbounded when those were the last writes before
-    // an idle period.
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("demo");
-    block_on(async {
-        // The root is published by whichever step gets there first: a
-        // create-if-absent for a namespace that has never flushed, a
-        // compare-and-swap after that. Both are the publication this test
-        // holds.
-        let blocking = Arc::new(BlockingStore::new(
-            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::metadata_root(&namespace_id),
-            OperationClass::Put,
-        ));
-        let store: SharedObjectStore = blocking.clone();
-        let writer = FsWriter::builder_with_store(store)
-            .writer_id("handle-test-writer")
-            .background_work(FsBackgroundWork::Enabled)
-            .build()
-            .await
-            .expect("build writer");
-        writer
-            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
-            .await
-            .expect("create namespace");
-
-        // The threshold-crossing publish spawns the step; the armed store
-        // holds that step at its metadata root CAS.
-        blocking.block_next();
-        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
-        blocking.wait_until_blocked().await;
-
-        // A full second threshold's worth of publishes lands while the step
-        // is held; every crossing defers to the running step.
-        for round in 0..writes_past_wal_tail_threshold() {
-            writer
-                .put_file_bytes(
-                    &namespace_id,
-                    &format!("/docs/held/file-{round}.txt"),
-                    b"body",
-                    PutFileOptions::new(loonfs_test_support::test_actor()),
-                )
-                .await
-                .expect("put file during held step");
-        }
-
-        blocking.release();
-        writer
-            .flush_background()
-            .await
-            .expect("background maintenance quiesces");
-
-        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
-            .actor_id("handle-test-admin")
-            .build()
-            .await
-            .expect("build admin");
-        let status = admin
-            .get_namespace_diagnostics(&namespace_id)
-            .await
-            .expect("status after deferred rerun");
-        assert!(
-            status.wal_tail_segments < wal_tail_segment_threshold(),
-            "deferred crossings must rerun the step and bound the tail: {status:?}"
-        );
-        writer
-            .shutdown()
-            .await
-            .expect("shut down writer background work");
-    });
-}
-
-#[test]
-fn a_step_queued_at_the_global_cap_runs_without_another_publish() {
-    let temp_dir = tempdir().expect("tempdir");
-    let active_namespace = namespace_id("active");
-    let queued_namespace = namespace_id("queued");
-    block_on(async {
-        // The root is published by whichever step gets there first: a
-        // create-if-absent for a namespace that has never flushed, a
-        // compare-and-swap after that. Both are the publication this test
-        // holds.
-        let blocking = Arc::new(BlockingStore::new(
-            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::metadata_root(&active_namespace),
-            OperationClass::Put,
-        ));
-        let store: SharedObjectStore = blocking.clone();
-        let writer = FsWriter::builder_with_store(store)
-            .writer_id("handle-test-writer")
-            .background_work(FsBackgroundWork::Enabled)
-            .max_concurrent_maintenance(1)
-            .build()
-            .await
-            .expect("build writer");
-        for namespace_id in [&active_namespace, &queued_namespace] {
-            writer
-                .create_namespace(namespace_id, CreateNamespaceOptions::default())
-                .await
-                .expect("create namespace");
-        }
-
-        blocking.block_next();
-        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
-        blocking.wait_until_blocked().await;
-        fill_wal_tail_past_threshold(&writer, &queued_namespace).await;
-
-        blocking.release();
-        writer
-            .flush_background()
-            .await
-            .expect("queued maintenance quiesces");
-
-        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
-            .actor_id("handle-test-admin")
-            .build()
-            .await
-            .expect("build admin");
-        let status = admin
-            .get_namespace_diagnostics(&queued_namespace)
-            .await
-            .expect("queued namespace status");
-        assert!(
-            status.wal_tail_segments < wal_tail_segment_threshold(),
-            "the queued step must run without another publish: {status:?}"
-        );
-        writer
-            .shutdown()
-            .await
-            .expect("shut down writer background work");
-    });
-}
-
-#[test]
-fn a_write_stopped_namespace_queued_at_the_global_cap_unblocks_itself() {
-    let temp_dir = tempdir().expect("tempdir");
-    let active_namespace = namespace_id("active");
-    let write_stopped_namespace = namespace_id("write-stopped");
-    block_on(async {
-        // The root is published by whichever step gets there first: a
-        // create-if-absent for a namespace that has never flushed, a
-        // compare-and-swap after that. Both are the publication this test
-        // holds.
-        let blocking = Arc::new(BlockingStore::new(
-            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::metadata_root(&active_namespace),
-            OperationClass::Put,
-        ));
-        let store: SharedObjectStore = blocking.clone();
-        let writer = FsWriter::builder_with_store(store)
-            .writer_id("handle-test-writer")
-            .background_work(FsBackgroundWork::Enabled)
-            .max_concurrent_maintenance(1)
-            .build()
-            .await
-            .expect("build writer");
-        for namespace_id in [&active_namespace, &write_stopped_namespace] {
-            writer
-                .create_namespace(namespace_id, CreateNamespaceOptions::default())
-                .await
-                .expect("create namespace");
-        }
-
-        blocking.block_next();
-        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
-        blocking.wait_until_blocked().await;
-        fill_wal_tail_to_write_stop(&writer, &write_stopped_namespace).await;
-        let error = writer
-            .put_file_bytes(
-                &write_stopped_namespace,
-                "/write-stop/rejected.txt",
-                b"body",
-                PutFileOptions::new(loonfs_test_support::test_actor()),
-            )
-            .await
-            .expect_err("writes against a tail at the hard limit must reject");
-        assert_eq!(error.code(), ErrorCode::MaintenanceRequired);
-
-        blocking.release();
-        writer
-            .flush_background()
-            .await
-            .expect("queued maintenance quiesces");
-
-        writer
-            .put_file_bytes(
-                &write_stopped_namespace,
-                "/write-stop/rejected.txt",
-                b"body",
-                PutFileOptions::new(loonfs_test_support::test_actor()),
-            )
-            .await
-            .expect("the queued step must unblock writes without another publish");
-        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
-            .actor_id("handle-test-admin")
-            .build()
-            .await
-            .expect("build admin");
-        let status = admin
-            .get_namespace_diagnostics(&write_stopped_namespace)
-            .await
-            .expect("write-stopped namespace status");
-        assert!(
-            status.wal_tail_segments < wal_tail_segment_threshold(),
-            "the queued step must flush the write-stopped tail before the retry: {status:?}"
-        );
-        writer
-            .shutdown()
-            .await
-            .expect("shut down writer background work");
-    });
+async fn fill_wal_tail_to_write_stop<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) {
+    append_wal_segments(
+        store,
+        namespace_id,
+        loonfs_core::limits::MAX_UNFLUSHED_WAL_SEGMENTS,
+        &MutationContext {
+            writer_id: loonfs_api::WriterId::parse("wal-tail-test-writer").expect("writer id"),
+            now_ms: 1_000,
+        },
+    )
+    .await
+    .expect("fill WAL tail to write-stop bound");
 }
 
 #[test]
@@ -322,7 +113,7 @@ fn shutdown_clears_a_non_empty_maintenance_queue_without_spawning_it() {
             OperationClass::Put,
         ));
         let store: SharedObjectStore = blocking.clone();
-        let writer = FsWriter::builder_with_store(store)
+        let writer = FsWriter::builder_with_store(store.clone())
             .writer_id("handle-test-writer")
             .background_work(FsBackgroundWork::Enabled)
             .max_concurrent_maintenance(1)
@@ -336,10 +127,16 @@ fn shutdown_clears_a_non_empty_maintenance_queue_without_spawning_it() {
                 .expect("create namespace");
         }
 
+        fill_wal_tail_past_threshold(blocking.as_ref(), &active_namespace).await;
         blocking.block_next();
-        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
+        writer
+            .maintenance()
+            .nudge(MaintenanceJobId::METADATA, &active_namespace);
         blocking.wait_until_blocked().await;
-        fill_wal_tail_past_threshold(&writer, &queued_namespace).await;
+        fill_wal_tail_past_threshold(blocking.as_ref(), &queued_namespace).await;
+        writer
+            .maintenance()
+            .nudge(MaintenanceJobId::METADATA, &queued_namespace);
 
         let mut shutdown = Box::pin(writer.shutdown());
         assert!(
@@ -531,14 +328,22 @@ fn admin_over_writer_core_invalidates_shared_caches() {
             .await
             .expect("create namespace");
         let reader = writer.reader();
-        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+        for round in 0..writes_past_wal_tail_threshold() {
+            writer
+                .put_file_bytes(
+                    &namespace_id,
+                    &format!("/docs/file-{round}.txt"),
+                    b"body",
+                    PutFileOptions::new(loonfs_test_support::test_actor()),
+                )
+                .await
+                .expect("put file");
+        }
         writer
             .flush_background()
             .await
             .expect("background maintenance quiesces");
 
-        // The scheduled step ran: it published a manifest and bounded the
-        // tail, both through the writer's own runtime.
         let admin = FsAdmin::builder(store_config(temp_dir.path()))
             .actor_id("handle-test-admin")
             .build()
@@ -665,7 +470,7 @@ fn put_file_bytes_and_prepare_then_put_commit_equivalent_state() {
 }
 
 #[test]
-fn manual_only_writer_never_schedules_maintenance() {
+fn manual_only_writer_folds_without_scheduling_maintenance() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     block_on(async {
@@ -674,7 +479,17 @@ fn manual_only_writer_never_schedules_maintenance() {
             .create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("create namespace");
-        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+        for round in 0..=(wal_tail_segment_threshold() * 2) {
+            writer
+                .put_file_bytes(
+                    &namespace_id,
+                    &format!("/docs/file-{round}.txt"),
+                    b"body",
+                    PutFileOptions::new(loonfs_test_support::test_actor()),
+                )
+                .await
+                .expect("put file");
+        }
         writer
             .flush_background()
             .await
@@ -690,35 +505,13 @@ fn manual_only_writer_never_schedules_maintenance() {
             .await
             .expect("status after writes");
         assert_eq!(
-            status.current_manifest_no, None,
-            "manual-only writer must not publish checkpoints: {status:?}"
-        );
-        assert!(
-            status.wal_tail_segments >= wal_tail_segment_count_past_threshold(),
-            "manual-only writer must leave the tail alone: {status:?}"
-        );
-
-        // Explicit admin maintenance bounds the tail the writer left.
-        let step = admin
-            .maintain_metadata(&namespace_id, MetadataMaintenanceOptions::default())
-            .await
-            .expect("explicit maintenance step");
-        assert_ne!(
-            step.wal_flush,
-            loonfs::WalFlushStepOutcome::NotNeeded,
-            "step should act on the oversized tail"
-        );
-        let status = admin
-            .get_namespace_diagnostics(&namespace_id)
-            .await
-            .expect("status after explicit step");
-        assert!(
-            status.current_manifest_no.is_some(),
-            "explicit step should publish a manifest: {status:?}"
+            status.current_manifest_no,
+            Some(ManifestNo(2)),
+            "the writer should have folded twice without a maintenance runner: {status:?}"
         );
         assert!(
             status.wal_tail_segments < wal_tail_segment_threshold(),
-            "explicit step should bound the tail: {status:?}"
+            "the writer must keep its own tail below the fold threshold: {status:?}"
         );
     });
 }
@@ -772,7 +565,17 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
             );
             assert_eq!(status.wal_tail_segments, 1, "{status:?}");
 
-            fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+            for round in 0..writes_past_wal_tail_threshold() {
+                writer
+                    .put_file_bytes(
+                        &namespace_id,
+                        &format!("/docs/file-{round}.txt"),
+                        b"body",
+                        PutFileOptions::new(loonfs_test_support::test_actor()),
+                    )
+                    .await
+                    .expect("put file");
+            }
             writer
                 .flush_background()
                 .await
@@ -799,7 +602,7 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
 }
 
 #[test]
-fn a_refused_publish_schedules_the_step_that_relieves_the_debt() {
+fn a_runtime_publish_folds_a_preexisting_write_stopped_tail_and_lands() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     block_on(async {
@@ -813,41 +616,14 @@ fn a_refused_publish_schedules_the_step_that_relieves_the_debt() {
             .create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("create namespace");
-        fill_wal_tail_to_write_stop(&stalled, &namespace_id).await;
+        let tail_store = LocalFsStore::new(temp_dir.path()).expect("open tail store");
+        fill_wal_tail_to_write_stop(&tail_store, &namespace_id).await;
         stalled
             .shutdown()
             .await
             .expect("shut down the first writer");
 
         let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
-        let refused = writer
-            .put_file_bytes(
-                &namespace_id,
-                "/write-stop/refused.txt",
-                b"body",
-                PutFileOptions::new(loonfs_test_support::test_actor()),
-            )
-            .await
-            .expect_err("a tail at the write-stop bound refuses the publish");
-        assert_eq!(refused.code(), ErrorCode::MaintenanceRequired);
-
-        writer
-            .flush_background()
-            .await
-            .expect("the step the refusal asked for settles");
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
-            .build()
-            .await
-            .expect("build admin");
-        let status = admin
-            .get_namespace_diagnostics(&namespace_id)
-            .await
-            .expect("status after the refused publish");
-        assert!(
-            status.wal_tail_segments < wal_tail_segment_threshold(),
-            "the refused publish must schedule the flush that unblocks it: {status:?}"
-        );
         writer
             .put_file_bytes(
                 &namespace_id,
@@ -856,11 +632,103 @@ fn a_refused_publish_schedules_the_step_that_relieves_the_debt() {
                 PutFileOptions::new(loonfs_test_support::test_actor()),
             )
             .await
-            .expect("the retry lands once the debt is cleared");
+            .expect("the runtime publish folds the preexisting tail and lands");
+        let admin = FsAdmin::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .get_namespace_diagnostics(&namespace_id)
+            .await
+            .expect("status after the folding publish");
+        assert_eq!(status.wal_tail_segments, 1, "{status:?}");
+        assert!(status.current_manifest_no.is_some(), "{status:?}");
         writer
             .shutdown()
             .await
             .expect("shut down writer background work");
+    });
+}
+
+#[test]
+fn a_failed_fold_preserves_the_write_stop_until_the_store_recovers() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    block_on(async {
+        let failing = Arc::new(FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::family(DurableObjectFamily::MetadataManifest),
+            OperationClass::Put,
+            InjectedError::PermissionDenied("manifest writes disabled".to_owned()),
+        ));
+        let store: SharedObjectStore = failing.clone();
+        let writer = FsWriter::builder_with_store(store)
+            .writer_id("fold-failure-writer")
+            .background_work(FsBackgroundWork::ManualOnly)
+            .build()
+            .await
+            .expect("build writer");
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        let seed_segments = wal_tail_segment_threshold() - 1;
+        append_wal_segments(
+            failing.as_ref(),
+            &namespace_id,
+            seed_segments,
+            &MutationContext {
+                writer_id: loonfs_api::WriterId::parse("fold-failure-seed").expect("writer id"),
+                now_ms: 1_000,
+            },
+        )
+        .await
+        .expect("seed WAL tail below fold threshold");
+
+        failing.fail_all();
+        for round in 0..(loonfs_core::limits::MAX_UNFLUSHED_WAL_SEGMENTS - seed_segments) {
+            writer
+                .put_file_bytes(
+                    &namespace_id,
+                    &format!("/failed-fold/file-{round}.txt"),
+                    b"body",
+                    PutFileOptions::new(loonfs_test_support::test_actor()),
+                )
+                .await
+                .expect("publishes below the write-stop bound continue after a failed fold");
+        }
+        let error = writer
+            .put_file_bytes(
+                &namespace_id,
+                "/failed-fold/refused.txt",
+                b"body",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect_err("the write-stop invariant still refuses the full tail");
+        assert_eq!(error.code(), ErrorCode::MaintenanceRequired);
+
+        failing.clear();
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                "/failed-fold/recovered.txt",
+                b"body",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("the recovered manifest store lets the next publish fold and land");
+        let admin = FsAdmin::builder_with_store(failing as SharedObjectStore)
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .get_namespace_diagnostics(&namespace_id)
+            .await
+            .expect("status after fold recovery");
+        assert_eq!(status.wal_tail_segments, 1, "{status:?}");
     });
 }
 

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -17,6 +17,8 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_api::{AdvanceRetentionRequest, GcRequest, MetadataCompactionRequest};
+use loonfs_core::test_support::append_wal_segments;
+use loonfs_core::MutationContext;
 use loonfs_objectstore::keys::{
     checkpoint_prefix, metadata_manifest_object, wal_head, wal_segment_prefix,
 };
@@ -191,15 +193,16 @@ fn a_head_that_under_describes_its_tail_is_repaired_by_an_explicit_flush() {
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    for revision in 0..LEGACY_RECENT_SEGMENTS + 4 {
-        fs.put_file_bytes_blocking(
-            &namespace_id,
-            &format!("/docs/hello-{revision}.txt"),
-            format!("rev {revision}").as_bytes(),
-            PutFileOptions::new(loonfs_test_support::test_actor()),
-        )
-        .expect("put file");
-    }
+    block_on(append_wal_segments(
+        store.as_ref(),
+        &namespace_id,
+        u64::try_from(LEGACY_RECENT_SEGMENTS + 4).expect("segment count"),
+        &MutationContext {
+            writer_id: loonfs_api::WriterId::parse("legacy-tail-writer").expect("writer id"),
+            now_ms: 1_000,
+        },
+    ))
+    .expect("build legacy WAL tail");
     truncate_recent_segments(&store, &namespace_id, LEGACY_RECENT_SEGMENTS);
 
     let error = fs

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -117,6 +117,11 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
         counter(&snapshot, "loonfs.publisher.batches", &[]),
         "every batch taken files its size"
     );
+    assert_eq!(
+        counter(&snapshot, "loonfs.publisher.wal_folds", &[]),
+        1,
+        "the threshold-crossing publish records its fold"
+    );
 
     // The runner: a write nudges the metadata job, and whatever it
     // concluded, the step settled under its own job label.

--- a/crates/loonfs/tests/tracing_capture.rs
+++ b/crates/loonfs/tests/tracing_capture.rs
@@ -15,9 +15,12 @@
 //! installed, and the assertion is deterministic.
 
 use loonfs::{
-    CreateNamespaceOptions, FsBackgroundWork, FsWriter, MetadataMaintenanceOptions, NamespaceId,
-    PutFileOptions, StoreConfig,
+    CreateNamespaceOptions, FsBackgroundWork, FsWriter, MaintenanceJobId,
+    MetadataMaintenanceOptions, NamespaceId, StoreConfig,
 };
+use loonfs_core::test_support::append_wal_segments;
+use loonfs_core::MutationContext;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use std::path::Path;
@@ -51,18 +54,19 @@ async fn writer(root: &Path) -> FsWriter {
         .expect("build writer")
 }
 
-async fn fill_wal_tail_past_threshold(writer: &FsWriter, namespace_id: &NamespaceId) {
-    for round in 0..writes_past_wal_tail_threshold() {
-        writer
-            .put_file_bytes(
-                namespace_id,
-                &format!("/docs/file-{round}.txt"),
-                b"body",
-                PutFileOptions::new(loonfs_test_support::test_actor()),
-            )
-            .await
-            .expect("put file");
-    }
+async fn fill_wal_tail_past_threshold(root: &Path, namespace_id: &NamespaceId) {
+    let store = LocalFsStore::new(root).expect("open tail store");
+    append_wal_segments(
+        &store,
+        namespace_id,
+        u64::from(writes_past_wal_tail_threshold()),
+        &MutationContext {
+            writer_id: loonfs_api::WriterId::parse("tracing-tail-writer").expect("writer id"),
+            now_ms: 1_000,
+        },
+    )
+    .await
+    .expect("fill WAL tail past threshold");
 }
 
 struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
@@ -102,7 +106,10 @@ fn background_step_conclusions_emit_debug_events() {
             .create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("create namespace");
-        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+        fill_wal_tail_past_threshold(temp_dir.path(), &namespace_id).await;
+        writer
+            .maintenance()
+            .nudge(MaintenanceJobId::METADATA, &namespace_id);
         writer
             .flush_background()
             .await

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -88,7 +88,7 @@ provider outage does not make every namespace retry at the same time.
 
 | Job | Step | Admission |
 | --- | --- | --- |
-| `metadata` | Flush the WAL tail when needed, then perform one bounded reorganization step. | Automatic after publication. |
+| `metadata` | Merge one bounded reorganization unit; flush a WAL tail another writer left behind. | Automatic after a fold. |
 | `gc` | Perform one bounded mark-and-sweep pass. | Automatic after publication or when a lease or grace period expires. |
 | `grep-index` | Build or reorganize one bounded unit of the grep index. | Automatic on hosts configured to maintain the index. |
 | `grep-gc` | Inspect one bounded part of a namespace's grep objects. | Runs only when explicitly requested. |

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2138,8 +2138,8 @@ Maintenance keeps read cost bounded, retention safe, and durable state clean.
 Maintenance **effects** are normative format semantics; maintenance
 **scheduling and triggering** are not. Two behaviors keep an un-administered
 deployment's read costs bounded regardless of scheduling: the reference
-implementation nudges its maintenance runner after any runtime publish that
-observes the WAL tail at or past the WAL-tail policy's checkpoint threshold
+implementation's writer folds the WAL tail into a manifest before a publish
+that observes the tail at or past the WAL-tail policy's checkpoint threshold
 (32 segments at defaults), and every publish surface rejects with
 `maintenance_required` once the tail reaches the same policy's
 write-rejection threshold (128 at defaults). Reads never gate on tail


### PR DESCRIPTION
Writers now fold an oversized WAL tail into a manifest before publishing another commit. The fold uses the writer’s in-memory metadata projection instead of reading the WAL again, so writers can keep accepting commits without depending on a background maintenance runner.

A root conflict falls back to the existing store-based flush. Other fold failures do not fail the pending commit unless the WAL has reached the existing hard limit. Successful folds schedule metadata maintenance to merge the new delta run. The explicit WAL flush remains available for tails left by writers that are no longer running.