### PR TITLE
feat(core): use one compaction lease per metadata group

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -89,6 +89,30 @@ pub enum MetadataFamilyGroup {
 }
 
 impl MetadataFamilyGroup {
+    /// Every family group in serialized declaration order.
+    pub const ALL: [Self; 7] = [
+        Self::Bindings,
+        Self::Revisions,
+        Self::Inodes,
+        Self::Tombstones,
+        Self::ActiveDeletions,
+        Self::CommitReceipts,
+        Self::Attributes,
+    ];
+
+    /// Returns the snake-case name used in durable keys and serialized values.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Bindings => "bindings",
+            Self::Revisions => "revisions",
+            Self::Inodes => "inodes",
+            Self::Tombstones => "tombstones",
+            Self::ActiveDeletions => "active_deletions",
+            Self::CommitReceipts => "commit_receipts",
+            Self::Attributes => "attributes",
+        }
+    }
+
     /// Returns the families this group merges together.
     pub const fn families(self) -> &'static [MetadataRowFamily] {
         match self {

--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -12,7 +12,6 @@ use super::streaming_compaction::MetadataCompactionSpec;
 use crate::control_object::{
     expect_identity_field, expect_namespace, load_control_object, ControlObjectLoadError,
 };
-use crate::control_update::create_control_object_under_generated_id;
 use crate::error::{CoreError, Result};
 use crate::limits::{
     METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS, METADATA_COMPACTION_LEASE_EXPIRY_MS,
@@ -23,11 +22,8 @@ use loonfs_api::wire::control::{
     encode_control_state, CompactionLeaseStatus, ControlObjectKind, MetadataCompactionLeaseState,
 };
 use loonfs_api::{MetadataCompactionId, MetadataFamilyGroup, NamespaceId};
-use loonfs_objectstore::keys::{
-    metadata_compaction_job_id_from_key, metadata_compaction_lease, metadata_compaction_prefix,
-};
+use loonfs_objectstore::keys::metadata_compaction_lease;
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
-use std::collections::BTreeSet;
 
 /// Who owns the objects under one job's prefix, as a collector reads it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,45 +43,64 @@ pub(crate) enum CompactionPrefixOwner {
     NoOne,
 }
 
-/// Returns the current prefix owner, claiming an expired lease when possible.
-///
-/// A collector parses `metadata_compaction_id` from the key it is deciding.
-/// A lease naming a different job or namespace is corrupt because the key
-/// and embedded fence disagree.
-///
-/// An expired lease is not collectable until the compare-and-swap succeeds;
-/// the job may still resume and refresh it first.
-pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
+/// Returns the current prefix owner, claiming its expired group lease when possible.
+#[cfg(test)]
+pub(crate) async fn claim_group_lease<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
     metadata_compaction_id: &MetadataCompactionId,
     now_ms: u64,
 ) -> Result<CompactionPrefixOwner> {
-    let object_key = metadata_compaction_lease(namespace_id, metadata_compaction_id);
+    let Some(loaded) = load_group_lease(store, namespace_id, group).await? else {
+        return Ok(CompactionPrefixOwner::NoOne);
+    };
+    claim_loaded_group_lease(store, namespace_id, metadata_compaction_id, loaded, now_ms).await
+}
+
+pub(crate) type LoadedCompactionLease =
+    crate::control_object::LoadedControl<MetadataCompactionLeaseState>;
+
+pub(crate) async fn load_group_lease<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
+) -> Result<Option<LoadedCompactionLease>> {
     let loaded = load_control_object(
         store,
-        object_key,
+        metadata_compaction_lease(namespace_id, group),
         ControlObjectKind::CompactionLease,
         |state: &MetadataCompactionLeaseState| {
             expect_namespace(namespace_id, &state.namespace_id)?;
             expect_identity_field(
-                "compaction job id",
-                metadata_compaction_id.as_str(),
-                state.job_id.as_str(),
+                "metadata family group",
+                group.as_str(),
+                state.group.as_str(),
             )
         },
     )
     .await;
-    let loaded = match loaded {
-        Ok(loaded) => loaded,
-        Err(ControlObjectLoadError::MissingObject { .. }) => {
-            return Ok(CompactionPrefixOwner::NoOne)
-        }
-        Err(error) => return Err(CoreError::ControlObjectLoad(error)),
-    };
+    match loaded {
+        Ok(loaded) => Ok(Some(loaded)),
+        Err(ControlObjectLoadError::MissingObject { .. }) => Ok(None),
+        Err(error) => Err(CoreError::ControlObjectLoad(error)),
+    }
+}
+
+pub(crate) async fn claim_loaded_group_lease<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    metadata_compaction_id: &MetadataCompactionId,
+    loaded: LoadedCompactionLease,
+    now_ms: u64,
+) -> Result<CompactionPrefixOwner> {
     let object_key = loaded.object_key;
     let expected_etag = loaded.etag;
     let state = loaded.state;
+    // A group lease protects only the staged objects written by the job id it names.
+    if state.job_id != *metadata_compaction_id {
+        return Ok(CompactionPrefixOwner::NoOne);
+    }
     // Terminal: somebody already fenced this job, so the reap goes on from
     // wherever the pass that started it stopped.
     if state.status == (CompactionLeaseStatus::Reaping {}) {
@@ -110,8 +125,8 @@ pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
                 job_id = metadata_compaction_id.as_str(),
                 writer_id = reaping.writer_id.as_str(),
                 heartbeat_at_ms = reaping.heartbeat_at_ms,
-                "a streaming metadata compaction lease expired; garbage collection claimed its \
-                 prefix and the job that wrote it can no longer publish"
+                "a streaming metadata compaction lease expired; garbage collection claimed the \
+                 group lease and the job that wrote it can no longer publish"
             );
             Ok(CompactionPrefixOwner::ThisCollector)
         }
@@ -125,44 +140,36 @@ pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Groups under an active, unexpired lease in this namespace.
-pub(crate) async fn groups_under_active_leases<S: ObjectStore + ?Sized>(
+/// Availability of one family group's deterministic lease.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GroupLeaseState {
+    /// No lease exists.
+    Free,
+    /// An unexpired job or a collector holds the lease.
+    Held,
+    /// The active lease may be taken over.
+    Expired,
+}
+
+/// Reads one family group's lease for planning.
+pub(super) async fn group_lease_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
     now_ms: u64,
-) -> Result<BTreeSet<MetadataFamilyGroup>> {
-    let prefix = metadata_compaction_prefix(namespace_id);
-    let keys = store
-        .list_prefix(&prefix)
-        .await
-        .map_err(|error| CoreError::store(&prefix, &error))?;
-    let job_ids = keys
-        .iter()
-        .filter_map(|key| metadata_compaction_job_id_from_key(key))
-        .filter_map(|job_id| MetadataCompactionId::parse(job_id).ok())
-        .collect::<BTreeSet<_>>();
-    let mut groups = BTreeSet::new();
-    for job_id in job_ids {
-        let loaded = load_control_object(
-            store,
-            metadata_compaction_lease(namespace_id, &job_id),
-            ControlObjectKind::CompactionLease,
-            |state: &MetadataCompactionLeaseState| {
-                expect_namespace(namespace_id, &state.namespace_id)?;
-                expect_identity_field("compaction job id", job_id.as_str(), state.job_id.as_str())
-            },
-        )
-        .await;
-        let state = match loaded {
-            Ok(loaded) => loaded.state,
-            Err(ControlObjectLoadError::MissingObject { .. }) => continue,
-            Err(error) => return Err(CoreError::ControlObjectLoad(error)),
-        };
-        if active_lease_is_unexpired(&state, now_ms) {
-            groups.insert(state.group);
-        }
-    }
-    Ok(groups)
+) -> Result<GroupLeaseState> {
+    let Some(loaded) = load_group_lease(store, namespace_id, group).await? else {
+        return Ok(GroupLeaseState::Free);
+    };
+    Ok(
+        if active_lease_is_unexpired(&loaded.state, now_ms)
+            || loaded.state.status == (CompactionLeaseStatus::Reaping {})
+        {
+            GroupLeaseState::Held
+        } else {
+            GroupLeaseState::Expired
+        },
+    )
 }
 
 fn active_lease_is_unexpired(state: &MetadataCompactionLeaseState, now_ms: u64) -> bool {
@@ -184,6 +191,14 @@ pub(super) enum LeaseHold {
     Fenced,
 }
 
+/// Result of trying to acquire a family group's lease.
+pub(super) enum LeaseAcquire<'a> {
+    /// This job owns the lease.
+    Acquired(CompactionLease<'a>),
+    /// Another job or a collector holds the lease.
+    Held,
+}
+
 /// One running job's claim on its own prefix.
 ///
 /// The wall clock is read once, when the job starts; every later heartbeat
@@ -200,30 +215,128 @@ pub(super) struct CompactionLease<'a> {
 }
 
 impl<'a> CompactionLease<'a> {
-    /// Writes the lease before the job's first output object.
-    pub(super) async fn create<S: ObjectStore + ?Sized>(
+    /// Acquires the group lease before the job's first output object.
+    pub(super) async fn acquire<S: ObjectStore + ?Sized>(
         store: &S,
         namespace_id: &NamespaceId,
         spec: &MetadataCompactionSpec,
         writer_id: &str,
         started_at_ms: u64,
         timer: &'a dyn MonotonicTimer,
-    ) -> Result<Self> {
+    ) -> Result<LeaseAcquire<'a>> {
         let started_monotonic_ms = timer.monotonic_now_ms();
-        let object_key = metadata_compaction_lease(namespace_id, spec.job_id());
+        let object_key = metadata_compaction_lease(namespace_id, spec.group());
         let state = initial_lease_state(namespace_id, spec, writer_id, started_at_ms);
         let encoded = encode_lease(&state)?;
-        let metadata =
-            create_control_object_under_generated_id(store, &object_key, encoded).await?;
-        let etag = required_etag(&object_key, metadata.etag)?;
-        Ok(Self {
+        let loaded = load_group_lease(store, namespace_id, spec.group()).await?;
+        let etag = match loaded {
+            Some(loaded) => {
+                return Self::take_over_expired(
+                    store,
+                    loaded,
+                    object_key,
+                    state,
+                    encoded,
+                    timer,
+                    started_monotonic_ms,
+                )
+                .await
+            }
+            None => match store.put_if_absent(&object_key, encoded.clone()).await {
+                Ok(metadata) => required_etag(&object_key, metadata.etag)?,
+                Err(ObjectStoreError::PreconditionFailed { .. }) => {
+                    let Some(loaded) = load_group_lease(store, namespace_id, spec.group()).await?
+                    else {
+                        return Ok(LeaseAcquire::Held);
+                    };
+                    return Self::take_over_expired(
+                        store,
+                        loaded,
+                        object_key,
+                        state,
+                        encoded,
+                        timer,
+                        started_monotonic_ms,
+                    )
+                    .await;
+                }
+                Err(error @ ObjectStoreError::Transport { .. }) => {
+                    let Some(loaded) = load_group_lease(store, namespace_id, spec.group()).await?
+                    else {
+                        return Err(CoreError::store(&object_key, &error));
+                    };
+                    if loaded.state == state {
+                        loaded.etag
+                    } else {
+                        return Self::take_over_expired(
+                            store,
+                            loaded,
+                            object_key,
+                            state,
+                            encoded,
+                            timer,
+                            started_monotonic_ms,
+                        )
+                        .await;
+                    }
+                }
+                Err(error) => return Err(CoreError::store(&object_key, &error)),
+            },
+        };
+        Ok(LeaseAcquire::Acquired(Self {
             object_key,
             state,
             etag,
             timer,
             started_monotonic_ms,
             next_heartbeat_monotonic_ms: started_monotonic_ms,
-        })
+        }))
+    }
+
+    async fn take_over_expired<S: ObjectStore + ?Sized>(
+        store: &S,
+        loaded: LoadedCompactionLease,
+        object_key: String,
+        state: MetadataCompactionLeaseState,
+        encoded: Bytes,
+        timer: &'a dyn MonotonicTimer,
+        started_monotonic_ms: u64,
+    ) -> Result<LeaseAcquire<'a>> {
+        if active_lease_is_unexpired(&loaded.state, state.started_at_ms)
+            || loaded.state.status == (CompactionLeaseStatus::Reaping {})
+        {
+            return Ok(LeaseAcquire::Held);
+        }
+        // Replacing the complete expired lease in one CAS fences the previous job's next heartbeat.
+        let etag = match store
+            .compare_and_swap(&object_key, &loaded.etag, encoded)
+            .await
+        {
+            Ok(metadata) => required_etag(&object_key, metadata.etag)?,
+            Err(
+                ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::NotFound { .. },
+            ) => return Ok(LeaseAcquire::Held),
+            Err(error @ ObjectStoreError::Transport { .. }) => {
+                let Some(confirmed) =
+                    load_group_lease(store, &state.namespace_id, state.group).await?
+                else {
+                    return Err(CoreError::store(&object_key, &error));
+                };
+                if confirmed.state != state {
+                    return Ok(LeaseAcquire::Held);
+                }
+                confirmed.etag
+            }
+            Err(error) => return Err(CoreError::store(&object_key, &error)),
+        };
+        Ok(LeaseAcquire::Acquired(Self {
+            object_key,
+            state,
+            etag,
+            timer,
+            started_monotonic_ms,
+            next_heartbeat_monotonic_ms: started_monotonic_ms,
+        }))
     }
 
     /// The clock the job paces itself by. One clock for the job's heartbeat
@@ -275,7 +388,7 @@ impl<'a> CompactionLease<'a> {
                     .saturating_add(METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS);
                 Ok(LeaseHold::Held)
             }
-            // Garbage collection claimed the prefix, or the object is gone.
+            // Garbage collection claimed the group lease, or the object is gone.
             // Either way this job no longer owns what it wrote.
             Err(
                 ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::NotFound { .. },
@@ -310,33 +423,27 @@ impl<'a> CompactionLease<'a> {
         started_at_ms: u64,
         timer: &'a dyn MonotonicTimer,
     ) -> Result<Self> {
-        let object_key = metadata_compaction_lease(namespace_id, spec.job_id());
-        let loaded = load_control_object(
-            store,
-            object_key.clone(),
-            ControlObjectKind::CompactionLease,
-            |state: &MetadataCompactionLeaseState| {
-                expect_namespace(namespace_id, &state.namespace_id)?;
-                expect_identity_field(
-                    "compaction job id",
-                    spec.job_id().as_str(),
-                    state.job_id.as_str(),
-                )
-            },
-        )
-        .await;
-        let loaded = match loaded {
-            Ok(loaded) => loaded,
-            Err(ControlObjectLoadError::MissingObject { .. }) => {
-                return Self::create(store, namespace_id, spec, writer_id, started_at_ms, timer)
-                    .await
-            }
-            Err(error) => return Err(CoreError::ControlObjectLoad(error)),
+        match Self::acquire(store, namespace_id, spec, writer_id, started_at_ms, timer).await? {
+            LeaseAcquire::Acquired(lease) => return Ok(lease),
+            LeaseAcquire::Held => {}
+        }
+        let object_key = metadata_compaction_lease(namespace_id, spec.group());
+        let Some(loaded) = load_group_lease(store, namespace_id, spec.group()).await? else {
+            return Err(CoreError::Internal(format!(
+                "the compaction lease `{object_key}` disappeared while a test reopened it"
+            )));
         };
+        if loaded.state.job_id != *spec.job_id()
+            || loaded.state.status != (CompactionLeaseStatus::Active {})
+        {
+            return Err(CoreError::Internal(format!(
+                "the compaction lease `{object_key}` is held by another owner"
+            )));
+        }
         let started_monotonic_ms = timer.monotonic_now_ms();
         Ok(Self {
             object_key,
-            state: initial_lease_state(namespace_id, spec, writer_id, started_at_ms),
+            state: loaded.state,
             etag: loaded.etag,
             timer,
             started_monotonic_ms,
@@ -372,7 +479,7 @@ fn required_etag(object_key: &str, etag: Option<String>) -> Result<String> {
 }
 
 fn encode_lease(state: &MetadataCompactionLeaseState) -> Result<Bytes> {
-    let object_key = metadata_compaction_lease(&state.namespace_id, &state.job_id);
+    let object_key = metadata_compaction_lease(&state.namespace_id, state.group);
     encode_control_state(ControlObjectKind::CompactionLease, state)
         .map(Bytes::from)
         .map_err(|error| CoreError::Codec {

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -63,7 +63,9 @@ pub use self::streaming_compaction::{
     MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,
 };
 
-pub(crate) use self::compaction_lease::{claim_compaction_prefix, CompactionPrefixOwner};
+pub(crate) use self::compaction_lease::{
+    claim_loaded_group_lease, load_group_lease, CompactionPrefixOwner, LoadedCompactionLease,
+};
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::data_block_load::DecodedRowWeight;
 pub(crate) use self::files::list_checkpoint_files_page;

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -9,7 +9,7 @@
 //! [`FrozenBasePolicy`] decides when a blocked base requires full compaction.
 
 use super::block_fetch::load_segment_index_for_reorganization;
-use super::compaction_lease::groups_under_active_leases;
+use super::compaction_lease::{group_lease_state, GroupLeaseState};
 use super::error::ManifestLoadError;
 use super::flush::{ensure_metadata_publication_budget, next_manifest_no_after, next_run_no_after};
 use super::load::load_verified_manifest_segments;
@@ -153,8 +153,6 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let snapshot = load_control_snapshot(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    let groups_under_active_leases =
-        groups_under_active_leases(store, namespace_id, context.now_ms).await?;
     let floor_seq = snapshot.retention_floor_seq;
     // A namespace that has published no manifest of its own has no runs to
     // fold: reorganization has nothing to do until its first flush.
@@ -183,7 +181,9 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             MetadataReorganizeOutcome::NotNeeded { delta_runs },
         ));
     }
-    let Some(group) = select_family_group(&previous.payload, &groups_under_active_leases) else {
+    let Some(group) =
+        select_family_group(store, namespace_id, &previous.payload, context.now_ms).await?
+    else {
         // Delta runs exist but hold no rows (empty families), or the only group
         // with rows is the one a job is rebuilding; nothing to fold here.
         return Ok(report(
@@ -749,7 +749,7 @@ fn manifest_has_reorganization_work(
     runs: &[MetadataRunManifest],
     policy: MetadataLsmPolicy,
 ) -> bool {
-    let has_group_rows = select_family_group(payload, &BTreeSet::new()).is_some();
+    let has_group_rows = !ranked_family_groups(payload).is_empty();
     (delta_run_count(payload) >= policy.max_delta_runs.get() && has_group_rows)
         || manifest_has_partial_reorganization(runs)
         || payload
@@ -793,33 +793,41 @@ async fn decoded_group_run_bytes<S: ObjectStore + ?Sized>(
     Ok(decoded_bytes)
 }
 
-/// The family group with the most delta rows to fold; ties resolve in group
-/// order. `None` when no group has delta rows.
+/// The available family group with the most delta rows to fold; ties resolve
+/// in group order. `None` when no available group has delta rows.
 ///
-/// Groups under active compaction leases are skipped. A job's snapshot is
-/// every run its group held, while merges of other groups leave those
-/// descriptors unchanged.
+/// Groups under unexpired active or reaping leases are skipped. A job's
+/// snapshot is every run its group held, while merges of other groups leave
+/// those descriptors unchanged.
 ///
 /// Without it the excluded group would win every step for as long as the job
 /// ran — its delta rows are frozen in the job's snapshot, so its count never
 /// falls, while every other group's falls the moment it folds — and the step
 /// would spend itself re-planning a job that is already running.
-pub(super) fn select_family_group(
+pub(super) async fn select_family_group<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
     payload: &NamespaceManifestPayload,
-    rebuilding: &BTreeSet<MetadataFamilyGroup>,
-) -> Option<MetadataFamilyGroup> {
-    REORGANIZE_FAMILY_GROUPS
+    now_ms: u64,
+) -> Result<Option<MetadataFamilyGroup>> {
+    for group in ranked_family_groups(payload) {
+        if group_lease_state(store, namespace_id, group, now_ms).await? != GroupLeaseState::Held {
+            return Ok(Some(group));
+        }
+    }
+    Ok(None)
+}
+
+pub(super) fn ranked_family_groups(payload: &NamespaceManifestPayload) -> Vec<MetadataFamilyGroup> {
+    let mut ranked = REORGANIZE_FAMILY_GROUPS
         .into_iter()
-        .filter(|group| !rebuilding.contains(group))
         .map(|group| (group_delta_rows(payload, group), group))
         .filter(|(rows, _)| *rows > 0)
-        .max_by(|(left_rows, left), (right_rows, right)| {
-            // On ties the EARLIER group must win, and group order is the
-            // enum's declaration order; comparing the groups reversed makes
-            // max_by pick it.
-            left_rows.cmp(right_rows).then_with(|| right.cmp(left))
-        })
-        .map(|(_, group)| group)
+        .collect::<Vec<_>>();
+    ranked.sort_by(|(left_rows, left), (right_rows, right)| {
+        right_rows.cmp(left_rows).then_with(|| left.cmp(right))
+    });
+    ranked.into_iter().map(|(_, group)| group).collect()
 }
 
 fn group_delta_rows(payload: &NamespaceManifestPayload, group: MetadataFamilyGroup) -> u64 {

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -30,15 +30,7 @@ pub(super) const CHECKPOINT_ROW_FAMILIES: [MetadataRowFamily; 10] = [
     MetadataRowFamily::Attributes,
 ];
 
-pub(super) const REORGANIZE_FAMILY_GROUPS: [MetadataFamilyGroup; 7] = [
-    MetadataFamilyGroup::Bindings,
-    MetadataFamilyGroup::Revisions,
-    MetadataFamilyGroup::Inodes,
-    MetadataFamilyGroup::Tombstones,
-    MetadataFamilyGroup::ActiveDeletions,
-    MetadataFamilyGroup::CommitReceipts,
-    MetadataFamilyGroup::Attributes,
-];
+pub(super) const REORGANIZE_FAMILY_GROUPS: [MetadataFamilyGroup; 7] = MetadataFamilyGroup::ALL;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct MetadataFamilySegments {

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -12,7 +12,7 @@
 use super::block_fetch::segment_object_len;
 use super::build::MetadataSegmentDestination;
 use super::cache::{MetadataSegmentCache, MetadataSegmentCacheConfig};
-use super::compaction_lease::{CompactionLease, LeaseHold};
+use super::compaction_lease::{CompactionLease, LeaseAcquire, LeaseHold};
 use super::compaction_merge::{
     locality_of, refill_iterators, select_next_iterator, LocalityGrouping,
     MetadataSegmentBlockLoader, MetadataSegmentRowIterator,
@@ -80,9 +80,9 @@ const MAX_FINALIZATION_ATTEMPTS: usize = 4;
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataCompactionSpec {
-    /// This job's identity, and the prefix its output and its lease live
-    /// under. Generated with the plan, so two plans for one group never write
-    /// into each other's prefix.
+    /// This job's identity and the prefix its output lives under. Generated
+    /// with the plan, so two plans for one group never write into each other's
+    /// prefix.
     job_id: MetadataCompactionId,
     group: MetadataFamilyGroup,
     /// Every run the group held when the plan was made, by run number. That
@@ -350,12 +350,12 @@ pub enum MetadataCompactionJobOutcome {
     /// group again from what the manifest now holds.
     Abandoned,
     /// The job lost its lease: it stopped heartbeating for longer than the
-    /// lease expiry and garbage collection claimed its prefix. Ownership does
-    /// not come back, so the job publishes nothing and the collector reclaims
-    /// what it wrote. A later step plans the group again.
+    /// lease expiry and garbage collection claimed its group's lease.
+    /// Ownership does not come back, so the job publishes nothing and the
+    /// collector reclaims what it wrote. A later step plans the group again.
     Fenced,
-    /// Every publication attempt lost the root race. The job is thrown away
-    /// and a later step plans it again.
+    /// Another job or collector held the group lease, or every publication
+    /// attempt lost the root race. A later step plans the group again.
     Superseded,
 }
 
@@ -388,7 +388,7 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
     };
     // The lease is written before the first output object, so no object under
     // the job's prefix is ever unclaimed.
-    let mut lease = CompactionLease::create(
+    let lease = CompactionLease::acquire(
         store,
         namespace_id,
         spec,
@@ -397,6 +397,9 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
         &timer,
     )
     .await?;
+    let LeaseAcquire::Acquired(mut lease) = lease else {
+        return Ok(MetadataCompactionJobOutcome::Superseded);
+    };
     tracing::info!(
         namespace_id = namespace_id.as_str(),
         job_id = spec.job_id().as_str(),
@@ -518,7 +521,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
             return Ok(MetadataCompactionJobOutcome::Cancelled);
         }
         // Refresh the lease before publishing. Its expiry exceeds the
-        // publication budget, so GC cannot claim the prefix before the CAS.
+        // publication budget, so GC cannot claim the group lease before the CAS.
         if lease.heartbeat(store).await? == LeaseHold::Fenced {
             return Ok(MetadataCompactionJobOutcome::Fenced);
         }

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -2019,9 +2019,15 @@ async fn select_reorganization_window<S: ObjectStore + ?Sized>(
     let segments = load_verified_manifest_segments(store, None, namespace_id, &manifest_object_id)
         .await
         .expect("load manifest segments");
-    let group =
-        super::reorganize::select_family_group(&segments.manifest().payload, &BTreeSet::new())
-            .expect("a family group with delta rows to fold");
+    let group = super::reorganize::select_family_group(
+        store,
+        namespace_id,
+        &segments.manifest().payload,
+        0,
+    )
+    .await
+    .expect("read family-group leases")
+    .expect("a family group with delta rows to fold");
     let frozen_floor_seq = read_floor_seq(store, namespace_id).await;
     let selection = super::reorganize::select_reorganization_input(
         &segments,

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -4,7 +4,7 @@
 //! independent of the size of what it merges.
 
 use super::super::compaction_lease::{
-    claim_compaction_prefix, CompactionLease, CompactionPrefixOwner, LeaseHold,
+    claim_group_lease, CompactionLease, CompactionPrefixOwner, LeaseHold,
 };
 use super::super::reorganize::{
     group_run_descriptors, select_reorganization_input, FrozenBasePolicy, ReorganizationPlan,
@@ -622,12 +622,29 @@ async fn write_active_lease<S: ObjectStore + ?Sized>(
     spec: &MetadataCompactionSpec,
     heartbeat_at_ms: u64,
 ) {
+    write_lease_in_state(
+        store,
+        namespace_id,
+        spec,
+        heartbeat_at_ms,
+        loonfs_api::wire::control::CompactionLeaseStatus::Active {},
+    )
+    .await;
+}
+
+async fn write_lease_in_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+    heartbeat_at_ms: u64,
+    status: loonfs_api::wire::control::CompactionLeaseStatus,
+) {
     let state = loonfs_api::wire::control::MetadataCompactionLeaseState {
         job_id: spec.job_id().clone(),
         namespace_id: namespace_id.clone(),
         group: spec.group(),
         writer_id: "test-writer".to_owned(),
-        status: loonfs_api::wire::control::CompactionLeaseStatus::Active {},
+        status,
         started_at_ms: heartbeat_at_ms,
         heartbeat_at_ms,
     };
@@ -638,7 +655,7 @@ async fn write_active_lease<S: ObjectStore + ?Sized>(
     .expect("encode lease");
     store
         .put_overwrite(
-            &metadata_compaction_lease(namespace_id, spec.job_id()),
+            &metadata_compaction_lease(namespace_id, spec.group()),
             Bytes::from(bytes),
         )
         .await
@@ -937,7 +954,7 @@ async fn a_step_that_plans_a_compaction_publishes_nothing_itself() {
 }
 
 #[tokio::test]
-async fn an_active_lease_excludes_its_group_until_it_expires() {
+async fn held_group_leases_are_skipped_and_an_expired_lease_is_available() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -953,10 +970,13 @@ async fn an_active_lease_excludes_its_group_until_it_expires() {
         METADATA_COMPACTION_LEASE_EXPIRY_MS.saturating_add(10_000),
     );
     let active_dir = tempdir().expect("tempdir");
+    let reaping_dir = tempdir().expect("tempdir");
     let expired_dir = tempdir().expect("tempdir");
     copy_store_tree(temp_dir.path(), active_dir.path());
+    copy_store_tree(temp_dir.path(), reaping_dir.path());
     copy_store_tree(temp_dir.path(), expired_dir.path());
     let active_store = LocalFsStore::new(active_dir.path()).expect("store");
+    let reaping_store = LocalFsStore::new(reaping_dir.path()).expect("store");
     let expired_store = LocalFsStore::new(expired_dir.path()).expect("store");
 
     write_active_lease(&active_store, &namespace_id, &spec, context.now_ms).await;
@@ -979,6 +999,35 @@ async fn an_active_lease_excludes_its_group_until_it_expires() {
     assert_ne!(
         active_group, group,
         "the active lease excludes its family group"
+    );
+
+    write_lease_in_state(
+        &reaping_store,
+        &namespace_id,
+        &spec,
+        0,
+        loonfs_api::wire::control::CompactionLeaseStatus::Reaping {},
+    )
+    .await;
+    let reaping = super::super::reorganize_metadata_step(
+        &reaping_store,
+        &namespace_id,
+        &context,
+        policy,
+        FrozenBasePolicy::default(),
+    )
+    .await
+    .expect("step with reaping lease");
+    let MetadataReorganizeOutcome::UnitPublished {
+        group: reaping_group,
+        ..
+    } = reaping.outcome
+    else {
+        panic!("expected another group to merge, got {:?}", reaping.outcome);
+    };
+    assert_ne!(
+        reaping_group, group,
+        "the reaping lease excludes its family group"
     );
 
     write_active_lease(&expired_store, &namespace_id, &spec, 0).await;
@@ -2091,6 +2140,8 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
         &namespace_id,
     )
     .await;
+    let store = LocalFsStore::new(interrupted_dir.path()).expect("store");
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
 
     let mut orphans = BTreeSet::new();
     let mut cancelled_attempts = 0;
@@ -2102,7 +2153,6 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
             reads_before_cancel,
             reads: AtomicUsize::new(0),
         };
-        let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
         let outcome = run_compaction(
             &store,
             &namespace_id,
@@ -2137,7 +2187,6 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
 
     // The re-run from the same spec, against the same durable state.
     let store = LocalFsStore::new(interrupted_dir.path()).expect("store");
-    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
     let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
     let Ok(result) = run_compaction(
         &store,
@@ -2210,7 +2259,7 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
     let group = MetadataFamilyGroup::Bindings;
     let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
     let spec = step_until_a_compaction_is_planned(&store, &namespace_id, &context, policy).await;
-    let lease_key = metadata_compaction_lease(&namespace_id, spec.job_id());
+    let lease_key = metadata_compaction_lease(&namespace_id, spec.group());
 
     let outcome = run_metadata_compaction_job(
         &store,
@@ -2227,8 +2276,8 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
         MetadataCompactionJobOutcome::Published { .. }
     ));
 
-    // The job writes every object under its own prefix, and the manifest now
-    // references the segments.
+    // The job writes every segment under its own prefix, and the manifest now
+    // references them.
     let staged = staged_object_keys(&store, &namespace_id).await;
     let referenced = referenced_segment_keys(&store, &namespace_id).await;
     let job_prefix = format!(
@@ -2241,16 +2290,79 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
         "every object a job writes belongs to that job's prefix: {staged:?}"
     );
     assert!(
-        !staged.is_empty()
-            && staged
-                .iter()
-                .all(|key| key == &lease_key || referenced.contains(key)),
+        !staged.is_empty() && staged.iter().all(|key| referenced.contains(key)),
         "the manifest must name every segment the job published"
     );
     assert!(
-        staged.contains(&lease_key),
+        store
+            .head(&lease_key)
+            .await
+            .expect("head the group lease")
+            .is_some(),
         "a published job leaves its final lease standing for the pass that has not seen the new \
          root yet"
+    );
+}
+
+#[tokio::test]
+async fn group_lease_acquisition_supersedes_a_second_job_and_fences_an_expired_owner() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let policy = small_segment_policy();
+    let first_spec =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let second_spec =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let timer = StdMonotonicTimer::default();
+    let mut first_lease = test_lease(&store, &namespace_id, &first_spec, &timer).await;
+
+    let staged_before = staged_object_keys(&store, &namespace_id).await;
+    let held = run_metadata_compaction_job(
+        &store,
+        &namespace_id,
+        &test_context(),
+        &second_spec,
+        policy,
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    .expect("try the held group");
+    assert_eq!(held, MetadataCompactionJobOutcome::Superseded);
+    assert_eq!(
+        staged_object_keys(&store, &namespace_id).await,
+        staged_before,
+        "a superseded job writes no staged object"
+    );
+
+    let takeover_context = mutation_context(
+        "takeover-writer",
+        test_context()
+            .now_ms
+            .saturating_add(METADATA_COMPACTION_LEASE_EXPIRY_MS)
+            .saturating_add(1),
+    );
+    let taken_over = run_metadata_compaction_job(
+        &store,
+        &namespace_id,
+        &takeover_context,
+        &second_spec,
+        policy,
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    .expect("take over the expired lease");
+    assert!(matches!(
+        taken_over,
+        MetadataCompactionJobOutcome::Published { .. }
+    ));
+    assert_eq!(
+        first_lease
+            .heartbeat(&store)
+            .await
+            .expect("heartbeat the old lease"),
+        LeaseHold::Fenced
     );
 }
 
@@ -2286,9 +2398,15 @@ async fn a_worker_whose_expired_lease_was_claimed_is_fenced_and_publishes_nothin
     // stamped its lease off a real clock, so the pass's clock has to clear
     // whatever it spent running.
     let expired_ms = test_context().now_ms + METADATA_COMPACTION_LEASE_EXPIRY_MS * 2;
-    let owner = claim_compaction_prefix(&store, &namespace_id, spec.job_id(), expired_ms)
-        .await
-        .expect("claim the expired prefix");
+    let owner = claim_group_lease(
+        &store,
+        &namespace_id,
+        spec.group(),
+        spec.job_id(),
+        expired_ms,
+    )
+    .await
+    .expect("claim the expired prefix");
     assert_eq!(
         owner,
         CompactionPrefixOwner::ThisCollector,
@@ -2340,7 +2458,7 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
     seed_bindings_workload(&store, &namespace_id).await;
     let spec =
         compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
-    let lease_key = metadata_compaction_lease(&namespace_id, spec.job_id());
+    let lease_key = metadata_compaction_lease(&namespace_id, spec.group());
     // The stepping clock below moves each heartbeat's stamp forward a few
     // seconds, so the pass's clock is set well past the expiry rather than one
     // millisecond past it.
@@ -2360,7 +2478,13 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
     );
     gated.block_next();
     let (claimed, beat) = tokio::join!(
-        claim_compaction_prefix(&gated, &namespace_id, spec.job_id(), expired_ms),
+        claim_group_lease(
+            &gated,
+            &namespace_id,
+            spec.group(),
+            spec.job_id(),
+            expired_ms,
+        ),
         async {
             gated.wait_until_blocked().await;
             let beat = lease.heartbeat(&store).await.expect("heartbeat the lease");
@@ -2382,9 +2506,15 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
     // The other order, on the same lease: the claim lands, and the heartbeat
     // behind it finds an etag it does not hold.
     assert_eq!(
-        claim_compaction_prefix(&store, &namespace_id, spec.job_id(), expired_ms)
-            .await
-            .expect("claim the prefix"),
+        claim_group_lease(
+            &store,
+            &namespace_id,
+            spec.group(),
+            spec.job_id(),
+            expired_ms,
+        )
+        .await
+        .expect("claim the prefix"),
         CompactionPrefixOwner::ThisCollector
     );
     assert_eq!(
@@ -2876,12 +3006,12 @@ async fn an_over_budget_group_is_rebuilt_by_a_job_while_maintenance_carries_on()
             steps_with_a_job_running += 1;
             if steps_with_a_job_running % 3 == 0 {
                 store
-                    .delete(&metadata_compaction_lease(&namespace_id, spec.job_id()))
+                    .delete(&metadata_compaction_lease(&namespace_id, spec.group()))
                     .await
                     .expect("remove the test lease before the job creates it");
                 publish_planned_compaction(&store, &namespace_id, &context, policy, &spec).await;
                 store
-                    .delete(&metadata_compaction_lease(&namespace_id, spec.job_id()))
+                    .delete(&metadata_compaction_lease(&namespace_id, spec.group()))
                     .await
                     .expect("expire the completed test job's lease");
                 published_jobs += 1;
@@ -2983,7 +3113,7 @@ async fn a_job_that_dies_mid_run_leaves_orphans_and_the_next_step_plans_it_again
     // the test picked, so several thresholds are tried until one lands after
     // the job has written something.
     let mut orphans = BTreeSet::new();
-    for reads_before_cancel in [8usize, 16, 24, 32] {
+    for (attempt, reads_before_cancel) in [8usize, 16, 24, 32].into_iter().enumerate() {
         let cancellation = MetadataCompactionCancellation::default();
         let dying_store = CancelAfterReadsStore {
             inner: LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -2991,10 +3121,18 @@ async fn a_job_that_dies_mid_run_leaves_orphans_and_the_next_step_plans_it_again
             reads_before_cancel,
             reads: AtomicUsize::new(0),
         };
+        let attempt_context = mutation_context(
+            "test-writer",
+            context.now_ms.saturating_add(
+                u64::try_from(attempt)
+                    .expect("four attempts should fit in u64")
+                    .saturating_mul(METADATA_COMPACTION_LEASE_EXPIRY_MS.saturating_mul(2)),
+            ),
+        );
         let outcome = run_metadata_compaction_job(
             &dying_store,
             &namespace_id,
-            &context,
+            &attempt_context,
             &spec,
             policy,
             &cancellation,
@@ -3008,7 +3146,7 @@ async fn a_job_that_dies_mid_run_leaves_orphans_and_the_next_step_plans_it_again
         );
         assert!(
             store
-                .head(&metadata_compaction_lease(&namespace_id, spec.job_id()))
+                .head(&metadata_compaction_lease(&namespace_id, spec.group()))
                 .await
                 .expect("head the lease")
                 .is_some(),
@@ -3045,7 +3183,7 @@ async fn a_job_that_dies_mid_run_leaves_orphans_and_the_next_step_plans_it_again
         "test-writer",
         context
             .now_ms
-            .saturating_add(METADATA_COMPACTION_LEASE_EXPIRY_MS.saturating_mul(2)),
+            .saturating_add(METADATA_COMPACTION_LEASE_EXPIRY_MS.saturating_mul(10)),
     );
     let spec =
         step_until_a_compaction_is_planned(&store, &namespace_id, &expired_context, policy).await;

--- a/crates/loonfs-core/src/gc/compaction_staging.rs
+++ b/crates/loonfs-core/src/gc/compaction_staging.rs
@@ -1,24 +1,36 @@
 //! Determines whether streaming-compaction output may be collected.
 //!
-//! A current lease protects every object under a compaction job's prefix. To
-//! collect an expired job, the collector first changes its lease from `Active`
-//! to `Reaping` with compare-and-swap. This fences the job from publishing and
-//! lets later passes safely resume collection.
+//! A current group lease protects only the staged objects written by its
+//! named job. Garbage collection claims expired leases before reclaiming that
+//! job's output, which fences the job from publishing.
 
-use crate::checkpoint::{claim_compaction_prefix, CompactionPrefixOwner};
+use crate::checkpoint::{
+    claim_loaded_group_lease, load_group_lease, CompactionPrefixOwner, LoadedCompactionLease,
+};
 use crate::error::{CoreError, Result};
-use loonfs_api::{MetadataCompactionId, NamespaceId};
-use loonfs_objectstore::keys::{metadata_compaction_job_id_from_key, metadata_compaction_lease};
+use loonfs_api::wire::control::CompactionLeaseStatus;
+use loonfs_api::{MetadataCompactionId, MetadataFamilyGroup, NamespaceId};
+use loonfs_objectstore::keys::{
+    metadata_compaction_job_id_from_key, metadata_compaction_lease_group_from_key,
+};
 use loonfs_objectstore::ObjectStore;
+use std::collections::BTreeMap;
 
-/// Tracks the confirmed owner of the current job prefix and any claimed lease
-/// that must be deleted after that prefix is processed.
+/// What the lease-key sweep should do with one recognized lease.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GroupLeaseSweep {
+    Retain,
+    Delete,
+}
+
+/// Tracks the seven group leases and any claim awaiting prefix completion.
 #[derive(Debug, Default)]
 pub(super) struct CompactionLeases {
+    by_job_id: BTreeMap<MetadataCompactionId, LoadedCompactionLease>,
     last_read: Option<LastPrefixRead>,
-    /// A successfully claimed lease, retained until all earlier staged objects
-    /// in the same job prefix have been processed.
     claimed_lease: Option<String>,
+    staging_complete: bool,
+    loaded: bool,
 }
 
 #[derive(Debug)]
@@ -28,9 +40,35 @@ struct LastPrefixRead {
 }
 
 impl CompactionLeases {
-    /// Returns the confirmed owner of `key`'s job prefix, or `None` when the
-    /// key names no job. One claim per job prefix is reused for every key
-    /// under it.
+    /// Reads every deterministic group lease once for this pass.
+    pub(super) async fn load_once<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+    ) -> Result<()> {
+        if self.loaded {
+            return Ok(());
+        }
+        let mut by_job_id = BTreeMap::new();
+        for group in MetadataFamilyGroup::ALL {
+            let Some(loaded) = load_group_lease(store, namespace_id, group).await? else {
+                continue;
+            };
+            if by_job_id
+                .insert(loaded.state.job_id.clone(), loaded)
+                .is_some()
+            {
+                return Err(CoreError::Internal(
+                    "two metadata family-group leases name the same compaction job".to_owned(),
+                ));
+            }
+        }
+        self.by_job_id = by_job_id;
+        self.loaded = true;
+        Ok(())
+    }
+
+    /// Returns the confirmed owner of `key`'s job prefix.
     pub(super) async fn owner_of<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,
@@ -46,18 +84,25 @@ impl CompactionLeases {
         let owner = match &self.last_read {
             Some(read) if read.job_id == metadata_compaction_id => read.owner,
             _ => {
-                // A different job prefix has started, so the previously
-                // claimed lease can now be deleted.
                 self.delete_claimed_lease(store).await?;
-                let owner =
-                    claim_compaction_prefix(store, namespace_id, &metadata_compaction_id, now_ms)
+                let owner = match self.by_job_id.get(&metadata_compaction_id).cloned() {
+                    Some(loaded) => {
+                        let lease_key = loaded.object_key.clone();
+                        let owner = claim_loaded_group_lease(
+                            store,
+                            namespace_id,
+                            &metadata_compaction_id,
+                            loaded,
+                            now_ms,
+                        )
                         .await?;
-                if owner == CompactionPrefixOwner::ThisCollector {
-                    self.claimed_lease = Some(metadata_compaction_lease(
-                        namespace_id,
-                        &metadata_compaction_id,
-                    ));
-                }
+                        if owner == CompactionPrefixOwner::ThisCollector {
+                            self.claimed_lease = Some(lease_key);
+                        }
+                        owner
+                    }
+                    None => CompactionPrefixOwner::NoOne,
+                };
                 self.last_read = Some(LastPrefixRead {
                     job_id: metadata_compaction_id,
                     owner,
@@ -68,16 +113,51 @@ impl CompactionLeases {
         Ok(Some(owner))
     }
 
-    /// Whether `key` is the lease this collector claimed for the current job.
-    pub(super) fn is_claimed_lease(&self, key: &str) -> bool {
-        self.claimed_lease.as_deref() == Some(key)
+    /// Records that the complete staging-prefix listing finished.
+    pub(super) fn staging_finished(&mut self) {
+        self.staging_complete = true;
+    }
+
+    /// Decides one lease object after the staging prefix has been walked.
+    pub(super) async fn sweep_group_lease<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        key: &str,
+        now_ms: u64,
+    ) -> Result<Option<GroupLeaseSweep>> {
+        let Some(group) = metadata_compaction_lease_group_from_key(key) else {
+            return Ok(None);
+        };
+        let Some(loaded) = self
+            .by_job_id
+            .values()
+            .find(|loaded| loaded.state.group == group)
+            .cloned()
+        else {
+            return Ok(Some(GroupLeaseSweep::Retain));
+        };
+        if !self.staging_complete
+            || (loaded.state.status == (CompactionLeaseStatus::Active {})
+                && now_ms
+                    <= loaded
+                        .state
+                        .heartbeat_at_ms
+                        .saturating_add(crate::limits::METADATA_COMPACTION_LEASE_EXPIRY_MS))
+        {
+            return Ok(Some(GroupLeaseSweep::Retain));
+        }
+        let job_id = loaded.state.job_id.clone();
+        let owner = claim_loaded_group_lease(store, namespace_id, &job_id, loaded, now_ms).await?;
+        Ok(Some(match owner {
+            CompactionPrefixOwner::ThisCollector => GroupLeaseSweep::Delete,
+            CompactionPrefixOwner::LiveJob | CompactionPrefixOwner::NoOne => {
+                GroupLeaseSweep::Retain
+            }
+        }))
     }
 
     /// Deletes a claimed lease after its job prefix has been processed.
-    ///
-    /// This runs when the pass reaches another job and again when the pass
-    /// ends. The lease does not need an age check because this collector
-    /// already claimed it with compare-and-swap.
     pub(super) async fn finish<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
         self.delete_claimed_lease(store).await
     }

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -6,8 +6,8 @@ use loonfs_api::{
     PageCursor,
 };
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_compaction_prefix, metadata_manifest_prefix,
-    metadata_segment_prefix, upload_session_prefix, wal_segment_prefix,
+    checkpoint_prefix, metadata_compaction_lease_prefix, metadata_compaction_prefix,
+    metadata_manifest_prefix, metadata_segment_prefix, upload_session_prefix, wal_segment_prefix,
 };
 use loonfs_objectstore::layout::manifest_object_id_of;
 use loonfs_objectstore::layout::{parse_object_key, DurableObjectFamily};
@@ -25,22 +25,21 @@ pub trait GcCursorKeyspace {
 pub(super) enum CandidateFamily {
     WalSegments,
     MetadataSegments,
-    /// Everything one streaming compaction job owns: the segments it wrote
-    /// and the lease that says it is still running. Its own family because
-    /// its objects are decided by that lease rather than by age alone — a job
-    /// outlives the ordinary grace window, so its output would otherwise read
-    /// as an aged orphan while it was still being written.
+    /// Segments written under streaming compaction job prefixes.
     CompactionStaging,
+    /// Family-group leases that protect staged compaction segments.
+    CompactionLeases,
     Manifests,
     Checkpoints,
     UploadSessions,
 }
 
 impl CandidateFamily {
-    pub(super) const ALL: [Self; 6] = [
+    pub(super) const ALL: [Self; 7] = [
         Self::WalSegments,
         Self::MetadataSegments,
         Self::CompactionStaging,
+        Self::CompactionLeases,
         Self::Manifests,
         Self::Checkpoints,
         Self::UploadSessions,
@@ -52,9 +51,10 @@ impl CandidateFamily {
             Self::WalSegments => 0,
             Self::MetadataSegments => 1,
             Self::CompactionStaging => 2,
-            Self::Manifests => 3,
-            Self::Checkpoints => 4,
-            Self::UploadSessions => 5,
+            Self::CompactionLeases => 3,
+            Self::Manifests => 4,
+            Self::Checkpoints => 5,
+            Self::UploadSessions => 6,
         }
     }
 
@@ -66,11 +66,8 @@ impl CandidateFamily {
         match self {
             Self::WalSegments => family == DurableObjectFamily::WalSegment,
             Self::MetadataSegments => family == DurableObjectFamily::MetadataSegment,
-            Self::CompactionStaging => matches!(
-                family,
-                DurableObjectFamily::MetadataCompactionStaging
-                    | DurableObjectFamily::MetadataCompactionLease
-            ),
+            Self::CompactionStaging => family == DurableObjectFamily::MetadataCompactionStaging,
+            Self::CompactionLeases => family == DurableObjectFamily::MetadataCompactionLease,
             Self::Manifests => matches!(manifest_object_id_of(key), Some(Ok(_))),
             Self::Checkpoints => family == DurableObjectFamily::CheckpointRecord,
             Self::UploadSessions => family == DurableObjectFamily::UploadSession,
@@ -82,6 +79,7 @@ impl CandidateFamily {
             Self::WalSegments => wal_segment_prefix(namespace_id),
             Self::MetadataSegments => metadata_segment_prefix(namespace_id),
             Self::CompactionStaging => metadata_compaction_prefix(namespace_id),
+            Self::CompactionLeases => metadata_compaction_lease_prefix(namespace_id),
             Self::Manifests => metadata_manifest_prefix(namespace_id),
             Self::Checkpoints => checkpoint_prefix(namespace_id),
             Self::UploadSessions => upload_session_prefix(namespace_id),

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -2,7 +2,7 @@
 //! and the bounded, resumable sweep.
 
 use super::budget::PassBudget;
-use super::compaction_staging::CompactionLeases;
+use super::compaction_staging::{CompactionLeases, GroupLeaseSweep};
 use super::config::{GcConfig, GcPolicy};
 use super::cursor::{cursor_after, CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
@@ -36,7 +36,7 @@ fn is_live(live: &LiveSet, family: CandidateFamily, key: &str) -> bool {
             .and_then(std::result::Result::ok)
             .is_some_and(|manifest_object_id| live.manifests.contains(&manifest_object_id)),
         CandidateFamily::Checkpoints => live.checkpoint_keys.contains(key),
-        CandidateFamily::UploadSessions => false,
+        CandidateFamily::CompactionLeases | CandidateFamily::UploadSessions => false,
     }
 }
 
@@ -183,6 +183,12 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
         // therefore leave data protected for an extra pass, never a readable
         // record whose basis was removed underneath it.
         for &family in &CandidateFamily::ALL[resume_family.index()..] {
+            if matches!(
+                family,
+                CandidateFamily::CompactionStaging | CandidateFamily::CompactionLeases
+            ) {
+                self.leases.load_once(self.store, self.namespace_id).await?;
+            }
             let prefix = family.prefix(self.namespace_id);
             let start_after = if family == resume_family {
                 resume_last_key.as_deref()
@@ -213,6 +219,10 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
                 self.budget.charge();
                 self.position = Some(cursor_after(self.namespace_id, family, key));
             }
+            if family == CandidateFamily::CompactionStaging {
+                self.leases.staging_finished();
+                self.leases.finish(self.store).await?;
+            }
         }
         Ok(PassEnd::Complete)
     }
@@ -237,6 +247,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             CandidateFamily::WalSegments
             | CandidateFamily::MetadataSegments
             | CandidateFamily::CompactionStaging
+            | CandidateFamily::CompactionLeases
             | CandidateFamily::Manifests
             | CandidateFamily::Checkpoints => {}
         };
@@ -276,6 +287,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
                     .await?
             }
             CandidateFamily::CompactionStaging => self.process_compaction_staging(key).await?,
+            CandidateFamily::CompactionLeases => self.process_compaction_lease(key).await?,
             CandidateFamily::Checkpoints => self.process_checkpoint(key).await?,
             CandidateFamily::UploadSessions => self.process_upload_session(key).await?,
         }
@@ -318,9 +330,6 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             return Ok(());
         }
 
-        // A compaction job's prefix holds the segments it has written and
-        // the lease that says who owns them. A claimed lease goes only after
-        // the objects it fenced, which [`Self::run`] enforces at every exit.
         match self
             .leases
             .owner_of(self.store, self.namespace_id, key, self.mutation.now_ms)
@@ -332,8 +341,6 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             None => {
                 self.report.retain(RetainedReason::UnrecognizedKey);
             }
-            // The claimed lease is deleted once its prefix is processed.
-            Some(CompactionPrefixOwner::ThisCollector) if self.leases.is_claimed_lease(key) => {}
             Some(CompactionPrefixOwner::ThisCollector | CompactionPrefixOwner::NoOne) => {
                 if key.ends_with(".sst.zst")
                     && self
@@ -343,6 +350,25 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
                     self.report.deleted.metadata_segments += 1;
                 }
             }
+        }
+        Ok(())
+    }
+
+    async fn process_compaction_lease(&mut self, key: &str) -> Result<()> {
+        if self.sweep.degraded {
+            self.report.retain(RetainedReason::DegradedRoots);
+            return Ok(());
+        }
+        match self
+            .leases
+            .sweep_group_lease(self.store, self.namespace_id, key, self.mutation.now_ms)
+            .await?
+        {
+            Some(GroupLeaseSweep::Delete) => self.delete_key(key).await?,
+            Some(GroupLeaseSweep::Retain) => {
+                self.report.retain(RetainedReason::WithinGraceWindow);
+            }
+            None => self.report.retain(RetainedReason::UnrecognizedKey),
         }
         Ok(())
     }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -2258,7 +2258,8 @@ async fn namespace_with_staged_output(
         .put_if_absent(&staged_key, Bytes::from_static(b"staged segment"))
         .await
         .expect("write a staged segment");
-    let lease_key = metadata_compaction_lease(namespace_id, metadata_compaction_id);
+    let lease_key =
+        metadata_compaction_lease(namespace_id, loonfs_api::MetadataFamilyGroup::Bindings);
     (store, staged_key, lease_key)
 }
 
@@ -2304,7 +2305,7 @@ async fn write_compaction_lease_in_state<S: ObjectStore + ?Sized>(
         loonfs_api::wire::control::encode_control_object(&envelope).expect("encode a lease");
     store
         .put(
-            &metadata_compaction_lease(namespace_id, metadata_compaction_id),
+            &metadata_compaction_lease(namespace_id, loonfs_api::MetadataFamilyGroup::Bindings),
             Bytes::from(bytes),
             PutMode::Overwrite,
         )
@@ -2496,8 +2497,8 @@ async fn a_candidate_error_still_finishes_the_claimed_compaction_lease() {
     )
     .await;
 
-    // The lease sorts before the staged segment. GC claims it first, then this
-    // injected metadata failure makes the segment decision return early.
+    // GC claims the cached group lease before deciding the staged segment,
+    // then this injected metadata failure makes the decision return early.
     let store = FailStore::new(
         inner,
         KeyPredicate::exact(staged_key.clone()),
@@ -2546,18 +2547,11 @@ async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
         died_at_ms,
     )
     .await;
-    let reclaimable = context(
-        now_after_newest_object(
-            store.inner(),
-            &namespace_id,
-            METADATA_COMPACTION_STAGING_GRACE_MS + 1,
-        )
-        .await,
-    );
+    let reclaimable = context(died_at_ms + METADATA_COMPACTION_LEASE_EXPIRY_MS + 1);
     let marking = marking_units(&store, &namespace_id, &reclaimable).await;
 
-    // Resume immediately before compaction staging and buy exactly its lease
-    // candidate. The staged segment is the lookahead that stops the pass.
+    // Resume immediately before compaction staging and buy exactly its staged
+    // segment. The lease family is the lookahead that stops the pass.
     let mut bounded = config();
     bounded.max_objects = Some(marking + 1);
     bounded.cursor = Some(
@@ -2589,7 +2583,7 @@ async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
             .await
             .expect("head the unvisited segment")
             .is_some(),
-        "the cursor leaves the unvisited segment for the resumed pass"
+        "the claimed job's young segment remains for a later pass"
     );
 }
 
@@ -2755,7 +2749,7 @@ async fn a_published_jobs_lease_expires_and_the_pass_removes_only_the_lease() {
     .await;
     let staged =
         crate::checkpoint::tests::staged_keys_of_the_current_manifest(&store, &namespace_id).await;
-    let lease_key = metadata_compaction_lease(&namespace_id, spec.job_id());
+    let lease_key = metadata_compaction_lease(&namespace_id, spec.group());
     assert!(
         store
             .head(&lease_key)

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -27,8 +27,9 @@ use loonfs_grep::{
     GrepReorganizeOutcome, GrepService, GrepWorker, GREP_GC_GRACE_WINDOW_MS,
 };
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, checkpoint_record, metadata_compaction_prefix, metadata_manifest_object,
-    metadata_manifest_prefix, metadata_segment_prefix, upload_session_prefix, wal_segment_prefix,
+    checkpoint_prefix, checkpoint_record, metadata_compaction_lease_prefix,
+    metadata_compaction_prefix, metadata_manifest_object, metadata_manifest_prefix,
+    metadata_segment_prefix, upload_session_prefix, wal_segment_prefix,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectStore, PutMode};
@@ -2360,6 +2361,7 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
             wal_segment_prefix(&live_namespace),
             metadata_segment_prefix(&live_namespace),
             metadata_compaction_prefix(&live_namespace),
+            metadata_compaction_lease_prefix(&live_namespace),
             metadata_manifest_prefix(&live_namespace),
             checkpoint_prefix(&live_namespace),
             upload_session_prefix(&live_namespace),

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -4,12 +4,13 @@
 
 use crate::layout::{
     metadata_compaction_job_id_from_key as parse_metadata_compaction_job_id,
+    metadata_compaction_lease_group_from_key as parse_metadata_compaction_lease_group,
     wal_segment_id_from_key as parse_wal_segment_id,
 };
 use loonfs_api::wire::manifest::MetadataSegmentRef;
 use loonfs_api::{
     CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
-    MetadataSegmentId, NamespaceId, UploadId, WalSegmentId,
+    MetadataFamilyGroup, MetadataSegmentId, NamespaceId, UploadId, WalSegmentId,
 };
 
 /// Builds the listing prefix containing every durable object owned by one namespace.
@@ -102,13 +103,20 @@ pub fn metadata_segment_object_key(descriptor: &MetadataSegmentRef) -> String {
     }
 }
 
-/// Builds the mutable lease key one streaming compaction job holds over its
-/// own prefix.
-pub fn metadata_compaction_lease(
-    namespace_id: &NamespaceId,
-    metadata_compaction_id: &MetadataCompactionId,
-) -> String {
-    format!("namespaces/{namespace_id}/metadata/compactions/{metadata_compaction_id}/lease.json")
+/// Builds the mutable lease key for one metadata family group.
+pub fn metadata_compaction_lease(namespace_id: &NamespaceId, group: MetadataFamilyGroup) -> String {
+    let group = group.as_str();
+    format!("namespaces/{namespace_id}/metadata/compaction_leases/{group}.json")
+}
+
+/// Builds the listing prefix containing every metadata family-group lease.
+pub fn metadata_compaction_lease_prefix(namespace_id: &NamespaceId) -> String {
+    format!("namespaces/{namespace_id}/metadata/compaction_leases/")
+}
+
+/// Extracts the family group from a current-format compaction lease key.
+pub fn metadata_compaction_lease_group_from_key(key: &str) -> Option<MetadataFamilyGroup> {
+    parse_metadata_compaction_lease_group(key)
 }
 
 /// Builds the listing prefix containing every streaming compaction job's
@@ -119,8 +127,7 @@ pub fn metadata_compaction_prefix(namespace_id: &NamespaceId) -> String {
 
 /// Extracts the job id from a key under one namespace's compaction prefix.
 ///
-/// Returns `None` for a key under the prefix that is neither a job's lease
-/// nor one of its staged segments.
+/// Returns `None` for a key under the prefix that is not a staged segment.
 pub fn metadata_compaction_job_id_from_key(key: &str) -> Option<&str> {
     parse_metadata_compaction_job_id(key)
 }
@@ -154,16 +161,17 @@ pub fn content_blob(content_store_id: &ContentStoreId, content_id: &ContentId) -
 #[cfg(test)]
 mod tests {
     use super::{
-        checkpoint_record, content_blob, metadata_compaction_lease, metadata_compaction_prefix,
-        metadata_compaction_segment, metadata_manifest_object, metadata_root, metadata_segment,
-        metadata_segment_object_key, upload_session, wal_floor, wal_head, wal_segment,
-        wal_segment_id_from_key, wal_segment_prefix,
+        checkpoint_record, content_blob, metadata_compaction_lease,
+        metadata_compaction_lease_prefix, metadata_compaction_prefix, metadata_compaction_segment,
+        metadata_manifest_object, metadata_root, metadata_segment, metadata_segment_object_key,
+        upload_session, wal_floor, wal_head, wal_segment, wal_segment_id_from_key,
+        wal_segment_prefix,
     };
     use loonfs_api::wire::manifest::{MetadataRowFamily, MetadataSegmentRef};
     use loonfs_api::wire::sst_blocks::BlockHandle;
     use loonfs_api::{
         CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
-        MetadataSegmentId, NamespaceId, UploadId, WalSegmentId,
+        MetadataFamilyGroup, MetadataSegmentId, NamespaceId, UploadId, WalSegmentId,
     };
 
     const CONTENT_ID: &str = "con_abcdef0123456789abcdef0123456789";
@@ -250,6 +258,7 @@ mod tests {
                 )
                 .replace("{checkpoint_id}", "chk_00000000000000000000000000000001")
                 .replace("{job_id}", "cmp_00000000000000000000000000000001")
+                .replace("{group}", "bindings")
                 .replace("{segment_id}", "seg_00000000000000000000000000000001")
                 .replace("{upload_id}", "upl_00000000000000000000000000000001")
                 .replace("{content_id[4..6]}", &CONTENT_ID[4..6])
@@ -293,7 +302,7 @@ mod tests {
             ),
             (
                 "Compaction leases",
-                metadata_compaction_lease(&namespace_id(), &metadata_compaction_id()),
+                metadata_compaction_lease(&namespace_id(), MetadataFamilyGroup::Bindings),
             ),
             (
                 "Upload sessions",
@@ -349,6 +358,10 @@ mod tests {
         assert_eq!(
             metadata_compaction_prefix(&namespace_id()),
             "namespaces/ns-1/metadata/compactions/"
+        );
+        assert_eq!(
+            metadata_compaction_lease_prefix(&namespace_id()),
+            "namespaces/ns-1/metadata/compaction_leases/"
         );
     }
 

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -1,6 +1,6 @@
 //! The durable key grammar: object families and key classification.
 
-use loonfs_api::{GeneratedIdValidationError, ManifestObjectId, UploadId};
+use loonfs_api::{GeneratedIdValidationError, ManifestObjectId, MetadataFamilyGroup, UploadId};
 
 /// One family in the [durable object key grammar].
 ///
@@ -21,7 +21,7 @@ pub enum DurableObjectFamily {
     MetadataSegment,
     /// Classifies an immutable metadata segment written by a streaming compaction.
     MetadataCompactionStaging,
-    /// Classifies the mutable lease for one streaming compaction.
+    /// Classifies the mutable lease for one metadata family group.
     MetadataCompactionLease,
     /// Classifies a mutable checkpoint lifecycle record.
     CheckpointRecord,
@@ -115,11 +115,17 @@ pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
                 Some(job_id),
             ))
         }
-        ["namespaces", namespace, "metadata", "compactions", job_id, "lease.json"] => Some(parsed(
-            DurableObjectFamily::MetadataCompactionLease,
-            Some(namespace),
-            Some(job_id),
-        )),
+        ["namespaces", namespace, "metadata", "compaction_leases", lease] => {
+            lease.strip_suffix(".json").and_then(|group| {
+                parse_metadata_family_group(group).map(|_| {
+                    parsed(
+                        DurableObjectFamily::MetadataCompactionLease,
+                        Some(namespace),
+                        Some(group),
+                    )
+                })
+            })
+        }
         ["namespaces", namespace, "checkpoints", checkpoint] => {
             checkpoint.strip_suffix(".json").map(|identifier| {
                 parsed(
@@ -168,14 +174,21 @@ pub fn upload_id_of(key: &str) -> Option<UploadId> {
 
 pub(crate) fn metadata_compaction_job_id_from_key(key: &str) -> Option<&str> {
     parse_object_key(key)
-        .filter(|parsed| {
-            matches!(
-                parsed.family(),
-                DurableObjectFamily::MetadataCompactionStaging
-                    | DurableObjectFamily::MetadataCompactionLease
-            )
-        })
+        .filter(|parsed| parsed.family() == DurableObjectFamily::MetadataCompactionStaging)
         .and_then(|parsed| parsed.identifier())
+}
+
+pub(crate) fn metadata_compaction_lease_group_from_key(key: &str) -> Option<MetadataFamilyGroup> {
+    parse_object_key(key)
+        .filter(|parsed| parsed.family() == DurableObjectFamily::MetadataCompactionLease)
+        .and_then(|parsed| parsed.identifier())
+        .and_then(parse_metadata_family_group)
+}
+
+fn parse_metadata_family_group(value: &str) -> Option<MetadataFamilyGroup> {
+    MetadataFamilyGroup::ALL
+        .into_iter()
+        .find(|group| group.as_str() == value)
 }
 
 fn parsed<'a>(
@@ -194,13 +207,14 @@ fn parsed<'a>(
 mod tests {
     use super::{parse_object_key, DurableObjectFamily};
     use crate::keys::{
-        checkpoint_record, content_blob, metadata_compaction_lease, metadata_compaction_segment,
-        metadata_manifest_object, metadata_root, metadata_segment, metadata_segment_prefix,
-        upload_session, wal_floor, wal_head, wal_segment, wal_segment_prefix,
+        checkpoint_record, content_blob, metadata_compaction_lease,
+        metadata_compaction_lease_prefix, metadata_compaction_segment, metadata_manifest_object,
+        metadata_root, metadata_segment, metadata_segment_prefix, upload_session, wal_floor,
+        wal_head, wal_segment, wal_segment_prefix,
     };
     use loonfs_api::{
         CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
-        MetadataSegmentId, NamespaceId, UploadId, WalSegmentId,
+        MetadataFamilyGroup, MetadataSegmentId, NamespaceId, UploadId, WalSegmentId,
     };
 
     #[test]
@@ -255,9 +269,9 @@ mod tests {
                 Some(compaction_id.as_str()),
             ),
             (
-                metadata_compaction_lease(&namespace_id, &compaction_id),
+                metadata_compaction_lease(&namespace_id, MetadataFamilyGroup::Bindings),
                 DurableObjectFamily::MetadataCompactionLease,
-                Some(compaction_id.as_str()),
+                Some("bindings"),
             ),
             (
                 checkpoint_record(&namespace_id, &checkpoint_id),
@@ -288,20 +302,19 @@ mod tests {
     }
 
     #[test]
-    fn listing_prefixes_hold_only_their_family_and_a_lease_sorts_first() {
+    fn listing_prefixes_hold_only_their_family() {
         let namespace_id = NamespaceId::parse("ns-1").expect("namespace id");
         let job = MetadataCompactionId::parse("cmp_00000000000000000000000000000001")
             .expect("compaction id");
-        let next_job = MetadataCompactionId::parse("cmp_00000000000000000000000000000002")
-            .expect("compaction id");
         let segment_id =
             MetadataSegmentId::parse("seg_00000000000000000000000000000001").expect("segment id");
-        let lease = metadata_compaction_lease(&namespace_id, &job);
         let staged = metadata_compaction_segment(&namespace_id, &job, &segment_id);
 
-        assert!(lease < staged);
-        assert!(staged < metadata_compaction_lease(&namespace_id, &next_job));
         assert!(!staged.starts_with(&metadata_segment_prefix(&namespace_id)));
+        assert!(
+            metadata_compaction_lease(&namespace_id, MetadataFamilyGroup::Bindings)
+                .starts_with(&metadata_compaction_lease_prefix(&namespace_id))
+        );
         let wal_segments = wal_segment_prefix(&namespace_id);
         assert!(!wal_head(&namespace_id).starts_with(&wal_segments));
         assert!(!wal_floor(&namespace_id).starts_with(&wal_segments));
@@ -315,6 +328,8 @@ mod tests {
             "namespaces/ns-1/wal/wal_00000000000000000001-0123456789abcdef.wal.zst",
             "namespaces/ns-1/wal/segments/random.tmp",
             "namespaces/ns-1/metadata/compactions/cmp_1/segments/seg_1.tmp",
+            "namespaces/ns-1/metadata/compactions/cmp_1/lease.json",
+            "namespaces/ns-1/metadata/compaction_leases/unknown.json",
             "content-stores/cs-1/objects/ab/deadbeef",
         ] {
             assert!(

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -32,7 +32,7 @@ Merges above the base can continue reducing delta-run count, but they cannot app
 ## Non-goals
 
 - Durable resume after a process restart.
-- More than one active metadata compaction per namespace.
+- More than one active metadata compaction per family group.
 - A fixed wall-clock limit for the complete job.
 - Changes to the metadata segment format.
 - Configurable process-wide concurrency. The `metadata-compaction` job uses a fixed limit of two concurrent runs.
@@ -54,7 +54,7 @@ Normal bounded merges remain the preferred path. Streaming compaction is selecte
 The complete operation has five stages:
 
 1. Capture an immutable compaction specification containing a generated job ID, the family group, selected input runs, output identity, and retention floor.
-2. Create the job lease, open sorted iterators over the selected runs, and merge their rows in key order.
+2. Acquire the family-group lease, open sorted iterators over the selected runs, and merge their rows in key order.
 3. Apply the retention rules and write completed output segments under `metadata/compactions/{job_id}/segments/`.
 4. Reload the current manifest and confirm that every selected input is still present and unchanged.
 5. Publish one manifest update that removes the selected inputs and adds the completed output.
@@ -94,7 +94,7 @@ The count is stored in the namespace manifest for each `MetadataFamilyGroup`. It
 
 Callers provide a `FrozenBasePolicy` when planning. The `metadata` job uses `Amortized`, which reads the manifest's per-group count. `FsMaintenance::compact_metadata` uses `CompactImmediately` because the caller explicitly requested full compaction.
 
-The bounded step reports `compaction_required`; the `metadata-compaction` job runs the streaming compaction under its own two-permit limit. The planner excludes every family group whose compaction lease is active and unexpired, so the lease excludes that group while unrelated groups remain available. Runner shutdown cancels running jobs.
+The bounded step reports `compaction_required`; the `metadata-compaction` job runs the streaming compaction under its own two-permit limit. The planner considers family groups in ranked order and reads each selected group's lease by key, skipping an `active` unexpired or `reaping` lease while unrelated groups remain available. Runner shutdown cancels running jobs.
 
 Runs published after the snapshot was captured are not part of the compaction input. Final publication preserves those runs.
 
@@ -149,17 +149,17 @@ Step budgets therefore price the selected logical input, and a step-contained me
 
 ## Job leases and garbage collection
 
-Each job owns `metadata/compactions/{job_id}/`. Output segments are stored in its `segments/` subdirectory, and lifecycle ownership is recorded in `lease.json` beside that directory.
+Each family group has one lease at `metadata/compaction_leases/{group}.json`, and its payload names the job whose output under `metadata/compactions/{job_id}/segments/` it protects. An `active` unexpired or `reaping` group lease excludes every other job for that group.
 
 The lease records the job ID, namespace ID, owner ID, status, start time, and most recent heartbeat. It does not contain a cursor, output descriptors, offsets, or progress, so it cannot be used to resume a failed job.
 
-The job creates the lease with `active` status and create-if-absent semantics before writing the first output segment. Every refresh uses compare-and-swap with the ETag returned by the preceding lease write. Refreshes occur every five minutes while the job runs and at the start of every finalization attempt. An active lease remains valid for 25 minutes after its last heartbeat, which covers missed heartbeats and the complete manifest-publication budget.
+The job creates a missing lease with `active` status and create-if-absent semantics before writing the first output segment. It takes over an expired `active` lease with one compare-and-swap that replaces the job, writer, start, and heartbeat fields; a held unexpired or `reaping` lease supersedes the new job. Every refresh uses compare-and-swap with the ETag returned by the preceding lease write. Refreshes occur every five minutes while the job runs and at the start of every finalization attempt. An active lease remains valid for 25 minutes after its last heartbeat, which covers missed heartbeats and the complete manifest-publication budget.
 
-Garbage collection reads at most one lease per job prefix during a pass. A fresh active lease keeps the complete prefix regardless of object age. For an expired active lease, the collector uses compare-and-swap to change the status to `reaping`. If a concurrent heartbeat wins, the collector retains the prefix. If the collector wins, the job's next heartbeat fails, the job returns a fenced outcome without publishing, and unreferenced objects in the prefix become eligible for collection. The `reaping` status is terminal, so a later pass can continue an interrupted cleanup without repeating the ownership decision.
+Garbage collection reads the seven group lease keys once per namespace per pass and maps each named job to its lease. A fresh active lease keeps only that job's objects regardless of age. For an expired active lease, the collector uses compare-and-swap to change the status to `reaping`. If a concurrent heartbeat wins, the collector retains the job's objects. If the collector wins, the job's next heartbeat fails, the job returns a fenced outcome without publishing, and its unreferenced objects become eligible for collection. The `reaping` status is terminal, so a later pass can continue an interrupted cleanup without repeating the ownership decision.
 
-A missing, invalid, or mismatched lease provides no ownership claim. Unreferenced objects in that prefix become eligible after a staging grace period derived from the lease expiry and the normal publication grace. Unrecognized keys under the compaction prefix are retained because ownership cannot be established safely.
+A missing lease or a lease naming another job provides no ownership claim. An invalid lease fails the pass. Unreferenced objects in that prefix become eligible after a staging grace period derived from the lease expiry and the normal publication grace. Unrecognized keys under the compaction prefix are retained because ownership cannot be established safely.
 
-After publication, the job stops heartbeating but leaves its final active lease in place. This protects the output from a collection pass that captured its live references before the manifest update. After the lease expires, a later pass reads the updated manifest, retains the referenced output segments, claims the lease, and deletes the lease after processing the rest of the prefix. Failed, cancelled, abandoned, superseded, and fenced jobs leave unreferenced output that is eventually collected.
+After publication, the job stops heartbeating but leaves its final active lease in place. This protects the output from a collection pass that captured its live references before the manifest update. After the lease expires, a later pass reads the updated manifest, retains the referenced output segments, claims the lease, and deletes it after processing the named job's prefix. Failed, cancelled, abandoned, superseded, and fenced jobs leave unreferenced output that is eventually collected.
 
 ## Finalization
 
@@ -200,7 +200,7 @@ The implementation is validated with the following tests:
 - Fence a job after garbage collection claims its prefix and verify that the job publishes nothing.
 - Leave the final lease after publication and verify that an older collection pass cannot remove the published output.
 - Reclaim staged output after a lease expires, is already marked `reaping`, or is missing.
-- Reject malformed and mismatched leases as job ownership records.
+- Reject malformed leases and leases whose namespace or group disagrees with their key.
 - Exercise continuous delta creation and verify that metadata maintenance requests full compaction after two published delta merges.
 - Verify that explicit compaction selects full compaction immediately for a frozen base.
 - Process large attribute histories and heavily reused binding slots while holding at most one row in retention state.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -94,7 +94,7 @@ The required durable object families and standard key patterns are:
 | **Checkpoint records** | Mutable lifecycle | Durable stable-view pins to a metadata manifest, each carrying a required owner (user, fork target, or snapshot). The record's `status` is monotonic: a record is created `active` under a generated id, released once by compare-and-swap, and deleted a grace window after that release. | `namespaces/{namespace_id}/checkpoints/{checkpoint_id}.json` |
 | **Metadata segments** | Immutable | Store metadata rows referenced by manifests. Segments may be owned by the namespace itself or by a fork source namespace. | `namespaces/{owner_namespace_id}/metadata/segments/{segment_id}.sst.zst` |
 | **Compaction staging** | Immutable | Holds segments written by a streaming compaction before publication. The descriptor stores the job id used to derive this key. | `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/segments/{segment_id}.sst.zst` |
-| **Compaction leases** | Mutable lifecycle | Record ownership of a compaction output prefix. A job creates and refreshes an `active` lease. Garbage collection may change an expired lease to terminal `reaping` before reclaiming the output. | `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/lease.json` |
+| **Compaction leases** | Mutable lifecycle | Record ownership of one family group's active compaction output. A job creates or takes over and refreshes an `active` lease. Garbage collection may change an expired lease to terminal `reaping` before reclaiming the named job's output. | `namespaces/{owner_namespace_id}/metadata/compaction_leases/{group}.json` |
 | **Upload sessions** | Mutable lifecycle | Track one staged-content upload. The record's `status` is monotonic: a session is created `open` under a lease, and moves once to `completed` or `aborted`, both terminal. | `namespaces/{namespace_id}/uploads/{upload_id}.json` |
 | **Metadata root** | Mutable | Cold pointer to the best known materialized metadata root; monotonic CAS. | `namespaces/{namespace_id}/metadata/root.json` |
 | **WAL floor** | Mutable | Cold lower bound of retained WAL/change history; monotonic CAS. | `namespaces/{namespace_id}/wal/floor.json` |
@@ -2246,7 +2246,7 @@ because that makes "the newest at the floor" arbitrary and the drop unsafe.
 
 A rebuild that cannot fit within one maintenance step runs as a streaming compaction. The job merges every run in the group and writes output segments as they fill. These segments use `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/segments/{segment_id}.sst.zst` instead of `metadata/segments/`.
 
-The separate prefix prevents GC from treating unfinished output as abandoned metadata. The job id groups the output under one lease ("Garbage collection", rule 12). A published manifest references the segments in place, so publication does not move them. Each descriptor stores `compaction_job_id`, and readers use it to derive the key (section 4.2.1).
+The separate prefix prevents GC from treating unfinished output as abandoned metadata. Each family group has one lease at `namespaces/{owner_namespace_id}/metadata/compaction_leases/{group}.json`, and an `active` unexpired or `reaping` lease excludes every other job for that group. A job acquires a missing lease with create-if-absent before its first output object, or takes over an expired `active` lease with one compare-and-swap that replaces the job, writer, start, and heartbeat fields. Garbage collection changes an expired `active` lease to terminal `reaping` with compare-and-swap before reclaiming output belonging to the job id the lease names. A group lease never protects objects written by another job id. Collection passes are shorter than `METADATA_COMPACTION_LEASE_EXPIRY_MS`, so a pass does not mistake a lease that it observed as live for one that expired during the pass. A published manifest references the segments in place, so publication does not move them. Each descriptor stores `compaction_job_id`, and readers use it to derive the key (section 4.2.1).
 
 The rules a rebuild applies are the same however it runs them. A bounded
 merge holds every row of its window and decides them together. A streaming
@@ -2300,8 +2300,8 @@ does not exist, so there is nothing to collect and nothing to ignore.
 
 v1 GC is listing mark-and-sweep. Its inputs are `wal/head.json`,
 `wal/floor.json`, `metadata/root.json`, and the `metadata/manifests/`,
-`metadata/segments/`, `metadata/compactions/`, `checkpoints/`, and
-`wal/segments/` collections. A live manifest roots every object key its
+`metadata/segments/`, `metadata/compactions/`, `metadata/compaction_leases/`,
+`checkpoints/`, and `wal/segments/` collections. A live manifest roots every object key its
 `runs` list names, wherever that key sits. The pass also
 sweeps `uploads/`, and that sweep owns content reclamation as well; the two
 halves are split at the completed line and described in rule 11.
@@ -2482,15 +2482,17 @@ publishing CAS) — under these rules:
    a job may run, which is exactly what the design refuses to bound.
 
    The lease says so instead. Every job owns the prefix
-   `namespaces/{namespace_id}/metadata/compactions/{job_id}/`, writes its
-   output under `segments/` inside it, and holds a lease at `lease.json` beside
-   that directory. The lease carries ownership only — job, namespace, group,
-   owner, the tagged `status`, `started_at_ms`, `heartbeat_at_ms` — and never a
-   cursor, an output descriptor, an offset, or resumable progress. The job
-   creates it `active` with create-if-absent before its first output object,
-   and refreshes it by compare-and-swap on the etag it last observed, every
-   `METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS` while it runs and at the top of
-   every finalization attempt.
+   `namespaces/{namespace_id}/metadata/compactions/{job_id}/` and writes its
+   output under `segments/` inside it, while its family group has one lease at
+   `namespaces/{namespace_id}/metadata/compaction_leases/{group}.json`. The
+   lease carries ownership only — job, namespace, group, owner, the tagged
+   `status`, `started_at_ms`, `heartbeat_at_ms` — and never a cursor, an output
+   descriptor, an offset, or resumable progress. The job creates a missing
+   lease `active` with create-if-absent before its first output object, takes
+   over an expired `active` lease with one compare-and-swap, and refreshes the
+   etag it last observed every `METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS`
+   while it runs and at the top of every finalization attempt. An `active`
+   unexpired or `reaping` lease excludes every other job for the group.
 
    The lease is a fence, not a timestamp. An expired lease alone proves
    nothing — the job may be resuming from a long stall — so a pass claims one
@@ -2515,14 +2517,15 @@ publishing CAS) — under these rules:
    owns them. The fresh lease covers that pass, a later pass reads a root that
    already references the objects, and that pass removes the expired lease.
 
-   A pass decides one of the prefix's objects as follows. An object the
-   manifest references is live, like every other referenced object. Otherwise,
-   if the owning job's lease decodes, is `active`, and its `heartbeat_at_ms`
-   is within `METADATA_COMPACTION_LEASE_EXPIRY_MS`, the object is retained
-   whatever its age; so is one whose expired lease the pass tried and failed
-   to claim. Otherwise the prefix is orphaned and the object ages as an
-   ordinary unreferenced orphan under `METADATA_COMPACTION_STAGING_GRACE_MS`,
-   which is derived rather than tuned:
+   A pass reads the seven group lease keys once and decides one staged object
+   as follows. An object the manifest references is live, like every other
+   referenced object. Otherwise, if a lease naming that job is `active` and
+   its `heartbeat_at_ms` is within `METADATA_COMPACTION_LEASE_EXPIRY_MS`, the
+   object is retained whatever its age; so is one whose expired lease the pass
+   tried and failed to claim. A lease naming a different job protects nothing
+   in this prefix. Otherwise the object ages as an ordinary unreferenced orphan
+   under `METADATA_COMPACTION_STAGING_GRACE_MS`, which is derived rather than
+   tuned:
 
    ```
    METADATA_COMPACTION_STAGING_GRACE_MS
@@ -2539,16 +2542,18 @@ publishing CAS) — under these rules:
    at the top of an attempt cannot have its prefix claimed before that
    attempt's root compare-and-swap.
 
-   Deletion within a claimed prefix runs objects first and the lease last, for
-   the same reason deletion runs data before records everywhere else: a pass
-   that stops in between leaves a `reaping` lease saying the reap is
-   unfinished, rather than nothing at all.
+   Deletion processes a claimed job's staged prefix before its group lease,
+   for the same reason deletion runs data before records everywhere else: a
+   pass that stops in between leaves a `reaping` lease saying the reap is
+   unfinished, rather than nothing at all. A pass also claims and deletes an
+   expired `active` lease after confirming its named job has no staged object
+   left.
 
    The lease is a mutable control object and decodes strictly like every
-   other. A lease that does not decode, or that names another job or another
-   namespace, is treated as missing and reported: nothing else reads the
-   object, so believing a corrupt one would keep its prefix alive forever and
-   nothing would ever say why. Every other rule — the reference anchor,
+   other. A lease that does not decode, or whose namespace or group disagrees
+   with its key, fails the pass and is reported: nothing else reads the object,
+   so believing a corrupt one would keep its named job's output alive forever
+   and nothing would ever say why. Every other rule — the reference anchor,
    delete-time re-verification, degraded roots — applies here exactly as it
    applies to `metadata/segments/`.
 


### PR DESCRIPTION
Uses one deterministic compaction lease for each metadata family group instead of listing every staged compaction object to discover active work. The planner reads leases directly and checks at most seven keys while choosing a group.

Lease creation, takeover, heartbeats, and garbage collection use compare-and-swap so only one compaction or collector owns a group at a time. Staged output remains under its job-specific prefix, and a group lease protects only the job it names.