### PR TITLE
refactor(core): represent genesis without a fabricated manifest

### DIFF
--- a/crates/loonfs-core/src/checkpoint/block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/block_load.rs
@@ -198,10 +198,8 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
 #[cfg(test)]
 mod tests {
     use super::super::cache::MetadataSegmentBlockKind;
-    use super::super::load::genesis_basis_manifest;
     use super::*;
     use loonfs_api::wire::sst_blocks::{decode_filter_block, SegmentBlocksBuilder};
-    use loonfs_api::NamespaceId;
 
     fn key(kind: MetadataSegmentBlockKind, offset: u64) -> MetadataSegmentCacheKey {
         MetadataSegmentCacheKey {
@@ -238,12 +236,12 @@ mod tests {
     }
 
     fn manifest_block() -> DecodedMetadataSegmentBlock {
-        let namespace_id = NamespaceId::parse("memo").expect("namespace id");
+        let manifest = loonfs_api::wire::manifest::decode_namespace_manifest_json(include_bytes!(
+            "../../../loonfs-api/tests/golden/namespace_manifest.v4.json"
+        ))
+        .expect("valid manifest fixture");
         DecodedMetadataSegmentBlock::Manifest {
-            manifest: (
-                Arc::new(genesis_basis_manifest(&namespace_id)),
-                Arc::new(Vec::new()),
-            ),
+            manifest: (Arc::new(manifest), Arc::new(Vec::new())),
             decoded_bytes: 1,
         }
     }

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -9,7 +9,7 @@
 
 use super::build::{build_manifest_delta_run_segments, build_manifest_segments};
 use super::cache::MetadataSegmentCache;
-use super::load::{head_from_manifest, load_basis_metadata_segments};
+use super::load::load_basis_metadata_segments;
 use super::publish::{
     manifest_ref_for, manifest_write_failure, publish_metadata_root, write_namespace_manifest,
     ManifestPublicationOutcome,
@@ -241,7 +241,6 @@ pub async fn fold_wal_tail<S: ObjectStore + ?Sized>(
     let loaded_basis = load_basis_metadata_segments(
         store,
         segment_cache,
-        namespace_id,
         &snapshot.basis,
         snapshot.head.created_at_ms,
     )
@@ -266,7 +265,7 @@ pub async fn fold_wal_tail<S: ObjectStore + ?Sized>(
         head: snapshot.head,
         basis: snapshot.basis,
         floor_seq,
-        manifest_segments: ProjectionManifestSegments::Loaded(loaded_basis.segments),
+        manifest_segments: loaded_basis.segments,
         tail_state: snapshot.tail_state,
     };
     // A fold publishes metadata without updating the namespace head.
@@ -286,25 +285,11 @@ fn flush_wal_response(namespace_id: &NamespaceId, basis: FlushedBasis) -> FlushW
     }
 }
 
-pub(super) enum ProjectionManifestSegments<'a, S: ObjectStore + ?Sized> {
-    Loaded(VerifiedMetadataSegments<'a, S>),
-}
-
-impl<'a, S: ObjectStore + ?Sized> std::ops::Deref for ProjectionManifestSegments<'a, S> {
-    type Target = VerifiedMetadataSegments<'a, S>;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Loaded(segments) => segments,
-        }
-    }
-}
-
 pub(super) struct RootProjection<'a, S: ObjectStore + ?Sized> {
     pub(super) head: HeadState,
     pub(super) basis: MetadataBasis,
     pub(super) floor_seq: ChangeSeq,
-    pub(super) manifest_segments: ProjectionManifestSegments<'a, S>,
+    pub(super) manifest_segments: VerifiedMetadataSegments<'a, S>,
     /// Rows that are not in any segment yet: the genesis root inode when the
     /// basis is genesis, plus the replayed WAL tail.
     pub(super) tail_state: Arc<MetadataState>,
@@ -328,9 +313,9 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
         ));
     }
     let loaded_basis =
-        load_basis_metadata_segments(store, None, namespace_id, &basis, head.created_at_ms).await?;
+        load_basis_metadata_segments(store, None, &basis, head.created_at_ms).await?;
+    let manifest_head = loaded_basis.replay_head(&head);
     let manifest_segments = loaded_basis.segments;
-    let manifest_head = head_from_manifest(&head, manifest_segments.manifest());
     let wal_chain = load_wal_chain(
         store,
         WalChainLoadRequest {
@@ -365,7 +350,7 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
         head,
         basis,
         floor_seq,
-        manifest_segments: ProjectionManifestSegments::Loaded(manifest_segments),
+        manifest_segments,
         tail_state: Arc::new(replayed.resulting_metadata_state),
     })
 }
@@ -419,13 +404,6 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
     manifest_object_id: ManifestObjectId,
 ) -> Result<NamespaceManifestEnvelope> {
     let head_seq = projection.head.seq;
-    let previous_manifest = projection.manifest_segments.manifest();
-
-    // The manifest that first names a run allocates its number. A flush writes
-    // at most one run, so it takes at most one number, and a flush that writes
-    // none leaves the allocator where the previous manifest left it.
-    let run_no = previous_manifest.payload.next_run_no;
-
     // A WAL flush keeps existing runs and writes the WAL delta as one new delta
     // run. Reorganization merges delta runs into the base separately.
     //
@@ -434,6 +412,7 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
     // that sequence would carry. The namespace's first manifest is
     // therefore one complete base run over the whole projected state.
     let (base_seq, runs, next_run_no) = if matches!(projection.basis, MetadataBasis::Genesis) {
+        let run_no = RunNo(0);
         (
             head_seq,
             vec![MetadataRunRef {
@@ -453,6 +432,10 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
             next_run_no_after(run_no)?,
         )
     } else {
+        let previous_manifest = projection.manifest_segments.manifest();
+        // The manifest that first names a run allocates its number. A flush
+        // takes one number for its delta, or none when the head is unchanged.
+        let run_no = previous_manifest.payload.next_run_no;
         let mut runs = previous_manifest.payload.runs.clone();
         let mut next_run_no = run_no;
         if previous_manifest.payload.head_seq < head_seq {

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -15,14 +15,11 @@ use super::scan::VerifiedMetadataSegments;
 use super::validate::{validate_manifest, validate_namespace_manifest};
 use crate::error::{CoreError, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
-use crate::namespace::basis::{genesis_next_inode_id, MetadataBasis, MetadataBasisIdentity};
+use crate::namespace::basis::{MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::bootstrap::bootstrap_metadata_state;
-use loonfs_api::wire::control::{genesis_commit_id, HeadState, ManifestRef};
-use loonfs_api::wire::manifest::{
-    decode_namespace_manifest_json, NamespaceManifestEnvelope, NamespaceManifestKind,
-    NamespaceManifestPayload, NAMESPACE_MANIFEST_FORMAT_VERSION,
-};
-use loonfs_api::{ChangeSeq, ManifestNo, ManifestObjectId, NamespaceId, RunNo, WriterEpoch};
+use loonfs_api::wire::control::{HeadState, ManifestRef};
+use loonfs_api::wire::manifest::{decode_namespace_manifest_json, NamespaceManifestEnvelope};
+use loonfs_api::{ChangeSeq, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -96,36 +93,6 @@ pub(crate) fn ensure_manifest_reference_matches(
     )))
 }
 
-/// The genesis basis: one root-inode row and no metadata files.
-///
-/// A created namespace publishes no manifest, so reads before its first
-/// flush replay the WAL over this synthesized state. The object id is a
-/// sentinel that no generator produces and that nothing ever writes; it
-/// exists because the manifest payload shape requires one.
-const GENESIS_MANIFEST_OBJECT_ID: &str = "man_00000000000000000000-0000000000000000";
-
-pub(super) fn genesis_basis_manifest(namespace_id: &NamespaceId) -> NamespaceManifestEnvelope {
-    NamespaceManifestEnvelope {
-        kind: NamespaceManifestKind::NamespaceManifest,
-        format_version: NAMESPACE_MANIFEST_FORMAT_VERSION,
-        payload_checksum: String::new(),
-        payload: NamespaceManifestPayload {
-            namespace_id: namespace_id.clone(),
-            manifest_no: ManifestNo(0),
-            manifest_object_id: ManifestObjectId::parse(GENESIS_MANIFEST_OBJECT_ID)
-                .expect("genesis manifest object id is valid"),
-            head_seq: ChangeSeq(0),
-            head_commit_id: genesis_commit_id(),
-            base_seq: ChangeSeq(0),
-            writer_epoch: WriterEpoch(0),
-            next_inode_id: genesis_next_inode_id(),
-            next_run_no: RunNo(0),
-            retention_floor_seq: ChangeSeq(0),
-            runs: Vec::new(),
-        },
-    }
-}
-
 /// A verified basis with its identity, segments, and in-memory base rows.
 pub(crate) struct LoadedMetadataBasis<'a, S: ObjectStore + ?Sized> {
     pub(crate) identity: MetadataBasisIdentity,
@@ -133,6 +100,27 @@ pub(crate) struct LoadedMetadataBasis<'a, S: ObjectStore + ?Sized> {
     /// Rows the basis contributes outside any segment: the genesis root inode,
     /// and nothing at all once a manifest exists.
     pub(crate) base_state: MetadataState,
+}
+
+impl<S: ObjectStore + ?Sized> LoadedMetadataBasis<'_, S> {
+    /// Reconstructs the head from which this basis replays its WAL tail.
+    pub(crate) fn replay_head(&self, current_head: &HeadState) -> HeadState {
+        match self.identity.basis() {
+            MetadataBasis::Genesis => {
+                let mut head = HeadState::initial(
+                    current_head.namespace_id.clone(),
+                    current_head.content_store_id.clone(),
+                    current_head.created_at_ms,
+                );
+                head.writer = current_head.writer.clone();
+                head.status = current_head.status;
+                head
+            }
+            MetadataBasis::Manifest(_) => {
+                head_from_manifest(current_head, self.segments.manifest())
+            }
+        }
+    }
 }
 
 /// Loads the segments referenced by a resolved basis.
@@ -145,19 +133,13 @@ pub(crate) struct LoadedMetadataBasis<'a, S: ObjectStore + ?Sized> {
 pub(crate) async fn load_basis_metadata_segments<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     segment_cache: Option<&'a MetadataSegmentCache>,
-    namespace_id: &NamespaceId,
     basis: &MetadataBasis,
     genesis_created_at_ms: u64,
 ) -> crate::error::Result<LoadedMetadataBasis<'a, S>> {
     let Some(manifest) = basis.manifest() else {
-        let segments =
-            VerifiedMetadataSegments::synthesized(store, genesis_basis_manifest(namespace_id));
         return Ok(LoadedMetadataBasis {
-            identity: MetadataBasisIdentity::from_verified_basis(
-                basis.clone(),
-                segments.manifest().payload.head_seq,
-            ),
-            segments,
+            identity: MetadataBasisIdentity::from_verified_basis(basis.clone(), ChangeSeq(0)),
+            segments: VerifiedMetadataSegments::empty(store),
             base_state: bootstrap_metadata_state(genesis_created_at_ms),
         });
     };

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -73,7 +73,7 @@ pub(crate) use self::files::list_checkpoint_files_page;
 pub(crate) use self::flush::flush_wal;
 pub(crate) use self::list::list_checkpoints_page;
 pub(crate) use self::load::{
-    head_from_manifest, load_basis_metadata_segments, load_manifest_segments_for_inspection,
+    load_basis_metadata_segments, load_manifest_segments_for_inspection,
     load_namespace_manifest_envelope, load_namespace_manifest_envelope_if_present,
     LoadedMetadataBasis,
 };

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -57,22 +57,14 @@ impl<'a, S: ObjectStore + ?Sized> VerifiedMetadataSegments<'a, S> {
         self.store
     }
 
-    /// Wraps a manifest that was synthesized rather than loaded: the
-    /// genesis basis of a namespace that has published none. It names no
-    /// metadata files, so no scan it backs ever reaches the store, and its
-    /// object key is never read or written.
-    pub(crate) fn synthesized(store: &'a S, manifest: NamespaceManifestEnvelope) -> Self {
-        debug_assert!(
-            manifest.payload.runs.is_empty(),
-            "a synthesized manifest must name no durable metadata files"
-        );
-        let scan_runs = Arc::new(Vec::new());
+    /// Genesis has no manifest and no durable metadata rows to scan.
+    pub(crate) fn empty(store: &'a S) -> Self {
         Self {
             store,
             segment_cache: None,
             manifest_object_key: String::new(),
-            manifest: Some(Arc::new(manifest)),
-            scan_runs,
+            manifest: None,
+            scan_runs: Arc::new(Vec::new()),
             block_memo: SessionBlockMemo::default(),
         }
     }

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -212,6 +212,29 @@ async fn manifest_round_trip_supports_empty_namespace() {
         .await
         .expect("bootstrap");
 
+    let genesis = super::super::load::load_basis_metadata_segments(
+        &store,
+        None,
+        &crate::namespace::basis::MetadataBasis::Genesis,
+        context.now_ms,
+    )
+    .await
+    .expect("load genesis without a manifest");
+    assert!(genesis.segments.manifest.is_none());
+    let head = load_head_object(&store, &namespace_id)
+        .await
+        .expect("head")
+        .state;
+    assert_eq!(genesis.replay_head(&head), head);
+    for family in CHECKPOINT_ROW_FAMILIES {
+        assert!(genesis
+            .segments
+            .scan_prefix(family, "")
+            .await
+            .expect("empty scan")
+            .is_empty());
+    }
+
     let checkpoint = create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("create checkpoint");
@@ -230,6 +253,18 @@ async fn manifest_round_trip_supports_empty_namespace() {
     assert!(CheckpointId::parse(record.checkpoint_id.as_str()).is_ok());
     assert_eq!(record.manifest.manifest_head_seq, ChangeSeq(0));
     assert_eq!(record.manifest.manifest_no, ManifestNo(1));
+    let published =
+        load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestNo(1))
+            .await
+            .expect("first manifest is valid");
+    assert_eq!(published.manifest.payload.next_run_no, RunNo(1));
+    assert_eq!(published.manifest.payload.runs.len(), 1);
+    assert_eq!(published.manifest.payload.runs[0].run_no, RunNo(0));
+    assert_eq!(published.manifest.payload.runs[0].tier, RunTier::Base);
+    assert!(metadata_states_equivalent(
+        &published.metadata_state,
+        &genesis.base_state
+    ));
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -86,12 +86,6 @@ pub(crate) fn metadata_basis_without_root(head: &HeadState) -> MetadataBasis {
     }
 }
 
-/// The genesis head fields a synthesized basis replays from: sequence zero,
-/// the genesis commit, and the root inode already reserved.
-pub(crate) fn genesis_next_inode_id() -> loonfs_api::InodeId {
-    loonfs_api::FIRST_ALLOCATABLE_INODE_ID
-}
-
 /// The sequence a namespace's own history begins at: zero for a created
 /// namespace, the fork point for a fork target.
 pub(crate) fn namespace_birth_seq(head: &HeadState) -> ChangeSeq {

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -4,8 +4,8 @@
 use super::current_files::resolve_visible_inode;
 use super::listing::{invalid_cursor, validate_cursor_head, validate_directory_cursor};
 use crate::checkpoint::{
-    head_from_manifest, load_basis_metadata_segments, MetadataSegmentCache,
-    VerifiedMetadataSegments, WalTailProjectionCache, WalTailProjectionCacheKey,
+    load_basis_metadata_segments, MetadataSegmentCache, VerifiedMetadataSegments,
+    WalTailProjectionCache, WalTailProjectionCacheKey,
 };
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, MetadataViewError, Result};
@@ -186,13 +186,12 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let loaded_basis = load_basis_metadata_segments(
             store,
             load_context.segment_cache,
-            namespace_id,
             basis,
             head.created_at_ms,
         )
         .await?;
+        let manifest_head = loaded_basis.replay_head(&head);
         let segments = loaded_basis.segments;
-        let manifest_head = head_from_manifest(&head, segments.manifest());
         let anchor = ReadAnchor {
             head_seq: head.seq,
             manifest_no,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -3,9 +3,7 @@
 //! publishers.
 
 use crate::checkpoint::VerifiedMetadataSegments;
-use crate::checkpoint::{
-    head_from_manifest, load_basis_metadata_segments, LoadedMetadataBasis, MetadataSegmentCache,
-};
+use crate::checkpoint::{load_basis_metadata_segments, LoadedMetadataBasis, MetadataSegmentCache};
 use crate::control_object::ControlObjectLoadError;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result, StoreFailureClass};
@@ -179,14 +177,9 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     }
     ensure_writer_not_fenced(&head, &acquired_writer)?;
     let catalog_entry = VerifiedNamespaceCatalogEntry::from_head(&head);
-    let loaded_basis = load_basis_metadata_segments(
-        store,
-        segment_cache,
-        namespace_id,
-        &loaded.basis,
-        head.created_at_ms,
-    )
-    .await?;
+    let loaded_basis =
+        load_basis_metadata_segments(store, segment_cache, &loaded.basis, head.created_at_ms)
+            .await?;
     let key = PublishProjectionKey {
         namespace_id: namespace_id.clone(),
         head: HeadAnchor {
@@ -228,7 +221,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     key: PublishProjectionKey,
     loaded_basis: &LoadedMetadataBasis<'_, S>,
 ) -> Result<PublishTailProjection> {
-    let manifest_head = head_from_manifest(head, loaded_basis.segments.manifest());
+    let manifest_head = loaded_basis.replay_head(head);
     let wal_chain = load_wal_chain(
         store,
         WalChainLoadRequest {


### PR DESCRIPTION
A new namespace has no manifest, but reads and flushes manufacture one with a sentinel object ID and an empty checksum. Reconstruct its sequence-zero head from the explicit genesis basis and scan an empty segment set, removing the fabricated envelope and one-variant projection wrapper. Durable bytes are unchanged, and the first-flush test verifies that genesis becomes a valid base run. All 2,058 workspace tests, full Clippy, formatting, OpenAPI checks, and CI pass.