### PR TITLE
fix(storage): verify manifest references and enforce strict durable decoding

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -301,10 +301,8 @@ pub struct CheckpointRecordState {
 
 /// Links one accepted WAL segment identity to its verified sequence range.
 ///
-/// Pointers in immutable WAL segments accept unknown fields. The mutable head
-/// uses a strict decoder for the same shape so a rewrite cannot discard data.
-/// Both decoders reject a pointer whose `segment_id` does not encode its
-/// `start_seq`.
+/// Every stored pointer rejects unknown fields and verifies that its
+/// `segment_id` encodes `start_seq`.
 ///
 /// See [WAL segment rules](../../../docs/specs/format.md#15-wal-segment-rules).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -329,6 +327,7 @@ impl<'de> Deserialize<'de> for WalSegmentPointer {
     {
         /// Stored fields before validating the segment position.
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct StoredWalSegmentPointer {
             segment_id: WalSegmentId,
             start_seq: ChangeSeq,
@@ -361,27 +360,6 @@ pub(crate) fn validate_wal_segment_start_seq(
     ))
 }
 
-/// Strict WAL pointer shape used only while decoding the mutable head.
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct StrictWalSegmentPointer {
-    segment_id: WalSegmentId,
-    start_seq: ChangeSeq,
-    end_seq: ChangeSeq,
-    payload_checksum: String,
-}
-
-impl From<StrictWalSegmentPointer> for WalSegmentPointer {
-    fn from(pointer: StrictWalSegmentPointer) -> Self {
-        Self {
-            segment_id: pointer.segment_id,
-            start_seq: pointer.start_seq,
-            end_seq: pointer.end_seq,
-            payload_checksum: pointer.payload_checksum,
-        }
-    }
-}
-
 /// Applies the shared position check after strict decoding.
 fn validated_wal_segment_pointer<E>(pointer: WalSegmentPointer) -> Result<WalSegmentPointer, E>
 where
@@ -391,33 +369,18 @@ where
     Ok(pointer)
 }
 
-/// Decodes the head's visible WAL tip without accepting unknown fields.
-fn strict_wal_segment_pointer<'de, D>(
-    deserializer: D,
-) -> Result<Option<WalSegmentPointer>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Option::<StrictWalSegmentPointer>::deserialize(deserializer)?
-        .map(|pointer| validated_wal_segment_pointer(pointer.into()))
-        .transpose()
-}
-
 /// Decodes the head's predecessor hints without accepting unknown fields.
-fn strict_wal_segment_pointers<'de, D>(deserializer: D) -> Result<Vec<WalSegmentPointer>, D::Error>
+fn deserialize_recent_segments<'de, D>(deserializer: D) -> Result<Vec<WalSegmentPointer>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let pointers = Vec::<StrictWalSegmentPointer>::deserialize(deserializer)?;
+    let pointers = Vec::<WalSegmentPointer>::deserialize(deserializer)?;
     if pointers.len() > RECENT_SEGMENTS_LIMIT {
         return Err(serde::de::Error::custom(format_args!(
             "head `recent_segments` exceeds {RECENT_SEGMENTS_LIMIT} entries"
         )));
     }
-    pointers
-        .into_iter()
-        .map(|pointer| validated_wal_segment_pointer(pointer.into()))
-        .collect()
+    Ok(pointers)
 }
 
 /// Who most recently acquired the writer epoch, and when.
@@ -526,11 +489,7 @@ pub struct HeadState {
     /// First namespace-scoped inode identity available for allocation.
     pub next_inode_id: InodeId,
     /// Accepted tip of the visible WAL chain, or `None` before the first commit.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "strict_wal_segment_pointer"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub visible_wal_tip: Option<WalSegmentPointer>,
     /// Bounded newest-first predecessor accelerator below `visible_wal_tip`.
     /// Chain links remain the only history authority — any disagreement
@@ -538,7 +497,7 @@ pub struct HeadState {
     /// from GC.
     /// An empty list is written as `[]`. A head that omits the field fails
     /// to decode.
-    #[serde(deserialize_with = "strict_wal_segment_pointers")]
+    #[serde(deserialize_with = "deserialize_recent_segments")]
     pub recent_segments: Vec<WalSegmentPointer>,
     /// Whether the namespace is active or terminally deleted. Every head
     /// writes it, and a head that omits it fails to decode.
@@ -1118,7 +1077,7 @@ pub fn decode_control_object<T>(
 where
     T: DeserializeOwned,
 {
-    let decoded = crate::envelope::decode_strict_json_envelope(
+    let decoded = crate::envelope::decode_json_envelope(
         bytes,
         expected_kind.format_version(),
         // The kind registry reports unknown kinds distinctly from

--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -158,16 +158,8 @@ pub fn verify_checksum_fresh(
 /// directly readable JSON while `payload_checksum` covers the exact
 /// fragment bytes as stored.
 #[derive(Serialize, Deserialize)]
-struct JsonEnvelopeDocument {
-    kind: String,
-    format_version: u32,
-    payload_checksum: String,
-    payload: Box<RawValue>,
-}
-
-#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct StrictJsonEnvelopeDocument {
+struct JsonEnvelopeDocument {
     kind: String,
     format_version: u32,
     payload_checksum: String,
@@ -217,7 +209,7 @@ pub struct DecodedJsonEnvelope<T> {
 }
 
 /// Decodes one JSON-bodied envelope, then checks its kind, version, checksum,
-/// and payload.
+/// and payload. Unknown envelope fields are rejected for every durable family.
 ///
 /// `classify_kind` lets a family with a kind registry report unknown kinds
 /// distinctly from mismatched ones; families with one kind pass
@@ -227,31 +219,13 @@ pub fn decode_json_envelope<T: DeserializeOwned>(
     supported_version: u32,
     classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
 ) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+    let probe: EnvelopeProbe = serde_json::from_slice(bytes)
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+    classify_kind(&probe.kind)?;
+    verify_version(&probe.kind, probe.format_version, supported_version)?;
     let document: JsonEnvelopeDocument = serde_json::from_slice(bytes)
         .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
-    classify_kind(&document.kind)?;
-    verify_version(&document.kind, document.format_version, supported_version)?;
     decode_json_envelope_payload(document)
-}
-
-/// Immutable envelope families tolerate unknown fields, while mutable control-object envelopes
-/// reject them. A tolerant read followed by rewrite would erase fields the current binary does
-/// not understand.
-pub fn decode_strict_json_envelope<T: DeserializeOwned>(
-    bytes: &[u8],
-    supported_version: u32,
-    classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
-) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
-    let document: StrictJsonEnvelopeDocument = serde_json::from_slice(bytes)
-        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
-    classify_kind(&document.kind)?;
-    verify_version(&document.kind, document.format_version, supported_version)?;
-    decode_json_envelope_payload(JsonEnvelopeDocument {
-        kind: document.kind,
-        format_version: document.format_version,
-        payload_checksum: document.payload_checksum,
-        payload: document.payload,
-    })
 }
 
 fn decode_json_envelope_payload<T: DeserializeOwned>(

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -148,6 +148,7 @@ pub enum RunTier {
 ///
 /// See [metadata segments](../../../docs/specs/format.md#421-metadata-segments).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MetadataRunRef {
     /// Run identity allocated by the manifest.
     pub run_no: RunNo,
@@ -163,6 +164,7 @@ pub struct MetadataRunRef {
 ///
 /// See [metadata segments](../../../docs/specs/format.md#421-metadata-segments).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MetadataSegmentRef {
     /// Namespace that stores the segment. This may be a fork source.
     pub owner_namespace_id: NamespaceId,
@@ -206,7 +208,7 @@ pub struct MetadataSegmentRef {
 ///
 /// See [metadata segments](../../../docs/specs/format.md#421-metadata-segments).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum MetadataRow {
     /// Establishes one inode's immutable identity and kind.
     Inode(InodeRecord),
@@ -237,6 +239,7 @@ pub enum MetadataRow {
 
 /// One inode's immutable identity and creation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InodeRecord {
     /// Namespace-scoped inode identity allocated by the publishing writer.
     pub inode_id: InodeId,
@@ -254,6 +257,7 @@ pub struct InodeRecord {
 
 /// One generation of a directory name binding.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DirentryBindRecord {
     /// Directory in which the name was bound.
     pub parent_inode_id: InodeId,
@@ -271,6 +275,7 @@ pub struct DirentryBindRecord {
 
 /// One event that retires an exact directory-binding generation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DirentryUnbindRecord {
     /// Directory that held the targeted binding.
     pub parent_inode_id: InodeId,
@@ -292,6 +297,7 @@ pub struct DirentryUnbindRecord {
 
 /// One immutable content revision for a file inode.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RevisionRecord {
     /// File inode whose history contains the revision.
     pub inode_id: InodeId,
@@ -313,6 +319,7 @@ pub struct RevisionRecord {
 
 /// One event that changes whether a root inode has an active subtree tombstone.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubtreeTombstoneRecord {
     /// Inode whose rooted subtree the event governs.
     pub root_inode_id: InodeId,
@@ -330,6 +337,7 @@ pub struct SubtreeTombstoneRecord {
 
 /// One current-state row for a recoverable deletion.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ActiveDeletionRecord {
     /// Subtree root the deletion covers.
     pub root_inode_id: InodeId,
@@ -352,6 +360,7 @@ impl ActiveDeletionRecord {
 
 /// One durable commit idempotency receipt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CommitReceiptRecord {
     /// Caller idempotency key whose later reuse is checked against this row.
     pub commit_id: CommitId,
@@ -370,6 +379,7 @@ pub struct CommitReceiptRecord {
 
 /// One inode's complete attribute map at one revision.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AttributesRevisionRecord {
     /// Inode whose attributes this revision states.
     pub inode_id: InodeId,
@@ -394,11 +404,10 @@ pub struct AttributesRevisionRecord {
 ///
 /// Shared by the tombstone row and the WAL delta that revokes one, so a
 /// revoke names its target in the same spelling everywhere.
-///
-/// This type appears only in immutable data, so it accepts unknown fields.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
+#[serde(deny_unknown_fields)]
 pub struct TombstoneGeneration {
     /// Commit sequence that published the event.
     pub seq: ChangeSeq,
@@ -410,9 +419,8 @@ pub struct TombstoneGeneration {
 ///
 /// Tombstones retain this binding after the corresponding unbind row may be
 /// collected. Undelete uses it to restore the original parent and name.
-///
-/// This type appears only in immutable data, so it accepts unknown fields.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeletedDirentry {
     /// Directory that held the binding.
     pub parent_inode_id: InodeId,
@@ -423,10 +431,8 @@ pub struct DeletedDirentry {
 }
 
 /// Tombstone-row event vocabulary (format spec, "Tombstones and deletion").
-///
-/// This type appears only in immutable rows, so it accepts unknown fields.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum TombstoneRowAction {
     /// The subtree rooted at the row's inode is deleted.
     Set {
@@ -448,7 +454,7 @@ pub enum TombstoneRowAction {
 /// suppress restored entries. Reorganization later removes the cancelled
 /// pair.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ActiveDeletionRowAction {
     /// The deletion is recoverable; these are the fields the trash entry
     /// renders, denormalized so a page needs no per-entry join.
@@ -970,6 +976,7 @@ pub mod lookup_keys {
 ///
 /// See [manifest publication](../../../docs/specs/format.md#61-manifest-publication-and-checkpoint-verification).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NamespaceManifestPayload {
     /// Namespace whose materialized state this manifest describes.
     pub namespace_id: NamespaceId,
@@ -1004,6 +1011,7 @@ pub struct NamespaceManifestPayload {
 /// [`encode_namespace_manifest_json`] and validated only by
 /// [`decode_namespace_manifest_json`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NamespaceManifestEnvelope {
     /// Durable-family discriminator checked before payload decoding.
     pub kind: NamespaceManifestKind,

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -55,6 +55,7 @@ pub(crate) const ZSTD_LEVEL: i32 = 3;
 /// Where one stored section lives inside a segment object, and how to
 /// verify it: the CRC32C of the stored bytes and their decoded length.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlockHandle {
     /// Zero-based byte offset of the section within its immutable segment object.
     pub offset: u64,
@@ -68,6 +69,7 @@ pub struct BlockHandle {
 
 /// One index entry: the last row key of a data block plus its handle.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SegmentIndexEntry {
     /// Greatest row key in `block`, used to binary-search candidate blocks.
     pub last_row_key: String,

--- a/crates/loonfs-api/src/wal.rs
+++ b/crates/loonfs-api/src/wal.rs
@@ -41,7 +41,7 @@ impl WalEnvelopeKind {
 ///
 /// See [standard mutation operations](../../../docs/specs/format.md#35-standard-mutation-operations).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum WalDelta {
     /// Introduces an inode whose identity and kind remain fixed for its lifetime.
     CreateInode {
@@ -139,6 +139,7 @@ pub enum WalDelta {
 ///
 /// See [logical commits](../../../docs/specs/format.md#33-logical-commits-sequence-numbers-and-visibility).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalCommitDelta {
     /// Zero-based request-operation position used to attribute one or more resulting deltas.
     pub semantic_op_index: u32,
@@ -150,6 +151,7 @@ pub struct WalCommitDelta {
 ///
 /// See [WAL segment rules](../../../docs/specs/format.md#15-wal-segment-rules).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalCommitPayload {
     /// Namespace-wide commit position; segment records must cover their range contiguously.
     pub seq: ChangeSeq,
@@ -175,6 +177,7 @@ pub struct WalCommitPayload {
 ///
 /// See [WAL segment rules](../../../docs/specs/format.md#15-wal-segment-rules).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalSegmentPayload {
     /// Namespace this segment belongs to; recovery rejects cross-namespace content.
     pub namespace_id: NamespaceId,
@@ -201,6 +204,7 @@ pub struct WalSegmentPayload {
 /// [`encode_wal_segment_envelope_zstd`] and validated only by
 /// [`decode_wal_segment_envelope_zstd`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalSegmentEnvelope {
     /// Durable-family discriminator checked before payload decoding.
     pub kind: WalEnvelopeKind,
@@ -240,9 +244,10 @@ impl WalSegmentEnvelope {
 /// Durable layout of a WAL segment object (before zstd compression): the
 /// envelope fields plus the payload as an opaque CBOR byte string.
 /// `payload_checksum` covers exactly those bytes, so integrity verification
-/// never depends on re-encoding the payload with this build's schema and a
-/// payload with unknown additive fields still verifies.
+/// never depends on re-encoding the payload with this build's schema. Unknown
+/// payload fields are rejected after checksum verification.
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct WalSegmentDocument {
     kind: String,
     format_version: u32,

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -14,12 +14,9 @@
 //! - If a fixture stops decoding, the current reader can no longer read bytes
 //!   another implementation of the same format version wrote — a
 //!   compatibility break once that format is deployed.
-//! - Additive payload fields in immutable families must keep decoding
-//!   (`*_tolerates_additive_*`), at every level of nesting. Mutable control
-//!   objects reject unknown fields so an older reader cannot erase them
-//!   during a guarded rewrite. `ContentRef`, `Checksum`, and `ActorRef` are
-//!   closed shapes: they reject unknown fields everywhere, because the same
-//!   types decode HTTP request bodies.
+//! - Every durable family rejects unknown fields at every nesting level.
+//!   Compaction and WAL folding write successor records, so permissive
+//!   decoding could erase a field introduced by an unsupported writer.
 
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointOwner, CheckpointRecordState,
@@ -1621,32 +1618,32 @@ fn wal_decode_rejects_tampered_payload_bytes_as_checksum_mismatch() {
 }
 
 #[test]
-fn wal_decode_tolerates_additive_payload_fields() {
-    // Simulate a same-format-version writer that added a payload field: the
-    // payload bytes change (and so does their checksum), but readers that do
-    // not know the field must still decode the segment.
+fn wal_decode_rejects_unknown_payload_fields() {
+    // A valid checksum does not authorize unknown payload fields.
     let envelope = sample_wal_envelope();
     let document = wal_document_with_payload_edit(&envelope, with_future_field);
 
-    let decoded = decode_wal_segment_envelope_zstd(&document)
-        .expect("additive payload fields must remain readable");
-    assert_eq!(decoded.payload, envelope.payload);
+    let error = decode_wal_segment_envelope_zstd(&document)
+        .expect_err("unknown durable fields must be rejected");
+    assert!(matches!(error, EnvelopeCodecError::PayloadDecode(message)
+        if message.contains("unknown field") && message.contains("field_from_the_future")));
 }
 
 #[test]
-fn wal_decode_tolerates_an_additive_field_inside_the_predecessor_pointer() {
+fn wal_decode_rejects_unknown_predecessor_fields() {
     let envelope = sample_wal_envelope();
     let document = wal_document_with_payload_edit(&envelope, |payload| {
         with_future_field(cbor_entry(payload, "prev_visible_segment"));
     });
 
-    let decoded = decode_wal_segment_envelope_zstd(&document)
-        .expect("an additive field inside the predecessor pointer must remain readable");
-    assert_eq!(decoded.payload, envelope.payload);
+    let error = decode_wal_segment_envelope_zstd(&document)
+        .expect_err("unknown durable fields must be rejected");
+    assert!(matches!(error, EnvelopeCodecError::PayloadDecode(message)
+        if message.contains("unknown field") && message.contains("field_from_the_future")));
 }
 
 #[test]
-fn wal_decode_tolerates_additive_fields_inside_tombstone_deltas() {
+fn wal_decode_rejects_unknown_fields_inside_tombstone_deltas() {
     let envelope = wal_envelope_with_deltas(vec![
         WalCommitDelta {
             semantic_op_index: 0,
@@ -1678,9 +1675,10 @@ fn wal_decode_tolerates_additive_fields_inside_tombstone_deltas() {
         with_future_field(cbor_entry(commit_delta(payload, 1), "target"));
     });
 
-    let decoded = decode_wal_segment_envelope_zstd(&document)
-        .expect("additive fields inside a delta must remain readable");
-    assert_eq!(decoded.payload, envelope.payload);
+    let error = decode_wal_segment_envelope_zstd(&document)
+        .expect_err("unknown durable fields must be rejected");
+    assert!(matches!(error, EnvelopeCodecError::PayloadDecode(message)
+        if message.contains("unknown field") && message.contains("field_from_the_future")));
 }
 
 #[test]
@@ -1797,26 +1795,53 @@ fn namespace_manifest_v2_rejects_missing_frozen_base_delta_merges() {
 }
 
 #[test]
-fn namespace_manifest_decode_tolerates_additive_payload_fields() {
+fn namespace_manifest_decode_rejects_unknown_fields_at_every_level() {
     let envelope = sample_manifest_envelope();
     let encoded = encode_namespace_manifest_json(&envelope).expect("manifest");
-    let mut document: serde_json::Value =
-        serde_json::from_slice(&encoded).expect("decode document");
-    document["payload"]["field_from_the_future"] = serde_json::Value::from(true);
-    let future_payload =
-        serde_json::to_string(&document["payload"]).expect("encode future payload");
-    document["payload_checksum"] =
-        serde_json::Value::from(sha256_digest(future_payload.as_bytes()));
-    // Rebuild the document so the embedded payload bytes are exactly the
-    // bytes the checksum was computed over.
-    let future_document = format!(
-        "{{\"kind\":{},\"format_version\":{},\"payload_checksum\":{},\"payload\":{}}}",
-        document["kind"], document["format_version"], document["payload_checksum"], future_payload,
-    );
+    for path in [
+        "",
+        "/runs/0",
+        "/runs/0/segments/0",
+        "/runs/0/segments/0/index_block",
+        "/runs/0/segments/0/filter_block",
+    ] {
+        let mut document: serde_json::Value = serde_json::from_slice(&encoded).expect("document");
+        document["payload"]
+            .pointer_mut(path)
+            .expect("fixture object")["field_from_the_future"] = serde_json::Value::from(true);
+        let payload = serde_json::to_string(&document["payload"]).expect("payload");
+        let checksum = serde_json::to_string(&sha256_digest(payload.as_bytes())).expect("checksum");
+        let future_document = format!(
+            "{{\"kind\":{},\"format_version\":{},\"payload_checksum\":{},\"payload\":{}}}",
+            document["kind"], document["format_version"], checksum, payload,
+        );
+        let error = decode_namespace_manifest_json(future_document.as_bytes())
+            .expect_err("unknown durable fields must be rejected");
+        assert!(
+            matches!(error, EnvelopeCodecError::PayloadDecode(message)
+            if message.contains("unknown field") && message.contains("field_from_the_future")),
+            "path {path}"
+        );
+    }
+}
 
-    let decoded = decode_namespace_manifest_json(future_document.as_bytes())
-        .expect("additive payload fields must remain readable");
-    assert_eq!(decoded.payload, envelope.payload);
+#[test]
+fn immutable_envelopes_reject_unknown_fields() {
+    let mut manifest =
+        encode_namespace_manifest_json(&sample_manifest_envelope()).expect("manifest");
+    assert_eq!(manifest.pop(), Some(b'}'));
+    manifest.extend_from_slice(br#", "field_from_the_future": true}"#);
+    assert!(matches!(decode_namespace_manifest_json(&manifest),
+        Err(EnvelopeCodecError::EnvelopeDecode(message)) if message.contains("field_from_the_future")));
+
+    let encoded = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let mut document: ciborium::Value =
+        ciborium::de::from_reader(encoded.as_slice()).expect("document");
+    with_future_field(&mut document);
+    let mut future = Vec::new();
+    ciborium::ser::into_writer(&document, &mut future).expect("encode document");
+    assert!(matches!(decode_wal_segment_envelope_zstd(&rezstd(&future)),
+        Err(EnvelopeCodecError::EnvelopeDecode(message)) if message.contains("field_from_the_future")));
 }
 
 // ---------------------------------------------------------------------------
@@ -2381,13 +2406,6 @@ fn assert_row_is_corrupt(row: &ciborium::Value, why: &str) -> String {
 }
 
 /// Decodes a row after applying an edit to its CBOR representation.
-fn decode_edited_row(row: &ciborium::Value, why: &str) -> MetadataRow {
-    let mut encoded = Vec::new();
-    ciborium::ser::into_writer(row, &mut encoded).expect("encode edited row");
-    ciborium::de::from_reader::<MetadataRow, _>(encoded.as_slice())
-        .unwrap_or_else(|error| panic!("{why}, but the row failed to decode: {error}"))
-}
-
 #[test]
 fn tombstone_rows_reject_a_partial_deleted_direntry() {
     for missing in ["parent_inode_id", "name_key", "display_name"] {
@@ -2403,7 +2421,7 @@ fn tombstone_rows_reject_a_partial_deleted_direntry() {
 }
 
 #[test]
-fn tombstone_rows_tolerate_additive_fields_at_every_level() {
+fn tombstone_rows_reject_unknown_fields_at_every_level() {
     let expected = sample_tombstone_set_row();
     let paths: [&[&str]; 3] = [
         &["generation"],
@@ -2418,19 +2436,16 @@ fn tombstone_rows_tolerate_additive_fields_at_every_level() {
             target = cbor_entry(target, key);
         }
         with_future_field(target);
-        assert_eq!(
-            decode_edited_row(
-                &row,
-                "an immutable row tolerates a field it does not define"
-            ),
-            expected,
-            "the unknown field under {path:?} changed the decoded row"
+        let refusal = assert_row_is_corrupt(&row, "unknown durable fields must be rejected");
+        assert!(
+            refusal.contains("field_from_the_future"),
+            "{path:?}: {refusal}"
         );
     }
 }
 
 #[test]
-fn tombstone_revoke_rows_ignore_a_deleted_direntry() {
+fn tombstone_revoke_rows_reject_a_deleted_direntry() {
     let expected = sample_tombstone_revoke_row();
     let mut row = row_cbor(&expected);
     cbor_map_of(cbor_entry(&mut row, "action")).push((
@@ -2438,10 +2453,8 @@ fn tombstone_revoke_rows_ignore_a_deleted_direntry() {
         sample_deleted_direntry_cbor(),
     ));
 
-    assert_eq!(
-        decode_edited_row(&row, "a revoke tolerates a field it does not define"),
-        expected
-    );
+    let refusal = assert_row_is_corrupt(&row, "a revoke carries no deleted direntry");
+    assert!(refusal.contains("deleted_direntry"), "{refusal}");
 }
 
 #[test]
@@ -2459,7 +2472,7 @@ fn tombstone_rows_reject_flat_binding_fields() {
         "a tombstone states its generation as one value",
     );
     assert!(
-        refusal.contains("missing field `generation`"),
+        refusal.contains("unknown field `tombstone_seq`"),
         "unexpected refusal: {refusal}"
     );
     let refusal = assert_row_is_corrupt(
@@ -2467,7 +2480,8 @@ fn tombstone_rows_reject_flat_binding_fields() {
         "a `set` states its binding, even when it has none",
     );
     assert!(
-        refusal.contains("missing field `deleted_direntry`"),
+        refusal.contains("missing field `deleted_direntry`")
+            || refusal.contains("unknown field `parent_inode_id`"),
         "unexpected refusal: {refusal}"
     );
 }
@@ -2491,7 +2505,8 @@ fn active_deletion_rows_reject_a_partial_or_absent_deleted_direntry() {
     let refusal =
         assert_row_is_corrupt(&row, "a `listed` states its binding, even when it has none");
     assert!(
-        refusal.contains("missing field `deleted_direntry`"),
+        refusal.contains("missing field `deleted_direntry`")
+            || refusal.contains("unknown field `parent_inode_id`"),
         "unexpected refusal: {refusal}"
     );
 }
@@ -2693,4 +2708,23 @@ fn sst_block_index_entry_schema_matches_golden_bytes() {
     let decoded: Vec<SegmentIndexEntry> =
         ciborium::de::from_reader(encoded.as_slice()).expect("decode index entries");
     assert_eq!(decoded, entries);
+}
+
+#[test]
+fn every_metadata_row_rejects_unknown_fields() {
+    use loonfs_api::wire::sst_blocks::decode_data_block;
+    let built = sample_segment_blocks();
+    for entry in sample_segment_index(&built) {
+        let block = decode_data_block(segment_section(&built.bytes, &entry.block), &entry.block)
+            .expect("decode fixture block");
+        for row in block.rows {
+            let mut encoded = row_cbor(&row);
+            with_future_field(&mut encoded);
+            let refusal = assert_row_is_corrupt(&encoded, "every durable row is strict");
+            assert!(
+                refusal.contains("field_from_the_future"),
+                "{row:?}: {refusal}"
+            );
+        }
+    }
 }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -17,7 +17,7 @@ use crate::error::{CoreError, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
 use crate::namespace::basis::{genesis_next_inode_id, MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::bootstrap::bootstrap_metadata_state;
-use loonfs_api::wire::control::{genesis_commit_id, HeadState, ManifestRef, MetadataRootState};
+use loonfs_api::wire::control::{genesis_commit_id, HeadState, ManifestRef};
 use loonfs_api::wire::manifest::{
     decode_namespace_manifest_json, NamespaceManifestEnvelope, NamespaceManifestKind,
     NamespaceManifestPayload, NAMESPACE_MANIFEST_FORMAT_VERSION,
@@ -39,18 +39,6 @@ pub(crate) use super::tests::inspection_materialization::{
     load_manifest_materialization_for_inspection,
     load_manifest_metadata_state_for_inspection_from_manifest,
 };
-
-pub(super) fn ensure_root_matches_manifest(
-    namespace_id: &NamespaceId,
-    root: &MetadataRootState,
-    manifest: &NamespaceManifestEnvelope,
-) -> crate::error::Result<()> {
-    ensure_manifest_reference_matches(
-        &format!("metadata root for namespace `{namespace_id}`"),
-        &root.manifest,
-        manifest,
-    )
-}
 
 /// Verifies every coordinate by which a durable control object binds one
 /// immutable manifest.
@@ -174,21 +162,7 @@ pub(crate) async fn load_basis_metadata_segments<'a, S: ObjectStore + ?Sized>(
             base_state: bootstrap_metadata_state(genesis_created_at_ms),
         });
     };
-    let segments = load_verified_manifest_segments(
-        store,
-        segment_cache,
-        &manifest.owner_namespace_id,
-        &manifest.manifest_object_id,
-    )
-    .await
-    .map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-    })?;
-    ensure_manifest_reference_matches(
-        &format!("namespace `{namespace_id}` metadata basis"),
-        manifest,
-        segments.manifest(),
-    )?;
+    let segments = load_manifest_segments(store, segment_cache, manifest).await?;
     let manifest_head_seq = segments.manifest().payload.head_seq;
     Ok(LoadedMetadataBasis {
         identity: MetadataBasisIdentity::from_verified_basis(basis.clone(), manifest_head_seq),
@@ -218,9 +192,37 @@ pub(crate) async fn load_namespace_manifest_envelope<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Loads the current manifest's verified segment descriptors without fetching
-/// metadata segment row payloads or constructing `MetadataState`.
-pub(crate) async fn load_verified_manifest_segments<'a, S: ObjectStore + ?Sized>(
+/// Loads a durable manifest reference and verifies every field before exposing its segments.
+pub(crate) async fn load_manifest_segments<'a, S: ObjectStore + ?Sized>(
+    store: &'a S,
+    segment_cache: Option<&'a MetadataSegmentCache>,
+    reference: &ManifestRef,
+) -> crate::error::Result<VerifiedMetadataSegments<'a, S>> {
+    let segments = load_manifest_segments_for_inspection(
+        store,
+        segment_cache,
+        &reference.owner_namespace_id,
+        &reference.manifest_object_id,
+    )
+    .await
+    .map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+    })?;
+    ensure_manifest_reference_matches(
+        &format!(
+            "namespace `{}` manifest reference",
+            reference.owner_namespace_id
+        ),
+        reference,
+        segments.manifest(),
+    )?;
+    Ok(segments)
+}
+
+/// Inspects an object by ID, validating its envelope and segment descriptors.
+/// This does not verify a root or checkpoint reference. Authoritative reads
+/// and publication paths must use `load_manifest_segments` instead.
+pub(crate) async fn load_manifest_segments_for_inspection<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     segment_cache: Option<&'a MetadataSegmentCache>,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -72,8 +72,8 @@ pub(crate) use self::files::list_checkpoint_files_page;
 pub(crate) use self::flush::flush_wal;
 pub(crate) use self::list::list_checkpoints_page;
 pub(crate) use self::load::{
-    head_from_manifest, load_basis_metadata_segments, load_namespace_manifest_envelope,
-    load_namespace_manifest_envelope_if_present, load_verified_manifest_segments,
+    head_from_manifest, load_basis_metadata_segments, load_manifest_segments_for_inspection,
+    load_namespace_manifest_envelope, load_namespace_manifest_envelope_if_present,
     LoadedMetadataBasis,
 };
 #[cfg(test)]

--- a/crates/loonfs-core/src/checkpoint/read_basis.rs
+++ b/crates/loonfs-core/src/checkpoint/read_basis.rs
@@ -2,9 +2,7 @@
 
 use super::cache::MetadataSegmentCache;
 use super::error::ManifestLoadError;
-use super::load::{
-    ensure_manifest_reference_matches, head_from_manifest, load_verified_manifest_segments,
-};
+use super::load::{head_from_manifest, load_manifest_segments};
 use super::record::load_checkpoint_record;
 use super::scan::VerifiedMetadataSegments;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
@@ -48,25 +46,16 @@ pub(crate) async fn load_pinned_checkpoint_basis_from_record<'a, S: ObjectStore 
     record: CheckpointRecordState,
 ) -> Result<PinnedCheckpointBasis<'a, S>> {
     let checkpoint_id = &record.checkpoint_id;
-    let namespace_id = &record.namespace_id;
-    let segments = load_verified_manifest_segments(
-        store,
-        segment_cache,
-        namespace_id,
-        &record.manifest.manifest_object_id,
-    )
-    .await
-    .map_err(|error| match error {
-        ManifestLoadError::MissingManifest { object_key } => CoreError::CheckpointUnavailable(
-            format!("checkpoint `{checkpoint_id}` pins manifest `{object_key}`, which is gone"),
-        ),
-        other => CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(other)),
-    })?;
-    ensure_manifest_reference_matches(
-        &format!("checkpoint `{checkpoint_id}` basis"),
-        &record.manifest,
-        segments.manifest(),
-    )?;
+    let segments = load_manifest_segments(store, segment_cache, &record.manifest)
+        .await
+        .map_err(|error| match error {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(
+                ManifestLoadError::MissingManifest { object_key },
+            )) => CoreError::CheckpointUnavailable(format!(
+                "checkpoint `{checkpoint_id}` pins manifest `{object_key}`, which is gone"
+            )),
+            other => other,
+        })?;
     Ok(PinnedCheckpointBasis {
         manifest: record.manifest,
         segments,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -12,7 +12,7 @@ use super::block_fetch::load_segment_index_for_reorganization;
 use super::compaction_lease::{group_lease_state, GroupLeaseState};
 use super::error::ManifestLoadError;
 use super::flush::{ensure_metadata_publication_budget, next_manifest_no_after, next_run_no_after};
-use super::load::load_verified_manifest_segments;
+use super::load::load_manifest_segments;
 use super::publish::{
     manifest_write_failure, publish_metadata_root, write_namespace_manifest,
     ManifestPublicationOutcome,
@@ -162,16 +162,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             MetadataReorganizeOutcome::NotNeeded { delta_runs: 0 },
         ));
     };
-    let segments = load_verified_manifest_segments(
-        store,
-        None,
-        namespace_id,
-        &root.manifest.manifest_object_id,
-    )
-    .await
-    .map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-    })?;
+    let segments = load_manifest_segments(store, None, &root.manifest).await?;
     let previous = segments.manifest();
 
     let delta_runs = delta_run_count(&previous.payload);
@@ -326,17 +317,7 @@ pub async fn metadata_maintenance_due<S: ObjectStore + ?Sized>(
     let Some(root) = snapshot.root else {
         return Ok(false);
     };
-    let segments = load_verified_manifest_segments(
-        store,
-        segment_cache,
-        namespace_id,
-        &root.state.manifest.manifest_object_id,
-    )
-    .await
-    .map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-    })?;
-    super::load::ensure_root_matches_manifest(namespace_id, &root.state, segments.manifest())?;
+    let segments = load_manifest_segments(store, segment_cache, &root.state.manifest).await?;
     Ok(manifest_has_reorganization_work(
         &segments.manifest().payload,
         segments.scan_runs.as_ref(),

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -1,7 +1,7 @@
 //! Retention floor advancement against the current verified manifest.
 
 use super::error::ManifestLoadError;
-use super::load::{ensure_root_matches_manifest, load_verified_manifest_segments};
+use super::load::load_manifest_segments;
 use super::runs::MAX_MAINTENANCE_SEGMENT_IO;
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
@@ -104,17 +104,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         });
     };
     let root = loaded_root.state;
-    let manifest_segments = load_verified_manifest_segments(
-        store,
-        None,
-        namespace_id,
-        &root.manifest.manifest_object_id,
-    )
-    .await
-    .map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-    })?;
-    ensure_root_matches_manifest(namespace_id, &root, manifest_segments.manifest())?;
+    let manifest_segments = load_manifest_segments(store, None, &root.manifest).await?;
     // Grep tolerates retention gaps by checkpointed rebootstrap, so its
     // independent watermark never holds the core WAL floor back.
     let target_floor = manifest_segments.manifest().payload.head_seq;

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -25,7 +25,7 @@ use super::frozen_floor::{
     bind_survives_frozen_floor, unbinding_at_or_below_floor, unbindings_at_or_below_floor,
     BindingGeneration,
 };
-use super::load::load_verified_manifest_segments;
+use super::load::load_manifest_segments;
 use super::publish::{publish_metadata_root, ManifestPublicationOutcome};
 use super::reorganize::{
     group_run_descriptors, write_replacement_manifest, MergePlacement, ReplacementOutput,
@@ -363,11 +363,9 @@ pub enum MetadataCompactionJobOutcome {
 /// rebuilt run in with one manifest publication.
 ///
 /// This is what the maintenance runner spawns from the spec a step planned.
-/// Nothing durable records that the job is running, so every way it can end
-/// short of publishing — cancellation, a snapshot that moved, a lost race, an
-/// error — costs the work it did and nothing else: the old manifest stays
-/// valid, the staged segments stay invisible, and a later step plans the group
-/// again.
+/// A durable lease protects staged output until publication or cleanup. If
+/// the job stops before publication, the old manifest stays valid, staged
+/// segments stay invisible, and a later step may plan the group again.
 pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -533,14 +531,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         else {
             return Ok(MetadataCompactionJobOutcome::Abandoned);
         };
-        let segments = load_verified_manifest_segments(
-            store,
-            None,
-            namespace_id,
-            &root.manifest.manifest_object_id,
-        )
-        .await
-        .map_err(manifest_load_failure)?;
+        let segments = load_manifest_segments(store, None, &root.manifest).await?;
         if snapshot_segment_keys(&segments, spec).as_ref() != Some(snapshot_keys) {
             tracing::info!(
                 namespace_id = namespace_id.as_str(),
@@ -638,10 +629,9 @@ async fn load_current_manifest_segments<'a, S: ObjectStore + ?Sized>(
     else {
         return Ok(None);
     };
-    load_verified_manifest_segments(store, None, namespace_id, &root.manifest.manifest_object_id)
+    load_manifest_segments(store, None, &root.manifest)
         .await
         .map(Some)
-        .map_err(manifest_load_failure)
 }
 
 /// The object keys the spec's runs hold for its group, or `None` when the

--- a/crates/loonfs-core/src/checkpoint/tests/attributes.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/attributes.rs
@@ -237,7 +237,7 @@ async fn a_published_segment_answers_at_the_sequence_the_read_asks_for() {
         flatten_manifest_segments(segments),
     )
     .await;
-    let verified = load_verified_manifest_segments(&store, None, &namespace_id, &manifest)
+    let verified = load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest)
         .await
         .expect("load manifest segments");
 

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -35,7 +35,7 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
     // The default cache config carries a decoded-byte budget, so a scan wider
     // than the small-scan limit populates the cache instead of reading through.
     let cache = super::MetadataSegmentCache::new(Default::default());
-    let segments = super::load_verified_manifest_segments(
+    let segments = super::load_manifest_segments_for_inspection(
         &store,
         Some(&cache),
         &namespace_id,
@@ -57,7 +57,7 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
 
     // A fresh view has no per-view segment memo; only the shared cache can
     // answer, so the repeated scan must issue no segment fetches.
-    let fresh_segments = super::load_verified_manifest_segments(
+    let fresh_segments = super::load_manifest_segments_for_inspection(
         &store,
         Some(&cache),
         &namespace_id,
@@ -99,7 +99,7 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
         "a wide range scan should admit its segments to the cache"
     );
 
-    let fresh_segments = super::load_verified_manifest_segments(
+    let fresh_segments = super::load_manifest_segments_for_inspection(
         &store,
         Some(&cache),
         &namespace_id,
@@ -127,7 +127,7 @@ async fn a_byte_budgeted_cache_admits_wide_scans_and_holds_to_its_budget() {
     let degenerate = MetadataSegmentCache::new(MetadataSegmentCacheConfig {
         max_decoded_bytes: 1,
     });
-    let degenerate_segments = super::load_verified_manifest_segments(
+    let degenerate_segments = super::load_manifest_segments_for_inspection(
         &store,
         Some(&degenerate),
         &namespace_id,
@@ -161,7 +161,7 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
     let cache = super::MetadataSegmentCache::new(MetadataSegmentCacheConfig::default());
     // A solo pass over its own cold cache measures the true per-scan
     // fetch count.
-    let solo_segments = super::load_verified_manifest_segments(
+    let solo_segments = super::load_manifest_segments_for_inspection(
         &store,
         Some(&cache),
         &namespace_id,
@@ -181,7 +181,7 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
     // Concurrent requests race over a second cold cache, each with its own
     // segments view; single-flight is what keeps the pair at the solo count.
     let paired_cache = super::MetadataSegmentCache::new(MetadataSegmentCacheConfig::default());
-    let first_segments = super::load_verified_manifest_segments(
+    let first_segments = super::load_manifest_segments_for_inspection(
         &store,
         Some(&paired_cache),
         &namespace_id,
@@ -189,7 +189,7 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
     )
     .await
     .expect("load first segments");
-    let second_segments = super::load_verified_manifest_segments(
+    let second_segments = super::load_manifest_segments_for_inspection(
         &store,
         Some(&paired_cache),
         &namespace_id,
@@ -244,7 +244,7 @@ async fn cached_manifest_carries_its_scan_order_runs() {
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
 
     let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig::default());
-    let first = super::load_verified_manifest_segments(
+    let first = super::load_manifest_segments_for_inspection(
         &store,
         Some(&cache),
         &namespace_id,
@@ -252,7 +252,7 @@ async fn cached_manifest_carries_its_scan_order_runs() {
     )
     .await
     .expect("load first segments");
-    let second = super::load_verified_manifest_segments(
+    let second = super::load_manifest_segments_for_inspection(
         &store,
         Some(&cache),
         &namespace_id,
@@ -302,10 +302,14 @@ async fn segment_range_page_merges_base_and_delta_in_row_key_order() {
         .expect("write b");
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
-    let segments =
-        super::load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id)
-            .await
-            .expect("load segments");
+    let segments = super::load_manifest_segments_for_inspection(
+        &store,
+        None,
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load segments");
 
     let docs_inode_id = InodeId(2);
     let lower_bound = format!("direntry-bind-{:020}-", docs_inode_id.0);
@@ -405,7 +409,7 @@ async fn lookup_skips_segments_whose_filter_rules_the_name_out() {
 
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig::default());
-    let segments = super::load_verified_manifest_segments(
+    let segments = super::load_manifest_segments_for_inspection(
         &store,
         Some(&cache),
         &namespace_id,
@@ -489,10 +493,14 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     // a lookup must not re-fetch — the per-view memo is the only reuse this
     // configuration has, and without it a cold list degrades from one fetch
     // per block to one fetch per lookup.
-    let segments =
-        super::load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id)
-            .await
-            .expect("load segments");
+    let segments = super::load_manifest_segments_for_inspection(
+        &store,
+        None,
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load segments");
     store.reset();
     let key = "inode-00000000000000000001";
     assert!(segments
@@ -555,7 +563,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
     }
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let segments =
-        load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id)
+        load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
             .await
             .expect("load segments");
     let direntry_descriptors: Vec<_> = segments
@@ -631,7 +639,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
         .await
         .expect("write stripped manifest");
     let stripped_segments =
-        load_verified_manifest_segments(&store, None, &namespace_id, &stripped_object_id)
+        load_manifest_segments_for_inspection(&store, None, &namespace_id, &stripped_object_id)
             .await
             .expect("load stripped segments");
     store.reset();
@@ -675,7 +683,7 @@ async fn corrupt_inline_filter_fails_the_lookup() {
         .expect("create checkpoint");
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let segments =
-        load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id)
+        load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
             .await
             .expect("load segments");
     let descriptor = segments
@@ -746,7 +754,7 @@ async fn checkpointed_direntry_segment() -> (
         .expect("create checkpoint");
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let segments =
-        load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id)
+        load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
             .await
             .expect("load segments");
     let mut descriptor = segments
@@ -1014,7 +1022,7 @@ async fn multi_block_direntry_segment() -> (
         .expect("create checkpoint");
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let segments =
-        load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id)
+        load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
             .await
             .expect("load segments");
     let mut descriptor = segments

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -186,7 +186,7 @@ async fn load_perturbed_manifest(
     write_namespace_manifest(store, &envelope)
         .await
         .expect("write perturbed manifest");
-    load_verified_manifest_segments(store, None, namespace_id, &manifest_object_id)
+    load_manifest_segments_for_inspection(store, None, namespace_id, &manifest_object_id)
         .await
         .map(|_| ())
 }
@@ -260,9 +260,10 @@ async fn current_manifest(
     namespace_id: &NamespaceId,
 ) -> NamespaceManifestEnvelope {
     let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
-    let segments = load_verified_manifest_segments(store, None, namespace_id, &manifest_object_id)
-        .await
-        .expect("load the current manifest's segments");
+    let segments =
+        load_manifest_segments_for_inspection(store, None, namespace_id, &manifest_object_id)
+            .await
+            .expect("load the current manifest's segments");
     segments.manifest().clone()
 }
 
@@ -662,7 +663,9 @@ async fn manifest_load_rejects_unequal_index_descriptor_counts() {
     let manifest_object_id = manifest.payload.manifest_object_id.clone();
     overwrite_manifest(&store, &namespace_id, manifest).await;
 
-    match load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id).await {
+    match load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
+        .await
+    {
         Err(ManifestLoadError::RunManifestMismatch { .. }) => {}
         Err(other) => panic!("expected run manifest mismatch, got {other:?}"),
         Ok(_) => panic!("tampered descriptor counts must not load"),
@@ -1321,7 +1324,7 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
 
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let segments =
-        load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id)
+        load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
             .await
             .expect("the rewritten manifest should load");
     for row in &inode_rows {
@@ -1361,7 +1364,7 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
         .expect("create checkpoint");
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let segments =
-        load_verified_manifest_segments(&store, None, &namespace_id, &manifest_object_id)
+        load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
             .await
             .expect("load segments");
     let payload = segments.manifest().payload.clone();

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -22,7 +22,8 @@ use super::error::ManifestLoadError;
 use super::frozen_floor::{bind_survives_frozen_floor, unbindings_at_or_below_floor};
 use super::load::{
     append_rows_to_metadata, head_from_manifest, load_manifest_materialization_for_inspection,
-    load_manifest_metadata_state_for_inspection_from_manifest, load_verified_manifest_segments,
+    load_manifest_metadata_state_for_inspection_from_manifest,
+    load_manifest_segments_for_inspection,
 };
 use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
 use super::record::load_checkpoint_record;
@@ -482,7 +483,7 @@ pub(crate) async fn staged_keys_of_the_current_manifest<S: ObjectStore + ?Sized>
     let staging_prefix = loonfs_objectstore::keys::metadata_compaction_prefix(namespace_id);
     let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
     let staged: BTreeSet<String> =
-        load_verified_manifest_segments(store, None, namespace_id, &manifest_object_id)
+        load_manifest_segments_for_inspection(store, None, namespace_id, &manifest_object_id)
             .await
             .expect("load the published manifest")
             .manifest()

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -336,7 +336,7 @@ async fn retention_advancement_uses_published_manifest_and_updates_floor_only() 
         .await
         .expect("load metadata root")
         .state;
-    let referenced_segment_count = load_verified_manifest_segments(
+    let referenced_segment_count = load_manifest_segments_for_inspection(
         &store,
         None,
         &namespace_id,
@@ -414,7 +414,7 @@ async fn retention_floor_does_not_advance_past_a_missing_basis_segment() {
         .await
         .expect("load metadata root")
         .state;
-    let segments = load_verified_manifest_segments(
+    let segments = load_manifest_segments_for_inspection(
         &store,
         None,
         &namespace_id,
@@ -479,7 +479,7 @@ async fn retention_floor_does_not_advance_when_a_basis_segment_cannot_be_checked
         .await
         .expect("load metadata root")
         .state;
-    let segments = load_verified_manifest_segments(
+    let segments = load_manifest_segments_for_inspection(
         &setup_store,
         None,
         &namespace_id,
@@ -2016,9 +2016,10 @@ async fn select_reorganization_window<S: ObjectStore + ?Sized>(
     super::reorganize::ReorganizationSelection,
 ) {
     let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
-    let segments = load_verified_manifest_segments(store, None, namespace_id, &manifest_object_id)
-        .await
-        .expect("load manifest segments");
+    let segments =
+        load_manifest_segments_for_inspection(store, None, namespace_id, &manifest_object_id)
+            .await
+            .expect("load manifest segments");
     let group = super::reorganize::select_family_group(
         store,
         namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -540,7 +540,7 @@ async fn load_current_manifest_segments<'a, S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
 ) -> VerifiedMetadataSegments<'a, S> {
     let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
-    load_verified_manifest_segments(store, None, namespace_id, &manifest_object_id)
+    load_manifest_segments_for_inspection(store, None, namespace_id, &manifest_object_id)
         .await
         .expect("load the current manifest's segments")
 }
@@ -3665,4 +3665,178 @@ async fn a_cancelled_finalization_does_not_take_the_races_it_has_left() {
         manifest_before,
         "and nothing may be published"
     );
+}
+
+fn mismatched_references(reference: &ManifestRef) -> Vec<(&'static str, ManifestRef)> {
+    let mut number = reference.clone();
+    number.manifest_no = ManifestNo(reference.manifest_no.0 + 1);
+    let mut sequence = reference.clone();
+    sequence.manifest_head_seq = ChangeSeq(reference.manifest_head_seq.0 - 1);
+    let mut checksum = reference.clone();
+    checksum.manifest_payload_checksum = format!("sha256:{}", "0".repeat(64));
+    vec![
+        ("manifest_no", number),
+        ("manifest_head_seq", sequence),
+        ("manifest_payload_checksum", checksum),
+    ]
+}
+
+async fn replace_root_reference(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    reference: ManifestRef,
+) -> Bytes {
+    use loonfs_api::wire::control::{encode_control_state, ControlObjectKind};
+    let mut root = load_metadata_root_object(store, namespace_id)
+        .await
+        .expect("load root")
+        .state;
+    root.manifest = reference;
+    let bytes = Bytes::from(
+        encode_control_state(ControlObjectKind::MetadataRoot, &root).expect("encode root"),
+    );
+    store
+        .put_overwrite(&metadata_root(namespace_id), bytes.clone())
+        .await
+        .expect("replace root reference");
+    bytes
+}
+
+fn assert_reference_corrupt(error: CoreError, field: &str) {
+    assert!(
+        matches!(&error, CoreError::NamespaceCorrupt(message) if message.contains(field)),
+        "expected corrupt {field}, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn compaction_rejects_mismatched_manifest_references_before_writing() {
+    let directory = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(directory.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("namespace");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let spec =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let root = load_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("root")
+        .state;
+    let cache = MetadataSegmentCache::new(MetadataSegmentCacheConfig::default());
+    super::super::load::load_manifest_segments(&store, Some(&cache), &root.manifest)
+        .await
+        .expect("warm manifest cache");
+
+    for (field, reference) in mismatched_references(&root.manifest) {
+        let error = super::super::load::load_manifest_segments(&store, Some(&cache), &reference)
+            .await
+            .err()
+            .expect("cache hits must verify the reference too");
+        assert_reference_corrupt(error, field);
+        let corrupted = replace_root_reference(&store, &namespace_id, reference).await;
+        let recording = RecordingStore::new(store.clone(), KeyPredicate::any());
+        let error = load_current_projection(&recording, &namespace_id)
+            .await
+            .expect_err("ordinary reads must reject the reference");
+        assert_reference_corrupt(error, field);
+        for max_bytes in [usize::MAX, 1] {
+            let error = reorganize_metadata_step(
+                &recording,
+                &namespace_id,
+                &test_context(),
+                MetadataLsmPolicy {
+                    max_delta_runs: NonZeroUsize::MIN,
+                    max_decoded_input_bytes_per_step: NonZeroUsize::new(max_bytes)
+                        .expect("nonzero budget"),
+                    ..MetadataLsmPolicy::default()
+                },
+                FrozenBasePolicy::default(),
+            )
+            .await
+            .expect_err("bounded merges and full-job planning must reject the reference");
+            assert_reference_corrupt(error, field);
+        }
+        let error = run_metadata_compaction_job(
+            &recording,
+            &namespace_id,
+            &test_context(),
+            &spec,
+            MetadataLsmPolicy::default(),
+            &MetadataCompactionCancellation::default(),
+        )
+        .await
+        .expect_err("job startup must reject the reference");
+        assert_reference_corrupt(error, field);
+        assert_eq!(
+            recording.counts().puts,
+            0,
+            "no output or lease may be written"
+        );
+        assert_eq!(recording.counts().compare_and_swaps, 0);
+        assert_eq!(
+            store
+                .get(&metadata_root(&namespace_id), None)
+                .await
+                .expect("read root"),
+            Some(corrupted),
+        );
+    }
+}
+
+#[tokio::test]
+async fn compaction_finalization_rechecks_the_complete_manifest_reference() {
+    let directory = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(directory.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("namespace");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let spec =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
+    let result = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    .expect("build staged output");
+    let timer = StdMonotonicTimer::default();
+    let mut lease = test_lease(&store, &namespace_id, &spec, &timer).await;
+    let root = load_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("root")
+        .state;
+    for (field, reference) in mismatched_references(&root.manifest) {
+        let corrupted = replace_root_reference(&store, &namespace_id, reference).await;
+        let lease_key = metadata_compaction_lease(&namespace_id, spec.group());
+        let recording = RecordingStore::new(
+            store.clone(),
+            KeyPredicate::new(move |key| key != lease_key),
+        );
+        let error = finalize_metadata_compaction(
+            &recording,
+            &namespace_id,
+            &spec,
+            &snapshot_keys,
+            result.clone(),
+            &MetadataCompactionCancellation::default(),
+            &mut lease,
+        )
+        .await
+        .expect_err("finalization must reject an inconsistent reference");
+        assert_reference_corrupt(error, field);
+        assert_eq!(
+            recording.counts().puts,
+            0,
+            "no replacement manifest may be written"
+        );
+        assert_eq!(
+            store
+                .get(&metadata_root(&namespace_id), None)
+                .await
+                .expect("read root"),
+            Some(corrupted),
+            "finalization must not replace the inconsistent root",
+        );
+    }
 }

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -11,7 +11,7 @@
 
 use super::budget::PassBudget;
 use super::live_set::LiveSet;
-use crate::checkpoint::{load_verified_manifest_segments, ManifestLoadFailureClass};
+use crate::checkpoint::{load_manifest_segments_for_inspection, ManifestLoadFailureClass};
 use crate::context::MutationContext;
 use crate::control_update::{
     load_upload_session_state, try_update_upload_session, CasAttempt, UploadSessionUpdate,
@@ -341,28 +341,32 @@ pub(super) async fn collect_referenced_content<S: ObjectStore + ?Sized>(
         if !budget.try_charge() {
             return Ok(CollectedReferences::Deferred);
         }
-        let segments =
-            match load_verified_manifest_segments(store, None, namespace_id, manifest_object_id)
-                .await
-            {
-                Ok(segments) => segments,
-                Err(error) => match error.failure_class() {
-                    ManifestLoadFailureClass::Store => {
-                        tracing::warn!(
-                            namespace_id = %namespace_id,
-                            manifest_object_id = %manifest_object_id,
-                            error = %error,
-                            "a content-reference manifest did not read; retaining completed content"
-                        );
-                        return Ok(CollectedReferences::Unavailable);
-                    }
-                    ManifestLoadFailureClass::Corrupt => {
-                        return Err(CoreError::NamespaceCorrupt(format!(
-                            "a content-reference manifest does not load: {error}"
-                        )));
-                    }
-                },
-            };
+        let segments = match load_manifest_segments_for_inspection(
+            store,
+            None,
+            namespace_id,
+            manifest_object_id,
+        )
+        .await
+        {
+            Ok(segments) => segments,
+            Err(error) => match error.failure_class() {
+                ManifestLoadFailureClass::Store => {
+                    tracing::warn!(
+                        namespace_id = %namespace_id,
+                        manifest_object_id = %manifest_object_id,
+                        error = %error,
+                        "a content-reference manifest did not read; retaining completed content"
+                    );
+                    return Ok(CollectedReferences::Unavailable);
+                }
+                ManifestLoadFailureClass::Corrupt => {
+                    return Err(CoreError::NamespaceCorrupt(format!(
+                        "a content-reference manifest does not load: {error}"
+                    )));
+                }
+            },
+        };
         let mut lower_bound = lookup_keys::REVISION_ROW_PREFIX.to_owned();
         let upper_bound = string_prefix_upper_bound(lookup_keys::REVISION_ROW_PREFIX);
         loop {

--- a/crates/loonfs-grep/src/codec.rs
+++ b/crates/loonfs-grep/src/codec.rs
@@ -201,7 +201,7 @@ fn malformed_varint(error: SstBlockCodecError) -> IndexGramsCodecError {
 /// One row of a gram index segment. Kind-tagged so a later released format
 /// version can define additional row kinds.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum IndexRow {
     GramPostings {
         gram: Gram,

--- a/crates/loonfs-grep/src/root/codec.rs
+++ b/crates/loonfs-grep/src/root/codec.rs
@@ -7,8 +7,8 @@
 use super::error::GrepEnvelopeCodecError;
 use super::state::{GrepManifestState, GrepRootPointer};
 use loonfs_api::wire::envelope::{
-    decode_json_envelope, decode_strict_json_envelope, encode_json_envelope, json_payload_checksum,
-    verify_kind, DecodedJsonEnvelope,
+    decode_json_envelope, encode_json_envelope, json_payload_checksum, verify_kind,
+    DecodedJsonEnvelope,
 };
 
 /// Durable kind string for a grep root-pointer envelope.
@@ -105,7 +105,7 @@ pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepEnve
 /// would erase what this binary does not understand.
 pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepEnvelopeCodecError> {
     let decoded: DecodedJsonEnvelope<GrepRootPointer> =
-        decode_strict_json_envelope(bytes, GREP_ROOT_FORMAT_VERSION, |found| {
+        decode_json_envelope(bytes, GREP_ROOT_FORMAT_VERSION, |found| {
             verify_kind(GREP_ROOT_KIND, found)
         })?;
     Ok(GrepRootEnvelope {
@@ -131,9 +131,7 @@ pub fn encode_grep_manifest(
 
 /// Decodes only the current manifest format and verifies it.
 ///
-/// Manifests are immutable, so additive fields are tolerated: nothing
-/// rewrites these bytes, and a reader that drops what it cannot name loses
-/// nothing durable.
+/// Unknown fields are rejected because indexing and compaction write successor manifests.
 pub fn decode_grep_manifest(bytes: &[u8]) -> Result<GrepManifestEnvelope, GrepEnvelopeCodecError> {
     let decoded: DecodedJsonEnvelope<GrepManifestState> =
         decode_json_envelope(bytes, GREP_MANIFEST_FORMAT_VERSION, |found| {

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -53,7 +53,7 @@ impl GrepRootPointer {
 /// target and progress. An active index records how far indexing has
 /// progressed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum GrepIndexStatus {
     /// Initial materialization is walking the checkpointed file set.
     Backfilling {
@@ -88,9 +88,7 @@ pub enum GrepIndexStatus {
     },
     /// Grep indexing and queries are disabled for this namespace.
     ///
-    /// The braces spell this status the same way as the other two and as
-    /// every durable control object's status. A manifest is immutable, so
-    /// this decoder still tolerates fields it does not know.
+    /// This closed status carries no phase-specific state.
     Disabled {},
 }
 
@@ -133,6 +131,7 @@ impl From<&GrepIndexStatus> for loonfs_api::v0::GrepIndexLifecycle {
 
 /// Resumable state for one partitioned segment reorganize.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GrepReorganizeState {
     /// Fixed input snapshot retained until the completing root swap.
     pub snapshot_segment_ids: Vec<IndexSegmentId>,
@@ -152,6 +151,7 @@ pub struct GrepReorganizeState {
 /// indexing. Shared state therefore lives here, while phase-specific state
 /// lives in [`GrepIndexStatus`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GrepIndexState {
     /// One in-progress partitioned reorganize, if present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -211,6 +211,7 @@ impl ChangeFeedResume {
 
 /// Query-visible descriptor for one immutable grep segment.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GrepSegmentRef {
     pub segment_id: IndexSegmentId,
     pub run_no: RunNo,
@@ -238,6 +239,7 @@ pub struct GrepSegmentRef {
 /// Fields stay private so every constructed or decoded manifest passes the
 /// inexpensive reorganize/segment and run-allocation checks in [`Self::new`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GrepManifestState {
     namespace_id: NamespaceId,
     status: GrepIndexStatus,

--- a/crates/loonfs-grep/tests/it/root_format.rs
+++ b/crates/loonfs-grep/tests/it/root_format.rs
@@ -101,20 +101,32 @@ fn the_manifest_status_is_a_kind_tagged_object() {
 }
 
 #[test]
-fn immutable_manifest_decoder_reads_frozen_bytes_with_additive_fields() {
-    let additive = edited_document(ACTIVE_MANIFEST_FIXTURE, UNKNOWN_ENVELOPE_FIELD, |payload| {
-        payload["future_root"] = serde_json::Value::from(true);
-        payload["status"]["future_status"] = serde_json::Value::from("ignored");
-        payload["index"]["future_index"] = serde_json::Value::from(17);
-        payload["segments"][0]["future_segment"] = serde_json::Value::from("ignored");
-    });
-
-    let decoded = decode_grep_manifest(&additive).expect("decode additive manifest fixture");
-
-    assert_eq!(
-        decoded.manifest_state(),
-        &sample_active_manifest(ChangeSeq(11), 5)
-    );
+fn manifest_decoder_rejects_unknown_fields_at_every_level() {
+    let envelope = edited_document(ACTIVE_MANIFEST_FIXTURE, UNKNOWN_ENVELOPE_FIELD, |_| {});
+    assert!(matches!(
+        decode_grep_manifest(&envelope),
+        Err(GrepEnvelopeCodecError::Envelope(
+            EnvelopeCodecError::EnvelopeDecode(_)
+        ))
+    ));
+    for path in [
+        "",
+        "/status",
+        "/index",
+        "/segments/0",
+        "/segments/0/index_block",
+    ] {
+        let edited = edited_document(ACTIVE_MANIFEST_FIXTURE, "", |payload| {
+            payload.pointer_mut(path).expect("fixture object")["field_from_the_future"] =
+                serde_json::Value::from(true);
+        });
+        assert!(
+            matches!(decode_grep_manifest(&edited),
+            Err(GrepEnvelopeCodecError::Envelope(EnvelopeCodecError::PayloadDecode(message)))
+                if message.contains("field_from_the_future")),
+            "path {path}"
+        );
+    }
 }
 
 #[test]

--- a/crates/loonfs/src/fs/namespaces.rs
+++ b/crates/loonfs/src/fs/namespaces.rs
@@ -80,7 +80,8 @@ impl FsWriter {
     /// spec, "Tombstones and deletion"). Commits acknowledged before the
     /// swap stay committed; reads, writes, forks, and re-creation of the id
     /// fail with `namespace_deleted` afterward. Deletion does not reclaim
-    /// storage; reclamation is explicit garbage collection.
+    /// published content. Garbage collection can release derived metadata and
+    /// upload-owned content, but there is no published-content purge guarantee.
     ///
     /// Sequenced as a barrier through the publication service: mutations
     /// admitted before the delete publish first, and mutations admitted

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1055,6 +1055,10 @@ candidate under `no_reference_manifest`.
 
 #### Deleting, retaining, and reclaiming
 
+The launch contract provides no purge operation or guarantee for previously
+published file content. Such content may remain indefinitely, including after
+namespace deletion. Deletion ends access; it does not promise physical erasure.
+
 Two horizons decide when a namespace actually gets smaller, and they are
 independent.
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -35,13 +35,12 @@ meant to send:
   request, at every level of nesting.
 - **HTTP response bodies tolerate them**, so a client keeps working against a
   server newer than itself.
-- **Immutable, never-rewritten durable families tolerate them**, at every
-  level of nesting, for the same reason: nothing rewrites them, so nothing
-  can erase a field it did not understand.
-- **Mutable control-object envelopes and payloads reject them**, because a
-  reader that tolerated an unknown field would erase it on the next
-  read-modify-write and still report a successful guarded update
-  (section 1.7).
+- **All authoritative durable envelopes and records reject them**, at every
+  level of nesting. This includes immutable manifests, WAL records, metadata
+  rows, and grep state: folding and compaction re-encode their contents into
+  successor objects, so a reader must not accept fields it cannot preserve.
+  New durable meaning requires a supported family format version; an older
+  binary refuses newer data rather than silently dropping it.
 - **`ContentRef`, `Checksum`, and `ActorRef` are closed shapes.** They reject
   unknown fields wherever they appear, in request bodies and in durable rows
   alike, because the same types decode request bodies. They evolve only by
@@ -351,17 +350,11 @@ plus `METADATA_COMPACTION_LEASE_EXPIRY_MS` when it creates or refreshes the
 lease. Readers compare their current time directly with that stored instant;
 they do not apply the writer's lifetime policy again.
 
-Mutable control-object decoders reject unknown fields in both the envelope and
-the complete nested payload. Otherwise, an older binary could tolerate a
-newer field, erase it during read-modify-write, and still report a successful
-guarded update. All six registered kinds use that strict decoder; immutable
-WAL segments, metadata segments, namespace manifests, grep segments, and grep
-manifests remain tolerant of additive fields.
-
-WAL segment pointers in immutable segments may contain unknown fields. The
-same pointers in the mutable head may not. The head uses strict decoders for
-`visible_wal_tip` and `recent_segments` so a guarded rewrite cannot discard
-unknown data.
+Every durable decoder rejects unknown fields in its envelope and complete
+nested payload. Mutable updates, WAL folding, and compaction all write
+successor state; none may silently discard a field an older binary did not
+understand. WAL pointers therefore use the same strict decoder in the head
+and in immutable segments. New fields require a supported family version.
 
 A durable object that references a namespace manifest stores this shape under `manifest`:
 
@@ -2007,9 +2000,8 @@ mismatches without fallback, and validate namespace, status, fold,
 run-allocation, and segment invariants at every boundary. A manifest
 load additionally requires the loaded envelope's `payload_checksum` to equal
 what the pointer promised, which is the same binding a metadata root holds
-over its namespace manifest. The mutable
-root-pointer decoder rejects unknown envelope and payload fields; the
-immutable manifest decoder tolerates additive fields.
+over its namespace manifest. Both root pointers and immutable manifests reject
+unknown envelope and payload fields, including nested state and descriptors.
 
 The nested `index` object holds what every phase has — the in-progress
 `reorganize` state and the `next_run_no` allocator — while each phase's own
@@ -2307,9 +2299,10 @@ moves only when an operator requests an explicit retention advance.
 
 ### 6.4 Garbage collection
 
-Delete is tombstone-first. Garbage collection is the separate process that
-eventually reclaims content or metadata that is no longer reachable and no
-longer protected by retention policy. GC and floor advancement are the only
+Delete is tombstone-first. Garbage collection reclaims unreachable metadata
+and content still owned by upload-session records under the rules below.
+There is no general sweep or purge guarantee for previously published content;
+content may remain indefinitely after file or namespace deletion. GC and floor advancement are the only
 consumers of listing, and nothing sweeps by default: a pass runs only through
 the maintenance endpoint or an explicit maintenance-step opt-in.
 


### PR DESCRIPTION
Compaction must verify the complete manifest reference before publishing, including when the manifest is cached. Durable decoders now reject unknown nested fields consistently so rewrites cannot silently drop state, and the launch contract makes clear that namespace deletion provides no content-purge guarantee. Existing valid durable bytes are unchanged. Workspace tests (excluding loonfs-sim), OpenAPI checks, and Clippy across all targets and features pass.
