### PR TITLE
refactor(core): replace FsAdmin with FsMaintenance

### DIFF
--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -748,7 +748,7 @@ impl ResolvedTarget {
         match self {
             Self::Embedded(target) => target
                 .backend
-                .admin
+                .writer
                 .release_snapshot(namespace_id, snapshot_id)
                 .await
                 .scoped(namespace_id),
@@ -812,7 +812,7 @@ impl ResolvedTarget {
         match self {
             Self::Embedded(target) => target
                 .backend
-                .admin
+                .maintenance
                 .release_checkpoint(namespace_id, checkpoint_id)
                 .await
                 .scoped(namespace_id),

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -8,11 +8,11 @@ use crate::render::write_stderr_warning;
 use loonfs::{
     ByteStream, CheckpointPageCursor, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, CreateSnapshotOptions, DeleteNamespaceOptions, DeleteNamespaceResponse,
-    DeleteOptions, FsAdmin, FsReader, FsWriter, ListChangesOptions as RuntimeListChangesOptions,
-    ListChangesResponse, ListPathEntriesOptions, MaintenanceHandle, MaintenanceJob,
-    MaintenanceJobId, MaintenanceStepConclusion, MoveOptions, PutFileOptions,
-    RestoreRevisionOptions, RuntimeError, SharedObjectStore, StatPathOptions, UndeleteOptions,
-    UpdateAttributesOptions,
+    DeleteOptions, FsMaintenance, FsReader, FsWriter,
+    ListChangesOptions as RuntimeListChangesOptions, ListChangesResponse, ListPathEntriesOptions,
+    MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenanceStepConclusion, MoveOptions,
+    PutFileOptions, RestoreRevisionOptions, RuntimeError, SharedObjectStore, StatPathOptions,
+    UndeleteOptions, UpdateAttributesOptions,
 };
 use loonfs_api::{
     v0::{
@@ -39,7 +39,7 @@ use super::{GrepWaitProgress, MaintenanceDrainProgress, MaintenanceKeyProgress, 
 
 /// Purpose-specific handles over one shared store client: reads go through
 /// the reader, mutations through the writer, and maintenance through the
-/// admin handle. The embedded writer runs `FsBackgroundWork::Enabled` — the
+/// maintenance handle. The embedded writer runs `FsBackgroundWork::Enabled` — the
 /// same policy as the reference server — so a publish that crosses the WAL
 /// threshold schedules its own maintenance step, and every mutation settles
 /// scheduled work before the one-shot process exits. A publish gated on
@@ -50,7 +50,7 @@ use super::{GrepWaitProgress, MaintenanceDrainProgress, MaintenanceKeyProgress, 
 pub(crate) struct EmbeddedBackend {
     pub(crate) writer: FsWriter,
     pub(crate) reader: FsReader,
-    pub(crate) admin: FsAdmin,
+    pub(crate) maintenance: FsMaintenance,
     /// Grep is composed here rather than by the runtime: this service owns
     /// the query side for the length of the command.
     pub(crate) grep: GrepService,
@@ -128,12 +128,12 @@ impl EmbeddedBackend {
 
     /// A grep worker over this backend's own handles: grep's keyspace rides
     /// the writer's store client, its filesystem reads the reader, and its
-    /// backfill checkpoints the admin handle.
+    /// backfill checkpoints the maintenance handle.
     pub(super) fn grep_worker(&self) -> GrepWorker<SharedObjectStore> {
         GrepWorker::with_block_cache(
             self.writer.object_store(),
             self.reader.clone(),
-            self.admin.clone(),
+            self.maintenance.clone(),
             Arc::clone(&self.grep_block_cache),
         )
     }
@@ -463,7 +463,7 @@ impl EmbeddedBackend {
     /// counts below a lie — and then walks the assignment, carrying each
     /// key's continuation from one step to the next exactly as the runner
     /// would have. Shutting the writer down does not disarm the steps: a
-    /// job compare-and-swaps the namespace head through `FsAdmin`, never
+    /// job compare-and-swaps the namespace head through `FsMaintenance`, never
     /// through the publication service the shutdown closed.
     pub(super) async fn drain_maintenance(
         &self,
@@ -738,7 +738,7 @@ impl EmbeddedBackend {
         let now_ms = validate_embedded_snapshot_ttl(namespace_id, ttl_ms)?;
         let expires_at_ms = now_ms.saturating_add(ttl_ms);
         let checkpoint = self
-            .admin
+            .writer
             .create_snapshot_with_quota(
                 namespace_id,
                 CreateSnapshotOptions {
@@ -776,7 +776,7 @@ impl EmbeddedBackend {
                     CliError::invalid_request(error.to_string()).with_param("cursor")
                 })?,
         };
-        self.admin
+        self.reader
             .list_snapshots_page(namespace_id, request)
             .await
             .scoped(namespace_id)
@@ -789,7 +789,7 @@ impl EmbeddedBackend {
         ttl_ms: u64,
     ) -> Result<SnapshotSummary, CliError> {
         let now_ms = validate_embedded_snapshot_ttl(namespace_id, ttl_ms)?;
-        self.admin
+        self.writer
             .extend_snapshot(
                 namespace_id,
                 snapshot_id,
@@ -810,7 +810,7 @@ impl EmbeddedBackend {
         namespace_id: &NamespaceId,
         request: CreateCheckpointRequest,
     ) -> Result<Checkpoint, CliError> {
-        self.admin
+        self.maintenance
             .create_checkpoint(namespace_id, CreateCheckpointOptions::from_request(request))
             .await
             .scoped(namespace_id)
@@ -837,7 +837,7 @@ impl EmbeddedBackend {
                     CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
                 })?,
         };
-        self.admin
+        self.maintenance
             .list_checkpoints_page(namespace_id, request)
             .await
             .scoped(namespace_id)
@@ -848,7 +848,10 @@ impl EmbeddedBackend {
         namespace_id: &NamespaceId,
         request: MaintenanceRunRequest,
     ) -> Result<MaintenanceRunResponse, CliError> {
-        let result = self.admin.run_maintenance(namespace_id, request).await;
+        let result = self
+            .maintenance
+            .run_maintenance(namespace_id, request)
+            .await;
         let invalid_threshold = matches!(&result, Err(RuntimeError::Config(_)));
         let result = result.scoped(namespace_id);
         if invalid_threshold {
@@ -1189,7 +1192,7 @@ mod tests {
         for namespace_id in [&indexed, &unindexed] {
             let status = target
                 .backend
-                .admin
+                .maintenance
                 .get_namespace_diagnostics(namespace_id)
                 .await
                 .expect("diagnostics after the drain");
@@ -1305,7 +1308,7 @@ mod tests {
         // host left rather than a race with it.
         let status = target
             .backend
-            .admin
+            .maintenance
             .get_namespace_diagnostics(&namespace)
             .await
             .expect("diagnostics after hosting");

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -10,7 +10,8 @@ use crate::config::{
 use crate::error::CliError;
 use crate::profiles::default_namespace;
 use loonfs::{
-    DecodedBlockCacheConfig, FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreKind,
+    DecodedBlockCacheConfig, FsBackgroundWork, FsMaintenance, FsWriter, SharedObjectStore,
+    TraceStoreKind,
 };
 use loonfs_api::{ActorId, ActorKind, ActorRef, NamespaceId, SecretString};
 use loonfs_client::Client;
@@ -228,7 +229,7 @@ impl EmbeddedTarget {
             .await
             .map_err(map_runtime_error)?;
         let reader = writer.reader();
-        let admin = FsAdmin::builder_with_store(store)
+        let maintenance = FsMaintenance::builder_with_store(store)
             .actor_id(writer_id)
             .trace_store_kind(trace_store_kind)
             .build()
@@ -240,7 +241,7 @@ impl EmbeddedTarget {
         let backend = EmbeddedBackend {
             writer,
             reader,
-            admin,
+            maintenance,
             // Embedded mode composes grep itself: the runtime handles above
             // know nothing about it.
             grep: GrepService::new(Arc::clone(&grep_block_cache)),

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -25,9 +25,9 @@ use futures::StreamExt as _;
 use loonfs::{
     delete_if_aged, ensure_metadata_publication_budget, next_run_no_after, refill_iterators,
     select_next_iterator, write_segments_in_waves, CheckpointFilesPageCursor, CoreError,
-    CreateCheckpointOptions, FsAdmin, FsReader, GcCursorKeyspace, GraceAge, NamespaceGcCursor,
-    PassBudget, RuntimeError, SegmentBlockLoader, SegmentRowIterator, StoreFailureClass,
-    DEFAULT_GC_MAX_OBJECTS, GC_DEFAULT_GRACE_WINDOW_MS, GC_MIN_GRACE_WINDOW_MS,
+    CreateCheckpointOptions, FsMaintenance, FsReader, GcCursorKeyspace, GraceAge,
+    NamespaceGcCursor, PassBudget, RuntimeError, SegmentBlockLoader, SegmentRowIterator,
+    StoreFailureClass, DEFAULT_GC_MAX_OBJECTS, GC_DEFAULT_GRACE_WINDOW_MS, GC_MIN_GRACE_WINDOW_MS,
 };
 use loonfs_api::v0::{FilesystemChange, GrepIndex, GrepIndexLifecycle};
 use loonfs_api::wire::sst_blocks::{
@@ -201,14 +201,14 @@ pub struct GrepGcReport {
 /// Bounded writer for grep-owned durable state.
 ///
 /// The worker writes only grep keys. It reads namespace state through
-/// `FsReader` and creates or releases backfill checkpoints through `FsAdmin`,
-/// preserving the admin handle's actor identity. Scheduling is external to
+/// `FsReader` and creates or releases backfill checkpoints through `FsMaintenance`,
+/// preserving the maintenance handle's actor identity. Scheduling is external to
 /// this type.
 #[derive(Clone)]
 pub struct GrepWorker<S> {
     store: S,
     reader: FsReader,
-    admin: FsAdmin,
+    maintenance: FsMaintenance,
     block_cache: Arc<GrepBlockCache>,
 }
 
@@ -227,11 +227,11 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     /// Creates a worker over one grep-keyspace store handle and the runtime
     /// handles it reads and checkpoints through, with a fresh default-sized
     /// block cache.
-    pub fn new(store: S, reader: FsReader, admin: FsAdmin) -> Self {
+    pub fn new(store: S, reader: FsReader, maintenance: FsMaintenance) -> Self {
         Self::with_block_cache(
             store,
             reader,
-            admin,
+            maintenance,
             Arc::new(GrepBlockCache::new(
                 loonfs::DecodedBlockCacheConfig::with_max_decoded_bytes(
                     DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
@@ -244,13 +244,13 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     pub fn with_block_cache(
         store: S,
         reader: FsReader,
-        admin: FsAdmin,
+        maintenance: FsMaintenance,
         block_cache: Arc<GrepBlockCache>,
     ) -> Self {
         Self {
             store,
             reader,
-            admin,
+            maintenance,
             block_cache,
         }
     }
@@ -475,7 +475,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
     ) -> Result<loonfs_api::Checkpoint> {
         Ok(self
-            .admin
+            .maintenance
             .create_checkpoint(
                 namespace_id,
                 CreateCheckpointOptions {
@@ -491,7 +491,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         checkpoint_id: &CheckpointId,
     ) -> Result<()> {
-        self.admin
+        self.maintenance
             .release_checkpoint(namespace_id, checkpoint_id)
             .await?;
         Ok(())

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -7,7 +7,9 @@
 
 #![allow(dead_code)]
 
-use loonfs::{FsAdmin, FsReader, MaintenanceJob, MaintenanceStepConclusion, SharedObjectStore};
+use loonfs::{
+    FsMaintenance, FsReader, MaintenanceJob, MaintenanceStepConclusion, SharedObjectStore,
+};
 use loonfs_api::v0::{GrepIndex, GrepIndexLifecycle};
 use loonfs_api::{
     ChangeSeq, EffectiveLimit, GrepRequest, GrepResponse, NamespaceId, PaginationPolicy, RunNo,
@@ -23,7 +25,7 @@ use std::sync::Arc;
 pub(crate) struct GrepHost {
     pub(crate) store: SharedObjectStore,
     pub(crate) reader: FsReader,
-    pub(crate) admin: FsAdmin,
+    pub(crate) maintenance: FsMaintenance,
     pub(crate) service: GrepService,
     pub(crate) worker: GrepWorker<SharedObjectStore>,
     pub(crate) block_cache: Arc<GrepBlockCache>,
@@ -35,11 +37,11 @@ impl GrepHost {
             .build()
             .await
             .expect("build reader");
-        let admin = FsAdmin::builder_with_store(store.clone())
+        let maintenance = FsMaintenance::builder_with_store(store.clone())
             .actor_id(actor)
             .build()
             .await
-            .expect("build admin");
+            .expect("build maintenance");
         let block_cache = Arc::new(GrepBlockCache::new(
             loonfs::DecodedBlockCacheConfig::with_max_decoded_bytes(
                 DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
@@ -48,12 +50,12 @@ impl GrepHost {
         Self {
             store: store.clone(),
             reader: reader.clone(),
-            admin: admin.clone(),
+            maintenance: maintenance.clone(),
             service: GrepService::new(Arc::clone(&block_cache)),
             worker: GrepWorker::with_block_cache(
                 store.clone(),
                 reader,
-                admin,
+                maintenance,
                 Arc::clone(&block_cache),
             ),
             block_cache,

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -92,7 +92,7 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-admin").await;
+    let host = GrepHost::new(&store, "grams-maintenance").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -196,7 +196,7 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-auto-admin").await;
+    let host = GrepHost::new(&store, "grams-auto-maintenance").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -269,7 +269,7 @@ async fn a_worker_policy_bounds_each_build_step() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-config-admin").await;
+    let host = GrepHost::new(&store, "grams-config-maintenance").await;
     let policy = GramIndexBuildPolicy {
         max_files_per_step: nonzero_usize(3),
         ..GramIndexBuildPolicy::default()
@@ -338,7 +338,7 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-thousand-admin").await;
+    let host = GrepHost::new(&store, "grams-thousand-maintenance").await;
     let first_worker = &host.worker;
 
     writer
@@ -572,7 +572,7 @@ async fn grep_answers_identically_across_tiered_reorganizations() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-tiered-admin").await;
+    let host = GrepHost::new(&store, "grams-tiered-maintenance").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -650,7 +650,7 @@ async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-cache-admin").await;
+    let host = GrepHost::new(&store, "grams-cache-maintenance").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -721,7 +721,7 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-fault-admin").await;
+    let host = GrepHost::new(&store, "grams-fault-maintenance").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -831,7 +831,7 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-oversized-admin").await;
+    let host = GrepHost::new(&store, "grams-oversized-maintenance").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -953,7 +953,7 @@ async fn worker_and_service_share_decoded_index_blocks() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-shared-cache-admin").await;
+    let host = GrepHost::new(&store, "grams-shared-cache-maintenance").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -1043,7 +1043,7 @@ async fn a_cold_reorganization_fans_out_its_segment_opens_within_the_io_cap() {
         .build()
         .await
         .expect("build writer");
-    let host = GrepHost::new(&store, "grams-fan-out-admin").await;
+    let host = GrepHost::new(&store, "grams-fan-out-maintenance").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())

--- a/crates/loonfs-grep/tests/it/grep_service_differential.rs
+++ b/crates/loonfs-grep/tests/it/grep_service_differential.rs
@@ -7,8 +7,8 @@ use crate::common::{control, default_page_limit, grep_with, page_limit, GrepHost
 use loonfs::publish::{CommitCandidate, CommitRequest, FilesystemOperation};
 use loonfs::{
     CommitId, CoreError, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions,
-    DestinationBehavior, FsAdmin, FsReader, FsWriter, MetadataMaintenanceOptions, MoveOptions,
-    NamespaceId, PutFileOptions, SharedObjectStore,
+    DestinationBehavior, FsMaintenance, FsReader, FsWriter, MetadataMaintenanceOptions,
+    MoveOptions, NamespaceId, PutFileOptions, SharedObjectStore,
 };
 use loonfs_api::{AbsolutePath, EffectiveLimit, GrepRequest, GrepResponse};
 use loonfs_grep::root::load_grep_root;
@@ -184,7 +184,7 @@ struct PlanlessBoundaryFixture {
     store: SharedObjectStore,
     namespace_id: NamespaceId,
     writer: FsWriter,
-    admin: FsAdmin,
+    maintenance: FsMaintenance,
 }
 
 async fn planless_boundary_fixture(namespace: &str) -> PlanlessBoundaryFixture {
@@ -198,11 +198,11 @@ async fn planless_boundary_fixture(namespace: &str) -> PlanlessBoundaryFixture {
         .build()
         .await
         .expect("build writer");
-    let admin = FsAdmin::builder_with_store(store.clone())
-        .actor_id("planless-boundary-admin")
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
+        .actor_id("planless-boundary-maintenance")
         .build()
         .await
-        .expect("build admin");
+        .expect("build maintenance");
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -215,7 +215,7 @@ async fn planless_boundary_fixture(namespace: &str) -> PlanlessBoundaryFixture {
         store,
         namespace_id,
         writer,
-        admin,
+        maintenance,
     }
 }
 
@@ -249,7 +249,7 @@ async fn planless_scan_returns_exact_materialized_and_wal_boundary_revisions_onc
         .expect("write materialized file");
     let materialized_head = control::head(&fixture.store, &fixture.namespace_id).await;
     fixture
-        .admin
+        .maintenance
         .maintain_metadata(
             &fixture.namespace_id,
             MetadataMaintenanceOptions {
@@ -327,7 +327,7 @@ async fn planless_scan_deduplicates_an_inode_revised_across_materialization() {
         .await
         .expect("write materialized revision");
     fixture
-        .admin
+        .maintenance
         .maintain_metadata(
             &fixture.namespace_id,
             MetadataMaintenanceOptions {

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -6,7 +6,7 @@
 use crate::common::{control, default_page_limit, grep_with, page_limit, GrepHost};
 use bytes::Bytes;
 use loonfs::{
-    CoreError, CreateNamespaceOptions, DeleteNamespaceOptions, ErrorCode, FsAdmin, FsReader,
+    CoreError, CreateNamespaceOptions, DeleteNamespaceOptions, ErrorCode, FsMaintenance, FsReader,
     FsWriter, GcConfig, MetadataMaintenanceOptions, NamespaceId, PutFileOptions, RuntimeError,
     SharedObjectStore,
 };
@@ -113,8 +113,11 @@ async fn new_query_page(
     .await
 }
 
-async fn flush_wal_and_advance_retention(admin: &FsAdmin, namespace_id: &NamespaceId) -> ChangeSeq {
-    admin
+async fn flush_wal_and_advance_retention(
+    maintenance: &FsMaintenance,
+    namespace_id: &NamespaceId,
+) -> ChangeSeq {
+    maintenance
         .maintain_metadata(
             namespace_id,
             MetadataMaintenanceOptions {
@@ -123,7 +126,7 @@ async fn flush_wal_and_advance_retention(admin: &FsAdmin, namespace_id: &Namespa
         )
         .await
         .expect("flush wal");
-    admin
+    maintenance
         .advance_retention_floor(namespace_id)
         .await
         .expect("advance retention")
@@ -478,7 +481,7 @@ async fn enable_creates_no_checkpoint_when_the_root_load_fails() {
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    let host = GrepHost::new(&store, "enable-root-failure-admin").await;
+    let host = GrepHost::new(&store, "enable-root-failure-maintenance").await;
     let grep_root_key = root_key(&namespace_id);
     let root_loads = Arc::new(AtomicUsize::new(0));
     let observed_root_loads = Arc::clone(&root_loads);
@@ -495,7 +498,7 @@ async fn enable_creates_no_checkpoint_when_the_root_load_fails() {
     let worker = GrepWorker::with_block_cache(
         failing_store.clone(),
         host.reader.clone(),
-        host.admin.clone(),
+        host.maintenance.clone(),
         Arc::clone(&host.block_cache),
     );
 
@@ -512,7 +515,9 @@ async fn enable_creates_no_checkpoint_when_the_root_load_fails() {
             .expect("default page limit"),
         cursor: None,
     };
-    let mut pager = host.admin.list_checkpoints_pager(&namespace_id, request);
+    let mut pager = host
+        .maintenance
+        .list_checkpoints_pager(&namespace_id, request);
     let checkpoints = pager
         .next()
         .await
@@ -541,7 +546,7 @@ async fn enable_retains_its_checkpoint_when_the_root_write_result_is_ambiguous()
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    let host = GrepHost::new(&store, "ambiguous-enable-admin").await;
+    let host = GrepHost::new(&store, "ambiguous-enable-maintenance").await;
     let grep_root_key = root_key(&namespace_id);
     let failing_store = Arc::new(
         FailStore::matching(
@@ -564,7 +569,7 @@ async fn enable_retains_its_checkpoint_when_the_root_write_result_is_ambiguous()
     let worker = GrepWorker::with_block_cache(
         failing_store.clone(),
         host.reader.clone(),
-        host.admin.clone(),
+        host.maintenance.clone(),
         Arc::clone(&host.block_cache),
     );
 
@@ -595,13 +600,13 @@ async fn restart_retains_its_checkpoint_when_the_root_write_result_is_ambiguous(
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    let host = GrepHost::new(&store, "ambiguous-restart-admin").await;
+    let host = GrepHost::new(&store, "ambiguous-restart-maintenance").await;
     host.worker
         .enable(&namespace_id)
         .await
         .expect("enable grep");
     let previous_checkpoint_id = assert_fresh_backfill_attempt(&store, &namespace_id).await;
-    host.admin
+    host.maintenance
         .release_checkpoint(&namespace_id, &previous_checkpoint_id)
         .await
         .expect("make the current backfill restart");
@@ -628,7 +633,7 @@ async fn restart_retains_its_checkpoint_when_the_root_write_result_is_ambiguous(
     let worker = GrepWorker::with_block_cache(
         failing_store.clone(),
         host.reader.clone(),
-        host.admin.clone(),
+        host.maintenance.clone(),
         Arc::clone(&host.block_cache),
     );
 
@@ -656,11 +661,11 @@ async fn retention_gap_and_vanished_checkpoint_restart_fresh_backfill() {
         .build()
         .await
         .expect("writer");
-    let admin = FsAdmin::builder_with_store(store.clone())
-        .actor_id("gap-admin")
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
+        .actor_id("gap-maintenance")
         .build()
         .await
-        .expect("admin");
+        .expect("maintenance");
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -678,7 +683,7 @@ async fn retention_gap_and_vanished_checkpoint_restart_fresh_backfill() {
         )
         .await
         .expect("write after watermark");
-    let retention_floor_seq = flush_wal_and_advance_retention(&admin, &namespace_id).await;
+    let retention_floor_seq = flush_wal_and_advance_retention(&maintenance, &namespace_id).await;
     assert!(retention_floor_seq > ChangeSeq(0));
 
     // The feed can no longer reach the watermark, which the worker must
@@ -696,7 +701,7 @@ async fn retention_gap_and_vanished_checkpoint_restart_fresh_backfill() {
     // The second trigger: the pinned checkpoint stops pinning its basis
     // mid-backfill. The enumeration says so out loud instead of quietly
     // answering current state, and the worker starts over again.
-    admin
+    maintenance
         .release_checkpoint(&namespace_id, &gap_checkpoint_id)
         .await
         .expect("remove checkpoint mid-backfill");
@@ -734,11 +739,11 @@ async fn retention_passing_a_backfill_checkpoint_never_serves_a_partial_query() 
         .build()
         .await
         .expect("writer");
-    let admin = FsAdmin::builder_with_store(store.clone())
-        .actor_id("handoff-gap-admin")
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
+        .actor_id("handoff-gap-maintenance")
         .build()
         .await
-        .expect("admin");
+        .expect("maintenance");
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -790,7 +795,7 @@ async fn retention_passing_a_backfill_checkpoint_never_serves_a_partial_query() 
         )
         .await
         .expect("write during backfill");
-    let retention_floor_seq = flush_wal_and_advance_retention(&admin, &namespace_id).await;
+    let retention_floor_seq = flush_wal_and_advance_retention(&maintenance, &namespace_id).await;
     assert!(retention_floor_seq > target_seq);
 
     // Checkpoint pages remain readable after retention passes their basis,
@@ -2154,11 +2159,11 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .build()
         .await
         .expect("writer");
-    let admin = FsAdmin::builder_with_store(store.clone())
-        .actor_id("gc-admin")
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
+        .actor_id("gc-maintenance")
         .build()
         .await
-        .expect("admin");
+        .expect("maintenance");
     for namespace_id in [&live_namespace, &deleted_namespace, &corrupt_namespace] {
         writer
             .create_namespace(namespace_id, CreateNamespaceOptions::default())
@@ -2332,7 +2337,7 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .await
         .expect("write grep sentinel");
     aged_store.reset();
-    admin
+    maintenance
         .gc_namespace(&live_namespace, &GcConfig::default())
         .await
         .expect("core gc");

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -5,7 +5,7 @@
 use crate::common::is_content_object;
 use bytes::Bytes;
 use loonfs::{
-    DeleteNamespaceOptions, FsAdmin, FsBackgroundWork, FsReader, FsWriter, MaintenanceJob,
+    DeleteNamespaceOptions, FsBackgroundWork, FsMaintenance, FsReader, FsWriter, MaintenanceJob,
     MaintenanceProbe, MaintenanceStepConclusion, SharedObjectStore,
 };
 use loonfs_api::{ChangeSeq, IndexSegmentId, NamespaceId};
@@ -339,12 +339,12 @@ async fn worker<S: ObjectStore + 'static>(store: Arc<S>, actor: &str) -> GrepWor
         .build()
         .await
         .expect("build reader");
-    let admin = FsAdmin::builder_with_store(shared)
+    let maintenance = FsMaintenance::builder_with_store(shared)
         .actor_id(actor)
         .build()
         .await
-        .expect("build admin");
-    GrepWorker::new(store, reader, admin)
+        .expect("build maintenance");
+    GrepWorker::new(store, reader, maintenance)
 }
 
 async fn seed<S: ObjectStore + 'static>(store: Arc<S>, namespace_id: &NamespaceId) -> FsWriter {

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -371,7 +371,7 @@ default. Long metadata compactions can log progress for an extended period.
 No action is required unless failures repeat.
 
 `compaction_required` applies only to embedded deployments without a
-background worker. Those deployments must call `FsAdmin::compact_metadata`.
+background worker. Those deployments must call `FsMaintenance::compact_metadata`.
 The self-hosted server schedules that work itself.
 
 ## Current limitations

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -278,7 +278,7 @@ pub(super) async fn get_namespace_diagnostics(
     AppQuery(_): AppQuery<NoQuery>,
 ) -> Result<Json<loonfs_api::NamespaceDiagnostics>, ApiResponseError> {
     let diagnostics = state
-        .admin
+        .maintenance
         .get_namespace_diagnostics(&namespace_id)
         .await
         .map_err(ApiResponseError::for_namespace(&namespace_id))?;
@@ -412,7 +412,7 @@ pub(super) async fn create_snapshot(
     let now_ms = super::handlers_uploads::current_unix_ms()?;
     let expires_at_ms = snapshot_expiry_from_ttl(&state, now_ms, request.ttl_ms)?;
     let checkpoint = state
-        .admin
+        .writer
         .create_snapshot_with_quota(
             &namespace_id,
             CreateSnapshotOptions {
@@ -470,7 +470,7 @@ pub(super) async fn list_snapshots(
 ) -> Result<Json<ListSnapshotsResponse>, ApiResponseError> {
     let cursor = decode_checkpoint_cursor(query.cursor.as_deref(), &namespace_id)?;
     let response = state
-        .admin
+        .reader
         .list_snapshots_page(
             &namespace_id,
             PageRequest {
@@ -519,7 +519,7 @@ pub(super) async fn extend_snapshot(
     let now_ms = super::handlers_uploads::current_unix_ms()?;
     let requested_expires_at_ms = snapshot_expiry_from_ttl(&state, now_ms, request.ttl_ms)?;
     let response = state
-        .admin
+        .writer
         .extend_snapshot(
             &namespace_id,
             &snapshot_id,
@@ -561,7 +561,7 @@ pub(super) async fn release_snapshot(
 ) -> Result<Json<ReleaseSnapshotResponse>, ApiResponseError> {
     let snapshot_id = parse_path_id::<CheckpointId>("snapshot_id", &snapshot_id)?;
     let response = state
-        .admin
+        .writer
         .release_snapshot(&namespace_id, &snapshot_id)
         .await
         .map_err(ApiResponseError::for_namespace(&namespace_id))?;
@@ -635,7 +635,7 @@ pub(super) async fn create_checkpoint(
     AppJson(request): AppJson<CreateCheckpointRequest>,
 ) -> Result<Json<Checkpoint>, ApiResponseError> {
     let response = state
-        .admin
+        .maintenance
         .create_checkpoint(
             &namespace_id,
             loonfs::CreateCheckpointOptions::from_request(request),
@@ -686,7 +686,7 @@ pub(super) async fn list_checkpoints(
 ) -> Result<Json<ListCheckpointsResponse>, ApiResponseError> {
     let cursor = decode_checkpoint_cursor(query.cursor.as_deref(), &namespace_id)?;
     let response = state
-        .admin
+        .maintenance
         .list_checkpoints_page(
             &namespace_id,
             PageRequest {
@@ -730,7 +730,7 @@ pub(super) async fn release_checkpoint(
 ) -> Result<Json<ReleaseCheckpointResponse>, ApiResponseError> {
     let checkpoint_id = parse_path_id::<CheckpointId>("checkpoint_id", &checkpoint_id)?;
     let response = state
-        .admin
+        .maintenance
         .release_checkpoint(&namespace_id, &checkpoint_id)
         .await
         .map_err(ApiResponseError::for_namespace(&namespace_id))?;
@@ -787,7 +787,7 @@ pub(super) async fn run_maintenance(
     AppJson(request): AppJson<MaintenanceRunRequest>,
 ) -> Result<Json<MaintenanceRunResponse>, ApiResponseError> {
     let result = state
-        .admin
+        .maintenance
         .run_maintenance(&namespace_id, request)
         .await
         .map_err(|error| {

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -468,7 +468,7 @@ async fn method_not_allowed() -> ApiResponseError {
 ///
 /// The long-lived server writer opts into background maintenance; the
 /// reader shares its caches so read endpoints observe writes immediately;
-/// the `FsAdmin` handle drives the explicit maintenance endpoints under its own
+/// the `FsMaintenance` handle drives the explicit maintenance endpoints under its own
 /// actor identity, sharing the writer's decoded-block cache under the
 /// configured budget. All three deliberately share one provider client
 /// inside this one runtime ownership domain.

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -13,7 +13,7 @@ use axum::response::Response;
 use axum::Router;
 use loonfs::metrics::{JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder};
 use loonfs::{
-    FsAdmin, FsReader, FsWriter, MaintenanceHandle, MaintenanceJob, MaintenanceProbe,
+    FsMaintenance, FsReader, FsWriter, MaintenanceHandle, MaintenanceJob, MaintenanceProbe,
     SharedObjectStore, StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, TraceMode,
     TraceStoreKind,
 };
@@ -125,7 +125,7 @@ impl http_body::Body for DrainedBody {
 /// Request handles built over one shared store client.
 ///
 /// Read handlers use `reader`, mutations use `writer`, and maintenance uses
-/// `admin`. The host also shuts down `writer` after the listener drains.
+/// `maintenance`. The host also shuts down `writer` after the listener drains.
 /// `reader` is stored separately because most handlers require only read
 /// access.
 #[derive(Clone)]
@@ -134,7 +134,7 @@ pub struct AppState {
     /// Writer handle that owns publication and maintenance work.
     pub writer: FsWriter,
     pub(super) reader: FsReader,
-    pub(super) admin: FsAdmin,
+    pub(super) maintenance: FsMaintenance,
     /// The store itself, for the one endpoint whose subject is the store
     /// rather than a namespace: the contract probe. It is the same
     /// instrumented client the handles were built on, so a probe measures
@@ -270,7 +270,7 @@ pub async fn app(
     // the writer for its publications to reach the index: the job says on
     // the trait that publications concern it, and registering it is what
     // subscribes it.
-    let (writer, reader, admin) = build_handles(
+    let (writer, reader, maintenance) = build_handles(
         &config,
         store,
         &metrics,
@@ -292,7 +292,7 @@ pub async fn app(
             GrepWorker::with_block_cache(
                 writer.object_store(),
                 reader.clone(),
-                admin.clone(),
+                maintenance.clone(),
                 Arc::clone(&grep_block_cache),
             )
         });
@@ -337,7 +337,7 @@ pub async fn app(
         config,
         writer,
         reader,
-        admin,
+        maintenance,
         probe_store,
         direct_transfers,
         grep_worker,
@@ -379,14 +379,14 @@ async fn open_local_cache(
 ///
 /// An optional JSONL recorder receives the same object-store samples. The
 /// local block cache is installed once on the writer's shared runtime core,
-/// so the reader and admin use the same decoded cache hierarchy.
+/// so the reader and maintenance use the same decoded cache hierarchy.
 pub(super) async fn build_handles(
     config: &ServerConfig,
     store: SharedObjectStore,
     metrics: &ServerMetrics,
     metrics_jsonl_path: Option<OsString>,
     local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
-) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
+) -> Result<(FsWriter, FsReader, FsMaintenance), ServerConfigError> {
     let trace_store_kind = TraceStoreKind::from(config.store.kind());
     let samples = object_store_metrics_recorder(metrics_jsonl_path)?;
     let runtime_error = |error: loonfs::RuntimeError| ServerConfigError::InvalidField {
@@ -415,9 +415,9 @@ pub(super) async fn build_handles(
     let writer = writer_builder.build().await.map_err(runtime_error)?;
     let reader = writer.reader();
 
-    let mut admin_builder = FsAdmin::builder_with_store(store)
-        .actor_id(format!("{}-admin", config.writer_id))
-        // The admin honors the configured cache sizing and shares the
+    let mut maintenance_builder = FsMaintenance::builder_with_store(store)
+        .actor_id(format!("{}-maintenance", config.writer_id))
+        // The maintenance honors the configured cache sizing and shares the
         // writer's decoded-block cache instance, so explicit maintenance
         // reuses blocks reader traffic already decoded instead of
         // populating a second, default-sized cache. It also shares the
@@ -429,11 +429,11 @@ pub(super) async fn build_handles(
         .trace_store_kind(trace_store_kind)
         .metrics_recorder(metrics.recorder());
     if let Some(samples) = samples {
-        admin_builder = admin_builder.object_store_metrics_recorder(samples);
+        maintenance_builder = maintenance_builder.object_store_metrics_recorder(samples);
     }
-    let admin = admin_builder.build().await.map_err(runtime_error)?;
+    let maintenance = maintenance_builder.build().await.map_err(runtime_error)?;
 
-    Ok((writer, reader, admin))
+    Ok((writer, reader, maintenance))
 }
 
 fn object_store_metrics_recorder(

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -14,7 +14,7 @@ use axum::body::Bytes;
 use axum::http::StatusCode;
 use futures::stream::StreamExt;
 use loonfs::{
-    CreateNamespaceOptions, DeleteOptions, FsAdmin, FsReader, FsWriter, MaintenanceJob,
+    CreateNamespaceOptions, DeleteOptions, FsMaintenance, FsReader, FsWriter, MaintenanceJob,
     MaintenanceJobId, MaintenanceProbe, MaintenanceStepConclusion, MaintenanceStepReport,
     PutFileOptions, StoredMetadataBlockCache, TraceMode, TraceStoreKind,
 };
@@ -624,7 +624,7 @@ async fn build_handles_installs_jsonl_object_store_metrics_recorder() {
     let metrics_path = metrics_dir.path().join("object-store.ndjson");
 
     {
-        let (writer, _reader, _admin) = build_handles(
+        let (writer, _reader, _maintenance) = build_handles(
             &config,
             store,
             &ServerMetrics::new(),
@@ -3363,12 +3363,12 @@ async fn grep_worker(store: &SharedObjectStore, actor: &str) -> GrepWorker<Share
         .build()
         .await
         .expect("build reader");
-    let admin = FsAdmin::builder_with_store(store.clone())
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
         .actor_id(actor)
         .build()
         .await
-        .expect("build admin");
-    GrepWorker::new(store.clone(), reader, admin)
+        .expect("build maintenance");
+    GrepWorker::new(store.clone(), reader, maintenance)
 }
 
 fn grep_error_request() -> GrepRequest {

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -6,7 +6,7 @@ use axum::body::{to_bytes, Body};
 use axum::http::{Method, Request, StatusCode};
 use axum::Router;
 use loonfs::{CreateNamespaceOptions, FsWriter, PutFileOptions};
-use loonfs::{FsAdmin, FsReader};
+use loonfs::{FsMaintenance, FsReader};
 use loonfs_api::v0::{GrepGcResponse, GrepIndex, GrepIndexLifecycle};
 use loonfs_api::{
     ApiError, CapabilityDocument, ChangeSeq, GrepResponse, NamespaceId,
@@ -915,12 +915,12 @@ async fn grep_worker(store: &SharedObjectStore, actor: &str) -> GrepWorker<Share
         .build()
         .await
         .expect("build reader");
-    let admin = FsAdmin::builder_with_store(store.clone())
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
         .actor_id(actor)
         .build()
         .await
-        .expect("build admin");
-    GrepWorker::new(store.clone(), reader, admin)
+        .expect("build maintenance");
+    GrepWorker::new(store.clone(), reader, maintenance)
 }
 
 /// The api.md section 2.1 example describes a reference deployment: the

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -1,4 +1,4 @@
-//! [`FsAdmin`]'s explicit maintenance: steps, GC, checkpoints, WAL
+//! [`FsMaintenance`]'s explicit maintenance: steps, GC, checkpoints, WAL
 //! flushes, and retention.
 //!
 //! Derived indexes are not here and not in this crate: `loonfs-grep`
@@ -7,21 +7,19 @@
 
 use crate::maintenance_runner::CompactionStart;
 use crate::trace::phase_span;
-use crate::FsAdmin;
+use crate::FsMaintenance;
 use crate::NamespaceDiagnostics;
 use crate::{
-    AdvanceRetentionResponse, Checkpoint, CheckpointId, CreateCheckpointOptions,
-    CreateSnapshotOptions, ErrorCode, FlushWalOutcome, FlushWalResponse, ListCheckpointsResponse,
-    ListSnapshotsResponse, MaintenanceRunRequest, MaintenanceRunResponse,
-    MetadataCompactionOutcome, MetadataCompactionResponse, MetadataMaintenanceOptions,
-    MetadataMaintenanceResponse, NamespaceId, ReleaseCheckpointResponse, ReleaseSnapshotResponse,
-    ReorganizeStepOutcome, SharedObjectStore, SnapshotSummary, WalFlushStepOutcome,
+    AdvanceRetentionResponse, Checkpoint, CheckpointId, CreateCheckpointOptions, ErrorCode,
+    FlushWalOutcome, FlushWalResponse, ListCheckpointsResponse, MaintenanceRunRequest,
+    MaintenanceRunResponse, MetadataCompactionOutcome, MetadataCompactionResponse,
+    MetadataMaintenanceOptions, MetadataMaintenanceResponse, NamespaceId,
+    ReleaseCheckpointResponse, ReorganizeStepOutcome, SharedObjectStore, WalFlushStepOutcome,
 };
 use crate::{ChangeSeq, Result, RuntimeError};
 use loonfs_api::PageRequest;
 use loonfs_core::cache::{load_namespace_flush_basis, NamespaceStorageDiagnostics};
 use loonfs_core::CheckpointPageCursor;
-use std::num::NonZeroU32;
 use tokio::time::Instant;
 use tracing::Instrument;
 
@@ -73,7 +71,7 @@ fn metadata_compaction_response(
     MetadataCompactionResponse { outcome }
 }
 
-impl FsAdmin {
+impl FsMaintenance {
     /// A mutating engine under this handle's actor identity.
     fn engine(
         &self,
@@ -466,7 +464,7 @@ impl FsAdmin {
                 tracing::warn!(
                     families = ?families,
                     "a family group needs a streaming metadata compaction, and this handle \
-                     schedules no background work; run `FsAdmin::compact_metadata` to rebuild it"
+                     schedules no background work; run `FsMaintenance::compact_metadata` to rebuild it"
                 );
                 ReorganizeStepOutcome::CompactionRequired
             }
@@ -682,102 +680,6 @@ impl FsAdmin {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    /// Creates a snapshot of the current namespace state.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.maintenance.snapshot_create",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "maintenance.snapshot_create",
-            namespace_id = %namespace_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn create_snapshot(
-        &self,
-        namespace_id: &NamespaceId,
-        options: CreateSnapshotOptions,
-    ) -> Result<Checkpoint> {
-        let span = tracing::Span::current();
-        self.core.record_trace_context(&span);
-        let result = self
-            .engine(namespace_id)
-            .create_snapshot(options.name, options.expires_at_ms)
-            .await
-            .map_err(RuntimeError::from);
-        self.finish_namespace_mutation(namespace_id, result)
-    }
-
-    /// Creates a snapshot only when the namespace has quota for it.
-    ///
-    /// A caller that exceeds the quota releases its tentative snapshot before
-    /// returning the quota error.
-    pub async fn create_snapshot_with_quota(
-        &self,
-        namespace_id: &NamespaceId,
-        options: CreateSnapshotOptions,
-        now_ms: u64,
-        max_live: usize,
-    ) -> Result<Checkpoint> {
-        let checkpoint = self.create_snapshot(namespace_id, options).await?;
-        if let Err(error) = self
-            .ensure_live_snapshot_limit(namespace_id, now_ms, max_live, 0)
-            .await
-        {
-            self.release_snapshot(namespace_id, &checkpoint.checkpoint_id)
-                .await?;
-            return Err(error);
-        }
-        Ok(checkpoint)
-    }
-
-    async fn ensure_live_snapshot_limit(
-        &self,
-        namespace_id: &NamespaceId,
-        now_ms: u64,
-        max_live: usize,
-        additional_live: usize,
-    ) -> Result<()> {
-        let page_limit = loonfs_api::PaginationPolicy::default().max_limit();
-        let mut cursor = None;
-        let mut live_with_additional = additional_live;
-        let quota_error = || {
-            RuntimeError::Core(loonfs_core::Error::SnapshotQuotaExceeded {
-                namespace_id: namespace_id.clone(),
-                max_live,
-            })
-        };
-        if live_with_additional > max_live {
-            return Err(quota_error());
-        }
-        loop {
-            let page = self
-                .engine(namespace_id)
-                .list_checkpoints_page(PageRequest {
-                    limit: loonfs_api::EffectiveLimit::new(page_limit),
-                    cursor,
-                })
-                .await
-                .map_err(RuntimeError::from)?;
-            for checkpoint in page.items {
-                if SnapshotSummary::from_checkpoint(checkpoint)
-                    .is_some_and(|snapshot| snapshot.expires_at_ms > now_ms)
-                {
-                    live_with_additional = live_with_additional.saturating_add(1);
-                    if live_with_additional > max_live {
-                        return Err(quota_error());
-                    }
-                }
-            }
-            let Some(next_cursor) = page.next_cursor else {
-                return Ok(());
-            };
-            cursor = Some(next_cursor);
-        }
-    }
-
     /// Creates a checkpoint pager beginning at `request.cursor`.
     pub fn list_checkpoints_pager(
         &self,
@@ -788,10 +690,10 @@ impl FsAdmin {
             loonfs_api::encode_cursor(cursor).expect("typed checkpoint cursor should encode")
         });
         let limit = request.limit;
-        let admin = self.clone();
+        let maintenance = self.clone();
         let namespace_id = namespace_id.clone();
         loonfs_api::Pager::new(cursor, move |cursor| {
-            let admin = admin.clone();
+            let maintenance = maintenance.clone();
             let namespace_id = namespace_id.clone();
             async move {
                 let cursor = cursor
@@ -799,7 +701,7 @@ impl FsAdmin {
                     .map(loonfs_api::decode_cursor)
                     .transpose()
                     .map_err(|error| crate::CoreError::InvalidCursor(error.to_string()))?;
-                admin
+                maintenance
                     .list_checkpoints_page(&namespace_id, PageRequest { limit, cursor })
                     .await
             }
@@ -832,128 +734,6 @@ impl FsAdmin {
             .await?;
         response.next_cursor = super::core::encode_next_cursor(next_cursor.as_ref())?;
         Ok(response)
-    }
-
-    /// Lists one page of live snapshots.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.maintenance.list_snapshots",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "maintenance.list_snapshots",
-            method = "list_snapshots_page",
-            namespace_id = %namespace_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn list_snapshots_page(
-        &self,
-        namespace_id: &NamespaceId,
-        request: PageRequest<CheckpointPageCursor>,
-    ) -> Result<ListSnapshotsResponse> {
-        self.core.record_trace_context(&tracing::Span::current());
-        let now_ms = self.actor.mutation_context()?.now_ms;
-        let requested = request.limit.as_usize();
-        let mut cursor = request.cursor;
-        let mut snapshots = Vec::with_capacity(requested);
-        loop {
-            let remaining = requested - snapshots.len();
-            let limit = NonZeroU32::new(u32::try_from(remaining).map_err(|error| {
-                RuntimeError::Core(loonfs_core::Error::Internal(format!(
-                    "snapshot page limit does not fit u32: {error}"
-                )))
-            })?)
-            .expect("a snapshot page with room remaining has a nonzero limit");
-            let page = self
-                .engine(namespace_id)
-                .list_checkpoints_page(PageRequest {
-                    limit: loonfs_api::EffectiveLimit::new(limit),
-                    cursor,
-                })
-                .await
-                .map_err(RuntimeError::from)?;
-            snapshots.extend(page.items.into_iter().filter_map(|checkpoint| {
-                SnapshotSummary::from_checkpoint(checkpoint)
-                    .filter(|snapshot| snapshot.expires_at_ms > now_ms)
-            }));
-            match page.next_cursor {
-                Some(next_cursor) if snapshots.len() < requested => cursor = Some(next_cursor),
-                next_cursor => {
-                    return Ok(ListSnapshotsResponse {
-                        namespace_id: namespace_id.clone(),
-                        snapshots,
-                        next_cursor: super::core::encode_next_cursor(next_cursor.as_ref())?,
-                    })
-                }
-            }
-        }
-    }
-
-    /// Extends a live snapshot, capped from its durable creation time.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.maintenance.snapshot_extend",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "maintenance.snapshot_extend",
-            namespace_id = %namespace_id,
-            snapshot_id = %snapshot_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn extend_snapshot(
-        &self,
-        namespace_id: &NamespaceId,
-        snapshot_id: &CheckpointId,
-        requested_expires_at_ms: u64,
-        max_lifetime_ms: u64,
-    ) -> Result<SnapshotSummary> {
-        self.core.record_trace_context(&tracing::Span::current());
-        let result = self
-            .engine(namespace_id)
-            .extend_snapshot(snapshot_id, requested_expires_at_ms, max_lifetime_ms)
-            .await
-            .map_err(RuntimeError::from)
-            .and_then(|checkpoint| {
-                SnapshotSummary::from_checkpoint(checkpoint).ok_or_else(|| {
-                    RuntimeError::Core(loonfs_core::Error::Internal(
-                        "snapshot extension returned a non-snapshot checkpoint".to_owned(),
-                    ))
-                })
-            });
-        self.finish_namespace_mutation(namespace_id, result)
-    }
-
-    /// Releases a snapshot. Repeated releases succeed.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.maintenance.snapshot_release",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "maintenance.snapshot_release",
-            namespace_id = %namespace_id,
-            snapshot_id = %snapshot_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn release_snapshot(
-        &self,
-        namespace_id: &NamespaceId,
-        snapshot_id: &CheckpointId,
-    ) -> Result<ReleaseSnapshotResponse> {
-        self.core.record_trace_context(&tracing::Span::current());
-        let result = self
-            .engine(namespace_id)
-            .release_snapshot(snapshot_id)
-            .await
-            .map_err(RuntimeError::from);
-        self.finish_namespace_mutation(namespace_id, result)
     }
 
     async fn list_checkpoints_page_typed(

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -4,12 +4,12 @@
 //! These tests need a family group whose base run no bounded step can fold,
 //! with delta runs still arriving above it. The shipped row budget only
 //! reaches that state at a scale no test can write, so the budget is narrowed
-//! through [`FsAdmin::starve_reorganization_row_budget`]. Everything else —
+//! through [`FsMaintenance::starve_reorganization_row_budget`]. Everything else —
 //! planning, admission, the executor, the finalizer — is the shipped path.
 
 use crate::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};
 use crate::{
-    CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter,
+    CreateCheckpointOptions, CreateNamespaceOptions, FsBackgroundWork, FsMaintenance, FsWriter,
     MaintenanceRunRequest, MaintenanceRunResponse, MetadataCompactionOutcome, MoveOptions,
     NamespaceId, PutFileOptions, ReorganizeStepOutcome, SharedObjectStore,
 };
@@ -33,16 +33,21 @@ use tempfile::tempdir;
 /// descriptors are per family, so its families are what they are filtered by.
 const BINDINGS: MetadataFamilyGroup = MetadataFamilyGroup::Bindings;
 
-/// A `ManualOnly` deployment: a writer that schedules nothing, and an admin
+/// A `ManualOnly` deployment: a writer that schedules nothing, and an maintenance
 /// handle with no background work behind it, over one store.
 ///
 /// This is the shape the explicit compaction path exists for. The second
-/// admin is the contrast — the same store, but attached to the writer's
+/// maintenance is the contrast — the same store, but attached to the writer's
 /// runner, so its steps plan under the amortizing policy a writer's own
 /// upkeep runs under.
 async fn manual_deployment(
     root: &std::path::Path,
-) -> (FsWriter, FsAdmin, FsAdmin, Arc<DefaultMetricsRecorder>) {
+) -> (
+    FsWriter,
+    FsMaintenance,
+    FsMaintenance,
+    Arc<DefaultMetricsRecorder>,
+) {
     let store: SharedObjectStore =
         Arc::new(LocalFsStore::new(root).expect("create local-fs store"));
     let recorder = Arc::new(DefaultMetricsRecorder::new());
@@ -52,18 +57,18 @@ async fn manual_deployment(
         .build()
         .await
         .expect("build the writer");
-    let standalone = FsAdmin::builder_with_store(Arc::clone(&store))
-        .actor_id("standalone-admin")
+    let standalone = FsMaintenance::builder_with_store(Arc::clone(&store))
+        .actor_id("standalone-maintenance")
         .metrics_recorder(recorder.clone())
         .build()
         .await
-        .expect("build the standalone admin");
-    let scheduled = FsAdmin::builder_with_store(store)
-        .actor_id("scheduled-admin")
+        .expect("build the standalone maintenance");
+    let scheduled = FsMaintenance::builder_with_store(store)
+        .actor_id("scheduled-maintenance")
         .over_writer(&writer)
         .build()
         .await
-        .expect("build the writer-backed admin");
+        .expect("build the writer-backed maintenance");
     (writer, standalone, scheduled, recorder)
 }
 
@@ -90,10 +95,10 @@ fn metadata_request() -> MaintenanceRunRequest {
 }
 
 #[tokio::test]
-async fn an_admin_gc_step_records_the_pass_counters_once() {
+async fn a_maintenance_gc_step_records_the_pass_counters_once() {
     let temp_dir = tempdir().expect("tempdir");
-    let (writer, admin, _scheduled, recorder) = manual_deployment(temp_dir.path()).await;
-    let namespace = namespace_id("admin-gc-metrics");
+    let (writer, maintenance, _scheduled, recorder) = manual_deployment(temp_dir.path()).await;
+    let namespace = namespace_id("maintenance-gc-metrics");
     writer
         .create_namespace(&namespace, CreateNamespaceOptions::default())
         .await
@@ -109,10 +114,10 @@ async fn an_admin_gc_step_records_the_pass_counters_once() {
         .expect("write a live GC candidate");
 
     assert_eq!(counter(&recorder.snapshot(), "loonfs.gc.retained", &[]), 0);
-    let response = admin
+    let response = maintenance
         .run_maintenance(&namespace, MaintenanceRunRequest::Gc(GcRequest::default()))
         .await
-        .expect("run the admin GC step");
+        .expect("run the maintenance GC step");
     let gc = match response {
         MaintenanceRunResponse::Gc(gc) => Some(gc),
         _ => None,
@@ -127,7 +132,7 @@ async fn an_admin_gc_step_records_the_pass_counters_once() {
     assert_eq!(
         counter(&snapshot, "loonfs.gc.retained", &[]),
         gc.retained_candidates,
-        "the admin pass records its retained count exactly once"
+        "the maintenance pass records its retained count exactly once"
     );
     for (category, reclaimed) in [
         ("deleted_wal_segments", gc.deleted.wal_segments),
@@ -153,7 +158,7 @@ async fn an_admin_gc_step_records_the_pass_counters_once() {
         assert_eq!(
             counter(&snapshot, "loonfs.gc.reclaimed", &[("category", category)],),
             reclaimed,
-            "the admin pass records `{category}` exactly once"
+            "the maintenance pass records `{category}` exactly once"
         );
     }
 }
@@ -161,7 +166,7 @@ async fn an_admin_gc_step_records_the_pass_counters_once() {
 /// Writes one file and folds the tail, so each call leaves one more delta run.
 async fn write_and_flush(
     writer: &FsWriter,
-    admin: &FsAdmin,
+    maintenance: &FsMaintenance,
     namespace_id: &NamespaceId,
     path: &str,
 ) {
@@ -174,7 +179,10 @@ async fn write_and_flush(
         )
         .await
         .expect("put a file");
-    admin.flush_wal(namespace_id).await.expect("fold the tail");
+    maintenance
+        .flush_wal(namespace_id)
+        .await
+        .expect("fold the tail");
 }
 
 /// Builds a namespace whose bindings group holds one base run of real size,
@@ -189,7 +197,7 @@ async fn write_and_flush(
 /// a compaction.
 async fn namespace_with_a_frozen_base(
     writer: &FsWriter,
-    admin: &FsAdmin,
+    maintenance: &FsMaintenance,
     namespace_id: &NamespaceId,
 ) {
     writer
@@ -199,7 +207,7 @@ async fn namespace_with_a_frozen_base(
     for index in 0..24 {
         write_and_flush(
             writer,
-            admin,
+            maintenance,
             namespace_id,
             &format!("/docs/file-{index}.txt"),
         )
@@ -218,12 +226,18 @@ async fn namespace_with_a_frozen_base(
             .await
             .expect("rename a file");
     }
-    admin.flush_wal(namespace_id).await.expect("fold the tail");
+    maintenance
+        .flush_wal(namespace_id)
+        .await
+        .expect("fold the tail");
 
     // Fold everything into one base run per group, under the shipped budgets
     // and with the floor still at the bottom, so the churn lands in the base.
     for _ in 0..64 {
-        let response = admin.flush_wal(namespace_id).await.expect("fold a unit");
+        let response = maintenance
+            .flush_wal(namespace_id)
+            .await
+            .expect("fold a unit");
         if response.reorganize == ReorganizeStepOutcome::NotNeeded {
             break;
         }
@@ -231,7 +245,7 @@ async fn namespace_with_a_frozen_base(
 
     // Now the floor moves past that churn, so the next bottom-anchored rebuild
     // is the one that may drop it.
-    admin
+    maintenance
         .create_checkpoint(
             namespace_id,
             CreateCheckpointOptions {
@@ -241,7 +255,7 @@ async fn namespace_with_a_frozen_base(
         )
         .await
         .expect("checkpoint the namespace");
-    admin
+    maintenance
         .advance_retention_floor(namespace_id)
         .await
         .expect("advance the retention floor past the churn");
@@ -250,14 +264,18 @@ async fn namespace_with_a_frozen_base(
 /// Keeps writing while the group's base is frozen, so a delta-only merge is
 /// always available above it.
 ///
-/// The admin here is the starved one, which is what makes these runs pile up:
+/// The maintenance here is the starved one, which is what makes these runs pile up:
 /// its steps can no longer fold the group they land in, so each write leaves
 /// one more delta run behind rather than being merged into the base.
-async fn sustained_writes(writer: &FsWriter, admin: &FsAdmin, namespace_id: &NamespaceId) {
+async fn sustained_writes(
+    writer: &FsWriter,
+    maintenance: &FsMaintenance,
+    namespace_id: &NamespaceId,
+) {
     for index in 0..10 {
         write_and_flush(
             writer,
-            admin,
+            maintenance,
             namespace_id,
             &format!("/arrivals/arrival-{index}.txt"),
         )
@@ -412,12 +430,12 @@ async fn explicit_compaction_runs_the_job_while_a_delta_merge_is_still_available
         .build()
         .await
         .expect("build a fresh writer");
-    let fresh_scheduled = FsAdmin::builder_with_store(fresh_store)
-        .actor_id("fresh-scheduled-admin")
+    let fresh_scheduled = FsMaintenance::builder_with_store(fresh_store)
+        .actor_id("fresh-scheduled-maintenance")
         .over_writer(&fresh_writer)
         .build()
         .await
-        .expect("build a fresh writer-backed admin")
+        .expect("build a fresh writer-backed maintenance")
         .starve_reorganization_row_budget(budget);
     let response = fresh_scheduled
         .run_maintenance(&automatic, metadata_request())

--- a/crates/loonfs/src/fs/mod.rs
+++ b/crates/loonfs/src/fs/mod.rs
@@ -4,6 +4,7 @@ mod core;
 mod maintenance;
 mod namespaces;
 mod reads;
+mod snapshots;
 mod uploads;
 mod writes;
 
@@ -12,6 +13,7 @@ pub use reads::{
     ChangesPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager, PathEntriesPager,
     TrashPager,
 };
+pub use snapshots::SnapshotsPager;
 
 pub(crate) use core::{should_invalidate_after_result, ReadCore, WriterBits, WriterIdentity};
 pub(crate) use namespaces::delete_namespace_with_engine;

--- a/crates/loonfs/src/fs/snapshots.rs
+++ b/crates/loonfs/src/fs/snapshots.rs
@@ -1,0 +1,264 @@
+//! Snapshot reads and mutations.
+
+use crate::{
+    Checkpoint, CheckpointId, CreateSnapshotOptions, FsReader, FsWriter, ListSnapshotsResponse,
+    NamespaceId, ReleaseSnapshotResponse, Result, RuntimeError, SnapshotSummary,
+};
+use loonfs_api::PageRequest;
+use loonfs_core::CheckpointPageCursor;
+use std::num::NonZeroU32;
+
+/// A pager over live snapshots.
+pub type SnapshotsPager = loonfs_api::Pager<ListSnapshotsResponse, RuntimeError>;
+
+impl FsReader {
+    /// Creates a snapshot pager beginning at `request.cursor`.
+    pub fn list_snapshots_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        request: PageRequest<CheckpointPageCursor>,
+    ) -> SnapshotsPager {
+        let cursor = request.cursor.as_ref().map(|cursor| {
+            loonfs_api::encode_cursor(cursor).expect("typed checkpoint cursor should encode")
+        });
+        let limit = request.limit;
+        let reader = self.clone();
+        let namespace_id = namespace_id.clone();
+        loonfs_api::Pager::new(cursor, move |cursor| {
+            let reader = reader.clone();
+            let namespace_id = namespace_id.clone();
+            async move {
+                let cursor = cursor
+                    .as_deref()
+                    .map(loonfs_api::decode_cursor)
+                    .transpose()
+                    .map_err(|error| crate::CoreError::InvalidCursor(error.to_string()))?;
+                reader
+                    .list_snapshots_page(&namespace_id, PageRequest { limit, cursor })
+                    .await
+            }
+        })
+    }
+
+    /// Lists one page of live snapshots.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.list_snapshots",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "list_snapshots",
+            method = "list_snapshots_page",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn list_snapshots_page(
+        &self,
+        namespace_id: &NamespaceId,
+        request: PageRequest<CheckpointPageCursor>,
+    ) -> Result<ListSnapshotsResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
+        let now_ms = loonfs_core::time::current_time_ms()?;
+        let requested = request.limit.as_usize();
+        let mut cursor = request.cursor;
+        let mut snapshots = Vec::with_capacity(requested);
+        let engine = self.core.reader_engine(namespace_id);
+        loop {
+            let remaining = requested - snapshots.len();
+            let limit = NonZeroU32::new(u32::try_from(remaining).map_err(|error| {
+                RuntimeError::Core(loonfs_core::Error::Internal(format!(
+                    "snapshot page limit does not fit u32: {error}"
+                )))
+            })?)
+            .expect("a snapshot page with room remaining has a nonzero limit");
+            let page = engine
+                .list_checkpoints_page(PageRequest {
+                    limit: loonfs_api::EffectiveLimit::new(limit),
+                    cursor,
+                })
+                .await
+                .map_err(RuntimeError::from)?;
+            snapshots.extend(page.items.into_iter().filter_map(|checkpoint| {
+                SnapshotSummary::from_checkpoint(checkpoint)
+                    .filter(|snapshot| snapshot.expires_at_ms > now_ms)
+            }));
+            match page.next_cursor {
+                Some(next_cursor) if snapshots.len() < requested => cursor = Some(next_cursor),
+                next_cursor => {
+                    return Ok(ListSnapshotsResponse {
+                        namespace_id: namespace_id.clone(),
+                        snapshots,
+                        next_cursor: super::core::encode_next_cursor(next_cursor.as_ref())?,
+                    })
+                }
+            }
+        }
+    }
+}
+
+impl FsWriter {
+    /// Creates a snapshot of the current namespace state.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.snapshot_create",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "snapshot_create",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn create_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateSnapshotOptions,
+    ) -> Result<Checkpoint> {
+        self.core.record_trace_context(&tracing::Span::current());
+        let result = self
+            .core
+            .writer_engine(&self.bits.identity, namespace_id)
+            .create_snapshot(options.name, options.expires_at_ms)
+            .await
+            .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
+    }
+
+    /// Creates a snapshot only when the namespace has quota for it.
+    ///
+    /// A caller that exceeds the quota releases its tentative snapshot before
+    /// returning the quota error.
+    pub async fn create_snapshot_with_quota(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateSnapshotOptions,
+        now_ms: u64,
+        max_live: usize,
+    ) -> Result<Checkpoint> {
+        let checkpoint = self.create_snapshot(namespace_id, options).await?;
+        if let Err(error) = self
+            .ensure_live_snapshot_limit(namespace_id, now_ms, max_live, 0)
+            .await
+        {
+            self.release_snapshot(namespace_id, &checkpoint.checkpoint_id)
+                .await?;
+            return Err(error);
+        }
+        Ok(checkpoint)
+    }
+
+    async fn ensure_live_snapshot_limit(
+        &self,
+        namespace_id: &NamespaceId,
+        now_ms: u64,
+        max_live: usize,
+        additional_live: usize,
+    ) -> Result<()> {
+        let page_limit = loonfs_api::PaginationPolicy::default().max_limit();
+        let mut cursor = None;
+        let mut live_with_additional = additional_live;
+        let quota_error = || {
+            RuntimeError::Core(loonfs_core::Error::SnapshotQuotaExceeded {
+                namespace_id: namespace_id.clone(),
+                max_live,
+            })
+        };
+        if live_with_additional > max_live {
+            return Err(quota_error());
+        }
+        let engine = self.core.writer_engine(&self.bits.identity, namespace_id);
+        loop {
+            let page = engine
+                .list_checkpoints_page(PageRequest {
+                    limit: loonfs_api::EffectiveLimit::new(page_limit),
+                    cursor,
+                })
+                .await
+                .map_err(RuntimeError::from)?;
+            for checkpoint in page.items {
+                if SnapshotSummary::from_checkpoint(checkpoint)
+                    .is_some_and(|snapshot| snapshot.expires_at_ms > now_ms)
+                {
+                    live_with_additional = live_with_additional.saturating_add(1);
+                    if live_with_additional > max_live {
+                        return Err(quota_error());
+                    }
+                }
+            }
+            let Some(next_cursor) = page.next_cursor else {
+                return Ok(());
+            };
+            cursor = Some(next_cursor);
+        }
+    }
+
+    /// Extends a live snapshot, capped from its durable creation time.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.snapshot_extend",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "snapshot_extend",
+            namespace_id = %namespace_id,
+            snapshot_id = %snapshot_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn extend_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        snapshot_id: &CheckpointId,
+        requested_expires_at_ms: u64,
+        max_lifetime_ms: u64,
+    ) -> Result<SnapshotSummary> {
+        self.core.record_trace_context(&tracing::Span::current());
+        let result = self
+            .core
+            .writer_engine(&self.bits.identity, namespace_id)
+            .extend_snapshot(snapshot_id, requested_expires_at_ms, max_lifetime_ms)
+            .await
+            .map_err(RuntimeError::from)
+            .and_then(|checkpoint| {
+                SnapshotSummary::from_checkpoint(checkpoint).ok_or_else(|| {
+                    RuntimeError::Core(loonfs_core::Error::Internal(
+                        "snapshot extension returned a non-snapshot checkpoint".to_owned(),
+                    ))
+                })
+            });
+        self.finish_namespace_mutation(namespace_id, result)
+    }
+
+    /// Releases a snapshot. Repeated releases succeed.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.snapshot_release",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "snapshot_release",
+            namespace_id = %namespace_id,
+            snapshot_id = %snapshot_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn release_snapshot(
+        &self,
+        namespace_id: &NamespaceId,
+        snapshot_id: &CheckpointId,
+    ) -> Result<ReleaseSnapshotResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
+        let result = self
+            .core
+            .writer_engine(&self.bits.identity, namespace_id)
+            .release_snapshot(snapshot_id)
+            .await
+            .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
+    }
+}

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -577,7 +577,7 @@ impl FsWriter {
     ///
     /// Deletion is tombstone-first: the commit hides the path without erasing
     /// history. Physical reclamation is explicit garbage collection: nothing
-    /// sweeps unless an operator asks, through `FsAdmin::gc_namespace` or a
+    /// sweeps unless an operator asks, through `FsMaintenance::gc_namespace` or a
     /// maintenance step that opted in.
     #[tracing::instrument(
         level = "debug",

--- a/crates/loonfs/src/handle/maintenance.rs
+++ b/crates/loonfs/src/handle/maintenance.rs
@@ -1,4 +1,4 @@
-//! The administrative and maintenance runtime handle.
+//! The maintenance runtime handle.
 
 use super::HandleBuilderCore;
 use crate::fs::{ReadCore, WriterIdentity};
@@ -11,16 +11,12 @@ use crate::{
 };
 use std::sync::Arc;
 
-/// Administrative and maintenance handle.
-///
-/// `FsAdmin` provides namespace diagnostics, checkpoints, retention changes,
-/// garbage collection, and one-shot maintenance steps. Each call runs in the
-/// caller's async task; this handle does not start background workers.
-///
-/// Admin operations that mutate durable control state carry the builder's
-/// `actor_id` for tracing, reports, and auditability.
+/// Maintenance handle: namespace diagnostics, operator checkpoints, WAL flush,
+/// metadata reorganization and compaction, garbage collection, and retention.
+/// Each call runs in the caller's task; the handle starts no background work.
+/// Operations that mutate durable control state record the builder's `actor_id`.
 #[derive(Clone)]
-pub struct FsAdmin {
+pub struct FsMaintenance {
     pub(crate) core: ReadCore,
     pub(crate) actor: WriterIdentity,
     pub(crate) writer: Option<WriterParts>,
@@ -37,23 +33,23 @@ pub(crate) struct WriterParts {
     pub(crate) compactions: BackgroundCompactions,
 }
 
-impl FsAdmin {
-    /// Starts an admin builder that constructs its object-store client from
+impl FsMaintenance {
+    /// Starts a maintenance builder that constructs its object-store client from
     /// configuration inside this handle's runtime ownership domain.
-    pub fn builder(store_config: StoreConfig) -> FsAdminBuilder {
-        FsAdminBuilder::new(HandleBuilderCore::from_config(store_config))
+    pub fn builder(store_config: StoreConfig) -> FsMaintenanceBuilder {
+        FsMaintenanceBuilder::new(HandleBuilderCore::from_config(store_config))
     }
 
-    /// Starts an admin builder over a caller-supplied store.
+    /// Starts a maintenance builder over a caller-supplied store.
     ///
     /// For callers who know the store is safe in this handle's runtime
     /// ownership domain. Do not use it to share one provider client across
     /// unrelated runtimes; open another handle from [`StoreConfig`] instead.
-    pub fn builder_with_store(store: SharedObjectStore) -> FsAdminBuilder {
-        FsAdminBuilder::new(HandleBuilderCore::from_store(store))
+    pub fn builder_with_store(store: SharedObjectStore) -> FsMaintenanceBuilder {
+        FsMaintenanceBuilder::new(HandleBuilderCore::from_store(store))
     }
 
-    /// Builds an admin over a writer's own runtime: its read core, its
+    /// Builds a maintenance handle over a writer's own runtime: its read core, its
     /// identity, and its publication service. Writer-scheduled background
     /// maintenance uses this so it runs the same operations an operator
     /// runs — and so its invalidations reach the writer's caches and
@@ -102,15 +98,15 @@ impl FsAdmin {
     // Maintenance operations live in `fs/maintenance.rs`.
 }
 
-/// Builder for [`FsAdmin`].
+/// Builder for [`FsMaintenance`].
 #[must_use]
-pub struct FsAdminBuilder {
+pub struct FsMaintenanceBuilder {
     core: HandleBuilderCore,
     actor_id: Option<String>,
     writer: Option<WriterParts>,
 }
 
-impl FsAdminBuilder {
+impl FsMaintenanceBuilder {
     fn new(core: HandleBuilderCore) -> Self {
         Self {
             core,
@@ -119,7 +115,7 @@ impl FsAdminBuilder {
         }
     }
 
-    /// Sets the actor id recorded by admin operations that mutate durable
+    /// Sets the actor id recorded by maintenance operations that mutate durable
     /// control state. Required.
     pub fn actor_id(mut self, actor_id: impl Into<String>) -> Self {
         self.actor_id = Some(actor_id.into());
@@ -132,9 +128,9 @@ impl FsAdminBuilder {
         self
     }
 
-    /// Connects this admin to a writer from the same runtime.
+    /// Connects this maintenance handle to a writer from the same runtime.
     ///
-    /// The admin shares the writer's decoded-block cache, publisher, and
+    /// The maintenance handle shares the writer's decoded-block cache, publisher, and
     /// background compactions. The shared cache keeps the writer's byte
     /// budget; [`Self::runtime_cache`] still configures this handle's other
     /// caches.
@@ -174,7 +170,7 @@ impl FsAdminBuilder {
     }
 
     /// Installs the metrics recorder this handle reports its instruments to
-    /// (see [`crate::metrics`]). An admin registers the object-store and
+    /// (see [`crate::metrics`]). A maintenance handle registers the object-store and
     /// collection instruments; the explicit maintenance it drives reports
     /// through the writer that scheduled it.
     pub fn metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
@@ -182,14 +178,14 @@ impl FsAdminBuilder {
         self
     }
 
-    /// Opens the admin handle inside the Tokio runtime that will drive its
+    /// Opens the maintenance handle inside the Tokio runtime that will drive its
     /// one-shot maintenance calls.
-    pub async fn build(self) -> Result<FsAdmin> {
+    pub async fn build(self) -> Result<FsMaintenance> {
         let actor_id = self
             .actor_id
             .ok_or_else(|| RuntimeError::Config("actor_id is required".to_owned()))?;
         let actor = WriterIdentity::new(actor_id)?;
-        Ok(FsAdmin {
+        Ok(FsMaintenance {
             core: self.core.open_read_core()?,
             actor,
             writer: self.writer,

--- a/crates/loonfs/src/handle/mod.rs
+++ b/crates/loonfs/src/handle/mod.rs
@@ -1,17 +1,17 @@
 //! Purpose-specific filesystem handles.
 //!
-//! [`FsWriter`] mutates namespaces, [`FsReader`] serves reads, and [`FsAdmin`]
+//! [`FsWriter`] mutates namespaces, [`FsReader`] serves reads, and [`FsMaintenance`]
 //! runs explicit maintenance. Each handle must be opened in the Tokio runtime
 //! where it will be used. Prefer builders that accept
 //! [`StoreConfig`](crate::StoreConfig); use `builder_with_store` only when the
 //! supplied store is safe to use from that runtime.
 
-mod admin;
 mod builder_core;
+mod maintenance;
 mod reader;
 mod writer;
 
-pub use admin::{FsAdmin, FsAdminBuilder};
+pub use maintenance::{FsMaintenance, FsMaintenanceBuilder};
 pub use reader::{FsReader, FsReaderBuilder};
 pub use writer::{FsWriter, FsWriterBuilder};
 

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 /// `FsWriter` owns the writer identity, mutations, uploads, namespace
 /// lifecycle, and commit publication. With [`FsBackgroundWork::Enabled`], it
 /// also schedules metadata maintenance and upload garbage collection.
-/// Retention-floor advancement remains an explicit [`FsAdmin`](crate::FsAdmin)
+/// Retention-floor advancement remains an explicit [`FsMaintenance`](crate::FsMaintenance)
 /// operation.
 ///
 /// Build the handle inside the Tokio runtime that will use it. Do not share a
@@ -310,7 +310,7 @@ impl FsWriterBuilder {
     /// Handles that share this writer's decoded cache also share this local
     /// cache. The host owns and closes it; object storage remains authoritative.
     ///
-    /// [`FsAdminBuilder::over_writer`]: crate::FsAdminBuilder::over_writer
+    /// [`FsMaintenanceBuilder::over_writer`]: crate::FsMaintenanceBuilder::over_writer
     pub fn stored_metadata_block_cache(
         mut self,
         stored_metadata_block_cache: Arc<dyn StoredMetadataBlockCache>,
@@ -427,8 +427,8 @@ impl FsWriterBuilder {
             runtime,
             std::time::Duration::from_millis(self.min_publish_interval_ms),
         );
-        // The runtime's own executors register last: they run as an admin
-        // over this writer's parts, so both have to exist first.
+        // The runtime's own executors register last: they run as a maintenance
+        // handle over this writer's parts, so both have to exist first.
         register_core_jobs(&bits.maintenance, &core, &bits, &publisher)?;
         Ok(FsWriter {
             core,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -1,6 +1,6 @@
 //! Embedded LoonFS runtime.
 //!
-//! Use [`FsWriter`] for mutations, [`FsReader`] for reads, and [`FsAdmin`] for
+//! Use [`FsWriter`] for mutations, [`FsReader`] for reads, and [`FsMaintenance`] for
 //! explicit maintenance. [`FsBackgroundWork`] controls whether a writer also
 //! schedules non-destructive maintenance.
 //!
@@ -53,7 +53,7 @@
 //! ```
 //!
 //! Writers schedule maintenance only for namespaces touched by or assigned to
-//! the process. [`FsWriter::shutdown`] drains that work. Readers and admins do
+//! the process. [`FsWriter::shutdown`] drains that work. Readers and maintenance handles do
 //! not start background tasks.
 #![warn(missing_docs)]
 
@@ -196,9 +196,11 @@ pub use cache::RuntimeCacheStats;
 pub use config::{RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE};
 pub use fs::{
     ChangesPager, CheckpointsPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager,
-    PathEntriesPager, TrashPager,
+    PathEntriesPager, SnapshotsPager, TrashPager,
 };
-pub use handle::{FsAdmin, FsAdminBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder};
+pub use handle::{
+    FsMaintenance, FsMaintenanceBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder,
+};
 pub use maintenance_runner::{
     FsBackgroundWork, MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,
     MaintenanceStepConclusion, MaintenanceStepReport, NamespacePublication,

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -43,13 +43,13 @@ const MAX_RECONCILE_PROBES_PER_SWEEP: usize = 64;
 ///
 /// Background work may compact metadata and collect expired uploads. It never
 /// advances the retention floor; that remains an explicit
-/// [`FsAdmin`](crate::FsAdmin) operation.
+/// [`FsMaintenance`](crate::FsMaintenance) operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FsBackgroundWork {
     /// Run maintenance for namespaces used or explicitly assigned to this
     /// process.
     Enabled,
-    /// Disable automatic maintenance. Explicit admin operations remain
+    /// Disable automatic maintenance. Explicit maintenance operations remain
     /// available.
     ManualOnly,
 }

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -5,7 +5,7 @@
 //! permits and are cancelled and joined during writer shutdown.
 
 use super::{MaintenanceJobId, RunnerInner};
-use crate::{FsAdmin, NamespaceId};
+use crate::{FsMaintenance, NamespaceId};
 use loonfs_core::{
     MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,
 };
@@ -98,11 +98,11 @@ impl BackgroundCompactions {
         Some(claim)
     }
 
-    /// Starts `spec` as a background job under `admin`'s identity, unless a
+    /// Starts `spec` as a background job under `maintenance`'s identity, unless a
     /// job already holds the namespace's one slot.
     pub(crate) fn start(
         &self,
-        admin: &FsAdmin,
+        maintenance: &FsMaintenance,
         namespace_id: &NamespaceId,
         spec: MetadataCompactionSpec,
     ) -> CompactionStart {
@@ -117,16 +117,16 @@ impl BackgroundCompactions {
         // moment it exists. A spawn a shutdown refuses drops the future
         // without polling it, and that drop is what gives the slot and the
         // permit back.
-        let admin = admin.clone();
+        let maintenance = maintenance.clone();
         let namespace_id = namespace_id.clone();
         runner.spawn(async move {
             if !claim.admitted().await {
-                admin.core.instruments().compaction_not_admitted();
+                maintenance.core.instruments().compaction_not_admitted();
                 return;
             }
             // Every ending is logged inside, including the error one, so what
             // a task nobody awaits needs from it is only what to do next.
-            let outcome = admin
+            let outcome = maintenance
                 .run_streaming_compaction(&namespace_id, &spec, claim.cancellation())
                 .await;
             let published = matches!(outcome, Ok(MetadataCompactionJobOutcome::Published { .. }));

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -1,8 +1,8 @@
 //! Runtime maintenance jobs for metadata upkeep and garbage collection.
 //!
-//! Both jobs use the public [`FsAdmin`] operations on the writer's runtime,
+//! Both jobs use the public [`FsMaintenance`] operations on the writer's runtime,
 //! so they share the same behavior and cache invalidation paths as manual
-//! maintenance. Retention-floor advancement remains an explicit admin action
+//! maintenance. Retention-floor advancement remains an explicit maintenance action
 //! because it discards replay history.
 
 use super::{
@@ -12,7 +12,7 @@ use super::{
 use crate::fs::{ReadCore, WriterBits};
 use crate::publisher::PublisherRegistry;
 use crate::{
-    ErrorCode, FsAdmin, GcConfig, GcResponse, MaintenanceRunRequest, MaintenanceRunResponse,
+    ErrorCode, FsMaintenance, GcConfig, GcResponse, MaintenanceRunRequest, MaintenanceRunResponse,
     MetadataMaintenanceOptions, MetadataMaintenanceResponse, NamespaceId, ReorganizeStepOutcome,
     Result, RuntimeError, WalFlushStepOutcome,
 };
@@ -80,15 +80,15 @@ struct StepContext {
 }
 
 impl StepContext {
-    fn admin(&self) -> Option<(Arc<WriterBits>, FsAdmin)> {
+    fn maintenance(&self) -> Option<(Arc<WriterBits>, FsMaintenance)> {
         let bits = self.bits.upgrade()?;
-        let admin = FsAdmin::from_writer_parts(
+        let maintenance = FsMaintenance::from_writer_parts(
             self.core.clone(),
             bits.identity.clone(),
             self.publisher.clone(),
             self.compactions.clone(),
         );
-        Some((bits, admin))
+        Some((bits, maintenance))
     }
 }
 
@@ -117,12 +117,15 @@ impl MaintenanceJob for MetadataJob {
         namespace_id: &NamespaceId,
         _continuation: Option<&str>,
     ) -> Result<MaintenanceStepReport> {
-        let Some((_writer, admin)) = self.context.admin() else {
+        let Some((_writer, maintenance)) = self.context.maintenance() else {
             return Ok(MaintenanceStepReport::concluded(
                 MaintenanceStepConclusion::NotEnabled,
             ));
         };
-        match admin.maintain_metadata(namespace_id, self.options).await {
+        match maintenance
+            .maintain_metadata(namespace_id, self.options)
+            .await
+        {
             Ok(metadata) => {
                 let conclusion = metadata_conclusion(&metadata);
                 Ok(MaintenanceStepReport::concluded(conclusion))
@@ -184,12 +187,12 @@ impl MaintenanceJob for GcJob {
         namespace_id: &NamespaceId,
         continuation: Option<&str>,
     ) -> Result<MaintenanceStepReport> {
-        let Some((_writer, admin)) = self.context.admin() else {
+        let Some((_writer, maintenance)) = self.context.maintenance() else {
             return Ok(MaintenanceStepReport::concluded(
                 MaintenanceStepConclusion::NotEnabled,
             ));
         };
-        let response = match admin
+        let response = match maintenance
             .run_maintenance(
                 namespace_id,
                 MaintenanceRunRequest::Gc(GcRequest {

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -408,7 +408,7 @@ impl RuntimeInstruments {
 
     /// Reports what one collection pass reclaimed and retained.
     ///
-    /// Every runtime collection path records at the shared admin pass before
+    /// Every runtime collection path records at the shared maintenance pass before
     /// its caller can drop the response.
     pub(crate) fn gc_pass(&self, gc: &GcResponse) {
         let Some(installed) = &self.installed else {

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -11,7 +11,7 @@ use crate::maintenance_runner::MaintenanceRunner;
 use crate::metrics::{DefaultMetricsRecorder, MetricValue, RuntimeInstruments};
 use crate::publish::{CommitRequest, ContentPreparationError, FilesystemOperation};
 use crate::{
-    CreateNamespaceOptions, ErrorCode, FsAdmin, RuntimeCacheConfig,
+    CreateNamespaceOptions, ErrorCode, FsMaintenance, RuntimeCacheConfig,
     SharedObjectStore as SharedStore, TraceMode, TraceStoreKind,
 };
 use async_trait::async_trait;
@@ -2191,7 +2191,7 @@ async fn retained_tail_projections_stay_within_the_namespace_count_cap() {
 }
 
 #[tokio::test]
-async fn admin_over_writer_invalidates_publisher_projection() {
+async fn maintenance_over_writer_invalidates_publisher_projection() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let writer = test_writer_with_interval(store.clone(), 0).await;
@@ -2210,13 +2210,13 @@ async fn admin_over_writer_invalidates_publisher_projection() {
         .expect("publish commit");
     assert_eq!(retained_projections(&writer.publisher()).projections, 1);
 
-    let admin = FsAdmin::builder_with_store(store)
-        .actor_id("admin")
+    let maintenance = FsMaintenance::builder_with_store(store)
+        .actor_id("maintenance")
         .over_writer(&writer)
         .build()
         .await
-        .expect("build admin");
-    admin.invalidate_namespace(&namespace_id);
+        .expect("build maintenance");
+    maintenance.invalidate_namespace(&namespace_id);
 
     assert_eq!(retained_projections(&writer.publisher()).projections, 0);
 }

--- a/crates/loonfs/tests/it/attribution_rows.rs
+++ b/crates/loonfs/tests/it/attribution_rows.rs
@@ -253,7 +253,7 @@ fn attributes_root_forks_and_trash_report_their_row_attribution() {
 
     fs.create_checkpoint_blocking(&source_id)
         .expect("checkpoint deletion rows");
-    block_on(fs.admin.advance_retention_floor(&source_id)).expect("advance retention");
+    block_on(fs.maintenance.advance_retention_floor(&source_id)).expect("advance retention");
     drop(fs);
 
     let reopened = open_runtime(object_store, "attribution-projections-reopened");

--- a/crates/loonfs/tests/it/bulk_file_reads.rs
+++ b/crates/loonfs/tests/it/bulk_file_reads.rs
@@ -459,7 +459,7 @@ async fn a_fork_targets_checkpoint_enumerates_the_source_state() {
     // The target has published nothing of its own, so its checkpoint's
     // manifest names metadata files the source owns.
     let checkpoint = fs
-        .admin
+        .maintenance
         .create_checkpoint(
             &target,
             CreateCheckpointOptions {
@@ -540,7 +540,7 @@ async fn a_released_checkpoint_refuses_enumeration_instead_of_answering_current_
         .create_checkpoint(&namespace_id)
         .await
         .expect("create checkpoint");
-    fs.admin
+    fs.maintenance
         .release_checkpoint(&namespace_id, &checkpoint.checkpoint_id)
         .await
         .expect("release checkpoint");

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -10,8 +10,8 @@
 //! wave count.
 
 use loonfs::{
-    CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MetadataMaintenanceOptions, NamespaceId,
-    PutFileOptions,
+    CreateNamespaceOptions, FsMaintenance, FsReader, FsWriter, MetadataMaintenanceOptions,
+    NamespaceId, PutFileOptions,
 };
 use loonfs_api::wire::manifest::{decode_namespace_manifest_json, MetadataRowFamily};
 use loonfs_api::AbsolutePath;
@@ -55,11 +55,11 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .build()
         .await
         .expect("build writer");
-    let admin = FsAdmin::builder_with_store(store.clone())
-        .actor_id("coldstat-admin")
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
+        .actor_id("coldstat-maintenance")
         .build()
         .await
-        .expect("build admin");
+        .expect("build maintenance");
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -78,7 +78,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         )
         .await
         .expect("seed the first manifest");
-    admin
+    maintenance
         .flush_wal(&namespace_id)
         .await
         .expect("publish first manifest");
@@ -129,7 +129,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
             ));
         }
         publish_candidates(&writer, &namespace_id, candidates).await;
-        admin
+        maintenance
             .maintain_metadata(
                 &namespace_id,
                 MetadataMaintenanceOptions {

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -106,7 +106,7 @@ async fn compact_receipt_past_horizon(
             .expect("create checkpoint");
     }
     let advanced = runtime
-        .admin
+        .maintenance
         .advance_retention_floor(namespace_id)
         .await
         .expect("advance retention floor");
@@ -122,7 +122,7 @@ async fn compact_receipt_past_horizon(
     let mut folded = false;
     for _ in 0..32 {
         let step = runtime
-            .admin
+            .maintenance
             .maintain_metadata(namespace_id, MetadataMaintenanceOptions::default())
             .await
             .expect("upkeep step");
@@ -620,7 +620,7 @@ async fn a_retention_trimmed_commit_seq_leaves_the_conflict_standing() {
         .await
         .expect("create checkpoint");
     let advanced = runtime
-        .admin
+        .maintenance
         .advance_retention_floor(&namespace_id)
         .await
         .expect("advance retention floor");
@@ -731,7 +731,7 @@ async fn concurrent_retries_past_the_receipt_horizon_commit_once() {
     );
     assert_eq!(
         runtime
-            .admin
+            .maintenance
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("namespace diagnostics")

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -9,8 +9,8 @@ use loonfs::uploads::ResolvedUploadCompletion;
 use loonfs::{
     AdvanceRetentionResponse, BeginUploadResponse, ChangeSeq, Checkpoint, ChecksumAlgorithm,
     CommitResponse, ContentRef, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
-    CreateNamespaceOptions, DeleteOptions, DirectoryPageCursor, ErrorCode, FileBytes, FsAdmin,
-    FsReader, FsWriter, FsWriterBuilder, ListChangesOptions, ListChangesResponse,
+    CreateNamespaceOptions, DeleteOptions, DirectoryPageCursor, ErrorCode, FileBytes,
+    FsMaintenance, FsReader, FsWriter, FsWriterBuilder, ListChangesOptions, ListChangesResponse,
     MaintenanceRunRequest, MaintenanceRunResponse, MetadataMaintenanceResponse, MoveOptions,
     NamespaceDiagnostics, NamespaceId, PageRequest, PaginationPolicy, PathEntry, PutFileOptions,
     RuntimeError, SharedObjectStore, UploadContentResponse, UploadId, UploadSession,
@@ -62,7 +62,7 @@ pub(crate) async fn collect_path_entries(
 }
 
 pub(crate) async fn collect_checkpoints(
-    admin: &FsAdmin,
+    maintenance: &FsMaintenance,
     namespace_id: &NamespaceId,
 ) -> loonfs::Result<loonfs::ListCheckpointsResponse> {
     let request = PageRequest {
@@ -71,7 +71,7 @@ pub(crate) async fn collect_checkpoints(
             .expect("default page limit"),
         cursor: None,
     };
-    let mut pager = admin.list_checkpoints_pager(namespace_id, request);
+    let mut pager = maintenance.list_checkpoints_pager(namespace_id, request);
     let mut response = pager.next().await.expect("first page")?;
     while let Some(page) = pager.next().await {
         let page = page?;
@@ -97,12 +97,12 @@ pub(crate) fn metadata_request(max_wal_tail_segments: u64) -> MaintenanceRunRequ
 }
 
 /// One handle set per test fixture: a writer, its derived reader, and an
-/// admin handle sharing the same store, exercised through the blocking
+/// maintenance handle sharing the same store, exercised through the blocking
 /// helpers below.
 pub(crate) struct TestRuntime {
     pub(crate) writer: FsWriter,
     pub(crate) reader: FsReader,
-    pub(crate) admin: FsAdmin,
+    pub(crate) maintenance: FsMaintenance,
 }
 
 pub(crate) fn runtime(root: &Path, writer_id: &str) -> TestRuntime {
@@ -136,15 +136,15 @@ pub(crate) async fn open_runtime_with_async(
         .await
         .expect("build writer");
     let reader = writer.reader();
-    let admin = FsAdmin::builder_with_store(store)
+    let maintenance = FsMaintenance::builder_with_store(store)
         .actor_id(writer_id)
         .build()
         .await
-        .expect("build admin");
+        .expect("build maintenance");
     TestRuntime {
         writer,
         reader,
-        admin,
+        maintenance,
     }
 }
 
@@ -250,7 +250,7 @@ impl TestRuntime {
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<Checkpoint> {
-        self.admin
+        self.maintenance
             .create_checkpoint(
                 namespace_id,
                 CreateCheckpointOptions {
@@ -428,7 +428,7 @@ impl RuntimeTestExt for TestRuntime {
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<NamespaceDiagnostics> {
-        block_on(self.admin.get_namespace_diagnostics(namespace_id))
+        block_on(self.maintenance.get_namespace_diagnostics(namespace_id))
     }
 
     fn maintenance_run_namespace_blocking(
@@ -436,14 +436,14 @@ impl RuntimeTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         request: MaintenanceRunRequest,
     ) -> loonfs::Result<MaintenanceRunResponse> {
-        block_on(self.admin.run_maintenance(namespace_id, request))
+        block_on(self.maintenance.run_maintenance(namespace_id, request))
     }
 
     fn flush_wal_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<MetadataMaintenanceResponse> {
-        block_on(self.admin.flush_wal(namespace_id))
+        block_on(self.maintenance.flush_wal(namespace_id))
     }
 
     fn stat_path_blocking(
@@ -616,7 +616,7 @@ impl RuntimeTestExt for TestRuntime {
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<AdvanceRetentionResponse> {
-        block_on(self.admin.advance_retention_floor(namespace_id))
+        block_on(self.maintenance.advance_retention_floor(namespace_id))
     }
 }
 

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -8,8 +8,8 @@
 
 use crate::common::collect_path_entries;
 use loonfs::{
-    CommitId, CreateCheckpointOptions, CreateNamespaceOptions, ErrorCode, FsAdmin,
-    FsBackgroundWork, FsReader, FsWriter, MaintenanceJobId, ManifestNo, MetadataMaintenanceOptions,
+    CommitId, CreateCheckpointOptions, CreateNamespaceOptions, ErrorCode, FsBackgroundWork,
+    FsMaintenance, FsReader, FsWriter, MaintenanceJobId, ManifestNo, MetadataMaintenanceOptions,
     NamespaceId, PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
@@ -149,12 +149,12 @@ fn shutdown_clears_a_non_empty_maintenance_queue_without_spawning_it() {
             .expect("shutdown must not hang with a non-empty queue")
             .expect("shut down writer background work");
 
-        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
-            .actor_id("handle-test-admin")
+        let maintenance = FsMaintenance::builder_with_store(blocking.clone() as SharedObjectStore)
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin");
-        let status = admin
+            .expect("build maintenance");
+        let status = maintenance
             .get_namespace_diagnostics(&queued_namespace)
             .await
             .expect("queued namespace status after shutdown");
@@ -184,7 +184,7 @@ fn shutdown_clears_a_non_empty_maintenance_queue_without_spawning_it() {
             .flush_background()
             .await
             .expect("nothing may spawn after shutdown");
-        let status = admin
+        let status = maintenance
             .get_namespace_diagnostics(&queued_namespace)
             .await
             .expect("queued namespace status after the post-shutdown nudge");
@@ -196,7 +196,7 @@ fn shutdown_clears_a_non_empty_maintenance_queue_without_spawning_it() {
 }
 
 #[test]
-fn writer_reader_and_admin_share_a_namespace_through_store_config() {
+fn writer_reader_and_maintenance_share_a_namespace_through_store_config() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     block_on(async {
@@ -241,20 +241,20 @@ fn writer_reader_and_admin_share_a_namespace_through_store_config() {
         assert_eq!(entries.len(), 1);
 
         // Admin inspects the same namespace through its own handle.
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
+        let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin");
-        let status = admin
+            .expect("build maintenance");
+        let status = maintenance
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("namespace status");
         assert_eq!(status.namespace_id, namespace_id);
         assert_eq!(status.wal_tail_segments, 1);
-        // Admin-driven work is observable through the admin handle's own
+        // Admin-driven work is observable through the maintenance handle's own
         // cache counters, like writer and reader work through theirs.
-        let _ = admin.runtime_cache_stats();
+        let _ = maintenance.runtime_cache_stats();
 
         // Only the writer owns background work, so only the writer has
         // anything to shut down.
@@ -318,7 +318,7 @@ fn standalone_reader_builds_without_writer_identity() {
 }
 
 #[test]
-fn admin_over_writer_core_invalidates_shared_caches() {
+fn maintenance_over_writer_core_invalidates_shared_caches() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     block_on(async {
@@ -344,12 +344,12 @@ fn admin_over_writer_core_invalidates_shared_caches() {
             .await
             .expect("background maintenance quiesces");
 
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
+        let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin");
-        let status = admin
+            .expect("build maintenance");
+        let status = maintenance
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("status after the scheduled step");
@@ -495,12 +495,12 @@ fn manual_only_writer_folds_without_scheduling_maintenance() {
             .await
             .expect("no background work to wait for");
 
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
+        let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin");
-        let status = admin
+            .expect("build maintenance");
+        let status = maintenance
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("status after writes");
@@ -537,11 +537,11 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
                 .await
                 .expect("create namespace");
 
-            let admin = FsAdmin::builder(store_config(temp_dir.path()))
-                .actor_id("handle-test-admin")
+            let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
+                .actor_id("handle-test-maintenance")
                 .build()
                 .await
-                .expect("build admin");
+                .expect("build maintenance");
             writer
                 .put_file_bytes(
                     &namespace_id,
@@ -555,7 +555,7 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
                 .flush_background()
                 .await
                 .expect("nothing was scheduled below the threshold");
-            let status = admin
+            let status = maintenance
                 .get_namespace_diagnostics(&namespace_id)
                 .await
                 .expect("status below the threshold");
@@ -581,7 +581,7 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
                 .await
                 .expect("background maintenance quiesces");
 
-            let status = admin
+            let status = maintenance
                 .get_namespace_diagnostics(&namespace_id)
                 .await
                 .expect("status after auto step");
@@ -633,12 +633,12 @@ fn a_runtime_publish_folds_a_preexisting_write_stopped_tail_and_lands() {
             )
             .await
             .expect("the runtime publish folds the preexisting tail and lands");
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
+        let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin");
-        let status = admin
+            .expect("build maintenance");
+        let status = maintenance
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("status after the folding publish");
@@ -719,12 +719,12 @@ fn a_failed_fold_preserves_the_write_stop_until_the_store_recovers() {
             )
             .await
             .expect("the recovered manifest store lets the next publish fold and land");
-        let admin = FsAdmin::builder_with_store(failing as SharedObjectStore)
-            .actor_id("handle-test-admin")
+        let maintenance = FsMaintenance::builder_with_store(failing as SharedObjectStore)
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin");
-        let status = admin
+            .expect("build maintenance");
+        let status = maintenance
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("status after fold recovery");
@@ -755,11 +755,11 @@ fn a_shut_down_writer_refuses_mutations_and_keeps_reading() {
             )
             .await
             .expect("put file before the shutdown");
-        let tail_at_shutdown = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
+        let tail_at_shutdown = FsMaintenance::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin")
+            .expect("build maintenance")
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("status before the shutdown")
@@ -790,12 +790,12 @@ fn a_shut_down_writer_refuses_mutations_and_keeps_reading() {
             .flush_background()
             .await
             .expect("nothing scheduled after the shutdown");
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
+        let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin");
-        let status = admin
+            .expect("build maintenance");
+        let status = maintenance
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("status after the shutdown");
@@ -827,7 +827,7 @@ fn builders_require_identity_and_a_runtime() {
         Err(other) => panic!("expected config error for a blank writer_id, got {other:?}"),
         Ok(_) => panic!("a whitespace-only writer_id must be rejected"),
     }
-    match block_on(FsAdmin::builder(store_config(temp_dir.path())).build()) {
+    match block_on(FsMaintenance::builder(store_config(temp_dir.path())).build()) {
         Err(RuntimeError::Config(_)) => {}
         Err(other) => panic!("expected config error for missing actor_id, got {other:?}"),
         Ok(_) => panic!("actor_id must be required"),
@@ -867,7 +867,7 @@ fn writer_builder_rejects_zero_maintenance_concurrency() {
 }
 
 #[test]
-fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
+fn maintenance_checkpoint_and_retention_are_explicit_one_shot_calls() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     block_on(async {
@@ -886,12 +886,12 @@ fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
             .await
             .expect("put file");
 
-        let admin = FsAdmin::builder(store_config(temp_dir.path()))
-            .actor_id("handle-test-admin")
+        let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-maintenance")
             .build()
             .await
-            .expect("build admin");
-        let checkpoint = admin
+            .expect("build maintenance");
+        let checkpoint = maintenance
             .create_checkpoint(
                 &namespace_id,
                 CreateCheckpointOptions {
@@ -902,7 +902,7 @@ fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
             .await
             .expect("create checkpoint");
         assert!(checkpoint.manifest_no > ManifestNo(0));
-        let retention = admin
+        let retention = maintenance
             .advance_retention_floor(&namespace_id)
             .await
             .expect("advance retention");
@@ -911,7 +911,7 @@ fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
 }
 
 #[test]
-fn enabled_writer_drains_reorganization_backlog_without_admin() {
+fn enabled_writer_drains_reorganization_backlog_without_maintenance() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     block_on(async {

--- a/crates/loonfs/tests/it/immutable_view_inputs.rs
+++ b/crates/loonfs/tests/it/immutable_view_inputs.rs
@@ -1,8 +1,8 @@
 //! Immutable view inputs are cached once per handle.
 
 use loonfs::{
-    CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MetadataMaintenanceOptions, NamespaceId,
-    PutFileOptions, SharedObjectStore,
+    CreateNamespaceOptions, FsMaintenance, FsReader, FsWriter, MetadataMaintenanceOptions,
+    NamespaceId, PutFileOptions, SharedObjectStore,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::stores::{KeyPredicate, RecordingStore};
@@ -23,11 +23,11 @@ async fn build_namespace(store: &SharedObjectStore, namespace_id: &NamespaceId) 
         .build()
         .await
         .expect("build writer");
-    let admin = FsAdmin::builder_with_store(store.clone())
-        .actor_id("seed-admin")
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
+        .actor_id("seed-maintenance")
         .build()
         .await
-        .expect("build admin");
+        .expect("build maintenance");
     writer
         .create_namespace(namespace_id, CreateNamespaceOptions::default())
         .await
@@ -43,7 +43,7 @@ async fn build_namespace(store: &SharedObjectStore, namespace_id: &NamespaceId) 
             .await
             .expect("seed file");
     }
-    admin
+    maintenance
         .maintain_metadata(
             namespace_id,
             MetadataMaintenanceOptions {

--- a/crates/loonfs/tests/it/main.rs
+++ b/crates/loonfs/tests/it/main.rs
@@ -28,6 +28,7 @@ mod publication;
 mod read_snapshot;
 mod request_accounting;
 mod runtime_config;
+mod snapshots;
 mod staged_content_reclamation;
 mod streamed_put;
 mod streamed_read;

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -7,9 +7,9 @@ use crate::common::*;
 use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
 use loonfs::{
     ChangeSeq, CheckpointOwnerSummary, CommitId, CreateCheckpointOptions, CreateNamespaceOptions,
-    CreateSnapshotOptions, DeleteNamespaceOptions, ErrorCode, FsAdmin, FsWriter,
-    MaintenanceRunRequest, MaintenanceRunResponse, ManifestNo, MetadataCompactionOutcome,
-    NamespaceId, PutFileOptions, ReorganizeStepOutcome, SharedObjectStore, WalFlushStepOutcome,
+    CreateSnapshotOptions, DeleteNamespaceOptions, ErrorCode, MaintenanceRunRequest,
+    MaintenanceRunResponse, ManifestNo, MetadataCompactionOutcome, NamespaceId, PutFileOptions,
+    ReorganizeStepOutcome, SharedObjectStore, WalFlushStepOutcome,
 };
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, ControlObjectEnvelope, ControlObjectKind,
@@ -26,12 +26,9 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{
-    BlockingStore, FailStore, InjectedError, KeyPredicate, OperationClass, OperationKind,
-    RecordingStore,
+    FailStore, InjectedError, KeyPredicate, OperationClass, RecordingStore,
 };
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
 use tempfile::tempdir;
 
 #[test]
@@ -117,7 +114,7 @@ fn namespace_diagnostics_counts_user_and_live_snapshot_records_only() {
 
     fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
         .expect("create namespace");
-    block_on(fs.admin.create_checkpoint(
+    block_on(fs.maintenance.create_checkpoint(
         &source,
         CreateCheckpointOptions {
             name: "durable".to_owned(),
@@ -125,7 +122,7 @@ fn namespace_diagnostics_counts_user_and_live_snapshot_records_only() {
         },
     ))
     .expect("create durable checkpoint");
-    block_on(fs.admin.create_checkpoint(
+    block_on(fs.maintenance.create_checkpoint(
         &source,
         CreateCheckpointOptions {
             name: "expired".to_owned(),
@@ -133,7 +130,7 @@ fn namespace_diagnostics_counts_user_and_live_snapshot_records_only() {
         },
     ))
     .expect("create expired checkpoint");
-    block_on(fs.admin.create_snapshot(
+    block_on(fs.writer.create_snapshot(
         &source,
         CreateSnapshotOptions {
             name: "expired".to_owned(),
@@ -141,7 +138,7 @@ fn namespace_diagnostics_counts_user_and_live_snapshot_records_only() {
         },
     ))
     .expect("create expired snapshot record");
-    block_on(fs.admin.create_snapshot(
+    block_on(fs.writer.create_snapshot(
         &source,
         CreateSnapshotOptions {
             name: "live".to_owned(),
@@ -609,7 +606,7 @@ fn maintenance_step_after_existing_manifest_writes_delta_manifest() {
 }
 
 #[test]
-fn a_standalone_admin_drives_metadata_compaction_itself() {
+fn a_standalone_maintenance_drives_metadata_compaction_itself() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "manual-compaction-test");
     let namespace_id = namespace_id("demo");
@@ -618,7 +615,7 @@ fn a_standalone_admin_drives_metadata_compaction_itself() {
         .expect("create namespace");
     // A namespace that has published no manifest has no runs to rebuild.
     assert_eq!(
-        block_on(fs.admin.compact_metadata(&namespace_id))
+        block_on(fs.maintenance.compact_metadata(&namespace_id))
             .expect("compact an empty namespace")
             .outcome,
         MetadataCompactionOutcome::NotNeeded
@@ -646,7 +643,7 @@ fn a_standalone_admin_drives_metadata_compaction_itself() {
     // this call reports exactly that: it published the unit the planner
     // chose, as the next maintenance step would have, and ran no job.
     assert_eq!(
-        block_on(fs.admin.compact_metadata(&namespace_id))
+        block_on(fs.maintenance.compact_metadata(&namespace_id))
             .expect("plan a compaction")
             .outcome,
         MetadataCompactionOutcome::BoundedMergePublished
@@ -750,177 +747,6 @@ fn maintenance_step_treats_metadata_root_cas_loss_as_benign_race() {
     assert_eq!(status.wal_tail_segments, 1);
 }
 
-#[test]
-fn a_created_snapshot_is_listed_with_its_snapshot_owner() {
-    let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "snapshot-create-test");
-    let namespace_id = namespace_id("demo");
-
-    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
-        .expect("create namespace");
-    fs.put_file_bytes_blocking(
-        &namespace_id,
-        "/docs/hello.txt",
-        b"hello",
-        PutFileOptions::new(loonfs_test_support::test_actor()),
-    )
-    .expect("put file");
-
-    let expires_at_ms = 4_102_444_800_000;
-    let snapshot = block_on(fs.admin.create_snapshot(
-        &namespace_id,
-        CreateSnapshotOptions {
-            name: "report-run".to_owned(),
-            expires_at_ms,
-        },
-    ))
-    .expect("create snapshot");
-    assert_eq!(
-        snapshot.owner,
-        CheckpointOwnerSummary::Snapshot {
-            name: "report-run".to_owned(),
-        }
-    );
-
-    let listed = block_on(collect_checkpoints(&fs.admin, &namespace_id)).expect("list checkpoints");
-    let listed_snapshot = listed
-        .checkpoints
-        .iter()
-        .find(|checkpoint| checkpoint.checkpoint_id == snapshot.checkpoint_id)
-        .expect("the snapshot is in the checkpoint listing");
-    assert_eq!(listed_snapshot.owner, snapshot.owner);
-    assert_eq!(listed_snapshot.expires_at_ms, Some(expires_at_ms));
-    assert_eq!(listed_snapshot.checkpoint_seq, snapshot.checkpoint_seq);
-}
-
-#[tokio::test]
-async fn snapshot_create_recovers_an_ambiguously_landed_record_write() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("snapshot-ambiguous-write");
-    let store = Arc::new(
-        FailStore::new(
-            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::prefix(checkpoint_prefix(&namespace_id)),
-            OperationClass::PutCreateIfAbsent,
-            InjectedError::Transport("lost checkpoint write acknowledgement".to_owned()),
-        )
-        .apply_then_fail(),
-    );
-    let object_store: SharedObjectStore = store.clone();
-    let fs = open_runtime_async(object_store, "snapshot-ambiguous-write").await;
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
-        .await
-        .expect("create namespace");
-    store.fail_next(1);
-
-    let snapshot = fs
-        .admin
-        .create_snapshot(
-            &namespace_id,
-            CreateSnapshotOptions {
-                name: "report-run".to_owned(),
-                expires_at_ms: u64::MAX,
-            },
-        )
-        .await
-        .expect("reconcile the durable snapshot record");
-
-    assert_eq!(store.attempts(), 1);
-    let listed = collect_checkpoints(&fs.admin, &namespace_id)
-        .await
-        .expect("list checkpoints");
-    assert_eq!(listed.checkpoints.len(), 1);
-    assert_eq!(listed.checkpoints[0].checkpoint_id, snapshot.checkpoint_id);
-}
-
-#[tokio::test]
-async fn snapshot_extension_recovers_an_ambiguously_landed_record_write() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("snapshot-ambiguous-extension");
-    let checkpoint_key_prefix = checkpoint_prefix(&namespace_id);
-    let store = Arc::new(
-        FailStore::new(
-            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::prefix(checkpoint_key_prefix),
-            OperationClass::CompareAndSwap,
-            InjectedError::Transport("lost snapshot extension acknowledgement".to_owned()),
-        )
-        .apply_then_fail(),
-    );
-    let object_store: SharedObjectStore = store.clone();
-    let fs = open_runtime_async(object_store, "snapshot-ambiguous-extension").await;
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
-        .await
-        .expect("create namespace");
-    let snapshot = fs
-        .admin
-        .create_snapshot(
-            &namespace_id,
-            CreateSnapshotOptions {
-                name: "report-run".to_owned(),
-                expires_at_ms: u64::MAX - 1,
-            },
-        )
-        .await
-        .expect("create snapshot");
-    store.fail_next(1);
-
-    let extended = fs
-        .admin
-        .extend_snapshot(&namespace_id, &snapshot.checkpoint_id, u64::MAX, u64::MAX)
-        .await
-        .expect("reconcile the durable snapshot extension");
-
-    assert_eq!(extended.expires_at_ms, u64::MAX);
-    assert_eq!(store.attempts(), 1);
-}
-
-#[tokio::test]
-async fn snapshot_release_recovers_an_ambiguously_landed_record_write() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("snapshot-ambiguous-release");
-    let store = Arc::new(
-        FailStore::new(
-            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::prefix(checkpoint_prefix(&namespace_id)),
-            OperationClass::CompareAndSwap,
-            InjectedError::Transport("lost snapshot release acknowledgement".to_owned()),
-        )
-        .apply_then_fail(),
-    );
-    let object_store: SharedObjectStore = store.clone();
-    let fs = open_runtime_async(object_store, "snapshot-ambiguous-release").await;
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
-        .await
-        .expect("create namespace");
-    let snapshot = fs
-        .admin
-        .create_snapshot(
-            &namespace_id,
-            CreateSnapshotOptions {
-                name: "report-run".to_owned(),
-                expires_at_ms: u64::MAX,
-            },
-        )
-        .await
-        .expect("create snapshot");
-    store.fail_next(1);
-
-    fs.admin
-        .release_snapshot(&namespace_id, &snapshot.checkpoint_id)
-        .await
-        .expect("reconcile the durable snapshot release");
-
-    assert_eq!(store.attempts(), 1);
-    let listed = collect_checkpoints(&fs.admin, &namespace_id)
-        .await
-        .expect("list checkpoints");
-    assert!(listed
-        .checkpoints
-        .iter()
-        .all(|checkpoint| checkpoint.checkpoint_id != snapshot.checkpoint_id));
-}
-
 #[tokio::test]
 async fn fork_recovers_an_ambiguously_landed_checkpoint_renewal() {
     let temp_dir = tempdir().expect("tempdir");
@@ -958,7 +784,7 @@ async fn fork_recovers_an_ambiguously_landed_checkpoint_renewal() {
 
     assert_eq!(store.attempts(), 1);
     assert_eq!(forked.namespace_id, target);
-    let checkpoints = collect_checkpoints(&fs.admin, &source)
+    let checkpoints = collect_checkpoints(&fs.maintenance, &source)
         .await
         .expect("list source checkpoints");
     let fork_checkpoint = checkpoints
@@ -975,193 +801,4 @@ async fn fork_recovers_an_ambiguously_landed_checkpoint_renewal() {
         })
         .expect("fork checkpoint remains installed");
     assert_eq!(fork_checkpoint.namespace_id, source);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn concurrent_snapshot_creates_cannot_both_claim_the_last_quota_slot() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("snapshot-quota-race");
-    let checkpoint_key_prefix = checkpoint_prefix(&namespace_id);
-    let checkpoint_writes = Arc::new(AtomicUsize::new(0));
-    let checkpoint_writes_seen = checkpoint_writes.clone();
-    let checkpoint_write_gate = Arc::new(BlockingStore::matching(
-        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-        move |operation| {
-            let matches = operation.key().starts_with(&checkpoint_key_prefix)
-                && matches!(
-                    operation.kind(),
-                    OperationKind::Put { .. } | OperationKind::PutStreamed { .. }
-                );
-            if matches {
-                checkpoint_writes_seen.fetch_add(1, Ordering::SeqCst);
-            }
-            matches
-        },
-    ));
-    let checkpoint_list_prefix = checkpoint_prefix(&namespace_id);
-    let checkpoint_lists = Arc::new(AtomicUsize::new(0));
-    let checkpoint_lists_seen = checkpoint_lists.clone();
-    let checkpoint_list_gate = Arc::new(BlockingStore::matching(
-        checkpoint_write_gate.clone(),
-        move |operation| {
-            let matches = operation.key() == checkpoint_list_prefix
-                && matches!(operation.kind(), OperationKind::List);
-            if matches {
-                checkpoint_lists_seen.fetch_add(1, Ordering::SeqCst);
-            }
-            matches
-        },
-    ));
-    let object_store: SharedObjectStore = checkpoint_list_gate.clone();
-    let fs = open_runtime_async(object_store, "snapshot-quota-race").await;
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
-        .await
-        .expect("create namespace");
-
-    checkpoint_list_gate.arm();
-    checkpoint_write_gate.arm();
-    let first_admin = fs.admin.clone();
-    let first_namespace = namespace_id.clone();
-    let first = tokio::spawn(async move {
-        first_admin
-            .create_snapshot_with_quota(
-                &first_namespace,
-                CreateSnapshotOptions {
-                    name: "first".to_owned(),
-                    expires_at_ms: u64::MAX,
-                },
-                0,
-                1,
-            )
-            .await
-    });
-    let second_admin = fs.admin.clone();
-    let second_namespace = namespace_id.clone();
-    let second = tokio::spawn(async move {
-        second_admin
-            .create_snapshot_with_quota(
-                &second_namespace,
-                CreateSnapshotOptions {
-                    name: "second".to_owned(),
-                    expires_at_ms: u64::MAX,
-                },
-                0,
-                1,
-            )
-            .await
-    });
-
-    wait_for_operations(&checkpoint_writes, 2).await;
-    checkpoint_write_gate.release();
-    wait_for_operations(&checkpoint_lists, 2).await;
-    checkpoint_list_gate.release();
-
-    let first = first.await.expect("first create task");
-    let second = second.await.expect("second create task");
-    assert_core_error_kind(first, ErrorCode::SnapshotQuotaExceeded);
-    assert_core_error_kind(second, ErrorCode::SnapshotQuotaExceeded);
-    let listed = collect_checkpoints(&fs.admin, &namespace_id)
-        .await
-        .expect("list checkpoints after raced creates");
-    assert!(listed.checkpoints.is_empty());
-}
-
-async fn wait_for_operations(counter: &AtomicUsize, expected: usize) {
-    tokio::time::timeout(Duration::from_secs(10), async {
-        while counter.load(Ordering::SeqCst) < expected {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .unwrap_or_else(|_| panic!("timed out waiting for {expected} operations"));
-}
-
-#[test]
-fn tombstoned_namespace_keeps_checkpoint_inventory_and_user_release_available() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = store(temp_dir.path());
-    let fs = open_runtime(store.clone(), "checkpoint-tombstone-setup");
-    let source = namespace_id("source");
-    let target = namespace_id("target");
-
-    fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
-        .expect("create source namespace");
-    fs.put_file_bytes_blocking(
-        &source,
-        "/docs/hello.txt",
-        b"hello",
-        PutFileOptions::new(loonfs_test_support::test_actor()),
-    )
-    .expect("put source file");
-    fs.fork_namespace_blocking(&source, &target)
-        .expect("fork source namespace");
-    let user_checkpoint = fs
-        .create_checkpoint_blocking(&source)
-        .expect("create user checkpoint");
-
-    let before_delete = block_on(collect_checkpoints(&fs.admin, &source))
-        .expect("list checkpoints before deletion");
-    let fork_checkpoint = before_delete
-        .checkpoints
-        .iter()
-        .find(|checkpoint| {
-            matches!(
-                &checkpoint.owner,
-                CheckpointOwnerSummary::Fork {
-                    target_namespace_id
-                } if target_namespace_id == &target
-            )
-        })
-        .expect("fork-owned checkpoint")
-        .checkpoint_id
-        .clone();
-
-    let deleter = block_on(
-        FsWriter::builder_with_store(store.clone())
-            .writer_id("checkpoint-tombstone-deleter")
-            .build(),
-    )
-    .expect("build deleting writer");
-    block_on(deleter.delete_namespace(&source, DeleteNamespaceOptions::default()))
-        .expect("delete source namespace");
-
-    let admin = block_on(
-        FsAdmin::builder_with_store(store)
-            .actor_id("checkpoint-tombstone-observer")
-            .build(),
-    )
-    .expect("build post-delete admin");
-    let listed = block_on(collect_checkpoints(&admin, &source))
-        .expect("list checkpoints on deleted namespace");
-    assert_eq!(listed.checkpoints.len(), 2);
-    assert!(listed
-        .checkpoints
-        .iter()
-        .any(|checkpoint| checkpoint.checkpoint_id == user_checkpoint.checkpoint_id));
-    assert!(listed
-        .checkpoints
-        .iter()
-        .any(|checkpoint| checkpoint.checkpoint_id == fork_checkpoint));
-
-    let released = block_on(admin.release_checkpoint(&source, &user_checkpoint.checkpoint_id))
-        .expect("release user checkpoint on deleted namespace");
-    assert_eq!(released.checkpoint_id, user_checkpoint.checkpoint_id);
-    assert_core_error_kind(
-        block_on(admin.release_checkpoint(&source, &fork_checkpoint)),
-        ErrorCode::InvalidRequest,
-    );
-    assert_core_error_kind(
-        block_on(admin.get_namespace_diagnostics(&source)),
-        ErrorCode::NamespaceDeleted,
-    );
-    assert_core_error_kind(
-        block_on(admin.create_checkpoint(
-            &source,
-            CreateCheckpointOptions {
-                name: "after-delete".to_owned(),
-                ttl_ms: None,
-            },
-        )),
-        ErrorCode::NamespaceDeleted,
-    );
 }

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -196,7 +196,7 @@ fn snapshot_pins_report_the_snapshot_view_counter() {
             .await
             .expect("create namespace");
         let checkpoint = fs
-            .admin
+            .maintenance
             .create_checkpoint(
                 &namespace_id,
                 CreateCheckpointOptions {
@@ -212,7 +212,7 @@ fn snapshot_pins_report_the_snapshot_view_counter() {
             .await
             .expect("pin checkpoint");
         let read_snapshot = fs
-            .admin
+            .writer
             .create_snapshot(
                 &namespace_id,
                 CreateSnapshotOptions {

--- a/crates/loonfs/tests/it/read_snapshot.rs
+++ b/crates/loonfs/tests/it/read_snapshot.rs
@@ -30,7 +30,7 @@ async fn snapshot_directory_cursor_resumes_only_at_its_snapshot() {
 
     let now_ms = loonfs::current_time_ms().expect("current time");
     let first_snapshot = runtime
-        .admin
+        .writer
         .create_snapshot(
             &namespace_id,
             CreateSnapshotOptions {
@@ -78,7 +78,7 @@ async fn snapshot_directory_cursor_resumes_only_at_its_snapshot() {
         .await
         .expect("change current directory");
     let second_snapshot = runtime
-        .admin
+        .writer
         .create_snapshot(
             &namespace_id,
             CreateSnapshotOptions {
@@ -407,7 +407,7 @@ async fn a_released_checkpoint_refuses_a_pin_instead_of_reading_current_state() 
         .await
         .expect("create checkpoint");
     runtime
-        .admin
+        .maintenance
         .release_checkpoint(&namespace_id, &checkpoint.checkpoint_id)
         .await
         .expect("release checkpoint");
@@ -446,7 +446,7 @@ async fn snapshot_pins_serve_captured_state_and_enforce_release() {
         .expect("resolve captured file");
     let now_ms = loonfs::current_time_ms().expect("current time");
     let snapshot = runtime
-        .admin
+        .writer
         .create_snapshot(
             &namespace_id,
             CreateSnapshotOptions {
@@ -512,7 +512,7 @@ async fn snapshot_pins_serve_captured_state_and_enforce_release() {
     );
 
     runtime
-        .admin
+        .writer
         .release_snapshot(&namespace_id, &snapshot.checkpoint_id)
         .await
         .expect("release snapshot");

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -8,8 +8,8 @@
 //!   cargo test -p loonfs --test it request_accounting -- --ignored --nocapture
 
 use loonfs::{
-    CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MetadataMaintenanceOptions, NamespaceId,
-    PageRequest, PaginationPolicy, PutFileOptions, SharedObjectStore,
+    CreateNamespaceOptions, FsMaintenance, FsReader, FsWriter, MetadataMaintenanceOptions,
+    NamespaceId, PageRequest, PaginationPolicy, PutFileOptions, SharedObjectStore,
 };
 use loonfs_api::AbsolutePath;
 
@@ -138,11 +138,11 @@ async fn warm_phase_request_accounting() {
         .build()
         .await
         .expect("build writer");
-    let admin = FsAdmin::builder_with_store(store.clone())
-        .actor_id("acct-admin")
+    let maintenance = FsMaintenance::builder_with_store(store.clone())
+        .actor_id("acct-maintenance")
         .build()
         .await
-        .expect("build admin");
+        .expect("build maintenance");
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -194,7 +194,7 @@ async fn warm_phase_request_accounting() {
         }
         publish_candidates(&writer, &namespace_id, candidates).await;
         if (index / BATCH) % STEP_EVERY_BATCHES == 0 {
-            admin
+            maintenance
                 .maintain_metadata(
                     &namespace_id,
                     MetadataMaintenanceOptions {

--- a/crates/loonfs/tests/it/snapshots.rs
+++ b/crates/loonfs/tests/it/snapshots.rs
@@ -1,0 +1,399 @@
+//! User-visible snapshots.
+
+#![allow(clippy::panic)]
+// Runtime integration tests use panic in helper assertions for precise diagnostics.
+
+use crate::common::*;
+use loonfs::{
+    CheckpointOwnerSummary, CreateCheckpointOptions, CreateNamespaceOptions, CreateSnapshotOptions,
+    DeleteNamespaceOptions, ErrorCode, FsMaintenance, FsReader, FsWriter, ListSnapshotsResponse,
+    NamespaceId, PageRequest, PaginationPolicy, PutFileOptions, SharedObjectStore,
+};
+use loonfs_objectstore::keys::checkpoint_prefix;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_test_support::ids::namespace_id;
+use loonfs_test_support::stores::{
+    BlockingStore, FailStore, InjectedError, KeyPredicate, OperationClass, OperationKind,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+
+async fn list_snapshots(
+    reader: &FsReader,
+    namespace_id: &NamespaceId,
+) -> loonfs::Result<ListSnapshotsResponse> {
+    let request = PageRequest {
+        limit: PaginationPolicy::default()
+            .resolve_limit(None)
+            .expect("default page limit"),
+        cursor: None,
+    };
+    let mut pager = reader.list_snapshots_pager(namespace_id, request);
+    let mut response = pager.next().await.expect("first page")?;
+    while let Some(page) = pager.next().await {
+        let page = page?;
+        response.snapshots.extend(page.snapshots);
+        response.next_cursor = page.next_cursor;
+    }
+    Ok(response)
+}
+
+#[test]
+fn a_created_snapshot_is_listed_with_its_snapshot_owner() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "snapshot-create-test");
+    let namespace_id = namespace_id("demo");
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::new(loonfs_test_support::test_actor()),
+    )
+    .expect("put file");
+
+    let expires_at_ms = 4_102_444_800_000;
+    let snapshot = block_on(fs.writer.create_snapshot(
+        &namespace_id,
+        CreateSnapshotOptions {
+            name: "report-run".to_owned(),
+            expires_at_ms,
+        },
+    ))
+    .expect("create snapshot");
+    assert_eq!(
+        snapshot.owner,
+        CheckpointOwnerSummary::Snapshot {
+            name: "report-run".to_owned(),
+        }
+    );
+
+    let listed = block_on(list_snapshots(&fs.reader, &namespace_id)).expect("list snapshots");
+    let listed_snapshot = listed
+        .snapshots
+        .iter()
+        .find(|listed| listed.snapshot_id == snapshot.checkpoint_id)
+        .expect("the snapshot is in the snapshot listing");
+    assert_eq!(listed_snapshot.name, "report-run");
+    assert_eq!(listed_snapshot.expires_at_ms, expires_at_ms);
+    assert_eq!(listed_snapshot.head_seq, snapshot.checkpoint_seq);
+}
+
+#[tokio::test]
+async fn snapshot_create_recovers_an_ambiguously_landed_record_write() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("snapshot-ambiguous-write");
+    let store = Arc::new(
+        FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::prefix(checkpoint_prefix(&namespace_id)),
+            OperationClass::PutCreateIfAbsent,
+            InjectedError::Transport("lost checkpoint write acknowledgement".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    let object_store: SharedObjectStore = store.clone();
+    let fs = open_runtime_async(object_store, "snapshot-ambiguous-write").await;
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    store.fail_next(1);
+
+    let snapshot = fs
+        .writer
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "report-run".to_owned(),
+                expires_at_ms: u64::MAX,
+            },
+        )
+        .await
+        .expect("reconcile the durable snapshot record");
+
+    assert_eq!(store.attempts(), 1);
+    let listed = list_snapshots(&fs.reader, &namespace_id)
+        .await
+        .expect("list snapshots");
+    assert_eq!(listed.snapshots.len(), 1);
+    assert_eq!(listed.snapshots[0].snapshot_id, snapshot.checkpoint_id);
+}
+
+#[tokio::test]
+async fn snapshot_extension_recovers_an_ambiguously_landed_record_write() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("snapshot-ambiguous-extension");
+    let checkpoint_key_prefix = checkpoint_prefix(&namespace_id);
+    let store = Arc::new(
+        FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::prefix(checkpoint_key_prefix),
+            OperationClass::CompareAndSwap,
+            InjectedError::Transport("lost snapshot extension acknowledgement".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    let object_store: SharedObjectStore = store.clone();
+    let fs = open_runtime_async(object_store, "snapshot-ambiguous-extension").await;
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let snapshot = fs
+        .writer
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "report-run".to_owned(),
+                expires_at_ms: u64::MAX - 1,
+            },
+        )
+        .await
+        .expect("create snapshot");
+    store.fail_next(1);
+
+    let extended = fs
+        .writer
+        .extend_snapshot(&namespace_id, &snapshot.checkpoint_id, u64::MAX, u64::MAX)
+        .await
+        .expect("reconcile the durable snapshot extension");
+
+    assert_eq!(extended.expires_at_ms, u64::MAX);
+    assert_eq!(store.attempts(), 1);
+}
+
+#[tokio::test]
+async fn snapshot_release_recovers_an_ambiguously_landed_record_write() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("snapshot-ambiguous-release");
+    let store = Arc::new(
+        FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::prefix(checkpoint_prefix(&namespace_id)),
+            OperationClass::CompareAndSwap,
+            InjectedError::Transport("lost snapshot release acknowledgement".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    let object_store: SharedObjectStore = store.clone();
+    let fs = open_runtime_async(object_store, "snapshot-ambiguous-release").await;
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let snapshot = fs
+        .writer
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "report-run".to_owned(),
+                expires_at_ms: u64::MAX,
+            },
+        )
+        .await
+        .expect("create snapshot");
+    store.fail_next(1);
+
+    fs.writer
+        .release_snapshot(&namespace_id, &snapshot.checkpoint_id)
+        .await
+        .expect("reconcile the durable snapshot release");
+
+    assert_eq!(store.attempts(), 1);
+    let listed = list_snapshots(&fs.reader, &namespace_id)
+        .await
+        .expect("list snapshots");
+    assert!(listed.snapshots.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_snapshot_creates_cannot_both_claim_the_last_quota_slot() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("snapshot-quota-race");
+    let checkpoint_key_prefix = checkpoint_prefix(&namespace_id);
+    let checkpoint_writes = Arc::new(AtomicUsize::new(0));
+    let checkpoint_writes_seen = checkpoint_writes.clone();
+    let checkpoint_write_gate = Arc::new(BlockingStore::matching(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        move |operation| {
+            let matches = operation.key().starts_with(&checkpoint_key_prefix)
+                && matches!(
+                    operation.kind(),
+                    OperationKind::Put { .. } | OperationKind::PutStreamed { .. }
+                );
+            if matches {
+                checkpoint_writes_seen.fetch_add(1, Ordering::SeqCst);
+            }
+            matches
+        },
+    ));
+    let checkpoint_list_prefix = checkpoint_prefix(&namespace_id);
+    let checkpoint_lists = Arc::new(AtomicUsize::new(0));
+    let checkpoint_lists_seen = checkpoint_lists.clone();
+    let checkpoint_list_gate = Arc::new(BlockingStore::matching(
+        checkpoint_write_gate.clone(),
+        move |operation| {
+            let matches = operation.key() == checkpoint_list_prefix
+                && matches!(operation.kind(), OperationKind::List);
+            if matches {
+                checkpoint_lists_seen.fetch_add(1, Ordering::SeqCst);
+            }
+            matches
+        },
+    ));
+    let object_store: SharedObjectStore = checkpoint_list_gate.clone();
+    let fs = open_runtime_async(object_store, "snapshot-quota-race").await;
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    checkpoint_list_gate.arm();
+    checkpoint_write_gate.arm();
+    let first_writer = fs.writer.clone();
+    let first_namespace = namespace_id.clone();
+    let first = tokio::spawn(async move {
+        first_writer
+            .create_snapshot_with_quota(
+                &first_namespace,
+                CreateSnapshotOptions {
+                    name: "first".to_owned(),
+                    expires_at_ms: u64::MAX,
+                },
+                0,
+                1,
+            )
+            .await
+    });
+    let second_writer = fs.writer.clone();
+    let second_namespace = namespace_id.clone();
+    let second = tokio::spawn(async move {
+        second_writer
+            .create_snapshot_with_quota(
+                &second_namespace,
+                CreateSnapshotOptions {
+                    name: "second".to_owned(),
+                    expires_at_ms: u64::MAX,
+                },
+                0,
+                1,
+            )
+            .await
+    });
+
+    wait_for_operations(&checkpoint_writes, 2).await;
+    checkpoint_write_gate.release();
+    wait_for_operations(&checkpoint_lists, 2).await;
+    checkpoint_list_gate.release();
+
+    let first = first.await.expect("first create task");
+    let second = second.await.expect("second create task");
+    assert_core_error_kind(first, ErrorCode::SnapshotQuotaExceeded);
+    assert_core_error_kind(second, ErrorCode::SnapshotQuotaExceeded);
+    let listed = list_snapshots(&fs.reader, &namespace_id)
+        .await
+        .expect("list snapshots after raced creates");
+    assert!(listed.snapshots.is_empty());
+}
+
+async fn wait_for_operations(counter: &AtomicUsize, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while counter.load(Ordering::SeqCst) < expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {expected} operations"));
+}
+
+#[test]
+fn tombstoned_namespace_keeps_checkpoint_inventory_and_user_release_available() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let fs = open_runtime(store.clone(), "checkpoint-tombstone-setup");
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+
+    fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
+        .expect("create source namespace");
+    fs.put_file_bytes_blocking(
+        &source,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::new(loonfs_test_support::test_actor()),
+    )
+    .expect("put source file");
+    fs.fork_namespace_blocking(&source, &target)
+        .expect("fork source namespace");
+    let user_checkpoint = fs
+        .create_checkpoint_blocking(&source)
+        .expect("create user checkpoint");
+
+    let before_delete = block_on(collect_checkpoints(&fs.maintenance, &source))
+        .expect("list checkpoints before deletion");
+    let fork_checkpoint = before_delete
+        .checkpoints
+        .iter()
+        .find(|checkpoint| {
+            matches!(
+                &checkpoint.owner,
+                CheckpointOwnerSummary::Fork {
+                    target_namespace_id
+                } if target_namespace_id == &target
+            )
+        })
+        .expect("fork-owned checkpoint")
+        .checkpoint_id
+        .clone();
+
+    let deleter = block_on(
+        FsWriter::builder_with_store(store.clone())
+            .writer_id("checkpoint-tombstone-deleter")
+            .build(),
+    )
+    .expect("build deleting writer");
+    block_on(deleter.delete_namespace(&source, DeleteNamespaceOptions::default()))
+        .expect("delete source namespace");
+
+    let maintenance = block_on(
+        FsMaintenance::builder_with_store(store)
+            .actor_id("checkpoint-tombstone-observer")
+            .build(),
+    )
+    .expect("build post-delete maintenance");
+    let listed = block_on(collect_checkpoints(&maintenance, &source))
+        .expect("list checkpoints on deleted namespace");
+    assert_eq!(listed.checkpoints.len(), 2);
+    assert!(listed
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint.checkpoint_id == user_checkpoint.checkpoint_id));
+    assert!(listed
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint.checkpoint_id == fork_checkpoint));
+
+    let released =
+        block_on(maintenance.release_checkpoint(&source, &user_checkpoint.checkpoint_id))
+            .expect("release user checkpoint on deleted namespace");
+    assert_eq!(released.checkpoint_id, user_checkpoint.checkpoint_id);
+    assert_core_error_kind(
+        block_on(maintenance.release_checkpoint(&source, &fork_checkpoint)),
+        ErrorCode::InvalidRequest,
+    );
+    assert_core_error_kind(
+        block_on(maintenance.get_namespace_diagnostics(&source)),
+        ErrorCode::NamespaceDeleted,
+    );
+    assert_core_error_kind(
+        block_on(maintenance.create_checkpoint(
+            &source,
+            CreateCheckpointOptions {
+                name: "after-delete".to_owned(),
+                ttl_ms: None,
+            },
+        )),
+        ErrorCode::NamespaceDeleted,
+    );
+}

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -8,7 +8,7 @@
 //! referenced by metadata or reclaimed, and none of them is immortal.
 //!
 //! Garbage collection is driven through `loonfs_core::gc_namespace` rather
-//! than `FsAdmin::gc_namespace`, because the admin handle stamps its pass
+//! than `FsMaintenance::gc_namespace`, because the maintenance handle stamps its pass
 //! from the wall clock and these deadlines are days out. The store is the
 //! same one the runtime wrote through, so the pass sees exactly what the
 //! puts left behind.

--- a/crates/loonfs/tests/operation_spans.rs
+++ b/crates/loonfs/tests/operation_spans.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::panic)]
 // Include the captured output when an assertion fails.
 
-//! Checks operation spans for the writer, reader, and admin handles.
+//! Checks operation spans for the writer, reader, and maintenance handles.
 
 use loonfs::{
-    CreateDirectoryOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter,
+    CreateDirectoryOptions, CreateNamespaceOptions, FsBackgroundWork, FsMaintenance, FsWriter,
     PutFileOptions, StoreConfig,
 };
 use loonfs_test_support::block_on::block_on;
@@ -81,11 +81,11 @@ fn every_handle_emits_an_operation_span_with_its_namespace() {
             .await
             .expect("read namespace state");
 
-        FsAdmin::builder_with_store(writer.object_store())
-            .actor_id("operation-span-admin")
+        FsMaintenance::builder_with_store(writer.object_store())
+            .actor_id("operation-span-maintenance")
             .build()
             .await
-            .expect("build admin")
+            .expect("build maintenance")
             .get_namespace_diagnostics(&namespace_id)
             .await
             .expect("read namespace diagnostics");

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -92,7 +92,7 @@ The planner balances these cases with the manifest's record of how many delta me
 
 The count is stored in the namespace manifest for each `MetadataFamilyGroup`. It is cleared after successful full compaction or after a bottom-anchored merge becomes possible.
 
-Callers provide a `FrozenBasePolicy` when planning. Background maintenance uses `Amortized`, which reads the manifest's per-group count. `FsAdmin::compact_metadata` uses `CompactImmediately` because the caller explicitly requested full compaction. A bounded maintenance step without a background runner also uses `CompactImmediately`, allowing it to report that compaction is required instead of repeatedly publishing delta merges that cannot rebuild the base.
+Callers provide a `FrozenBasePolicy` when planning. Background maintenance uses `Amortized`, which reads the manifest's per-group count. `FsMaintenance::compact_metadata` uses `CompactImmediately` because the caller explicitly requested full compaction. A bounded maintenance step without a background runner also uses `CompactImmediately`, allowing it to report that compaction is required instead of repeatedly publishing delta merges that cannot rebuild the base.
 
 The planner excludes every family group whose compaction lease is active and unexpired. A process keeps one compaction claim per namespace so it does not start two jobs itself, and allows at most two compaction jobs to run. Maintenance may continue processing unrelated groups in the same namespace. Shutdown cancels both queued and running jobs.
 
@@ -177,9 +177,9 @@ Cancellation and lease fencing never publish a partial result. A process restart
 
 ## Maintenance results and observability
 
-The maintenance API reports `compaction_started` when a step launches a background job. `compaction_at_capacity` means the job is queued for a process permit, `compaction_running` means the namespace already has a queued or running job, and `compaction_required` means the current handle has no background runner and an operator must call `FsAdmin::compact_metadata`.
+The maintenance API reports `compaction_started` when a step launches a background job. `compaction_at_capacity` means the job is queued for a process permit, `compaction_running` means the namespace already has a queued or running job, and `compaction_required` means the current handle has no background runner and an operator must call `FsMaintenance::compact_metadata`.
 
-An explicit `FsAdmin::compact_metadata` call reports `NoWork`, `BoundedMergePublished`, `AlreadyRunning`, or `Ran`. The separate no-work and bounded-merge outcomes tell callers whether the method changed the manifest without starting a full compaction.
+An explicit `FsMaintenance::compact_metadata` call reports `NoWork`, `BoundedMergePublished`, `AlreadyRunning`, or `Ran`. The separate no-work and bounded-merge outcomes tell callers whether the method changed the manifest without starting a full compaction.
 
 Lifecycle logging covers job selection, start, progress, publication, cancellation, abandonment, supersession, and failure. Progress records include the namespace, family group, input-run count, rows processed, output-segment count, peak retention rows, elapsed time, and final outcome.
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -10,6 +10,9 @@
 | **Access-control service** | Evaluates ACLs and shares, then authorizes LoonFS operations. This may be part of the authoritative runtime in a simple deployment. |
 | **Background workers** | Publish namespace manifests, create checkpoint records, advance retention safely, clean up expired control objects, and reclaim unreachable content. |
 
+The embedded runtime exposes `FsReader`, `FsWriter`, and `FsMaintenance` handles.
+Snapshot listing is an `FsReader` operation; snapshot create, extend, and release are `FsWriter` operations.
+
 Namespaces and content stores are separate durable domains. A namespace owns filesystem metadata and history; a content store owns immutable file bytes. A namespace descriptor references exactly one content store, but that reference is not lifecycle ownership. Forked namespaces share the source namespace's content store while keeping independent future metadata history. Fork provenance and GC pins may record source-owned immutable files needed by the fork.
 
 ## 2. Data plane, metadata plane, and control plane


### PR DESCRIPTION
Renames the embedded FsAdmin handle to FsMaintenance so its name describes the operations it provides rather than a caller role.

Snapshot operations move to the filesystem handles: readers list snapshots, while writers create, extend, and release them. These operations still use checkpoint records directly and do not publish WAL commits or change durable formats. Server handlers now use the reader and writer for snapshots and the maintenance handle for operational work.