### PR TITLE
fix(cli): persist upload journals atomically and surface failures

### DIFF
--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -529,7 +529,7 @@ impl ResolvedTarget {
                 let Some(journal) = journal else {
                     return Ok(target.client.put_file_stream(spec, source, options).await?);
                 };
-                let resume = journal.resume();
+                let resume = journal.resume().map_err(CliError::io)?;
                 Ok(target
                     .client
                     .put_file_stream_resumable(spec, source, options, journal, resume.as_ref())

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -27,6 +27,7 @@ use crate::config::ConfigLocation;
 use crate::error::CliError;
 use crate::payload::{read_whole_file, LocalPayload, STDIN_PATH};
 use crate::progress::{ProgressOp, ProgressReporter};
+use crate::resolve::ResolvedTarget;
 use crate::uploads::{SourceIdentity, UploadJournal};
 use loonfs_api::v0::UploadSessionStatus;
 use loonfs_api::{
@@ -1022,9 +1023,10 @@ pub(super) async fn put_payload(
 ) -> Result<CommitResponse, CliError> {
     // Resume only multipart uploads backed by a file that can be reopened.
     // Streams cannot be read again after an interruption.
-    let journal = payload
-        .resumable_source()
-        .and_then(|local_path| resume_journal(context, spec, local_path));
+    let journal = match (&context.target, payload.resumable_source()) {
+        (ResolvedTarget::Remote(_), Some(path)) => Some(resume_journal(context, spec, path)?),
+        _ => None,
+    };
     if let Some(journal) = journal.as_ref() {
         if let Some(committed) =
             commit_a_finished_upload(context, spec, options, journal, progress).await?
@@ -1049,24 +1051,24 @@ pub(super) async fn put_payload(
                 .await
         }
     };
-    if result.is_ok() {
+    if let Ok(committed) = &result {
         // The record exists to survive an interruption, and this upload was
         // not interrupted.
         if let Some(journal) = journal.as_ref() {
-            journal.forget();
+            forget_committed_upload(journal, committed)?;
         }
     }
     result
 }
 
-/// The record an interrupted upload of this payload would have left, or
-/// nothing when there is nowhere to keep one.
+/// Opens the journal for a resumable remote file upload.
 fn resume_journal(
     context: &CommandContext,
     spec: &NamespacePath,
     local_path: &Path,
-) -> Option<UploadJournal> {
-    let source = SourceIdentity::of(local_path).ok()?;
+) -> Result<UploadJournal, CliError> {
+    let source =
+        SourceIdentity::of(local_path).map_err(|error| CliError::io_for_path(local_path, error))?;
     UploadJournal::for_upload(
         &context.profile_name,
         context.namespace().as_str(),
@@ -1074,6 +1076,7 @@ fn resume_journal(
         local_path,
         source,
     )
+    .map_err(CliError::io)
 }
 
 /// Commits an upload whose bytes all landed before it was interrupted,
@@ -1092,16 +1095,13 @@ async fn commit_a_finished_upload(
     journal: &UploadJournal,
     progress: &ProgressReporter,
 ) -> Result<Option<CommitResponse>, CliError> {
-    let Some(resume) = journal.resume() else {
+    let Some(resume) = journal.resume().map_err(CliError::io)? else {
         return Ok(None);
     };
-    let Ok(status) = context
+    let status = context
         .target
         .get_upload(context.namespace(), &resume.upload_id)
-        .await
-    else {
-        return Ok(None);
-    };
+        .await?;
     let UploadSessionStatus::Completed {
         content_ref,
         content_token,
@@ -1116,10 +1116,21 @@ async fn commit_a_finished_upload(
         .target
         .commit_completed_upload(spec, content_ref, content_token, options)
         .await;
-    if result.is_ok() {
-        journal.forget();
-    }
-    Ok(Some(result?))
+    let committed = result?;
+    forget_committed_upload(journal, &committed)?;
+    Ok(Some(committed))
+}
+
+fn forget_committed_upload(
+    journal: &UploadJournal,
+    committed: &CommitResponse,
+) -> Result<(), CliError> {
+    journal.forget().map_err(|error| {
+        CliError::io_error(format!(
+        "file commit `{}` succeeded at sequence {}, but its journal could not be removed: {error}",
+        committed.commit_id, committed.committed_seq,
+    ))
+    })
 }
 
 fn put_file_options(

--- a/crates/loonfs-cli/src/uploads.rs
+++ b/crates/loonfs-cli/src/uploads.rs
@@ -5,6 +5,7 @@ use loonfs_api::v0::CompletedUploadPart;
 use loonfs_api::{Checksum, ChecksumAlgorithm, UploadId};
 use loonfs_client::{MultipartUploadJournal, MultipartUploadResume};
 use serde::{Deserialize, Serialize};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -17,7 +18,7 @@ const UPLOADS_SUBDIR: &str = "uploads";
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct UploadState {
-    upload_id: String,
+    upload_id: UploadId,
     part_size_bytes: u64,
     checksum_algorithm: ChecksumAlgorithm,
     parts: Vec<StatePart>,
@@ -38,23 +39,21 @@ struct StatePart {
 #[serde(deny_unknown_fields)]
 pub(crate) struct SourceIdentity {
     size_bytes: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    modified_ms: Option<u64>,
+    modified_ns: i128,
 }
 
 impl SourceIdentity {
-    /// Reads a file's length and optional modification time.
+    /// Reads a file's length and full-precision modification time.
     pub(crate) fn of(path: &Path) -> std::io::Result<Self> {
         let metadata = std::fs::metadata(path)?;
-        let modified_ms = metadata.modified().ok().and_then(|modified| {
-            modified
-                .duration_since(std::time::UNIX_EPOCH)
-                .ok()
-                .map(|since| since.as_millis() as u64)
-        });
+        let modified = metadata.modified()?;
+        let modified_ns = match modified.duration_since(std::time::UNIX_EPOCH) {
+            Ok(since) => since.as_nanos() as i128,
+            Err(before) => -(before.duration().as_nanos() as i128),
+        };
         Ok(Self {
             size_bytes: metadata.len(),
-            modified_ms,
+            modified_ns,
         })
     }
 }
@@ -69,46 +68,52 @@ pub(crate) struct UploadJournal {
 }
 
 impl UploadJournal {
-    /// Returns a journal when a writable state directory is available.
+    /// Resolves the journal path. Missing state-directory configuration is an error.
     pub(crate) fn for_upload(
         profile: &str,
         namespace: &str,
         remote_path: &str,
         local_path: &Path,
         source: SourceIdentity,
-    ) -> Option<Self> {
-        let key = Checksum::sha256(
-            format!(
-                "{profile}\u{0}{namespace}\u{0}{remote_path}\u{0}{}",
-                local_path.display()
-            )
-            .as_bytes(),
-        )
+    ) -> io::Result<Self> {
+        let local_path = local_path.canonicalize()?;
+        let key = Checksum::sha256(&serde_json::to_vec(&(
+            profile,
+            namespace,
+            remote_path,
+            local_path.as_os_str().as_encoded_bytes(),
+        ))?)
         .value;
-        Some(Self {
-            path: uploads_dir()?.join(format!("{key}.json")),
+        Ok(Self {
+            path: uploads_dir()
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "upload journals require an absolute XDG_STATE_HOME or HOME",
+                    )
+                })?
+                .join(format!("{key}.json")),
             source,
             state: Mutex::new(None),
         })
     }
 
-    /// Returns valid state from an earlier run, deleting stale state.
-    pub(crate) fn resume(&self) -> Option<MultipartUploadResume> {
-        let recorded = std::fs::read(&self.path).ok()?;
-        let recorded: UploadState = serde_json::from_slice(&recorded).ok().or_else(|| {
-            self.forget();
-            None
-        })?;
+    /// Loads an existing record. Only a missing file means there is no upload.
+    pub(crate) fn resume(&self) -> io::Result<Option<MultipartUploadResume>> {
+        let bytes = match std::fs::read(&self.path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(self.error(error)),
+        };
+        let recorded: UploadState =
+            serde_json::from_slice(&bytes).map_err(|error| self.error(error))?;
         if recorded.source != self.source {
-            self.forget();
-            return None;
+            return Err(
+                self.error("source file changed; remove this journal to start a new upload")
+            );
         }
-        let upload_id = UploadId::parse(&recorded.upload_id).ok().or_else(|| {
-            self.forget();
-            None
-        })?;
         let resume = MultipartUploadResume {
-            upload_id,
+            upload_id: recorded.upload_id.clone(),
             part_size_bytes: recorded.part_size_bytes,
             checksum_algorithm: recorded.checksum_algorithm,
             parts: recorded
@@ -121,29 +126,44 @@ impl UploadJournal {
                 })
                 .collect(),
         };
-        // Preserve earlier parts when this run appends new ones.
         *self.lock() = Some(recorded);
-        Some(resume)
+        Ok(Some(resume))
     }
 
-    /// Removes the record. Called when the upload commits, and whenever
-    /// what is on disk turns out to describe something else.
-    pub(crate) fn forget(&self) {
-        let _ = std::fs::remove_file(&self.path);
+    /// Removes an acknowledged upload's record. Removal errors remain visible.
+    pub(crate) fn forget(&self) -> io::Result<()> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => self.sync_directory().map_err(|error| self.error(error))?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(self.error(error)),
+        }
         *self.lock() = None;
+        Ok(())
     }
 
-    /// Writes the journal. Failure only disables future resumption.
-    fn flush(&self, state: &UploadState) {
-        let Some(parent) = self.path.parent() else {
-            return;
+    /// Replace the record only after the complete new file reaches disk.
+    fn flush(&self, state: &UploadState) -> io::Result<()> {
+        let write = || -> io::Result<()> {
+            let parent = self.path.parent().expect("journal has a directory");
+            std::fs::create_dir_all(parent)?;
+            let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+            serde_json::to_writer(&mut temporary, state)?;
+            temporary.flush()?;
+            temporary.as_file().sync_all()?;
+            temporary.persist(&self.path).map_err(|error| error.error)?;
+            self.sync_directory()
         };
-        if std::fs::create_dir_all(parent).is_err() {
-            return;
-        }
-        if let Ok(encoded) = serde_json::to_vec(state) {
-            let _ = std::fs::write(&self.path, encoded);
-        }
+        write().map_err(|error| self.error(error))
+    }
+
+    fn sync_directory(&self) -> io::Result<()> {
+        #[cfg(unix)]
+        std::fs::File::open(self.path.parent().expect("journal has a directory"))?.sync_all()?;
+        Ok(())
+    }
+
+    fn error(&self, error: impl std::fmt::Display) -> io::Error {
+        io::Error::other(format!("upload journal `{}`: {error}", self.path.display()))
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Option<UploadState>> {
@@ -159,31 +179,33 @@ impl MultipartUploadJournal for UploadJournal {
         upload_id: &UploadId,
         part_size_bytes: u64,
         checksum_algorithm: ChecksumAlgorithm,
-    ) {
+    ) -> io::Result<()> {
         let state = UploadState {
-            upload_id: upload_id.to_string(),
+            upload_id: upload_id.clone(),
             part_size_bytes,
             checksum_algorithm,
             parts: Vec::new(),
             source: self.source.clone(),
         };
-        self.flush(&state);
+        self.flush(&state)?;
         *self.lock() = Some(state);
+        Ok(())
     }
 
-    fn part_completed(&self, part: &CompletedUploadPart) {
+    fn part_completed(&self, part: &CompletedUploadPart) -> io::Result<()> {
         let mut held = self.lock();
-        let Some(state) = held.as_mut() else {
-            // No session was opened and no record was picked up, so this
-            // part belongs to an upload nobody is keeping track of.
-            return;
-        };
-        state.parts.push(StatePart {
+        let mut next = held
+            .as_ref()
+            .ok_or_else(|| self.error("no upload session was recorded"))?
+            .clone();
+        next.parts.push(StatePart {
             part_number: part.part_number,
             etag: part.etag.clone(),
             checksum: part.checksum.clone(),
         });
-        self.flush(state);
+        self.flush(&next)?;
+        *held = Some(next);
+        Ok(())
     }
 }
 
@@ -206,148 +228,156 @@ fn uploads_dir() -> Option<PathBuf> {
 mod tests {
     use super::*;
 
-    fn identity(size_bytes: u64, modified_ms: u64) -> SourceIdentity {
+    fn source(size_bytes: u64) -> SourceIdentity {
         SourceIdentity {
             size_bytes,
-            modified_ms: Some(modified_ms),
+            modified_ns: 7,
         }
     }
 
-    fn journal_at(dir: &Path, remote_path: &str, source: SourceIdentity) -> UploadJournal {
+    fn journal_at(path: &Path) -> UploadJournal {
         UploadJournal {
-            path: dir.join(format!("{}.json", remote_path.replace('/', "_"))),
-            source,
+            path: path.to_owned(),
+            source: source(1024),
             state: Mutex::new(None),
         }
     }
 
-    fn part(part_number: u32) -> CompletedUploadPart {
+    fn begin(journal: &UploadJournal) {
+        journal
+            .began(
+                &UploadId::parse("upl_00000000000000000000000000000001").expect("id"),
+                1024 * 1024,
+                ChecksumAlgorithm::Crc64nvme,
+            )
+            .expect("record session");
+    }
+
+    fn part(number: u32) -> CompletedUploadPart {
         CompletedUploadPart {
-            part_number,
-            etag: format!("\"etag-{part_number}\""),
-            checksum: Checksum::crc64nvme(format!("part-{part_number}").as_bytes()),
+            part_number: number,
+            etag: format!("etag-{number}"),
+            checksum: Checksum::crc64nvme(format!("part-{number}").as_bytes()),
         }
     }
 
-    fn upload_id() -> UploadId {
-        UploadId::parse("upl_00000000000000000000000000000001").expect("valid upload id")
-    }
-
     #[test]
-    fn a_record_hands_the_next_run_the_parts_that_landed() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let source = identity(1024, 7);
-        let journal = journal_at(dir.path(), "/big.bin", source.clone());
-        assert_eq!(journal.resume(), None, "nothing recorded resumes nothing");
-
-        journal.began(&upload_id(), 1024 * 1024, ChecksumAlgorithm::Crc64nvme);
-        journal.part_completed(&part(1));
-        journal.part_completed(&part(2));
-
-        let resumed = journal_at(dir.path(), "/big.bin", source.clone())
-            .resume()
-            .expect("a record of the same upload");
-        assert_eq!(resumed.upload_id, upload_id());
+    fn a_record_survives_repeated_interruptions_and_is_removed_after_acknowledgement() {
+        let dir = tempfile::tempdir().expect("directory");
+        let path = dir.path().join("upload.json");
+        let first = journal_at(&path);
+        assert!(first.resume().expect("read").is_none());
+        begin(&first);
+        first.part_completed(&part(1)).expect("first part");
+        let next = journal_at(&path);
+        let resumed = next.resume().expect("read").expect("session");
+        assert_eq!(resumed.parts, vec![part(1)]);
         assert_eq!(resumed.part_size_bytes, 1024 * 1024);
         assert_eq!(resumed.checksum_algorithm, ChecksumAlgorithm::Crc64nvme);
+        next.part_completed(&part(2)).expect("second part");
         assert_eq!(
-            resumed
-                .parts
-                .iter()
-                .map(|p| p.part_number)
-                .collect::<Vec<_>>(),
-            vec![1, 2]
-        );
-
-        // A run that resumed and was interrupted again leaves a record of
-        // everything that landed, its own parts included.
-        let second = journal_at(dir.path(), "/big.bin", source.clone());
-        second.resume().expect("a record to pick up");
-        second.part_completed(&part(3));
-        assert_eq!(
-            journal_at(dir.path(), "/big.bin", source)
+            journal_at(&path)
                 .resume()
-                .expect("a record")
-                .parts
-                .iter()
-                .map(|p| p.part_number)
-                .collect::<Vec<_>>(),
-            vec![1, 2, 3]
+                .expect("read")
+                .expect("session")
+                .parts,
+            vec![part(1), part(2)]
         );
-
-        journal.forget();
-        assert_eq!(journal.resume(), None, "a committed upload keeps nothing");
+        next.forget().expect("remove acknowledged record");
+        assert!(next.resume().expect("read").is_none());
+        next.forget().expect("already absent");
     }
 
     #[test]
-    fn a_source_that_changed_invalidates_its_record() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let journal = journal_at(dir.path(), "/big.bin", identity(1024, 7));
-        journal.began(&upload_id(), 1024 * 1024, ChecksumAlgorithm::Crc64nvme);
-        journal.part_completed(&part(1));
-
-        let rewritten = journal_at(dir.path(), "/big.bin", identity(1024, 8));
-        assert_eq!(rewritten.resume(), None, "a newer file is a different file");
-        assert!(
-            !rewritten.path.exists(),
-            "an invalidated record is removed rather than left to mislead"
-        );
-
-        let resized = journal_at(dir.path(), "/big.bin", identity(2048, 7));
-        assert_eq!(resized.resume(), None, "a longer file is a different file");
-    }
-
-    #[test]
-    fn an_unreadable_record_is_discarded() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let journal = journal_at(dir.path(), "/big.bin", identity(1024, 7));
-        std::fs::write(&journal.path, b"{\"upload_id\":").expect("write torn record");
-        assert_eq!(journal.resume(), None);
-        assert!(!journal.path.exists());
-    }
-
-    #[test]
-    fn an_old_upload_journal_cleanly_starts_a_fresh_session() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let journal = journal_at(dir.path(), "/big.bin", identity(1024, 7));
-        std::fs::write(
-            &journal.path,
-            format!(
-                "{{\"upload_id\":\"{}\",\"part_size_bytes\":1048576,\"parts\":[],\"source\":{{\"size_bytes\":1024,\"modified_ms\":7}}}}",
-                upload_id()
-            ),
-        )
-        .expect("write old journal");
-
-        assert_eq!(journal.resume(), None);
-        assert!(!journal.path.exists());
-    }
-
-    #[test]
-    fn the_record_is_named_by_what_decides_which_upload_it_is() {
-        let source = identity(1024, 7);
-        let path = |profile, namespace, remote, local| {
-            UploadJournal::for_upload(profile, namespace, remote, Path::new(local), source.clone())
-                .map(|journal| journal.path)
-        };
-        let baseline = path("default", "demo", "/big.bin", "/tmp/big.bin");
-        assert!(baseline.is_some(), "a home directory names a state file");
+    fn malformed_and_unreadable_records_are_errors_and_are_preserved() {
+        let dir = tempfile::tempdir().expect("directory");
+        let path = dir.path().join("upload.json");
+        let journal = journal_at(&path);
+        std::fs::write(&path, b"{\"upload_id\":").expect("torn record");
+        assert!(journal
+            .resume()
+            .expect_err("invalid record")
+            .to_string()
+            .contains("upload.json"));
         assert_eq!(
-            baseline,
-            path("default", "demo", "/big.bin", "/tmp/big.bin")
+            std::fs::read(&path).expect("preserved record"),
+            b"{\"upload_id\":"
         );
-        assert_ne!(baseline, path("other", "demo", "/big.bin", "/tmp/big.bin"));
-        assert_ne!(
-            baseline,
-            path("default", "prod", "/big.bin", "/tmp/big.bin")
+        std::fs::remove_file(&path).expect("remove fixture");
+        std::fs::create_dir(&path).expect("unreadable record");
+        assert!(journal.resume().is_err());
+        assert!(journal.forget().is_err());
+    }
+
+    #[test]
+    fn a_changed_source_requires_an_explicit_new_upload() {
+        let dir = tempfile::tempdir().expect("directory");
+        let path = dir.path().join("upload.json");
+        let journal = journal_at(&path);
+        begin(&journal);
+        let mut changed = journal_at(&path);
+        changed.source = source(2048);
+        assert!(changed
+            .resume()
+            .expect_err("changed source")
+            .to_string()
+            .contains("source file changed"));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn a_failed_update_preserves_the_last_durable_parts() {
+        let dir = tempfile::tempdir().expect("directory");
+        let parent = dir.path().join("uploads");
+        let saved = dir.path().join("saved");
+        let journal = journal_at(&parent.join("upload.json"));
+        begin(&journal);
+        journal.part_completed(&part(1)).expect("first part");
+        std::fs::rename(&parent, &saved).expect("move directory");
+        std::fs::write(&parent, b"not a directory").expect("block journal writes");
+        assert!(journal.part_completed(&part(2)).is_err());
+        assert_eq!(journal.lock().as_ref().expect("state").parts.len(), 1);
+        std::fs::remove_file(&parent).expect("remove blocker");
+        std::fs::rename(&saved, &parent).expect("restore directory");
+        assert_eq!(
+            journal_at(&journal.path)
+                .resume()
+                .expect("read")
+                .expect("session")
+                .parts,
+            vec![part(1)]
         );
-        assert_ne!(
-            baseline,
-            path("default", "demo", "/other.bin", "/tmp/big.bin")
-        );
-        assert_ne!(
-            baseline,
-            path("default", "demo", "/big.bin", "/tmp/other.bin")
-        );
+    }
+
+    #[test]
+    fn missing_session_state_cannot_silently_discard_a_part() {
+        let dir = tempfile::tempdir().expect("directory");
+        assert!(journal_at(&dir.path().join("upload.json"))
+            .part_completed(&part(1))
+            .is_err());
+    }
+
+    #[test]
+    fn the_journal_key_includes_both_endpoints_and_the_source_path() {
+        let dir = tempfile::tempdir().expect("directory");
+        let first = dir.path().join("file");
+        let other = dir.path().join("other");
+        std::fs::write(&first, b"data").expect("source");
+        std::fs::write(&other, b"data").expect("source");
+        let path = |profile, namespace, remote, local: &Path| {
+            UploadJournal::for_upload(profile, namespace, remote, local, source(1024))
+                .expect("journal path")
+                .path
+        };
+        let original = path("default", "demo", "/file", &first);
+        assert_eq!(original, path("default", "demo", "/file", &first));
+        for candidate in [
+            path("other", "demo", "/file", &first),
+            path("default", "other", "/file", &first),
+            path("default", "demo", "/other", &first),
+            path("default", "demo", "/file", &other),
+        ] {
+            assert_ne!(original, candidate);
+        }
     }
 }

--- a/crates/loonfs-client/src/uploads/staging.rs
+++ b/crates/loonfs-client/src/uploads/staging.rs
@@ -40,7 +40,8 @@ pub struct MultipartUploadResume {
 ///
 /// The client calls these methods synchronously after opening the session and
 /// after each successful part upload. Implementations may persist this data
-/// before the next network request starts.
+/// before the next network request starts. A journal error stops the upload;
+/// the server session remains available for resumption or explicit abort.
 pub trait MultipartUploadJournal: Send + Sync {
     /// Records a newly opened session and its required part size and checksum algorithm.
     fn began(
@@ -48,9 +49,9 @@ pub trait MultipartUploadJournal: Send + Sync {
         upload_id: &UploadId,
         part_size_bytes: u64,
         checksum_algorithm: ChecksumAlgorithm,
-    );
+    ) -> std::io::Result<()>;
     /// Records a part after it has been uploaded successfully.
-    fn part_completed(&self, part: &CompletedUploadPart);
+    fn part_completed(&self, part: &CompletedUploadPart) -> std::io::Result<()>;
 }
 
 /// Optional state for resuming and recording a multipart upload.
@@ -480,7 +481,8 @@ impl Client {
     /// One pass computes part checksums and the final object checksum while
     /// reading the payload. The total size does not need to be known first.
     ///
-    /// A session that fails partway is aborted rather than left open.
+    /// Errors leave the session open so the caller can resume or explicitly
+    /// abort it. Session expiry reclaims uploads the caller abandons.
     async fn stage_via_multipart(
         &self,
         namespace_id: &NamespaceId,
@@ -512,12 +514,16 @@ impl Client {
                     return Err(negotiated_a_different_upload_mode());
                 };
                 if let Some(journal) = continuity.journal {
-                    journal.began(&upload_id, part_size_bytes, checksum_algorithm);
+                    journal
+                        .began(&upload_id, part_size_bytes, checksum_algorithm)
+                        .map_err(|error| {
+                            ClientError::Io(format!("recording upload `{upload_id}`: {error}"))
+                        })?;
                 }
                 (upload_id, part_size_bytes, checksum_algorithm)
             }
         };
-        let uploaded = match self
+        let uploaded = self
             .upload_every_part(
                 namespace_id,
                 &upload_id,
@@ -526,15 +532,7 @@ impl Client {
                 checksum_algorithm,
                 continuity,
             )
-            .await
-        {
-            Ok(uploaded) => uploaded,
-            Err(error) => {
-                // Abort best-effort and preserve the original upload error.
-                let _ = self.abort_upload(namespace_id, &upload_id).await;
-                return Err(error);
-            }
-        };
+            .await?;
         if uploaded.parts.is_empty() {
             // Providers cannot assemble zero parts, so use the proxied empty
             // upload path instead.
@@ -613,7 +611,9 @@ impl Client {
                 let uploaded = self.upload_wave(namespace_id, upload_id, wave).await?;
                 if let Some(journal) = continuity.journal {
                     for part in &uploaded {
-                        journal.part_completed(part);
+                        journal.part_completed(part).map_err(|error| {
+                            ClientError::Io(format!("recording upload `{upload_id}`: {error}"))
+                        })?;
                     }
                 }
                 parts.extend(uploaded);

--- a/crates/loonfs-client/src/uploads/staging/tests.rs
+++ b/crates/loonfs-client/src/uploads/staging/tests.rs
@@ -358,13 +358,15 @@ impl MultipartUploadJournal for RecordingJournal {
         upload_id: &UploadId,
         part_size_bytes: u64,
         checksum_algorithm: ChecksumAlgorithm,
-    ) {
+    ) -> std::io::Result<()> {
         *self.began.lock().expect("journal lock") =
             Some((upload_id.clone(), part_size_bytes, checksum_algorithm));
+        Ok(())
     }
 
-    fn part_completed(&self, part: &CompletedUploadPart) {
+    fn part_completed(&self, part: &CompletedUploadPart) -> std::io::Result<()> {
         self.parts.lock().expect("journal lock").push(part.clone());
+        Ok(())
     }
 }
 
@@ -405,10 +407,7 @@ async fn a_resumed_multipart_put_uploads_only_the_parts_that_are_missing() {
             first.push(Outcome::PartAccepted(format!("\"etag-{part_number}\"")));
         }
     }
-    // The signing request for the third wave never lands, and the abort
-    // that follows a failed session does not either. Retry is off so each
-    // is one attempt and the script stays exactly this long.
-    first.push(Outcome::TransportFailure);
+    // A failed signing request leaves the session open. No abort is sent.
     first.push(Outcome::TransportFailure);
     let transport = test_transport::script(first);
     let interrupted = client_without_retry()
@@ -910,4 +909,55 @@ async fn an_unsized_source_frames_its_body_chunked() {
         !head.contains("content-length"),
         "a body of unknown length cannot declare one: {head}"
     );
+}
+
+struct FailingJournal {
+    fail_at_begin: bool,
+}
+
+impl MultipartUploadJournal for FailingJournal {
+    fn began(&self, _: &UploadId, _: u64, _: ChecksumAlgorithm) -> std::io::Result<()> {
+        if self.fail_at_begin {
+            Err(std::io::Error::other("journal disk full"))
+        } else {
+            Ok(())
+        }
+    }
+    fn part_completed(&self, _: &CompletedUploadPart) -> std::io::Result<()> {
+        Err(std::io::Error::other("journal disk full"))
+    }
+}
+
+#[tokio::test]
+async fn journal_failures_stop_uploads_without_aborting_the_resumable_session() {
+    for fail_at_begin in [true, false] {
+        let mut script = vec![capabilities(true), begin_multipart()];
+        if !fail_at_begin {
+            script.push(signed_parts(1, 4));
+            for number in 1..=4 {
+                script.push(Outcome::PartAccepted(format!("etag-{number}")));
+            }
+        }
+        let expected_attempts = script.len();
+        let transport = test_transport::script(script);
+        let bytes = vec![0; TEST_PART_BYTES as usize * 5];
+        let error = client_without_retry()
+            .put_file_stream_resumable(
+                &spec(),
+                PayloadSource::stream(
+                    futures::stream::once(async move { Ok(Bytes::from(bytes)) }).boxed(),
+                ),
+                &PutFileOptions::new(loonfs_test_support::test_actor()),
+                &FailingJournal { fail_at_begin },
+                None,
+            )
+            .await
+            .expect_err("journal error");
+        assert!(matches!(error, ClientError::Io(message) if message.contains("journal disk full")));
+        assert_eq!(
+            transport.attempts(),
+            expected_attempts,
+            "no subsequent wave, completion, commit, or abort may be sent"
+        );
+    }
 }

--- a/docs/design/cli-upload-recovery.md
+++ b/docs/design/cli-upload-recovery.md
@@ -1,0 +1,40 @@
+# CLI upload recovery
+
+Remote uploads of large local files keep multipart progress in
+`$XDG_STATE_HOME/loonfs/uploads`, or `$HOME/.local/state/loonfs/uploads`.
+The journal key includes the profile, namespace, remote path, and canonical
+local path. Local path bytes are encoded without lossy Unicode conversion.
+Embedded uploads and standard-input streams do not create multipart journals.
+
+The record contains the upload ID, part geometry, checksum algorithm, accepted
+parts, and source file length and full-precision modification time. Only a
+missing record means a new upload. An unreadable or malformed record, unavailable
+source metadata, or changed source stops the command with an error. Records are
+preserved for inspection; remove the named journal to explicitly start again.
+There is no reader for earlier development journal layouts.
+
+Each update writes and syncs a temporary file in the journal directory before
+atomically replacing the record. Unix hosts also sync the directory after
+replacement or removal. The in-memory record advances only after persistence
+succeeds. A failed update therefore leaves the preceding record recoverable,
+although a failure after rename can mean that the new record already landed.
+Temporary files are removed when their owners are dropped.
+
+The client's `MultipartUploadJournal` callbacks return I/O errors. Failure to
+record the session prevents part uploads; failure to record an accepted part
+prevents the next wave, completion, and file commit. Accepted parts missing from
+the last saved record may be uploaded again safely. Journal failures include the
+server upload ID and the local record path in the error.
+
+Transfer errors leave the multipart session open. The caller can resume it or
+explicitly abort it; abandoned sessions wait for expiry and garbage collection.
+This costs temporary storage compared with aborting immediately after an error,
+but preserves accepted parts after a recoverable failure. No partially uploaded
+file becomes visible.
+
+A completed upload can be committed without transferring its content again.
+Successful file commits remove their journal; if removal fails, the error names
+the successful commit and its sequence so the outcome is clear. Journal progress
+does not yet preserve the complete file-commit request or coordinate concurrent
+commands targeting the same journal. Retaining that request and exclusive journal
+ownership are follow-up work for exact PUT retries.


### PR DESCRIPTION
An interrupted upload needs a journal that survives process failure and reports when it cannot save recovery state. Persist journals atomically, propagate read and write failures, and leave failed multipart sessions available for resume instead of aborting them automatically. Abandoned sessions now rely on explicit abort or expiry cleanup, and changed source files require explicit resolution; retaining the exact PUT request remains separate work. Workspace tests, full Clippy, formatting, and focused recovery tests pass.