### PR TITLE
refactor(core): retain typed writer and binding identities

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -407,7 +407,7 @@ pub struct WriterBlock {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AcquiredWriter {
     /// Stable writer label copied into the head's observability block.
-    pub writer_id: String,
+    pub writer_id: WriterId,
     /// Fencing epoch every commit publication from this session must match.
     pub writer_epoch: WriterEpoch,
 }

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -4,7 +4,7 @@ use super::ContentToken;
 use crate::{
     AbsolutePath, AttributeKey, AttributeRevisionNo, AttributeValue, BindingGeneration, ChangeSeq,
     CheckpointId, CommitId, ContentRef, DisplayName, InodeId, ManifestNo, NamespaceId, RevisionNo,
-    WriterEpoch,
+    WriterEpoch, WriterId,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -61,7 +61,8 @@ pub struct ErrorDetails {
     pub active_writer_epoch: Option<WriterEpoch>,
     /// The writer ID recorded for the current epoch, when available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_writer: Option<String>,
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub active_writer: Option<WriterId>,
     /// The Unix-millisecond time when the current writer acquired its epoch, when available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_acquired_at_ms: Option<u64>,

--- a/crates/loonfs-core/src/checkpoint/compaction_retention.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_retention.rs
@@ -4,7 +4,7 @@
 //! rows require point reads because binds and unbinds use different key
 //! prefixes; [`super::streaming_compaction`] handles those reads.
 
-use super::frozen_floor::{bind_survives_frozen_floor, BindingGeneration};
+use super::frozen_floor::{bind_survives_frozen_floor, BindingIdentity};
 use crate::error::{CoreError, Result};
 use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow, MetadataRowFamily};
 use loonfs_api::{AttributeRevisionNo, ChangeSeq};
@@ -234,11 +234,11 @@ pub(super) struct BindingRetention {
     /// One entry at most — every unbind in the group names the same
     /// generation — and it is the set both bind families are judged against, so
     /// bind families reach `bind_survives_frozen_floor` by the same route.
-    unbound_at_floor: BTreeSet<BindingGeneration>,
+    unbound_at_floor: BTreeSet<BindingIdentity>,
     /// The one bind at or below the floor in this slot that nothing retired,
     /// or `None` while the slot has none. A second one means the first was
     /// superseded without an unbind.
-    unretired_at_floor: Option<BindingGeneration>,
+    unretired_at_floor: Option<BindingIdentity>,
 }
 
 impl BindingRetention {
@@ -258,12 +258,12 @@ impl BindingRetention {
                 // A spent marker: the floor covers it, so nothing can observe
                 // the binding it retired, and it retires that binding for the
                 // bind row held above.
-                self.unbound_at_floor.insert((
-                    *parent_inode_id,
-                    name_key.clone(),
-                    *bind_seq,
-                    *bind_delta_index,
-                ));
+                self.unbound_at_floor.insert(BindingIdentity {
+                    parent_inode_id: *parent_inode_id,
+                    name_key: name_key.clone(),
+                    bind_seq: *bind_seq,
+                    bind_delta_index: *bind_delta_index,
+                });
                 None
             }
             // A bind above the floor survives whatever retired it later, so
@@ -296,12 +296,12 @@ impl BindingRetention {
         else {
             return Ok(Some(row));
         };
-        let generation = (
-            *parent_inode_id,
-            name_key.clone(),
-            *bind_seq,
-            *bind_delta_index,
-        );
+        let generation = BindingIdentity {
+            parent_inode_id: *parent_inode_id,
+            name_key: name_key.clone(),
+            bind_seq: *bind_seq,
+            bind_delta_index: *bind_delta_index,
+        };
         self.check_the_slot_invariant(&generation)?;
         let survives = bind_survives_frozen_floor(&row, floor_seq, &unbound_at_floor);
         self.unretired_at_floor = survives.then_some(generation);
@@ -315,11 +315,13 @@ impl BindingRetention {
     /// Generations arrive in ascending order, so a second unretired bind in
     /// the same slot proves that the earlier bind was superseded without an
     /// unbind. Cleanup is rejected when that occurs.
-    fn check_the_slot_invariant(&mut self, generation: &BindingGeneration) -> Result<()> {
+    fn check_the_slot_invariant(&mut self, generation: &BindingIdentity) -> Result<()> {
         let Some(previous) = self.unretired_at_floor.take() else {
             return Ok(());
         };
-        if (&previous.0, &previous.1) != (&generation.0, &generation.1) {
+        if previous.parent_inode_id != generation.parent_inode_id
+            || previous.name_key != generation.name_key
+        {
             // A different parent-and-name slot: the previous slot's latest
             // bind was its latest, which is exactly what the invariant
             // allows.
@@ -328,7 +330,7 @@ impl BindingRetention {
         Err(CoreError::NamespaceCorrupt(format!(
             "bind at seq `{}` delta {} for parent `{}` is superseded at or below the retention \
              floor without an unbind; refusing to drop rows",
-            previous.2, previous.3, previous.0
+            previous.bind_seq, previous.bind_delta_index, previous.parent_inode_id
         )))
     }
 }

--- a/crates/loonfs-core/src/checkpoint/frozen_floor.rs
+++ b/crates/loonfs-core/src/checkpoint/frozen_floor.rs
@@ -12,13 +12,15 @@ use loonfs_api::wire::manifest::MetadataRow;
 use loonfs_api::{ChangeSeq, InodeId, NameKey};
 use std::collections::BTreeSet;
 
-/// Identifies one binding generation, which is what an unbind names and what
-/// the bind drop matches on.
-///
-/// Identity here omits `child_inode_id` (the read path also matches it); the
-/// 4-tuple is already unique for writer-produced rows, so the predicates
-/// agree on every legal history.
-pub(super) type BindingGeneration = (InodeId, NameKey, ChangeSeq, u32);
+/// Identifies one durable binding by its parent, name, and originating delta.
+/// The writer assigns this identity once; a matching unbind retires it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct BindingIdentity {
+    pub(super) parent_inode_id: InodeId,
+    pub(super) name_key: NameKey,
+    pub(super) bind_seq: ChangeSeq,
+    pub(super) bind_delta_index: u32,
+}
 
 /// The binding generations an unbind at or below `retention_floor_seq`
 /// retires.
@@ -30,7 +32,7 @@ pub(super) type BindingGeneration = (InodeId, NameKey, ChangeSeq, u32);
 pub(super) fn unbindings_at_or_below_floor(
     unbind_rows: &[MetadataRow],
     retention_floor_seq: ChangeSeq,
-) -> BTreeSet<BindingGeneration> {
+) -> BTreeSet<BindingIdentity> {
     unbind_rows
         .iter()
         .filter_map(|row| unbinding_at_or_below_floor(row, retention_floor_seq))
@@ -46,7 +48,7 @@ pub(super) fn unbindings_at_or_below_floor(
 pub(super) fn unbinding_at_or_below_floor(
     row: &MetadataRow,
     retention_floor_seq: ChangeSeq,
-) -> Option<BindingGeneration> {
+) -> Option<BindingIdentity> {
     let MetadataRow::DirentryUnbind(crate::metadata::DirentryUnbindRecord {
         parent_inode_id,
         name_key,
@@ -58,13 +60,11 @@ pub(super) fn unbinding_at_or_below_floor(
     else {
         return None;
     };
-    (*unbind_seq <= retention_floor_seq).then(|| {
-        (
-            *parent_inode_id,
-            name_key.clone(),
-            *bind_seq,
-            *bind_delta_index,
-        )
+    (*unbind_seq <= retention_floor_seq).then(|| BindingIdentity {
+        parent_inode_id: *parent_inode_id,
+        name_key: name_key.clone(),
+        bind_seq: *bind_seq,
+        bind_delta_index: *bind_delta_index,
     })
 }
 
@@ -77,7 +77,7 @@ pub(super) fn unbinding_at_or_below_floor(
 pub(super) fn bind_survives_frozen_floor(
     row: &MetadataRow,
     retention_floor_seq: ChangeSeq,
-    unbound_at_floor: &BTreeSet<BindingGeneration>,
+    unbound_at_floor: &BTreeSet<BindingIdentity>,
 ) -> bool {
     let MetadataRow::DirentryBind(crate::metadata::DirentryBindRecord {
         parent_inode_id,
@@ -90,10 +90,10 @@ pub(super) fn bind_survives_frozen_floor(
         return true;
     };
     *bind_seq > retention_floor_seq
-        || !unbound_at_floor.contains(&(
-            *parent_inode_id,
-            name_key.clone(),
-            *bind_seq,
-            *bind_delta_index,
-        ))
+        || !unbound_at_floor.contains(&BindingIdentity {
+            parent_inode_id: *parent_inode_id,
+            name_key: name_key.clone(),
+            bind_seq: *bind_seq,
+            bind_delta_index: *bind_delta_index,
+        })
 }

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -23,7 +23,7 @@ use super::error::ManifestLoadError;
 use super::flush::ensure_metadata_publication_budget;
 use super::frozen_floor::{
     bind_survives_frozen_floor, unbinding_at_or_below_floor, unbindings_at_or_below_floor,
-    BindingGeneration,
+    BindingIdentity,
 };
 use super::load::load_manifest_segments;
 use super::publish::{publish_metadata_root, ManifestPublicationOutcome};
@@ -665,7 +665,7 @@ enum ReverseBindResolution {
     /// Probe the snapshot for each reverse row, with a bounded cache.
     PointProbeSnapshot,
     /// Use unbound generations collected from the bounded forward-bind input.
-    CollectedUnbinds(BTreeSet<BindingGeneration>),
+    CollectedUnbinds(BTreeSet<BindingIdentity>),
 }
 
 /// One set of families the engine merges and judges together, and how it

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -24,7 +24,7 @@ async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
         .await
         .expect("load head");
     let acquired_writer = loonfs_api::wire::control::AcquiredWriter {
-        writer_id: context.writer_id.to_string(),
+        writer_id: context.writer_id.clone(),
         writer_epoch: head.state.writer_epoch,
     };
     let (_, projection) = crate::protocol::load_publish_metadata_view(

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -17,7 +17,7 @@ use crate::wal::{WalChainLoadError, WalSegmentError};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::{
     ChangeSeq, CommitId, ErrorDetails, InodeId, InodeKind, NamespaceId, RevisionNo, UploadId,
-    WriterEpoch,
+    WriterEpoch, WriterId,
 };
 use loonfs_objectstore::{ImmutableWriteError, ObjectStoreError};
 use thiserror::Error;
@@ -672,7 +672,7 @@ pub struct WriterFence {
     /// Epoch that owns the namespace now.
     pub active_epoch: WriterEpoch,
     /// Writer label recorded by the winning acquirer, when known.
-    pub active_writer: Option<String>,
+    pub active_writer: Option<WriterId>,
     /// When the winning acquirer took the epoch, in Unix milliseconds, when
     /// known.
     pub active_acquired_at_ms: Option<u64>,
@@ -698,7 +698,7 @@ impl std::fmt::Display for WriterFence {
         )?;
         // These fields normally appear together, but format a useful message when
         // only one is available.
-        match (self.active_writer.as_deref(), self.active_acquired_at_ms) {
+        match (self.active_writer.as_ref(), self.active_acquired_at_ms) {
             (Some(writer), Some(acquired_at_ms)) => {
                 write!(f, " (writer `{writer}`, acquired at {acquired_at_ms} ms)")
             }
@@ -839,13 +839,16 @@ mod tests {
         let fenced = CoreError::WriterFenced(WriterFence {
             fenced_epoch: WriterEpoch(3),
             active_epoch: WriterEpoch(4),
-            active_writer: Some("writer-b".to_owned()),
+            active_writer: Some(loonfs_api::WriterId::parse("writer-b").expect("writer id")),
             active_acquired_at_ms: Some(2_000),
         });
         let details = fenced.details().expect("fence details");
         assert_eq!(details.fenced_writer_epoch, Some(WriterEpoch(3)));
         assert_eq!(details.active_writer_epoch, Some(WriterEpoch(4)));
-        assert_eq!(details.active_writer.as_deref(), Some("writer-b"));
+        assert_eq!(
+            details.active_writer.as_ref().map(|writer| writer.as_str()),
+            Some("writer-b")
+        );
         assert_eq!(details.active_acquired_at_ms, Some(2_000));
 
         let anonymous = CoreError::WriterFenced(WriterFence {

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -81,7 +81,7 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
         Ok(HeadReplacement {
             next: Box::new(head_with_writer(head, next_epoch, context)?),
             outcome: AcquiredWriter {
-                writer_id: context.writer_id.to_string(),
+                writer_id: context.writer_id.clone(),
                 writer_epoch: next_epoch,
             },
         })
@@ -100,10 +100,7 @@ pub(crate) fn ensure_writer_not_fenced(
     Err(CoreError::WriterFenced(WriterFence {
         fenced_epoch: acquired_writer.writer_epoch,
         active_epoch: head.writer_epoch,
-        active_writer: head
-            .writer
-            .as_ref()
-            .map(|writer| writer.writer_id.to_string()),
+        active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
         active_acquired_at_ms: head.writer.as_ref().map(|writer| writer.acquired_at_ms),
     }))
 }
@@ -421,7 +418,7 @@ mod tests {
             .expect("takeover acquire");
 
         assert_eq!(acquired.writer_epoch, WriterEpoch(8));
-        assert_eq!(acquired.writer_id, "writer-b");
+        assert_eq!(acquired.writer_id.as_str(), "writer-b");
         let head = load_head_object(&store, &namespace_id)
             .await
             .expect("read head")

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -358,7 +358,7 @@ fn error_detail_fields_match_the_api_spec_table() {
         operation_index: Some(0),
         fenced_writer_epoch: Some(WriterEpoch::from(1)),
         active_writer_epoch: Some(WriterEpoch::from(2)),
-        active_writer: Some("writer".to_owned()),
+        active_writer: Some(loonfs_api::WriterId::parse("writer").expect("writer id")),
         active_acquired_at_ms: Some(1),
         inode_id: Some(InodeId(1)),
         expected_inode_id: Some(InodeId(2)),

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -1009,7 +1009,7 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
                 // it structurally means a caller never parses the message.
                 let details = details.expect("a fenced error carries structured details");
                 assert_eq!(
-                    details.active_writer.as_deref(),
+                    details.active_writer.as_ref().map(|writer| writer.as_str()),
                     Some("loonfs-server-b"),
                     "attempt {attempt}"
                 );

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -216,7 +216,10 @@ async fn fenced_session_cannot_delete_namespace() {
             .await,
         "a fenced session must not delete the namespace",
     );
-    assert_eq!(fence.active_writer.as_deref(), Some("writer-b"));
+    assert_eq!(
+        fence.active_writer.as_ref().map(|writer| writer.as_str()),
+        Some("writer-b")
+    );
     assert_eq!(fence.active_epoch, head_after_fencing.writer_epoch);
 
     // The namespace is untouched: same epoch, still active, still writer B's.
@@ -326,7 +329,10 @@ async fn fenced_writer_stays_fenced_after_its_tail_projection_is_evicted() {
     );
     let head_after_fencing = head_state(&store, &ns_fence).await;
     assert_eq!(fence.active_epoch, head_after_fencing.writer_epoch);
-    assert_eq!(fence.active_writer.as_deref(), Some("writer-b"));
+    assert_eq!(
+        fence.active_writer.as_ref().map(|writer| writer.as_str()),
+        Some("writer-b")
+    );
 
     // More budget pressure, now against a publisher whose session is fenced:
     // fencing is session state, so no eviction can reach it.

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -802,8 +802,8 @@
             "type": "integer"
           },
           "active_writer": {
-            "description": "The writer ID recorded for the current epoch, when available.",
-            "type": "string"
+            "$ref": "#/components/schemas/WriterId",
+            "description": "The writer ID recorded for the current epoch, when available."
           },
           "active_writer_epoch": {
             "$ref": "#/components/schemas/WriterEpoch",
@@ -2692,6 +2692,10 @@
         "maximum": 9007199254740991,
         "minimum": 0,
         "type": "integer"
+      },
+      "WriterId": {
+        "description": "Stable writer label supplied by the embedding process.",
+        "type": "string"
       }
     }
   },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1073,8 +1073,8 @@
             "type": "integer"
           },
           "active_writer": {
-            "description": "The writer ID recorded for the current epoch, when available.",
-            "type": "string"
+            "$ref": "#/components/schemas/WriterId",
+            "description": "The writer ID recorded for the current epoch, when available."
           },
           "active_writer_epoch": {
             "$ref": "#/components/schemas/WriterEpoch",
@@ -4191,6 +4191,10 @@
         "maximum": 9007199254740991,
         "minimum": 0,
         "type": "integer"
+      },
+      "WriterId": {
+        "description": "Stable writer label supplied by the embedding process.",
+        "type": "string"
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
Writer sessions and fencing errors should carry the same validated identity as the namespace head, so retain WriterId through those paths and expose it in OpenAPI. Give binding cleanup a named BindingIdentity instead of a tuple that shares its name with the public opaque generation token. Existing valid JSON and durable bytes are unchanged; 2,053 workspace tests, full Clippy, and formatting pass, and both OpenAPI documents are regenerated.