### PR TITLE
feat(core): manage namespace writer sessions

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -136,6 +136,8 @@ error_codes! {
     CommitIdReuseConflict => "commit_id_reuse_conflict",
     CommitOutcomeUnknown => "commit_outcome_unknown",
     CommitQueueFull => "commit_queue_full",
+    WriterSessionClosed => "writer_session_closed",
+    WriterCapacityExceeded => "writer_capacity_exceeded",
     ServerBusy => "server_busy",
     ShuttingDown => "shutting_down",
     DeadlineExceeded => "deadline_exceeded",
@@ -181,6 +183,8 @@ impl ErrorCode {
             ErrorCode::NamespaceExists => ErrorKind::AlreadyExists,
             ErrorCode::DeadlineExceeded => ErrorKind::DeadlineExceeded,
             ErrorCode::CommitQueueFull
+            | ErrorCode::WriterSessionClosed
+            | ErrorCode::WriterCapacityExceeded
             | ErrorCode::ServerBusy
             | ErrorCode::ShuttingDown
             | ErrorCode::CheckpointUnavailable
@@ -254,6 +258,8 @@ impl ErrorCode {
             | ErrorCode::WouldCycle
             | ErrorCode::CommitIdReuseConflict
             | ErrorCode::CommitOutcomeUnknown
+            | ErrorCode::WriterSessionClosed
+            | ErrorCode::WriterCapacityExceeded
             | ErrorCode::DeadlineExceeded
             | ErrorCode::CheckpointUnavailable
             | ErrorCode::MaintenanceRequired

--- a/crates/loonfs-client/tests/snapshots.rs
+++ b/crates/loonfs-client/tests/snapshots.rs
@@ -29,6 +29,7 @@ async fn start_server(name: &str) -> TestServer {
         auth_token: Some("test-token".into()),
         content_token_secret: "test-content-token-secret".into(),
         writer_id: name.to_owned(),
+        max_open_namespaces: None,
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
         grep: GrepConfig::default(),

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -135,6 +135,10 @@ pub enum CoreError {
     ContentPreparation(#[from] ContentPreparationError),
     #[error("commit queue is full; slow down and retry")]
     CommitQueueFull,
+    #[error("writer session for namespace `{namespace_id}` is closed; new work is not admitted")]
+    WriterSessionClosed { namespace_id: NamespaceId },
+    #[error("writer session capacity is {max_open_namespaces}; new work is not admitted")]
+    WriterCapacityExceeded { max_open_namespaces: usize },
     /// The service is shutting down. New requests are rejected, while requests
     /// accepted earlier may finish.
     #[error("shutting down; new work is not admitted")]
@@ -430,6 +434,8 @@ impl CoreError {
             CoreError::CommitIdReuseConflict { .. } => ErrorCode::CommitIdReuseConflict,
             CoreError::ContentPreparation(_) => ErrorCode::ContentNotPrepared,
             CoreError::CommitQueueFull => ErrorCode::CommitQueueFull,
+            CoreError::WriterSessionClosed { .. } => ErrorCode::WriterSessionClosed,
+            CoreError::WriterCapacityExceeded { .. } => ErrorCode::WriterCapacityExceeded,
             CoreError::ShuttingDown => ErrorCode::ShuttingDown,
             // An over-budget publication aborts pre-CAS and is retryable
             // after maintenance, exactly the checkpoint_unavailable contract.
@@ -523,6 +529,8 @@ impl CoreError {
             | CoreError::CommitIdReuseConflict { .. }
             | CoreError::ContentPreparation(_)
             | CoreError::CommitQueueFull
+            | CoreError::WriterSessionClosed { .. }
+            | CoreError::WriterCapacityExceeded { .. }
             | CoreError::ShuttingDown
             | CoreError::CheckpointUnavailable(_)
             | CoreError::InvalidCheckpointRequest(_)

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -7,6 +7,7 @@ bind = "127.0.0.1:9400"
 auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-local"
+#max_open_namespaces = 10000 # Maximum writer sessions held by this server.
 
 # Terminating TLS in this process. Uncomment the [tls] table at the bottom of
 # this file to turn it on. A non-loopback bind refuses to load without it,

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use std::env;
 use std::fs;
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use thiserror::Error;
 
@@ -42,6 +43,9 @@ pub struct ServerConfig {
     #[serde(default)]
     pub content_token_secret: SecretString,
     pub writer_id: String,
+    /// Maximum writer sessions held by this server.
+    #[serde(default)]
+    pub max_open_namespaces: Option<NonZeroUsize>,
     #[serde(default)]
     pub runtime_cache: RuntimeCacheConfigOverrides,
     /// The node-local cache of encoded metadata blocks, if this deployment

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -445,6 +445,9 @@ pub(super) async fn build_handles(
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind)
         .metrics_recorder(metrics.recorder());
+    if let Some(limit) = config.max_open_namespaces {
+        writer_builder = writer_builder.max_open_namespaces(limit);
+    }
     if let Some(observer) = maintenance_hint_observer {
         writer_builder = writer_builder.maintenance_hint_observer(move |hint| observer(hint));
     }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -3522,6 +3522,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         auth_token: Some("test-token".into()),
         content_token_secret: "test-content-token-secret".into(),
         writer_id: writer_id.to_owned(),
+        max_open_namespaces: None,
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
         grep: crate::config::GrepConfig {

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -303,6 +303,7 @@ pub(crate) fn test_config(
         auth_token: Some(auth_token.into()),
         content_token_secret: content_token_secret.into(),
         writer_id: writer_id.to_owned(),
+        max_open_namespaces: None,
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
         grep: GrepConfig {

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -706,6 +706,7 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
         auth_token: Some("test-token".into()),
         content_token_secret: "test-content-token-secret".into(),
         writer_id: format!("grep-mode-{mode:?}"),
+        max_open_namespaces: None,
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
         grep: GrepConfig {

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -17,6 +17,8 @@ pub(crate) const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES: usize =
 /// concurrent submissions amortize into fewer, larger WAL segments. Zero
 /// keeps only the batching that in-flight publications force.
 pub(crate) const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 15;
+/// Default maximum writer sessions held at once.
+pub const DEFAULT_MAX_OPEN_NAMESPACES: usize = 10_000;
 /// Default cap on concurrently running maintenance invocations.
 /// Each job already runs at most once per namespace at a time; this bounds how many may run at
 /// once, so a write burst across many namespaces cannot fan out into

--- a/crates/loonfs/src/handle/mod.rs
+++ b/crates/loonfs/src/handle/mod.rs
@@ -13,6 +13,6 @@ mod writer;
 
 pub use maintenance::{FsMaintenance, FsMaintenanceBuilder};
 pub use reader::{FsReader, FsReaderBuilder};
-pub use writer::{FsWriter, FsWriterBuilder};
+pub use writer::{FsWriter, FsWriterBuilder, NamespaceSessionPolicy};
 
 use builder_core::{owning_runtime, HandleBuilderCore};

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -3,16 +3,31 @@
 use super::{owning_runtime, FsReader, HandleBuilderCore};
 use crate::fs::{ReadCore, WriterBits, WriterIdentity};
 use crate::metrics::{MetricsRecorder, ObjectStoreMetricsRecorder};
-use crate::publisher::{NamespaceAdvanceHint, NamespaceAdvanceObserver, PublisherRegistry};
+use crate::publisher::{
+    CloseNamespaceReport, NamespaceAdvanceHint, NamespaceAdvanceObserver, NamespaceSessionState,
+    PublisherRegistry, WriterSessionStats,
+};
 use crate::{
-    CapabilityDocument, FsMaintenance, MaintenanceHint, MaintenanceHintObserver, Result,
-    RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
-    TraceStoreKind,
+    CapabilityDocument, FsMaintenance, MaintenanceHint, MaintenanceHintObserver, NamespaceId,
+    Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig,
+    TraceMode, TraceStoreKind,
 };
 #[cfg(test)]
 use loonfs_core::cache::MetadataSegmentCache;
 use loonfs_core::cache::StoredMetadataBlockCache;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
+
+/// How a writer treats a namespace it has no open session for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamespaceSessionPolicy {
+    /// The first mutation opens a session. Used by the reference server and CLI.
+    OpenOnFirstWrite,
+    /// Only [`FsWriter::open_namespace`] opens a session.
+    ///
+    /// A mutation without an open session fails with `writer_session_closed`.
+    ExplicitOpen,
+}
 
 /// Write-capable runtime handle for applications and servers.
 ///
@@ -86,6 +101,65 @@ impl FsWriter {
         self.publisher.clone()
     }
 
+    /// Opens a session for `namespace_id`, or returns if one is open.
+    ///
+    /// Fails with `writer_capacity_exceeded` at the limit, with
+    /// `writer_session_closed` while a close is draining, and with
+    /// `shutting_down` after shutdown begins. Opening acquires no writer
+    /// epoch; the first publish does.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.open_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "open_namespace",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub fn open_namespace(&self, namespace_id: &NamespaceId) -> Result<()> {
+        self.core.record_trace_context(&tracing::Span::current());
+        self.publisher.open_namespace(namespace_id)?;
+        Ok(())
+    }
+
+    /// Closes and drains the session for `namespace_id`.
+    ///
+    /// Admissions stop for every clone of the publisher. Admitted work
+    /// finishes, and a later open starts a new session. Calling this for a
+    /// closed namespace has no additional effect.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.close_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "close_namespace",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn close_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<CloseNamespaceReport> {
+        self.core.record_trace_context(&tracing::Span::current());
+        Ok(self.publisher.close_namespace(namespace_id).await?)
+    }
+
+    /// Returns the writer session state for `namespace_id`.
+    pub fn namespace_session_state(&self, namespace_id: &NamespaceId) -> NamespaceSessionState {
+        self.publisher.namespace_session_state(namespace_id)
+    }
+
+    /// Returns this writer's namespace session totals and capacity.
+    pub fn writer_session_stats(&self) -> WriterSessionStats {
+        self.publisher.writer_session_stats()
+    }
+
     /// Closes publication admission before shutdown drains.
     ///
     /// Later mutations fail with `shutting_down`. Calling this more than once
@@ -149,6 +223,8 @@ pub struct FsWriterBuilder {
     core: HandleBuilderCore,
     writer_id: Option<String>,
     min_publish_interval_ms: u64,
+    namespace_session_policy: NamespaceSessionPolicy,
+    max_open_namespaces: NonZeroUsize,
     namespace_advance_observer: Option<NamespaceAdvanceObserver>,
     maintenance_hint_observer: Option<MaintenanceHintObserver>,
 }
@@ -159,6 +235,9 @@ impl FsWriterBuilder {
             core,
             writer_id: None,
             min_publish_interval_ms: crate::config::DEFAULT_MIN_PUBLISH_INTERVAL_MS,
+            namespace_session_policy: NamespaceSessionPolicy::OpenOnFirstWrite,
+            max_open_namespaces: NonZeroUsize::new(crate::config::DEFAULT_MAX_OPEN_NAMESPACES)
+                .expect("default maximum open namespaces should be nonzero"),
             namespace_advance_observer: None,
             maintenance_hint_observer: None,
         }
@@ -190,6 +269,22 @@ impl FsWriterBuilder {
     /// batching that in-flight publications force.
     pub fn min_publish_interval_ms(mut self, min_publish_interval_ms: u64) -> Self {
         self.min_publish_interval_ms = min_publish_interval_ms;
+        self
+    }
+
+    /// Sets how namespaces without an open writer session are handled.
+    /// Defaults to [`NamespaceSessionPolicy::OpenOnFirstWrite`].
+    pub fn namespace_sessions(mut self, policy: NamespaceSessionPolicy) -> Self {
+        self.namespace_session_policy = policy;
+        self
+    }
+
+    /// Sets the maximum number of writer sessions held at once.
+    ///
+    /// Opening past the limit fails with `writer_capacity_exceeded`. The
+    /// default is [`crate::DEFAULT_MAX_OPEN_NAMESPACES`].
+    pub fn max_open_namespaces(mut self, limit: NonZeroUsize) -> Self {
+        self.max_open_namespaces = limit;
         self
     }
 
@@ -304,6 +399,8 @@ impl FsWriterBuilder {
             Arc::downgrade(&bits),
             runtime,
             std::time::Duration::from_millis(self.min_publish_interval_ms),
+            self.namespace_session_policy,
+            self.max_open_namespaces,
         );
         Ok(FsWriter {
             core,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -170,13 +170,16 @@ pub use loonfs_objectstore::{
 };
 
 pub use cache::RuntimeCacheStats;
-pub use config::{RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE};
+pub use config::{
+    RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE, DEFAULT_MAX_OPEN_NAMESPACES,
+};
 pub use fs::{
     ChangesPager, CheckpointsPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager,
     PathEntriesPager, SnapshotsPager, TrashPager,
 };
 pub use handle::{
     FsMaintenance, FsMaintenanceBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder,
+    NamespaceSessionPolicy,
 };
 pub use maintenance::{
     GarbageCollectionJob, MaintenanceAssignment, MaintenanceCancellation, MaintenanceConclusion,
@@ -193,6 +196,7 @@ pub use options::{
     ReadFileStreamOptions, RestoreRevisionOptions, StatPathOptions, UndeleteOptions,
     UpdateAttributesOptions,
 };
+pub use publisher::{CloseNamespaceReport, NamespaceSessionState, WriterSessionStats};
 pub use trace::{payload_class, TraceMode, TraceStoreKind};
 
 /// Result type used by the embedded runtime.

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -415,6 +415,20 @@ impl RuntimeInstruments {
             .set(i64::try_from(queue_depth).unwrap_or(i64::MAX));
     }
 
+    pub(crate) fn publisher_sessions(&self, open: usize, closing: usize) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed
+            .publisher
+            .sessions_open
+            .set(i64::try_from(open).unwrap_or(i64::MAX));
+        installed
+            .publisher
+            .sessions_closing
+            .set(i64::try_from(closing).unwrap_or(i64::MAX));
+    }
+
     /// Reports the WAL-tail projections this writer retains across its
     /// namespace publishers, after one publish or eviction settled them.
     pub(crate) fn publisher_retained_projections(&self, projections: usize, decoded_bytes: usize) {
@@ -956,6 +970,8 @@ struct PublisherInstruments {
     wal_folds: Arc<dyn CounterHandle>,
     batch_size: Arc<dyn HistogramHandle>,
     queue_depth: Arc<dyn GaugeHandle>,
+    sessions_open: Arc<dyn GaugeHandle>,
+    sessions_closing: Arc<dyn GaugeHandle>,
     retained_projections: Arc<dyn GaugeHandle>,
     retained_projection_bytes: Arc<dyn GaugeHandle>,
     publishes: LabeledCounters<PublishOutcome>,
@@ -986,6 +1002,16 @@ impl PublisherInstruments {
             queue_depth: recorder.register_gauge(
                 "loonfs.publisher.queue_depth",
                 "Candidates queued at the namespace publisher that last admitted or took work",
+                &[],
+            ),
+            sessions_open: recorder.register_gauge(
+                "loonfs.publisher.sessions_open",
+                "Open namespace writer sessions",
+                &[],
+            ),
+            sessions_closing: recorder.register_gauge(
+                "loonfs.publisher.sessions_closing",
+                "Namespace writer sessions draining a close",
                 &[],
             ),
             // Totals, not samples: these are what the writer holds across

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -26,7 +26,7 @@ use loonfs_core::publish::{
     NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState, WriterSessionState,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -40,6 +40,7 @@ use tracing::Instrument;
 
 type CommitResult = Result<ApiCommitResponse, RuntimeError>;
 type DeleteResult = Result<DeleteNamespaceResponse, RuntimeError>;
+type CloseCompletion = watch::Receiver<Option<CloseNamespaceReport>>;
 
 /// A report that one namespace's durable mutation history advanced.
 ///
@@ -141,9 +142,9 @@ pub struct PublisherRegistry {
 /// publisher instances, retained projections, and contained panic count.
 struct RegistryShared {
     state: Mutex<RegistryState>,
-    /// Publications and deletes whose panic a worker survived. Workers
-    /// contain panics to keep their namespace writable, so this — not a
-    /// task join error — is what a drain reports.
+    /// Publication, deletion, and namespace-close units whose panic a task
+    /// survived. Tasks contain panics to keep the registry usable, so this —
+    /// not a task join error — is what a drain reports.
     panicked_units: AtomicUsize,
 }
 
@@ -152,8 +153,17 @@ struct RegistryState {
     policy: NamespaceSessionPolicy,
     capacity: NonZeroUsize,
     publishers: HashMap<NamespaceId, NamespacePublisher>,
-    closing: HashSet<NamespaceId>,
+    closing: HashMap<NamespaceId, CloseCompletion>,
     projections: RetainedProjections,
+}
+
+impl RegistryState {
+    fn session_counts(&self) -> (usize, usize) {
+        (
+            self.publishers.len() - self.closing.len(),
+            self.closing.len(),
+        )
+    }
 }
 
 impl RegistryShared {
@@ -172,9 +182,12 @@ impl RegistryShared {
         instruments: &crate::metrics::RuntimeInstruments,
     ) -> RetainedProjectionTotals {
         let mut state = self.lock_state();
-        state.publishers.remove(namespace_id);
+        if !state.closing.contains_key(namespace_id) {
+            state.publishers.remove(namespace_id);
+        }
         state.projections.forget(namespace_id);
-        instruments.publisher_sessions(state.publishers.len(), state.closing.len());
+        let (open, closing) = state.session_counts();
+        instruments.publisher_sessions(open, closing);
         state.projections.totals()
     }
 
@@ -333,7 +346,7 @@ impl PublisherRegistry {
                     policy,
                     capacity,
                     publishers: HashMap::new(),
-                    closing: HashSet::new(),
+                    closing: HashMap::new(),
                     projections: RetainedProjections::default(),
                 }),
                 panicked_units: AtomicUsize::new(0),
@@ -423,7 +436,7 @@ impl PublisherRegistry {
         if state.closed {
             return Err(CoreError::ShuttingDown);
         }
-        if state.closing.contains(namespace_id) {
+        if state.closing.contains_key(namespace_id) {
             return Err(CoreError::WriterSessionClosed {
                 namespace_id: namespace_id.clone(),
             });
@@ -453,7 +466,8 @@ impl PublisherRegistry {
         state
             .publishers
             .insert(namespace_id.clone(), publisher.clone());
-        self.report_session_counts(state.publishers.len(), state.closing.len());
+        let (open, closing) = state.session_counts();
+        self.report_session_counts(open, closing);
         Ok(publisher)
     }
 
@@ -467,40 +481,51 @@ impl PublisherRegistry {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<CloseNamespaceReport, CoreError> {
-        let taken = {
+        let (completion, close_in_progress) = {
             let mut state = self.shared.lock_state();
-            state.publishers.remove(namespace_id).map(|publisher| {
-                state.closing.insert(namespace_id.clone());
+            if state.closed {
+                return Err(CoreError::ShuttingDown);
+            }
+            let Some(publisher) = state.publishers.get(namespace_id).cloned() else {
+                return Ok(CloseNamespaceReport {
+                    was_open: false,
+                    drained_commits: 0,
+                    fenced: false,
+                });
+            };
+            if let Some(completion) = state.closing.get(namespace_id) {
+                (completion.clone(), true)
+            } else {
                 // Flipping admission while the registry lock is held is the close
                 // linearization point.
                 let drained_commits = publisher.close_session_admission();
-                self.report_session_counts(state.publishers.len(), state.closing.len());
-                (publisher, drained_commits)
-            })
+                let (sender, completion) = watch::channel(None);
+                state
+                    .closing
+                    .insert(namespace_id.clone(), completion.clone());
+                let (open, closing) = state.session_counts();
+                self.report_session_counts(open, closing);
+                let shared = Arc::clone(&self.shared);
+                let namespace_id = namespace_id.clone();
+                self.runtime.spawn(async move {
+                    finish_namespace_close(
+                        shared,
+                        publisher,
+                        namespace_id,
+                        drained_commits,
+                        sender,
+                    )
+                    .await;
+                });
+                (completion, false)
+            }
         };
-        let Some((publisher, drained_commits)) = taken else {
-            return Ok(CloseNamespaceReport {
-                was_open: false,
-                drained_commits: 0,
-                fenced: false,
-            });
-        };
-
-        publisher.wait_for_worker().await;
-        let fenced = publisher.session_is_fenced();
-        let totals = {
-            let mut state = self.shared.lock_state();
-            state.projections.forget(namespace_id);
-            state.closing.remove(namespace_id);
-            self.report_session_counts(state.publishers.len(), state.closing.len());
-            state.projections.totals()
-        };
-        publisher.report_retained_projections(totals);
-        Ok(CloseNamespaceReport {
-            was_open: true,
-            drained_commits,
-            fenced,
-        })
+        let mut report = wait_for_close(completion).await?;
+        if close_in_progress {
+            report.was_open = false;
+            report.drained_commits = 0;
+        }
+        Ok(report)
     }
 
     pub(crate) fn namespace_session_state(
@@ -509,7 +534,7 @@ impl PublisherRegistry {
     ) -> NamespaceSessionState {
         let publisher = {
             let state = self.shared.lock_state();
-            if state.closing.contains(namespace_id) {
+            if state.closing.contains_key(namespace_id) {
                 return NamespaceSessionState::Closing;
             }
             state.publishers.get(namespace_id).cloned()
@@ -524,16 +549,20 @@ impl PublisherRegistry {
     }
 
     pub(crate) fn writer_session_stats(&self) -> WriterSessionStats {
-        let (publishers, closing, capacity) = {
+        let (publishers, open, closing, capacity) = {
             let state = self.shared.lock_state();
-            (
-                state.publishers.values().cloned().collect::<Vec<_>>(),
-                state.closing.len(),
-                state.capacity.get(),
-            )
+            let publishers = state
+                .publishers
+                .iter()
+                .filter_map(|(namespace_id, publisher)| {
+                    (!state.closing.contains_key(namespace_id)).then_some(publisher.clone())
+                })
+                .collect::<Vec<_>>();
+            let (open, closing) = state.session_counts();
+            (publishers, open, closing, state.capacity.get())
         };
         WriterSessionStats {
-            open: publishers.len(),
+            open,
             closing,
             fenced: publishers
                 .iter()
@@ -591,6 +620,16 @@ impl PublisherRegistry {
         for publisher in publishers {
             publisher.wait_for_worker().await;
         }
+        let closes = self
+            .shared
+            .lock_state()
+            .closing
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for completion in closes {
+            let _ = wait_for_close(completion).await;
+        }
         let panicked = self.shared.panicked_units.load(Ordering::SeqCst);
         if panicked > 0 {
             return Err(RuntimeError::RuntimeTask(format!(
@@ -599,6 +638,61 @@ impl PublisherRegistry {
         }
         Ok(())
     }
+}
+
+async fn wait_for_close(
+    mut completion: CloseCompletion,
+) -> Result<CloseNamespaceReport, CoreError> {
+    loop {
+        if let Some(report) = *completion.borrow_and_update() {
+            return Ok(report);
+        }
+        // The sender drops without a report only when the runtime shut down
+        // under the close task.
+        if completion.changed().await.is_err() {
+            return Err(CoreError::ShuttingDown);
+        }
+    }
+}
+
+async fn finish_namespace_close(
+    shared: Arc<RegistryShared>,
+    publisher: NamespacePublisher,
+    namespace_id: NamespaceId,
+    drained_commits: usize,
+    sender: watch::Sender<Option<CloseNamespaceReport>>,
+) {
+    let fenced = match AssertUnwindSafe(async {
+        publisher.wait_for_worker().await;
+        publisher.session_is_fenced()
+    })
+    .catch_unwind()
+    .await
+    {
+        Ok(fenced) => fenced,
+        Err(_) => {
+            shared.panicked_units.fetch_add(1, Ordering::SeqCst);
+            publisher.session_is_fenced()
+        }
+    };
+    let totals = {
+        let mut state = shared.lock_state();
+        state.publishers.remove(&namespace_id);
+        state.projections.forget(&namespace_id);
+        state.closing.remove(&namespace_id);
+        let (open, closing) = state.session_counts();
+        publisher
+            .read_core
+            .instruments()
+            .publisher_sessions(open, closing);
+        state.projections.totals()
+    };
+    publisher.report_retained_projections(totals);
+    let _ = sender.send(Some(CloseNamespaceReport {
+        was_open: true,
+        drained_commits,
+        fenced,
+    }));
 }
 
 #[derive(Clone)]

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -13,7 +13,8 @@ use crate::metrics::{PublishOutcome, RESULT_OK};
 use crate::publish::CommitCandidate;
 use crate::trace::{phase_event, phase_span};
 use crate::{
-    CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeCacheConfig, RuntimeError,
+    CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, NamespaceSessionPolicy,
+    RuntimeCacheConfig, RuntimeError,
 };
 use futures::FutureExt;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
@@ -21,9 +22,12 @@ use loonfs_api::{ChangeSeq, CommitId, NamespaceId};
 use loonfs_core::cache::Recency;
 use loonfs_core::commit::{CommitFingerprint, CommitHeadPublishError};
 use loonfs_core::limits::{CHECKPOINT_AT_WAL_SEGMENTS, CONTENTION_RETRY_LIMIT};
-use loonfs_core::publish::{NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState};
+use loonfs_core::publish::{
+    NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState, WriterSessionState,
+};
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
@@ -60,6 +64,49 @@ pub struct NamespaceAdvanceHint {
 /// [`FsWriterBuilder::namespace_advance_observer`](crate::FsWriterBuilder::namespace_advance_observer),
 /// which documents what the callback may do.
 pub type NamespaceAdvanceObserver = Arc<dyn Fn(NamespaceAdvanceHint) + Send + Sync + 'static>;
+
+/// Result of closing one namespace writer session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CloseNamespaceReport {
+    /// False when no session was open.
+    pub was_open: bool,
+    /// Commits admitted before the close and published during the drain.
+    pub drained_commits: usize,
+    /// Whether the closed session had been fenced.
+    pub fenced: bool,
+}
+
+/// Current state of one namespace writer session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamespaceSessionState {
+    /// No session is open.
+    ///
+    /// Under [`NamespaceSessionPolicy::ExplicitOpen`], mutations fail with
+    /// `writer_session_closed`.
+    Closed,
+    /// The session is admitting work.
+    Open {
+        /// Whether another writer superseded this session.
+        fenced: bool,
+        /// Commits waiting to be published.
+        queued_commits: usize,
+    },
+    /// A close is draining admitted work.
+    Closing,
+}
+
+/// Totals for the namespace writer sessions held by one writer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriterSessionStats {
+    /// Sessions admitting work.
+    pub open: usize,
+    /// Sessions draining a close.
+    pub closing: usize,
+    /// Open sessions that have been fenced.
+    pub fenced: usize,
+    /// Maximum sessions this writer may hold at once.
+    pub capacity: usize,
+}
 
 /// Maximum candidates queued for one namespace before admission reports
 /// `commit_queue_full`.
@@ -102,7 +149,10 @@ struct RegistryShared {
 
 struct RegistryState {
     closed: bool,
+    policy: NamespaceSessionPolicy,
+    capacity: NonZeroUsize,
     publishers: HashMap<NamespaceId, NamespacePublisher>,
+    closing: HashSet<NamespaceId>,
     projections: RetainedProjections,
 }
 
@@ -116,10 +166,15 @@ impl RegistryShared {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    fn evict(&self, namespace_id: &NamespaceId) -> RetainedProjectionTotals {
+    fn evict(
+        &self,
+        namespace_id: &NamespaceId,
+        instruments: &crate::metrics::RuntimeInstruments,
+    ) -> RetainedProjectionTotals {
         let mut state = self.lock_state();
         state.publishers.remove(namespace_id);
         state.projections.forget(namespace_id);
+        instruments.publisher_sessions(state.publishers.len(), state.closing.len());
         state.projections.totals()
     }
 
@@ -268,12 +323,17 @@ impl PublisherRegistry {
         writer: Weak<WriterBits>,
         runtime: Handle,
         min_publish_interval: Duration,
+        policy: NamespaceSessionPolicy,
+        capacity: NonZeroUsize,
     ) -> Self {
         Self {
             shared: Arc::new(RegistryShared {
                 state: Mutex::new(RegistryState {
                     closed: false,
+                    policy,
+                    capacity,
                     publishers: HashMap::new(),
+                    closing: HashSet::new(),
                     projections: RetainedProjections::default(),
                 }),
                 panicked_units: AtomicUsize::new(0),
@@ -294,8 +354,12 @@ impl PublisherRegistry {
         namespace_id: NamespaceId,
         options: DeleteNamespaceOptions,
     ) -> DeleteResult {
-        let publisher = self.publisher_for(&namespace_id)?;
-        publisher.submit_delete(options).await
+        let receiver = {
+            let mut state = self.shared.lock_state();
+            let publisher = self.publisher_for(&mut state, &namespace_id, false)?;
+            publisher.admit_delete(options)?
+        };
+        receive_delete(receiver).await
     }
 
     /// Submits one already-classified candidate; the runtime's direct
@@ -305,8 +369,17 @@ impl PublisherRegistry {
         namespace_id: NamespaceId,
         candidate: CommitCandidate,
     ) -> CommitResult {
-        let publisher = self.publisher_for(&namespace_id)?;
-        publisher.submit(candidate).await
+        submit_with_admission(
+            &namespace_id,
+            candidate,
+            self.timer.as_ref(),
+            |commit_id, candidate, semantic_identity, waiter, enqueued_at| {
+                let mut state = self.shared.lock_state();
+                let publisher = self.publisher_for(&mut state, &namespace_id, false)?;
+                publisher.admit(commit_id, candidate, semantic_identity, waiter, enqueued_at)
+            },
+        )
+        .await
     }
 
     /// Invalidates the namespace's rebuildable WAL-tail projection without
@@ -332,28 +405,148 @@ impl PublisherRegistry {
             .publisher_retained_projections(totals.projections, totals.decoded_bytes);
     }
 
-    /// Looks up or creates the namespace's publisher, refusing once
-    /// admission is closed.
-    fn publisher_for(&self, namespace_id: &NamespaceId) -> Result<NamespacePublisher, CoreError> {
+    #[cfg(test)]
+    fn test_publisher_for(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<NamespacePublisher, CoreError> {
         let mut state = self.shared.lock_state();
+        self.publisher_for(&mut state, namespace_id, false)
+    }
+
+    fn publisher_for(
+        &self,
+        state: &mut RegistryState,
+        namespace_id: &NamespaceId,
+        explicit_open: bool,
+    ) -> Result<NamespacePublisher, CoreError> {
         if state.closed {
             return Err(CoreError::ShuttingDown);
         }
-        Ok(state
+        if state.closing.contains(namespace_id) {
+            return Err(CoreError::WriterSessionClosed {
+                namespace_id: namespace_id.clone(),
+            });
+        }
+        if let Some(publisher) = state.publishers.get(namespace_id) {
+            return Ok(publisher.clone());
+        }
+        if !explicit_open && state.policy == NamespaceSessionPolicy::ExplicitOpen {
+            return Err(CoreError::WriterSessionClosed {
+                namespace_id: namespace_id.clone(),
+            });
+        }
+        if state.publishers.len() >= state.capacity.get() {
+            return Err(CoreError::WriterCapacityExceeded {
+                max_open_namespaces: state.capacity.get(),
+            });
+        }
+        let publisher = NamespacePublisher::new(
+            namespace_id.clone(),
+            self.read_core.clone(),
+            self.writer.clone(),
+            Arc::downgrade(&self.shared),
+            self.runtime.clone(),
+            Arc::clone(&self.timer),
+            self.min_publish_interval,
+        );
+        state
             .publishers
-            .entry(namespace_id.clone())
-            .or_insert_with(|| {
-                NamespacePublisher::new(
-                    namespace_id.clone(),
-                    self.read_core.clone(),
-                    self.writer.clone(),
-                    Arc::downgrade(&self.shared),
-                    self.runtime.clone(),
-                    Arc::clone(&self.timer),
-                    self.min_publish_interval,
-                )
+            .insert(namespace_id.clone(), publisher.clone());
+        self.report_session_counts(state.publishers.len(), state.closing.len());
+        Ok(publisher)
+    }
+
+    pub(crate) fn open_namespace(&self, namespace_id: &NamespaceId) -> Result<(), CoreError> {
+        let mut state = self.shared.lock_state();
+        self.publisher_for(&mut state, namespace_id, true)?;
+        Ok(())
+    }
+
+    pub(crate) async fn close_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<CloseNamespaceReport, CoreError> {
+        let taken = {
+            let mut state = self.shared.lock_state();
+            state.publishers.remove(namespace_id).map(|publisher| {
+                state.closing.insert(namespace_id.clone());
+                // Flipping admission while the registry lock is held is the close
+                // linearization point.
+                let drained_commits = publisher.close_session_admission();
+                self.report_session_counts(state.publishers.len(), state.closing.len());
+                (publisher, drained_commits)
             })
-            .clone())
+        };
+        let Some((publisher, drained_commits)) = taken else {
+            return Ok(CloseNamespaceReport {
+                was_open: false,
+                drained_commits: 0,
+                fenced: false,
+            });
+        };
+
+        publisher.wait_for_worker().await;
+        let fenced = publisher.session_is_fenced();
+        let totals = {
+            let mut state = self.shared.lock_state();
+            state.projections.forget(namespace_id);
+            state.closing.remove(namespace_id);
+            self.report_session_counts(state.publishers.len(), state.closing.len());
+            state.projections.totals()
+        };
+        publisher.report_retained_projections(totals);
+        Ok(CloseNamespaceReport {
+            was_open: true,
+            drained_commits,
+            fenced,
+        })
+    }
+
+    pub(crate) fn namespace_session_state(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> NamespaceSessionState {
+        let publisher = {
+            let state = self.shared.lock_state();
+            if state.closing.contains(namespace_id) {
+                return NamespaceSessionState::Closing;
+            }
+            state.publishers.get(namespace_id).cloned()
+        };
+        let Some(publisher) = publisher else {
+            return NamespaceSessionState::Closed;
+        };
+        NamespaceSessionState::Open {
+            fenced: publisher.session_is_fenced(),
+            queued_commits: publisher.queued_commits(),
+        }
+    }
+
+    pub(crate) fn writer_session_stats(&self) -> WriterSessionStats {
+        let (publishers, closing, capacity) = {
+            let state = self.shared.lock_state();
+            (
+                state.publishers.values().cloned().collect::<Vec<_>>(),
+                state.closing.len(),
+                state.capacity.get(),
+            )
+        };
+        WriterSessionStats {
+            open: publishers.len(),
+            closing,
+            fenced: publishers
+                .iter()
+                .filter(|publisher| publisher.session_is_fenced())
+                .count(),
+            capacity,
+        }
+    }
+
+    fn report_session_counts(&self, open: usize, closing: usize) {
+        self.read_core
+            .instruments()
+            .publisher_sessions(open, closing);
     }
 
     /// Whether [`Self::close_admission`] has run: later submissions fail
@@ -419,6 +612,7 @@ struct NamespacePublisher {
     /// Locked only by the worker, across one publication or delete, and by
     /// [`Self::invalidate_projection`], which never waits for it.
     engine: Arc<AsyncMutex<EngineSlot>>,
+    session: SharedWriterSessionState,
     /// Weak: the registry map owns its publishers, and a strong reference
     /// back would cycle the whole structure into a leak. A publisher whose
     /// registry is gone keeps serving, with an unowned worker.
@@ -451,6 +645,7 @@ enum PublisherAdmissionState {
     /// Set by the registry's admission close. Later admissions fail with
     /// `shutting_down`; everything already queued keeps publishing.
     Closed,
+    SessionClosed,
     /// Terminal: set once a delete succeeds. Admissions fail fast from then
     /// on without touching the store.
     Deleted,
@@ -536,6 +731,7 @@ impl NamespacePublisher {
         timer: Arc<dyn MonotonicTimer>,
         min_publish_interval: Duration,
     ) -> Self {
+        let session = SharedWriterSessionState::default();
         Self {
             namespace_id,
             read_core,
@@ -549,8 +745,9 @@ impl NamespacePublisher {
             })),
             engine: Arc::new(AsyncMutex::new(EngineSlot {
                 engine: None,
-                session: SharedWriterSessionState::default(),
+                session: Arc::clone(&session),
             })),
+            session,
             shared,
             runtime,
             timer,
@@ -577,13 +774,38 @@ impl NamespacePublisher {
         }
     }
 
+    fn close_session_admission(&self) -> usize {
+        let mut state = self.lock_state();
+        if matches!(state.admission, PublisherAdmissionState::Open) {
+            state.admission = PublisherAdmissionState::SessionClosed;
+        }
+        state.in_flight.len()
+    }
+
     /// Returns the error for the current admission state, or succeeds when open.
     fn check_admission(&self, state: &NamespacePublisherState) -> Result<(), CoreError> {
         match state.admission {
             PublisherAdmissionState::Open => Ok(()),
             PublisherAdmissionState::Closed => Err(CoreError::ShuttingDown),
+            PublisherAdmissionState::SessionClosed => Err(CoreError::WriterSessionClosed {
+                namespace_id: self.namespace_id.clone(),
+            }),
             PublisherAdmissionState::Deleted => Err(self.namespace_deleted()),
         }
+    }
+
+    fn session_is_fenced(&self) -> bool {
+        matches!(
+            *self
+                .session
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            WriterSessionState::Fenced(_)
+        )
+    }
+
+    fn queued_commits(&self) -> usize {
+        queued_candidates(&self.lock_state())
     }
 
     /// Drops the engine's tail projection, reporting whether it took the
@@ -626,53 +848,17 @@ impl NamespacePublisher {
     /// claim on its commit ID, or returns an error. Once the candidate enters
     /// the queue, cancelling the caller only drops result delivery; the worker
     /// still owns and publishes the request.
+    #[cfg(test)]
     async fn submit(&self, candidate: CommitCandidate) -> CommitResult {
-        let commit_id = candidate.commit_id().clone();
-        let enqueued_at = self.timer.monotonic_now_ms();
-        let mut candidate = candidate;
-        let mut semantic_identity = candidate.semantic_identity(&self.namespace_id)?;
-        for _ in 0..CONTENTION_RETRY_LIMIT {
-            let (sender, receiver) = oneshot::channel();
-            let admission = self.admit(
-                commit_id.clone(),
-                candidate,
-                semantic_identity,
-                sender,
-                enqueued_at,
-            )?;
-            let result = receiver.await.map_err(|_| {
-                CoreError::HeadPublish(CommitHeadPublishError::OutcomeUnknown(
-                    "publisher task stopped before reporting an outcome".to_owned(),
-                ))
-            })?;
-            match admission {
-                SubmissionAdmission::OwnOutcome => return result,
-                SubmissionAdmission::Contended {
-                    primary_identity,
-                    candidate: returned_candidate,
-                    semantic_identity: returned_identity,
-                } => match result {
-                    Ok(response) => {
-                        return Err(CoreError::CommitIdReuseConflict {
-                            commit_id: commit_id.to_string(),
-                            committed_seq: Some(response.committed_seq),
-                            committed_fingerprint: Some(primary_identity.as_str().to_owned()),
-                        }
-                        .into())
-                    }
-                    Err(_) => {
-                        candidate = returned_candidate;
-                        semantic_identity = returned_identity;
-                    }
-                },
-            }
-        }
-        Err(CoreError::CommitIdReuseConflict {
-            commit_id: commit_id.to_string(),
-            committed_seq: None,
-            committed_fingerprint: None,
-        }
-        .into())
+        submit_with_admission(
+            &self.namespace_id,
+            candidate,
+            self.timer.as_ref(),
+            |commit_id, candidate, semantic_identity, waiter, enqueued_at| {
+                self.admit(commit_id, candidate, semantic_identity, waiter, enqueued_at)
+            },
+        )
+        .await
     }
 
     fn admit(
@@ -737,7 +923,16 @@ impl NamespacePublisher {
     /// `namespace_deleted` once it succeeds. If the delete fails (for
     /// example a stale `expected_head_seq`), later requests publish
     /// normally — nothing is rejected for a delete that did not happen.
+    #[cfg(test)]
     async fn submit_delete(&self, options: DeleteNamespaceOptions) -> DeleteResult {
+        let receiver = self.admit_delete(options)?;
+        receive_delete(receiver).await
+    }
+
+    fn admit_delete(
+        &self,
+        options: DeleteNamespaceOptions,
+    ) -> Result<oneshot::Receiver<DeleteResult>, CoreError> {
         let (sender, receiver) = oneshot::channel();
         {
             let mut state = self.lock_state();
@@ -756,14 +951,7 @@ impl NamespacePublisher {
             }
             self.ensure_worker(&mut state);
         }
-        receiver.await.unwrap_or_else(|_| {
-            Err(
-                CoreError::HeadPublish(CommitHeadPublishError::OutcomeUnknown(
-                    "publisher task stopped mid-delete".to_owned(),
-                ))
-                .into(),
-            )
-        })
+        Ok(receiver)
     }
 
     /// Makes sure a worker owns this publisher's queue.
@@ -1013,7 +1201,8 @@ impl NamespacePublisher {
                 // gets a fresh publisher whose publish fails on the durable
                 // tombstone.
                 if let Some(shared) = self.shared.upgrade() {
-                    self.report_retained_projections(shared.evict(&self.namespace_id));
+                    let totals = shared.evict(&self.namespace_id, self.read_core.instruments());
+                    self.report_retained_projections(totals);
                 }
                 for waiter in waiters {
                     let _ = waiter.send(Ok(response.clone()));
@@ -1180,6 +1369,80 @@ impl NamespacePublisher {
             reason
         );
     }
+}
+
+async fn submit_with_admission<F>(
+    namespace_id: &NamespaceId,
+    candidate: CommitCandidate,
+    timer: &dyn MonotonicTimer,
+    mut admit: F,
+) -> CommitResult
+where
+    F: FnMut(
+        CommitId,
+        CommitCandidate,
+        CommitFingerprint,
+        oneshot::Sender<CommitResult>,
+        u64,
+    ) -> Result<SubmissionAdmission, CoreError>,
+{
+    let commit_id = candidate.commit_id().clone();
+    let enqueued_at = timer.monotonic_now_ms();
+    let mut candidate = candidate;
+    let mut semantic_identity = candidate.semantic_identity(namespace_id)?;
+    for _ in 0..CONTENTION_RETRY_LIMIT {
+        let (sender, receiver) = oneshot::channel();
+        let admission = admit(
+            commit_id.clone(),
+            candidate,
+            semantic_identity,
+            sender,
+            enqueued_at,
+        )?;
+        let result = receiver.await.map_err(|_| {
+            CoreError::HeadPublish(CommitHeadPublishError::OutcomeUnknown(
+                "publisher task stopped before reporting an outcome".to_owned(),
+            ))
+        })?;
+        match admission {
+            SubmissionAdmission::OwnOutcome => return result,
+            SubmissionAdmission::Contended {
+                primary_identity,
+                candidate: returned_candidate,
+                semantic_identity: returned_identity,
+            } => match result {
+                Ok(response) => {
+                    return Err(CoreError::CommitIdReuseConflict {
+                        commit_id: commit_id.to_string(),
+                        committed_seq: Some(response.committed_seq),
+                        committed_fingerprint: Some(primary_identity.as_str().to_owned()),
+                    }
+                    .into())
+                }
+                Err(_) => {
+                    candidate = returned_candidate;
+                    semantic_identity = returned_identity;
+                }
+            },
+        }
+    }
+    Err(CoreError::CommitIdReuseConflict {
+        commit_id: commit_id.to_string(),
+        committed_seq: None,
+        committed_fingerprint: None,
+    }
+    .into())
+}
+
+async fn receive_delete(receiver: oneshot::Receiver<DeleteResult>) -> DeleteResult {
+    receiver.await.unwrap_or_else(|_| {
+        Err(
+            CoreError::HeadPublish(CommitHeadPublishError::OutcomeUnknown(
+                "publisher task stopped mid-delete".to_owned(),
+            ))
+            .into(),
+        )
+    })
 }
 
 /// Waiters a landed delete barrier leaves behind, one vector per result

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -572,7 +572,9 @@ async fn rejected_duplicate_joins_ready_in_flight_primary() {
         .await
         .expect("bootstrap");
     let registry = writer.publisher();
-    let publisher = registry.publisher_for(&namespace_id).expect("publisher");
+    let publisher = registry
+        .test_publisher_for(&namespace_id)
+        .expect("publisher");
     let request = create_directory_request("ready-primary", "ready-primary");
 
     let primary = try_admit_candidate(
@@ -613,7 +615,9 @@ async fn ready_duplicate_joins_rejected_in_flight_primary() {
         .await
         .expect("bootstrap");
     let registry = writer.publisher();
-    let publisher = registry.publisher_for(&namespace_id).expect("publisher");
+    let publisher = registry
+        .test_publisher_for(&namespace_id)
+        .expect("publisher");
     let request = create_directory_request("rejected-primary", "rejected-primary");
 
     let primary = try_admit_candidate(
@@ -1528,7 +1532,9 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
                 .await
         })
     };
-    let publisher = registry.publisher_for(&namespace_id).expect("publisher");
+    let publisher = registry
+        .test_publisher_for(&namespace_id)
+        .expect("publisher");
     wait_for_queued_candidates(&publisher, 2).await;
 
     store.release();
@@ -1676,7 +1682,9 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
                 .await
         })
     };
-    let publisher = registry.publisher_for(&namespace_id).expect("publisher");
+    let publisher = registry
+        .test_publisher_for(&namespace_id)
+        .expect("publisher");
     wait_for_queued_candidates(&publisher, 2).await;
 
     store.release();

--- a/crates/loonfs/tests/it/main.rs
+++ b/crates/loonfs/tests/it/main.rs
@@ -23,6 +23,7 @@ mod invalidation;
 mod maintenance;
 mod metrics_instruments;
 mod namespace_advance_observer;
+mod namespace_sessions;
 mod pagination;
 mod publication;
 mod read_snapshot;

--- a/crates/loonfs/tests/it/namespace_sessions.rs
+++ b/crates/loonfs/tests/it/namespace_sessions.rs
@@ -1,0 +1,307 @@
+//! Namespace writer session lifecycle and admission policy.
+
+#![allow(clippy::panic)]
+
+use loonfs::{
+    CreateDirectoryOptions, CreateNamespaceOptions, ErrorCode, FsWriter, NamespaceId,
+    NamespaceSessionPolicy, NamespaceSessionState, SharedObjectStore,
+};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Barrier};
+use tempfile::tempdir;
+
+async fn writer(store: SharedObjectStore, writer_id: &str) -> FsWriter {
+    FsWriter::builder_with_store(store)
+        .writer_id(writer_id)
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+fn directory_options() -> CreateDirectoryOptions {
+    CreateDirectoryOptions::new(loonfs_test_support::test_actor())
+}
+
+async fn create_namespace(writer: &FsWriter, namespace_id: &NamespaceId) {
+    writer
+        .create_namespace(namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+}
+
+async fn writer_epoch(store: &SharedObjectStore, namespace_id: &NamespaceId) -> u64 {
+    loonfs::control::load_namespace_head_control(store, namespace_id)
+        .await
+        .expect("load namespace head")
+        .state
+        .writer_epoch
+        .0
+}
+
+fn expect_code<T: std::fmt::Debug>(result: loonfs::Result<T>, code: ErrorCode) {
+    let error = result.expect_err("operation must fail");
+    assert_eq!(error.code(), code, "unexpected error: {error:?}");
+}
+
+#[tokio::test]
+async fn concurrent_opens_create_one_namespace_session() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("create store"));
+    let writer = writer(store, "concurrent-open").await;
+    let namespace_id = NamespaceId::parse("concurrent").expect("namespace id");
+    let barrier = Arc::new(Barrier::new(8));
+
+    std::thread::scope(|scope| {
+        for _ in 0..8 {
+            let writer = writer.clone();
+            let namespace_id = namespace_id.clone();
+            let barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                barrier.wait();
+                writer
+                    .open_namespace(&namespace_id)
+                    .expect("open namespace session");
+            });
+        }
+    });
+
+    assert_eq!(writer.writer_session_stats().open, 1);
+    assert_eq!(
+        writer.namespace_session_state(&namespace_id),
+        NamespaceSessionState::Open {
+            fenced: false,
+            queued_commits: 0,
+        }
+    );
+}
+
+#[tokio::test]
+async fn close_refuses_late_work_and_drains_admitted_commits() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("close-drain").expect("namespace id");
+    let blocking = Arc::new(BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create store"),
+        KeyPredicate::wal_head(&namespace_id),
+        OperationClass::CompareAndSwap,
+    ));
+    let store: SharedObjectStore = blocking.clone();
+    let writer = writer(store, "close-drain").await;
+    create_namespace(&writer, &namespace_id).await;
+
+    blocking.block_next();
+    let first = tokio::spawn({
+        let writer = writer.clone();
+        let namespace_id = namespace_id.clone();
+        async move {
+            writer
+                .create_directory(&namespace_id, "/first", directory_options())
+                .await
+        }
+    });
+    blocking.wait_until_blocked().await;
+
+    let mut second =
+        Box::pin(writer.create_directory(&namespace_id, "/second", directory_options()));
+    assert!(futures::poll!(second.as_mut()).is_pending());
+    let mut close = Box::pin(writer.close_namespace(&namespace_id));
+    assert!(futures::poll!(close.as_mut()).is_pending());
+    assert_eq!(
+        writer.namespace_session_state(&namespace_id),
+        NamespaceSessionState::Closing
+    );
+
+    expect_code(
+        writer
+            .create_directory(&namespace_id, "/third", directory_options())
+            .await,
+        ErrorCode::WriterSessionClosed,
+    );
+
+    blocking.release();
+    first
+        .await
+        .expect("join first mutation")
+        .expect("first mutation lands");
+    second.await.expect("second mutation lands");
+    let report = close.await.expect("close namespace session");
+    assert!(report.was_open);
+    assert_eq!(report.drained_commits, 2);
+    assert!(!report.fenced);
+    assert_eq!(
+        writer.namespace_session_state(&namespace_id),
+        NamespaceSessionState::Closed
+    );
+}
+
+#[tokio::test]
+async fn reopening_starts_a_new_epoch_and_explicit_policy_requires_open() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("create store"));
+    let namespace_id = NamespaceId::parse("reopen").expect("namespace id");
+    let automatic = writer(store.clone(), "automatic").await;
+    create_namespace(&automatic, &namespace_id).await;
+    automatic
+        .create_directory(&namespace_id, "/before", directory_options())
+        .await
+        .expect("first session publishes");
+    let before_close = writer_epoch(&store, &namespace_id).await;
+
+    automatic
+        .close_namespace(&namespace_id)
+        .await
+        .expect("close first session");
+    automatic
+        .create_directory(&namespace_id, "/after", directory_options())
+        .await
+        .expect("automatic policy reopens");
+    assert_eq!(writer_epoch(&store, &namespace_id).await, before_close + 1);
+
+    let explicit = FsWriter::builder_with_store(store)
+        .writer_id("explicit")
+        .min_publish_interval_ms(0)
+        .namespace_sessions(NamespaceSessionPolicy::ExplicitOpen)
+        .build()
+        .await
+        .expect("build explicit writer");
+    expect_code(
+        explicit
+            .create_directory(&namespace_id, "/refused", directory_options())
+            .await,
+        ErrorCode::WriterSessionClosed,
+    );
+    explicit
+        .open_namespace(&namespace_id)
+        .expect("open assigned namespace");
+    explicit
+        .create_directory(&namespace_id, "/explicit", directory_options())
+        .await
+        .expect("explicitly opened session publishes");
+}
+
+#[tokio::test]
+async fn fencing_is_sticky_until_the_session_is_closed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("create store"));
+    let namespace_id = NamespaceId::parse("sticky-fence").expect("namespace id");
+    let writer_a = writer(store.clone(), "writer-a").await;
+    let writer_b = writer(store, "writer-b").await;
+    create_namespace(&writer_a, &namespace_id).await;
+    writer_a
+        .create_directory(&namespace_id, "/a-one", directory_options())
+        .await
+        .expect("writer A acquires its session");
+    writer_b
+        .create_directory(&namespace_id, "/b-one", directory_options())
+        .await
+        .expect("writer B takes over");
+
+    for path in ["/a-two", "/a-three"] {
+        expect_code(
+            writer_a
+                .create_directory(&namespace_id, path, directory_options())
+                .await,
+            ErrorCode::WriterFenced,
+        );
+    }
+    assert_eq!(
+        writer_a.namespace_session_state(&namespace_id),
+        NamespaceSessionState::Open {
+            fenced: true,
+            queued_commits: 0,
+        }
+    );
+    assert_eq!(writer_a.writer_session_stats().fenced, 1);
+
+    let report = writer_a
+        .close_namespace(&namespace_id)
+        .await
+        .expect("close fenced session");
+    assert!(report.fenced);
+    writer_a
+        .create_directory(&namespace_id, "/a-four", directory_options())
+        .await
+        .expect("writer A opens a new session");
+    expect_code(
+        writer_b
+            .create_directory(&namespace_id, "/b-two", directory_options())
+            .await,
+        ErrorCode::WriterFenced,
+    );
+}
+
+#[tokio::test]
+async fn capacity_refuses_without_eviction_and_close_releases_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("create store"));
+    let writer = FsWriter::builder_with_store(store)
+        .writer_id("bounded")
+        .min_publish_interval_ms(0)
+        .max_open_namespaces(NonZeroUsize::new(2).expect("nonzero capacity"))
+        .build()
+        .await
+        .expect("build bounded writer");
+    let first = NamespaceId::parse("capacity-one").expect("namespace id");
+    let second = NamespaceId::parse("capacity-two").expect("namespace id");
+    let third = NamespaceId::parse("capacity-three").expect("namespace id");
+    for namespace_id in [&first, &second, &third] {
+        create_namespace(&writer, namespace_id).await;
+    }
+    writer.open_namespace(&first).expect("open first session");
+    writer.open_namespace(&second).expect("open second session");
+
+    expect_code(
+        writer
+            .create_directory(&third, "/refused", directory_options())
+            .await,
+        ErrorCode::WriterCapacityExceeded,
+    );
+    writer
+        .create_directory(&first, "/first", directory_options())
+        .await
+        .expect("first session remains open");
+    writer
+        .create_directory(&second, "/second", directory_options())
+        .await
+        .expect("second session remains open");
+    writer
+        .close_namespace(&first)
+        .await
+        .expect("close first session");
+    writer
+        .create_directory(&third, "/third", directory_options())
+        .await
+        .expect("third session opens after close");
+    writer
+        .close_namespace(&second)
+        .await
+        .expect("close second session");
+    writer
+        .close_namespace(&third)
+        .await
+        .expect("close third session");
+
+    for index in 0..20 {
+        let namespace_id =
+            NamespaceId::parse(format!("cycled-{index}")).expect("valid cycled namespace id");
+        writer
+            .open_namespace(&namespace_id)
+            .expect("open cycled session");
+        create_namespace(&writer, &namespace_id).await;
+        writer
+            .create_directory(&namespace_id, "/written", directory_options())
+            .await
+            .expect("write through cycled session");
+        writer
+            .close_namespace(&namespace_id)
+            .await
+            .expect("close cycled session");
+    }
+    assert_eq!(writer.writer_session_stats().open, 0);
+}

--- a/crates/loonfs/tests/it/namespace_sessions.rs
+++ b/crates/loonfs/tests/it/namespace_sessions.rs
@@ -103,6 +103,7 @@ async fn close_refuses_late_work_and_drains_admitted_commits() {
         }
     });
     blocking.wait_until_blocked().await;
+    let open_before_close = writer.writer_session_stats().open;
 
     let mut second =
         Box::pin(writer.create_directory(&namespace_id, "/second", directory_options()));
@@ -113,6 +114,12 @@ async fn close_refuses_late_work_and_drains_admitted_commits() {
         writer.namespace_session_state(&namespace_id),
         NamespaceSessionState::Closing
     );
+    drop(close);
+    let joined_close = tokio::spawn({
+        let writer = writer.clone();
+        let namespace_id = namespace_id.clone();
+        async move { writer.close_namespace(&namespace_id).await }
+    });
 
     expect_code(
         writer
@@ -127,14 +134,88 @@ async fn close_refuses_late_work_and_drains_admitted_commits() {
         .expect("join first mutation")
         .expect("first mutation lands");
     second.await.expect("second mutation lands");
-    let report = close.await.expect("close namespace session");
-    assert!(report.was_open);
-    assert_eq!(report.drained_commits, 2);
+    let report = joined_close
+        .await
+        .expect("join close waiter")
+        .expect("wait for namespace close");
+    assert!(!report.was_open);
+    assert_eq!(report.drained_commits, 0);
     assert!(!report.fenced);
     assert_eq!(
         writer.namespace_session_state(&namespace_id),
         NamespaceSessionState::Closed
     );
+    writer
+        .create_directory(&namespace_id, "/after", directory_options())
+        .await
+        .expect("a later mutation opens a new session");
+    assert_eq!(writer.writer_session_stats().open, open_before_close);
+}
+
+#[tokio::test]
+async fn closing_session_holds_capacity_and_shutdown_waits_for_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let first = NamespaceId::parse("closing-capacity-one").expect("namespace id");
+    let second = NamespaceId::parse("closing-capacity-two").expect("namespace id");
+    let blocking = Arc::new(BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create store"),
+        KeyPredicate::wal_head(&first),
+        OperationClass::CompareAndSwap,
+    ));
+    let store: SharedObjectStore = blocking.clone();
+    let setup = writer(store.clone(), "closing-capacity-setup").await;
+    create_namespace(&setup, &first).await;
+    create_namespace(&setup, &second).await;
+    setup.shutdown().await.expect("shut down setup writer");
+
+    let writer = FsWriter::builder_with_store(store)
+        .writer_id("closing-capacity")
+        .min_publish_interval_ms(0)
+        .max_open_namespaces(NonZeroUsize::new(1).expect("nonzero capacity"))
+        .build()
+        .await
+        .expect("build bounded writer");
+    blocking.block_next();
+    let mutation = tokio::spawn({
+        let writer = writer.clone();
+        let first = first.clone();
+        async move {
+            writer
+                .create_directory(&first, "/first", directory_options())
+                .await
+        }
+    });
+    blocking.wait_until_blocked().await;
+
+    let mut close = Box::pin(writer.close_namespace(&first));
+    assert!(futures::poll!(close.as_mut()).is_pending());
+    let stats = writer.writer_session_stats();
+    assert_eq!(stats.open, 0);
+    assert_eq!(stats.closing, 1);
+    expect_code(
+        writer.open_namespace(&second),
+        ErrorCode::WriterCapacityExceeded,
+    );
+
+    let shutdown = tokio::spawn({
+        let writer = writer.clone();
+        async move { writer.shutdown().await }
+    });
+    tokio::task::yield_now().await;
+    assert!(!shutdown.is_finished());
+
+    blocking.release();
+    mutation
+        .await
+        .expect("join mutation")
+        .expect("mutation lands");
+    let report = close.await.expect("close namespace session");
+    assert!(report.was_open);
+    assert_eq!(report.drained_commits, 1);
+    shutdown
+        .await
+        .expect("join shutdown")
+        .expect("shutdown waits for close");
 }
 
 #[tokio::test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -291,6 +291,8 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `not_supported` | 501 | The deployment does not implement the requested op or feature. |
 | `commit_outcome_unknown` | 503 | The publish outcome was not observed; the commit may or may not be visible. Retry with the same commit id or reconcile. |
 | `commit_queue_full` | 503 | The namespace write queue is full; back off and retry. |
+| `writer_session_closed` | 503 | This node holds no open writer session for the namespace. The request was not admitted; retry on the node the namespace is assigned to. |
+| `writer_capacity_exceeded` | 503 | This node holds its maximum number of writer sessions. The request was not admitted. |
 | `server_busy` | 503 | The server is at its configured concurrency limit for this kind of work (proxied upload bodies or proxied content reads); back off and retry. |
 | `shutting_down` | 503 | The serving process closed admission for shutdown; work admitted earlier still settles. Retry against a live instance. |
 | `deadline_exceeded` | 503 | The server cancelled a bounded request at its configured `request_deadline_ms`. A commit may still land after this response; reconcile it by commit id before retrying. |
@@ -669,6 +671,10 @@ its next publish fails with `writer_fenced`, terminally for that session.
 The error's `details` name the epoch and writer that displaced it, so an
 operator can tell a planned failover from two writers misconfigured against
 one namespace.
+
+A node closes a session to hand a namespace off. Closing writes nothing durable.
+The next node's first publish acquires the next writer epoch. A node holds a
+bounded number of sessions and refuses to open one beyond that limit.
 
 The standard mutation operations are defined in `format.md` ("Standard
 mutation operations"). `POST /commits` (section 6.8) exposes those operations

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -12,6 +12,7 @@
 
 The embedded runtime exposes `FsReader`, `FsWriter`, and `FsMaintenance` handles.
 Snapshot listing is an `FsReader` operation; snapshot create, extend, and release are `FsWriter` operations.
+`FsWriter::open_namespace` and `FsWriter::close_namespace` control its namespace writer sessions.
 
 Namespaces and content stores are separate durable domains. A namespace owns filesystem metadata and history; a content store owns immutable file bytes. A namespace descriptor references exactly one content store, but that reference is not lifecycle ownership. Forked namespaces share the source namespace's content store while keeping independent future metadata history. Fork provenance and GC pins may record source-owned immutable files needed by the fork.
 


### PR DESCRIPTION
Add lifecycle controls and a capacity limit for per-namespace writer sessions.

Writers still open sessions on the first write by default. Callers can instead require namespaces to be opened explicitly, close a session after accepted work drains, inspect session state, and limit how many sessions remain open. Reopening a namespace creates a new session and acquires a new writer epoch on its first publish. A fenced session stays fenced until it is closed.

The server accepts an optional max_open_namespaces setting. New retryable errors report writes to closed sessions and attempts to exceed the configured capacity.

Review fix, second commit: the publisher stays registered while a spawned task drains the close, so a cancelled caller cannot strand the namespace, shutdown waits for closes, and a closing session still counts toward the capacity limit.
