### PR TITLE
refactor(core): align maintenance code with project conventions

### DIFF
--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -10,7 +10,7 @@ use crate::config::{
 use crate::error::CliError;
 use crate::profiles::default_namespace;
 use loonfs::{
-    DecodedBlockCacheConfig, FsWriter, GarbageCollectionJob, MaintenanceHintRelay,
+    maintenance_hint_relay, DecodedBlockCacheConfig, FsWriter, GarbageCollectionJob,
     MaintenanceRegistry, MaintenanceRunner, MetadataCompactionJob, MetadataMaintenanceJob,
     SharedObjectStore, TraceStoreKind,
 };
@@ -218,7 +218,7 @@ impl EmbeddedTarget {
         let writer_id = writer_id
             .map(ToOwned::to_owned)
             .unwrap_or_else(default_writer_id);
-        let (observer, receiver) = MaintenanceHintRelay::new(
+        let (observer, receiver) = maintenance_hint_relay(
             std::num::NonZeroUsize::new(1024).expect("relay capacity is nonzero"),
         );
         let writer = FsWriter::builder_with_store(store.clone())

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -20,6 +20,7 @@ use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::stores::{
     BlockingStore, ConcurrencyWatchStore, KeyPredicate, MetadataMapStore, OperationClass,
 };
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
@@ -319,7 +320,10 @@ async fn a_refused_resume_position_restarts_the_collection_pass() {
 fn host_runner(max_concurrent_maintenance: usize) -> (MaintenanceRegistry, MaintenanceRunner) {
     let jobs = MaintenanceRegistry::new();
     let runner = MaintenanceRunner::builder(jobs.clone())
-        .max_concurrent(max_concurrent_maintenance)
+        .max_concurrent(
+            NonZeroUsize::new(max_concurrent_maintenance)
+                .expect("test maintenance concurrency should be nonzero"),
+        )
         .build()
         .expect("build host runner");
     (jobs, runner)

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -13,8 +13,8 @@ use axum::response::Response;
 use axum::Router;
 use loonfs::metrics::{JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder};
 use loonfs::{
-    FsMaintenance, FsReader, FsWriter, GarbageCollectionJob, MaintenanceHandle,
-    MaintenanceHintObserver, MaintenanceHintRelay, MaintenanceJob, MaintenanceProbe,
+    maintenance_hint_relay, FsMaintenance, FsReader, FsWriter, GarbageCollectionJob,
+    MaintenanceHandle, MaintenanceHintObserver, MaintenanceJob, MaintenanceProbe,
     MaintenanceRegistry, MaintenanceRunner, MetadataCompactionJob, MetadataMaintenanceJob,
     SharedObjectStore, StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, TraceMode,
     TraceStoreKind,
@@ -29,6 +29,7 @@ use loonfs_objectstore::{run_store_contract_probe, StoreProbeReport};
 use std::ffi::OsString;
 use std::future::{Future, IntoFuture};
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -265,9 +266,8 @@ pub async fn app(
     let automatic = config.maintenance.runs_automatically();
     let maintains_grep_index = config.grep.mode.maintains_index();
     let (maintenance_hint_observer, maintenance_hint_receiver) = if automatic {
-        let (observer, receiver) = MaintenanceHintRelay::new(
-            std::num::NonZeroUsize::new(4096).expect("relay capacity is nonzero"),
-        );
+        let (observer, receiver) =
+            maintenance_hint_relay(NonZeroUsize::new(4096).expect("relay capacity is nonzero"));
         (Some(observer), Some(receiver))
     } else {
         (None, None)
@@ -339,7 +339,10 @@ pub async fn app(
     };
     let runner = if automatic {
         let runner = MaintenanceRunner::builder(jobs.clone())
-            .max_concurrent(config.max_concurrent_maintenance)
+            .max_concurrent(
+                NonZeroUsize::new(config.max_concurrent_maintenance)
+                    .expect("validated maintenance concurrency should be nonzero"),
+            )
             .metrics_recorder(metrics.recorder())
             .build()
             .map_err(maintenance_config_error)?;

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -21,6 +21,8 @@ pub(crate) const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 15;
 pub const DEFAULT_MAX_OPEN_NAMESPACES: usize = 10_000;
 /// Default maximum WAL-tail folds one writer runs concurrently.
 pub const DEFAULT_MAX_CONCURRENT_FOLDS: usize = 2;
+/// Default maximum streaming metadata compactions one job runs concurrently.
+pub const DEFAULT_MAX_CONCURRENT_COMPACTIONS: usize = 2;
 /// Default cap on concurrently running maintenance invocations.
 /// Each job already runs at most once per namespace at a time; this bounds how many may run at
 /// once, so a write burst across many namespaces cannot fan out into

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -105,7 +105,7 @@ impl WriterBits {
         );
     }
 
-    fn send_maintenance_hint(&self, namespace_id: &NamespaceId, hint: MaintenanceHint) {
+    pub(crate) fn send_maintenance_hint(&self, namespace_id: &NamespaceId, hint: MaintenanceHint) {
         let Some(observer) = &self.maintenance_hint_observer else {
             return;
         };

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -32,18 +32,20 @@ impl FsWriter {
     /// the one failure that would cost something: the pass would find the
     /// session retained, park, and have nothing left to bring it back.
     fn schedule_upload_session_reclamation(&self, namespace_id: &NamespaceId) {
-        let Some(observer) = &self.bits.maintenance_hint_observer else {
+        if self.bits.maintenance_hint_observer.is_none() {
             return;
-        };
+        }
         let Ok(now_ms) = loonfs_core::time::current_time_ms() else {
             return;
         };
-        let hint = MaintenanceHint::DueAt {
-            namespace_id: namespace_id.clone(),
-            job: MaintenanceJobId::GC,
-            not_before_ms: upload_session_reclaim_at_ms(now_ms),
-        };
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| observer(hint)));
+        self.bits.send_maintenance_hint(
+            namespace_id,
+            MaintenanceHint::DueAt {
+                namespace_id: namespace_id.clone(),
+                job: MaintenanceJobId::GC,
+                not_before_ms: upload_session_reclaim_at_ms(now_ms),
+            },
+        );
     }
 
     /// Plants the deadline a completed session's content just created. The
@@ -51,18 +53,20 @@ impl FsWriter {
     /// removes it — so completion schedules its own pass rather than
     /// relying on the one the session's lease already asked for.
     fn schedule_completed_upload_reclamation(&self, namespace_id: &NamespaceId) {
-        let Some(observer) = &self.bits.maintenance_hint_observer else {
+        if self.bits.maintenance_hint_observer.is_none() {
             return;
-        };
+        }
         let Ok(now_ms) = loonfs_core::time::current_time_ms() else {
             return;
         };
-        let hint = MaintenanceHint::DueAt {
-            namespace_id: namespace_id.clone(),
-            job: MaintenanceJobId::GC,
-            not_before_ms: completed_upload_reclaim_at_ms(now_ms),
-        };
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| observer(hint)));
+        self.bits.send_maintenance_hint(
+            namespace_id,
+            MaintenanceHint::DueAt {
+                namespace_id: namespace_id.clone(),
+                job: MaintenanceJobId::GC,
+                not_before_ms: completed_upload_reclaim_at_ms(now_ms),
+            },
+        );
     }
 
     /// Starts a durable upload session for a namespace.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -7,11 +7,11 @@
 //! use std::num::NonZeroUsize;
 //! use std::sync::Arc;
 //! use loonfs::{
-//!     FsWriter, GarbageCollectionJob, MaintenanceHintRelay, MaintenanceRegistry,
+//!     maintenance_hint_relay, FsWriter, GarbageCollectionJob, MaintenanceRegistry,
 //!     MaintenanceRunner, MetadataCompactionJob, MetadataMaintenanceJob,
 //! };
 //!
-//! let (observer, receiver) = MaintenanceHintRelay::new(
+//! let (observer, receiver) = maintenance_hint_relay(
 //!     NonZeroUsize::new(1024).expect("nonzero capacity"),
 //! );
 //! let writer = FsWriter::builder(store_config)
@@ -171,8 +171,8 @@ pub use loonfs_objectstore::{
 
 pub use cache::RuntimeCacheStats;
 pub use config::{
-    RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_FOLDS, DEFAULT_MAX_CONCURRENT_MAINTENANCE,
-    DEFAULT_MAX_OPEN_NAMESPACES,
+    RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_COMPACTIONS, DEFAULT_MAX_CONCURRENT_FOLDS,
+    DEFAULT_MAX_CONCURRENT_MAINTENANCE, DEFAULT_MAX_OPEN_NAMESPACES,
 };
 pub use fs::{
     ChangesPager, CheckpointsPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager,
@@ -183,11 +183,11 @@ pub use handle::{
     NamespaceSessionPolicy,
 };
 pub use maintenance::{
-    GarbageCollectionJob, MaintenanceAssignment, MaintenanceCancellation, MaintenanceConclusion,
-    MaintenanceHandle, MaintenanceHint, MaintenanceHintObserver, MaintenanceHintReceiver,
-    MaintenanceHintRelay, MaintenanceJob, MaintenanceJobId, MaintenanceProbe, MaintenanceRegistry,
-    MaintenanceRunReport, MaintenanceRunner, MaintenanceRunnerBuilder, MaintenanceRunnerStats,
-    MetadataCompactionJob, MetadataMaintenanceJob, NamespacePublication,
+    maintenance_hint_relay, GarbageCollectionJob, MaintenanceAssignment, MaintenanceCancellation,
+    MaintenanceConclusion, MaintenanceHandle, MaintenanceHint, MaintenanceHintObserver,
+    MaintenanceHintReceiver, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,
+    MaintenanceRegistry, MaintenanceRunReport, MaintenanceRunner, MaintenanceRunnerBuilder,
+    MaintenanceRunnerStats, MetadataCompactionJob, MetadataMaintenanceJob, NamespacePublication,
 };
 pub use options::{
     gc_config_from_request, CommitOptions, CopyOptions, CreateCheckpointOptions,

--- a/crates/loonfs/src/maintenance/gc.rs
+++ b/crates/loonfs/src/maintenance/gc.rs
@@ -1,3 +1,5 @@
+//! Garbage-collection scheduling over the runtime maintenance handle.
+
 use super::{
     MaintenanceCancellation, MaintenanceConclusion, MaintenanceJob, MaintenanceJobId,
     MaintenanceProbe, MaintenanceRunReport,
@@ -6,6 +8,7 @@ use crate::{
     ErrorCode, FsMaintenance, GcConfig, GcResponse, MaintenanceRunRequest, MaintenanceRunResponse,
     NamespaceId, Result, RuntimeError,
 };
+use async_trait::async_trait;
 use loonfs_api::GcRequest;
 use loonfs_core::limits::{
     CONTENT_RECLAMATION_GRACE_MS, GC_SAFETY_MARGIN_MS, UPLOAD_SESSION_LEASE_MS,
@@ -36,7 +39,7 @@ impl GarbageCollectionJob {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl MaintenanceJob for GarbageCollectionJob {
     fn id(&self) -> MaintenanceJobId {
         MaintenanceJobId::GC
@@ -66,7 +69,7 @@ impl MaintenanceJob for GarbageCollectionJob {
                 ));
             }
             Err(error) if continuation.is_some() && error.code() == ErrorCode::InvalidRequest => {
-                tracing::info!(
+                tracing::warn!(
                     namespace_id = %namespace_id,
                     error = %error.public_message(),
                     "collection rejected its resume position; restarting the pass"

--- a/crates/loonfs/src/maintenance/hints.rs
+++ b/crates/loonfs/src/maintenance/hints.rs
@@ -1,11 +1,13 @@
+//! Best-effort maintenance hints and their bounded relay.
+
 use super::{MaintenanceJobId, NamespacePublication};
 use crate::NamespaceId;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Best-effort request to consider maintenance work.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MaintenanceHint {
     /// A namespace publication was attempted.
     Published(NamespacePublication),
@@ -30,38 +32,29 @@ pub type MaintenanceHintObserver = Arc<dyn Fn(MaintenanceHint) + Send + Sync + '
 
 static HINTS_DROPPED: AtomicU64 = AtomicU64::new(0);
 
-/// Creates bounded observer and receiver pairs.
-pub struct MaintenanceHintRelay;
-
 /// Receiving side attached to a maintenance runner.
 pub struct MaintenanceHintReceiver {
     pub(crate) receiver: tokio::sync::mpsc::Receiver<MaintenanceHint>,
     pub(crate) dropped_at_creation: u64,
 }
 
-impl MaintenanceHintRelay {
-    /// Creates a relay whose full channel drops new hints.
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(capacity: NonZeroUsize) -> (MaintenanceHintObserver, MaintenanceHintReceiver) {
-        let (sender, receiver) = tokio::sync::mpsc::channel(capacity.get());
-        let observer = Arc::new(move |hint| {
-            if sender.try_send(hint).is_err() {
-                HINTS_DROPPED.fetch_add(1, Ordering::Relaxed);
-            }
-        });
-        (
-            observer,
-            MaintenanceHintReceiver {
-                receiver,
-                dropped_at_creation: HINTS_DROPPED.load(Ordering::Relaxed),
-            },
-        )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn dropped() -> u64 {
-        HINTS_DROPPED.load(Ordering::Relaxed)
-    }
+/// Creates a relay whose full channel drops new hints.
+pub fn maintenance_hint_relay(
+    capacity: NonZeroUsize,
+) -> (MaintenanceHintObserver, MaintenanceHintReceiver) {
+    let (sender, receiver) = tokio::sync::mpsc::channel(capacity.get());
+    let observer = Arc::new(move |hint| {
+        if sender.try_send(hint).is_err() {
+            HINTS_DROPPED.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    (
+        observer,
+        MaintenanceHintReceiver {
+            receiver,
+            dropped_at_creation: HINTS_DROPPED.load(Ordering::Relaxed),
+        },
+    )
 }
 
 pub(crate) fn dropped_hints() -> u64 {

--- a/crates/loonfs/src/maintenance/job.rs
+++ b/crates/loonfs/src/maintenance/job.rs
@@ -1,4 +1,7 @@
+//! Contracts and reports shared by registered maintenance jobs.
+
 use crate::{ChangeSeq, NamespaceId, Result};
+use async_trait::async_trait;
 use std::fmt;
 
 /// Stable identifier for a registered maintenance job.
@@ -133,8 +136,8 @@ impl MaintenanceCancellation {
     }
 }
 
-#[async_trait::async_trait]
 /// One maintenance operation available to a registry.
+#[async_trait]
 pub trait MaintenanceJob: Send + Sync + 'static {
     /// Returns this job's stable identifier.
     fn id(&self) -> MaintenanceJobId;

--- a/crates/loonfs/src/maintenance/metadata.rs
+++ b/crates/loonfs/src/maintenance/metadata.rs
@@ -1,3 +1,5 @@
+//! Bounded metadata maintenance over the runtime maintenance handle.
+
 use super::{
     MaintenanceCancellation, MaintenanceConclusion, MaintenanceJob, MaintenanceJobId,
     MaintenanceProbe, MaintenanceRunReport,
@@ -6,6 +8,7 @@ use crate::{
     ErrorCode, FsMaintenance, MetadataMaintenanceOptions, MetadataMaintenanceResponse, NamespaceId,
     ReorganizeStepOutcome, Result, RuntimeError, WalFlushStepOutcome,
 };
+use async_trait::async_trait;
 
 /// Flushes the WAL tail and runs bounded metadata reorganization.
 pub struct MetadataMaintenanceJob {
@@ -16,19 +19,20 @@ pub struct MetadataMaintenanceJob {
 impl MetadataMaintenanceJob {
     /// Creates a job with default metadata options.
     pub fn new(maintenance: FsMaintenance) -> Self {
-        Self::with_options(maintenance, MetadataMaintenanceOptions::default())
-    }
-
-    /// Creates a job with explicit metadata options.
-    pub fn with_options(maintenance: FsMaintenance, options: MetadataMaintenanceOptions) -> Self {
         Self {
             maintenance,
-            options,
+            options: MetadataMaintenanceOptions::default(),
         }
+    }
+
+    /// Sets the metadata maintenance options.
+    pub fn options(mut self, options: MetadataMaintenanceOptions) -> Self {
+        self.options = options;
+        self
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl MaintenanceJob for MetadataMaintenanceJob {
     fn id(&self) -> MaintenanceJobId {
         MaintenanceJobId::METADATA

--- a/crates/loonfs/src/maintenance/metadata_compaction.rs
+++ b/crates/loonfs/src/maintenance/metadata_compaction.rs
@@ -1,14 +1,15 @@
+//! Streaming metadata compaction under a process-local concurrency limit.
+
 use super::runner::RECONCILE_INTERVAL_MS;
 use super::{
     MaintenanceCancellation, MaintenanceConclusion, MaintenanceJob, MaintenanceJobId,
     MaintenanceProbe, MaintenanceRunReport,
 };
 use crate::{FsMaintenance, MetadataCompactionOutcome, NamespaceId, Result};
+use async_trait::async_trait;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
-
-pub(super) const MAX_CONCURRENT_COMPACTIONS: usize = 2;
 
 /// Runs streaming metadata compaction under a process-local permit limit.
 pub struct MetadataCompactionJob {
@@ -21,7 +22,9 @@ impl MetadataCompactionJob {
     pub fn new(maintenance: FsMaintenance) -> Self {
         Self {
             maintenance,
-            permits: Arc::new(Semaphore::new(MAX_CONCURRENT_COMPACTIONS)),
+            permits: Arc::new(Semaphore::new(
+                crate::config::DEFAULT_MAX_CONCURRENT_COMPACTIONS,
+            )),
         }
     }
 
@@ -32,7 +35,7 @@ impl MetadataCompactionJob {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl MaintenanceJob for MetadataCompactionJob {
     fn id(&self) -> MaintenanceJobId {
         MaintenanceJobId::METADATA_COMPACTION

--- a/crates/loonfs/src/maintenance/mod.rs
+++ b/crates/loonfs/src/maintenance/mod.rs
@@ -1,3 +1,5 @@
+//! Runtime maintenance jobs, hint delivery, registry execution, and optional scheduling.
+
 mod admission;
 mod gc;
 mod hints;
@@ -12,7 +14,7 @@ mod tests;
 pub use gc::GarbageCollectionJob;
 pub(crate) use gc::{completed_upload_reclaim_at_ms, upload_session_reclaim_at_ms};
 pub use hints::{
-    MaintenanceHint, MaintenanceHintObserver, MaintenanceHintReceiver, MaintenanceHintRelay,
+    maintenance_hint_relay, MaintenanceHint, MaintenanceHintObserver, MaintenanceHintReceiver,
 };
 pub use job::{
     MaintenanceCancellation, MaintenanceConclusion, MaintenanceJob, MaintenanceJobId,
@@ -20,17 +22,7 @@ pub use job::{
 };
 pub use metadata::MetadataMaintenanceJob;
 pub use metadata_compaction::MetadataCompactionJob;
-pub use registry::MaintenanceRegistry;
+pub use registry::{MaintenanceAssignment, MaintenanceRegistry};
 pub use runner::{
     MaintenanceHandle, MaintenanceRunner, MaintenanceRunnerBuilder, MaintenanceRunnerStats,
 };
-
-/// One maintenance job assigned to one namespace.
-pub struct MaintenanceAssignment {
-    /// Namespace to maintain.
-    pub namespace_id: crate::NamespaceId,
-    /// Registered job to run.
-    pub job: MaintenanceJobId,
-    /// Process-local resume position.
-    pub continuation: Option<String>,
-}

--- a/crates/loonfs/src/maintenance/registry.rs
+++ b/crates/loonfs/src/maintenance/registry.rs
@@ -1,15 +1,27 @@
+//! Registration and direct execution for maintenance jobs.
+
 use super::{
-    MaintenanceAssignment, MaintenanceCancellation, MaintenanceJob, MaintenanceJobId,
-    MaintenanceProbe, MaintenanceRunReport,
+    MaintenanceCancellation, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,
+    MaintenanceRunReport,
 };
 use crate::{NamespaceId, Result, RuntimeError};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-#[derive(Clone, Default)]
 /// Thread-safe set of maintenance jobs.
+#[derive(Clone, Default)]
 pub struct MaintenanceRegistry {
     jobs: Arc<Mutex<BTreeMap<MaintenanceJobId, Arc<dyn MaintenanceJob>>>>,
+}
+
+/// One maintenance job assigned to one namespace.
+pub struct MaintenanceAssignment {
+    /// Namespace to maintain.
+    pub namespace_id: NamespaceId,
+    /// Registered job to run.
+    pub job: MaintenanceJobId,
+    /// Process-local resume position.
+    pub continuation: Option<String>,
 }
 
 impl MaintenanceRegistry {

--- a/crates/loonfs/src/maintenance/runner.rs
+++ b/crates/loonfs/src/maintenance/runner.rs
@@ -11,6 +11,8 @@ use crate::{NamespaceId, Result, RuntimeError};
 use futures::FutureExt as _;
 use std::fmt;
 use std::future::Future;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 use std::time::Duration;
 use tokio::sync::Notify;
@@ -45,7 +47,7 @@ pub(crate) trait MaintenanceClock: fmt::Debug + Send + Sync {
 #[derive(Debug)]
 pub(crate) struct SystemMaintenanceClock {
     /// Counter behind the backoff jitter, advanced once per draw.
-    jitter: std::sync::atomic::AtomicU64,
+    jitter: AtomicU64,
 }
 
 /// The odd increment SplitMix64 walks its counter by.
@@ -58,7 +60,7 @@ impl Default for SystemMaintenanceClock {
         let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
         hasher.write_u64(JITTER_GAMMA);
         Self {
-            jitter: std::sync::atomic::AtomicU64::new(hasher.finish()),
+            jitter: AtomicU64::new(hasher.finish()),
         }
     }
 }
@@ -76,9 +78,7 @@ impl MaintenanceClock for SystemMaintenanceClock {
         if span_ms == 0 {
             return 0;
         }
-        let counter = self
-            .jitter
-            .fetch_add(JITTER_GAMMA, std::sync::atomic::Ordering::Relaxed);
+        let counter = self.jitter.fetch_add(JITTER_GAMMA, Ordering::Relaxed);
         split_mix_64(counter) % span_ms
     }
 }
@@ -188,7 +188,7 @@ pub struct MaintenanceRunner {
 /// Builder for [`MaintenanceRunner`].
 pub struct MaintenanceRunnerBuilder {
     registry: MaintenanceRegistry,
-    max_concurrent: usize,
+    max_concurrent: NonZeroUsize,
     metrics_recorder: Option<Arc<dyn MetricsRecorder>>,
     #[cfg(test)]
     clock: Option<Arc<dyn MaintenanceClock>>,
@@ -214,16 +214,14 @@ pub struct MaintenanceRunnerStats {
 #[derive(Debug, Default)]
 struct RunnerCounters {
     /// Steps that failed and were scheduled for a backoff retry.
-    backoff_scheduled: std::sync::atomic::AtomicU64,
+    backoff_scheduled: AtomicU64,
     /// Timer wakes that found at least one not-before deadline arrived.
-    not_before_wakes: std::sync::atomic::AtomicU64,
+    not_before_wakes: AtomicU64,
 }
 
 impl RunnerCounters {
-    fn bump(counter: &std::sync::atomic::AtomicU64) -> u64 {
-        counter
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            .saturating_add(1)
+    fn bump(counter: &AtomicU64) -> u64 {
+        counter.fetch_add(1, Ordering::Relaxed).saturating_add(1)
     }
 }
 
@@ -241,7 +239,7 @@ pub(crate) struct RunnerInner {
     counters: RunnerCounters,
     /// Tasks a later spawn reaped after they panicked. Their join handles no
     /// longer reach [`MaintenanceRunner::drain`], so the count does.
-    panicked_tasks: std::sync::atomic::AtomicUsize,
+    panicked_tasks: AtomicUsize,
     /// Where settled steps report. The two [`RunnerCounters`] above stay
     /// where they are: they answer "is this happening at all", which a
     /// number on an existing trace answers for a reader with no metrics
@@ -267,7 +265,8 @@ impl MaintenanceRunner {
     pub fn builder(registry: MaintenanceRegistry) -> MaintenanceRunnerBuilder {
         MaintenanceRunnerBuilder {
             registry,
-            max_concurrent: crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+            max_concurrent: NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE)
+                .expect("default maintenance concurrency should be nonzero"),
             metrics_recorder: None,
             #[cfg(test)]
             clock: None,
@@ -298,7 +297,7 @@ impl MaintenanceRunner {
                 clock,
                 wake: Arc::new(Notify::new()),
                 counters: RunnerCounters::default(),
-                panicked_tasks: std::sync::atomic::AtomicUsize::new(0),
+                panicked_tasks: AtomicUsize::new(0),
                 instruments: MaintenanceInstruments::new(metrics_recorder),
             }),
         }
@@ -385,10 +384,7 @@ impl MaintenanceRunner {
                 }
             }
         }
-        panicked += self
-            .inner
-            .panicked_tasks
-            .load(std::sync::atomic::Ordering::SeqCst);
+        panicked += self.inner.panicked_tasks.load(Ordering::SeqCst);
         if panicked > 0 {
             return Err(RuntimeError::RuntimeTask(format!(
                 "{panicked} background maintenance task(s) panicked"
@@ -507,7 +503,7 @@ impl MaintenanceRunner {
 
 impl MaintenanceRunnerBuilder {
     /// Sets the shared invocation permit count.
-    pub fn max_concurrent(mut self, permits: usize) -> Self {
+    pub fn max_concurrent(mut self, permits: NonZeroUsize) -> Self {
         self.max_concurrent = permits;
         self
     }
@@ -526,11 +522,6 @@ impl MaintenanceRunnerBuilder {
 
     /// Builds the runner on the current Tokio runtime.
     pub fn build(self) -> Result<MaintenanceRunner> {
-        if self.max_concurrent == 0 {
-            return Err(RuntimeError::Config(
-                "`max_concurrent` must be greater than zero".to_owned(),
-            ));
-        }
         let runtime = tokio::runtime::Handle::try_current().map_err(|_| {
             RuntimeError::Config(
                 "maintenance runner must be built inside a Tokio runtime".to_owned(),
@@ -545,7 +536,7 @@ impl MaintenanceRunnerBuilder {
         Ok(MaintenanceRunner::new(
             self.registry,
             runtime,
-            self.max_concurrent,
+            self.max_concurrent.get(),
             clock,
             self.metrics_recorder,
         ))
@@ -584,8 +575,7 @@ impl RunnerInner {
                 .now_or_never()
                 .is_some_and(|outcome| outcome.is_err_and(|error| error.is_panic()))
             {
-                self.panicked_tasks
-                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                self.panicked_tasks.fetch_add(1, Ordering::SeqCst);
             }
             false
         });
@@ -736,7 +726,7 @@ fn report_compactions(state: &RunnerState, instruments: &MaintenanceInstruments)
         .keys()
         .filter(|key| key.job == MaintenanceJobId::METADATA_COMPACTION)
         .count();
-    let running = active.min(super::metadata_compaction::MAX_CONCURRENT_COMPACTIONS);
+    let running = active.min(crate::config::DEFAULT_MAX_CONCURRENT_COMPACTIONS);
     instruments.compactions(running, active.saturating_sub(running));
 }
 

--- a/crates/loonfs/src/maintenance/tests.rs
+++ b/crates/loonfs/src/maintenance/tests.rs
@@ -7,6 +7,7 @@
 
 use super::runner::{MaintenanceClock, SystemMaintenanceClock};
 use super::*;
+use crate::maintenance::hints::dropped_hints;
 use crate::{ChangeSeq, NamespaceId, Result, RuntimeError};
 use loonfs_test_support::ids::{namespace_id, nonzero_usize};
 use std::collections::VecDeque;
@@ -298,7 +299,7 @@ fn runner_with(
     let registry = MaintenanceRegistry::new();
     registry.register(job).expect("register the test job");
     let runner = MaintenanceRunner::builder(registry)
-        .max_concurrent(nonzero_usize(1).get())
+        .max_concurrent(nonzero_usize(1))
         .clock(clock)
         .build()
         .expect("build the runner");
@@ -875,7 +876,7 @@ async fn wal_fold_finished_hints_coalesce_and_follow_ups_admit_once() {
         .register(compaction.clone())
         .expect("compaction job");
     let runner = MaintenanceRunner::builder(registry)
-        .max_concurrent(2)
+        .max_concurrent(nonzero_usize(2))
         .build()
         .expect("runner");
     let namespace_id = namespace_id("hints");
@@ -936,18 +937,18 @@ async fn reconciliation_recovers_a_hint_dropped_before_attachment() {
     let runner = MaintenanceRunner::builder(registry)
         .build()
         .expect("runner");
-    let (observer, receiver) = MaintenanceHintRelay::new(NonZeroUsize::new(1).expect("nonzero"));
+    let (observer, receiver) = maintenance_hint_relay(NonZeroUsize::new(1).expect("nonzero"));
     let namespace_id = namespace_id("dropped");
     let hint = MaintenanceHint::Published(NamespacePublication {
         namespace_id: namespace_id.clone(),
         committed_through_seq: Some(ChangeSeq(1)),
         wal_tail_segments: 0,
     });
-    let dropped_before = MaintenanceHintRelay::dropped();
+    let dropped_before = dropped_hints();
 
     observer(hint.clone());
     observer(hint);
-    assert_eq!(MaintenanceHintRelay::dropped(), dropped_before + 1);
+    assert_eq!(dropped_hints(), dropped_before + 1);
 
     runner.attach_hints(receiver);
     wait_for(

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -15,11 +15,8 @@ use crate::{GcResponse, MaintenanceConclusion, MaintenanceJobId, MetadataCompact
 use loonfs_core::cache::{DecodedBlockCacheObserver, DecodedBlockWeight};
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
-
-const WAL_FOLD_MS_BOUNDARIES: &[f64] = &[
-    1.0, 3.0, 10.0, 30.0, 100.0, 300.0, 1_000.0, 3_000.0, 10_000.0, 30_000.0, 60_000.0, 120_000.0,
-];
 
 trait MetricLabel: Copy + PartialEq + 'static {
     const VALUES: &'static [Self];
@@ -169,7 +166,7 @@ const GC_CATEGORIES: [GcCategory; 10] = [
 /// Instruments owned by one maintenance runner.
 pub(crate) struct MaintenanceInstruments {
     installed: Option<InstalledMaintenance>,
-    observed_hints_dropped: std::sync::atomic::AtomicU64,
+    observed_hints_dropped: AtomicU64,
 }
 
 struct InstalledMaintenance {
@@ -208,7 +205,7 @@ impl MaintenanceInstruments {
                 ),
                 recorder,
             }),
-            observed_hints_dropped: std::sync::atomic::AtomicU64::new(0),
+            observed_hints_dropped: AtomicU64::new(0),
         })
     }
 
@@ -267,9 +264,7 @@ impl MaintenanceInstruments {
     }
 
     pub(crate) fn hints_dropped(&self, total: u64) {
-        let previous = self
-            .observed_hints_dropped
-            .swap(total, std::sync::atomic::Ordering::Relaxed);
+        let previous = self.observed_hints_dropped.swap(total, Ordering::Relaxed);
         if let Some(installed) = &self.installed {
             installed
                 .hints_dropped
@@ -480,7 +475,10 @@ impl RuntimeInstruments {
         let Some(installed) = &self.installed else {
             return;
         };
-        installed.publisher.wal_fold_ms.record(elapsed_ms as f64);
+        installed
+            .publisher
+            .wal_fold_seconds
+            .record(seconds_from_ms(elapsed_ms));
     }
 
     pub(crate) fn publisher_write_stop_refusal(&self) {
@@ -997,7 +995,7 @@ struct PublisherInstruments {
     batches: Arc<dyn CounterHandle>,
     wal_folds: Arc<dyn CounterHandle>,
     wal_folds_waiting: Arc<dyn GaugeHandle>,
-    wal_fold_ms: Arc<dyn HistogramHandle>,
+    wal_fold_seconds: Arc<dyn HistogramHandle>,
     write_stop_refusals: Arc<dyn CounterHandle>,
     batch_size: Arc<dyn HistogramHandle>,
     queue_depth: Arc<dyn GaugeHandle>,
@@ -1026,11 +1024,11 @@ impl PublisherInstruments {
                 "WAL-tail folds waiting for a writer permit",
                 &[],
             ),
-            wal_fold_ms: recorder.register_histogram(
-                "loonfs.publisher.wal_fold_ms",
-                "Duration of a WAL-tail fold in milliseconds",
+            wal_fold_seconds: recorder.register_histogram(
+                "loonfs.publisher.wal_fold_seconds",
+                "Duration of a WAL-tail fold in seconds",
                 &[],
-                WAL_FOLD_MS_BOUNDARIES,
+                LATENCY_SECONDS_BOUNDARIES,
             ),
             write_stop_refusals: recorder.register_counter(
                 "loonfs.publisher.write_stop_refusals",

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -690,9 +690,12 @@ async fn finish_namespace_close(
     let fenced = match AssertUnwindSafe(async {
         publisher.wait_for_worker().await;
         if let Err(error) = publisher.wait_for_fold().await {
-            tracing::info!(
-                namespace_id = %publisher.namespace_id,
-                error = %error,
+            phase_event!(
+                publisher.read_core,
+                "wal_fold",
+                publisher.namespace_id,
+                tracing::Level::WARN,
+                error = %error.public_message(),
                 "wal fold failed while the namespace session closed"
             );
         }
@@ -820,6 +823,34 @@ struct FoldExit(watch::Sender<bool>);
 impl Drop for FoldExit {
     fn drop(&mut self) {
         let _ = self.0.send(true);
+    }
+}
+
+/// A fold counted as waiting for a writer permit.
+struct WaitingFold<'a> {
+    counter: &'a AtomicUsize,
+    instruments: &'a crate::metrics::RuntimeInstruments,
+}
+
+impl<'a> WaitingFold<'a> {
+    fn new(counter: &'a AtomicUsize, instruments: &'a crate::metrics::RuntimeInstruments) -> Self {
+        let waiting_fold = Self {
+            counter,
+            instruments,
+        };
+        let waiting = counter.fetch_add(1, Ordering::SeqCst).saturating_add(1);
+        instruments.publisher_wal_folds_waiting(waiting);
+        waiting_fold
+    }
+}
+
+impl Drop for WaitingFold<'_> {
+    fn drop(&mut self) {
+        let waiting = self
+            .counter
+            .fetch_sub(1, Ordering::SeqCst)
+            .saturating_sub(1);
+        self.instruments.publisher_wal_folds_waiting(waiting);
     }
 }
 
@@ -1331,6 +1362,9 @@ impl NamespacePublisher {
         })
     }
 
+    /// Starts a fold task after its triggering publication releases the engine.
+    /// A panicked fold is retried by the next publish over the threshold. The
+    /// drain reports the contained panic.
     fn start_fold(&self) -> Option<oneshot::Sender<()>> {
         let mut state = self.lock_state();
         if state
@@ -1370,19 +1404,13 @@ impl NamespacePublisher {
         let Some(writer) = self.writer.upgrade() else {
             return;
         };
-        let waiting = writer.wal_folds_waiting.fetch_add(1, Ordering::SeqCst) + 1;
-        self.read_core
-            .instruments()
-            .publisher_wal_folds_waiting(waiting);
+        let waiting = WaitingFold::new(&writer.wal_folds_waiting, self.read_core.instruments());
         let _permit = writer
             .wal_fold_permits
             .acquire()
             .await
             .expect("fold permit semaphore should remain open");
-        let waiting = writer.wal_folds_waiting.fetch_sub(1, Ordering::SeqCst) - 1;
-        self.read_core
-            .instruments()
-            .publisher_wal_folds_waiting(waiting);
+        drop(waiting);
         let snapshot = {
             let slot = self.engine.lock().await;
             let snapshot = slot
@@ -1400,9 +1428,12 @@ impl NamespacePublisher {
         let context = match writer.identity.mutation_context() {
             Ok(context) => context,
             Err(error) => {
-                tracing::info!(
-                    namespace_id = %self.namespace_id,
-                    error = %error,
+                phase_event!(
+                    self.read_core,
+                    "wal_fold",
+                    self.namespace_id,
+                    tracing::Level::WARN,
+                    error = %error.public_message(),
                     "WAL-tail fold failed"
                 );
                 return;
@@ -1428,9 +1459,13 @@ impl NamespacePublisher {
                 self.read_core.instruments().publisher_wal_fold();
             }
             Err(error) => {
-                tracing::info!(
-                    namespace_id = %self.namespace_id,
-                    error = %error.message(),
+                let error = RuntimeError::Core(error);
+                phase_event!(
+                    self.read_core,
+                    "wal_fold",
+                    self.namespace_id,
+                    tracing::Level::WARN,
+                    error = %error.public_message(),
                     "WAL-tail fold failed"
                 );
             }
@@ -1464,9 +1499,12 @@ impl NamespacePublisher {
                     take_queued_waiters(&mut state)
                 };
                 if let Err(error) = self.wait_for_fold().await {
-                    tracing::info!(
-                        namespace_id = %self.namespace_id,
-                        error = %error,
+                    phase_event!(
+                        self.read_core,
+                        "wal_fold",
+                        self.namespace_id,
+                        tracing::Level::WARN,
+                        error = %error.public_message(),
                         "wal fold failed while the namespace was deleted"
                     );
                 }

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -38,6 +38,24 @@ pub(crate) fn store(root: &Path) -> SharedObjectStore {
     Arc::new(LocalFsStore::new(root).expect("create local-fs store"))
 }
 
+pub(crate) async fn writer(store: SharedObjectStore, writer_id: &str) -> FsWriter {
+    FsWriter::builder_with_store(store)
+        .writer_id(writer_id)
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+pub(crate) fn directory_options() -> CreateDirectoryOptions {
+    CreateDirectoryOptions::new(loonfs_test_support::test_actor())
+}
+
+pub(crate) fn expect_code<T: std::fmt::Debug>(result: loonfs::Result<T>, code: ErrorCode) {
+    let error = result.expect_err("operation must fail");
+    assert_eq!(error.code(), code, "unexpected error: {error:?}");
+}
+
 pub(crate) async fn collect_path_entries(
     reader: &FsReader,
     namespace_id: &NamespaceId,

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -8,10 +8,11 @@
 
 use crate::common::collect_path_entries;
 use loonfs::{
-    CommitId, CreateCheckpointOptions, CreateNamespaceOptions, ErrorCode, FsMaintenance, FsReader,
-    FsWriter, GarbageCollectionJob, MaintenanceHintRelay, MaintenanceRegistry, MaintenanceRunner,
-    ManifestNo, MetadataCompactionJob, MetadataMaintenanceJob, MetadataMaintenanceOptions,
-    NamespaceId, PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig,
+    maintenance_hint_relay, CommitId, CreateCheckpointOptions, CreateNamespaceOptions, ErrorCode,
+    FsMaintenance, FsReader, FsWriter, GarbageCollectionJob, MaintenanceRegistry,
+    MaintenanceRunner, ManifestNo, MetadataCompactionJob, MetadataMaintenanceJob,
+    MetadataMaintenanceOptions, NamespaceId, PutFileOptions, RuntimeCacheConfig, RuntimeError,
+    SharedObjectStore, StoreConfig,
 };
 use loonfs_core::test_support::append_wal_segments;
 use loonfs_core::MutationContext;
@@ -64,7 +65,7 @@ async fn writer_with_runner(
     runtime_cache: RuntimeCacheConfig,
 ) -> (FsWriter, FsMaintenance, MaintenanceRunner) {
     let (observer, receiver) =
-        MaintenanceHintRelay::new(NonZeroUsize::new(64).expect("relay capacity is nonzero"));
+        maintenance_hint_relay(NonZeroUsize::new(64).expect("relay capacity is nonzero"));
     let writer = FsWriter::builder(store_config(root))
         .writer_id("handle-test-writer")
         .runtime_cache(runtime_cache)
@@ -504,7 +505,7 @@ fn a_runner_retries_a_failed_writer_fold_without_another_write() {
             InjectedError::PermissionDenied("injected manifest write failure".to_owned()),
         ));
         let (observer, receiver) =
-            MaintenanceHintRelay::new(NonZeroUsize::new(64).expect("relay capacity is nonzero"));
+            maintenance_hint_relay(NonZeroUsize::new(64).expect("relay capacity is nonzero"));
         let store: SharedObjectStore = failing.clone();
         let writer = FsWriter::builder_with_store(store)
             .writer_id("fold-retry-writer")
@@ -923,12 +924,6 @@ fn builders_require_identity_and_a_runtime() {
 
     let outside_runtime = MaintenanceRunner::builder(MaintenanceRegistry::new()).build();
     assert!(matches!(outside_runtime, Err(RuntimeError::Config(_))));
-    block_on(async {
-        let zero = MaintenanceRunner::builder(MaintenanceRegistry::new())
-            .max_concurrent(0)
-            .build();
-        assert!(matches!(zero, Err(RuntimeError::Config(_))));
-    });
 }
 
 #[test]

--- a/crates/loonfs/tests/it/handoff.rs
+++ b/crates/loonfs/tests/it/handoff.rs
@@ -2,11 +2,11 @@
 
 #![allow(clippy::panic)]
 
-use crate::common::collect_path_entries;
+use crate::common::{collect_path_entries, directory_options, expect_code, writer};
 use loonfs::{
-    CreateDirectoryOptions, CreateNamespaceOptions, ErrorCode, FsMaintenance, FsReader, FsWriter,
-    MaintenanceRunRequest, MaintenanceRunResponse, ManifestNo, MetadataMaintenanceOptions,
-    NamespaceId, NamespaceSessionPolicy, NamespaceSessionState, PutFileOptions, SharedObjectStore,
+    CreateNamespaceOptions, ErrorCode, FsMaintenance, FsReader, FsWriter, MaintenanceRunRequest,
+    MaintenanceRunResponse, ManifestNo, MetadataMaintenanceOptions, NamespaceId,
+    NamespaceSessionPolicy, NamespaceSessionState, PutFileOptions, SharedObjectStore,
     WalFlushStepOutcome, GC_MIN_GRACE_WINDOW_MS,
 };
 use loonfs_api::{GcRequest, WriterId};
@@ -22,15 +22,6 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use tempfile::tempdir;
 
-async fn writer(store: SharedObjectStore, writer_id: &str) -> FsWriter {
-    FsWriter::builder_with_store(store)
-        .writer_id(writer_id)
-        .min_publish_interval_ms(0)
-        .build()
-        .await
-        .expect("build writer")
-}
-
 async fn explicit_writer(store: SharedObjectStore, writer_id: &str) -> FsWriter {
     FsWriter::builder_with_store(store)
         .writer_id(writer_id)
@@ -41,17 +32,8 @@ async fn explicit_writer(store: SharedObjectStore, writer_id: &str) -> FsWriter 
         .expect("build explicit writer")
 }
 
-fn directory_options() -> CreateDirectoryOptions {
-    CreateDirectoryOptions::new(loonfs_test_support::test_actor())
-}
-
 fn file_options() -> PutFileOptions {
     PutFileOptions::new(loonfs_test_support::test_actor())
-}
-
-fn expect_code<T: std::fmt::Debug>(result: loonfs::Result<T>, code: ErrorCode) {
-    let error = result.expect_err("operation must fail");
-    assert_eq!(error.code(), code, "unexpected error: {error:?}");
 }
 
 async fn fresh_reader(store: SharedObjectStore) -> FsReader {

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -8,8 +8,8 @@
 use crate::common::*;
 use loonfs::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};
 use loonfs::{
-    CreateCheckpointOptions, CreateNamespaceOptions, CreateSnapshotOptions, GarbageCollectionJob,
-    MaintenanceConclusion, MaintenanceHintRelay, MaintenanceJobId, MaintenanceRegistry,
+    maintenance_hint_relay, CreateCheckpointOptions, CreateNamespaceOptions, CreateSnapshotOptions,
+    GarbageCollectionJob, MaintenanceConclusion, MaintenanceJobId, MaintenanceRegistry,
     MaintenanceRunner, MetadataCompactionJob, MetadataMaintenanceJob, MetadataMaintenanceOptions,
     PutFileOptions,
 };
@@ -64,7 +64,7 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
         + 1;
     let snapshot = block_on(async {
         let (observer, receiver) =
-            MaintenanceHintRelay::new(NonZeroUsize::new(64).expect("relay capacity is nonzero"));
+            maintenance_hint_relay(NonZeroUsize::new(64).expect("relay capacity is nonzero"));
         let fs = open_runtime_with_async(store(temp_dir.path()), "metrics-writer", |builder| {
             builder
                 .maintenance_hint_observer(move |hint| observer(hint))
@@ -161,7 +161,7 @@ fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
         "the completed fold leaves no waiter"
     );
     assert_eq!(
-        histogram_count(&snapshot, "loonfs.publisher.wal_fold_ms"),
+        histogram_count(&snapshot, "loonfs.publisher.wal_fold_seconds"),
         1,
         "the completed fold records its duration"
     );

--- a/crates/loonfs/tests/it/namespace_advance_observer.rs
+++ b/crates/loonfs/tests/it/namespace_advance_observer.rs
@@ -4,8 +4,8 @@
 // The panicking observer under test is written as a `panic!` closure.
 
 use loonfs::{
-    CreateNamespaceOptions, FsWriter, MaintenanceCancellation, MaintenanceConclusion,
-    MaintenanceHintRelay, MaintenanceJob, MaintenanceJobId, MaintenanceProbe, MaintenanceRegistry,
+    maintenance_hint_relay, CreateNamespaceOptions, FsWriter, MaintenanceCancellation,
+    MaintenanceConclusion, MaintenanceJob, MaintenanceJobId, MaintenanceProbe, MaintenanceRegistry,
     MaintenanceRunReport, MaintenanceRunner, NamespaceAdvanceHint, NamespacePublication,
     PutFileOptions, Result, SharedObjectStore,
 };
@@ -112,7 +112,7 @@ async fn an_observer_panic_leaves_the_commit_the_publisher_and_maintenance_intac
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let (observer, receiver) =
-        MaintenanceHintRelay::new(NonZeroUsize::new(16).expect("relay capacity is nonzero"));
+        maintenance_hint_relay(NonZeroUsize::new(16).expect("relay capacity is nonzero"));
     let writer = FsWriter::builder_with_store(store)
         .writer_id("observer-panic-writer")
         .min_publish_interval_ms(0)

--- a/crates/loonfs/tests/it/namespace_sessions.rs
+++ b/crates/loonfs/tests/it/namespace_sessions.rs
@@ -2,28 +2,16 @@
 
 #![allow(clippy::panic)]
 
+use crate::common::{directory_options, expect_code, writer};
 use loonfs::{
-    CreateDirectoryOptions, CreateNamespaceOptions, ErrorCode, FsWriter, NamespaceId,
-    NamespaceSessionPolicy, NamespaceSessionState, SharedObjectStore,
+    CreateNamespaceOptions, ErrorCode, FsWriter, NamespaceId, NamespaceSessionPolicy,
+    NamespaceSessionState, SharedObjectStore,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Barrier};
 use tempfile::tempdir;
-
-async fn writer(store: SharedObjectStore, writer_id: &str) -> FsWriter {
-    FsWriter::builder_with_store(store)
-        .writer_id(writer_id)
-        .min_publish_interval_ms(0)
-        .build()
-        .await
-        .expect("build writer")
-}
-
-fn directory_options() -> CreateDirectoryOptions {
-    CreateDirectoryOptions::new(loonfs_test_support::test_actor())
-}
 
 async fn create_namespace(writer: &FsWriter, namespace_id: &NamespaceId) {
     writer
@@ -39,11 +27,6 @@ async fn writer_epoch(store: &SharedObjectStore, namespace_id: &NamespaceId) -> 
         .state
         .writer_epoch
         .0
-}
-
-fn expect_code<T: std::fmt::Debug>(result: loonfs::Result<T>, code: ErrorCode) {
-    let error = result.expect_err("operation must fail");
-    assert_eq!(error.code(), code, "unexpected error: {error:?}");
 }
 
 #[tokio::test]

--- a/crates/loonfs/tests/it/standalone_maintenance.rs
+++ b/crates/loonfs/tests/it/standalone_maintenance.rs
@@ -1,3 +1,5 @@
+//! Standalone execution of every core maintenance job through a registry.
+
 use loonfs::{
     CreateNamespaceOptions, FsMaintenance, FsWriter, GarbageCollectionJob, MaintenanceAssignment,
     MaintenanceJobId, MaintenanceRegistry, MetadataCompactionJob, MetadataMaintenanceJob,


### PR DESCRIPTION
Aligns the maintenance code with existing project conventions. This moves MaintenanceAssignment into the registry module, standardizes builder methods and constants, uses seconds for the WAL fold histogram, and replaces the MaintenanceHintRelay type with a helper function.

It also fixes two failure paths. A drop guard now decrements the waiting-fold gauge if a fold task exits early, and upload cleanup hints now use the shared panic-safe sender.

Verified with rustfmt, clippy, and the loonfs, grep, server, and CLI test suites.