### PR TITLE
fix(runtime): bound publication admission across namespaces

### DIFF
--- a/crates/loonfs-client/tests/snapshots.rs
+++ b/crates/loonfs-client/tests/snapshots.rs
@@ -31,6 +31,7 @@ async fn start_server(name: &str) -> TestServer {
         writer_id: name.to_owned(),
         max_writer_sessions: 10_000,
         max_concurrent_folds: 2,
+        publication: Default::default(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
         grep: GrepConfig::default(),

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -107,6 +107,54 @@ impl CommitCandidate {
         commit_fingerprint(namespace_id, &self.request)
     }
 
+    /// Estimates retained request data and prepared proofs for publication
+    /// admission. Counts inline storage plus JSON payload bytes without
+    /// allocating a second request. Allocator slack and publication working
+    /// copies are excluded; this is a sizing policy, not a heap measurement.
+    pub fn estimated_retained_bytes(&self) -> Result<usize> {
+        let mut bytes = RequestByteCounter(
+            std::mem::size_of_val(self)
+                .saturating_add(std::mem::size_of_val(self.request.operations.as_slice())),
+        );
+        serde_json::to_writer(
+            &mut bytes,
+            &(
+                &self.request.commit_id,
+                &self.request.actor,
+                &self.request.message,
+                &self.request.operations,
+            ),
+        )
+        .map_err(|error| CoreError::InvalidCommitRequest(error.to_string()))?;
+        match &self.content {
+            ContentPreparation::Ready(proofs) => {
+                bytes.0 = bytes
+                    .0
+                    .saturating_add(std::mem::size_of_val(proofs.as_slice()));
+                for proof in proofs {
+                    bytes.0 = bytes.0.saturating_add(proof.estimated_payload_bytes());
+                }
+            }
+            ContentPreparation::Rejected(ContentPreparationError::ContentToken(rejections)) => {
+                bytes.0 = bytes
+                    .0
+                    .saturating_add(std::mem::size_of_val(rejections.as_slice()));
+                for (content_id, error) in rejections {
+                    bytes.0 = bytes.0.saturating_add(content_id.as_str().len());
+                    if let ContentTokenError::Codec(message) = error {
+                        bytes.0 = bytes.0.saturating_add(message.len());
+                    }
+                }
+            }
+            ContentPreparation::Rejected(ContentPreparationError::ContentNotPrepared {
+                content_id,
+            }) => {
+                bytes.0 = bytes.0.saturating_add(content_id.as_str().len());
+            }
+        }
+        Ok(bytes.0)
+    }
+
     pub(crate) fn validate_request_limits(&self) -> Result<()> {
         // Apply limits to the complete request because the serialized publisher
         // processes every operation before releasing the write path.
@@ -159,6 +207,19 @@ impl CommitCandidate {
                 "mutation request carries no operations".to_owned(),
             ));
         }
+        Ok(())
+    }
+}
+
+struct RequestByteCounter(usize);
+
+impl std::io::Write for RequestByteCounter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0 = self.0.saturating_add(bytes.len());
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
 }
@@ -600,6 +661,43 @@ mod tests {
                 parents: false,
             },
         )
+    }
+
+    #[test]
+    fn admission_weight_includes_annotation_proofs_and_preparation_errors() {
+        let request = create_dir_request("weight", "docs");
+        let baseline = CommitCandidate::new(request.clone())
+            .estimated_retained_bytes()
+            .expect("weight");
+        let mut annotated = request.clone();
+        annotated.message = Some("x".repeat(4096));
+        assert!(
+            CommitCandidate::new(annotated)
+                .estimated_retained_bytes()
+                .expect("weight")
+                >= baseline + 4096
+        );
+        let proof = PreparedContent::for_durable_content_write(
+            NamespaceId::parse("demo").expect("namespace"),
+            ContentStoreId::parse("cs_00000000000000000000000000000001").expect("store"),
+            ContentRef::blob_v1(ContentId::generate(), b"proof"),
+        );
+        let prepared = CommitCandidate::prepared(request.clone(), vec![proof; 100]);
+        assert!(
+            prepared.estimated_retained_bytes().expect("weight")
+                > baseline + 100 * std::mem::size_of::<PreparedContent>()
+        );
+        let rejected = CommitCandidate::rejected(
+            request,
+            ContentPreparationError::ContentToken(vec![
+                (
+                    ContentId::generate(),
+                    ContentTokenError::Codec("x".repeat(4096))
+                );
+                10
+            ]),
+        );
+        assert!(rejected.estimated_retained_bytes().expect("weight") > baseline + 40960);
     }
 
     #[test]

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -670,12 +670,16 @@ mod tests {
             .estimated_retained_bytes()
             .expect("weight");
         let mut annotated = request.clone();
+        annotated.message = Some(String::new());
+        let empty_annotation = CommitCandidate::new(annotated.clone())
+            .estimated_retained_bytes()
+            .expect("weight");
         annotated.message = Some("x".repeat(4096));
         assert!(
             CommitCandidate::new(annotated)
                 .estimated_retained_bytes()
                 .expect("weight")
-                >= baseline + 4096
+                >= empty_annotation + 4096
         );
         let proof = PreparedContent::for_durable_content_write(
             NamespaceId::parse("demo").expect("namespace"),

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -57,6 +57,15 @@ pub struct PreparedContent {
 }
 
 impl PreparedContent {
+    pub(crate) fn estimated_payload_bytes(&self) -> usize {
+        self.namespace_id
+            .as_str()
+            .len()
+            .saturating_add(self.content_store_id.as_str().len())
+            .saturating_add(self.content_ref.content_id.as_str().len())
+            .saturating_add(self.content_ref.checksum.value.len())
+    }
+
     pub(crate) fn content_id(&self) -> &ContentId {
         &self.content_ref.content_id
     }

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -132,3 +132,12 @@ writer_id = "loonfs-server-local"
 kind = "local-fs"
 root = "./.loonfs-store"
 key_prefix = "local-demo"
+
+# Shared publication admission. Includes active requests, duplicate callers,
+# and namespace deletes. Full admission returns `commit_queue_full`.
+#[publication]
+#max_requests = 8192
+#max_requests_per_namespace = 1024
+#max_estimated_bytes = 67108864
+#max_estimated_bytes_per_namespace = 8388608
+#max_concurrent_publications = 8

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -319,6 +319,28 @@ must keep more namespaces writable at once.
 cap; raise it only after accounting for the additional object-store and CPU
 work.
 
+Publication admission counts queued and active callers, including duplicate
+commits, conflicts, and namespace deletes. A caller that disconnects stays
+charged until its admitted work settles. Requests past a count or estimated
+byte limit receive `commit_queue_full`; admitted work waits for a shared
+publication slot. Each namespace has its own allowance so one busy tenant
+cannot consume the default host budget.
+
+```toml
+[publication]
+max_requests = 8192
+max_requests_per_namespace = 1024
+max_estimated_bytes = 67108864
+max_estimated_bytes_per_namespace = 8388608
+max_concurrent_publications = 8
+```
+
+These are the defaults; every value must be positive. The byte estimate counts
+request data, prepared proofs, and queue bookkeeping. It excludes allocator
+slack, HTTP request buffers, and the metadata/working copies a publication
+loads. Size process memory for those costs and the separate fold/cache limits
+too. Embedded hosts set the same limits with `FsWriterBuilder::publication_limits`.
+
 ## Optional local cache
 
 The local cache stores replaceable copies of metadata blocks. It is not

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -16,6 +16,38 @@ use thiserror::Error;
 
 pub use loonfs_objectstore::StoreConfig;
 
+/// Optional overrides for the writer's shared publication budget.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PublicationLimitsOverrides {
+    pub max_requests: Option<std::num::NonZeroUsize>,
+    pub max_requests_per_namespace: Option<std::num::NonZeroUsize>,
+    pub max_estimated_bytes: Option<std::num::NonZeroUsize>,
+    pub max_estimated_bytes_per_namespace: Option<std::num::NonZeroUsize>,
+    pub max_concurrent_publications: Option<std::num::NonZeroUsize>,
+}
+
+impl PublicationLimitsOverrides {
+    pub(crate) fn resolve(&self) -> loonfs::PublicationLimits {
+        let defaults = loonfs::PublicationLimits::default();
+        loonfs::PublicationLimits {
+            max_requests: self.max_requests.unwrap_or(defaults.max_requests),
+            max_requests_per_namespace: self
+                .max_requests_per_namespace
+                .unwrap_or(defaults.max_requests_per_namespace),
+            max_estimated_bytes: self
+                .max_estimated_bytes
+                .unwrap_or(defaults.max_estimated_bytes),
+            max_estimated_bytes_per_namespace: self
+                .max_estimated_bytes_per_namespace
+                .unwrap_or(defaults.max_estimated_bytes_per_namespace),
+            max_concurrent_publications: self
+                .max_concurrent_publications
+                .unwrap_or(defaults.max_concurrent_publications),
+        }
+    }
+}
+
 /// The only request-authentication decisions exposed to HTTP helpers.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum AuthPolicy<'a> {
@@ -50,6 +82,9 @@ pub struct ServerConfig {
     /// `loonfs.publisher.wal_folds_waiting` gauge means this cap is too low.
     #[serde(default = "default_max_concurrent_folds")]
     pub max_concurrent_folds: usize,
+    /// Shared request and concurrency limits for namespace publications.
+    #[serde(default)]
+    pub publication: PublicationLimitsOverrides,
     #[serde(default)]
     pub runtime_cache: RuntimeCacheConfigOverrides,
     /// The node-local cache of encoded metadata blocks, if this deployment
@@ -543,6 +578,14 @@ impl ServerConfig {
                 });
             }
         }
+        if self.publication.resolve().max_concurrent_publications.get()
+            > tokio::sync::Semaphore::MAX_PERMITS
+        {
+            return Err(ServerConfigError::InvalidField {
+                field: "publication.max_concurrent_publications",
+                reason: format!("must not exceed {}", tokio::sync::Semaphore::MAX_PERMITS),
+            });
+        }
         if let Err(error) = self.grep.worker_config().validate() {
             return Err(ServerConfigError::InvalidField {
                 field: "grep",
@@ -650,8 +693,8 @@ mod tests {
     // Config tests use panic in unexpected match arms for precise diagnostics.
 
     use super::{
-        load_server_config, ServerConfigError, AUTH_TOKEN_ENV, CONTENT_TOKEN_SECRET_ENV,
-        DISK_BLOCK_BYTES, MIN_DISK_BYTES,
+        load_server_config, PublicationLimitsOverrides, ServerConfigError, AUTH_TOKEN_ENV,
+        CONTENT_TOKEN_SECRET_ENV, DISK_BLOCK_BYTES, MIN_DISK_BYTES,
     };
     use loonfs_test_support::EnvGuard;
     use std::fs;
@@ -1255,6 +1298,27 @@ root = "/tmp/loonfs-server"
             let error = load_server_config(&path).expect_err("zero deadline must be rejected");
             assert_invalid_field(error, field);
         }
+    }
+
+    #[test]
+    fn publication_overrides_are_strict_and_positive() {
+        let defaults: PublicationLimitsOverrides = toml::from_str("").expect("empty overrides");
+        assert_eq!(defaults.resolve(), loonfs::PublicationLimits::default());
+        for field in [
+            "max_requests",
+            "max_requests_per_namespace",
+            "max_estimated_bytes",
+            "max_estimated_bytes_per_namespace",
+            "max_concurrent_publications",
+        ] {
+            assert!(toml::from_str::<PublicationLimitsOverrides>(&format!("{field} = 0")).is_err());
+        }
+        assert!(toml::from_str::<PublicationLimitsOverrides>("max_requsets = 10").is_err());
+        let overrides: PublicationLimitsOverrides =
+            toml::from_str("max_requests = 12\nmax_concurrent_publications = 3")
+                .expect("overrides");
+        assert_eq!(overrides.resolve().max_requests.get(), 12);
+        assert_eq!(overrides.resolve().max_concurrent_publications.get(), 3);
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -443,6 +443,7 @@ pub(super) async fn build_handles(
             std::num::NonZeroUsize::new(config.max_writer_sessions)
                 .expect("validated maximum writer sessions should be nonzero"),
         )
+        .publication_limits(config.publication.resolve())
         .max_concurrent_folds(
             std::num::NonZeroUsize::new(config.max_concurrent_folds)
                 .expect("validated maximum concurrent folds should be nonzero"),

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -3622,6 +3622,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         writer_id: writer_id.to_owned(),
         max_writer_sessions: loonfs::DEFAULT_MAX_WRITER_SESSIONS,
         max_concurrent_folds: loonfs::DEFAULT_MAX_CONCURRENT_FOLDS,
+        publication: Default::default(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
         grep: crate::config::GrepConfig {

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -305,6 +305,7 @@ pub(crate) fn test_config(
         writer_id: writer_id.to_owned(),
         max_writer_sessions: loonfs::DEFAULT_MAX_WRITER_SESSIONS,
         max_concurrent_folds: loonfs::DEFAULT_MAX_CONCURRENT_FOLDS,
+        publication: Default::default(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
         grep: GrepConfig {

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -708,6 +708,7 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
         writer_id: format!("grep-mode-{mode:?}"),
         max_writer_sessions: loonfs::DEFAULT_MAX_WRITER_SESSIONS,
         max_concurrent_folds: loonfs::DEFAULT_MAX_CONCURRENT_FOLDS,
+        publication: Default::default(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         local_cache: None,
         grep: GrepConfig {

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -30,6 +30,44 @@ pub const DEFAULT_MAX_CONCURRENT_COMPACTIONS: usize = 2;
 /// dropped: it takes the next one that frees.
 pub const DEFAULT_MAX_CONCURRENT_MAINTENANCE: usize = 2;
 
+/// Shared limits for queued and active publications owned by one writer.
+///
+/// Every admitted caller counts, including duplicate commits and namespace
+/// deletes. Counts and bytes remain charged until the work settles, even if
+/// the caller disconnects. Reaching either admission limit returns
+/// `commit_queue_full`; admitted work waits for a publication slot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationLimits {
+    /// Maximum admitted requests across all namespaces. Defaults to 8,192.
+    pub max_requests: std::num::NonZeroUsize,
+    /// Maximum admitted requests for one namespace. Defaults to 1,024.
+    pub max_requests_per_namespace: std::num::NonZeroUsize,
+    /// Approximate retained request bytes across all namespaces. Defaults to
+    /// 64 MiB. This includes request data, prepared proofs, and waiter overhead;
+    /// it is not a bound on allocator capacity or working publication memory.
+    pub max_estimated_bytes: std::num::NonZeroUsize,
+    /// Approximate retained request bytes for one namespace. Defaults to 8 MiB.
+    pub max_estimated_bytes_per_namespace: std::num::NonZeroUsize,
+    /// Maximum publication batches or deletes running at once. Defaults to 8.
+    pub max_concurrent_publications: std::num::NonZeroUsize,
+}
+
+impl Default for PublicationLimits {
+    fn default() -> Self {
+        Self {
+            max_requests: std::num::NonZeroUsize::new(8192).expect("nonzero request limit"),
+            max_requests_per_namespace: std::num::NonZeroUsize::new(1024)
+                .expect("nonzero namespace request limit"),
+            max_estimated_bytes: std::num::NonZeroUsize::new(64 * 1024 * 1024)
+                .expect("nonzero request byte limit"),
+            max_estimated_bytes_per_namespace: std::num::NonZeroUsize::new(8 * 1024 * 1024)
+                .expect("nonzero namespace byte limit"),
+            max_concurrent_publications: std::num::NonZeroUsize::new(8)
+                .expect("nonzero publication limit"),
+        }
+    }
+}
+
 /// Read and cache configuration shared by all handles.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ReadConfig {

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -245,6 +245,7 @@ pub struct FsWriterBuilder {
     min_publish_interval_ms: u64,
     namespace_session_policy: NamespaceSessionPolicy,
     max_writer_sessions: NonZeroUsize,
+    publication_limits: crate::PublicationLimits,
     max_concurrent_folds: NonZeroUsize,
     namespace_advance_observer: Option<NamespaceAdvanceObserver>,
     maintenance_hint_observer: Option<MaintenanceHintObserver>,
@@ -261,6 +262,7 @@ impl FsWriterBuilder {
                 .expect("default maximum writer sessions should be nonzero"),
             max_concurrent_folds: NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_FOLDS)
                 .expect("default maximum concurrent folds should be nonzero"),
+            publication_limits: crate::PublicationLimits::default(),
             namespace_advance_observer: None,
             maintenance_hint_observer: None,
         }
@@ -315,6 +317,12 @@ impl FsWriterBuilder {
     /// The default is [`crate::DEFAULT_MAX_CONCURRENT_FOLDS`].
     pub fn max_concurrent_folds(mut self, limit: NonZeroUsize) -> Self {
         self.max_concurrent_folds = limit;
+        self
+    }
+
+    /// Sets the shared admission and concurrency limits for publications.
+    pub fn publication_limits(mut self, limits: crate::PublicationLimits) -> Self {
+        self.publication_limits = limits;
         self
     }
 
@@ -416,6 +424,12 @@ impl FsWriterBuilder {
         let writer_id = self
             .writer_id
             .ok_or_else(|| RuntimeError::Config("writer_id is required".to_owned()))?;
+        if self.publication_limits.max_concurrent_publications.get() > Semaphore::MAX_PERMITS {
+            return Err(RuntimeError::Config(format!(
+                "max_concurrent_publications must not exceed {}",
+                Semaphore::MAX_PERMITS
+            )));
+        }
         let identity = WriterIdentity::new(writer_id)?;
         let runtime = owning_runtime()?;
         let core = self.core.open_read_core()?;
@@ -433,6 +447,7 @@ impl FsWriterBuilder {
             std::time::Duration::from_millis(self.min_publish_interval_ms),
             self.namespace_session_policy,
             self.max_writer_sessions,
+            self.publication_limits,
         );
         Ok(FsWriter {
             core,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -171,8 +171,8 @@ pub use loonfs_objectstore::{
 
 pub use cache::RuntimeCacheStats;
 pub use config::{
-    RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_COMPACTIONS, DEFAULT_MAX_CONCURRENT_FOLDS,
-    DEFAULT_MAX_CONCURRENT_MAINTENANCE, DEFAULT_MAX_WRITER_SESSIONS,
+    PublicationLimits, RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_COMPACTIONS,
+    DEFAULT_MAX_CONCURRENT_FOLDS, DEFAULT_MAX_CONCURRENT_MAINTENANCE, DEFAULT_MAX_WRITER_SESSIONS,
 };
 pub use fs::{
     ChangesPager, CheckpointsPager, FileRevisionsPager, FsReadSnapshot, InodeChildrenPager,

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -8,6 +8,8 @@
 //! admission and drains the queues through
 //! [`FsWriter::shutdown`](crate::FsWriter::shutdown).
 
+mod admission;
+
 use crate::fs::{ReadCore, WriterBits};
 use crate::metrics::{PublishOutcome, RESULT_OK};
 use crate::publish::CommitCandidate;
@@ -16,6 +18,7 @@ use crate::{
     CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, NamespaceSessionPolicy,
     RuntimeCacheConfig, RuntimeError,
 };
+use admission::{AdmittedWaiter, PublicationAdmission};
 use futures::FutureExt;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::{ChangeSeq, CommitId, NamespaceId};
@@ -109,10 +112,6 @@ pub struct WriterSessionStats {
     pub capacity: usize,
 }
 
-/// Maximum candidates queued for one namespace before admission reports
-/// `commit_queue_full`.
-const MAX_BATCH_CANDIDATES: usize = 1024;
-
 /// Registry of per-namespace publishers owned by one writer.
 ///
 /// Clones share the same publishers and worker tasks. Submit through the
@@ -141,6 +140,7 @@ pub struct PublisherRegistry {
 /// State shared by all publishers in this registry: admission status,
 /// publisher instances, retained projections, and contained panic count.
 struct RegistryShared {
+    admission: Arc<PublicationAdmission>,
     state: Mutex<RegistryState>,
     /// Publication, deletion, and namespace-close units whose panic a task
     /// survived. Tasks contain panics to keep the registry usable, so this —
@@ -338,9 +338,11 @@ impl PublisherRegistry {
         min_publish_interval: Duration,
         policy: NamespaceSessionPolicy,
         capacity: NonZeroUsize,
+        publication_limits: crate::PublicationLimits,
     ) -> Self {
         Self {
             shared: Arc::new(RegistryShared {
+                admission: Arc::new(PublicationAdmission::new(publication_limits)),
                 state: Mutex::new(RegistryState {
                     closed: false,
                     policy,
@@ -382,6 +384,15 @@ impl PublisherRegistry {
         namespace_id: NamespaceId,
         candidate: CommitCandidate,
     ) -> CommitResult {
+        let estimated_bytes = candidate.estimated_retained_bytes()?;
+        let permit = {
+            let mut state = self.shared.lock_state();
+            let publisher = self.publisher_for(&mut state, &namespace_id, false)?;
+            publisher.check_admission(&publisher.lock_state())?;
+            self.shared
+                .admission
+                .acquire(&namespace_id, estimated_bytes)?
+        };
         submit_with_admission(
             &namespace_id,
             candidate,
@@ -389,7 +400,13 @@ impl PublisherRegistry {
             |commit_id, candidate, semantic_identity, waiter, enqueued_at| {
                 let mut state = self.shared.lock_state();
                 let publisher = self.publisher_for(&mut state, &namespace_id, false)?;
-                publisher.admit(commit_id, candidate, semantic_identity, waiter, enqueued_at)
+                publisher.admit(
+                    commit_id,
+                    candidate,
+                    semantic_identity,
+                    AdmittedWaiter::new(waiter, &permit),
+                    enqueued_at,
+                )
             },
         )
         .await
@@ -454,15 +471,7 @@ impl PublisherRegistry {
                 max_writer_sessions: state.capacity.get(),
             });
         }
-        let publisher = NamespacePublisher::new(
-            namespace_id.clone(),
-            self.read_core.clone(),
-            self.writer.clone(),
-            Arc::downgrade(&self.shared),
-            self.runtime.clone(),
-            Arc::clone(&self.timer),
-            self.min_publish_interval,
-        );
+        let publisher = NamespacePublisher::new(namespace_id.clone(), self);
         state
             .publishers
             .insert(namespace_id.clone(), publisher.clone());
@@ -732,6 +741,7 @@ async fn finish_namespace_close(
 
 #[derive(Clone)]
 struct NamespacePublisher {
+    admission: Arc<PublicationAdmission>,
     namespace_id: NamespaceId,
     read_core: ReadCore,
     /// Weak for the same reason as the registry's reference: a publication
@@ -856,7 +866,7 @@ impl Drop for WaitingFold<'_> {
 
 struct PendingDelete {
     options: DeleteNamespaceOptions,
-    waiters: Vec<oneshot::Sender<DeleteResult>>,
+    waiters: Vec<AdmittedWaiter<DeleteResult>>,
 }
 
 enum WorkItem {
@@ -877,7 +887,7 @@ struct BatchCandidate {
 
 struct InFlightRequest {
     semantic_identity: CommitFingerprint,
-    waiters: Vec<oneshot::Sender<CommitResult>>,
+    waiters: Vec<AdmittedWaiter<CommitResult>>,
 }
 
 enum SubmissionAdmission {
@@ -895,20 +905,12 @@ enum SubmissionAdmission {
 }
 
 impl NamespacePublisher {
-    fn new(
-        namespace_id: NamespaceId,
-        read_core: ReadCore,
-        writer: Weak<WriterBits>,
-        shared: Weak<RegistryShared>,
-        runtime: Handle,
-        timer: Arc<dyn MonotonicTimer>,
-        min_publish_interval: Duration,
-    ) -> Self {
+    fn new(namespace_id: NamespaceId, registry: &PublisherRegistry) -> Self {
         let session = SharedWriterSessionState::default();
         Self {
             namespace_id,
-            read_core,
-            writer,
+            read_core: registry.read_core.clone(),
+            writer: registry.writer.clone(),
             state: Arc::new(Mutex::new(NamespacePublisherState {
                 queue: VecDeque::new(),
                 in_flight: HashMap::new(),
@@ -923,10 +925,11 @@ impl NamespacePublisher {
                 session: Arc::clone(&session),
             })),
             session,
-            shared,
-            runtime,
-            timer,
-            min_publish_interval,
+            shared: Arc::downgrade(&registry.shared),
+            runtime: registry.runtime.clone(),
+            timer: Arc::clone(&registry.timer),
+            min_publish_interval: registry.min_publish_interval,
+            admission: Arc::clone(&registry.shared.admission),
         }
     }
 
@@ -1025,12 +1028,22 @@ impl NamespacePublisher {
     /// still owns and publishes the request.
     #[cfg(test)]
     async fn submit(&self, candidate: CommitCandidate) -> CommitResult {
+        self.check_admission(&self.lock_state())?;
+        let permit = self
+            .admission
+            .acquire(&self.namespace_id, candidate.estimated_retained_bytes()?)?;
         submit_with_admission(
             &self.namespace_id,
             candidate,
             self.timer.as_ref(),
             |commit_id, candidate, semantic_identity, waiter, enqueued_at| {
-                self.admit(commit_id, candidate, semantic_identity, waiter, enqueued_at)
+                self.admit(
+                    commit_id,
+                    candidate,
+                    semantic_identity,
+                    AdmittedWaiter::new(waiter, &permit),
+                    enqueued_at,
+                )
             },
         )
         .await
@@ -1041,7 +1054,7 @@ impl NamespacePublisher {
         commit_id: CommitId,
         candidate: CommitCandidate,
         semantic_identity: CommitFingerprint,
-        waiter: oneshot::Sender<CommitResult>,
+        waiter: AdmittedWaiter<CommitResult>,
         enqueued_at: u64,
     ) -> Result<SubmissionAdmission, CoreError> {
         let mut state = self.lock_state();
@@ -1063,10 +1076,6 @@ impl NamespacePublisher {
         }
 
         let queued = queued_candidates(&state);
-        if queued >= MAX_BATCH_CANDIDATES {
-            self.trace_enqueue(queued, "full");
-            return Err(CoreError::CommitQueueFull);
-        }
         let candidate = BatchCandidate {
             commit_id: commit_id.clone(),
             candidate,
@@ -1112,6 +1121,8 @@ impl NamespacePublisher {
         {
             let mut state = self.lock_state();
             self.check_admission(&state)?;
+            let permit = self.admission.acquire(&self.namespace_id, 0)?;
+            let sender = AdmittedWaiter::new(sender, &permit);
             match state.queue.back_mut() {
                 // A delete queued with the same options is the same request:
                 // both callers share its outcome. Different options ask for
@@ -1165,6 +1176,14 @@ impl NamespacePublisher {
             // namespace publishes immediately; requests arriving during a publish or
             // pacing interval form the next batch.
             self.await_cas_slot().await;
+            // Queue ownership and admission remain intact while another
+            // namespace uses the shared publication slots. No engine is held.
+            let _publication = self
+                .admission
+                .publications
+                .acquire()
+                .await
+                .expect("publication semaphore is never closed");
             let Some(item) = self.take_next_item() else {
                 return;
             };
@@ -1800,8 +1819,8 @@ async fn receive_delete(receiver: oneshot::Receiver<DeleteResult>) -> DeleteResu
 /// type.
 #[derive(Default)]
 struct QueuedWaiters {
-    commits: Vec<oneshot::Sender<CommitResult>>,
-    deletes: Vec<oneshot::Sender<DeleteResult>>,
+    commits: Vec<AdmittedWaiter<CommitResult>>,
+    deletes: Vec<AdmittedWaiter<DeleteResult>>,
 }
 
 /// Empties the queue and hands back every waiter it held. Called once the

--- a/crates/loonfs/src/publisher/admission.rs
+++ b/crates/loonfs/src/publisher/admission.rs
@@ -1,0 +1,248 @@
+//! One budget for every caller whose publication has been admitted.
+
+use super::{CoreError, NamespaceId};
+use crate::PublicationLimits;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::{oneshot, Semaphore};
+
+pub(super) struct PublicationAdmission {
+    limits: PublicationLimits,
+    usage: Mutex<Usage>,
+    pub(super) publications: Semaphore,
+}
+
+#[derive(Default)]
+struct Usage {
+    total: RequestWeight,
+    namespaces: HashMap<NamespaceId, RequestWeight>,
+}
+
+#[derive(Default)]
+struct RequestWeight {
+    requests: usize,
+    estimated_bytes: usize,
+}
+
+impl PublicationAdmission {
+    pub(super) fn new(limits: PublicationLimits) -> Self {
+        Self {
+            publications: Semaphore::new(limits.max_concurrent_publications.get()),
+            limits,
+            usage: Mutex::new(Usage::default()),
+        }
+    }
+
+    fn lock_usage(&self) -> std::sync::MutexGuard<'_, Usage> {
+        self.usage
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[cfg(test)]
+    pub(super) fn used_requests(&self) -> usize {
+        self.lock_usage().total.requests
+    }
+
+    pub(super) fn acquire(
+        self: &Arc<Self>,
+        namespace_id: &NamespaceId,
+        estimated_request_bytes: usize,
+    ) -> Result<Arc<AdmissionPermit>, CoreError> {
+        // Include the channel, ID copies, fingerprint and queue bookkeeping.
+        // Deletes carry only fixed-size options. Candidate bytes include any
+        // proof or rejection data retained while waiting to publish.
+        let estimated_bytes = estimated_request_bytes
+            .saturating_add(512)
+            .saturating_add(namespace_id.as_str().len());
+        let mut usage = self.lock_usage();
+        let empty = RequestWeight::default();
+        let namespace = usage.namespaces.get(namespace_id).unwrap_or(&empty);
+        if usage.total.requests >= self.limits.max_requests.get()
+            || namespace.requests >= self.limits.max_requests_per_namespace.get()
+            || estimated_bytes
+                > self
+                    .limits
+                    .max_estimated_bytes_per_namespace
+                    .get()
+                    .saturating_sub(namespace.estimated_bytes)
+            || estimated_bytes
+                > self
+                    .limits
+                    .max_estimated_bytes
+                    .get()
+                    .saturating_sub(usage.total.estimated_bytes)
+        {
+            return Err(CoreError::CommitQueueFull);
+        }
+        usage.total.requests += 1;
+        usage.total.estimated_bytes += estimated_bytes;
+        let namespace = usage.namespaces.entry(namespace_id.clone()).or_default();
+        namespace.requests += 1;
+        namespace.estimated_bytes += estimated_bytes;
+        Ok(Arc::new(AdmissionPermit {
+            budget: Arc::clone(self),
+            namespace_id: namespace_id.clone(),
+            estimated_bytes,
+        }))
+    }
+}
+
+pub(super) struct AdmissionPermit {
+    budget: Arc<PublicationAdmission>,
+    namespace_id: NamespaceId,
+    estimated_bytes: usize,
+}
+
+impl Drop for AdmissionPermit {
+    fn drop(&mut self) {
+        let mut usage = self.budget.lock_usage();
+        usage.total.requests -= 1;
+        usage.total.estimated_bytes -= self.estimated_bytes;
+        if let Some(namespace) = usage.namespaces.get_mut(&self.namespace_id) {
+            namespace.requests -= 1;
+            namespace.estimated_bytes -= self.estimated_bytes;
+            if namespace.requests == 0 {
+                usage.namespaces.remove(&self.namespace_id);
+            }
+        }
+    }
+}
+
+/// The worker retains admission until delivery, even if the receiver is gone.
+/// A contending caller also holds this permit while retaining its candidate;
+/// retries share it instead of competing for a second admission slot.
+pub(super) struct AdmittedWaiter<T> {
+    sender: oneshot::Sender<T>,
+    _permit: Arc<AdmissionPermit>,
+}
+
+impl<T> AdmittedWaiter<T> {
+    pub(super) fn new(sender: oneshot::Sender<T>, permit: &Arc<AdmissionPermit>) -> Self {
+        Self {
+            sender,
+            _permit: Arc::clone(permit),
+        }
+    }
+
+    pub(super) fn send(self, value: T) -> Result<(), T> {
+        self.sender.send(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::publish::CommitCandidate;
+    use std::num::NonZeroUsize;
+
+    fn limit(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("nonzero test limit")
+    }
+
+    #[test]
+    fn global_and_namespace_limits_share_one_charge_until_last_owner_drops() {
+        let budget = Arc::new(PublicationAdmission::new(PublicationLimits {
+            max_requests: limit(3),
+            max_requests_per_namespace: limit(2),
+            ..PublicationLimits::default()
+        }));
+        let a = NamespaceId::parse("a").expect("namespace");
+        let b = NamespaceId::parse("b").expect("namespace");
+        let first = budget.acquire(&a, 0).expect("first");
+        let second = budget.acquire(&a, 0).expect("second");
+        assert!(matches!(
+            budget.acquire(&a, 0),
+            Err(CoreError::CommitQueueFull)
+        ));
+        let third = budget.acquire(&b, 0).expect("other namespace has room");
+        assert!(matches!(
+            budget.acquire(&b, 0),
+            Err(CoreError::CommitQueueFull)
+        ));
+        let (sender, receiver) = oneshot::channel();
+        let waiter = AdmittedWaiter::new(sender, &first);
+        drop(receiver);
+        drop(first);
+        assert_eq!(
+            budget.lock_usage().total.requests,
+            3,
+            "disconnect keeps worker charged"
+        );
+        let _ = waiter.send(());
+        assert_eq!(budget.lock_usage().total.requests, 2);
+        drop((second, third));
+        let usage = budget.lock_usage();
+        assert_eq!(usage.total.requests, 0);
+        assert_eq!(usage.total.estimated_bytes, 0);
+        assert!(
+            usage.namespaces.is_empty(),
+            "closed namespaces leave no accounting entries"
+        );
+    }
+
+    #[test]
+    fn namespace_byte_limit_leaves_room_for_another_tenant() {
+        let a = NamespaceId::parse("a").expect("namespace");
+        let b = NamespaceId::parse("b").expect("namespace");
+        let budget = Arc::new(PublicationAdmission::new(PublicationLimits {
+            max_estimated_bytes: limit(1026),
+            max_estimated_bytes_per_namespace: limit(513),
+            ..PublicationLimits::default()
+        }));
+        let first = budget.acquire(&a, 0).expect("first tenant");
+        assert!(matches!(
+            budget.acquire(&a, 0),
+            Err(CoreError::CommitQueueFull)
+        ));
+        let second = budget.acquire(&b, 0).expect("other tenant has room");
+        drop((first, second));
+        assert_eq!(budget.used_requests(), 0);
+    }
+
+    #[test]
+    fn byte_limit_rejects_before_count_limit_and_refunds_exactly() {
+        let namespace = NamespaceId::parse("bytes").expect("namespace");
+        let candidate = CommitCandidate::new(super::super::tests::create_directory_request(
+            "wide", "wide",
+        ));
+        let charge = candidate
+            .estimated_retained_bytes()
+            .expect("request weight")
+            + 512
+            + namespace.as_str().len();
+        let budget = Arc::new(PublicationAdmission::new(PublicationLimits {
+            max_estimated_bytes: limit(charge),
+            ..PublicationLimits::default()
+        }));
+        let permit = budget
+            .acquire(
+                &namespace,
+                candidate.estimated_retained_bytes().expect("weight"),
+            )
+            .expect("exact fit");
+        assert!(matches!(
+            budget.acquire(&namespace, 0),
+            Err(CoreError::CommitQueueFull)
+        ));
+        drop(permit);
+        assert!(budget
+            .acquire(
+                &namespace,
+                candidate.estimated_retained_bytes().expect("weight")
+            )
+            .is_ok());
+        let too_small = Arc::new(PublicationAdmission::new(PublicationLimits {
+            max_estimated_bytes: limit(charge - 1),
+            ..PublicationLimits::default()
+        }));
+        assert!(matches!(
+            too_small.acquire(
+                &namespace,
+                candidate.estimated_retained_bytes().expect("weight")
+            ),
+            Err(CoreError::CommitQueueFull)
+        ));
+        assert!(too_small.lock_usage().namespaces.is_empty());
+    }
+}

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -437,15 +437,16 @@ async fn settle_delete(handle: tokio::task::JoinHandle<DeleteResult>, label: &st
 /// fallback the production paths reserve for a dropped registry. The
 /// caller keeps `runtime` alive; the publisher holds its bits weakly.
 fn standalone_publisher(namespace_id: &NamespaceId, runtime: &TestRuntime) -> NamespacePublisher {
-    NamespacePublisher::new(
-        namespace_id.clone(),
+    let registry = PublisherRegistry::new(
         runtime.core.clone(),
         Arc::downgrade(&runtime.bits),
-        Weak::new(),
         tokio::runtime::Handle::current(),
-        Arc::new(loonfs_objectstore::timing::StdMonotonicTimer::default()),
         TEST_STANDALONE_PACING,
-    )
+        NamespaceSessionPolicy::OpenOnFirstWrite,
+        NonZeroUsize::new(crate::DEFAULT_MAX_WRITER_SESSIONS).expect("nonzero session limit"),
+        crate::PublicationLimits::default(),
+    );
+    NamespacePublisher::new(namespace_id.clone(), &registry)
 }
 
 #[allow(clippy::disallowed_methods)]
@@ -460,7 +461,7 @@ async fn wait_past_cas_pacing() {
 
 /// One directory creation directly under the root, named by the directory
 /// the test wants: the cheapest mutation that is distinct per name.
-fn create_directory_request(
+pub(super) fn create_directory_request(
     commit_id: impl Into<String>,
     directory_name: impl AsRef<str>,
 ) -> CommitRequest {
@@ -499,13 +500,17 @@ fn try_admit_candidate(
     candidate: CommitCandidate,
 ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
     let commit_id = candidate.commit_id().clone();
+    publisher.check_admission(&publisher.lock_state())?;
+    let permit = publisher
+        .admission
+        .acquire(namespace_id, candidate.estimated_retained_bytes()?)?;
     let semantic_identity = candidate.semantic_identity(namespace_id)?;
     let (sender, receiver) = oneshot::channel();
     let admission = publisher.admit(
         commit_id,
         candidate,
         semantic_identity,
-        sender,
+        AdmittedWaiter::new(sender, &permit),
         publisher.timer.monotonic_now_ms(),
     )?;
     assert!(matches!(admission, SubmissionAdmission::OwnOutcome));
@@ -551,7 +556,16 @@ async fn publisher_delivery_preserves_bootstrap_namespace_exists_code() {
         commit_id.clone(),
         InFlightRequest {
             semantic_identity,
-            waiters: vec![sender],
+            waiters: vec![AdmittedWaiter::new(
+                sender,
+                &publisher
+                    .admission
+                    .acquire(
+                        &namespace_id,
+                        candidate.estimated_retained_bytes().expect("weight"),
+                    )
+                    .expect("admit request"),
+            )],
         },
     );
     let selected_at = publisher.timer.monotonic_now_ms();
@@ -761,7 +775,11 @@ async fn publisher_contender_retries_after_active_request_fails() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let runtime = test_runtime(store);
     create_namespace(&runtime, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &runtime);
+    let mut publisher = standalone_publisher(&namespace_id, &runtime);
+    publisher.admission = Arc::new(PublicationAdmission::new(crate::PublicationLimits {
+        max_requests: NonZeroUsize::new(1).expect("one slot"),
+        ..crate::PublicationLimits::default()
+    }));
     let commit_id = CommitId::parse("handoff").expect("valid commit id");
     let primary_identity = CommitCandidate::new(create_directory_request("handoff", "first"))
         .semantic_identity(&namespace_id)
@@ -800,6 +818,7 @@ async fn publisher_contender_retries_after_active_request_fails() {
         .expect("contender publishes after the failed primary");
     assert_eq!(response.commit_id, commit_id);
     assert_eq!(response.committed_seq, ChangeSeq(1));
+    assert_eq!(publisher.admission.used_requests(), 0);
 }
 
 #[tokio::test]
@@ -860,7 +879,7 @@ async fn publisher_contender_reports_conflict_after_retry_limit() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
+async fn publisher_limit_counts_active_duplicate_contended_and_delete_requests() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
@@ -877,8 +896,12 @@ async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
     );
     store.wait_until_blocked().await;
 
-    let mut pending = Vec::with_capacity(MAX_BATCH_CANDIDATES);
-    for index in 0..MAX_BATCH_CANDIDATES {
+    let mut pending = Vec::new();
+    for index in 0..crate::PublicationLimits::default()
+        .max_requests_per_namespace
+        .get()
+        - 3
+    {
         pending.push(admit_commit(
             &publisher,
             &namespace_id,
@@ -905,6 +928,19 @@ async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
         create_directory_request("overflow", "overflow"),
     );
     assert!(matches!(overflow, Err(CoreError::CommitQueueFull)));
+
+    assert!(matches!(
+        try_admit_commit(
+            &publisher,
+            &namespace_id,
+            create_directory_request("pending-0", "pending-0")
+        ),
+        Err(CoreError::CommitQueueFull)
+    ));
+    assert!(matches!(
+        publisher.admit_delete(DeleteNamespaceOptions::default()),
+        Err(CoreError::CommitQueueFull)
+    ));
 
     store.release();
     assert_eq!(
@@ -946,8 +982,11 @@ async fn publisher_takes_a_cold_full_batch_immediately() {
     let publisher = standalone_publisher(&namespace_id, &runtime);
 
     store.block_next();
-    let mut receivers = Vec::with_capacity(MAX_BATCH_CANDIDATES);
-    for index in 0..MAX_BATCH_CANDIDATES {
+    let mut receivers = Vec::new();
+    for index in 0..crate::PublicationLimits::default()
+        .max_requests_per_namespace
+        .get()
+    {
         receivers.push(admit_commit(
             &publisher,
             &namespace_id,
@@ -1892,6 +1931,11 @@ async fn worker_survives_panic_and_processes_later_queue_items() {
         drain_error.to_string().contains("panicked"),
         "drain reports panicked publisher tasks: {drain_error}"
     );
+    assert_eq!(
+        registry.shared.admission.used_requests(),
+        0,
+        "panic and drain refund admission"
+    );
 }
 
 #[tokio::test]
@@ -2795,4 +2839,89 @@ async fn a_skipped_eviction_leaves_the_namespace_accounted() {
         .drain()
         .await
         .expect("drain settles every publisher");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn registry_shares_admission_and_publication_slots_after_caller_cancellation() {
+    let temp_dir = tempdir().expect("tempdir");
+    let a = NamespaceId::parse("a").expect("namespace");
+    let b = NamespaceId::parse("b").expect("namespace");
+    let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &a));
+    let writer = crate::FsWriter::builder_with_store(store.clone())
+        .writer_id("bounded-writer")
+        .publication_limits(crate::PublicationLimits {
+            max_requests: NonZeroUsize::new(2).expect("two requests"),
+            max_requests_per_namespace: NonZeroUsize::new(1).expect("one request per namespace"),
+            max_concurrent_publications: NonZeroUsize::new(1).expect("one publication"),
+            ..crate::PublicationLimits::default()
+        })
+        .build()
+        .await
+        .expect("writer");
+    for namespace in [&a, &b] {
+        writer
+            .create_namespace(namespace, CreateNamespaceOptions::default())
+            .await
+            .expect("bootstrap");
+    }
+    let registry = writer.publisher();
+    store.block_next();
+    let first = {
+        let registry = registry.clone();
+        let namespace = a.clone();
+        tokio::spawn(async move {
+            registry
+                .submit_candidate(
+                    namespace,
+                    CommitCandidate::new(create_directory_request("first", "first")),
+                )
+                .await
+        })
+    };
+    store.wait_until_blocked().await;
+    let second = {
+        let registry = registry.clone();
+        let namespace = b.clone();
+        tokio::spawn(async move {
+            registry
+                .submit_candidate(
+                    namespace,
+                    CommitCandidate::new(create_directory_request("second", "second")),
+                )
+                .await
+        })
+    };
+    let publisher = registry.test_publisher_for(&b).expect("publisher");
+    wait_for_queued_candidates(&publisher, 1).await;
+    assert_eq!(
+        registry.shared.admission.publications.available_permits(),
+        0
+    );
+    assert!(
+        publisher.engine.lock().await.engine.is_none(),
+        "waiting for a slot must not load the other namespace's engine"
+    );
+    first.abort();
+    let _ = first.await;
+    assert_eq!(
+        registry.shared.admission.used_requests(),
+        2,
+        "disconnected work remains charged"
+    );
+    let error = registry
+        .submit_delete(a, DeleteNamespaceOptions::default())
+        .await
+        .expect_err("budget remains full");
+    assert_eq!(error.code(), ErrorCode::CommitQueueFull);
+    store.release();
+    second
+        .await
+        .expect("second task")
+        .expect("second publication");
+    writer.shutdown().await.expect("drain");
+    assert_eq!(registry.shared.admission.used_requests(), 0);
+    assert_eq!(
+        registry.shared.admission.publications.available_permits(),
+        1
+    );
 }


### PR DESCRIPTION
Duplicate callers and namespace deletes could bypass publication admission, and independent namespaces could start unlimited concurrent publications. All admitted callers now share request and estimated-byte budgets, per-namespace allowances, and a publication concurrency limit; their admission remains charged through cancellation, contention retries, and worker settlement. Embedded hosts and the server can configure these limits, with earlier commit_queue_full responses under overload and an additional sizing pass per request. Workspace tests excluding loonfs-sim, all-target/all-feature Clippy, formatting, and OpenAPI checks pass, including cancellation, contention, panic recovery, and cross-namespace admission regressions.