### PR TITLE
fix(cli): retain exact PUT requests across retries

### DIFF
--- a/crates/loonfs-api/src/options.rs
+++ b/crates/loonfs-api/src/options.rs
@@ -26,7 +26,8 @@ impl std::fmt::Display for AttributeInclusion {
 }
 
 /// Commit settings shared by every filesystem mutation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CommitOptions {
     /// Actor responsible for the commit, as supplied by the application.
     pub actor: ActorRef,
@@ -111,7 +112,8 @@ impl UpdateAttributesOptions {
 }
 
 /// Options for writing a file path.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PutFileOptions {
     /// Create-only or replace-existing behavior.
     pub behavior: DestinationBehavior,

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -508,9 +508,8 @@ impl ResolvedTarget {
     /// Writes a file from a source stream with bounded memory use.
     ///
     /// Each profile opens the source in the form its transport requires.
-    /// `progress` counts bytes read from the source. Remote multipart uploads
-    /// use `journal` to resume interrupted sessions; embedded and proxied
-    /// uploads do not need it.
+    /// `progress` counts bytes read from the source. Remote file uploads use
+    /// `journal` to retain their final commit request and any multipart progress.
     pub(crate) async fn put_file_stream(
         &self,
         spec: &NamespacePath,
@@ -529,7 +528,7 @@ impl ResolvedTarget {
                 let Some(journal) = journal else {
                     return Ok(target.client.put_file_stream(spec, source, options).await?);
                 };
-                let resume = journal.resume().map_err(CliError::io)?;
+                let resume = journal.resume();
                 Ok(target
                     .client
                     .put_file_stream_resumable(spec, source, options, journal, resume.as_ref())
@@ -550,6 +549,18 @@ impl ResolvedTarget {
         }
     }
 
+    /// Replays the exact request retained before an interrupted remote PUT.
+    pub(crate) async fn replay_file_commit(
+        &self,
+        namespace_id: &NamespaceId,
+        request: &loonfs_api::v0::CommitRequest,
+    ) -> Result<CommitResponse, CliError> {
+        match self {
+            Self::Embedded(_) => Err(upload_sessions_need_a_remote_profile()),
+            Self::Remote(target) => Ok(target.client.create_commit(namespace_id, request).await?),
+        }
+    }
+
     /// Commits content an upload session already completed, moving no bytes.
     pub(crate) async fn commit_completed_upload(
         &self,
@@ -557,12 +568,13 @@ impl ResolvedTarget {
         content_ref: ContentRef,
         content_token: Option<loonfs_api::v0::ContentToken>,
         options: &PutFileOptions,
+        journal: &UploadJournal,
     ) -> Result<CommitResponse, CliError> {
         match self {
             Self::Embedded(_) => Err(upload_sessions_need_a_remote_profile()),
             Self::Remote(target) => Ok(target
                 .client
-                .commit_completed_upload(spec, content_ref, content_token, options)
+                .commit_completed_upload(spec, content_ref, content_token, options, Some(journal))
                 .await?),
         }
     }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -1009,9 +1009,8 @@ async fn commit_put(
 
 /// Uploads one file and commits it at `spec`.
 ///
-/// Small payloads are buffered. Large payloads and streams are uploaded in
-/// chunks with bounded memory. Multipart uploads from files can resume after
-/// an interruption.
+/// Remote files retain their upload progress and final commit request. Embedded
+/// writes buffer small files and stream large files with bounded memory.
 ///
 /// Recursive uploads share `progress` across their files.
 pub(super) async fn put_payload(
@@ -1021,13 +1020,29 @@ pub(super) async fn put_payload(
     options: &PutFileOptions,
     progress: &Arc<ProgressReporter>,
 ) -> Result<CommitResponse, CliError> {
-    // Resume only multipart uploads backed by a file that can be reopened.
-    // Streams cannot be read again after an interruption.
-    let journal = match (&context.target, payload.resumable_source()) {
-        (ResolvedTarget::Remote(_), Some(path)) => Some(resume_journal(context, spec, path)?),
+    // File-backed remote PUTs retain their exact request across interruptions.
+    let journal = match (&context.target, payload.file_path()) {
+        (ResolvedTarget::Remote(remote), Some(path)) => Some(resume_journal(
+            context,
+            remote.client.server_url(),
+            spec,
+            path,
+            options,
+        )?),
         _ => None,
     };
+    let retained_options = journal.as_ref().map(UploadJournal::options);
+    let options = retained_options.as_ref().unwrap_or(options);
     if let Some(journal) = journal.as_ref() {
+        if let Some(request) = journal.prepared_request() {
+            progress.phase("committing");
+            let committed = context
+                .target
+                .replay_file_commit(context.namespace(), &request)
+                .await?;
+            acknowledge_committed_upload(journal, &committed)?;
+            return Ok(committed);
+        }
         if let Some(committed) =
             commit_a_finished_upload(context, spec, options, journal, progress).await?
         {
@@ -1038,13 +1053,13 @@ pub(super) async fn put_payload(
         // A payload small enough to hold travels as one request, so there is
         // no midpoint to report: it is read, and then the commit is all
         // that is left.
-        Some(path) => {
+        Some(path) if journal.is_none() => {
             let bytes = read_whole_file(path).await?;
             progress.advance(bytes.len() as u64);
             progress.phase("committing");
             context.target.put_file_bytes(spec, &bytes, options).await
         }
-        None => {
+        _ => {
             context
                 .target
                 .put_file_stream(spec, payload, options, progress, journal.as_ref())
@@ -1052,10 +1067,8 @@ pub(super) async fn put_payload(
         }
     };
     if let Ok(committed) = &result {
-        // The record exists to survive an interruption, and this upload was
-        // not interrupted.
         if let Some(journal) = journal.as_ref() {
-            forget_committed_upload(journal, committed)?;
+            acknowledge_committed_upload(journal, committed)?;
         }
     }
     result
@@ -1064,17 +1077,20 @@ pub(super) async fn put_payload(
 /// Opens the journal for a resumable remote file upload.
 fn resume_journal(
     context: &CommandContext,
+    server_url: &str,
     spec: &NamespacePath,
     local_path: &Path,
+    options: &PutFileOptions,
 ) -> Result<UploadJournal, CliError> {
     let source =
         SourceIdentity::of(local_path).map_err(|error| CliError::io_for_path(local_path, error))?;
     UploadJournal::for_upload(
         &context.profile_name,
-        context.namespace().as_str(),
-        spec.absolute_path().as_str(),
+        server_url,
+        spec,
         local_path,
         source,
+        options,
     )
     .map_err(CliError::io)
 }
@@ -1095,7 +1111,7 @@ async fn commit_a_finished_upload(
     journal: &UploadJournal,
     progress: &ProgressReporter,
 ) -> Result<Option<CommitResponse>, CliError> {
-    let Some(resume) = journal.resume().map_err(CliError::io)? else {
+    let Some(resume) = journal.resume() else {
         return Ok(None);
     };
     let status = context
@@ -1114,18 +1130,18 @@ async fn commit_a_finished_upload(
     progress.phase("committing");
     let result = context
         .target
-        .commit_completed_upload(spec, content_ref, content_token, options)
+        .commit_completed_upload(spec, content_ref, content_token, options, journal)
         .await;
     let committed = result?;
-    forget_committed_upload(journal, &committed)?;
+    acknowledge_committed_upload(journal, &committed)?;
     Ok(Some(committed))
 }
 
-fn forget_committed_upload(
+fn acknowledge_committed_upload(
     journal: &UploadJournal,
     committed: &CommitResponse,
 ) -> Result<(), CliError> {
-    journal.forget().map_err(|error| {
+    journal.acknowledge().map_err(|error| {
         CliError::io_error(format!(
         "file commit `{}` succeeded at sequence {}, but its journal could not be removed: {error}",
         committed.commit_id, committed.committed_seq,

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -1100,10 +1100,10 @@ fn resume_journal(
 ///
 /// An interruption between the last part and the commit leaves a session
 /// the server already completed: the object is assembled and admitted, and
-/// only the commit is missing. Asking the session what became of it is one
-/// round trip and saves the whole transfer. Any other answer — still open,
-/// aborted, or gone — leaves this to the ordinary upload, which the
-/// recorded parts make cheap anyway.
+/// only the commit request is missing. A completed session supplies its content
+/// and proof in one round trip. An open session resumes from recorded parts;
+/// lookup and completion errors remain visible. Prepared requests skip this
+/// lookup entirely.
 async fn commit_a_finished_upload(
     context: &CommandContext,
     spec: &NamespacePath,

--- a/crates/loonfs-cli/src/payload.rs
+++ b/crates/loonfs-cli/src/payload.rs
@@ -37,10 +37,10 @@ impl LocalPayload {
         }
     }
 
-    /// Returns a source that may be reopened to resume a multipart upload.
-    pub(crate) fn resumable_source(&self) -> Option<&Path> {
+    /// Returns a file that may be reopened after an interrupted PUT.
+    pub(crate) fn file_path(&self) -> Option<&Path> {
         match self {
-            Self::File { path, size_bytes } if *size_bytes >= STREAMING_PUT_MIN_BYTES => Some(path),
+            Self::File { path, .. } => Some(path),
             _ => None,
         }
     }

--- a/crates/loonfs-cli/src/uploads.rs
+++ b/crates/loonfs-cli/src/uploads.rs
@@ -22,12 +22,14 @@ struct UploadState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", deny_unknown_fields)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
 enum UploadProgress {
     Uploading {
         multipart: Option<MultipartUploadResume>,
     },
-    Prepared(Box<CommitRequest>),
+    Prepared {
+        request: Box<CommitRequest>,
+    },
 }
 
 /// File properties used to detect changes before resuming an upload.
@@ -96,14 +98,17 @@ impl UploadJournal {
         options: &PutFileOptions,
     ) -> io::Result<Self> {
         let parent = path.parent().expect("journal has a directory");
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent).map_err(|error| journal_error(&path, error))?;
         let ownership = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
-            .open(path.with_extension("lock"))?;
-        if !fs4::fs_std::FileExt::try_lock_exclusive(&ownership)? {
+            .open(path.with_extension("lock"))
+            .map_err(|error| journal_error(&path, error))?;
+        if !fs4::fs_std::FileExt::try_lock_exclusive(&ownership)
+            .map_err(|error| journal_error(&path, error))?
+        {
             return Err(journal_error(
                 &path,
                 "another command owns this PUT attempt",
@@ -123,7 +128,7 @@ impl UploadJournal {
                 if recorded.source != source {
                     return Err(journal_error(
                         &path,
-                        "source file changed; resolve this attempt before starting another",
+                        "source file changed; use a new --commit-id or remove this journal to start another attempt",
                     ));
                 }
                 let commit_id = recorded
@@ -135,9 +140,9 @@ impl UploadJournal {
                 let mut requested = options.clone();
                 requested.commit.commit_id.get_or_insert(commit_id);
                 if requested != recorded.options {
-                    return Err(journal_error(&path, "PUT options changed; resume with the original actor, message, and overwrite guards"));
+                    return Err(journal_error(&path, "PUT options changed; resume with the original options or use a new --commit-id for another attempt"));
                 }
-                if let UploadProgress::Prepared(request) = &recorded.progress {
+                if let UploadProgress::Prepared { request } = &recorded.progress {
                     if !request_matches_options(request, &recorded.options) {
                         return Err(journal_error(
                             &path,
@@ -179,14 +184,14 @@ impl UploadJournal {
     pub(crate) fn resume(&self) -> Option<MultipartUploadResume> {
         match &self.lock().progress {
             UploadProgress::Uploading { multipart } => multipart.clone(),
-            UploadProgress::Prepared(_) => None,
+            UploadProgress::Prepared { .. } => None,
         }
     }
 
     /// A saved request is replayed directly, even after its upload session expires.
     pub(crate) fn prepared_request(&self) -> Option<CommitRequest> {
         match &self.lock().progress {
-            UploadProgress::Prepared(request) => Some((**request).clone()),
+            UploadProgress::Prepared { request } => Some((**request).clone()),
             UploadProgress::Uploading { .. } => None,
         }
     }
@@ -284,11 +289,13 @@ impl PutFileJournal for UploadJournal {
         }
         self.update(|progress| match progress {
             UploadProgress::Uploading { .. } => {
-                *progress = UploadProgress::Prepared(Box::new(request.clone()));
+                *progress = UploadProgress::Prepared {
+                    request: Box::new(request.clone()),
+                };
                 Ok(())
             }
-            UploadProgress::Prepared(saved) if **saved == *request => Ok(()),
-            UploadProgress::Prepared(_) => {
+            UploadProgress::Prepared { request: saved } if **saved == *request => Ok(()),
+            UploadProgress::Prepared { .. } => {
                 Err(self.error("the prepared commit request cannot change"))
             }
         })

--- a/crates/loonfs-cli/src/uploads.rs
+++ b/crates/loonfs-cli/src/uploads.rs
@@ -1,37 +1,33 @@
-//! Local journals used to resume interrupted multipart uploads.
+//! Durable recovery records for file-backed remote PUT attempts.
 
 use crate::config::absolute_env_path;
-use loonfs_api::v0::CompletedUploadPart;
-use loonfs_api::{Checksum, ChecksumAlgorithm, UploadId};
-use loonfs_client::{MultipartUploadJournal, MultipartUploadResume};
+use loonfs_api::v0::{CommitRequest, CompletedUploadPart, FilesystemOperation};
+use loonfs_api::{Checksum, ChecksumAlgorithm, CommitId, UploadId};
+use loonfs_client::{MultipartUploadResume, NamespacePath, PutFileJournal, PutFileOptions};
 use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-/// Directory under `$XDG_STATE_HOME`.
 const XDG_STATE_SUBDIR: &str = "loonfs";
-/// Per-upload journal directory.
 const UPLOADS_SUBDIR: &str = "uploads";
 
-/// State required to resume one upload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct UploadState {
-    upload_id: UploadId,
-    part_size_bytes: u64,
-    checksum_algorithm: ChecksumAlgorithm,
-    parts: Vec<StatePart>,
     source: SourceIdentity,
+    options: PutFileOptions,
+    progress: UploadProgress,
 }
 
-/// A completed multipart upload part.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct StatePart {
-    part_number: u32,
-    etag: String,
-    checksum: Checksum,
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+enum UploadProgress {
+    Uploading {
+        multipart: Option<MultipartUploadResume>,
+    },
+    Prepared(Box<CommitRequest>),
 }
 
 /// File properties used to detect changes before resuming an upload.
@@ -58,94 +54,159 @@ impl SourceIdentity {
     }
 }
 
-/// Local journal for one upload.
+/// One PUT attempt, exclusively owned until this value is dropped.
 #[derive(Debug)]
 pub(crate) struct UploadJournal {
     path: PathBuf,
-    source: SourceIdentity,
-    /// Latest state, flushed after every change.
-    state: Mutex<Option<UploadState>>,
+    state: Mutex<UploadState>,
+    /// Explicit commit IDs retain their requests for subsequent invocations.
+    keep_after_ack: bool,
+    /// A stable sidecar inode prevents rename/removal from bypassing the lock.
+    _ownership: File,
 }
 
 impl UploadJournal {
-    /// Resolves the journal path. Missing state-directory configuration is an error.
     pub(crate) fn for_upload(
         profile: &str,
-        namespace: &str,
-        remote_path: &str,
+        server_url: &str,
+        spec: &NamespacePath,
         local_path: &Path,
         source: SourceIdentity,
+        options: &PutFileOptions,
     ) -> io::Result<Self> {
-        let local_path = local_path.canonicalize()?;
-        let key = Checksum::sha256(&serde_json::to_vec(&(
+        let key = journal_key(
             profile,
-            namespace,
-            remote_path,
-            local_path.as_os_str().as_encoded_bytes(),
-        ))?)
-        .value;
-        Ok(Self {
-            path: uploads_dir()
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::NotFound,
-                        "upload journals require an absolute XDG_STATE_HOME or HOME",
-                    )
-                })?
-                .join(format!("{key}.json")),
-            source,
-            state: Mutex::new(None),
-        })
+            server_url,
+            spec,
+            local_path,
+            options.commit.commit_id.as_ref(),
+        )?;
+        let dir = uploads_dir().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "upload journals require an absolute XDG_STATE_HOME or HOME",
+            )
+        })?;
+        Self::open_at(dir.join(format!("{key}.json")), source, options)
     }
 
-    /// Loads an existing record. Only a missing file means there is no upload.
-    pub(crate) fn resume(&self) -> io::Result<Option<MultipartUploadResume>> {
-        let bytes = match std::fs::read(&self.path) {
-            Ok(bytes) => bytes,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-            Err(error) => return Err(self.error(error)),
-        };
-        let recorded: UploadState =
-            serde_json::from_slice(&bytes).map_err(|error| self.error(error))?;
-        if recorded.source != self.source {
-            return Err(
-                self.error("source file changed; remove this journal to start a new upload")
-            );
+    fn open_at(
+        path: PathBuf,
+        source: SourceIdentity,
+        options: &PutFileOptions,
+    ) -> io::Result<Self> {
+        let parent = path.parent().expect("journal has a directory");
+        std::fs::create_dir_all(parent)?;
+        let ownership = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path.with_extension("lock"))?;
+        if !fs4::fs_std::FileExt::try_lock_exclusive(&ownership)? {
+            return Err(journal_error(
+                &path,
+                "another command owns this PUT attempt",
+            ));
         }
-        let resume = MultipartUploadResume {
-            upload_id: recorded.upload_id.clone(),
-            part_size_bytes: recorded.part_size_bytes,
-            checksum_algorithm: recorded.checksum_algorithm,
-            parts: recorded
-                .parts
-                .iter()
-                .map(|part| CompletedUploadPart {
-                    part_number: part.part_number,
-                    etag: part.etag.clone(),
-                    checksum: part.checksum.clone(),
-                })
-                .collect(),
+        let recorded = match std::fs::read(&path) {
+            Ok(bytes) => Some(
+                serde_json::from_slice::<UploadState>(&bytes)
+                    .map_err(|error| journal_error(&path, error))?,
+            ),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(journal_error(&path, error)),
         };
-        *self.lock() = Some(recorded);
-        Ok(Some(resume))
+        let is_new = recorded.is_none();
+        let state = match recorded {
+            Some(recorded) => {
+                if recorded.source != source {
+                    return Err(journal_error(
+                        &path,
+                        "source file changed; resolve this attempt before starting another",
+                    ));
+                }
+                let commit_id = recorded
+                    .options
+                    .commit
+                    .commit_id
+                    .clone()
+                    .ok_or_else(|| journal_error(&path, "record has no commit ID"))?;
+                let mut requested = options.clone();
+                requested.commit.commit_id.get_or_insert(commit_id);
+                if requested != recorded.options {
+                    return Err(journal_error(&path, "PUT options changed; resume with the original actor, message, and overwrite guards"));
+                }
+                if let UploadProgress::Prepared(request) = &recorded.progress {
+                    if !request_matches_options(request, &recorded.options) {
+                        return Err(journal_error(
+                            &path,
+                            "prepared request does not match its PUT options",
+                        ));
+                    }
+                }
+                recorded
+            }
+            None => {
+                let mut options = options.clone();
+                options
+                    .commit
+                    .commit_id
+                    .get_or_insert_with(CommitId::generate);
+                UploadState {
+                    source,
+                    options,
+                    progress: UploadProgress::Uploading { multipart: None },
+                }
+            }
+        };
+        let journal = Self {
+            path,
+            state: Mutex::new(state),
+            keep_after_ack: options.commit.commit_id.is_some(),
+            _ownership: ownership,
+        };
+        if is_new {
+            journal.flush(&journal.lock())?;
+        }
+        Ok(journal)
     }
 
-    /// Removes an acknowledged upload's record. Removal errors remain visible.
-    pub(crate) fn forget(&self) -> io::Result<()> {
+    pub(crate) fn options(&self) -> PutFileOptions {
+        self.lock().options.clone()
+    }
+
+    pub(crate) fn resume(&self) -> Option<MultipartUploadResume> {
+        match &self.lock().progress {
+            UploadProgress::Uploading { multipart } => multipart.clone(),
+            UploadProgress::Prepared(_) => None,
+        }
+    }
+
+    /// A saved request is replayed directly, even after its upload session expires.
+    pub(crate) fn prepared_request(&self) -> Option<CommitRequest> {
+        match &self.lock().progress {
+            UploadProgress::Prepared(request) => Some((**request).clone()),
+            UploadProgress::Uploading { .. } => None,
+        }
+    }
+
+    /// Removes ordinary attempts after acknowledgement. Explicit IDs keep their
+    /// exact request so repeating the same command can replay it without uploading.
+    pub(crate) fn acknowledge(&self) -> io::Result<()> {
+        if self.keep_after_ack {
+            return Ok(());
+        }
         match std::fs::remove_file(&self.path) {
-            Ok(()) => self.sync_directory().map_err(|error| self.error(error))?,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(self.error(error)),
+            Ok(()) => self.sync_directory().map_err(|error| self.error(error)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(self.error(error)),
         }
-        *self.lock() = None;
-        Ok(())
     }
 
-    /// Replace the record only after the complete new file reaches disk.
     fn flush(&self, state: &UploadState) -> io::Result<()> {
         let write = || -> io::Result<()> {
             let parent = self.path.parent().expect("journal has a directory");
-            std::fs::create_dir_all(parent)?;
             let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
             serde_json::to_writer(&mut temporary, state)?;
             temporary.flush()?;
@@ -158,55 +219,114 @@ impl UploadJournal {
 
     fn sync_directory(&self) -> io::Result<()> {
         #[cfg(unix)]
-        std::fs::File::open(self.path.parent().expect("journal has a directory"))?.sync_all()?;
+        File::open(self.path.parent().expect("journal has a directory"))?.sync_all()?;
         Ok(())
     }
 
     fn error(&self, error: impl std::fmt::Display) -> io::Error {
-        io::Error::other(format!("upload journal `{}`: {error}", self.path.display()))
+        journal_error(&self.path, error)
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<'_, Option<UploadState>> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, UploadState> {
         self.state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
+
+    fn update(&self, change: impl FnOnce(&mut UploadProgress) -> io::Result<()>) -> io::Result<()> {
+        let mut held = self.lock();
+        let mut next = held.clone();
+        change(&mut next.progress)?;
+        self.flush(&next)?;
+        *held = next;
+        Ok(())
+    }
 }
 
-impl MultipartUploadJournal for UploadJournal {
+impl PutFileJournal for UploadJournal {
     fn began(
         &self,
         upload_id: &UploadId,
         part_size_bytes: u64,
         checksum_algorithm: ChecksumAlgorithm,
     ) -> io::Result<()> {
-        let state = UploadState {
-            upload_id: upload_id.clone(),
-            part_size_bytes,
-            checksum_algorithm,
-            parts: Vec::new(),
-            source: self.source.clone(),
-        };
-        self.flush(&state)?;
-        *self.lock() = Some(state);
-        Ok(())
+        self.update(|progress| match progress {
+            UploadProgress::Uploading { multipart } if multipart.is_none() => {
+                *multipart = Some(MultipartUploadResume {
+                    upload_id: upload_id.clone(),
+                    part_size_bytes,
+                    checksum_algorithm,
+                    parts: Vec::new(),
+                });
+                Ok(())
+            }
+            _ => {
+                Err(self.error("this PUT attempt already has an upload session or commit request"))
+            }
+        })
     }
 
     fn part_completed(&self, part: &CompletedUploadPart) -> io::Result<()> {
-        let mut held = self.lock();
-        let mut next = held
-            .as_ref()
-            .ok_or_else(|| self.error("no upload session was recorded"))?
-            .clone();
-        next.parts.push(StatePart {
-            part_number: part.part_number,
-            etag: part.etag.clone(),
-            checksum: part.checksum.clone(),
-        });
-        self.flush(&next)?;
-        *held = Some(next);
-        Ok(())
+        self.update(|progress| match progress {
+            UploadProgress::Uploading {
+                multipart: Some(resume),
+            } => {
+                resume.parts.push(part.clone());
+                Ok(())
+            }
+            _ => Err(self.error("no active multipart session was recorded")),
+        })
     }
+
+    fn commit_prepared(&self, request: &CommitRequest) -> io::Result<()> {
+        if !request_matches_options(request, &self.options()) {
+            return Err(self.error("prepared request does not match its PUT options"));
+        }
+        self.update(|progress| match progress {
+            UploadProgress::Uploading { .. } => {
+                *progress = UploadProgress::Prepared(Box::new(request.clone()));
+                Ok(())
+            }
+            UploadProgress::Prepared(saved) if **saved == *request => Ok(()),
+            UploadProgress::Prepared(_) => {
+                Err(self.error("the prepared commit request cannot change"))
+            }
+        })
+    }
+}
+
+fn request_matches_options(request: &CommitRequest, options: &PutFileOptions) -> bool {
+    options.commit.commit_id.as_ref() == Some(&request.commit_id)
+        && options.commit.actor == request.actor
+        && options.commit.message == request.message
+        && matches!(request.operations.as_slice(), [FilesystemOperation::PutFile {
+            behavior, expected_inode_id, expected_revision_no, ..
+        }] if *behavior == options.behavior
+            && *expected_inode_id == options.expected_inode_id
+            && *expected_revision_no == options.expected_revision_no)
+}
+
+fn journal_error(path: &Path, error: impl std::fmt::Display) -> io::Error {
+    io::Error::other(format!("upload journal `{}`: {error}", path.display()))
+}
+
+fn journal_key(
+    profile: &str,
+    server_url: &str,
+    spec: &NamespacePath,
+    local_path: &Path,
+    commit_id: Option<&CommitId>,
+) -> io::Result<String> {
+    let local_path = local_path.canonicalize()?;
+    Ok(Checksum::sha256(&serde_json::to_vec(&(
+        profile,
+        server_url,
+        spec.namespace(),
+        spec.absolute_path(),
+        local_path.as_os_str().as_encoded_bytes(),
+        commit_id,
+    ))?)
+    .value)
 }
 
 /// Where per-upload records live: `$XDG_STATE_HOME/loonfs/uploads` when that
@@ -234,25 +354,21 @@ mod tests {
             modified_ns: 7,
         }
     }
-
-    fn journal_at(path: &Path) -> UploadJournal {
-        UploadJournal {
-            path: path.to_owned(),
-            source: source(1024),
-            state: Mutex::new(None),
-        }
+    fn options() -> PutFileOptions {
+        PutFileOptions::new(loonfs_test_support::test_actor())
     }
-
+    fn open(path: &Path) -> UploadJournal {
+        UploadJournal::open_at(path.to_owned(), source(1024), &options()).expect("open journal")
+    }
     fn begin(journal: &UploadJournal) {
         journal
             .began(
                 &UploadId::parse("upl_00000000000000000000000000000001").expect("id"),
-                1024 * 1024,
+                1024,
                 ChecksumAlgorithm::Crc64nvme,
             )
             .expect("record session");
     }
-
     fn part(number: u32) -> CompletedUploadPart {
         CompletedUploadPart {
             part_number: number,
@@ -260,122 +376,199 @@ mod tests {
             checksum: Checksum::crc64nvme(format!("part-{number}").as_bytes()),
         }
     }
+    fn request(journal: &UploadJournal) -> CommitRequest {
+        let options = journal.options();
+        CommitRequest::single(
+            options.commit.commit_id.expect("chosen ID"),
+            options.commit.actor,
+            options.commit.message,
+            FilesystemOperation::PutFile {
+                path: loonfs_api::AbsolutePath::parse("/file").expect("path"),
+                content_ref: loonfs_test_support::ids::content_ref(b"data"),
+                behavior: options.behavior,
+                expected_inode_id: options.expected_inode_id,
+                expected_revision_no: options.expected_revision_no,
+            },
+        )
+    }
 
     #[test]
-    fn a_record_survives_repeated_interruptions_and_is_removed_after_acknowledgement() {
+    fn interruptions_preserve_the_commit_id_parts_and_exact_request() {
         let dir = tempfile::tempdir().expect("directory");
         let path = dir.path().join("upload.json");
-        let first = journal_at(&path);
-        assert!(first.resume().expect("read").is_none());
+        let first = open(&path);
+        let chosen = first.options();
+        assert!(chosen.commit.commit_id.is_some());
+        assert!(first.resume().is_none());
         begin(&first);
         first.part_completed(&part(1)).expect("first part");
-        let next = journal_at(&path);
-        let resumed = next.resume().expect("read").expect("session");
-        assert_eq!(resumed.parts, vec![part(1)]);
-        assert_eq!(resumed.part_size_bytes, 1024 * 1024);
-        assert_eq!(resumed.checksum_algorithm, ChecksumAlgorithm::Crc64nvme);
+        drop(first);
+        let next = open(&path);
+        assert_eq!(next.options(), chosen);
+        assert_eq!(next.resume().expect("session").parts, vec![part(1)]);
         next.part_completed(&part(2)).expect("second part");
+        drop(next);
+        let next = open(&path);
         assert_eq!(
-            journal_at(&path)
-                .resume()
-                .expect("read")
-                .expect("session")
-                .parts,
+            next.resume().expect("session").parts,
             vec![part(1), part(2)]
         );
-        next.forget().expect("remove acknowledged record");
-        assert!(next.resume().expect("read").is_none());
-        next.forget().expect("already absent");
+        let expected = request(&next);
+        let mut wrong_options = expected.clone();
+        wrong_options.message = Some("different intent".to_owned());
+        assert!(next.commit_prepared(&wrong_options).is_err());
+        assert!(next.prepared_request().is_none());
+        next.commit_prepared(&expected).expect("save commit");
+        drop(next);
+        let replay = open(&path);
+        assert!(replay.resume().is_none());
+        assert_eq!(replay.prepared_request(), Some(expected.clone()));
+        assert!(replay.part_completed(&part(3)).is_err());
+        let mut changed = expected;
+        changed.commit_id = CommitId::generate();
+        assert!(replay.commit_prepared(&changed).is_err());
+        replay.acknowledge().expect("acknowledged");
+        assert!(!path.exists());
+        replay.acknowledge().expect("already removed");
     }
 
     #[test]
-    fn malformed_and_unreadable_records_are_errors_and_are_preserved() {
+    fn explicit_commit_ids_keep_the_request_after_acknowledgement() {
         let dir = tempfile::tempdir().expect("directory");
         let path = dir.path().join("upload.json");
-        let journal = journal_at(&path);
-        std::fs::write(&path, b"{\"upload_id\":").expect("torn record");
-        assert!(journal
-            .resume()
-            .expect_err("invalid record")
-            .to_string()
-            .contains("upload.json"));
+        let mut options = options();
+        options.commit.commit_id = Some(CommitId::generate());
+        let journal =
+            UploadJournal::open_at(path.clone(), source(1024), &options).expect("journal");
+        let expected = request(&journal);
+        journal.commit_prepared(&expected).expect("record");
+        journal.acknowledge().expect("acknowledged");
+        drop(journal);
+        assert!(path.exists());
         assert_eq!(
-            std::fs::read(&path).expect("preserved record"),
-            b"{\"upload_id\":"
+            UploadJournal::open_at(path, source(1024), &options)
+                .expect("reopen")
+                .prepared_request(),
+            Some(expected)
         );
+    }
+
+    #[test]
+    fn only_one_command_can_own_an_attempt_even_after_its_record_is_removed() {
+        let dir = tempfile::tempdir().expect("directory");
+        let path = dir.path().join("upload.json");
+        let journal = open(&path);
+        for removed in [false, true] {
+            if removed {
+                journal.acknowledge().expect("remove record");
+            }
+            assert!(
+                UploadJournal::open_at(path.clone(), source(1024), &options())
+                    .expect_err("owned")
+                    .to_string()
+                    .contains("another command")
+            );
+        }
+        drop(journal);
+        let reopened = open(&path);
+        assert!(reopened.resume().is_none());
+    }
+
+    #[test]
+    fn corrupt_unreadable_and_changed_records_are_preserved() {
+        let dir = tempfile::tempdir().expect("directory");
+        let path = dir.path().join("upload.json");
+        std::fs::write(&path, b"{").expect("corrupt record");
+        assert!(UploadJournal::open_at(path.clone(), source(1024), &options()).is_err());
+        assert_eq!(std::fs::read(&path).expect("preserved"), b"{");
         std::fs::remove_file(&path).expect("remove fixture");
         std::fs::create_dir(&path).expect("unreadable record");
-        assert!(journal.resume().is_err());
-        assert!(journal.forget().is_err());
-    }
-
-    #[test]
-    fn a_changed_source_requires_an_explicit_new_upload() {
-        let dir = tempfile::tempdir().expect("directory");
-        let path = dir.path().join("upload.json");
-        let journal = journal_at(&path);
-        begin(&journal);
-        let mut changed = journal_at(&path);
-        changed.source = source(2048);
-        assert!(changed
-            .resume()
-            .expect_err("changed source")
+        assert!(UploadJournal::open_at(path.clone(), source(1024), &options()).is_err());
+        std::fs::remove_dir(&path).expect("remove fixture");
+        let original = open(&path).options();
+        assert!(
+            UploadJournal::open_at(path.clone(), source(2048), &options())
+                .expect_err("changed file")
+                .to_string()
+                .contains("source file changed")
+        );
+        let mut changed = options();
+        changed.commit.message = Some("different".to_owned());
+        assert!(UploadJournal::open_at(path.clone(), source(1024), &changed)
+            .expect_err("changed options")
             .to_string()
-            .contains("source file changed"));
-        assert!(path.exists());
+            .contains("PUT options changed"));
+        changed = options();
+        changed.commit.commit_id = Some(CommitId::generate());
+        assert!(UploadJournal::open_at(path.clone(), source(1024), &changed).is_err());
+        assert_eq!(open(&path).options(), original);
     }
 
     #[test]
-    fn a_failed_update_preserves_the_last_durable_parts() {
+    fn failed_updates_preserve_the_last_durable_state() {
         let dir = tempfile::tempdir().expect("directory");
         let parent = dir.path().join("uploads");
         let saved = dir.path().join("saved");
-        let journal = journal_at(&parent.join("upload.json"));
+        let path = parent.join("upload.json");
+        let journal = open(&path);
+        assert!(journal.part_completed(&part(1)).is_err());
         begin(&journal);
         journal.part_completed(&part(1)).expect("first part");
         std::fs::rename(&parent, &saved).expect("move directory");
-        std::fs::write(&parent, b"not a directory").expect("block journal writes");
+        std::fs::write(&parent, b"blocked").expect("block writes");
         assert!(journal.part_completed(&part(2)).is_err());
-        assert_eq!(journal.lock().as_ref().expect("state").parts.len(), 1);
-        std::fs::remove_file(&parent).expect("remove blocker");
-        std::fs::rename(&saved, &parent).expect("restore directory");
+        assert!(journal.commit_prepared(&request(&journal)).is_err());
         assert_eq!(
-            journal_at(&journal.path)
-                .resume()
-                .expect("read")
-                .expect("session")
-                .parts,
+            journal.resume().expect("original state").parts,
+            vec![part(1)]
+        );
+        std::fs::remove_file(&parent).expect("unblock");
+        std::fs::rename(&saved, &parent).expect("restore");
+        drop(journal);
+        assert_eq!(
+            open(&path).resume().expect("durable state").parts,
             vec![part(1)]
         );
     }
 
     #[test]
-    fn missing_session_state_cannot_silently_discard_a_part() {
-        let dir = tempfile::tempdir().expect("directory");
-        assert!(journal_at(&dir.path().join("upload.json"))
-            .part_completed(&part(1))
-            .is_err());
-    }
-
-    #[test]
-    fn the_journal_key_includes_both_endpoints_and_the_source_path() {
+    fn keys_include_the_server_paths_profile_and_explicit_commit_id() {
         let dir = tempfile::tempdir().expect("directory");
         let first = dir.path().join("file");
         let other = dir.path().join("other");
         std::fs::write(&first, b"data").expect("source");
         std::fs::write(&other, b"data").expect("source");
-        let path = |profile, namespace, remote, local: &Path| {
-            UploadJournal::for_upload(profile, namespace, remote, local, source(1024))
-                .expect("journal path")
-                .path
+        let spec = NamespacePath::parse("demo", "/file").expect("path");
+        let key = |profile, url, spec: &NamespacePath, file: &Path, id| {
+            journal_key(profile, url, spec, file, id).expect("key")
         };
-        let original = path("default", "demo", "/file", &first);
-        assert_eq!(original, path("default", "demo", "/file", &first));
+        let original = key("default", "https://one", &spec, &first, None);
+        assert_eq!(original, key("default", "https://one", &spec, &first, None));
         for candidate in [
-            path("other", "demo", "/file", &first),
-            path("default", "other", "/file", &first),
-            path("default", "demo", "/other", &first),
-            path("default", "demo", "/file", &other),
+            key("other", "https://one", &spec, &first, None),
+            key("default", "https://two", &spec, &first, None),
+            key(
+                "default",
+                "https://one",
+                &NamespacePath::parse("other", "/file").expect("path"),
+                &first,
+                None,
+            ),
+            key(
+                "default",
+                "https://one",
+                &NamespacePath::parse("demo", "/other").expect("path"),
+                &first,
+                None,
+            ),
+            key("default", "https://one", &spec, &other, None),
+            key(
+                "default",
+                "https://one",
+                &spec,
+                &first,
+                Some(&CommitId::generate()),
+            ),
         ] {
             assert_ne!(original, candidate);
         }

--- a/crates/loonfs-cli/tests/it/common/mod.rs
+++ b/crates/loonfs-cli/tests/it/common/mod.rs
@@ -167,6 +167,7 @@ impl Harness {
         command
             .env("HOME", &self.home_dir)
             .env_remove("XDG_CONFIG_HOME")
+            .env_remove("XDG_STATE_HOME")
             .env_remove("LOONFS_CONFIG")
             .env_remove("LOONFS_PROFILE")
             .env_remove("LOONFS_NAMESPACE")
@@ -191,6 +192,7 @@ impl Harness {
             .arg(&script)
             .env("HOME", &self.home_dir)
             .env_remove("XDG_CONFIG_HOME")
+            .env_remove("XDG_STATE_HOME")
             .env_remove("LOONFS_CONFIG")
             .env_remove("LOONFS_PROFILE")
             .env_remove("LOONFS_NAMESPACE")

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -2036,3 +2036,61 @@ fn cp_and_mv_land_inside_an_existing_directory_in_both_modes() {
         assert_eq!(json_data(&tree)["destination"], "demo:/archive/docs");
     }
 }
+
+#[test]
+fn a_remote_put_replays_its_exact_request_after_the_upload_session_is_gone() {
+    let harness = Harness::new();
+    let server =
+        harness.start_external_server(harness.write_server_config("remote", "put-recovery"));
+    assert_success(&harness.run(&[
+        "profile",
+        "create",
+        "remote",
+        "default",
+        "--server-url",
+        &server.server_url,
+        "--auth-token",
+        "test-token",
+    ]));
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = harness.temp_dir.path().join("payload");
+    fs::write(&payload, b"retained request").expect("source");
+    let args = [
+        "--json",
+        "put",
+        payload.to_str().expect("path"),
+        "/file",
+        "--commit-id",
+        "retained-put",
+    ];
+    let first = harness.run(&args);
+    assert_success(&first);
+    let uploads = harness
+        .store_root("remote")
+        .join("put-recovery/namespaces/demo/uploads");
+    let records = fs::read_dir(&uploads)
+        .expect("upload sessions")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("records");
+    assert!(!records.is_empty(), "the first call opened an upload");
+    for entry in records {
+        fs::remove_file(entry.path()).expect("expire session record");
+    }
+    let replay = harness.run(&args);
+    assert_success(&replay);
+    assert_eq!(
+        json_data(&replay)["commit_id"],
+        json_data(&first)["commit_id"]
+    );
+    assert_eq!(
+        json_data(&replay)["committed_seq"],
+        json_data(&first)["committed_seq"]
+    );
+    assert_eq!(
+        fs::read_dir(&uploads).expect("upload directory").count(),
+        0,
+        "replay never creates or reads an upload session"
+    );
+    assert_eq!(download(&harness, "/file", "readback"), b"retained request");
+}

--- a/crates/loonfs-cli/tests/it/recursive.rs
+++ b/crates/loonfs-cli/tests/it/recursive.rs
@@ -160,6 +160,10 @@ fn a_recursive_put_streams_a_large_file_over_the_remote_transport() {
         .map(|entries| {
             entries
                 .map(|entry| entry.expect("dir entry").path())
+                .filter(|path| {
+                    path.extension()
+                        .is_some_and(|extension| extension == "json")
+                })
                 .collect()
         })
         .unwrap_or_default();

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -80,9 +80,7 @@ pub type Result<T> = std::result::Result<T, ClientError>;
 
 pub use downloads::{DirectDownloadStream, DownloadOptions};
 pub use namespace_path::NamespacePath;
-pub use uploads::staging::{
-    MultipartUploadJournal, MultipartUploadResume, STREAMING_PUT_MIN_BYTES,
-};
+pub use uploads::staging::{MultipartUploadResume, PutFileJournal, STREAMING_PUT_MIN_BYTES};
 
 /// Async HTTP client for LoonFS.
 ///
@@ -110,6 +108,11 @@ pub struct Client {
 }
 
 impl Client {
+    /// The configured server URL, without a trailing slash.
+    pub fn server_url(&self) -> &str {
+        &self.base_url
+    }
+
     /// Creates a client, validating the config exactly as
     /// [`ClientConfig::load`] does — direct Rust construction cannot bypass
     /// validation.

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -65,7 +65,7 @@ impl Client {
         let staged = self
             .stage_bytes_as_content_ref(spec.namespace(), bytes)
             .await?;
-        self.commit_staged_file(spec, staged, options, ContentEvidence::Bytes(bytes))
+        self.commit_staged_file(spec, staged, options, ContentEvidence::Bytes(bytes), None)
             .await
     }
 
@@ -92,8 +92,10 @@ impl Client {
 
     /// Uploads a stream with optional multipart resume state.
     ///
-    /// For multipart uploads, `journal` records completed parts and `resume`
-    /// restores that state. Proxied and direct-PUT uploads ignore both values.
+    /// The journal records the complete commit request before submission for
+    /// every transport. Multipart uploads also record session geometry and parts.
+    /// Save the request and replay it with [`Self::create_commit`] after an
+    /// interruption; it carries the original content reference and commit ID.
     ///
     /// A resumed multipart attempt still receives the source from the
     /// beginning because the final checksum covers the complete object.
@@ -102,7 +104,7 @@ impl Client {
         spec: &NamespacePath,
         source: PayloadSource,
         options: &PutFileOptions,
-        journal: &dyn MultipartUploadJournal,
+        journal: &dyn PutFileJournal,
         resume: Option<&MultipartUploadResume>,
     ) -> Result<ApiCommitResponse> {
         self.put_file_stream_continuing(
@@ -136,6 +138,7 @@ impl Client {
             staged,
             options,
             ContentEvidence::ContentRef(&uploaded),
+            continuity.journal,
         )
         .await
     }
@@ -144,13 +147,14 @@ impl Client {
     ///
     /// Call [`Self::get_upload`] to recover the content reference and token.
     /// This method then commits the existing content without uploading it
-    /// again.
+    /// again. An optional journal saves the complete request before submission.
     pub async fn commit_completed_upload(
         &self,
         spec: &NamespacePath,
         content_ref: ContentRef,
         content_token: Option<ContentToken>,
         options: &PutFileOptions,
+        journal: Option<&dyn PutFileJournal>,
     ) -> Result<ApiCommitResponse> {
         let uploaded = content_ref.clone();
         let staged = StagedContent {
@@ -162,38 +166,44 @@ impl Client {
             staged,
             options,
             ContentEvidence::ContentRef(&uploaded),
+            journal,
         )
         .await
     }
 
-    /// Commits one staged payload at a path, reconciling a reused commit id
-    /// against what was just uploaded.
+    /// Saves an exact request when journaled. Unjournaled convenience calls
+    /// reconcile fresh content when a commit ID was already used.
     async fn commit_staged_file(
         &self,
         spec: &NamespacePath,
         staged: StagedContent,
         options: &PutFileOptions,
         uploaded: ContentEvidence<'_>,
+        journal: Option<&dyn PutFileJournal>,
     ) -> Result<ApiCommitResponse> {
         let commit_id = commit_id_or_generated(&options.commit);
-        let response = self
-            .create_commit(
-                spec.namespace(),
-                &CommitRequest {
-                    commit_id: commit_id.clone(),
-                    actor: options.commit.actor.clone(),
-                    message: options.commit.message.clone(),
-                    content_tokens: staged.content_token.into_iter().collect(),
-                    operations: vec![FilesystemOperation::PutFile {
-                        path: spec.absolute_path().clone(),
-                        content_ref: staged.content_ref,
-                        behavior: options.behavior,
-                        expected_inode_id: options.expected_inode_id,
-                        expected_revision_no: options.expected_revision_no,
-                    }],
-                },
-            )
-            .await;
+        let request = CommitRequest {
+            commit_id: commit_id.clone(),
+            actor: options.commit.actor.clone(),
+            message: options.commit.message.clone(),
+            content_tokens: staged.content_token.into_iter().collect(),
+            operations: vec![FilesystemOperation::PutFile {
+                path: spec.absolute_path().clone(),
+                content_ref: staged.content_ref,
+                behavior: options.behavior,
+                expected_inode_id: options.expected_inode_id,
+                expected_revision_no: options.expected_revision_no,
+            }],
+        };
+        if let Some(journal) = journal {
+            journal.commit_prepared(&request).map_err(|error| {
+                ClientError::Io(format!(
+                    "could not record file commit `{commit_id}` before submission: {error}"
+                ))
+            })?;
+            return self.create_commit(spec.namespace(), &request).await;
+        }
+        let response = self.create_commit(spec.namespace(), &request).await;
         match response {
             Ok(response) => Ok(response),
             Err(error) if error.code() == Some(ErrorCode::CommitIdReuseConflict) => {

--- a/crates/loonfs-client/src/uploads/staging.rs
+++ b/crates/loonfs-client/src/uploads/staging.rs
@@ -58,7 +58,7 @@ pub trait PutFileJournal: Send + Sync {
     fn commit_prepared(&self, request: &CommitRequest) -> std::io::Result<()>;
 }
 
-/// Optional state for resuming and recording a multipart upload.
+/// Optional multipart resume state and a journal for the complete PUT attempt.
 #[derive(Clone, Copy, Default)]
 pub(crate) struct UploadContinuity<'a> {
     pub(crate) resume: Option<&'a MultipartUploadResume>,

--- a/crates/loonfs-client/src/uploads/staging.rs
+++ b/crates/loonfs-client/src/uploads/staging.rs
@@ -23,7 +23,8 @@ const DIRECT_MULTIPART_PART_ATTEMPTS: usize = 3;
 /// client retains the upload id, part size, and accepted part metadata.
 /// Missing entries are safely re-uploaded; incorrect entries cause completion
 /// to fail.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MultipartUploadResume {
     /// Upload session ID returned by the server.
     pub upload_id: UploadId,
@@ -36,13 +37,13 @@ pub struct MultipartUploadResume {
     pub parts: Vec<CompletedUploadPart>,
 }
 
-/// Saves direct multipart upload progress so an interrupted upload can resume.
+/// Saves upload progress and the exact file commit request before submission.
 ///
-/// The client calls these methods synchronously after opening the session and
-/// after each successful part upload. Implementations may persist this data
-/// before the next network request starts. A journal error stops the upload;
-/// the server session remains available for resumption or explicit abort.
-pub trait MultipartUploadJournal: Send + Sync {
+/// Multipart transfers record session geometry and completed parts. Every
+/// transport records its final commit request, including the chosen commit ID
+/// and content proof. A journal error stops the operation before the next
+/// request; uploaded content remains available for recovery or expiry cleanup.
+pub trait PutFileJournal: Send + Sync {
     /// Records a newly opened session and its required part size and checksum algorithm.
     fn began(
         &self,
@@ -52,13 +53,16 @@ pub trait MultipartUploadJournal: Send + Sync {
     ) -> std::io::Result<()>;
     /// Records a part after it has been uploaded successfully.
     fn part_completed(&self, part: &CompletedUploadPart) -> std::io::Result<()>;
+    /// Persists the complete request before any attempt to submit its commit.
+    /// Replay this value with [`Client::create_commit`] after an interruption.
+    fn commit_prepared(&self, request: &CommitRequest) -> std::io::Result<()>;
 }
 
 /// Optional state for resuming and recording a multipart upload.
 #[derive(Clone, Copy, Default)]
 pub(crate) struct UploadContinuity<'a> {
     pub(crate) resume: Option<&'a MultipartUploadResume>,
-    pub(crate) journal: Option<&'a dyn MultipartUploadJournal>,
+    pub(crate) journal: Option<&'a dyn PutFileJournal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loonfs-client/src/uploads/staging/tests.rs
+++ b/crates/loonfs-client/src/uploads/staging/tests.rs
@@ -318,6 +318,7 @@ fn multipart_script(parts: u32, uploaded: ContentRef) -> Vec<Outcome> {
 struct RecordingJournal {
     began: Mutex<Option<(UploadId, u64, ChecksumAlgorithm)>>,
     parts: Mutex<Vec<CompletedUploadPart>>,
+    request: Mutex<Option<CommitRequest>>,
 }
 
 impl RecordingJournal {
@@ -352,7 +353,12 @@ impl RecordingJournal {
     }
 }
 
-impl MultipartUploadJournal for RecordingJournal {
+impl PutFileJournal for RecordingJournal {
+    fn commit_prepared(&self, request: &CommitRequest) -> std::io::Result<()> {
+        *self.request.lock().expect("journal lock") = Some(request.clone());
+        Ok(())
+    }
+
     fn began(
         &self,
         upload_id: &UploadId,
@@ -915,7 +921,11 @@ struct FailingJournal {
     fail_at_begin: bool,
 }
 
-impl MultipartUploadJournal for FailingJournal {
+impl PutFileJournal for FailingJournal {
+    fn commit_prepared(&self, _: &CommitRequest) -> std::io::Result<()> {
+        Err(std::io::Error::other("journal disk full"))
+    }
+
     fn began(&self, _: &UploadId, _: u64, _: ChecksumAlgorithm) -> std::io::Result<()> {
         if self.fail_at_begin {
             Err(std::io::Error::other("journal disk full"))
@@ -960,4 +970,94 @@ async fn journal_failures_stop_uploads_without_aborting_the_resumable_session() 
             "no subsequent wave, completion, commit, or abort may be sent"
         );
     }
+}
+
+#[tokio::test]
+async fn a_lost_commit_ack_replays_the_saved_request_without_reopening_the_upload() {
+    let bytes = payload(1_000);
+    let uploaded = content_ref(&bytes);
+    let proof = ContentToken {
+        content_ref: uploaded.clone(),
+        token: "saved-proof".to_owned(),
+    };
+    let (source, _) = watched_source(&bytes, 512);
+    let transport = test_transport::script(vec![
+        capabilities(false),
+        begin_proxied(),
+        json(&UploadContentResponse {
+            namespace_id: namespace_id(),
+            upload_id: upload_id(),
+            content_ref: uploaded.clone(),
+        }),
+        json(&UploadSession {
+            namespace_id: namespace_id(),
+            upload_id: upload_id(),
+            mode: UploadMode::ServiceProxied,
+            status: UploadSessionStatus::Completed {
+                completed_at_ms: 1,
+                content_ref: uploaded.clone(),
+                content_token: Some(proof.clone()),
+            },
+        }),
+        Outcome::TransportFailure,
+    ]);
+    let journal = RecordingJournal::default();
+    let mut options = PutFileOptions::new(loonfs_test_support::test_actor());
+    options.commit.commit_id = Some(CommitId::parse("saved-put").expect("ID"));
+    options.commit.message = Some("original message".to_owned());
+    options.behavior = loonfs_api::DestinationBehavior::Replace;
+    options.expected_inode_id = Some(loonfs_api::InodeId(7));
+    options.expected_revision_no = Some(loonfs_api::RevisionNo(9));
+    client_without_retry()
+        .put_file_stream_resumable(&spec(), source, &options, &journal, None)
+        .await
+        .expect_err("lost acknowledgement");
+    assert_eq!(transport.attempts(), 5);
+    let saved = journal
+        .request
+        .lock()
+        .expect("journal")
+        .clone()
+        .expect("request saved before submission");
+    assert_eq!(Some(&saved.commit_id), options.commit.commit_id.as_ref());
+    assert_eq!(saved.actor, options.commit.actor);
+    assert_eq!(saved.message, options.commit.message);
+    assert_eq!(
+        saved.operations,
+        vec![FilesystemOperation::PutFile {
+            path: spec().absolute_path().clone(),
+            content_ref: uploaded,
+            behavior: options.behavior,
+            expected_inode_id: options.expected_inode_id,
+            expected_revision_no: options.expected_revision_no,
+        }]
+    );
+    assert_eq!(saved.content_tokens, vec![proof]);
+    drop(transport);
+    let transport = test_transport::script(vec![commit_landed()]);
+    client_without_retry()
+        .create_commit(&namespace_id(), &saved)
+        .await
+        .expect("replay exact request");
+    assert_eq!(transport.attempts(), 1);
+    assert!(transport.sent()[0].url.ends_with("/commits"));
+}
+
+#[tokio::test]
+async fn a_commit_journal_failure_prevents_submission_of_completed_content() {
+    let transport = test_transport::script(Vec::new());
+    let error = client_without_retry()
+        .commit_completed_upload(
+            &spec(),
+            content_ref(b"data"),
+            None,
+            &PutFileOptions::new(loonfs_test_support::test_actor()),
+            Some(&FailingJournal {
+                fail_at_begin: false,
+            }),
+        )
+        .await
+        .expect_err("cannot save commit request");
+    assert!(error.to_string().contains("before submission"));
+    assert_eq!(transport.attempts(), 0);
 }

--- a/crates/loonfs-conformance/tests/reference.rs
+++ b/crates/loonfs-conformance/tests/reference.rs
@@ -370,6 +370,7 @@ async fn run_direct_put(harness: &Harness, case: &Case) {
             content_ref.clone(),
             content_token,
             &put_options(&request.actor, &request.commit_id),
+            None,
         )
         .await
         .expect("commit direct PUT");
@@ -524,6 +525,7 @@ async fn run_multipart(harness: &Harness, case: &Case) {
             first_content_ref,
             replayed.content_token().cloned(),
             &put_options(&request.actor, &request.commit_id),
+            None,
         )
         .await
         .expect("commit multipart upload");

--- a/docs/design/cli-upload-recovery.md
+++ b/docs/design/cli-upload-recovery.md
@@ -1,40 +1,49 @@
 # CLI upload recovery
 
-Remote uploads of large local files keep multipart progress in
-`$XDG_STATE_HOME/loonfs/uploads`, or `$HOME/.local/state/loonfs/uploads`.
-The journal key includes the profile, namespace, remote path, and canonical
-local path. Local path bytes are encoded without lossy Unicode conversion.
-Embedded uploads and standard-input streams do not create multipart journals.
+File-backed remote PUTs keep recovery records in `$XDG_STATE_HOME/loonfs/uploads`,
+or `$HOME/.local/state/loonfs/uploads`. The key includes the profile, server URL,
+namespace, remote path, canonical local path, and any explicit commit ID. Local
+path bytes are encoded without lossy Unicode conversion. Embedded uploads and
+standard-input streams do not use these records.
 
-The record contains the upload ID, part geometry, checksum algorithm, accepted
-parts, and source file length and full-precision modification time. Only a
-missing record means a new upload. An unreadable or malformed record, unavailable
-source metadata, or changed source stops the command with an error. Records are
-preserved for inspection; remove the named journal to explicitly start again.
-There is no reader for earlier development journal layouts.
+Before opening an upload, the CLI saves the chosen commit ID, actor, message,
+overwrite guards, source length, and full-precision modification time. The record
+has two states: uploading, with optional multipart progress; and prepared, with
+the complete commit request. A resumed command uses the saved options. Changed
+source metadata or options, an unreadable record, or malformed JSON stops the
+command and preserves the record. Source checks compare metadata, not a full
+file hash; the saved request always refers to the original uploaded content.
 
-Each update writes and syncs a temporary file in the journal directory before
-atomically replacing the record. Unix hosts also sync the directory after
-replacement or removal. The in-memory record advances only after persistence
-succeeds. A failed update therefore leaves the preceding record recoverable,
-although a failure after rename can mean that the new record already landed.
-Temporary files are removed when their owners are dropped.
+The client's `PutFileJournal` records multipart geometry and accepted parts, then
+records the complete commit request before submission for every transport.
+Callback failures stop the operation before its next request. A prepared request
+includes its original content reference and proof; the CLI resends it directly
+through `create_commit`, without reopening the upload or reconciling new content
+against the earlier commit. Durable commit receipts can resolve a lost response
+even after the upload session has disappeared. If the request never committed and
+its proof expired, the server rejects it; recovery does not silently create a new
+attempt. Client calls without a journal still use the existing convenience retry
+reconciliation.
 
-The client's `MultipartUploadJournal` callbacks return I/O errors. Failure to
-record the session prevents part uploads; failure to record an accepted part
-prevents the next wave, completion, and file commit. Accepted parts missing from
-the last saved record may be uploaded again safely. Journal failures include the
-server upload ID and the local record path in the error.
+Each update writes and syncs a private temporary file in the journal directory,
+then atomically replaces the record. Unix hosts also sync the directory after
+replacement or removal. In-memory progress changes only after persistence
+succeeds. A failure after rename can mean the new record already landed.
 
-Transfer errors leave the multipart session open. The caller can resume it or
-explicitly abort it; abandoned sessions wait for expiry and garbage collection.
-This costs temporary storage compared with aborting immediately after an error,
-but preserves accepted parts after a recoverable failure. No partially uploaded
-file becomes visible.
+An exclusive sidecar-file lock spans the entire command. A competing command
+fails immediately. The lock file remains after completion so an already-open
+file descriptor cannot bypass ownership when a record is replaced or removed.
+The OS releases ownership when the process exits.
 
-A completed upload can be committed without transferring its content again.
-Successful file commits remove their journal; if removal fails, the error names
-the successful commit and its sequence so the outcome is clear. Journal progress
-does not yet preserve the complete file-commit request or coordinate concurrent
-commands targeting the same journal. Retaining that request and exclusive journal
-ownership are follow-up work for exact PUT retries.
+Ordinary attempts remove their record after acknowledgement. Explicit commit
+IDs retain the prepared request so later invocations with the same ID can replay
+it without another upload. These records and the small lock files consume local
+storage until deliberately removed; receipt retention on the server still limits
+how long a commit can be replayed. Removing a record abandons its local recovery
+information. Cleanup errors after a successful commit name its ID and sequence.
+
+All file-backed remote PUTs pay for durable local writes, including small files.
+Transfer errors preserve multipart sessions for resume or explicit abort;
+abandoned sessions wait for expiry and GC. This uses temporary storage but keeps
+accepted parts after a recoverable failure. Partially uploaded files never become
+visible.


### PR DESCRIPTION
When a CLI upload loses its final commit response, rerunning can choose another commit ID or upload new content. Persist the original intent and complete request, replay that request directly, and hold an exclusive journal lock through the command. File-backed remote PUTs now pay for durable local writes; explicit IDs keep their requests after acknowledgement, and changed source files or options require a new attempt. All 2,061 workspace tests, focused failure and recovery tests, full Clippy, formatting, and OpenAPI checks pass.