### PR TITLE
refactor(cli): use fixed config and state locations

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -100,7 +100,7 @@ Config file location
     2. LOONFS_CONFIG=<path>
     3. $XDG_CONFIG_HOME/loonfs/config.toml, when XDG_CONFIG_HOME names an
        absolute directory
-    4. ~/.loonfs/config.toml
+    4. ~/.config/loonfs/config.toml
   Profile selection uses --profile, then LOONFS_PROFILE=<name>, then the
   configured default. Namespace selection uses --namespace, then
   LOONFS_NAMESPACE=<name>, then the profile default.
@@ -115,9 +115,9 @@ Config file location
   `loonfs config path` reads nothing, so it keeps answering while the file
   it names is unreadable.
 
-  While XDG_CONFIG_HOME is set but holds no config of its own, an existing
-  ~/.loonfs/config.toml stays in use and `loonfs config path` names the
-  preferred path to move it to.
+  File existence does not affect selection. An unset or relative
+  XDG_CONFIG_HOME uses the default in rule 4; an absolute XDG_CONFIG_HOME
+  selects rule 3 even before the file is created.
 
 Profile management
   loonfs profile create s3 <name> [s3-options]
@@ -515,7 +515,7 @@ Interrupted transfers
   An upload resumes only where the transfer had parts to lose: a remote
   profile's direct multipart upload of a file past 8 MiB. The parts that
   landed are recorded under $XDG_STATE_HOME/loonfs/uploads (or
-  ~/.loonfs/state/uploads when XDG_STATE_HOME is unset), and a rerun sends
+  ~/.local/state/loonfs/uploads when XDG_STATE_HOME is unset), and a rerun sends
   only the ones still missing — or, when the transfer had actually
   finished and only the commit was lost, commits what is already stored
   and sends nothing. A source that changed since the record was written

--- a/crates/loonfs-cli/src/commands/config.rs
+++ b/crates/loonfs-cli/src/commands/config.rs
@@ -74,10 +74,6 @@ pub(crate) fn run_config_command(
             data: CommandData::ConfigPath {
                 path: config_path.display().to_string(),
                 source: location.source,
-                preferred_path: location
-                    .preferred_path
-                    .as_ref()
-                    .map(|path| path.display().to_string()),
             },
         }),
         ConfigCommand::Show => {

--- a/crates/loonfs-cli/src/commands/inspection.rs
+++ b/crates/loonfs-cli/src/commands/inspection.rs
@@ -447,7 +447,7 @@ fn config_resolution_message(location: &crate::config::ConfigLocation) -> String
     match location.source {
         ConfigSource::Flag => format!("resolved {} from --config", location.path.display()),
         ConfigSource::Env => format!("resolved {} from LOONFS_CONFIG", location.path.display()),
-        ConfigSource::Xdg | ConfigSource::Legacy => {
+        ConfigSource::Xdg | ConfigSource::Default => {
             format!("defaulted to {}", location.path.display())
         }
     }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -337,10 +337,6 @@ pub(crate) enum CommandData {
         path: String,
         /// Which rule chose the path.
         source: ConfigSource,
-        /// Where the file belongs now, while a legacy file is in use only
-        /// because the preferred location holds none yet.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        preferred_path: Option<String>,
     },
     ConfigShow {
         config: CliConfig,

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -39,8 +39,6 @@ pub(crate) fn absolute_env_path(name: &str) -> Option<PathBuf> {
 const CONFIG_FILE_NAME: &str = "config.toml";
 /// Directory under `$XDG_CONFIG_HOME`.
 const XDG_CONFIG_SUBDIR: &str = "loonfs";
-/// Directory under `$HOME`, where installs predating XDG support live.
-const LEGACY_CONFIG_SUBDIR: &str = ".loonfs";
 
 /// Recovery instructions appended to config-load errors.
 ///
@@ -276,7 +274,7 @@ fn profile_store_error(profile_name: &str, error: &StoreConfigError) -> CliError
 
 /// How [`resolve_config_location`] chose the file, so `config path` answers
 /// both "which file" and "why that one". The serialized spellings are the
-/// `--json` surface: `flag`, `env`, `xdg`, `legacy`.
+/// `--json` surface: `flag`, `env`, `xdg`, `default`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ConfigSource {
@@ -286,26 +284,19 @@ pub(crate) enum ConfigSource {
     Env,
     /// `$XDG_CONFIG_HOME/loonfs/config.toml`.
     Xdg,
-    /// `~/.loonfs/config.toml`.
-    Legacy,
+    /// `$HOME/.config/loonfs/config.toml`.
+    Default,
 }
 
 /// The one config file this invocation reads and writes.
 pub(crate) struct ConfigLocation {
     pub path: PathBuf,
     pub source: ConfigSource,
-    /// Where the file belongs now. Set only while a legacy file is in use
-    /// because `XDG_CONFIG_HOME` is set and holds no config yet.
-    pub preferred_path: Option<PathBuf>,
 }
 
 impl ConfigLocation {
     fn at(path: PathBuf, source: ConfigSource) -> Self {
-        Self {
-            path,
-            source,
-            preferred_path: None,
-        }
+        Self { path, source }
     }
 }
 
@@ -325,36 +316,26 @@ pub(crate) fn resolve_config_location(flag: Option<&Path>) -> Result<ConfigLocat
     default_config_location()
 }
 
-/// Returns the default config location.
-///
-/// An absolute `XDG_CONFIG_HOME` selects the XDG path. Otherwise the legacy
-/// `~/.loonfs/config.toml` path is used. During migration, an existing legacy
-/// file remains active until a file exists at the XDG path.
+/// Selects `$XDG_CONFIG_HOME/loonfs/config.toml` when the variable is
+/// absolute, otherwise `$HOME/.config/loonfs/config.toml`. File existence
+/// never changes which location is selected.
 fn default_config_location() -> Result<ConfigLocation, CliError> {
-    let legacy = legacy_config_path();
-    let Some(xdg_dir) = absolute_env_path("XDG_CONFIG_HOME") else {
-        let path = legacy.ok_or_else(|| {
-            CliError::invalid_config(format!(
-                "unable to determine the home directory; name the config file with \
-                 `--config <path>` or `{CONFIG_PATH_ENV}=<path>`"
-            ))
-        })?;
-        return Ok(ConfigLocation::at(path, ConfigSource::Legacy));
+    let (directory, source) = match absolute_env_path("XDG_CONFIG_HOME") {
+        Some(directory) => (directory, ConfigSource::Xdg),
+        None => {
+            let home = absolute_env_path("HOME").ok_or_else(|| {
+                CliError::invalid_config(format!(
+                    "unable to determine the home directory; name the config file with \
+                     `--config <path>` or `{CONFIG_PATH_ENV}=<path>`"
+                ))
+            })?;
+            (home.join(".config"), ConfigSource::Default)
+        }
     };
-    let xdg_path = xdg_dir.join(XDG_CONFIG_SUBDIR).join(CONFIG_FILE_NAME);
-    match legacy.filter(|path| !xdg_path.exists() && path.exists()) {
-        Some(legacy_path) => Ok(ConfigLocation {
-            path: legacy_path,
-            source: ConfigSource::Legacy,
-            preferred_path: Some(xdg_path),
-        }),
-        None => Ok(ConfigLocation::at(xdg_path, ConfigSource::Xdg)),
-    }
-}
-
-fn legacy_config_path() -> Option<PathBuf> {
-    let home = absolute_env_path("HOME")?;
-    Some(home.join(LEGACY_CONFIG_SUBDIR).join(CONFIG_FILE_NAME))
+    Ok(ConfigLocation::at(
+        directory.join(XDG_CONFIG_SUBDIR).join(CONFIG_FILE_NAME),
+        source,
+    ))
 }
 
 pub(crate) fn validate_profile_name(name: &str) -> Result<(), CliError> {

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -123,11 +123,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             committed_seq,
             commit_id,
         } => human_path_move(output.kind, from, to, *committed_seq, commit_id),
-        CommandData::ConfigPath {
-            path,
-            source,
-            preferred_path,
-        } => human_config_path(path, *source, preferred_path.as_deref()),
+        CommandData::ConfigPath { path, source } => human_config_path(path, *source),
         CommandData::ConfigShow { config } => human_config_show(config),
         CommandData::ConfigShowDegraded { error, config_toml } => {
             human_config_show_degraded(error, config_toml)
@@ -405,15 +401,12 @@ fn human_path_move(
     }
 }
 
-fn human_config_path(path: &str, source: ConfigSource, preferred_path: Option<&str>) -> String {
-    let chosen = match (source, preferred_path) {
-        (ConfigSource::Flag, _) => "from --config".to_owned(),
-        (ConfigSource::Env, _) => "from LOONFS_CONFIG".to_owned(),
-        (ConfigSource::Xdg, _) => "from XDG_CONFIG_HOME".to_owned(),
-        (ConfigSource::Legacy, Some(preferred)) => {
-            format!("legacy location; move it to {preferred} once convenient")
-        }
-        (ConfigSource::Legacy, None) => "default location".to_owned(),
+fn human_config_path(path: &str, source: ConfigSource) -> String {
+    let chosen = match source {
+        ConfigSource::Flag => "from --config",
+        ConfigSource::Env => "from LOONFS_CONFIG",
+        ConfigSource::Xdg => "from XDG_CONFIG_HOME",
+        ConfigSource::Default => "default location",
     };
     format!("{path} ({chosen})")
 }

--- a/crates/loonfs-cli/src/uploads.rs
+++ b/crates/loonfs-cli/src/uploads.rs
@@ -10,8 +10,6 @@ use std::sync::Mutex;
 
 /// Directory under `$XDG_STATE_HOME`.
 const XDG_STATE_SUBDIR: &str = "loonfs";
-/// Legacy state directory under `$HOME`.
-const LEGACY_STATE_SUBDIR: &str = ".loonfs/state";
 /// Per-upload journal directory.
 const UPLOADS_SUBDIR: &str = "uploads";
 
@@ -190,14 +188,18 @@ impl MultipartUploadJournal for UploadJournal {
 }
 
 /// Where per-upload records live: `$XDG_STATE_HOME/loonfs/uploads` when that
-/// variable names an absolute directory, and `~/.loonfs/state/uploads`
+/// variable names an absolute directory, and `$HOME/.local/state/loonfs/uploads`
 /// otherwise — the same order, and the same reasoning, as the config file's.
 fn uploads_dir() -> Option<PathBuf> {
     if let Some(state_home) = absolute_env_path("XDG_STATE_HOME") {
         return Some(state_home.join(XDG_STATE_SUBDIR).join(UPLOADS_SUBDIR));
     }
     let home = absolute_env_path("HOME")?;
-    Some(home.join(LEGACY_STATE_SUBDIR).join(UPLOADS_SUBDIR))
+    Some(
+        home.join(".local/state")
+            .join(XDG_STATE_SUBDIR)
+            .join(UPLOADS_SUBDIR),
+    )
 }
 
 #[cfg(test)]

--- a/crates/loonfs-cli/tests/it/common/mod.rs
+++ b/crates/loonfs-cli/tests/it/common/mod.rs
@@ -138,7 +138,7 @@ impl Harness {
         let home_dir = temp_dir.path().join("home");
         fs::create_dir_all(&home_dir).expect("create temp home");
         Self {
-            config_path: home_dir.join(".loonfs").join("config.toml"),
+            config_path: home_dir.join(".config").join("loonfs").join("config.toml"),
             home_dir,
             temp_dir,
         }

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -279,8 +279,8 @@ fn concurrent_embedded_puts_land_or_report_the_fence() {
         .iter()
         .enumerate()
         .map(|(index, path)| {
-            Command::new(loon_binary_path())
-                .env("HOME", &harness.home_dir)
+            harness
+                .command()
                 .args([
                     "--json",
                     "put",

--- a/crates/loonfs-cli/tests/it/profile.rs
+++ b/crates/loonfs-cli/tests/it/profile.rs
@@ -207,43 +207,37 @@ root = "{}"
 }
 
 #[test]
-fn config_resolution_prefers_the_flag_then_the_environment_then_xdg_then_legacy() {
+fn config_resolution_is_independent_of_file_existence() {
     let harness = Harness::new();
     harness.write_cli_config(MINIMAL_CONFIG);
-    let legacy_path = harness.config_path.display().to_string();
+    let default_path = harness.config_path.display().to_string();
 
     let xdg_home = harness.temp_dir.path().join("xdg");
     let xdg_path = xdg_home.join("loonfs").join("config.toml");
     let named_path = harness.temp_dir.path().join("named.toml");
     let flagged_path = harness.temp_dir.path().join("flagged.toml");
 
-    // Without XDG the legacy path is simply the default, with nothing to
-    // migrate to.
     let default = json_data(&harness.run(&["--json", "config", "path"]));
-    assert_eq!(default["path"], legacy_path);
-    assert_eq!(default["source"], "legacy");
-    assert!(default["preferred_path"].is_null(), "{default}");
+    assert_eq!(default["path"], default_path);
+    assert_eq!(default["source"], "default");
 
-    // XDG set but holding no config: the existing legacy file keeps
-    // working, and the answer names where it belongs.
-    let migrating = json_data(&harness.run_with_env(
-        &[("XDG_CONFIG_HOME", &xdg_home)],
-        &["--json", "config", "path"],
-    ));
-    assert_eq!(migrating["path"], legacy_path);
-    assert_eq!(migrating["source"], "legacy");
-    assert_eq!(migrating["preferred_path"], xdg_path.display().to_string());
-
-    // A config at the preferred path wins as soon as one exists there.
-    fs::create_dir_all(xdg_path.parent().expect("xdg config dir")).expect("create xdg config dir");
-    fs::write(&xdg_path, MINIMAL_CONFIG).expect("write xdg config");
-    let xdg = json_data(&harness.run_with_env(
-        &[("XDG_CONFIG_HOME", &xdg_home)],
-        &["--json", "config", "path"],
-    ));
-    assert_eq!(xdg["path"], xdg_path.display().to_string());
-    assert_eq!(xdg["source"], "xdg");
-    assert!(xdg["preferred_path"].is_null(), "{xdg}");
+    // Even an existing old file cannot override the selected XDG location.
+    let old_path = harness.home_dir.join(".loonfs").join("config.toml");
+    fs::create_dir_all(old_path.parent().expect("old config directory")).expect("directory");
+    fs::write(&old_path, MINIMAL_CONFIG).expect("old config");
+    for exists in [false, true] {
+        if exists {
+            fs::create_dir_all(xdg_path.parent().expect("xdg directory")).expect("directory");
+            fs::write(&xdg_path, MINIMAL_CONFIG).expect("xdg config");
+        }
+        let xdg = json_data(&harness.run_with_env(
+            &[("XDG_CONFIG_HOME", &xdg_home)],
+            &["--json", "config", "path"],
+        ));
+        assert_eq!(xdg["path"], xdg_path.display().to_string());
+        assert_eq!(xdg["source"], "xdg");
+        assert!(xdg.get("preferred_path").is_none());
+    }
 
     // The environment beats both defaults, by being spelled rather than by
     // the file it names existing.
@@ -301,7 +295,7 @@ fn config_path_answers_while_the_config_file_is_unreadable() {
         json_data(&path)["path"],
         harness.config_path.display().to_string()
     );
-    assert_eq!(json_data(&path)["source"], "legacy");
+    assert_eq!(json_data(&path)["source"], "default");
 
     // The human line carries both answers: the file, and why that file.
     let human = harness.run(&["config", "path"]);


### PR DESCRIPTION
CLI configuration discovery depended on whether an older file existed, adding migration behavior for a pre-release format with no deployed users. Selection now follows --config, LOONFS_CONFIG, absolute XDG_CONFIG_HOME, then ~/.config/loonfs/config.toml without probing alternate files; upload journals use XDG_STATE_HOME or ~/.local/state/loonfs/uploads. This removes the legacy source and preferred-path output, so developers must move existing local files or select a config explicitly. All CLI tests, workspace all-target/all-feature Clippy, and formatting pass, including config precedence and profile integration tests.