### PR TITLE
feat(server): allow maintenance routes to be disabled

### DIFF
--- a/crates/loonfs-client/tests/snapshots.rs
+++ b/crates/loonfs-client/tests/snapshots.rs
@@ -34,6 +34,7 @@ async fn start_server(name: &str) -> TestServer {
         local_cache: None,
         grep: GrepConfig::default(),
         maintenance: MaintenanceMode::Automatic,
+        serve_maintenance: true,
         min_publish_interval_ms: 0,
         request_deadline_ms: 60_000,
         shutdown_deadline_ms: 60_000,

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -23,8 +23,8 @@ writer_id = "loonfs-server-local"
 # `loonfs maintenance` operation working exactly as before. Set "manual" on a
 # write-serving node when a dedicated maintenance process owns these
 # namespaces, and assign them to it with `loonfs maintenance run --namespaces ...`.
-# This word and the grep mode are the only maintenance switches.
 #maintenance = "automatic"
+#serve_maintenance = true # Set false to hide the /v0/maintenance/ routes.
 
 # Largest request body accepted for service-proxied upload content, in
 # bytes. The server never holds the body whole. It forwards one transfer

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -63,6 +63,12 @@ pub struct ServerConfig {
     /// Automatic by default; see [`MaintenanceMode`].
     #[serde(default)]
     pub maintenance: MaintenanceMode,
+    /// Whether this server mounts the maintenance API group: the routes under
+    /// `/v0/maintenance/`. Default true. A serving node behind a control plane
+    /// that runs maintenance elsewhere sets it false; the node still maintains
+    /// what it touches when `maintenance = "automatic"`.
+    #[serde(default = "default_true")]
+    pub serve_maintenance: bool,
     /// Minimum interval between publication starts per namespace, in
     /// milliseconds. A cold namespace publishes immediately; the interval
     /// paces follow-up batches so hot namespaces amortize into fewer,
@@ -206,6 +212,10 @@ fn default_max_concurrent_downloads() -> usize {
 
 fn default_max_concurrent_maintenance() -> usize {
     loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// The server's `[local_cache]` table: where the node-local cache of encoded
@@ -414,13 +424,18 @@ impl ServerConfig {
 
     /// The line `loonfs-server --check-config` prints when the config loads.
     ///
-    /// It names the two things an operator checks first: the address the
-    /// server would bind and the provider it would talk to.
+    /// It names the address, provider, and maintenance settings.
     pub fn check_summary(&self) -> String {
+        let maintenance = match self.maintenance {
+            MaintenanceMode::Automatic => "automatic",
+            MaintenanceMode::Manual => "manual",
+        };
         format!(
-            "config ok: bind {}, store {}",
+            "config ok: bind {}, store {}, maintenance {}, serve_maintenance {}",
             self.bind.trim(),
-            self.store.kind().as_str()
+            self.store.kind().as_str(),
+            maintenance,
+            self.serve_maintenance
         )
     }
 
@@ -677,6 +692,7 @@ root = "/tmp/loonfs-server"
         let config = load_server_config(&path).expect("valid config");
         assert_eq!(config.maintenance, super::MaintenanceMode::Automatic);
         assert!(config.maintenance.runs_automatically());
+        assert!(config.serve_maintenance);
 
         let path = write_config(
             r#"
@@ -684,6 +700,7 @@ bind = "127.0.0.1:9400"
 auth_token = "dev-token"
 writer_id = "loonfs-server"
 maintenance = "manual"
+serve_maintenance = false
 
 [store]
 kind = "local-fs"
@@ -697,6 +714,7 @@ root = "/tmp/loonfs-server"
             "write-serving nodes can hand maintenance to a dedicated process"
         );
         assert!(!config.maintenance.runs_automatically());
+        assert!(!config.serve_maintenance);
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -17,14 +17,15 @@ use loonfs_api::{
     CreateNamespaceRequest, CreateSnapshotRequest, ErrorCode, ExtendSnapshotRequest,
     ForkNamespaceRequest, ListCheckpointsResponse, ListSnapshotsResponse, MaintenanceRunRequest,
     MaintenanceRunResponse, PageRequest, PaginationPolicy, ReleaseCheckpointResponse,
-    ReleaseSnapshotResponse, SnapshotSummary, API_GROUP_QUERY_V0, FEATURE_DOWNLOADS_DIRECT_GET,
-    FEATURE_MAINTENANCE_GREP_INDEX, FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_MULTIPART,
-    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_DOWNLOAD_MAX_CONCURRENT, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES,
-    LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES,
-    LIMIT_QUERY_GREP_TAIL_BUDGET_FILES, LIMIT_SNAPSHOT_MAX_LIFETIME_MS,
-    LIMIT_SNAPSHOT_MAX_LIVE_PER_NAMESPACE, LIMIT_SNAPSHOT_MAX_TTL_MS,
-    LIMIT_UPLOAD_COMPLETION_MAX_BODY_BYTES, LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES,
-    LIMIT_UPLOAD_MAX_CONCURRENT, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
+    ReleaseSnapshotResponse, SnapshotSummary, API_GROUP_FILESYSTEM_V0, API_GROUP_MAINTENANCE_V0,
+    API_GROUP_QUERY_V0, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_MAINTENANCE_GREP_INDEX,
+    FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
+    LIMIT_DOWNLOAD_MAX_CONCURRENT, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_QUERY_GREP_DEFAULT,
+    LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
+    LIMIT_SNAPSHOT_MAX_LIFETIME_MS, LIMIT_SNAPSHOT_MAX_LIVE_PER_NAMESPACE,
+    LIMIT_SNAPSHOT_MAX_TTL_MS, LIMIT_UPLOAD_COMPLETION_MAX_BODY_BYTES,
+    LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES, LIMIT_UPLOAD_MAX_CONCURRENT,
+    LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
 
 /// Advertises a feature, or removes the key: an absent key and an
@@ -140,19 +141,19 @@ pub(super) async fn get_capabilities(
         LIMIT_SNAPSHOT_MAX_LIVE_PER_NAMESPACE.to_owned(),
         state.config.snapshot_max_live_per_namespace as u64,
     );
-    // The runtime handles describe the filesystem and maintenance API groups. Grep is a
-    // composed extension, so this deployment — not the runtime — says
-    // whether the query API group exists and what it costs.
-    //
-    // Serving searches and maintaining the index are separate jobs and
-    // separately deployable, so they are separately advertised. The
-    // maintenance key sits in the maintenance API group, which the runtime always
-    // advertises: a deployment that maintains an index it does not serve has
-    // no query API group for a `query.` key to be parented by.
+    // The HTTP deployment replaces the embedded document's API groups with
+    // the routes this router mounts. Serving searches and maintaining their
+    // index remain separately deployable.
+    capabilities.api_groups = vec![API_GROUP_FILESYSTEM_V0.to_owned()];
+    if state.config.serve_maintenance {
+        capabilities
+            .api_groups
+            .push(API_GROUP_MAINTENANCE_V0.to_owned());
+    }
     set_feature(
         &mut capabilities,
         FEATURE_MAINTENANCE_GREP_INDEX,
-        state.config.grep.mode.maintains_index(),
+        state.config.serve_maintenance && state.config.grep.mode.maintains_index(),
     );
     if state.config.grep.mode.serves_grep() {
         let pagination = PaginationPolicy::default();

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -262,7 +262,7 @@ fn router(state: AppState) -> Router {
     let public = Router::new()
         .route("/health", get(get_health))
         .route("/readiness", get(get_readiness));
-    let authenticated = Router::new()
+    let mut authenticated = Router::new()
         .route("/metrics", get(get_metrics))
         .route(
             "/v0/capabilities",
@@ -285,10 +285,6 @@ fn router(state: AppState) -> Router {
         .route(
             "/v0/namespaces/{namespace_id}/snapshots/{snapshot_id}/release",
             post(release_snapshot),
-        )
-        .route(
-            "/v0/maintenance/namespaces/{namespace_id}/diagnostics",
-            get(get_namespace_diagnostics),
         )
         .route(
             "/v0/namespaces/{namespace_id}/filesystem/entries",
@@ -314,38 +310,6 @@ fn router(state: AppState) -> Router {
         .route(
             "/v0/namespaces/{namespace_id}/grep",
             gated(serves_grep, get(grep), get(grep_queries_not_served)),
-        )
-        .route(
-            "/v0/maintenance/namespaces/{namespace_id}/grep/index",
-            gated(
-                maintains_index,
-                get(get_grep_index),
-                get(grep_index_not_maintained),
-            ),
-        )
-        .route(
-            "/v0/maintenance/namespaces/{namespace_id}/grep/index/enable",
-            gated(
-                maintains_index,
-                post(enable_grep_index),
-                post(grep_index_not_maintained),
-            ),
-        )
-        .route(
-            "/v0/maintenance/namespaces/{namespace_id}/grep/index/disable",
-            gated(
-                maintains_index,
-                post(disable_grep_index),
-                post(grep_index_not_maintained),
-            ),
-        )
-        .route(
-            "/v0/maintenance/namespaces/{namespace_id}/grep/index/gc",
-            gated(
-                maintains_index,
-                post(gc_grep_index),
-                post(grep_index_not_maintained),
-            ),
         )
         .route(
             "/v0/namespaces/{namespace_id}/filesystem/revisions",
@@ -404,25 +368,65 @@ fn router(state: AppState) -> Router {
             "/v0/namespaces/{namespace_id}/uploads/{upload_id}",
             get(get_upload),
         )
-        .route("/v0/namespaces/{namespace_id}/changes", get(list_changes))
-        .route(
-            "/v0/maintenance/namespaces/{namespace_id}/checkpoints",
-            post(create_checkpoint).get(list_checkpoints),
-        )
-        .route(
-            "/v0/maintenance/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release",
-            post(release_checkpoint),
-        )
-        .route(
-            "/v0/maintenance/namespaces/{namespace_id}/runs",
-            post(run_maintenance),
-        )
-        // The one maintenance route whose subject is the store rather than a
-        // namespace, so it sits beside them rather than under one.
-        .route(
-            "/v0/maintenance/store/probe",
-            post(handlers_store::probe_store),
-        )
+        .route("/v0/namespaces/{namespace_id}/changes", get(list_changes));
+    if state.config.serve_maintenance {
+        authenticated = authenticated
+            .route(
+                "/v0/maintenance/namespaces/{namespace_id}/diagnostics",
+                get(get_namespace_diagnostics),
+            )
+            .route(
+                "/v0/maintenance/namespaces/{namespace_id}/grep/index",
+                gated(
+                    maintains_index,
+                    get(get_grep_index),
+                    get(grep_index_not_maintained),
+                ),
+            )
+            .route(
+                "/v0/maintenance/namespaces/{namespace_id}/grep/index/enable",
+                gated(
+                    maintains_index,
+                    post(enable_grep_index),
+                    post(grep_index_not_maintained),
+                ),
+            )
+            .route(
+                "/v0/maintenance/namespaces/{namespace_id}/grep/index/disable",
+                gated(
+                    maintains_index,
+                    post(disable_grep_index),
+                    post(grep_index_not_maintained),
+                ),
+            )
+            .route(
+                "/v0/maintenance/namespaces/{namespace_id}/grep/index/gc",
+                gated(
+                    maintains_index,
+                    post(gc_grep_index),
+                    post(grep_index_not_maintained),
+                ),
+            )
+            .route(
+                "/v0/maintenance/namespaces/{namespace_id}/checkpoints",
+                post(create_checkpoint).get(list_checkpoints),
+            )
+            .route(
+                "/v0/maintenance/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release",
+                post(release_checkpoint),
+            )
+            .route(
+                "/v0/maintenance/namespaces/{namespace_id}/runs",
+                post(run_maintenance),
+            )
+            // The one maintenance route whose subject is the store rather than a
+            // namespace, so it sits beside them rather than under one.
+            .route(
+                "/v0/maintenance/store/probe",
+                post(handlers_store::probe_store),
+            );
+    }
+    let authenticated = authenticated
         .route_layer(middleware::from_fn(move |request: Request, next: Next| {
             with_request_deadline(request_deadline_ms, request, next)
         }))

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -23,8 +23,9 @@ use loonfs_api::{
     AttributeRevisionNo, ErrorCode, ErrorDetails, InodeId, WriterEpoch, ALL_LIMIT_KEYS,
 };
 use loonfs_api::{
-    ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, GrepRequest, NamespaceId,
-    PaginationPolicy, RevisionNo, FEATURE_QUERY_GREP,
+    CapabilityDocument, ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior,
+    GrepRequest, NamespaceId, PaginationPolicy, RevisionNo, API_GROUP_FILESYSTEM_V0,
+    API_GROUP_QUERY_V0, FEATURE_QUERY_GREP,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MoveOptions, NamespacePath};
 use loonfs_grep::keyspace::{manifest_key as grep_manifest_key, root_key as grep_root_key};
@@ -2686,6 +2687,97 @@ async fn put_streamed_writes_a_multi_part_payload_one_part_at_a_time() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hidden_maintenance_surface_keeps_filesystem_and_query_routes_served() {
+    use tower::ServiceExt;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let mut config = test_config(temp_dir.path(), "hidden-maintenance-writer");
+    config.serve_maintenance = false;
+    let (router, state) = app(config, options_with_store(store))
+        .await
+        .expect("build app");
+    assert!(state.runner.is_some());
+
+    let capabilities_response = router
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/v0/capabilities")
+                .header(axum::http::header::AUTHORIZATION, "Bearer test-token")
+                .body(axum::body::Body::empty())
+                .expect("capabilities request"),
+        )
+        .await
+        .expect("capabilities response");
+    assert_eq!(capabilities_response.status(), StatusCode::OK);
+    let capabilities_body = axum::body::to_bytes(capabilities_response.into_body(), usize::MAX)
+        .await
+        .expect("capabilities body");
+    let capabilities: CapabilityDocument =
+        serde_json::from_slice(&capabilities_body).expect("capability document");
+    assert_eq!(
+        capabilities.api_groups,
+        vec![
+            API_GROUP_FILESYSTEM_V0.to_owned(),
+            API_GROUP_QUERY_V0.to_owned(),
+        ]
+    );
+    assert!(!capabilities
+        .features
+        .keys()
+        .any(|feature| feature.starts_with("maintenance.")));
+    capabilities
+        .validate()
+        .expect("the capability document is well formed");
+
+    let diagnostics_response = router
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/v0/maintenance/namespaces/hidden/diagnostics")
+                .header(axum::http::header::AUTHORIZATION, "Bearer test-token")
+                .body(axum::body::Body::empty())
+                .expect("diagnostics request"),
+        )
+        .await
+        .expect("diagnostics response");
+    assert_eq!(diagnostics_response.status(), StatusCode::NOT_FOUND);
+    let diagnostics_body = axum::body::to_bytes(diagnostics_response.into_body(), usize::MAX)
+        .await
+        .expect("diagnostics body");
+    let diagnostics_error: serde_json::Value =
+        serde_json::from_slice(&diagnostics_body).expect("diagnostics error");
+    assert_eq!(diagnostics_error["code"], "route_not_found");
+
+    let namespace_id = namespace_id("hidden");
+    state
+        .writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let commit_response = router
+        .oneshot(
+            axum::http::Request::builder()
+                .method(axum::http::Method::POST)
+                .uri("/v0/namespaces/hidden/commits")
+                .header(axum::http::header::AUTHORIZATION, "Bearer test-token")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(
+                    r#"{
+                        "commit_id":"hidden-maintenance-commit",
+                        "actor":{"kind":"service","id":"test-service"},
+                        "operations":[{"kind":"create_directory","path":"/docs"}]
+                    }"#,
+                ))
+                .expect("commit request"),
+        )
+        .await
+        .expect("commit response");
+    assert_eq!(commit_response.status(), StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_unknown_routes_and_methods_answer_in_envelope() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
@@ -3530,6 +3622,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
             ..crate::config::GrepConfig::default()
         },
         maintenance: crate::config::MaintenanceMode::Automatic,
+        serve_maintenance: true,
         min_publish_interval_ms: 0,
         request_deadline_ms: 60_000,
         shutdown_deadline_ms: 600_000,

--- a/crates/loonfs-server/tests/it/check_config.rs
+++ b/crates/loonfs-server/tests/it/check_config.rs
@@ -174,7 +174,8 @@ fn check_config_accepts_a_valid_config_and_names_what_it_validated() {
     );
     assert_eq!(
         stdout.trim(),
-        "config ok: bind 127.0.0.1:9400, store local-fs"
+        "config ok: bind 127.0.0.1:9400, store local-fs, maintenance automatic, \
+         serve_maintenance true"
     );
     // The documented caveat: constructing a local-fs store creates its root.
     assert!(store_root.is_dir(), "local-fs check creates the store root");
@@ -209,7 +210,8 @@ root = "{}"
     );
     assert_eq!(
         stdout.trim(),
-        "config ok: bind 127.0.0.1:9400, store local-fs"
+        "config ok: bind 127.0.0.1:9400, store local-fs, maintenance automatic, \
+         serve_maintenance true"
     );
     assert!(!stdout.contains("inline-config-token"), "{stdout}");
     assert!(!stdout.contains("inline-content-secret"), "{stdout}");
@@ -354,7 +356,8 @@ fn check_config_opens_the_local_cache_and_leaves_it_openable() {
     );
     assert_eq!(
         stdout.trim(),
-        "config ok: bind 127.0.0.1:9400, store local-fs"
+        "config ok: bind 127.0.0.1:9400, store local-fs, maintenance automatic, \
+         serve_maintenance true"
     );
     assert!(
         cache_root.is_dir(),
@@ -387,7 +390,10 @@ fn check_config_does_not_bind_the_port() {
     );
     assert_eq!(
         stdout.trim(),
-        format!("config ok: bind {bind}, store local-fs")
+        format!(
+            "config ok: bind {bind}, store local-fs, maintenance automatic, \
+             serve_maintenance true"
+        )
     );
     drop(listener);
 }

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -311,6 +311,7 @@ pub(crate) fn test_config(
             ..GrepConfig::default()
         },
         maintenance: MaintenanceMode::Automatic,
+        serve_maintenance: true,
         min_publish_interval_ms: 0,
         request_deadline_ms: 60_000,
         shutdown_deadline_ms: 600_000,

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -714,6 +714,7 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
             ..GrepConfig::default()
         },
         maintenance: MaintenanceMode::Automatic,
+        serve_maintenance: true,
         min_publish_interval_ms: 0,
         request_deadline_ms: 60_000,
         shutdown_deadline_ms: 600_000,

--- a/crates/loonfs-server/tests/it/http_smoke.rs
+++ b/crates/loonfs-server/tests/it/http_smoke.rs
@@ -9,8 +9,9 @@ use loonfs::publish::{
     MAX_COMMIT_OPERATIONS,
 };
 use loonfs_api::{
-    ChangeSeq, CommitId, DestinationBehavior, InodeKind, DEFAULT_MAX_PAGE_LIMIT,
-    DEFAULT_PAGE_LIMIT, LIMIT_COMMIT_MAX_CONTENT_TOKENS, LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS,
+    ChangeSeq, CommitId, DestinationBehavior, InodeKind, API_GROUP_FILESYSTEM_V0,
+    API_GROUP_MAINTENANCE_V0, API_GROUP_QUERY_V0, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT,
+    LIMIT_COMMIT_MAX_CONTENT_TOKENS, LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS,
     LIMIT_COMMIT_MAX_MESSAGE_BYTES, LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_DOWNLOAD_MAX_CONCURRENT,
     LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
     LIMIT_SNAPSHOT_MAX_LIFETIME_MS, LIMIT_SNAPSHOT_MAX_LIVE_PER_NAMESPACE,
@@ -150,8 +151,17 @@ async fn capabilities_endpoint_advertises_capabilities() {
         .await
         .expect("fetch capabilities");
     assert_eq!(capabilities.protocol_version, "v0");
-    assert!(capabilities.has_api_group("filesystem/v0"));
-    assert!(capabilities.has_api_group("maintenance/v0"));
+    assert_eq!(
+        capabilities.api_groups,
+        vec![
+            API_GROUP_FILESYSTEM_V0.to_owned(),
+            API_GROUP_MAINTENANCE_V0.to_owned(),
+            API_GROUP_QUERY_V0.to_owned(),
+        ]
+    );
+    capabilities
+        .validate()
+        .expect("the capability document is well formed");
     assert!(!capabilities.supports("filesystem.namespaces.list"));
     assert!(capabilities.supports("filesystem.namespaces.create"));
     assert!(capabilities.supports("filesystem.namespaces.fork"));

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -35,9 +35,8 @@ Notes:
   `maintenance/v0` (maintenance is manually triggerable). A minimal server that
   wraps the embedded engine over HTTP advertises the same two API groups and is
   fully conformant.
-- A hosted server may disable individual features per tenant and typically
-  hides `maintenance/v0` because maintenance runs automatically. Both choices are
-  fully conformant.
+- A hosted LoonFS server may set `serve_maintenance = false` to hide
+  `maintenance/v0`; both serving choices are fully conformant.
 - API groups version independently (`filesystem/v0` could coexist with a future
   `maintenance/v1`). The group name — the segment before the slash — is the stable
   identity that feature keys reference.


### PR DESCRIPTION
Add a serve_maintenance setting that controls whether the server exposes the maintenance API. It defaults to true.

When disabled, maintenance routes return route_not_found and the capability document omits the maintenance API group and its features. Filesystem and query routes continue to work, and local background maintenance is unchanged.