### PR TITLE
feat(core): fold WAL tails in the background

### DIFF
--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -115,6 +115,10 @@ impl EmbeddedBackend {
             if !gated {
                 break;
             }
+            self.writer
+                .wait_for_fold(namespace_id)
+                .await
+                .map_err(map_runtime_error)?;
             self.runner.drain().await.map_err(map_runtime_error)?;
             result = attempt().await;
         }

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -8,6 +8,7 @@
 //! [`create`](super::create).
 
 use super::build::{build_manifest_delta_run_segments, build_manifest_segments};
+use super::cache::MetadataSegmentCache;
 use super::load::{head_from_manifest, load_basis_metadata_segments};
 use super::publish::{
     manifest_ref_for, manifest_write_failure, publish_metadata_root, write_namespace_manifest,
@@ -16,6 +17,7 @@ use super::publish::{
 use super::runs::{flatten_manifest_segments, MetadataLsmPolicy};
 use super::scan::VerifiedMetadataSegments;
 use crate::commit::CommitHeadPublishError;
+use crate::commit_engine::WalFoldSnapshot;
 use crate::context::MutationContext;
 use crate::control_update::{retry_while_contended, CasAttempt, WriteEvidence};
 use crate::error::CoreError;
@@ -23,9 +25,9 @@ use crate::error::MetadataProjectionLoadError;
 use crate::error::Result;
 use crate::limits::METADATA_PUBLICATION_BUDGET_MS;
 use crate::metadata::MetadataState;
-use crate::namespace::basis::MetadataBasis;
+use crate::namespace::basis::{metadata_basis_without_root, MetadataBasis};
+use crate::namespace::control::load_metadata_root_object_if_present;
 use crate::namespace::control_snapshot::{load_control_snapshot, resolve_retention_floor_seq};
-use crate::protocol::{PublishMetadataView, PublishTailProjection};
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use crate::wal::{
     ensure_replayed_head_matches, load_wal_chain, project_validated_wal_tail, WalChainLoadRequest,
@@ -225,26 +227,44 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
     })))
 }
 
-pub(crate) async fn fold_publish_tail_projection<S: ObjectStore + ?Sized>(
+pub async fn fold_wal_tail_snapshot<S: ObjectStore + ?Sized>(
     store: &S,
+    segment_cache: Option<&MetadataSegmentCache>,
     namespace_id: &NamespaceId,
-    publish_view: &PublishMetadataView<'_, S>,
-    projection: &PublishTailProjection,
+    snapshot: WalFoldSnapshot,
     context: &MutationContext,
     timer: &dyn MonotonicTimer,
 ) -> Result<FlushWalResponse> {
-    let floor_seq = match publish_view.retention_floor_seq() {
+    let loaded_basis = load_basis_metadata_segments(
+        store,
+        segment_cache,
+        namespace_id,
+        &snapshot.basis,
+        snapshot.head.created_at_ms,
+    )
+    .await?;
+    let current_root = load_metadata_root_object_if_present(store, namespace_id)
+        .await
+        .map_err(CoreError::ControlObjectLoad)?;
+    let current_basis = current_root.map_or_else(
+        || metadata_basis_without_root(&snapshot.head),
+        |root| MetadataBasis::Manifest(root.state.manifest),
+    );
+    if current_basis != snapshot.basis {
+        return flush_wal(store, namespace_id, context).await;
+    }
+    let floor_seq = match snapshot.retention_floor_seq {
         Some(floor_seq) => floor_seq,
-        None => resolve_retention_floor_seq(store, publish_view.head())
+        None => resolve_retention_floor_seq(store, &snapshot.head)
             .await
             .map_err(CoreError::ControlObjectLoad)?,
     };
     let root_projection = RootProjection {
-        head: publish_view.head().clone(),
-        basis: projection.basis().clone(),
+        head: snapshot.head,
+        basis: snapshot.basis,
         floor_seq,
-        manifest_segments: ProjectionManifestSegments::Borrowed(publish_view.manifest_segments()),
-        tail_state: Arc::clone(&projection.tail_state),
+        manifest_segments: ProjectionManifestSegments::Loaded(loaded_basis.segments),
+        tail_state: snapshot.tail_state,
     };
     // A fold publishes metadata without updating the namespace head.
     match try_flush_wal_projection(store, namespace_id, &root_projection, context, timer).await? {
@@ -265,7 +285,6 @@ fn flush_wal_response(namespace_id: &NamespaceId, basis: FlushedBasis) -> FlushW
 
 pub(super) enum ProjectionManifestSegments<'a, S: ObjectStore + ?Sized> {
     Loaded(VerifiedMetadataSegments<'a, S>),
-    Borrowed(&'a VerifiedMetadataSegments<'a, S>),
 }
 
 impl<'a, S: ObjectStore + ?Sized> std::ops::Deref for ProjectionManifestSegments<'a, S> {
@@ -274,7 +293,6 @@ impl<'a, S: ObjectStore + ?Sized> std::ops::Deref for ProjectionManifestSegments
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Loaded(segments) => segments,
-            Self::Borrowed(segments) => segments,
         }
     }
 }

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -48,7 +48,9 @@ pub use self::compaction_merge::{
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
-pub use self::flush::{ensure_metadata_publication_budget, next_run_no_after};
+pub use self::flush::{
+    ensure_metadata_publication_budget, fold_wal_tail_snapshot, next_run_no_after,
+};
 pub use self::list::CheckpointPageCursor;
 pub use self::read_basis::{load_checkpoint_read_basis, CheckpointReadBasis};
 pub use self::reorganize::{FrozenBasePolicy, MetadataReorganizeOutcome, MetadataReorganizeReport};
@@ -69,7 +71,7 @@ pub(crate) use self::compaction_lease::{
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::data_block_load::DecodedRowWeight;
 pub(crate) use self::files::list_checkpoint_files_page;
-pub(crate) use self::flush::{flush_wal, fold_publish_tail_projection};
+pub(crate) use self::flush::flush_wal;
 pub(crate) use self::list::list_checkpoints_page;
 pub(crate) use self::load::{
     head_from_manifest, load_basis_metadata_segments, load_namespace_manifest_envelope,

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -27,7 +27,7 @@ async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
         writer_id: context.writer_id.to_string(),
         writer_epoch: head.state.writer_epoch,
     };
-    let (publish_view, projection) = crate::protocol::load_publish_metadata_view(
+    let (_, projection) = crate::protocol::load_publish_metadata_view(
         &store,
         None,
         &namespace_id,
@@ -38,11 +38,19 @@ async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
     .await
     .expect("load publish projection");
 
-    let response = flush::fold_publish_tail_projection(
+    let snapshot = crate::WalFoldSnapshot {
+        head: projection.head.clone(),
+        head_etag: projection.head_etag().to_owned(),
+        basis: projection.basis().clone(),
+        retention_floor_seq: projection.retention_floor_seq,
+        tail_state: Arc::clone(&projection.tail_state),
+        wal_tail_segments: projection.wal_tail_segments,
+    };
+    let response = flush::fold_wal_tail_snapshot(
         &store,
+        None,
         &namespace_id,
-        &publish_view,
-        &projection,
+        snapshot,
         &context,
         &crate::time::StdMonotonicTimer::default(),
     )

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -40,7 +40,6 @@ async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
 
     let snapshot = crate::WalFoldSnapshot {
         head: projection.head.clone(),
-        head_etag: projection.head_etag().to_owned(),
         basis: projection.basis().clone(),
         retention_floor_seq: projection.retention_floor_seq,
         tail_state: Arc::clone(&projection.tail_state),

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -180,7 +180,6 @@ pub struct NamespaceCommitEnginePublishResult {
 #[derive(Debug, Clone)]
 pub struct WalFoldSnapshot {
     pub head: HeadState,
-    pub head_etag: String,
     pub basis: MetadataBasis,
     pub retention_floor_seq: Option<ChangeSeq>,
     pub tail_state: Arc<MetadataState>,
@@ -300,7 +299,6 @@ impl NamespaceCommitEngine {
             .as_ref()
             .map(|projection| WalFoldSnapshot {
                 head: projection.head.clone(),
-                head_etag: projection.head_etag().to_owned(),
                 basis: projection.basis().clone(),
                 retention_floor_seq: projection.retention_floor_seq,
                 tail_state: Arc::clone(&projection.tail_state),

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -2,7 +2,7 @@
 //! candidates as one WAL segment and one head compare-and-swap, then returns
 //! one result per candidate.
 
-use crate::checkpoint::{fold_publish_tail_projection, MetadataSegmentCache};
+use crate::checkpoint::MetadataSegmentCache;
 use crate::commit::CommitFingerprint;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataViewError, Result, WriterFence};
@@ -22,10 +22,8 @@ use loonfs_api::wire::control::{AcquiredWriter, HeadState};
 use loonfs_api::{ChangeSeq, CommitId, ContentId, DeleteNamespaceResponse, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashSet;
-use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
-use tracing::Instrument;
 
 /// One namespace mutation together with the result of preparing any content
 /// it references.
@@ -168,14 +166,25 @@ impl CommitCandidate {
 #[derive(Debug, Clone)]
 pub struct NamespaceCommitEnginePublishResult {
     pub results: Vec<Result<ApiCommitResponse>>,
-    /// Whether this publish first folded the WAL tail into a manifest.
-    pub folded: bool,
     /// WAL tail length observed by this publish, for opportunistic
     /// maintenance scheduling. Zero when no projection was loaded.
     pub wal_tail_segments: u64,
     /// Read state produced by a successful, unambiguous head CAS. Callers can
     /// use it to update read caches without reloading from object storage.
     pub resulting_read_state: Option<ResultingReadState>,
+}
+
+/// The tail a fold publishes: the head it was replayed against, the basis
+/// the manifest builds on, and the rows themselves. Cheap to take: an `Arc`
+/// clone and two small clones.
+#[derive(Debug, Clone)]
+pub struct WalFoldSnapshot {
+    pub head: HeadState,
+    pub head_etag: String,
+    pub basis: MetadataBasis,
+    pub retention_floor_seq: Option<ChangeSeq>,
+    pub tail_state: Arc<MetadataState>,
+    pub wal_tail_segments: u64,
 }
 
 /// A read anchor plus the projected WAL tail as of one landed publish.
@@ -218,7 +227,6 @@ pub type SharedWriterSessionState = Arc<Mutex<WriterSessionState>>;
 pub struct NamespaceCommitEngine {
     namespace_id: NamespaceId,
     publish_tail_projection: Option<PublishTailProjection>,
-    fold_wal_tail_at: Option<NonZeroU64>,
     /// This session's epoch and fencing for the namespace; see
     /// [`WriterSessionState`].
     session: SharedWriterSessionState,
@@ -235,7 +243,6 @@ impl NamespaceCommitEngine {
         Self {
             namespace_id,
             publish_tail_projection: None,
-            fold_wal_tail_at: None,
             session: SharedWriterSessionState::default(),
             timer: Arc::new(StdMonotonicTimer::default()),
             segment_cache: None,
@@ -246,12 +253,6 @@ impl NamespaceCommitEngine {
     /// persist across engine instances.
     pub fn writer_session(mut self, session: SharedWriterSessionState) -> Self {
         self.session = session;
-        self
-    }
-
-    /// Folds the WAL tail before a publish that observes this many segments.
-    pub fn fold_wal_tail_at(mut self, threshold: Option<NonZeroU64>) -> Self {
-        self.fold_wal_tail_at = threshold;
         self
     }
 
@@ -287,6 +288,24 @@ impl NamespaceCommitEngine {
         self.publish_tail_projection
             .as_ref()
             .map(PublishTailProjection::weight)
+    }
+
+    /// The retained projection as a fold input, or `None` when the engine
+    /// holds no projection.
+    ///
+    /// A completed fold needs no invalidation: the projection key carries the
+    /// basis identity, so the next view load reloads after the root changes.
+    pub fn wal_fold_snapshot(&self) -> Option<WalFoldSnapshot> {
+        self.publish_tail_projection
+            .as_ref()
+            .map(|projection| WalFoldSnapshot {
+                head: projection.head.clone(),
+                head_etag: projection.head_etag().to_owned(),
+                basis: projection.basis().clone(),
+                retention_floor_seq: projection.retention_floor_seq,
+                tail_state: Arc::clone(&projection.tail_state),
+                wal_tail_segments: projection.wal_tail_segments,
+            })
     }
 
     /// Returns the session's writer epoch, acquiring it on first use. A fenced
@@ -354,26 +373,7 @@ impl NamespaceCommitEngine {
         context: &MutationContext,
         tail_options: &PublishTailOptions,
     ) -> NamespaceCommitEnginePublishResult {
-        Box::pin(self.publish_batch_inner(store, candidates, context, tail_options, None)).await
-    }
-
-    /// Publishes a batch and instruments any configured WAL fold with `fold_span`.
-    pub async fn publish_batch_with_fold_span<S: ObjectStore + ?Sized>(
-        &mut self,
-        store: &S,
-        candidates: Vec<CommitCandidate>,
-        context: &MutationContext,
-        tail_options: &PublishTailOptions,
-        fold_span: tracing::Span,
-    ) -> NamespaceCommitEnginePublishResult {
-        Box::pin(self.publish_batch_inner(
-            store,
-            candidates,
-            context,
-            tail_options,
-            Some(fold_span),
-        ))
-        .await
+        Box::pin(self.publish_batch_inner(store, candidates, context, tail_options)).await
     }
 
     async fn publish_batch_inner<S: ObjectStore + ?Sized>(
@@ -382,12 +382,10 @@ impl NamespaceCommitEngine {
         candidates: Vec<CommitCandidate>,
         context: &MutationContext,
         tail_options: &PublishTailOptions,
-        fold_span: Option<tracing::Span>,
     ) -> NamespaceCommitEnginePublishResult {
         if candidates.is_empty() {
             return NamespaceCommitEnginePublishResult {
                 results: Vec::new(),
-                folded: false,
                 wal_tail_segments: 0,
                 resulting_read_state: None,
             };
@@ -399,18 +397,17 @@ impl NamespaceCommitEngine {
             Err(error) => {
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, error),
-                    folded: false,
                     wal_tail_segments: 0,
                     resulting_read_state: None,
                 };
             }
         };
 
-        let (mut publish_view, mut projection) = match load_publish_metadata_view(
+        let (publish_view, projection) = match load_publish_metadata_view(
             store,
             self.segment_cache.as_deref(),
             &self.namespace_id,
-            acquired_writer.clone(),
+            acquired_writer,
             self.publish_tail_projection.as_ref(),
             tail_options,
         )
@@ -424,75 +421,11 @@ impl NamespaceCommitEngine {
                 }
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, error),
-                    folded: false,
                     wal_tail_segments: 0,
                     resulting_read_state: None,
                 };
             }
         };
-
-        let mut folded = false;
-        if self
-            .fold_wal_tail_at
-            .is_some_and(|threshold| projection.wal_tail_segments >= threshold.get())
-        {
-            let wal_tail_segments = projection.wal_tail_segments;
-            let fold = fold_publish_tail_projection(
-                store,
-                &self.namespace_id,
-                &publish_view,
-                &projection,
-                context,
-                self.timer.as_ref(),
-            );
-            let fold = match fold_span {
-                Some(fold_span) => fold.instrument(fold_span).await,
-                None => fold.await,
-            };
-            match fold {
-                Ok(_) => {
-                    drop(publish_view);
-                    drop(projection);
-                    self.invalidate_projection();
-                    folded = true;
-                    match load_publish_metadata_view(
-                        store,
-                        self.segment_cache.as_deref(),
-                        &self.namespace_id,
-                        acquired_writer,
-                        None,
-                        tail_options,
-                    )
-                    .await
-                    {
-                        Ok((fresh_view, fresh_projection)) => {
-                            publish_view = fresh_view;
-                            projection = fresh_projection;
-                        }
-                        Err(error) => {
-                            if let CoreError::WriterFenced(fence) = &error {
-                                *self.lock_session() = WriterSessionState::Fenced(fence.clone());
-                            }
-                            return NamespaceCommitEnginePublishResult {
-                                results: repeated_error(candidate_count, error),
-                                folded,
-                                wal_tail_segments: 0,
-                                resulting_read_state: None,
-                            };
-                        }
-                    }
-                }
-                Err(error) => {
-                    // A failed fold does not fail the publish.
-                    tracing::info!(
-                        namespace_id = %self.namespace_id,
-                        wal_tail_segments,
-                        error = %error.message(),
-                        "WAL-tail fold failed; continuing the publish"
-                    );
-                }
-            }
-        }
 
         let reject_writes_at_segments = crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS;
         // `wal_tail_segments` is the tail this publish would extend, so
@@ -508,7 +441,6 @@ impl NamespaceCommitEngine {
             };
             return NamespaceCommitEnginePublishResult {
                 results: repeated_error(candidate_count, CoreError::from(error)),
-                folded,
                 wal_tail_segments,
                 resulting_read_state: None,
             };
@@ -545,7 +477,6 @@ impl NamespaceCommitEngine {
         };
         NamespaceCommitEnginePublishResult {
             results: published.results,
-            folded,
             wal_tail_segments,
             resulting_read_state,
         }
@@ -595,7 +526,7 @@ impl NamespaceCommitEngine {
                 for record in &records {
                     tail_state.apply_committed_wal_record_mut(record);
                 }
-                projection.reanchor(head.seq, head_etag);
+                projection.reanchor(head, head_etag);
                 if projection.within_limits(tail_options) {
                     self.publish_tail_projection = Some(projection);
                 } else {

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -145,7 +145,7 @@ pub mod publish {
     pub use crate::commit_engine::{
         CommitCandidate, ContentPreparationError, NamespaceCommitEngine,
         NamespaceCommitEnginePublishResult, ResultingReadState, SharedWriterSessionState,
-        WriterSessionState,
+        WalFoldSnapshot, WriterSessionState,
     };
     pub use crate::path::write::{CommitRequest, FilesystemOperation};
     pub use crate::protocol::{PublishTailOptions, PublishTailWeight};
@@ -156,12 +156,14 @@ pub mod publish {
 // `MetadataReorganizeReport` remains public because
 // `NamespaceEngine::reorganize_metadata` returns it.
 pub use checkpoint::{
-    ensure_metadata_publication_budget, next_run_no_after, refill_iterators, select_next_iterator,
-    write_segments_in_waves, CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor,
-    CheckpointPageCursor, FrozenBasePolicy, MetadataCompactionCancellation,
-    MetadataCompactionJobOutcome, MetadataCompactionSpec, MetadataFamilyGroup,
-    MetadataReorganizeOutcome, MetadataReorganizeReport, SegmentBlockLoader, SegmentRowIterator,
+    ensure_metadata_publication_budget, fold_wal_tail_snapshot, next_run_no_after,
+    refill_iterators, select_next_iterator, write_segments_in_waves, CheckpointFile,
+    CheckpointFilesPage, CheckpointFilesPageCursor, CheckpointPageCursor, FrozenBasePolicy,
+    MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,
+    MetadataFamilyGroup, MetadataReorganizeOutcome, MetadataReorganizeReport, SegmentBlockLoader,
+    SegmentRowIterator,
 };
+pub use commit_engine::WalFoldSnapshot;
 pub use context::MutationContext;
 pub use engine::RuntimeReadContext;
 pub use engine::{

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -12,9 +12,7 @@ pub(crate) use self::batch::{
     publish_namespace_commits_batch_against_publish_view, PublishViewEffect,
 };
 pub(crate) use self::changes::list_changes_after;
-pub(crate) use self::publish_view::{
-    load_publish_metadata_view, PublishMetadataView, PublishTailProjection,
-};
+pub(crate) use self::publish_view::{load_publish_metadata_view, PublishTailProjection};
 pub use self::publish_view::{PublishTailOptions, PublishTailWeight};
 pub(crate) use self::uploads::{
     abort_upload, begin_direct_multipart_upload_target, begin_direct_put_upload_target,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -32,7 +32,6 @@ pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     pub(super) acquired_writer: AcquiredWriter,
     manifest_segments: VerifiedMetadataSegments<'a, S>,
     tail_state: Arc<MetadataState>,
-    retention_floor_seq: Option<ChangeSeq>,
 }
 
 impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
@@ -42,18 +41,6 @@ impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
 
     pub(crate) fn content_store_id(&self) -> &ContentStoreId {
         &self.content_store_id
-    }
-
-    pub(crate) fn head(&self) -> &HeadState {
-        &self.head
-    }
-
-    pub(crate) fn manifest_segments(&self) -> &VerifiedMetadataSegments<'_, S> {
-        &self.manifest_segments
-    }
-
-    pub(crate) fn retention_floor_seq(&self) -> Option<ChangeSeq> {
-        self.retention_floor_seq
     }
 
     pub(super) async fn find_commit_receipt(
@@ -120,6 +107,8 @@ struct PublishProjectionKey {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PublishTailProjection {
     key: PublishProjectionKey,
+    pub(crate) head: HeadState,
+    pub(crate) retention_floor_seq: Option<ChangeSeq>,
     pub(crate) wal_tail_segments: u64,
     pub(crate) tail_state: Arc<MetadataState>,
 }
@@ -158,8 +147,12 @@ impl PublishTailProjection {
         self.key.basis.manifest_head_seq()
     }
 
-    pub(crate) fn reanchor(&mut self, seq: ChangeSeq, etag: String) {
-        self.key.head = HeadAnchor { seq, etag };
+    pub(crate) fn reanchor(&mut self, head: HeadState, etag: String) {
+        self.key.head = HeadAnchor {
+            seq: head.seq,
+            etag,
+        };
+        self.head = head;
     }
 }
 
@@ -207,7 +200,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     {
         cached.clone()
     } else {
-        load_publish_tail_projection(store, &head, key, &loaded_basis).await?
+        load_publish_tail_projection(store, &head, retention_floor_seq, key, &loaded_basis).await?
     };
 
     let manifest_segments = loaded_basis.segments;
@@ -223,7 +216,6 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
             acquired_writer,
             manifest_segments,
             tail_state,
-            retention_floor_seq,
         },
         projection,
     ))
@@ -232,6 +224,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
 async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     store: &S,
     head: &HeadState,
+    retention_floor_seq: Option<ChangeSeq>,
     key: PublishProjectionKey,
     loaded_basis: &LoadedMetadataBasis<'_, S>,
 ) -> Result<PublishTailProjection> {
@@ -266,6 +259,8 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     let wal_tail_segments = u64::try_from(wal_chain.segments().len()).unwrap_or(u64::MAX);
     let projection = PublishTailProjection {
         key,
+        head: head.clone(),
+        retention_floor_seq,
         wal_tail_segments,
         tail_state: Arc::new(replayed.resulting_metadata_state),
     };
@@ -367,7 +362,16 @@ mod tests {
     }
 
     fn projection(key: PublishProjectionKey) -> PublishTailProjection {
+        let mut head = HeadState::initial(
+            key.namespace_id.clone(),
+            ContentStoreId::parse("cs_0123456789abcdef0123456789abcdef")
+                .expect("valid content store id"),
+            1_000,
+        );
+        head.seq = key.head.seq;
         PublishTailProjection {
+            head,
+            retention_floor_seq: Some(ChangeSeq(0)),
             key,
             wal_tail_segments: 3,
             tail_state: Arc::new(bootstrap_metadata_state(1_000)),

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -914,6 +914,11 @@ impl FsWriter {
     }
 }
 
+pub(crate) struct EnginePublishResult {
+    pub(crate) results: Vec<Result<CommitResponse>>,
+    pub(crate) wal_tail_segments: u64,
+}
+
 /// Publishes already-classified candidates as one batch — one WAL
 /// segment, one head compare-and-swap — through the namespace
 /// publisher's own commit engine, and settles the runtime state the
@@ -928,12 +933,17 @@ pub(crate) async fn publish_batch_with_engine(
     namespace_id: &NamespaceId,
     engine: &mut loonfs_core::publish::NamespaceCommitEngine,
     candidates: Vec<CommitCandidate>,
-) -> Vec<Result<CommitResponse>> {
+) -> EnginePublishResult {
     let batch_size = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
     let store = core.store();
     let context = match writer.identity.mutation_context() {
         Ok(context) => context,
-        Err(error) => return candidates.iter().map(|_| Err(error.clone())).collect(),
+        Err(error) => {
+            return EnginePublishResult {
+                results: candidates.iter().map(|_| Err(error.clone())).collect(),
+                wal_tail_segments: 0,
+            };
+        }
     };
     let cache_config = core.runtime_cache_config();
     // The per-projection ceiling. The publisher applies the same two knobs
@@ -945,21 +955,8 @@ pub(crate) async fn publish_batch_with_engine(
     // Boxing erases the engine's deeply nested publish future; without
     // it, callers awaiting a put or commit (CLI, server, embedding
     // crates) exceed rustc's type-recursion depth.
-    let fold_span = phase_span!(core, "wal_fold", namespace_id);
-    let mut publish = Box::pin(engine.publish_batch_with_fold_span(
-        &store,
-        candidates,
-        &context,
-        &tail_options,
-        fold_span,
-    ))
-    .await;
-    if !core.control_cache_enabled() {
-        // Diagnostic mode: the publisher's engine outlives the publish
-        // even with caches off, so drop the tail projection it just
-        // built. Every publish then reads what a cold engine reads.
-        engine.invalidate_projection();
-    }
+    let mut publish =
+        Box::pin(engine.publish_batch(&store, candidates, &context, &tail_options)).await;
     {
         let _span = phase_span!(core, "batch_update_cache", namespace_id, batch_size).entered();
         match publish.resulting_read_state.take() {
@@ -977,10 +974,6 @@ pub(crate) async fn publish_batch_with_engine(
         }
     }
     let wal_tail_segments = publish.wal_tail_segments;
-    let folded = publish.folded;
-    if folded {
-        core.instruments().publisher_wal_fold();
-    }
     let results = publish
         .results
         .into_iter()
@@ -991,11 +984,14 @@ pub(crate) async fn publish_batch_with_engine(
         &NamespacePublication {
             namespace_id: namespace_id.clone(),
             committed_through_seq: highest_committed_seq(&results),
-            folded,
+            folded: false,
             wal_tail_segments,
         },
     );
-    results
+    EnginePublishResult {
+        results,
+        wal_tail_segments,
+    }
 }
 
 /// Returns the highest sequence committed by the batch.

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -150,6 +150,24 @@ impl FsWriter {
         Ok(self.publisher.close_namespace(namespace_id).await?)
     }
 
+    /// Waits for this writer's in-flight WAL-tail fold for `namespace_id`.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.wait_for_fold",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "wait_for_fold",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn wait_for_fold(&self, namespace_id: &NamespaceId) -> Result<()> {
+        self.core.record_trace_context(&tracing::Span::current());
+        self.publisher.wait_for_fold(namespace_id).await
+    }
+
     /// Returns the writer session state for `namespace_id`.
     pub fn namespace_session_state(&self, namespace_id: &NamespaceId) -> NamespaceSessionState {
         self.publisher.namespace_session_state(namespace_id)

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -17,6 +17,10 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard};
 
+const WAL_FOLD_MS_BOUNDARIES: &[f64] = &[
+    1.0, 3.0, 10.0, 30.0, 100.0, 300.0, 1_000.0, 3_000.0, 10_000.0, 30_000.0, 60_000.0, 120_000.0,
+];
+
 trait MetricLabel: Copy + PartialEq + 'static {
     const VALUES: &'static [Self];
 
@@ -460,6 +464,20 @@ impl RuntimeInstruments {
             return;
         };
         installed.publisher.wal_folds.increment(1);
+    }
+
+    pub(crate) fn publisher_wal_fold_duration(&self, elapsed_ms: u64) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed.publisher.wal_fold_ms.record(elapsed_ms as f64);
+    }
+
+    pub(crate) fn publisher_write_stop_refusal(&self) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed.publisher.write_stop_refusals.increment(1);
     }
 
     /// Reports one publication result delivered to its caller.
@@ -968,6 +986,8 @@ impl CompactionInstruments {
 struct PublisherInstruments {
     batches: Arc<dyn CounterHandle>,
     wal_folds: Arc<dyn CounterHandle>,
+    wal_fold_ms: Arc<dyn HistogramHandle>,
+    write_stop_refusals: Arc<dyn CounterHandle>,
     batch_size: Arc<dyn HistogramHandle>,
     queue_depth: Arc<dyn GaugeHandle>,
     sessions_open: Arc<dyn GaugeHandle>,
@@ -987,7 +1007,18 @@ impl PublisherInstruments {
             ),
             wal_folds: recorder.register_counter(
                 "loonfs.publisher.wal_folds",
-                "WAL tails folded on the publication path",
+                "WAL tails folded by namespace publishers",
+                &[],
+            ),
+            wal_fold_ms: recorder.register_histogram(
+                "loonfs.publisher.wal_fold_ms",
+                "Duration of a WAL-tail fold in milliseconds",
+                &[],
+                WAL_FOLD_MS_BOUNDARIES,
+            ),
+            write_stop_refusals: recorder.register_counter(
+                "loonfs.publisher.write_stop_refusals",
+                "Mutation batches refused because the WAL tail reached its write-stop bound",
                 &[],
             ),
             batch_size: recorder.register_histogram(
@@ -1381,6 +1412,8 @@ mod tests {
 
         instruments.publisher_batch(4);
         instruments.publisher_wal_fold();
+        instruments.publisher_wal_fold_duration(5);
+        instruments.publisher_write_stop_refusal();
         instruments.publisher_publish(PublishOutcome::Ok);
         MaintenanceInstruments::new(None).maintenance_step(
             MaintenanceJobId::GC,

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -13,8 +13,8 @@ use crate::metrics::{PublishOutcome, RESULT_OK};
 use crate::publish::CommitCandidate;
 use crate::trace::{phase_event, phase_span};
 use crate::{
-    CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, NamespaceSessionPolicy,
-    RuntimeCacheConfig, RuntimeError,
+    CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, NamespacePublication,
+    NamespaceSessionPolicy, RuntimeCacheConfig, RuntimeError,
 };
 use futures::FutureExt;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
@@ -23,7 +23,8 @@ use loonfs_core::cache::Recency;
 use loonfs_core::commit::{CommitFingerprint, CommitHeadPublishError};
 use loonfs_core::limits::{CHECKPOINT_AT_WAL_SEGMENTS, CONTENTION_RETRY_LIMIT};
 use loonfs_core::publish::{
-    NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState, WriterSessionState,
+    NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState, WalFoldSnapshot,
+    WriterSessionState,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::collections::{HashMap, VecDeque};
@@ -572,6 +573,22 @@ impl PublisherRegistry {
         }
     }
 
+    pub(crate) async fn wait_for_fold(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<(), RuntimeError> {
+        let publisher = self
+            .shared
+            .lock_state()
+            .publishers
+            .get(namespace_id)
+            .cloned();
+        if let Some(publisher) = publisher {
+            publisher.wait_for_fold().await?;
+        }
+        Ok(())
+    }
+
     fn report_session_counts(&self, open: usize, closing: usize) {
         self.read_core
             .instruments()
@@ -617,8 +634,14 @@ impl PublisherRegistry {
             .collect();
         // Awaited outside the registry lock, for the same nesting reason as
         // the admission sweep.
-        for publisher in publishers {
+        for publisher in &publishers {
             publisher.wait_for_worker().await;
+        }
+        let mut task_error = None;
+        for publisher in publishers {
+            if let Err(error) = publisher.wait_for_fold().await {
+                task_error.get_or_insert(error);
+            }
         }
         let closes = self
             .shared
@@ -635,6 +658,9 @@ impl PublisherRegistry {
             return Err(RuntimeError::RuntimeTask(format!(
                 "{panicked} publisher task(s) panicked"
             )));
+        }
+        if let Some(error) = task_error {
+            return Err(error);
         }
         Ok(())
     }
@@ -664,6 +690,13 @@ async fn finish_namespace_close(
 ) {
     let fenced = match AssertUnwindSafe(async {
         publisher.wait_for_worker().await;
+        if let Err(error) = publisher.wait_for_fold().await {
+            tracing::info!(
+                namespace_id = %publisher.namespace_id,
+                error = %error,
+                "wal fold failed while the namespace session closed"
+            );
+        }
         publisher.session_is_fenced()
     })
     .catch_unwind()
@@ -757,6 +790,8 @@ struct NamespacePublisherState {
     /// finds the queue empty. That single flight is what makes the delete
     /// barrier's admission order deterministic.
     worker: Option<WorkerHandle>,
+    fold: Option<FoldHandle>,
+    next_fold_generation: u64,
     /// Earliest instant the next head compare-and-swap may start. `None` is
     /// a cold namespace: it publishes immediately.
     next_allowed_cas_at: Option<u64>,
@@ -767,9 +802,23 @@ struct WorkerHandle {
     liveness: watch::Receiver<bool>,
 }
 
+struct FoldHandle {
+    generation: u64,
+    task: JoinHandle<()>,
+    liveness: watch::Receiver<bool>,
+}
+
 struct WorkerExit(watch::Sender<bool>);
 
 impl Drop for WorkerExit {
+    fn drop(&mut self) {
+        let _ = self.0.send(true);
+    }
+}
+
+struct FoldExit(watch::Sender<bool>);
+
+impl Drop for FoldExit {
     fn drop(&mut self) {
         let _ = self.0.send(true);
     }
@@ -835,6 +884,8 @@ impl NamespacePublisher {
                 in_flight: HashMap::new(),
                 admission: PublisherAdmissionState::Open,
                 worker: None,
+                fold: None,
+                next_fold_generation: 0,
                 next_allowed_cas_at: None,
             })),
             engine: Arc::new(AsyncMutex::new(EngineSlot {
@@ -1239,7 +1290,7 @@ impl NamespacePublisher {
     ) -> Vec<CommitResult> {
         let mut slot = self.engine.lock().await;
         let engine = self.engine_for(&mut slot);
-        let results = crate::fs::publish_batch_with_engine(
+        let publish = crate::fs::publish_batch_with_engine(
             &self.read_core,
             writer,
             &self.namespace_id,
@@ -1247,8 +1298,28 @@ impl NamespacePublisher {
             candidates,
         )
         .await;
+        let write_stopped =
+            !publish.results.is_empty() && publish.results.iter().all(is_maintenance_required);
+        if write_stopped {
+            self.read_core.instruments().publisher_write_stop_refusal();
+        }
+        let fold_start = if publish.wal_tail_segments >= CHECKPOINT_AT_WAL_SEGMENTS || write_stopped
+        {
+            engine
+                .wal_fold_snapshot()
+                .and_then(|snapshot| self.start_fold(snapshot, publish.wal_tail_segments))
+        } else {
+            None
+        };
+        if !self.read_core.control_cache_enabled() {
+            engine.invalidate_projection();
+        }
         self.settle_retained_projection(engine.retained_tail_weight());
-        results
+        drop(slot);
+        if let Some(start) = fold_start {
+            let _ = start.send(());
+        }
+        publish.results
     }
 
     /// Returns the publisher's lazily created commit engine.
@@ -1260,8 +1331,101 @@ impl NamespacePublisher {
             NamespaceCommitEngine::new(self.namespace_id.clone())
                 .segment_cache(self.read_core.metadata_segment_cache())
                 .writer_session(Arc::clone(&slot.session))
-                .fold_wal_tail_at(std::num::NonZeroU64::new(CHECKPOINT_AT_WAL_SEGMENTS))
         })
+    }
+
+    fn start_fold(
+        &self,
+        snapshot: WalFoldSnapshot,
+        wal_tail_segments: u64,
+    ) -> Option<oneshot::Sender<()>> {
+        let mut state = self.lock_state();
+        if state
+            .fold
+            .as_ref()
+            .is_some_and(|fold| !fold.task.is_finished())
+        {
+            return None;
+        }
+        let generation = state.next_fold_generation;
+        state.next_fold_generation = state.next_fold_generation.wrapping_add(1);
+        let (start, started) = oneshot::channel();
+        let (exit, liveness) = watch::channel(false);
+        let publisher = self.clone();
+        let task = self.runtime.spawn(async move {
+            let _exit = FoldExit(exit);
+            if started.await.is_err() {
+                return;
+            }
+            if AssertUnwindSafe(publisher.run_fold(snapshot, wal_tail_segments))
+                .catch_unwind()
+                .await
+                .is_err()
+            {
+                publisher.record_panic();
+            }
+        });
+        state.fold = Some(FoldHandle {
+            generation,
+            task,
+            liveness,
+        });
+        Some(start)
+    }
+
+    async fn run_fold(&self, snapshot: WalFoldSnapshot, wal_tail_segments: u64) {
+        let Some(writer) = self.writer.upgrade() else {
+            return;
+        };
+        let context = match writer.identity.mutation_context() {
+            Ok(context) => context,
+            Err(error) => {
+                tracing::info!(
+                    namespace_id = %self.namespace_id,
+                    wal_tail_segments,
+                    error = %error,
+                    "WAL-tail fold failed"
+                );
+                return;
+            }
+        };
+        let started_ms = self.timer.monotonic_now_ms();
+        let segment_cache = self.read_core.metadata_segment_cache();
+        let result = loonfs_core::fold_wal_tail_snapshot(
+            self.read_core.store(),
+            Some(segment_cache.as_ref()),
+            &self.namespace_id,
+            snapshot,
+            &context,
+            self.timer.as_ref(),
+        )
+        .instrument(phase_span!(self.read_core, "wal_fold", self.namespace_id))
+        .await;
+        self.read_core
+            .instruments()
+            .publisher_wal_fold_duration(self.elapsed_ms_since(started_ms));
+        match result {
+            Ok(_) => {
+                self.read_core.instruments().publisher_wal_fold();
+                writer.notify_after_publish(
+                    &self.namespace_id,
+                    &NamespacePublication {
+                        namespace_id: self.namespace_id.clone(),
+                        committed_through_seq: None,
+                        folded: true,
+                        wal_tail_segments: 0,
+                    },
+                );
+            }
+            Err(error) => {
+                tracing::info!(
+                    namespace_id = %self.namespace_id,
+                    wal_tail_segments,
+                    error = %error.message(),
+                    "WAL-tail fold failed"
+                );
+            }
+        }
     }
 
     /// Runs the delete barrier. Returns true when the publisher is now
@@ -1363,6 +1527,44 @@ impl NamespacePublisher {
                 }
             }
         }
+    }
+
+    async fn wait_for_fold(&self) -> Result<(), RuntimeError> {
+        let fold = self.lock_state().fold.as_ref().map(|fold| {
+            (
+                fold.generation,
+                fold.liveness.clone(),
+                fold.task.is_finished(),
+            )
+        });
+        let Some((generation, mut liveness, finished)) = fold else {
+            return Ok(());
+        };
+        if !finished {
+            while !*liveness.borrow_and_update() {
+                if liveness.changed().await.is_err() {
+                    break;
+                }
+            }
+        }
+        let task = {
+            let mut state = self.lock_state();
+            if state
+                .fold
+                .as_ref()
+                .is_some_and(|fold| fold.generation == generation)
+            {
+                state.fold.take().map(|fold| fold.task)
+            } else {
+                None
+            }
+        };
+        if let Some(task) = task {
+            task.await.map_err(|error| {
+                RuntimeError::RuntimeTask(format!("WAL-tail fold task failed: {error}"))
+            })?;
+        }
+        Ok(())
     }
 
     /// Waits until the namespace may start another head CAS.
@@ -1577,6 +1779,14 @@ fn is_retryable_head_publish(result: &CommitResult) -> bool {
         Err(RuntimeError::Core(CoreError::HeadPublish(
             CommitHeadPublishError::StaleHead | CommitHeadPublishError::OutcomeUnknown(_)
         )))
+    )
+}
+
+fn is_maintenance_required(result: &CommitResult) -> bool {
+    matches!(
+        result,
+        Err(RuntimeError::Core(error))
+            if error.code() == loonfs_core::ErrorCode::MaintenanceRequired
     )
 }
 

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1453,6 +1453,13 @@ impl NamespacePublisher {
                     state.admission = PublisherAdmissionState::Deleted;
                     take_queued_waiters(&mut state)
                 };
+                if let Err(error) = self.wait_for_fold().await {
+                    tracing::info!(
+                        namespace_id = %self.namespace_id,
+                        error = %error,
+                        "wal fold failed while the namespace was deleted"
+                    );
+                }
                 // The publisher is terminal; drop it from the registry map
                 // so the map stays bounded by live namespaces. Clones still
                 // in flight fail fast on `Deleted`, and a later submission

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -17,7 +17,10 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use loonfs_api::wire::wal::decode_wal_segment_envelope_zstd;
 use loonfs_api::{AbsolutePath, ActorId, ActorRef, ChangeSeq, DestinationBehavior};
+use loonfs_core::test_support::append_wal_segments;
+use loonfs_core::MutationContext;
 use loonfs_objectstore::keys::{wal_head, wal_segment_prefix};
+use loonfs_objectstore::layout::DurableObjectFamily;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use loonfs_test_support::stores::{
@@ -1879,9 +1882,14 @@ async fn worker_survives_panic_and_processes_later_queue_items() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn successful_delete_evicts_the_namespace_publisher() {
+async fn successful_delete_waits_for_fold_before_evicting_the_namespace_publisher() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let blocking = Arc::new(BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::family(DurableObjectFamily::MetadataManifest),
+        OperationClass::Put,
+    ));
+    let store = blocking.clone() as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let writer = test_writer(store.clone()).await;
     writer
@@ -1889,18 +1897,58 @@ async fn successful_delete_evicts_the_namespace_publisher() {
         .await
         .expect("bootstrap");
     let registry = writer.publisher();
+    append_wal_segments(
+        blocking.inner(),
+        &namespace_id,
+        CHECKPOINT_AT_WAL_SEGMENTS - 1,
+        &MutationContext {
+            writer_id: loonfs_api::WriterId::parse("fold-seed").expect("valid writer id"),
+            now_ms: 1_000,
+        },
+    )
+    .await
+    .expect("seed the WAL tail below the fold threshold");
 
+    blocking.block_next();
     registry
         .submit_candidate(
             namespace_id.clone(),
             CommitCandidate::new(create_directory_request("before", "before")),
         )
         .await
-        .expect("commit before delete");
+        .expect("threshold-crossing commit before delete");
+    blocking.wait_until_blocked().await;
     assert_eq!(registry.shared.lock_state().publishers.len(), 1);
+    let publisher = registry
+        .shared
+        .lock_state()
+        .publishers
+        .get(&namespace_id)
+        .cloned()
+        .expect("publisher exists while the fold is parked");
 
-    registry
-        .submit_delete(namespace_id.clone(), DeleteNamespaceOptions::default())
+    let mut delete = {
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move {
+            registry
+                .submit_delete(namespace_id, DeleteNamespaceOptions::default())
+                .await
+        })
+    };
+    while !matches!(
+        publisher_state(&publisher).admission,
+        PublisherAdmissionState::Deleted
+    ) {
+        tokio::task::yield_now().await;
+    }
+    if let Ok(completed) = timeout(Duration::from_millis(100), &mut delete).await {
+        blocking.release();
+        panic!("delete completed while its earlier fold was parked: {completed:?}");
+    }
+
+    blocking.release();
+    settle_delete(delete, "delete waiting for the earlier fold")
         .await
         .expect("delete namespace");
     assert!(
@@ -1918,8 +1966,7 @@ async fn successful_delete_evicts_the_namespace_publisher() {
         .await
         .expect_err("submission after delete");
     assert_eq!(late.code(), ErrorCode::NamespaceDeleted);
-    registry.close_admission();
-    registry.drain().await.expect("drain after delete");
+    writer.shutdown().await.expect("shut down after delete");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -20,10 +20,13 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
-use loonfs_test_support::stores::{FailStore, InjectedError, KeyPredicate, OperationClass};
+use loonfs_test_support::stores::{
+    BlockingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+};
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 use tempfile::tempdir;
 
 fn store_config(root: &Path) -> StoreConfig {
@@ -368,7 +371,7 @@ fn put_file_bytes_and_prepare_then_put_commit_equivalent_state() {
 }
 
 #[test]
-fn writer_folds_without_scheduling_maintenance() {
+fn manual_only_writer_folds_without_scheduling_maintenance() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     block_on(async {
@@ -388,6 +391,10 @@ fn writer_folds_without_scheduling_maintenance() {
                 .await
                 .expect("put file");
         }
+        writer
+            .wait_for_fold(&namespace_id)
+            .await
+            .expect("settle the writer's fold");
 
         let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
             .actor_id("handle-test-maintenance")
@@ -499,6 +506,20 @@ fn a_runtime_publish_folds_a_preexisting_write_stopped_tail_and_lands() {
             .expect("shut down the first writer");
 
         let writer = writer(temp_dir.path()).await;
+        let refused = writer
+            .put_file_bytes(
+                &namespace_id,
+                "/write-stop/recovered.txt",
+                b"body",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect_err("the write-stopped tail refuses the first publish");
+        assert_eq!(refused.code(), ErrorCode::MaintenanceRequired);
+        writer
+            .wait_for_fold(&namespace_id)
+            .await
+            .expect("settle the fold started by the refusal");
         writer
             .put_file_bytes(
                 &namespace_id,
@@ -507,7 +528,7 @@ fn a_runtime_publish_folds_a_preexisting_write_stopped_tail_and_lands() {
                 PutFileOptions::new(loonfs_test_support::test_actor()),
             )
             .await
-            .expect("the runtime publish folds the preexisting tail and lands");
+            .expect("the retry lands after the fold");
         let maintenance = FsMaintenance::builder(store_config(temp_dir.path()))
             .actor_id("handle-test-maintenance")
             .build()
@@ -585,6 +606,10 @@ fn a_failed_fold_preserves_the_write_stop_until_the_store_recovers() {
 
         failing.clear();
         writer
+            .wait_for_fold(&namespace_id)
+            .await
+            .expect("settle the fold after the manifest store recovers");
+        writer
             .put_file_bytes(
                 &namespace_id,
                 "/failed-fold/recovered.txt",
@@ -592,7 +617,7 @@ fn a_failed_fold_preserves_the_write_stop_until_the_store_recovers() {
                 PutFileOptions::new(loonfs_test_support::test_actor()),
             )
             .await
-            .expect("the recovered manifest store lets the next publish fold and land");
+            .expect("the recovered manifest store lets the retry land");
         let maintenance = FsMaintenance::builder_with_store(failing as SharedObjectStore)
             .actor_id("handle-test-maintenance")
             .build()
@@ -603,6 +628,81 @@ fn a_failed_fold_preserves_the_write_stop_until_the_store_recovers() {
             .await
             .expect("status after fold recovery");
         assert_eq!(status.wal_tail_segments, 1, "{status:?}");
+    });
+}
+
+#[test]
+fn a_threshold_crossing_publish_returns_before_its_fold_completes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    block_on(async {
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::family(DurableObjectFamily::MetadataManifest),
+            OperationClass::Put,
+        ));
+        let writer = FsWriter::builder_with_store(blocking.clone())
+            .writer_id("parked-fold-writer")
+            .build()
+            .await
+            .expect("build writer");
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        append_wal_segments(
+            blocking.inner(),
+            &namespace_id,
+            wal_tail_segment_threshold() - 1,
+            &MutationContext {
+                writer_id: loonfs_api::WriterId::parse("parked-fold-seed").expect("writer id"),
+                now_ms: 1_000,
+            },
+        )
+        .await
+        .expect("seed the WAL tail below the fold threshold");
+
+        blocking.block_next();
+        let put = tokio::spawn({
+            let writer = writer.clone();
+            let namespace_id = namespace_id.clone();
+            async move {
+                writer
+                    .put_file_bytes(
+                        &namespace_id,
+                        "/crossing.txt",
+                        b"body",
+                        PutFileOptions::new(loonfs_test_support::test_actor()),
+                    )
+                    .await
+            }
+        });
+        blocking.wait_until_blocked().await;
+        let published = match tokio::time::timeout(Duration::from_secs(1), put).await {
+            Ok(published) => published,
+            Err(error) => {
+                blocking.release();
+                panic!("the publish waited for its parked fold: {error}");
+            }
+        };
+        published
+            .expect("join the crossing publish")
+            .expect("the crossing publish lands");
+
+        blocking.release();
+        writer
+            .wait_for_fold(&namespace_id)
+            .await
+            .expect("settle the released fold");
+        let maintenance = writer
+            .maintenance_handle("parked-fold-inspection")
+            .expect("build maintenance handle");
+        let status = maintenance
+            .get_namespace_diagnostics(&namespace_id)
+            .await
+            .expect("inspect the folded namespace");
+        assert!(status.current_manifest_no.is_some(), "{status:?}");
+        writer.shutdown().await.expect("shut down writer");
     });
 }
 

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -92,6 +92,10 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
                 .await
                 .expect("put file");
         }
+        fs.writer
+            .wait_for_fold(&namespace_id)
+            .await
+            .expect("publisher fold settles");
         runner.drain().await.expect("maintenance settles");
         let snapshot = recorder.snapshot();
         runner.shutdown().await.expect("runner shutdown");
@@ -139,6 +143,16 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
         counter(&snapshot, "loonfs.publisher.wal_folds", &[]),
         1,
         "the threshold-crossing publish records its fold"
+    );
+    assert_eq!(
+        histogram_count(&snapshot, "loonfs.publisher.wal_fold_ms"),
+        1,
+        "the completed fold records its duration"
+    );
+    assert_eq!(
+        counter(&snapshot, "loonfs.publisher.write_stop_refusals", &[]),
+        0,
+        "the test stays below the write-stop bound"
     );
 
     // The runner: a write nudges the metadata job, and whatever it

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2140,10 +2140,10 @@ Maintenance keeps read cost bounded, retention safe, and durable state clean.
 Maintenance **effects** are normative format semantics; maintenance
 **scheduling and triggering** are not. Two behaviors keep an un-administered
 deployment's read costs bounded regardless of scheduling: the reference
-implementation's writer folds the WAL tail into a manifest before a publish
-that observes the tail at or past the WAL-tail policy's checkpoint threshold
-(32 segments at defaults), and every publish surface rejects with
-`maintenance_required` once the tail reaches the same policy's
+implementation's writer folds the WAL tail into a manifest after a publish
+observes the tail at or past the WAL-tail policy's checkpoint threshold
+(32 segments at defaults), without delaying that publish, and every publish
+surface rejects with `maintenance_required` once the tail reaches the same policy's
 write-rejection threshold (128 at defaults). Reads never gate on tail
 length. Bounded reads are the
 automatic half only: the retention floor never advances on its own, so


### PR DESCRIPTION
Move WAL tail folding out of the publish path so a write that reaches the fold threshold does not wait for manifest writes or a metadata root update.

Each namespace runs at most one fold at a time while later writes continue. If the WAL reaches the hard limit before folding catches up, the write returns maintenance_required and ensures that a fold is running so the caller can retry after it finishes.

Closing a namespace or shutting down the writer waits for active folds. New metrics record fold duration and writes refused at the hard limit.

Review fix, second commit: a successful delete joins the in-flight fold before it evicts the publisher, and the unused head_etag field is gone from the fold snapshot.
