### PR TITLE
feat(core): limit concurrent WAL folds

### DIFF
--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -227,14 +227,17 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
     })))
 }
 
-pub async fn fold_wal_tail_snapshot<S: ObjectStore + ?Sized>(
+pub async fn fold_wal_tail<S: ObjectStore + ?Sized>(
     store: &S,
     segment_cache: Option<&MetadataSegmentCache>,
     namespace_id: &NamespaceId,
-    snapshot: WalFoldSnapshot,
+    snapshot: Option<WalFoldSnapshot>,
     context: &MutationContext,
     timer: &dyn MonotonicTimer,
 ) -> Result<FlushWalResponse> {
+    let Some(snapshot) = snapshot else {
+        return flush_wal(store, namespace_id, context).await;
+    };
     let loaded_basis = load_basis_metadata_segments(
         store,
         segment_cache,

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -48,9 +48,7 @@ pub use self::compaction_merge::{
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
-pub use self::flush::{
-    ensure_metadata_publication_budget, fold_wal_tail_snapshot, next_run_no_after,
-};
+pub use self::flush::{ensure_metadata_publication_budget, fold_wal_tail, next_run_no_after};
 pub use self::list::CheckpointPageCursor;
 pub use self::read_basis::{load_checkpoint_read_basis, CheckpointReadBasis};
 pub use self::reorganize::{FrozenBasePolicy, MetadataReorganizeOutcome, MetadataReorganizeReport};

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -45,11 +45,11 @@ async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
         tail_state: Arc::clone(&projection.tail_state),
         wal_tail_segments: projection.wal_tail_segments,
     };
-    let response = flush::fold_wal_tail_snapshot(
+    let response = flush::fold_wal_tail(
         &store,
         None,
         &namespace_id,
-        snapshot,
+        Some(snapshot),
         &context,
         &crate::time::StdMonotonicTimer::default(),
     )

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -156,9 +156,9 @@ pub mod publish {
 // `MetadataReorganizeReport` remains public because
 // `NamespaceEngine::reorganize_metadata` returns it.
 pub use checkpoint::{
-    ensure_metadata_publication_budget, fold_wal_tail_snapshot, next_run_no_after,
-    refill_iterators, select_next_iterator, write_segments_in_waves, CheckpointFile,
-    CheckpointFilesPage, CheckpointFilesPageCursor, CheckpointPageCursor, FrozenBasePolicy,
+    ensure_metadata_publication_budget, fold_wal_tail, next_run_no_after, refill_iterators,
+    select_next_iterator, write_segments_in_waves, CheckpointFile, CheckpointFilesPage,
+    CheckpointFilesPageCursor, CheckpointPageCursor, FrozenBasePolicy,
     MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,
     MetadataFamilyGroup, MetadataReorganizeOutcome, MetadataReorganizeReport, SegmentBlockLoader,
     SegmentRowIterator,

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -19,6 +19,8 @@ pub(crate) const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES: usize =
 pub(crate) const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 15;
 /// Default maximum writer sessions held at once.
 pub const DEFAULT_MAX_OPEN_NAMESPACES: usize = 10_000;
+/// Default maximum WAL-tail folds one writer runs concurrently.
+pub const DEFAULT_MAX_CONCURRENT_FOLDS: usize = 2;
 /// Default cap on concurrently running maintenance invocations.
 /// Each job already runs at most once per namespace at a time; this bounds how many may run at
 /// once, so a write burst across many namespaces cannot fan out into

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -96,10 +96,10 @@ impl WriterBits {
         }
     }
 
-    pub(crate) fn notify_after_fold(&self, namespace_id: &NamespaceId) {
+    pub(crate) fn notify_fold_finished(&self, namespace_id: &NamespaceId) {
         self.send_maintenance_hint(
             namespace_id,
-            MaintenanceHint::WalFolded {
+            MaintenanceHint::WalFoldFinished {
                 namespace_id: namespace_id.clone(),
             },
         );

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -25,7 +25,9 @@ use loonfs_core::cache::{
 use loonfs_core::time::current_time_ms;
 use loonfs_core::{MutationContext, NamespaceReaderEngine, NamespaceWriterEngine};
 use std::collections::BTreeMap;
+use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex, MutexGuard};
+use tokio::sync::Semaphore;
 
 /// Shared object-store client, read configuration, caches, and metrics.
 #[derive(Clone)]
@@ -53,6 +55,8 @@ pub(crate) struct WriterIdentity {
 /// Writer state shared weakly with the publisher worker.
 pub(crate) struct WriterBits {
     pub(crate) identity: WriterIdentity,
+    pub(crate) wal_fold_permits: Semaphore,
+    pub(crate) wal_folds_waiting: AtomicUsize,
     pub(crate) maintenance_hint_observer: Option<MaintenanceHintObserver>,
     /// Optional synchronous notification after a mutation batch durably
     /// advances a namespace. Callers promise that it does not block.
@@ -67,17 +71,10 @@ impl WriterBits {
         namespace_id: &NamespaceId,
         publication: &NamespacePublication,
     ) {
-        if let Some(observer) = &self.maintenance_hint_observer {
-            let hint = MaintenanceHint::Published(publication.clone());
-            let observed =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| observer(hint)));
-            if observed.is_err() {
-                tracing::error!(
-                    namespace_id = %namespace_id,
-                    "maintenance hint observer panicked; publication state is durable"
-                );
-            }
-        }
+        self.send_maintenance_hint(
+            namespace_id,
+            MaintenanceHint::Published(publication.clone()),
+        );
 
         let Some(through_seq) = publication.committed_through_seq else {
             return;
@@ -95,6 +92,28 @@ impl WriterBits {
                 namespace_id = %namespace_id,
                 through_seq = through_seq.0,
                 "namespace advance observer panicked; the commit was already durable"
+            );
+        }
+    }
+
+    pub(crate) fn notify_after_fold(&self, namespace_id: &NamespaceId) {
+        self.send_maintenance_hint(
+            namespace_id,
+            MaintenanceHint::WalFolded {
+                namespace_id: namespace_id.clone(),
+            },
+        );
+    }
+
+    fn send_maintenance_hint(&self, namespace_id: &NamespaceId, hint: MaintenanceHint) {
+        let Some(observer) = &self.maintenance_hint_observer else {
+            return;
+        };
+        let observed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| observer(hint)));
+        if observed.is_err() {
+            tracing::error!(
+                namespace_id = %namespace_id,
+                "maintenance hint observer panicked; the durable state it describes is unaffected"
             );
         }
     }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -984,7 +984,6 @@ pub(crate) async fn publish_batch_with_engine(
         &NamespacePublication {
             namespace_id: namespace_id.clone(),
             committed_through_seq: highest_committed_seq(&results),
-            folded: false,
             wal_tail_segments,
         },
     );

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -16,7 +16,9 @@ use crate::{
 use loonfs_core::cache::MetadataSegmentCache;
 use loonfs_core::cache::StoredMetadataBlockCache;
 use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 
 /// How a writer treats a namespace it has no open session for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -243,6 +245,7 @@ pub struct FsWriterBuilder {
     min_publish_interval_ms: u64,
     namespace_session_policy: NamespaceSessionPolicy,
     max_open_namespaces: NonZeroUsize,
+    max_concurrent_folds: NonZeroUsize,
     namespace_advance_observer: Option<NamespaceAdvanceObserver>,
     maintenance_hint_observer: Option<MaintenanceHintObserver>,
 }
@@ -256,6 +259,8 @@ impl FsWriterBuilder {
             namespace_session_policy: NamespaceSessionPolicy::OpenOnFirstWrite,
             max_open_namespaces: NonZeroUsize::new(crate::config::DEFAULT_MAX_OPEN_NAMESPACES)
                 .expect("default maximum open namespaces should be nonzero"),
+            max_concurrent_folds: NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_FOLDS)
+                .expect("default maximum concurrent folds should be nonzero"),
             namespace_advance_observer: None,
             maintenance_hint_observer: None,
         }
@@ -303,6 +308,13 @@ impl FsWriterBuilder {
     /// default is [`crate::DEFAULT_MAX_OPEN_NAMESPACES`].
     pub fn max_open_namespaces(mut self, limit: NonZeroUsize) -> Self {
         self.max_open_namespaces = limit;
+        self
+    }
+
+    /// Sets the maximum number of WAL tails this writer folds concurrently.
+    /// The default is [`crate::DEFAULT_MAX_CONCURRENT_FOLDS`].
+    pub fn max_concurrent_folds(mut self, limit: NonZeroUsize) -> Self {
+        self.max_concurrent_folds = limit;
         self
     }
 
@@ -409,6 +421,8 @@ impl FsWriterBuilder {
         let core = self.core.open_read_core()?;
         let bits = Arc::new(WriterBits {
             identity,
+            wal_fold_permits: Semaphore::new(self.max_concurrent_folds.get()),
+            wal_folds_waiting: AtomicUsize::new(0),
             namespace_advance_observer: self.namespace_advance_observer,
             maintenance_hint_observer: self.maintenance_hint_observer,
         });

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -171,7 +171,8 @@ pub use loonfs_objectstore::{
 
 pub use cache::RuntimeCacheStats;
 pub use config::{
-    RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE, DEFAULT_MAX_OPEN_NAMESPACES,
+    RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_FOLDS, DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+    DEFAULT_MAX_OPEN_NAMESPACES,
 };
 pub use fs::{
     ChangesPager, CheckpointsPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager,

--- a/crates/loonfs/src/maintenance/hints.rs
+++ b/crates/loonfs/src/maintenance/hints.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 pub enum MaintenanceHint {
     /// A namespace publication was attempted.
     Published(NamespacePublication),
-    /// A namespace WAL tail was folded successfully.
-    WalFolded {
-        /// Namespace whose WAL tail was folded.
+    /// A namespace WAL-tail fold attempt finished.
+    WalFoldFinished {
+        /// Namespace whose WAL-tail fold attempt finished.
         namespace_id: NamespaceId,
     },
     /// A job becomes eligible at a durable deadline.

--- a/crates/loonfs/src/maintenance/hints.rs
+++ b/crates/loonfs/src/maintenance/hints.rs
@@ -9,6 +9,11 @@ use std::sync::Arc;
 pub enum MaintenanceHint {
     /// A namespace publication was attempted.
     Published(NamespacePublication),
+    /// A namespace WAL tail was folded successfully.
+    WalFolded {
+        /// Namespace whose WAL tail was folded.
+        namespace_id: NamespaceId,
+    },
     /// A job becomes eligible at a durable deadline.
     DueAt {
         /// Namespace to maintain.

--- a/crates/loonfs/src/maintenance/job.rs
+++ b/crates/loonfs/src/maintenance/job.rs
@@ -157,7 +157,7 @@ pub trait MaintenanceJob: Send + Sync + 'static {
         false
     }
 
-    /// Returns whether a successful WAL fold should nudge this job.
+    /// Returns whether a finished WAL-fold attempt should nudge this job.
     fn should_run_after_fold(&self) -> bool {
         false
     }

--- a/crates/loonfs/src/maintenance/job.rs
+++ b/crates/loonfs/src/maintenance/job.rs
@@ -90,8 +90,6 @@ pub struct NamespacePublication {
     pub namespace_id: NamespaceId,
     /// Highest sequence committed by this attempt.
     pub committed_through_seq: Option<ChangeSeq>,
-    /// Whether the attempt folded the WAL tail.
-    pub folded: bool,
     /// WAL segments visible after the attempt.
     pub wal_tail_segments: u64,
 }
@@ -156,6 +154,11 @@ pub trait MaintenanceJob: Send + Sync + 'static {
 
     /// Returns whether a publication should nudge this job.
     fn should_run_after_publication(&self, _publication: &NamespacePublication) -> bool {
+        false
+    }
+
+    /// Returns whether a successful WAL fold should nudge this job.
+    fn should_run_after_fold(&self) -> bool {
         false
     }
 }

--- a/crates/loonfs/src/maintenance/metadata.rs
+++ b/crates/loonfs/src/maintenance/metadata.rs
@@ -1,6 +1,6 @@
 use super::{
     MaintenanceCancellation, MaintenanceConclusion, MaintenanceJob, MaintenanceJobId,
-    MaintenanceProbe, MaintenanceRunReport, NamespacePublication,
+    MaintenanceProbe, MaintenanceRunReport,
 };
 use crate::{
     ErrorCode, FsMaintenance, MetadataMaintenanceOptions, MetadataMaintenanceResponse, NamespaceId,
@@ -68,8 +68,8 @@ impl MaintenanceJob for MetadataMaintenanceJob {
         }
     }
 
-    fn should_run_after_publication(&self, publication: &NamespacePublication) -> bool {
-        publication.folded || self.options.flush_is_due(publication.wal_tail_segments)
+    fn should_run_after_fold(&self) -> bool {
+        true
     }
 }
 

--- a/crates/loonfs/src/maintenance/metadata_compaction.rs
+++ b/crates/loonfs/src/maintenance/metadata_compaction.rs
@@ -4,6 +4,7 @@ use super::{
     MaintenanceProbe, MaintenanceRunReport,
 };
 use crate::{FsMaintenance, MetadataCompactionOutcome, NamespaceId, Result};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
@@ -22,6 +23,12 @@ impl MetadataCompactionJob {
             maintenance,
             permits: Arc::new(Semaphore::new(MAX_CONCURRENT_COMPACTIONS)),
         }
+    }
+
+    /// Sets the maximum compactions this job runs concurrently.
+    pub fn max_concurrent(mut self, max_concurrent: NonZeroUsize) -> Self {
+        self.permits = Arc::new(Semaphore::new(max_concurrent.get()));
+        self
     }
 }
 

--- a/crates/loonfs/src/maintenance/runner.rs
+++ b/crates/loonfs/src/maintenance/runner.rs
@@ -159,7 +159,7 @@ impl MaintenanceHandle {
                     }
                 }
             }
-            MaintenanceHint::WalFolded { namespace_id } => {
+            MaintenanceHint::WalFoldFinished { namespace_id } => {
                 for id in inner.registry.job_ids() {
                     if inner
                         .registry

--- a/crates/loonfs/src/maintenance/runner.rs
+++ b/crates/loonfs/src/maintenance/runner.rs
@@ -159,6 +159,17 @@ impl MaintenanceHandle {
                     }
                 }
             }
+            MaintenanceHint::WalFolded { namespace_id } => {
+                for id in inner.registry.job_ids() {
+                    if inner
+                        .registry
+                        .get(id)
+                        .is_some_and(|job| job.should_run_after_fold())
+                    {
+                        nudge_if_inactive(&inner, id, &namespace_id);
+                    }
+                }
+            }
             MaintenanceHint::DueAt {
                 namespace_id,
                 job,

--- a/crates/loonfs/src/maintenance/tests.rs
+++ b/crates/loonfs/src/maintenance/tests.rs
@@ -861,7 +861,7 @@ impl MaintenanceJob for BlockingJob {
 }
 
 #[tokio::test]
-async fn wal_folded_hints_coalesce_and_follow_ups_admit_once() {
+async fn wal_fold_finished_hints_coalesce_and_follow_ups_admit_once() {
     let metadata = BlockingJob::new(
         MaintenanceJobId::METADATA,
         false,
@@ -894,10 +894,10 @@ async fn wal_folded_hints_coalesce_and_follow_ups_admit_once() {
         "a due-tail publication does not schedule a metadata flush"
     );
 
-    runner.handle().hint(MaintenanceHint::WalFolded {
+    runner.handle().hint(MaintenanceHint::WalFoldFinished {
         namespace_id: namespace_id.clone(),
     });
-    runner.handle().hint(MaintenanceHint::WalFolded {
+    runner.handle().hint(MaintenanceHint::WalFoldFinished {
         namespace_id: namespace_id.clone(),
     });
     metadata.wait_entered(1).await;

--- a/crates/loonfs/src/maintenance/tests.rs
+++ b/crates/loonfs/src/maintenance/tests.rs
@@ -608,7 +608,6 @@ async fn a_publication_nudges_only_the_jobs_it_concerns() {
         .hint(MaintenanceHint::Published(NamespacePublication {
             namespace_id: namespace_id.clone(),
             committed_through_seq: None,
-            folded: false,
             wal_tail_segments: 4,
         }));
     runner.drain().await.expect("nothing was scheduled");
@@ -622,7 +621,6 @@ async fn a_publication_nudges_only_the_jobs_it_concerns() {
         .hint(MaintenanceHint::Published(NamespacePublication {
             namespace_id: namespace_id.clone(),
             committed_through_seq: Some(ChangeSeq(7)),
-            folded: false,
             wal_tail_segments: 5,
         }));
     runner.drain().await.expect("the subscriber's step settles");
@@ -784,6 +782,7 @@ async fn a_nudge_for_an_unregistered_job_runs_nothing() {
 struct BlockingJob {
     id: MaintenanceJobId,
     publication: bool,
+    fold: bool,
     follow_up: Option<MaintenanceJobId>,
     runs: AtomicUsize,
     entered: watch::Sender<usize>,
@@ -794,11 +793,13 @@ impl BlockingJob {
     fn new(
         id: MaintenanceJobId,
         publication: bool,
+        fold: bool,
         follow_up: Option<MaintenanceJobId>,
     ) -> Arc<Self> {
         Arc::new(Self {
             id,
             publication,
+            fold,
             follow_up,
             runs: AtomicUsize::new(0),
             entered: watch::channel(0).0,
@@ -853,16 +854,21 @@ impl MaintenanceJob for BlockingJob {
     fn should_run_after_publication(&self, _publication: &NamespacePublication) -> bool {
         self.publication
     }
+
+    fn should_run_after_fold(&self) -> bool {
+        self.fold
+    }
 }
 
 #[tokio::test]
-async fn published_hints_coalesce_and_follow_ups_admit_once() {
+async fn wal_folded_hints_coalesce_and_follow_ups_admit_once() {
     let metadata = BlockingJob::new(
         MaintenanceJobId::METADATA,
+        false,
         true,
         Some(MaintenanceJobId::METADATA_COMPACTION),
     );
-    let compaction = BlockingJob::new(MaintenanceJobId::METADATA_COMPACTION, false, None);
+    let compaction = BlockingJob::new(MaintenanceJobId::METADATA_COMPACTION, false, false, None);
     let registry = MaintenanceRegistry::new();
     registry.register(metadata.clone()).expect("metadata job");
     registry
@@ -873,19 +879,27 @@ async fn published_hints_coalesce_and_follow_ups_admit_once() {
         .build()
         .expect("runner");
     let namespace_id = namespace_id("hints");
-    let publication = NamespacePublication {
-        namespace_id: namespace_id.clone(),
-        committed_through_seq: Some(ChangeSeq(1)),
-        folded: true,
-        wal_tail_segments: 0,
-    };
 
     runner
         .handle()
-        .hint(MaintenanceHint::Published(publication.clone()));
-    runner
-        .handle()
-        .hint(MaintenanceHint::Published(publication));
+        .hint(MaintenanceHint::Published(NamespacePublication {
+            namespace_id: namespace_id.clone(),
+            committed_through_seq: Some(ChangeSeq(1)),
+            wal_tail_segments: loonfs_core::limits::CHECKPOINT_AT_WAL_SEGMENTS,
+        }));
+    runner.drain().await.expect("publication schedules nothing");
+    assert_eq!(
+        metadata.runs.load(Ordering::SeqCst),
+        0,
+        "a due-tail publication does not schedule a metadata flush"
+    );
+
+    runner.handle().hint(MaintenanceHint::WalFolded {
+        namespace_id: namespace_id.clone(),
+    });
+    runner.handle().hint(MaintenanceHint::WalFolded {
+        namespace_id: namespace_id.clone(),
+    });
     metadata.wait_entered(1).await;
     assert_eq!(metadata.runs.load(Ordering::SeqCst), 1);
     metadata.release();
@@ -927,7 +941,6 @@ async fn reconciliation_recovers_a_hint_dropped_before_attachment() {
     let hint = MaintenanceHint::Published(NamespacePublication {
         namespace_id: namespace_id.clone(),
         committed_through_seq: Some(ChangeSeq(1)),
-        folded: false,
         wal_tail_segments: 0,
     });
     let dropped_before = MaintenanceHintRelay::dropped();

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -466,6 +466,16 @@ impl RuntimeInstruments {
         installed.publisher.wal_folds.increment(1);
     }
 
+    pub(crate) fn publisher_wal_folds_waiting(&self, waiting: usize) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed
+            .publisher
+            .wal_folds_waiting
+            .set(i64::try_from(waiting).unwrap_or(i64::MAX));
+    }
+
     pub(crate) fn publisher_wal_fold_duration(&self, elapsed_ms: u64) {
         let Some(installed) = &self.installed else {
             return;
@@ -986,6 +996,7 @@ impl CompactionInstruments {
 struct PublisherInstruments {
     batches: Arc<dyn CounterHandle>,
     wal_folds: Arc<dyn CounterHandle>,
+    wal_folds_waiting: Arc<dyn GaugeHandle>,
     wal_fold_ms: Arc<dyn HistogramHandle>,
     write_stop_refusals: Arc<dyn CounterHandle>,
     batch_size: Arc<dyn HistogramHandle>,
@@ -1008,6 +1019,11 @@ impl PublisherInstruments {
             wal_folds: recorder.register_counter(
                 "loonfs.publisher.wal_folds",
                 "WAL tails folded by namespace publishers",
+                &[],
+            ),
+            wal_folds_waiting: recorder.register_gauge(
+                "loonfs.publisher.wal_folds_waiting",
+                "WAL-tail folds waiting for a writer permit",
                 &[],
             ),
             wal_fold_ms: recorder.register_histogram(
@@ -1412,6 +1428,7 @@ mod tests {
 
         instruments.publisher_batch(4);
         instruments.publisher_wal_fold();
+        instruments.publisher_wal_folds_waiting(1);
         instruments.publisher_wal_fold_duration(5);
         instruments.publisher_write_stop_refusal();
         instruments.publisher_publish(PublishOutcome::Ok);

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1426,7 +1426,6 @@ impl NamespacePublisher {
         match result {
             Ok(_) => {
                 self.read_core.instruments().publisher_wal_fold();
-                writer.notify_after_fold(&self.namespace_id);
             }
             Err(error) => {
                 tracing::info!(
@@ -1436,6 +1435,7 @@ impl NamespacePublisher {
                 );
             }
         }
+        writer.notify_fold_finished(&self.namespace_id);
     }
 
     /// Runs the delete barrier. Returns true when the publisher is now

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -13,8 +13,8 @@ use crate::metrics::{PublishOutcome, RESULT_OK};
 use crate::publish::CommitCandidate;
 use crate::trace::{phase_event, phase_span};
 use crate::{
-    CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, NamespacePublication,
-    NamespaceSessionPolicy, RuntimeCacheConfig, RuntimeError,
+    CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, NamespaceSessionPolicy,
+    RuntimeCacheConfig, RuntimeError,
 };
 use futures::FutureExt;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
@@ -23,8 +23,7 @@ use loonfs_core::cache::Recency;
 use loonfs_core::commit::{CommitFingerprint, CommitHeadPublishError};
 use loonfs_core::limits::{CHECKPOINT_AT_WAL_SEGMENTS, CONTENTION_RETRY_LIMIT};
 use loonfs_core::publish::{
-    NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState, WalFoldSnapshot,
-    WriterSessionState,
+    NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState, WriterSessionState,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::collections::{HashMap, VecDeque};
@@ -1305,9 +1304,7 @@ impl NamespacePublisher {
         }
         let fold_start = if publish.wal_tail_segments >= CHECKPOINT_AT_WAL_SEGMENTS || write_stopped
         {
-            engine
-                .wal_fold_snapshot()
-                .and_then(|snapshot| self.start_fold(snapshot, publish.wal_tail_segments))
+            self.start_fold()
         } else {
             None
         };
@@ -1334,11 +1331,7 @@ impl NamespacePublisher {
         })
     }
 
-    fn start_fold(
-        &self,
-        snapshot: WalFoldSnapshot,
-        wal_tail_segments: u64,
-    ) -> Option<oneshot::Sender<()>> {
+    fn start_fold(&self) -> Option<oneshot::Sender<()>> {
         let mut state = self.lock_state();
         if state
             .fold
@@ -1357,7 +1350,7 @@ impl NamespacePublisher {
             if started.await.is_err() {
                 return;
             }
-            if AssertUnwindSafe(publisher.run_fold(snapshot, wal_tail_segments))
+            if AssertUnwindSafe(publisher.run_fold())
                 .catch_unwind()
                 .await
                 .is_err()
@@ -1373,16 +1366,42 @@ impl NamespacePublisher {
         Some(start)
     }
 
-    async fn run_fold(&self, snapshot: WalFoldSnapshot, wal_tail_segments: u64) {
+    async fn run_fold(&self) {
         let Some(writer) = self.writer.upgrade() else {
             return;
+        };
+        let waiting = writer.wal_folds_waiting.fetch_add(1, Ordering::SeqCst) + 1;
+        self.read_core
+            .instruments()
+            .publisher_wal_folds_waiting(waiting);
+        let _permit = writer
+            .wal_fold_permits
+            .acquire()
+            .await
+            .expect("fold permit semaphore should remain open");
+        let waiting = writer.wal_folds_waiting.fetch_sub(1, Ordering::SeqCst) - 1;
+        self.read_core
+            .instruments()
+            .publisher_wal_folds_waiting(waiting);
+        let snapshot = {
+            let slot = self.engine.lock().await;
+            let snapshot = slot
+                .engine
+                .as_ref()
+                .and_then(NamespaceCommitEngine::wal_fold_snapshot);
+            if snapshot
+                .as_ref()
+                .is_some_and(|snapshot| snapshot.wal_tail_segments < CHECKPOINT_AT_WAL_SEGMENTS)
+            {
+                return;
+            }
+            snapshot
         };
         let context = match writer.identity.mutation_context() {
             Ok(context) => context,
             Err(error) => {
                 tracing::info!(
                     namespace_id = %self.namespace_id,
-                    wal_tail_segments,
                     error = %error,
                     "WAL-tail fold failed"
                 );
@@ -1391,7 +1410,7 @@ impl NamespacePublisher {
         };
         let started_ms = self.timer.monotonic_now_ms();
         let segment_cache = self.read_core.metadata_segment_cache();
-        let result = loonfs_core::fold_wal_tail_snapshot(
+        let result = loonfs_core::fold_wal_tail(
             self.read_core.store(),
             Some(segment_cache.as_ref()),
             &self.namespace_id,
@@ -1407,20 +1426,11 @@ impl NamespacePublisher {
         match result {
             Ok(_) => {
                 self.read_core.instruments().publisher_wal_fold();
-                writer.notify_after_publish(
-                    &self.namespace_id,
-                    &NamespacePublication {
-                        namespace_id: self.namespace_id.clone(),
-                        committed_through_seq: None,
-                        folded: true,
-                        wal_tail_segments: 0,
-                    },
-                );
+                writer.notify_after_fold(&self.namespace_id);
             }
             Err(error) => {
                 tracing::info!(
                     namespace_id = %self.namespace_id,
-                    wal_tail_segments,
                     error = %error.message(),
                     "WAL-tail fold failed"
                 );

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -1960,7 +1960,68 @@ async fn a_fold_reloads_the_tail_when_no_projection_is_retained() {
         )));
         assert!(hints.iter().any(|hint| matches!(
             hint,
-            MaintenanceHint::WalFolded { namespace_id: folded } if folded == &namespace_id
+            MaintenanceHint::WalFoldFinished { namespace_id: folded } if folded == &namespace_id
+        )));
+    }
+    writer.shutdown().await.expect("shut down writer");
+}
+
+#[tokio::test]
+async fn a_failed_fold_notifies_maintenance_when_the_attempt_finishes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let failing = Arc::new(FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::family(DurableObjectFamily::MetadataManifest),
+        OperationClass::Put,
+        InjectedError::PermissionDenied("injected manifest write failure".to_owned()),
+    ));
+    let namespace_id = NamespaceId::parse("failed-fold-hint").expect("valid namespace id");
+    let hints = Arc::new(Mutex::new(Vec::new()));
+    let writer = crate::FsWriter::builder_with_store(failing.clone())
+        .writer_id("writer-a")
+        .maintenance_hint_observer({
+            let hints = Arc::clone(&hints);
+            move |hint| hints.lock().expect("hint log").push(hint)
+        })
+        .build()
+        .await
+        .expect("build writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
+    append_wal_segments(
+        failing.as_ref(),
+        &namespace_id,
+        CHECKPOINT_AT_WAL_SEGMENTS - 1,
+        &MutationContext {
+            writer_id: loonfs_api::WriterId::parse("fold-seed").expect("valid writer id"),
+            now_ms: 1_000,
+        },
+    )
+    .await
+    .expect("seed the WAL tail below the fold threshold");
+
+    failing.fail_next(1);
+    writer
+        .publisher()
+        .submit_candidate(
+            namespace_id.clone(),
+            CommitCandidate::new(create_directory_request("cross-threshold", "docs")),
+        )
+        .await
+        .expect("publish across the fold threshold");
+    writer
+        .wait_for_fold(&namespace_id)
+        .await
+        .expect("settle the failed fold");
+
+    assert_eq!(failing.attempts(), 1);
+    {
+        let hints = hints.lock().expect("hint log");
+        assert!(hints.iter().any(|hint| matches!(
+            hint,
+            MaintenanceHint::WalFoldFinished { namespace_id: folded } if folded == &namespace_id
         )));
     }
     writer.shutdown().await.expect("shut down writer");

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -10,8 +10,8 @@ use crate::fs::WriterIdentity;
 use crate::metrics::{DefaultMetricsRecorder, MetricValue, RuntimeInstruments};
 use crate::publish::{CommitRequest, ContentPreparationError, FilesystemOperation};
 use crate::{
-    CreateNamespaceOptions, ErrorCode, RuntimeCacheConfig, SharedObjectStore as SharedStore,
-    TraceMode, TraceStoreKind,
+    CreateNamespaceOptions, ErrorCode, MaintenanceHint, RuntimeCacheConfig,
+    SharedObjectStore as SharedStore, TraceMode, TraceStoreKind,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -19,12 +19,13 @@ use loonfs_api::wire::wal::decode_wal_segment_envelope_zstd;
 use loonfs_api::{AbsolutePath, ActorId, ActorRef, ChangeSeq, DestinationBehavior};
 use loonfs_core::test_support::append_wal_segments;
 use loonfs_core::MutationContext;
-use loonfs_objectstore::keys::{wal_head, wal_segment_prefix};
+use loonfs_objectstore::keys::{metadata_manifest_prefix, wal_head, wal_segment_prefix};
 use loonfs_objectstore::layout::DurableObjectFamily;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use loonfs_test_support::stores::{
     delegate_object_store, BlockingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+    RecordingStore,
 };
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
@@ -183,6 +184,8 @@ fn test_read_core(store: SharedStore) -> ReadCore {
 fn test_writer_bits() -> Arc<WriterBits> {
     Arc::new(WriterBits {
         identity: WriterIdentity::new("writer-a".to_owned()).expect("valid writer identity"),
+        wal_fold_permits: tokio::sync::Semaphore::new(crate::config::DEFAULT_MAX_CONCURRENT_FOLDS),
+        wal_folds_waiting: AtomicUsize::new(0),
         maintenance_hint_observer: None,
         namespace_advance_observer: None,
     })
@@ -352,6 +355,16 @@ async fn wait_for_queued_candidates(publisher: &NamespacePublisher, expected: us
     while queued_candidates(&publisher_state(publisher)) < expected {
         tokio::task::yield_now().await;
     }
+}
+
+async fn wait_for_fold_waiters(writer: &crate::FsWriter, expected: usize) {
+    timeout(Duration::from_secs(10), async {
+        while writer.bits.wal_folds_waiting.load(Ordering::SeqCst) != expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("fold waiters should reach the expected count");
 }
 
 /// Yields until all expected callers are waiting on one in-flight commit ID.
@@ -1879,6 +1892,265 @@ async fn worker_survives_panic_and_processes_later_queue_items() {
         drain_error.to_string().contains("panicked"),
         "drain reports panicked publisher tasks: {drain_error}"
     );
+}
+
+#[tokio::test]
+async fn a_fold_reloads_the_tail_when_no_projection_is_retained() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("no-projection").expect("valid namespace id");
+    let hints = Arc::new(Mutex::new(Vec::new()));
+    let writer = crate::FsWriter::builder_with_store(store.clone())
+        .writer_id("writer-a")
+        .runtime_cache(RuntimeCacheConfig::disabled())
+        .maintenance_hint_observer({
+            let hints = Arc::clone(&hints);
+            move |hint| hints.lock().expect("hint log").push(hint)
+        })
+        .build()
+        .await
+        .expect("build writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
+    append_wal_segments(
+        store.as_ref(),
+        &namespace_id,
+        CHECKPOINT_AT_WAL_SEGMENTS - 1,
+        &MutationContext {
+            writer_id: loonfs_api::WriterId::parse("fold-seed").expect("valid writer id"),
+            now_ms: 1_000,
+        },
+    )
+    .await
+    .expect("seed the WAL tail below the fold threshold");
+
+    writer
+        .publisher()
+        .submit_candidate(
+            namespace_id.clone(),
+            CommitCandidate::new(create_directory_request("cross-threshold", "docs")),
+        )
+        .await
+        .expect("publish across the fold threshold");
+    writer
+        .wait_for_fold(&namespace_id)
+        .await
+        .expect("fold the uncached tail");
+
+    let status = writer
+        .maintenance_handle("fold-inspection")
+        .expect("maintenance handle")
+        .get_namespace_diagnostics(&namespace_id)
+        .await
+        .expect("inspect the folded namespace");
+    assert!(status.current_manifest_no.is_some(), "{status:?}");
+    assert!(
+        status.wal_tail_segments < CHECKPOINT_AT_WAL_SEGMENTS,
+        "{status:?}"
+    );
+    {
+        let hints = hints.lock().expect("hint log");
+        assert!(hints.iter().any(|hint| matches!(
+            hint,
+            MaintenanceHint::Published(publication)
+                if publication.namespace_id == namespace_id
+                    && publication.wal_tail_segments >= CHECKPOINT_AT_WAL_SEGMENTS
+        )));
+        assert!(hints.iter().any(|hint| matches!(
+            hint,
+            MaintenanceHint::WalFolded { namespace_id: folded } if folded == &namespace_id
+        )));
+    }
+    writer.shutdown().await.expect("shut down writer");
+}
+
+#[tokio::test]
+async fn wal_folds_share_the_writer_concurrency_bound() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespaces = [
+        NamespaceId::parse("fold-a").expect("valid namespace id"),
+        NamespaceId::parse("fold-b").expect("valid namespace id"),
+        NamespaceId::parse("fold-c").expect("valid namespace id"),
+    ];
+    let fold_c = BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespaces[2])),
+        OperationClass::Put,
+    );
+    let fold_b = BlockingStore::new(
+        fold_c,
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespaces[1])),
+        OperationClass::Put,
+    );
+    let blocking = Arc::new(BlockingStore::new(
+        fold_b,
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespaces[0])),
+        OperationClass::Put,
+    ));
+    let writer = crate::FsWriter::builder_with_store(blocking.clone())
+        .writer_id("writer-a")
+        .max_concurrent_folds(NonZeroUsize::new(1).expect("nonzero fold limit"))
+        .build()
+        .await
+        .expect("build writer");
+    for namespace_id in &namespaces {
+        writer
+            .create_namespace(namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("bootstrap");
+        append_wal_segments(
+            blocking.as_ref(),
+            namespace_id,
+            CHECKPOINT_AT_WAL_SEGMENTS - 1,
+            &MutationContext {
+                writer_id: loonfs_api::WriterId::parse("fold-seed").expect("valid writer id"),
+                now_ms: 1_000,
+            },
+        )
+        .await
+        .expect("seed the WAL tail below the fold threshold");
+    }
+    blocking.block_next();
+    blocking.inner().block_next();
+    blocking.inner().inner().block_next();
+
+    for (index, namespace_id) in namespaces.iter().enumerate() {
+        writer
+            .publisher()
+            .submit_candidate(
+                namespace_id.clone(),
+                CommitCandidate::new(create_directory_request(
+                    format!("cross-threshold-{index}"),
+                    "docs",
+                )),
+            )
+            .await
+            .expect("publish across the fold threshold");
+        if index == 0 {
+            blocking.wait_until_blocked().await;
+        } else {
+            wait_for_fold_waiters(&writer, index).await;
+        }
+    }
+    assert_eq!(writer.bits.wal_fold_permits.available_permits(), 0);
+    let closing = tokio::spawn({
+        let writer = writer.clone();
+        let namespace_id = namespaces[2].clone();
+        async move { writer.close_namespace(&namespace_id).await }
+    });
+    while writer.namespace_session_state(&namespaces[2]) != NamespaceSessionState::Closing {
+        tokio::task::yield_now().await;
+    }
+
+    blocking.release();
+    blocking.inner().wait_until_blocked().await;
+    blocking.inner().release();
+    blocking.inner().inner().wait_until_blocked().await;
+    blocking.inner().inner().release();
+    for namespace_id in &namespaces[..2] {
+        writer
+            .wait_for_fold(namespace_id)
+            .await
+            .expect("released fold settles");
+    }
+    timeout(Duration::from_secs(10), closing)
+        .await
+        .expect("namespace close should settle")
+        .expect("join namespace close")
+        .expect("close namespace with a waiting fold");
+    assert_eq!(writer.bits.wal_folds_waiting.load(Ordering::SeqCst), 0);
+    assert_eq!(writer.bits.wal_fold_permits.available_permits(), 1);
+    writer.shutdown().await.expect("shut down writer");
+}
+
+#[tokio::test]
+async fn a_late_fold_does_not_republish_an_already_folded_tail() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_a = NamespaceId::parse("fold-a").expect("valid namespace id");
+    let namespace_b = NamespaceId::parse("fold-b").expect("valid namespace id");
+    let blocked = BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_a)),
+        OperationClass::Put,
+    );
+    let recording = Arc::new(RecordingStore::new(
+        blocked,
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_b)),
+    ));
+    let writer = crate::FsWriter::builder_with_store(recording.clone())
+        .writer_id("writer-a")
+        .max_concurrent_folds(NonZeroUsize::new(1).expect("nonzero fold limit"))
+        .build()
+        .await
+        .expect("build writer");
+    for namespace_id in [&namespace_a, &namespace_b] {
+        writer
+            .create_namespace(namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("bootstrap");
+        append_wal_segments(
+            recording.as_ref(),
+            namespace_id,
+            CHECKPOINT_AT_WAL_SEGMENTS - 1,
+            &MutationContext {
+                writer_id: loonfs_api::WriterId::parse("fold-seed").expect("valid writer id"),
+                now_ms: 1_000,
+            },
+        )
+        .await
+        .expect("seed the WAL tail below the fold threshold");
+    }
+    recording.inner().block_next();
+
+    for (namespace_id, commit_id) in [(&namespace_a, "cross-a"), (&namespace_b, "cross-b")] {
+        writer
+            .publisher()
+            .submit_candidate(
+                namespace_id.clone(),
+                CommitCandidate::new(create_directory_request(commit_id, "docs")),
+            )
+            .await
+            .expect("publish across the fold threshold");
+        if namespace_id == &namespace_a {
+            recording.inner().wait_until_blocked().await;
+        } else {
+            wait_for_fold_waiters(&writer, 1).await;
+        }
+    }
+
+    writer
+        .maintenance_handle("late-fold-maintenance")
+        .expect("maintenance handle")
+        .flush_wal(&namespace_b)
+        .await
+        .expect("fold the waiting namespace tail");
+    assert_eq!(recording.count(OperationClass::Put), 1);
+    writer
+        .publisher()
+        .submit_candidate(
+            namespace_b.clone(),
+            CommitCandidate::new(create_directory_request("after-flush", "after-flush")),
+        )
+        .await
+        .expect("refresh the retained projection below the fold threshold");
+
+    recording.inner().release();
+    writer
+        .wait_for_fold(&namespace_a)
+        .await
+        .expect("first fold settles");
+    writer
+        .wait_for_fold(&namespace_b)
+        .await
+        .expect("late fold settles");
+    assert_eq!(
+        recording.count(OperationClass::Put),
+        1,
+        "the late fold must not write a second manifest"
+    );
+    writer.shutdown().await.expect("shut down writer");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -251,6 +251,10 @@ fn a_writer_maintenance_handle_invalidates_shared_read_caches() {
                 .await
                 .expect("put file");
         }
+        writer
+            .wait_for_fold(&namespace_id)
+            .await
+            .expect("writer fold settles");
         runner.drain().await.expect("maintenance quiesces");
         let status = maintenance
             .get_namespace_diagnostics(&namespace_id)
@@ -464,6 +468,10 @@ fn a_writer_with_a_runner_maintains_what_it_touches() {
                     .await
                     .expect("put file");
             }
+            writer
+                .wait_for_fold(&namespace_id)
+                .await
+                .expect("writer fold settles");
             runner.drain().await.expect("maintenance quiesces");
 
             let status = maintenance

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -493,6 +493,104 @@ fn a_writer_with_a_runner_maintains_what_it_touches() {
 }
 
 #[test]
+fn a_runner_retries_a_failed_writer_fold_without_another_write() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    block_on(async {
+        let failing = Arc::new(FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::family(DurableObjectFamily::MetadataManifest),
+            OperationClass::Put,
+            InjectedError::PermissionDenied("injected manifest write failure".to_owned()),
+        ));
+        let (observer, receiver) =
+            MaintenanceHintRelay::new(NonZeroUsize::new(64).expect("relay capacity is nonzero"));
+        let store: SharedObjectStore = failing.clone();
+        let writer = FsWriter::builder_with_store(store)
+            .writer_id("fold-retry-writer")
+            .maintenance_hint_observer(move |hint| observer(hint))
+            .build()
+            .await
+            .expect("build writer");
+        let maintenance = writer
+            .maintenance_handle("fold-retry-maintenance")
+            .expect("build maintenance handle");
+        let registry = MaintenanceRegistry::new();
+        registry
+            .register(Arc::new(MetadataMaintenanceJob::new(maintenance.clone())))
+            .expect("metadata job");
+        registry
+            .register(Arc::new(MetadataCompactionJob::new(maintenance.clone())))
+            .expect("metadata compaction job");
+        registry
+            .register(Arc::new(GarbageCollectionJob::new(maintenance.clone())))
+            .expect("garbage collection job");
+        let runner = MaintenanceRunner::builder(registry)
+            .build()
+            .expect("build runner");
+        runner.attach_hints(receiver);
+
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        append_wal_segments(
+            failing.as_ref(),
+            &namespace_id,
+            wal_tail_segment_threshold() - 1,
+            &MutationContext {
+                writer_id: loonfs_api::WriterId::parse("fold-retry-seed").expect("writer id"),
+                now_ms: 1_000,
+            },
+        )
+        .await
+        .expect("seed WAL tail below fold threshold");
+
+        failing.fail_next(1);
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/cross-threshold.txt",
+                b"body",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("publish across the fold threshold");
+        writer
+            .wait_for_fold(&namespace_id)
+            .await
+            .expect("writer fold settles");
+        runner.drain().await.expect("maintenance retry quiesces");
+
+        let status = maintenance
+            .get_namespace_diagnostics(&namespace_id)
+            .await
+            .expect("status after maintenance retry");
+        assert!(
+            status.current_manifest_no.is_some(),
+            "the maintenance retry should have published a manifest: {status:?}"
+        );
+        assert!(
+            status.wal_tail_segments < wal_tail_segment_threshold(),
+            "the maintenance retry should have bounded the tail: {status:?}"
+        );
+        assert_eq!(
+            failing.remaining(),
+            0,
+            "the one injected failure should have been consumed"
+        );
+        assert_eq!(
+            failing.attempts(),
+            2,
+            "only the failed writer attempt and successful runner retry should write a manifest"
+        );
+
+        writer.shutdown().await.expect("shut down writer");
+        runner.shutdown().await.expect("shut down runner");
+    });
+}
+
+#[test]
 fn a_runtime_publish_folds_a_preexisting_write_stopped_tail_and_lands() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -30,6 +30,17 @@ fn counter(snapshot: &MetricsSnapshot, name: &str, labels: &[(&str, &str)]) -> u
     }
 }
 
+fn gauge(snapshot: &MetricsSnapshot, name: &str, labels: &[(&str, &str)]) -> i64 {
+    let entry = snapshot
+        .by_name(name)
+        .find(|entry| entry.labels == labels)
+        .unwrap_or_else(|| panic!("no `{name}` registered with labels {labels:?}"));
+    match entry.value {
+        MetricValue::Gauge(value) => value,
+        ref other => panic!("expected a gauge, found {other:?}"),
+    }
+}
+
 fn histogram_count(snapshot: &MetricsSnapshot, name: &str) -> u64 {
     snapshot
         .by_name(name)
@@ -45,8 +56,8 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
     let temp_dir = tempdir().expect("tempdir");
     let recorder = Arc::new(DefaultMetricsRecorder::new());
     let namespace_id = namespace_id("demo");
-    // Enough writes to push the WAL tail past its threshold, which is what
-    // nudges the metadata job and gives the runner a step to settle.
+    // Enough writes to push the WAL tail past its threshold, so the writer
+    // folds it and nudges the metadata job to reorganize.
     let writes = MetadataMaintenanceOptions::default()
         .max_wal_tail_segments
         .get()
@@ -145,6 +156,11 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
         "the threshold-crossing publish records its fold"
     );
     assert_eq!(
+        gauge(&snapshot, "loonfs.publisher.wal_folds_waiting", &[]),
+        0,
+        "the completed fold leaves no waiter"
+    );
+    assert_eq!(
         histogram_count(&snapshot, "loonfs.publisher.wal_fold_ms"),
         1,
         "the completed fold records its duration"
@@ -155,7 +171,7 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
         "the test stays below the write-stop bound"
     );
 
-    // The runner: a write nudges the metadata job, and whatever it
+    // The runner: the fold nudges the metadata job, and whatever it
     // concluded, the step settled under its own job label.
     let metadata_steps: u64 = MetadataConclusions::all()
         .map(|conclusion| {

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -93,12 +93,16 @@ durable state.
 
 | Job | Run | Admission |
 | --- | --- | --- |
-| `metadata` | Flush a due WAL tail and merge one bounded reorganization unit. | After a fold or due WAL publication; reconciliation recovers missed hints. |
-| `metadata-compaction` | Run one streaming metadata compaction under its two-permit limit. | Follow-up from `metadata`. |
+| `metadata` | Flush a due WAL tail found by its own run and merge one bounded reorganization unit. | After a writer fold, reconciliation, or an explicit run. |
+| `metadata-compaction` | Run one streaming metadata compaction under its configured permit limit (two by default). | Follow-up from `metadata`. |
 | `gc` | Perform one bounded mark-and-sweep pass. | At reclamation deadlines. |
 | `grep-index` | Build or reorganize one bounded unit of the grep index. | After publication on hosts configured to maintain the index. |
 | `grep-gc` | Inspect one bounded part of a namespace's grep objects. | Explicit assignment. |
 | retention (*not a job*) | Advance the retention floor. | Explicit request. |
+
+A live writer folds the WAL tails of namespaces it publishes to under one writer-wide concurrency
+bound. The `metadata` job reorganizes after those folds and flushes only a due tail it finds during
+reconciliation or an explicit run; a publication hint does not start a flush.
 
 ### Hosts
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -93,7 +93,7 @@ durable state.
 
 | Job | Run | Admission |
 | --- | --- | --- |
-| `metadata` | Flush a due WAL tail found by its own run and merge one bounded reorganization unit. | After a writer fold, reconciliation, or an explicit run. |
+| `metadata` | Flush a due WAL tail found by its own run and merge one bounded reorganization unit. | When a writer's fold attempt ends, whatever its outcome, and during reconciliation or an explicit run. |
 | `metadata-compaction` | Run one streaming metadata compaction under its configured permit limit (two by default). | Follow-up from `metadata`. |
 | `gc` | Perform one bounded mark-and-sweep pass. | At reclamation deadlines. |
 | `grep-index` | Build or reorganize one bounded unit of the grep index. | After publication on hosts configured to maintain the index. |
@@ -101,8 +101,9 @@ durable state.
 | retention (*not a job*) | Advance the retention floor. | Explicit request. |
 
 A live writer folds the WAL tails of namespaces it publishes to under one writer-wide concurrency
-bound. The `metadata` job reorganizes after those folds and flushes only a due tail it finds during
-reconciliation or an explicit run; a publication hint does not start a flush.
+bound. The `metadata` job runs after each fold attempt ends, whatever its outcome, so it reorganizes
+after a successful fold and retries a failed one. It also flushes a due tail found by reconciliation
+or an explicit run; a publication hint does not start a flush.
 
 ### Hosts
 


### PR DESCRIPTION
Limit each writer to two concurrent background WAL folds by default. A queued fold waits for a permit and reads the current tail only after it can run, so queued work does not retain an extra snapshot. Callers can override the limit.

WAL folding no longer depends on a cached projection. If a projection is unavailable, the fold reloads namespace state from object storage, so reaching the threshold still starts maintenance when runtime caches are disabled or over budget.

The writer sends a dedicated notification after a successful fold. Metadata maintenance uses that notification to reorganize the result instead of racing the writer to flush the same tail. Explicit maintenance can still flush a due tail.

Tests cover uncached tails, the concurrency limit, namespace close while a fold waits, redundant queued folds, and maintenance scheduling.

Review fix, second commit: the fold hint is sent when the writer's attempt ends, success or failure, so the metadata job retries a fold that failed on a quiet namespace instead of waiting for its next write. One runner test proves the retry without another write.
