### PR TITLE
docs: link to the documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,11 @@ loonfs use {namespace_id}
 
 ## Server deployment
 
-See [Self-hosting LoonFS](crates/loonfs-server/docs/self-hosting.md) for the
-complete deployment guide. Applications that submit changes on behalf of
-users should also read the [actor attribution partner guide](crates/loonfs-server/docs/actor-attribution.md).
+See [Self-hosting LoonFS](crates/loonfs-server/docs/self-hosting.md) for the complete deployment guide.
 
 ## Documentation
 
-Visit loonfs.com/docs to learn more.
-
+Visit [loonfs.com/docs](https://loonfs.com/docs) to learn more.
 
 ## Core concepts
 


### PR DESCRIPTION
Remove the actor attribution note and link the README to the documentation site.