### PR TITLE
docs(storage): describe current invariants without implementation history

### DIFF
--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -375,8 +375,8 @@ fn validate_display_name(value: &str) -> Result<(), PathError> {
     // Portability floor: names every target filesystem can hold. Windows
     // cannot materialize its reserved characters, trailing dots or spaces,
     // or its reserved device names, and an all-whitespace name is invisible
-    // in every listing. Rejecting here is free pre-release; loosening later
-    // is compatible, tightening later would strand stored names.
+    // in every listing. Enforce this before storing a name so it remains
+    // possible to materialize every accepted path on those filesystems.
     if let Some(character) = first_windows_reserved_character(value) {
         return Err(PathError::UnportableDisplayNameCharacter {
             display_name: value.to_owned(),

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -2642,7 +2642,7 @@ fn sample_deleted_direntry_cbor() -> ciborium::Value {
     cbor_entry(cbor_entry(&mut set, "action"), "deleted_direntry").clone()
 }
 
-/// Spells the row's generation as the two loose fields it used to be.
+/// Moves generation fields out of their required nested object.
 fn with_flat_generation(mut row: ciborium::Value) -> ciborium::Value {
     let mut generation = cbor_entry(&mut row, "generation").clone();
     let seq = cbor_entry(&mut generation, "seq").clone();
@@ -2654,8 +2654,7 @@ fn with_flat_generation(mut row: ciborium::Value) -> ciborium::Value {
     row
 }
 
-/// Spells the deleted binding as the three loose row fields it used to be,
-/// leaving the `set` empty the way the old encoding left it.
+/// Moves binding fields out of `set` to test rejection of a malformed action.
 fn with_flat_binding(mut row: ciborium::Value) -> ciborium::Value {
     *cbor_entry(&mut row, "action") = ciborium::Value::Map(vec![(
         ciborium::Value::from("kind"),

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -1481,8 +1481,7 @@ mod tests {
 
         // More publishes than the WAL backpressure cap: the Enabled policy
         // must keep stepping the tail down so no write ever stalls on
-        // `maintenance_required` (each stall used to require a manual
-        // `loonfs maintenance metadata`).
+        // `maintenance_required`.
         for index in 0..140 {
             target
                 .backend

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -1061,10 +1061,8 @@ async fn multi_block_direntry_segment() -> (
     descriptor.index_block = built.index;
     descriptor.filter_block = built.filter;
     descriptor.object_checksum = loonfs_api::sha256_digest(&built.bytes);
-    // A one-byte target closes a block on every push, the last row
-    // included, so this fixture carries the shape that used to drop a
-    // segment's max key. Keyed scans prune on that key, so it has to name
-    // the last row here as it would at any block size.
+    // A one-byte target closes every row's block, including the last. The
+    // segment's max key must still name that row so keyed scans can find it.
     assert_eq!(
         descriptor.max_row_key,
         rows.last()

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -612,8 +612,7 @@ fn group_runs(
 ///
 /// A group holds at most one: only a merge that starts at the group's oldest
 /// run writes a base run, and such a merge always replaces the one that was
-/// there. More than one is the fragmented base a merge above the base used to
-/// create, which manifest load now refuses.
+/// there. Manifest loading rejects multiple base runs for a group.
 fn group_base_runs(
     manifest: &NamespaceManifestEnvelope,
     group: &[ApiMetadataRowFamily],

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -2650,9 +2650,7 @@ async fn a_merge_keeps_its_reads_and_its_decoded_blocks_bounded() {
     );
 
     // The same bounds hold for the same engine run inside a maintenance pass.
-    // The step's input budgets cap what a window may hold, but they say nothing
-    // about what merging it costs, and the old path read every row of the
-    // window into vectors.
+    // Input budgets and measured merge residency must both hold.
     let store = ConcurrencyWatchStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
         KeyPredicate::metadata_segment(),

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -2332,8 +2332,7 @@ async fn a_live_jobs_staged_output_survives_however_old_it_is() {
         namespace_with_staged_output(&temp_dir, &namespace_id, &test_metadata_compaction_id())
             .await;
 
-    // A day past the window the design used to apply here, with the job's
-    // lease refreshed a moment ago.
+    // Old staged output remains protected by a fresh job lease.
     let now_ms = now_after_newest_object(store.inner(), &namespace_id, 24 * 60 * 60 * 1000).await;
     write_compaction_lease(
         &store,

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -104,9 +104,8 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         // Whoever wrote the head owns the id. A caller retrying after a
         // lost acknowledgment gets the same answer as a caller who lost the
         // race outright, and the namespace it names is complete and usable
-        // either way — the old flow's `namespace_partial`, which named a
-        // namespace nobody could use, is gone. `allow_existing` is how a
-        // caller says "create it if it is not there", including on a retry.
+        // either way. `allow_existing` means "create it if it is not there",
+        // including on a retry.
         NamespaceHeadInstall::Exists if allow_existing => {}
         NamespaceHeadInstall::Exists => {
             return Err(BootstrapNamespaceError::NamespaceAlreadyExists {

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -743,8 +743,7 @@ struct IndexingStats {
 }
 
 /// The resume state collected by one worker step. Naming the two modes here
-/// prevents a backfill cursor from ever being paired with change-feed
-/// progress, which used to be possible in the flat unit record.
+/// prevents a backfill cursor from being paired with change-feed progress.
 enum CollectedProgress {
     Backfill {
         checkpoint_id: CheckpointId,

--- a/crates/loonfs-objectstore/src/store_io_runtime.rs
+++ b/crates/loonfs-objectstore/src/store_io_runtime.rs
@@ -4,8 +4,7 @@
 //! The default provider connector performs HTTP IO on whichever runtime
 //! issues the request. A store shared across current-thread runtimes then
 //! parks pooled connections until the client's 30s request timeout fires —
-//! reproduced and fixed in the S3 benchmark investigation by routing IO
-//! through a dedicated runtime. Every provider client is constructed with a
+//! so provider IO runs on a dedicated runtime. Every provider client uses a
 //! connector onto its store's own runtime, so caller runtime topology can
 //! never affect provider IO.
 

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -2040,9 +2040,7 @@ root = "/tmp/loonfs-server"
 
     #[test]
     fn unknown_config_tables_fail_decode() {
-        // Pre-release rule: no compatibility courtesies. An unrecognized
-        // table — including any removed one — fails through the config's
-        // own strict parsing, with no special-cased guidance.
+        // Unknown tables fail through the config's strict parsing.
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -4434,8 +4434,8 @@ mod direct_download {
     async fn a_payload_past_every_transport_is_refused_with_the_caps_named() {
         let temp_dir = tempdir().expect("tempdir");
         let object_base_url = serve_objects(object_store_at(temp_dir.path())).await;
-        // Reads only: neither write direction is on offer, which is the
-        // shape that used to push an oversized payload into the proxy.
+        // No direct upload transport is available. The proxy must enforce
+        // its size limit independently of the read transport.
         let transfers = DirectTransferIssuers {
             get: LoopbackIssuer::at(object_base_url),
             put: None,


### PR DESCRIPTION
Storage and recovery comments should explain the invariants a reader must preserve. Replace references to earlier implementations and investigations with the current behavior and test purpose; no executable code changes. Formatting and diff checks pass.
