### PR TITLE
refactor(client): retry file publication with prepared content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,6 @@ dependencies = [
  "ciborium",
  "crc32c",
  "crc64fast-nvme",
- "futures",
  "getrandom 0.3.4",
  "serde",
  "serde_bytes",

--- a/crates/loonfs-api/Cargo.toml
+++ b/crates/loonfs-api/Cargo.toml
@@ -33,8 +33,5 @@ zstd.workspace = true
 [features]
 openapi = ["dep:utoipa"]
 
-[dev-dependencies]
-futures.workspace = true
-
 [lints]
 workspace = true

--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -3,24 +3,21 @@
 //! whether two requests that use the same commit ID describe the same
 //! mutation.
 //!
-//! The runtime and HTTP client use the functions in this module so that they
-//! apply the same identity rules. The runtime stores a fingerprint in the
-//! commit receipt. A client can later recompute it when retrying a request.
+//! The publisher stores this fingerprint in the commit receipt and compares
+//! it when the same commit ID is submitted again.
 //!
 //! The commit ID is not part of the fingerprint input. The commit ID selects
 //! a receipt, while the fingerprint describes the mutation stored in that
 //! receipt.
 
-use crate::options::PutFileOptions;
 use crate::{
-    AbsolutePath, ActorKind, ActorRef, AttributeRevisionNo, ChangeSeq, CommitId, ContentEvidence,
-    ContentRef, DeleteDirectoryBehavior, DestinationBehavior, FilesystemOperation, InodeId,
-    NamespaceId, RevisionNo,
+    AbsolutePath, ActorKind, ActorRef, AttributeRevisionNo, ChangeSeq, ContentRef,
+    DeleteDirectoryBehavior, DestinationBehavior, FilesystemOperation, InodeId, NamespaceId,
+    RevisionNo,
 };
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::future::Future;
 use thiserror::Error;
 
 /// Domain separator included in every mutation fingerprint input.
@@ -386,152 +383,10 @@ fn canonical_commit_bytes(
     })?)
 }
 
-/// Computes the fingerprint for a retried single-file PUT using the content
-/// reference from the original commit.
-///
-/// Retrying an upload creates a new content object, so its content ID differs
-/// from the ID stored by the original commit. This function substitutes the
-/// original content reference before computing the fingerprint. The caller
-/// must separately verify that both content objects contain the same bytes.
-pub fn put_retry_fingerprint(
-    namespace_id: &NamespaceId,
-    path: &AbsolutePath,
-    options: &PutFileOptions,
-    committed_content_ref: &ContentRef,
-) -> Result<CommitFingerprint, SemanticFingerprintError> {
-    let operation = FilesystemOperation::PutFile {
-        path: path.clone(),
-        content_ref: committed_content_ref.clone(),
-        behavior: options.behavior,
-        expected_inode_id: options.expected_inode_id,
-        expected_revision_no: options.expected_revision_no,
-    };
-    semantic_commit_fingerprint(
-        namespace_id,
-        &options.commit.actor,
-        options.commit.message.as_deref(),
-        std::slice::from_ref(&operation),
-    )
-}
-
-/// Receipt data needed to verify a PUT that reused a commit ID.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PutRetryReceipt {
-    /// Sequence number assigned to the original commit.
-    pub committed_seq: ChangeSeq,
-    /// Semantic fingerprint stored in the original commit receipt.
-    pub committed_fingerprint: String,
-}
-
-/// Classification of an error encountered while verifying a retried PUT.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum PutRetryErrorClassification {
-    /// The commit ID was already used. The receipt is included when available.
-    CommitIdReuseConflict(Option<PutRetryReceipt>),
-    /// Retention removed the change record needed to verify the retry.
-    RebootstrapRequired,
-    /// Any error that does not have special handling during retry verification.
-    Other,
-}
-
-/// Details of the retried PUT being compared with an existing receipt.
-#[derive(Debug, Clone, Copy)]
-pub struct PutRetryAttempt<'a> {
-    /// Namespace targeted by the PUT.
-    pub namespace_id: &'a NamespaceId,
-    /// Absolute path targeted by the PUT.
-    pub path: &'a AbsolutePath,
-    /// Commit ID that was already used.
-    pub commit_id: &'a CommitId,
-    /// PUT options supplied by the caller.
-    pub options: &'a crate::options::PutFileOptions,
-    /// Checksum or byte evidence for the new upload.
-    pub staged: ContentEvidence<'a>,
-}
-
-/// Checks whether a PUT rejected for commit-ID reuse is an exact retry of an
-/// earlier successful PUT.
-///
-/// `read_change` receives the change-feed sequence immediately before the
-/// sequence in the receipt. It must return a page containing at most the
-/// expected change.
-///
-/// The function returns the original commit response only when both the
-/// request fingerprint and the uploaded content match the original commit.
-/// It returns the original conflict when the receipt or change record is
-/// missing, the retained history is unavailable, or either comparison fails.
-/// Other errors from `read_change` are returned unchanged.
-pub async fn reconcile_put_commit_id_reuse<E, ReadChange, ReadChangeFuture, ClassifyError>(
-    attempt: PutRetryAttempt<'_>,
-    conflict: E,
-    read_change: ReadChange,
-    classify_error: ClassifyError,
-) -> Result<crate::v0::CommitResponse, E>
-where
-    ReadChange: FnOnce(ChangeSeq) -> ReadChangeFuture,
-    ReadChangeFuture: Future<Output = Result<crate::v0::ListChangesResponse, E>>,
-    ClassifyError: Fn(&E) -> PutRetryErrorClassification,
-{
-    let PutRetryErrorClassification::CommitIdReuseConflict(Some(receipt)) =
-        classify_error(&conflict)
-    else {
-        return Err(conflict);
-    };
-    let after_seq = ChangeSeq(receipt.committed_seq.0.saturating_sub(1));
-    let page = match read_change(after_seq).await {
-        Ok(page) => page,
-        Err(error)
-            if matches!(
-                classify_error(&error),
-                PutRetryErrorClassification::RebootstrapRequired
-            ) =>
-        {
-            return Err(conflict);
-        }
-        Err(error) => return Err(error),
-    };
-    let Some(committed) = page.changes.into_iter().find(|change| {
-        change.committed_seq == receipt.committed_seq && &change.commit_id == attempt.commit_id
-    }) else {
-        return Err(conflict);
-    };
-    let Some(content_ref) = sole_committed_content_ref(&committed) else {
-        return Err(conflict);
-    };
-    let retried = put_retry_fingerprint(
-        attempt.namespace_id,
-        attempt.path,
-        attempt.options,
-        content_ref,
-    );
-    if retried.ok().as_ref().map(CommitFingerprint::as_str)
-        != Some(receipt.committed_fingerprint.as_str())
-        || !content_ref.matches_evidence(attempt.staged)
-    {
-        return Err(conflict);
-    }
-    Ok(crate::v0::CommitResponse::from_committed_change(
-        attempt.namespace_id.clone(),
-        committed,
-    ))
-}
-
-/// Returns the content reference when a committed change wrote exactly one
-/// file.
-fn sole_committed_content_ref(change: &crate::v0::CommittedChange) -> Option<&ContentRef> {
-    let mut content = change.events.iter().filter_map(|event| match event {
-        crate::v0::FilesystemChange::FileCreated { content_ref, .. }
-        | crate::v0::FilesystemChange::ContentChanged { content_ref, .. } => Some(content_ref),
-        _ => None,
-    });
-    let only = content.next()?;
-    content.next().is_none().then_some(only)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::options::PutFileOptions;
     use crate::{
         ActorId, AttributeKey, AttributeValue, Checksum, ContentId, ContentRefKind, DisplayName,
     };
@@ -834,9 +689,8 @@ mod tests {
     }
 
     #[test]
-    fn a_put_retry_reaches_the_pinned_fingerprint_under_every_checksum_algorithm() {
+    fn a_put_has_the_pinned_fingerprint_under_every_checksum_algorithm() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let options = PutFileOptions::new(test_actor());
         let content_id =
             ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id");
         let bytes = b"pinned put bytes";
@@ -857,11 +711,11 @@ mod tests {
             },
         ] {
             assert_eq!(
-                put_retry_fingerprint(
+                semantic_commit_fingerprint(
                     &namespace_id,
-                    &AbsolutePath::parse("/docs/report.txt").expect("path"),
-                    &options,
-                    &content_ref,
+                    &test_actor(),
+                    None,
+                    &[put("/docs/report.txt", content_ref)],
                 )
                 .expect("retry fingerprint")
                 .as_str(),
@@ -955,51 +809,28 @@ mod tests {
     }
 
     #[test]
-    fn put_retry_fingerprint_matches_the_equivalent_single_operation_request() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let path = AbsolutePath::parse("/docs/report.txt").expect("path");
-        let mut options = PutFileOptions::new(test_actor());
-        options.behavior = DestinationBehavior::Replace;
-        options.expected_inode_id = Some(InodeId(42));
-        options.expected_revision_no = Some(RevisionNo(4));
-        options.commit.message = Some("import batch".to_owned());
-        let content_ref = ContentRef::blob_v1(
-            ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
-            b"pinned put bytes",
-        );
-
-        let by_hand = semantic_commit_fingerprint(
-            &namespace_id,
-            &test_actor(),
-            Some("import batch"),
-            &[FilesystemOperation::PutFile {
-                path: path.clone(),
-                content_ref: content_ref.clone(),
-                behavior: DestinationBehavior::Replace,
-                expected_inode_id: Some(InodeId(42)),
-                expected_revision_no: Some(RevisionNo(4)),
-            }],
-        )
-        .expect("hand-built fingerprint");
-
-        assert_eq!(
-            put_retry_fingerprint(&namespace_id, &path, &options, &content_ref,)
-                .expect("retry fingerprint"),
-            by_hand
-        );
-    }
-
-    #[test]
-    fn put_retry_fingerprint_changes_with_every_request_field() {
+    fn put_fingerprint_changes_with_every_request_field() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let path = AbsolutePath::parse("/a.txt").expect("path");
         let content_ref = ContentRef::blob_v1(ContentId::generate(), b"hello");
         let mut options = PutFileOptions::new(test_actor());
         options.behavior = DestinationBehavior::Replace;
-        let fingerprint = |namespace_id, path, options| {
-            put_retry_fingerprint(namespace_id, path, options, &content_ref)
+        let fingerprint =
+            |namespace_id: &NamespaceId, path: &AbsolutePath, options: &PutFileOptions| {
+                semantic_commit_fingerprint(
+                    namespace_id,
+                    &options.commit.actor,
+                    options.commit.message.as_deref(),
+                    &[FilesystemOperation::PutFile {
+                        path: path.clone(),
+                        content_ref: content_ref.clone(),
+                        behavior: options.behavior,
+                        expected_inode_id: options.expected_inode_id,
+                        expected_revision_no: options.expected_revision_no,
+                    }],
+                )
                 .expect("retry fingerprint")
-        };
+            };
         let baseline = fingerprint(&namespace_id, &path, &options);
 
         let mut changed_behavior = options.clone();
@@ -1051,110 +882,5 @@ mod tests {
                 "changed {label} must change identity"
             );
         }
-    }
-
-    #[test]
-    fn put_retry_reconciliation_agrees_on_receipt_mismatch_and_unavailable_evidence() {
-        #[derive(Debug, Clone, PartialEq, Eq)]
-        enum ReconciliationError {
-            Conflict(PutRetryReceipt),
-            EvidenceUnavailable,
-        }
-
-        fn classify(error: &ReconciliationError) -> PutRetryErrorClassification {
-            match error {
-                ReconciliationError::Conflict(receipt) => {
-                    PutRetryErrorClassification::CommitIdReuseConflict(Some(receipt.clone()))
-                }
-                ReconciliationError::EvidenceUnavailable => {
-                    PutRetryErrorClassification::RebootstrapRequired
-                }
-            }
-        }
-
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let path = AbsolutePath::parse("/report.txt").expect("valid path");
-        let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
-        let committed_seq = ChangeSeq(7);
-        let bytes = b"stable bytes";
-        let content_ref = ContentRef::blob_v1(ContentId::generate(), bytes);
-        let mut options = crate::options::PutFileOptions::new(test_actor());
-        options.commit.commit_id = Some(commit_id.clone());
-        let receipt = PutRetryReceipt {
-            committed_seq,
-            committed_fingerprint: put_retry_fingerprint(
-                &namespace_id,
-                &path,
-                &options,
-                &content_ref,
-            )
-            .expect("fingerprint")
-            .as_str()
-            .to_owned(),
-        };
-        let page = crate::v0::ListChangesResponse {
-            namespace_id: namespace_id.clone(),
-            after_seq: ChangeSeq(6),
-            through_seq: committed_seq,
-            next_after_seq: None,
-            changes: vec![crate::v0::CommittedChange {
-                committed_seq,
-                commit_id: commit_id.clone(),
-                committed_by: test_actor(),
-                committed_at_ms: 1,
-                message: None,
-                events: vec![crate::v0::FilesystemChange::FileCreated {
-                    inode_id: InodeId(2),
-                    parent_inode_id: InodeId(1),
-                    display_name: DisplayName::parse("report.txt").expect("valid display name"),
-                    binding_generation: crate::BindingGeneration::parse("abcdef")
-                        .expect("binding generation"),
-                    revision_no: RevisionNo(1),
-                    content_ref,
-                }],
-            }],
-        };
-
-        let matching_attempt = PutRetryAttempt {
-            namespace_id: &namespace_id,
-            path: &path,
-            commit_id: &commit_id,
-            options: &options,
-            staged: ContentEvidence::Bytes(bytes),
-        };
-        let reconciled = futures::executor::block_on(reconcile_put_commit_id_reuse(
-            matching_attempt,
-            ReconciliationError::Conflict(receipt.clone()),
-            |after_seq| {
-                assert_eq!(after_seq, ChangeSeq(6));
-                std::future::ready(Ok(page.clone()))
-            },
-            classify,
-        ))
-        .expect("matching receipt and evidence reconcile");
-        assert_eq!(reconciled.commit_id, commit_id);
-        assert_eq!(reconciled.committed_seq, committed_seq);
-
-        let mismatch = futures::executor::block_on(reconcile_put_commit_id_reuse(
-            PutRetryAttempt {
-                staged: ContentEvidence::Bytes(b"different bytes"),
-                ..matching_attempt
-            },
-            ReconciliationError::Conflict(receipt.clone()),
-            |_| std::future::ready(Ok(page.clone())),
-            classify,
-        ));
-        assert_eq!(
-            mismatch,
-            Err(ReconciliationError::Conflict(receipt.clone()))
-        );
-
-        let unavailable = futures::executor::block_on(reconcile_put_commit_id_reuse(
-            matching_attempt,
-            ReconciliationError::Conflict(receipt.clone()),
-            |_| std::future::ready(Err(ReconciliationError::EvidenceUnavailable)),
-            classify,
-        ));
-        assert_eq!(unavailable, Err(ReconciliationError::Conflict(receipt)));
     }
 }

--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -368,15 +368,6 @@ pub struct ContentRef {
     pub checksum: Checksum,
 }
 
-/// Available proof that a payload matches a committed content reference.
-#[derive(Debug, Clone, Copy)]
-pub enum ContentEvidence<'a> {
-    /// Bytes that can be hashed with the committed reference's algorithm.
-    Bytes(&'a [u8]),
-    /// A reference carrying checksum evidence about its payload.
-    ContentRef(&'a ContentRef),
-}
-
 impl ContentRef {
     /// Builds a reference to a freshly minted content object holding these bytes.
     ///
@@ -405,22 +396,6 @@ impl ContentRef {
         }
     }
 
-    /// Whether `evidence` proves that a payload has the same bytes as this
-    /// reference.
-    ///
-    /// Reference evidence returns `false` when the size or checksum algorithm
-    /// differs. A checksum that was never computed is not evidence of a match.
-    pub fn matches_evidence(&self, evidence: ContentEvidence<'_>) -> bool {
-        match evidence {
-            ContentEvidence::Bytes(bytes) => {
-                self.size_bytes == bytes.len() as u64 && self.checksum.matches(bytes)
-            }
-            ContentEvidence::ContentRef(reference) => {
-                self.size_bytes == reference.size_bytes && self.checksum == reference.checksum
-            }
-        }
-    }
-
     /// Reports whether the reference is well formed enough to publish.
     ///
     /// This is a shape check on the reference itself; proving that the
@@ -441,8 +416,8 @@ impl ContentRef {
 #[cfg(test)]
 mod tests {
     use super::{
-        Checksum, ChecksumAlgorithm, ChecksumValidationError, ContentEvidence, ContentRef,
-        ContentRefKind, ContentRefValidationError, StreamingChecksum,
+        Checksum, ChecksumAlgorithm, ChecksumValidationError, ContentRef, ContentRefKind,
+        ContentRefValidationError, StreamingChecksum,
     };
     use crate::ids::ContentId;
 
@@ -631,49 +606,5 @@ mod tests {
             assert!(expected.matches(b"hello"));
             assert!(!expected.matches(b"other"));
         }
-    }
-
-    #[test]
-    fn a_reference_compares_bytes_using_its_checksum_and_size() {
-        let bytes = b"retried payload";
-        let reference = ContentRef {
-            kind: ContentRefKind::BlobV1,
-            content_id: content_id(),
-            size_bytes: bytes.len() as u64,
-            checksum: Checksum::crc32c(bytes),
-        };
-
-        assert!(reference.matches_evidence(ContentEvidence::Bytes(bytes)));
-        assert!(!reference.matches_evidence(ContentEvidence::Bytes(b"different payload")));
-        let mut wrong_size = reference.clone();
-        wrong_size.size_bytes += 1;
-        assert!(!wrong_size.matches_evidence(ContentEvidence::Bytes(bytes)));
-    }
-
-    #[test]
-    fn a_reference_requires_the_other_reference_to_carry_its_checksum_algorithm() {
-        let bytes = b"retried payload";
-        let crc_reference = ContentRef {
-            kind: ContentRefKind::BlobV1,
-            content_id: content_id(),
-            size_bytes: bytes.len() as u64,
-            checksum: Checksum::crc32c(bytes),
-        };
-        let sha_reference = ContentRef::blob_v1(content_id(), bytes);
-        let matching_crc_reference = ContentRef {
-            content_id: content_id(),
-            ..crc_reference.clone()
-        };
-        let different_size = ContentRef {
-            size_bytes: crc_reference.size_bytes + 1,
-            ..crc_reference.clone()
-        };
-
-        assert!(!crc_reference.matches_evidence(ContentEvidence::ContentRef(&sha_reference)));
-        assert!(
-            crc_reference.matches_evidence(ContentEvidence::ContentRef(&matching_crc_reference))
-        );
-        assert!(!crc_reference.matches_evidence(ContentEvidence::ContentRef(&different_size)));
-        assert!(sha_reference.matches_evidence(ContentEvidence::ContentRef(&sha_reference)));
     }
 }

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -93,13 +93,11 @@ pub use capability::{
     LIMIT_UPLOAD_MAX_CONCURRENT, LIMIT_UPLOAD_MAX_CONTENT_BYTES, PROTOCOL_VERSION,
 };
 pub use commit_identity::{
-    put_retry_fingerprint, reconcile_put_commit_id_reuse, semantic_commit_fingerprint,
-    CommitFingerprint, PutRetryAttempt, PutRetryErrorClassification, PutRetryReceipt,
-    SemanticFingerprintError,
+    semantic_commit_fingerprint, CommitFingerprint, SemanticFingerprintError,
 };
 pub use content::{
-    Checksum, ChecksumAlgorithm, ChecksumValidationError, ContentEvidence, ContentRef,
-    ContentRefKind, ContentRefValidationError, Crc32c, Crc64Nvme, Sha256, StreamingChecksum,
+    Checksum, ChecksumAlgorithm, ChecksumValidationError, ContentRef, ContentRefKind,
+    ContentRefValidationError, Crc32c, Crc64Nvme, Sha256, StreamingChecksum,
 };
 pub use digest::sha256_digest;
 pub use error::{ErrorCode, ErrorKind};

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -407,13 +407,8 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
         json_error(&conflicted)
     );
 
-    // A put's identity includes *which* content object it attaches, and
-    // `loonfs put` uploads its file every time it runs, so a rerun under the
-    // same commit id is a different mutation as far as the server is
-    // concerned. What makes rerunning safe anyway is the client comparing
-    // the bytes it just sent against what that commit id actually
-    // committed: identical bytes mean the command had already succeeded, so
-    // it reports the same commit rather than a conflict.
+    // Embedded PUTs upload a new object on each command invocation.
+    // The original receipt remains authoritative even when the bytes match.
     let local_payload = payload.to_str().expect("utf-8 path");
     let first = harness.run(&[
         "--json",
@@ -432,11 +427,12 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
         "--commit-id",
         "pinned-put",
     ]);
-    assert_success(&rerun);
+    assert_failure(&rerun);
+    assert_eq!(json_error(&rerun)["code"], "commit_id_reuse_conflict");
     assert_eq!(
-        json_data(&rerun)["committed_seq"],
+        json_error(&rerun)["details"]["committed_seq"],
         json_data(&first)["committed_seq"],
-        "rerunning an identical put must report the commit that already landed"
+        "the conflict identifies the original publication"
     );
 
     // Different bytes under that commit id are a different operation, and
@@ -486,8 +482,7 @@ fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
     assert_success(&first);
     assert_eq!(download(&harness, "/big.bin", "big-back.bin"), payload);
 
-    // The same reconciliation the buffered path has: the rerun uploads
-    // again, conflicts on identity, and resolves to the commit that landed.
+    // A second embedded upload creates another object and must conflict.
     let rerun = harness.run(&[
         "--json",
         "put",
@@ -497,11 +492,12 @@ fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
         "pinned-big",
         "--force",
     ]);
-    assert_success(&rerun);
+    assert_failure(&rerun);
+    assert_eq!(json_error(&rerun)["code"], "commit_id_reuse_conflict");
     assert_eq!(
-        json_data(&rerun)["committed_seq"],
+        json_error(&rerun)["details"]["committed_seq"],
         json_data(&first)["committed_seq"],
-        "rerunning an identical large put must report the commit that already landed"
+        "the conflict identifies the original publication"
     );
 
     let mut changed = payload.clone();

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -37,16 +37,15 @@ use loonfs_api::{
         UploadContentResponse, UploadPartChecksumClaim, UploadSession, UploadSessionStatus,
     },
     AbsolutePath, CapabilityDocument, ChangeSeq, Checkpoint, CheckpointId, Checksum,
-    ChecksumAlgorithm, CommitId, CommitRequest, ContentEvidence, ContentRef,
-    CreateCheckpointRequest, CreateNamespaceRequest, DeleteNamespaceResponse, ErrorCode,
-    FilesystemOperation, ForkNamespaceRequest, GrepRequest, GrepResponse, InodeId,
-    ListCheckpointsResponse, ListFileRevisionsResponse, ListInodeChildrenResponse,
-    ListPathEntriesResponse, ListTrashResponse, Namespace, NamespaceDiagnostics, NamespaceId,
-    PathEntry, PutRetryAttempt, PutRetryErrorClassification, PutRetryReceipt,
-    ReleaseCheckpointResponse, RevisionNo, RunMaintenanceRequest, RunMaintenanceResponse,
-    SecretString, StreamingChecksum, UploadId, FEATURE_DOWNLOADS_DIRECT_GET,
-    FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES,
-    LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
+    ChecksumAlgorithm, CommitId, CommitRequest, ContentRef, CreateCheckpointRequest,
+    CreateNamespaceRequest, DeleteNamespaceResponse, FilesystemOperation, ForkNamespaceRequest,
+    GrepRequest, GrepResponse, InodeId, ListCheckpointsResponse, ListFileRevisionsResponse,
+    ListInodeChildrenResponse, ListPathEntriesResponse, ListTrashResponse, Namespace,
+    NamespaceDiagnostics, NamespaceId, PathEntry, ReleaseCheckpointResponse, RevisionNo,
+    RunMaintenanceRequest, RunMaintenanceResponse, SecretString, StreamingChecksum, UploadId,
+    FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
+    LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES,
+    LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
 use payload::PartReader;
 use std::sync::{Arc, OnceLock};
@@ -80,7 +79,9 @@ pub type Result<T> = std::result::Result<T, ClientError>;
 
 pub use downloads::{DirectDownloadStream, DownloadOptions};
 pub use namespace_path::NamespacePath;
-pub use uploads::staging::{MultipartUploadResume, PutFileJournal, STREAMING_PUT_MIN_BYTES};
+pub use uploads::staging::{
+    MultipartUploadResume, PreparedContent, PutFileJournal, STREAMING_PUT_MIN_BYTES,
+};
 
 /// Async HTTP client for LoonFS.
 ///

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -2,29 +2,10 @@
 
 use super::*;
 use crate::transport::SendPolicy;
-use crate::uploads::staging::{StagedContent, UploadContinuity};
+use crate::uploads::staging::{PreparedContent, UploadContinuity};
 
 fn commit_id_or_generated(commit: &CommitOptions) -> CommitId {
     commit.commit_id.clone().unwrap_or_else(CommitId::generate)
-}
-
-fn classify_put_retry_error(error: &ClientError) -> PutRetryErrorClassification {
-    match error.code() {
-        Some(ErrorCode::CommitIdReuseConflict) => {
-            let receipt = match error {
-                ClientError::Api { details, .. } => details.as_ref().and_then(|details| {
-                    Some(PutRetryReceipt {
-                        committed_seq: details.committed_seq?,
-                        committed_fingerprint: details.committed_fingerprint.clone()?,
-                    })
-                }),
-                _ => None,
-            };
-            PutRetryErrorClassification::CommitIdReuseConflict(receipt)
-        }
-        Some(ErrorCode::RebootstrapRequired) => PutRetryErrorClassification::RebootstrapRequired,
-        _ => PutRetryErrorClassification::Other,
-    }
 }
 
 impl Client {
@@ -47,15 +28,9 @@ impl Client {
 
     /// Uploads bytes and commits them at a path.
     ///
-    /// Reusing a successful `commit_id` is safe when the request is unchanged.
-    /// A retry uploads a new content object, so the server initially reports
-    /// `commit_id_reuse_conflict`. The client reads the stored receipt and
-    /// compares the content and message. Matching values return the original
-    /// result; different values preserve the conflict.
-    ///
-    /// The freshly uploaded duplicate object is then referenced by nothing.
-    /// That is by design, not a leak: content garbage collection reclaims an
-    /// unreferenced completed upload once its grace passes.
+    /// Each call uploads a new content object. To retry publication, retain
+    /// the result of [`Self::prepare_file_bytes`] and call
+    /// [`Self::put_file_prepared`] with the same explicit commit ID and options.
     pub async fn put_file_bytes(
         &self,
         spec: &NamespacePath,
@@ -65,8 +40,7 @@ impl Client {
         let staged = self
             .stage_bytes_as_content_ref(spec.namespace(), bytes)
             .await?;
-        self.commit_staged_file(spec, staged, options, ContentEvidence::Bytes(bytes), None)
-            .await
+        self.commit_staged_file(spec, staged, options, None).await
     }
 
     /// Uploads a payload read once from its source and commits it at a path.
@@ -77,9 +51,8 @@ impl Client {
     /// Direct multipart uploads support at most 10,000 parts. Payloads larger
     /// than `part_size_bytes × 10_000` require a larger configured part size.
     ///
-    /// Retrying with a previously committed `commit_id` is safe for the same
-    /// reason as [`Self::put_file_bytes`]: the client measures the payload and
-    /// calculates the checksum used for reconciliation.
+    /// Each call uploads new content. For retries, retain the result of
+    /// [`Self::prepare_file_stream`] and use [`Self::put_file_prepared`].
     pub async fn put_file_stream(
         &self,
         spec: &NamespacePath,
@@ -129,18 +102,50 @@ impl Client {
         let staged = self
             .stage_source_as_content_ref(spec.namespace(), source, continuity)
             .await?;
-        // The staged reference is what the server verified about the bytes
-        // that just went past, and with the payload gone it is the only
-        // description of them that still exists.
-        let uploaded = staged.content_ref.clone();
-        self.commit_staged_file(
-            spec,
-            staged,
-            options,
-            ContentEvidence::ContentRef(&uploaded),
-            continuity.journal,
-        )
-        .await
+        self.commit_staged_file(spec, staged, options, continuity.journal)
+            .await
+    }
+
+    /// Uploads bytes and returns content ready for publication.
+    ///
+    /// Retain this value and an explicit commit ID to retry
+    /// [`Self::put_file_prepared`] without uploading again. Unpublished content
+    /// expires after the upload's receipt horizon.
+    pub async fn prepare_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        bytes: &[u8],
+    ) -> Result<PreparedContent> {
+        self.stage_bytes_as_content_ref(namespace_id, bytes).await
+    }
+
+    /// Uploads a stream once, in bounded chunks, for later publication.
+    ///
+    /// The result has the same retry contract as [`Self::prepare_file_bytes`].
+    pub async fn prepare_file_stream(
+        &self,
+        namespace_id: &NamespaceId,
+        source: PayloadSource,
+    ) -> Result<PreparedContent> {
+        self.stage_source_as_content_ref(namespace_id, source, UploadContinuity::default())
+            .await
+    }
+
+    /// Publishes already-prepared content without uploading it again.
+    ///
+    /// Retry with a clone of the prepared content, the same explicit
+    /// `options.commit.commit_id`, and unchanged options. A missing commit ID
+    /// generates a new one on each call. Replay is bounded by server receipt
+    /// retention. For process recovery, use [`Self::put_file_stream_resumable`]
+    /// to save the full request before submission.
+    pub async fn put_file_prepared(
+        &self,
+        spec: &NamespacePath,
+        prepared_content: PreparedContent,
+        options: &PutFileOptions,
+    ) -> Result<ApiCommitResponse> {
+        self.commit_staged_file(spec, prepared_content, options, None)
+            .await
     }
 
     /// Commits content after an upload completed but its file commit did not.
@@ -156,29 +161,20 @@ impl Client {
         options: &PutFileOptions,
         journal: Option<&dyn PutFileJournal>,
     ) -> Result<ApiCommitResponse> {
-        let uploaded = content_ref.clone();
-        let staged = StagedContent {
+        let staged = PreparedContent {
             content_token,
             content_ref,
         };
-        self.commit_staged_file(
-            spec,
-            staged,
-            options,
-            ContentEvidence::ContentRef(&uploaded),
-            journal,
-        )
-        .await
+        self.commit_staged_file(spec, staged, options, journal)
+            .await
     }
 
-    /// Saves an exact request when journaled. Unjournaled convenience calls
-    /// reconcile fresh content when a commit ID was already used.
+    /// Saves an exact request when journaled, then submits it unchanged.
     async fn commit_staged_file(
         &self,
         spec: &NamespacePath,
-        staged: StagedContent,
+        staged: PreparedContent,
         options: &PutFileOptions,
-        uploaded: ContentEvidence<'_>,
         journal: Option<&dyn PutFileJournal>,
     ) -> Result<ApiCommitResponse> {
         let commit_id = commit_id_or_generated(&options.commit);
@@ -201,52 +197,8 @@ impl Client {
                     "could not record file commit `{commit_id}` before submission: {error}"
                 ))
             })?;
-            return self.create_commit(spec.namespace(), &request).await;
         }
-        let response = self.create_commit(spec.namespace(), &request).await;
-        match response {
-            Ok(response) => Ok(response),
-            Err(error) if error.code() == Some(ErrorCode::CommitIdReuseConflict) => {
-                self.reconcile_commit_id_reuse(spec, &commit_id, options, uploaded, error)
-                    .await
-            }
-            Err(error) => Err(error),
-        }
-    }
-
-    /// Checks whether a commit-ID conflict came from retrying the same PUT.
-    ///
-    /// The shared helper loads the original change and compares the complete
-    /// request fingerprint. It also verifies that the new upload contains the
-    /// same bytes as the content from the original commit. If either check
-    /// cannot be completed or does not match, this method returns the original
-    /// conflict.
-    async fn reconcile_commit_id_reuse(
-        &self,
-        spec: &NamespacePath,
-        commit_id: &CommitId,
-        options: &PutFileOptions,
-        uploaded: ContentEvidence<'_>,
-        conflict: ClientError,
-    ) -> Result<ApiCommitResponse> {
-        let namespace_id = spec.namespace();
-        let list_options = ListChangesOptions {
-            limit: Some(1),
-            snapshot_id: None,
-        };
-        loonfs_api::reconcile_put_commit_id_reuse(
-            PutRetryAttempt {
-                namespace_id,
-                path: spec.absolute_path(),
-                commit_id,
-                options,
-                staged: uploaded,
-            },
-            conflict,
-            |after_seq| self.list_changes(namespace_id, after_seq, &list_options),
-            classify_put_retry_error,
-        )
-        .await
+        self.create_commit(spec.namespace(), &request).await
     }
 
     /// Creates a directory at the requested path.

--- a/crates/loonfs-client/src/uploads/staging.rs
+++ b/crates/loonfs-client/src/uploads/staging.rs
@@ -65,10 +65,21 @@ pub(crate) struct UploadContinuity<'a> {
     pub(crate) journal: Option<&'a dyn PutFileJournal>,
 }
 
+/// Uploaded content and its publication token, ready for a file commit.
+///
+/// Clone this value to retry publication with the same commit ID and options.
+/// Preparation alone does not publish a file or extend the upload's lifetime.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct StagedContent {
+pub struct PreparedContent {
     pub(crate) content_ref: ContentRef,
     pub(crate) content_token: Option<ContentToken>,
+}
+
+impl PreparedContent {
+    /// Returns the immutable content reference produced by the upload.
+    pub fn content_ref(&self) -> &ContentRef {
+        &self.content_ref
+    }
 }
 
 /// Upload path selected from the server capability document.
@@ -287,7 +298,7 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         bytes: &[u8],
-    ) -> Result<StagedContent> {
+    ) -> Result<PreparedContent> {
         // The exact size is known, so transport limits can reject it now.
         match self.transport_for_measured(bytes.len() as u64).await? {
             UploadTransport::Multipart => {
@@ -314,7 +325,7 @@ impl Client {
         namespace_id: &NamespaceId,
         source: PayloadSource,
         continuity: UploadContinuity<'_>,
-    ) -> Result<StagedContent> {
+    ) -> Result<PreparedContent> {
         // A declared length is only a routing hint. Rejection requires a size
         // measured while reading the payload.
         match self.provisional_transport(source.size_bytes()).await? {
@@ -433,7 +444,7 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         body: DirectPutBody<'_>,
-    ) -> Result<StagedContent> {
+    ) -> Result<PreparedContent> {
         let begin = self
             .create_direct_put_upload(namespace_id, body.size_hint())
             .await?;
@@ -492,7 +503,7 @@ impl Client {
         namespace_id: &NamespaceId,
         payload: MultipartPayload<'_>,
         continuity: UploadContinuity<'_>,
-    ) -> Result<StagedContent> {
+    ) -> Result<PreparedContent> {
         // Resume with the original session and part size so completed parts
         // remain usable.
         let (upload_id, part_size_bytes, checksum_algorithm) = match continuity.resume {
@@ -726,7 +737,7 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         bytes: &[u8],
-    ) -> Result<StagedContent> {
+    ) -> Result<PreparedContent> {
         let upload = self
             .create_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await?;
@@ -744,7 +755,7 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         source: PayloadSource,
-    ) -> Result<StagedContent> {
+    ) -> Result<PreparedContent> {
         let upload = self
             .create_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await?;
@@ -762,7 +773,7 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
-    ) -> Result<StagedContent> {
+    ) -> Result<PreparedContent> {
         let response = self
             .complete_upload(
                 namespace_id,
@@ -773,14 +784,14 @@ impl Client {
         Self::staged_from_completion(response)
     }
 
-    pub(crate) fn staged_from_completion(response: UploadSession) -> Result<StagedContent> {
+    pub(crate) fn staged_from_completion(response: UploadSession) -> Result<PreparedContent> {
         let status = match response.status {
             UploadSessionStatus::Completed {
                 content_ref,
                 content_token,
                 ..
             } => {
-                return Ok(StagedContent {
+                return Ok(PreparedContent {
                     content_ref,
                     content_token,
                 });

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -1160,14 +1160,17 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
     assert_eq!(received, payload);
     assert_direct_get_capability_serves_ranges(&harness.client, &target, &payload).await;
 
-    // And a rerun of the same put under the same commit id reconciles by
-    // content rather than conflicting, even with no whole-file sha256 to
-    // compare — the provider's crc is the evidence.
+    // Retaining provider-checksummed content supports exact publication replay.
+    let prepared = harness
+        .client
+        .prepare_file_bytes(&namespace_id, &payload)
+        .await
+        .expect("prepare provider content once");
     let rerun = harness
         .client
-        .put_file_bytes(
+        .put_file_prepared(
             &NamespacePath::parse(namespace, "/rerun.bin").expect("rerun target"),
-            &payload,
+            prepared.clone(),
             &loonfs_client::PutFileOptions {
                 behavior: DestinationBehavior::NoReplace,
                 commit: loonfs_api::options::CommitOptions {
@@ -1183,9 +1186,9 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
         .expect("a multipart put through the client");
     let replayed_rerun = harness
         .client
-        .put_file_bytes(
+        .put_file_prepared(
             &NamespacePath::parse(namespace, "/rerun.bin").expect("rerun target"),
-            &payload,
+            prepared.clone(),
             &loonfs_client::PutFileOptions {
                 behavior: DestinationBehavior::NoReplace,
                 commit: loonfs_api::options::CommitOptions {
@@ -1198,7 +1201,7 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
             },
         )
         .await
-        .expect("rerunning identical bytes is idempotent without a sha256");
+        .expect("prepared CRC content replays without another upload");
     assert_eq!(replayed_rerun, rerun);
 
     one_pass_puts_against_the_provider(&harness, namespace).await;

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -154,12 +154,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
         .expect("repeat put");
     assert_eq!(repeated, first);
 
-    // Re-running the put under the same commit id uploads a second content
-    // object, so the server sees a different commit and rejects it. The
-    // client resolves that by reading back what the commit id actually
-    // committed: same bytes, so the logical operation had already
-    // succeeded, and the original answer stands. The duplicate object is
-    // referenced by nothing and content collection reclaims it.
+    // Fresh content is a different request even when its bytes match.
     let reuploaded = harness
         .client
         .put_file_bytes(
@@ -177,8 +172,11 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
             },
         )
         .await
-        .expect("re-uploading identical bytes under a used commit id is idempotent");
-    assert_eq!(reuploaded, first);
+        .expect_err("fresh uploads must preserve the conflict");
+    assert_eq!(
+        reuploaded.code(),
+        Some(loonfs_api::ErrorCode::CommitIdReuseConflict)
+    );
 
     let entry = harness
         .client
@@ -193,8 +191,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
         .expect("read file");
     assert_eq!(bytes, b"stable bytes\n");
 
-    // Retry reconciliation includes the actor in the fingerprint. Identical
-    // content submitted by a different actor must still conflict.
+    // A different actor must still conflict.
     let different_actor = ActorRef::service(ActorId::parse("retry-worker").expect("actor id"));
     match harness
         .client
@@ -1041,4 +1038,84 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
 
     server_a.server.abort();
     server_b.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prepared_puts_replay_and_changed_options_conflict() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "prepared-put",
+        "prepared-put",
+    ))
+    .await;
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("namespace");
+    for streamed in [false, true] {
+        let target =
+            NamespacePath::parse("demo", &format!("/prepared-{streamed}.txt")).expect("path");
+        let bytes = b"prepared exactly once";
+        let prepared = if streamed {
+            harness
+                .client
+                .prepare_file_stream(&namespace, loonfs_client::PayloadSource::reader(&bytes[..]))
+                .await
+        } else {
+            harness.client.prepare_file_bytes(&namespace, bytes).await
+        }
+        .expect("prepare content");
+        let mut options = PutFileOptions::new(loonfs_test_support::test_actor());
+        options.commit.commit_id = Some(CommitId::generate());
+        let first = harness
+            .client
+            .put_file_prepared(&target, prepared.clone(), &options)
+            .await
+            .expect("first publication");
+        let repeated = harness
+            .client
+            .put_file_prepared(&target, prepared.clone(), &options)
+            .await
+            .expect("exact replay despite create-only behavior");
+        assert_eq!(repeated, first);
+        let mut changed = Vec::new();
+        let mut candidate = options.clone();
+        candidate.commit.message = Some("different".to_owned());
+        changed.push(candidate);
+        let mut candidate = options.clone();
+        candidate.commit.actor = ActorRef::system(ActorId::parse("another-actor").expect("actor"));
+        changed.push(candidate);
+        let mut candidate = options.clone();
+        candidate.behavior = DestinationBehavior::Replace;
+        changed.push(candidate);
+        let mut candidate = options.clone();
+        candidate.expected_inode_id = Some(loonfs_api::InodeId(123));
+        changed.push(candidate);
+        let mut candidate = options.clone();
+        candidate.expected_revision_no = Some(RevisionNo(123));
+        changed.push(candidate);
+        for candidate in changed {
+            let error = harness
+                .client
+                .put_file_prepared(&target, prepared.clone(), &candidate)
+                .await
+                .expect_err("changed options must not replay");
+            assert_eq!(
+                error.code(),
+                Some(loonfs_api::ErrorCode::CommitIdReuseConflict)
+            );
+        }
+        assert_eq!(
+            harness
+                .client
+                .get_file_bytes(&target, &Default::default())
+                .await
+                .expect("read published bytes"),
+            bytes
+        );
+    }
+    harness.server.abort();
 }

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -275,21 +275,26 @@ async fn http_put_conflict_stands_when_only_the_message_changed() {
         expected_revision_no: None,
     };
 
+    let prepared = harness
+        .client
+        .prepare_file_bytes(&namespace, b"stable bytes\n")
+        .await
+        .expect("prepare the content once");
     let first = harness
         .client
-        .put_file_bytes(&target, b"stable bytes\n", &options("import batch"))
+        .put_file_prepared(&target, prepared.clone(), &options("import batch"))
         .await
         .expect("first put");
     let replay = harness
         .client
-        .put_file_bytes(&target, b"stable bytes\n", &options("import batch"))
+        .put_file_prepared(&target, prepared.clone(), &options("import batch"))
         .await
-        .expect("re-uploading an identical request is idempotent");
+        .expect("resubmitting prepared content is idempotent");
     assert_eq!(replay, first);
 
     match harness
         .client
-        .put_file_bytes(&target, b"stable bytes\n", &options("second thoughts"))
+        .put_file_prepared(&target, prepared.clone(), &options("second thoughts"))
         .await
     {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
@@ -298,10 +303,10 @@ async fn http_put_conflict_stands_when_only_the_message_changed() {
 
     // Absent and empty are different messages too: the fingerprint takes
     // the annotation as given, so `null` and `""` are different commits and
-    // the client compares them the same way.
+    // publication checks them before replay.
     match harness
         .client
-        .put_file_bytes(&target, b"stable bytes\n", &{
+        .put_file_prepared(&target, prepared.clone(), &{
             let mut options = options("unused");
             options.commit.message = None;
             options

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -11,12 +11,7 @@ use crate::{
     PutFileOptions, RestoreRevisionOptions, RevisionNo, UndeleteOptions, UpdateAttributesOptions,
 };
 use crate::{Result, RuntimeError};
-use loonfs_api::{
-    ContentEvidence, EffectiveLimit, ErrorCode, PutRetryAttempt, PutRetryErrorClassification,
-    PutRetryReceipt,
-};
 use loonfs_core::NamespaceWriterEngine;
-use std::num::NonZeroU32;
 use std::sync::Arc;
 
 fn single_operation(commit: &CommitOptions, operation: FilesystemOperation) -> CommitRequest {
@@ -26,22 +21,6 @@ fn single_operation(commit: &CommitOptions, operation: FilesystemOperation) -> C
         commit.message.clone(),
         operation,
     )
-}
-
-fn classify_put_retry_error(error: &RuntimeError) -> PutRetryErrorClassification {
-    match error.code() {
-        ErrorCode::CommitIdReuseConflict => {
-            let receipt = error.details().and_then(|details| {
-                Some(PutRetryReceipt {
-                    committed_seq: details.committed_seq?,
-                    committed_fingerprint: details.committed_fingerprint?,
-                })
-            });
-            PutRetryErrorClassification::CommitIdReuseConflict(receipt)
-        }
-        ErrorCode::RebootstrapRequired => PutRetryErrorClassification::RebootstrapRequired,
-        _ => PutRetryErrorClassification::Other,
-    }
 }
 
 impl FsWriter {
@@ -76,6 +55,9 @@ impl FsWriter {
     /// The bytes become durable content first; metadata referencing them is
     /// published only afterward. `options.behavior` selects create-only or
     /// replace semantics.
+    /// Each call stages new content. For retries, retain the result of
+    /// [`Self::prepare_file_bytes`] and use [`Self::put_file_prepared`] with
+    /// the same explicit commit ID and options.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.put",
@@ -90,17 +72,6 @@ impl FsWriter {
             payload_class = tracing::field::Empty,
         )
     )]
-    /// A retry with the same `commit_id` is reconciled against the durable
-    /// receipt.
-    ///
-    /// Each retry stages a new content object, so its initial fingerprint differs
-    /// from the committed request. On a reuse conflict, the runtime reads the
-    /// committed change, rebuilds the fingerprint with the committed content
-    /// reference, and verifies that the staged bytes match. The retry succeeds
-    /// only when the complete request and payload are equivalent.
-    ///
-    /// The unused staged object remains unpublished and is reclaimed by content
-    /// garbage collection after the grace period.
     pub async fn put_file_bytes(
         &self,
         namespace_id: &NamespaceId,
@@ -111,35 +82,17 @@ impl FsWriter {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
-        let attempt = options.clone();
         let prepared_content = self.prepare_file_bytes_inner(namespace_id, bytes).await?;
-        let published = self
-            .put_file_prepared_inner(namespace_id, absolute_path, prepared_content, options)
-            .await;
-        self.settle_put(
-            namespace_id,
-            absolute_path,
-            &attempt,
-            published,
-            ContentEvidence::Bytes(bytes),
-        )
-        .await
+        self.put_file_prepared_inner(namespace_id, absolute_path, prepared_content, options)
+            .await
     }
 
     /// Writes a file from a payload read once from its source.
     ///
-    /// This is [`Self::put_file_bytes`] for a caller that should not hold
-    /// its payload: the stream is hashed as it is forwarded to object
-    /// storage and never held whole, so a large file costs one transfer
-    /// part of memory rather than its own size. Everything after the bytes
-    /// land is identical — same full-object checksum, same
-    /// publication, same retry reconciliation — so a caller that already
-    /// holds its bytes has no reason to come here.
-    ///
-    /// Retrying with a `commit_id` that already committed is safe in the
-    /// same way it is for the buffered call. The evidence is different only
-    /// because the payload is gone: what this pass measured and hashed on
-    /// the way past is what the reconciliation compares.
+    /// The stream is hashed while it is forwarded to object storage, using
+    /// one transfer part of memory. Each call stages new content. For retries,
+    /// retain [`Self::prepare_file_stream`]'s result and call
+    /// [`Self::put_file_prepared`] with the same explicit commit ID and options.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.put",
@@ -162,89 +115,9 @@ impl FsWriter {
         options: PutFileOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        let attempt = options.clone();
         let prepared_content = self.prepare_file_stream_inner(namespace_id, body).await?;
-        // The prepared reference describes the bytes that just went past,
-        // and with the payload gone it is the only description of them that
-        // still exists.
-        let staged = prepared_content.content_ref().clone();
-        let published = self
-            .put_file_prepared_inner(namespace_id, absolute_path, prepared_content, options)
-            .await;
-        self.settle_put(
-            namespace_id,
-            absolute_path,
-            &attempt,
-            published,
-            ContentEvidence::ContentRef(&staged),
-        )
-        .await
-    }
-
-    /// Turns a reused-commit-id rejection into the answer the retry
-    /// deserves, and passes everything else through.
-    async fn settle_put(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        attempt: &PutFileOptions,
-        published: Result<CommitResponse>,
-        staged: ContentEvidence<'_>,
-    ) -> Result<CommitResponse> {
-        match (published, attempt.commit.commit_id.as_ref()) {
-            (Err(error), Some(commit_id)) if error.code() == ErrorCode::CommitIdReuseConflict => {
-                self.reconcile_commit_id_reuse(
-                    namespace_id,
-                    absolute_path,
-                    commit_id,
-                    attempt,
-                    staged,
-                    error,
-                )
-                .await
-            }
-            (published, _) => published,
-        }
-    }
-
-    /// Checks whether a commit-ID conflict came from retrying the same file
-    /// write.
-    ///
-    /// The shared helper compares the full request fingerprint and verifies
-    /// that the new upload contains the same bytes as the original commit. If
-    /// either check cannot be completed or does not match, this method returns
-    /// the original conflict.
-    async fn reconcile_commit_id_reuse(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        commit_id: &CommitId,
-        attempt: &PutFileOptions,
-        staged: ContentEvidence<'_>,
-        conflict: RuntimeError,
-    ) -> Result<CommitResponse> {
-        let Ok(path) = loonfs_core::path::parse_mutation_path(absolute_path) else {
-            return Err(conflict);
-        };
-        let engine = self.engine(namespace_id);
-        loonfs_api::reconcile_put_commit_id_reuse(
-            PutRetryAttempt {
-                namespace_id,
-                path: &path,
-                commit_id,
-                options: attempt,
-                staged,
-            },
-            conflict,
-            |after_seq| async move {
-                engine
-                    .list_changes_after(after_seq, EffectiveLimit::new(NonZeroU32::MIN))
-                    .await
-                    .map_err(RuntimeError::from)
-            },
-            classify_put_retry_error,
-        )
-        .await
+        self.put_file_prepared_inner(namespace_id, absolute_path, prepared_content, options)
+            .await
     }
 
     /// Stores file bytes and returns proof that they are ready to publish.
@@ -344,7 +217,10 @@ impl FsWriter {
     /// Publishes a file revision from already-prepared content.
     ///
     /// Submission and publication perform no content I/O. `options.behavior`
-    /// selects create-only or replace semantics.
+    /// selects create-only or replace semantics. Retry with a clone of the
+    /// prepared content, the same explicit `options.commit.commit_id`, and
+    /// unchanged options. A missing commit ID generates a new one on each call.
+    /// Replay is bounded by the namespace's receipt retention horizon.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.put",

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -1,12 +1,5 @@
-//! Rerunning a put under a commit id that already committed.
-//!
-//! A commit's identity names *which* content object it wrote, so a rerun —
-//! which necessarily stages a fresh object — is a different commit as far as
-//! the publisher is concerned and it says so. What makes the rerun safe
-//! anyway is the runtime reading back what that commit id actually
-//! committed, rebuilding this request's fingerprint around the committed
-//! reference, and requiring the whole value to match before it proves the
-//! bytes agree. Nothing weaker counts as agreement.
+//! File publication replays the same prepared content and commit ID.
+//! Uploading again creates a new object and must preserve a reuse conflict.
 
 use crate::common::{open_runtime_async, store, TestRuntime};
 use bytes::Bytes;
@@ -171,7 +164,7 @@ async fn restart_replays_the_commit_actor_from_the_wal() {
 }
 
 #[tokio::test]
-async fn rerunning_a_put_with_the_same_commit_id_replays_on_identical_bytes() {
+async fn reuploading_identical_bytes_under_the_same_commit_id_conflicts() {
     let temp_dir = tempdir().expect("tempdir");
     let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
     let namespace_id = namespace(&runtime).await;
@@ -184,9 +177,13 @@ async fn rerunning_a_put_with_the_same_commit_id_replays_on_identical_bytes() {
     let rerun = runtime
         .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
         .await
-        .expect("rerunning identical bytes is idempotent");
+        .expect_err("a fresh upload is a different request");
 
-    assert_eq!(rerun, first);
+    assert_eq!(rerun.code(), ErrorCode::CommitIdReuseConflict);
+    assert_eq!(
+        rerun.details().expect("receipt").committed_seq,
+        Some(first.committed_seq)
+    );
     assert_eq!(
         runtime
             .reader
@@ -428,19 +425,28 @@ async fn same_length_different_bytes_conflict() {
 }
 
 #[tokio::test]
-async fn rerunning_a_put_with_the_same_message_replays_on_identical_bytes() {
+async fn prepared_content_replays_after_restart_with_the_same_message() {
     let temp_dir = tempdir().expect("tempdir");
     let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
     let namespace_id = namespace(&runtime).await;
     let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
     let options = || options_with_message(&commit_id, Some("import batch"));
 
+    let prepared = runtime
+        .writer
+        .prepare_file_stream(&namespace_id, streamed(b"stable bytes\n", 3))
+        .await
+        .expect("prepare content once");
     let first = runtime
-        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options())
+        .writer
+        .put_file_prepared(&namespace_id, PATH, prepared.clone(), options())
         .await
         .expect("first put");
+    drop(runtime);
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-b").await;
     let rerun = runtime
-        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options())
+        .writer
+        .put_file_prepared(&namespace_id, PATH, prepared.clone(), options())
         .await
         .expect("rerunning an identical request is idempotent");
 
@@ -634,7 +640,7 @@ async fn a_retention_trimmed_commit_seq_leaves_the_conflict_standing() {
     let error = runtime
         .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
         .await
-        .expect_err("evidence that cannot be read cannot reconcile to success");
+        .expect_err("fresh content must conflict while the receipt remains");
 
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
     assert_eq!(
@@ -716,9 +722,21 @@ async fn concurrent_retries_past_the_receipt_horizon_commit_once() {
     drop(runtime);
     let runtime = open_runtime_async(store(temp_dir.path()), "writer-b").await;
 
+    let prepared = runtime
+        .writer
+        .prepare_file_bytes(&namespace_id, b"stable bytes\n")
+        .await
+        .expect("prepare the new attempt once");
     let (left, right) = tokio::join!(
-        runtime.put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id)),
-        runtime.put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id)),
+        runtime.writer.put_file_prepared(
+            &namespace_id,
+            PATH,
+            prepared.clone(),
+            options(&commit_id)
+        ),
+        runtime
+            .writer
+            .put_file_prepared(&namespace_id, PATH, prepared, options(&commit_id)),
     );
     let left = left.expect("first late retry");
     let right = right.expect("second late retry");
@@ -770,7 +788,7 @@ async fn an_unused_commit_id_is_an_ordinary_commit() {
 }
 
 #[tokio::test]
-async fn rerunning_a_streamed_put_with_the_same_commit_id_replays_on_identical_bytes() {
+async fn reuploading_an_identical_stream_under_the_same_commit_id_conflicts() {
     let temp_dir = tempdir().expect("tempdir");
     let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
     let namespace_id = namespace(&runtime).await;
@@ -796,11 +814,12 @@ async fn rerunning_a_streamed_put_with_the_same_commit_id_replays_on_identical_b
             options(&commit_id),
         )
         .await
-        .expect("rerunning identical bytes is idempotent");
+        .expect_err("a fresh upload is a different request");
 
+    assert_eq!(rerun.code(), ErrorCode::CommitIdReuseConflict);
     assert_eq!(
-        rerun, first,
-        "the same bytes reconcile however the source chunked them"
+        rerun.details().expect("receipt").committed_seq,
+        Some(first.committed_seq)
     );
     assert_eq!(
         runtime
@@ -855,7 +874,7 @@ async fn different_streamed_bytes_under_a_used_commit_id_still_conflict() {
 }
 
 #[tokio::test]
-async fn a_streamed_rerun_reconciles_against_a_buffered_first_run() {
+async fn a_streamed_reupload_conflicts_with_a_buffered_first_run() {
     let temp_dir = tempdir().expect("tempdir");
     let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
     let namespace_id = namespace(&runtime).await;
@@ -875,7 +894,11 @@ async fn a_streamed_rerun_reconciles_against_a_buffered_first_run() {
             options(&commit_id),
         )
         .await
-        .expect("the same bytes, read differently, are the same commit");
+        .expect_err("a fresh upload is a different request");
 
-    assert_eq!(rerun, first);
+    assert_eq!(rerun.code(), ErrorCode::CommitIdReuseConflict);
+    assert_eq!(
+        rerun.details().expect("receipt").committed_seq,
+        Some(first.committed_seq)
+    );
 }

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -265,7 +265,7 @@ async fn imported_content_survives_collection_in_the_source_namespace() {
 }
 
 #[tokio::test]
-async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survives() {
+async fn a_conflicting_upload_is_reclaimed_and_the_published_content_survives() {
     let temp_dir = tempdir().expect("tempdir");
     let store = store(temp_dir.path());
     let runtime = open_runtime_async(store.clone(), "retrying-writer").await;
@@ -273,7 +273,7 @@ async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survi
     let options = || {
         let mut options = PutFileOptions::new(loonfs_test_support::test_actor());
         options.commit.commit_id =
-            Some(loonfs::CommitId::parse("cmt_reconciled").expect("valid commit id"));
+            Some(loonfs::CommitId::parse("cmt_original").expect("valid commit id"));
         options
     };
 
@@ -296,10 +296,11 @@ async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survi
         .writer
         .put_file_bytes(&namespace_id, "/docs/retry.txt", b"same bytes", options())
         .await
-        .expect("the rerun reconciles against what the commit id landed");
+        .expect_err("the fresh upload conflicts with the committed request");
     assert_eq!(
-        retry.committed_seq, first.committed_seq,
-        "the rerun reports the original commit, not a second one"
+        retry.details().expect("receipt").committed_seq,
+        Some(first.committed_seq),
+        "the conflict identifies the original commit"
     );
     assert_eq!(
         session_keys(&store, &namespace_id).await.len(),

--- a/docs/design/cli-upload-recovery.md
+++ b/docs/design/cli-upload-recovery.md
@@ -4,7 +4,10 @@ File-backed remote PUTs keep recovery records in `$XDG_STATE_HOME/loonfs/uploads
 or `$HOME/.local/state/loonfs/uploads`. The key includes the profile, server URL,
 namespace, remote path, canonical local path, and any explicit commit ID. Local
 path bytes are encoded without lossy Unicode conversion. Embedded uploads and
-standard-input streams do not use these records.
+standard-input streams do not use these records. Repeating those commands uploads
+new content and conflicts if the supplied commit ID already committed, even for
+identical bytes. The embedded Rust API supports retries through retained prepared
+content; the embedded CLI does not persist that proof across commands.
 
 Before opening an upload, the CLI saves the chosen commit ID, actor, message,
 overwrite guards, source length, and full-precision modification time. The record
@@ -22,8 +25,9 @@ through `create_commit`, without reopening the upload or reconciling new content
 against the earlier commit. Durable commit receipts can resolve a lost response
 even after the upload session has disappeared. If the request never committed and
 its proof expired, the server rejects it; recovery does not silently create a new
-attempt. Client calls without a journal still use the existing convenience retry
-reconciliation.
+attempt. Calls without a journal can retain prepared content and an explicit
+commit ID to retry publication. Repeating the upload creates a different request
+and returns a conflict if the ID already committed, even for identical bytes.
 
 Each update writes and syncs a private temporary file in the journal directory,
 then atomically replaces the record. Unix hosts also sync the directory after

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -588,64 +588,18 @@ Keep the `content_ref` a completed upload returned and reuse it across
 commit retries; that is the cheapest retry and the one the server can
 answer on its own.
 
-**Client-side retry reconciliation.** Rerunning a whole upload-then-commit
-sequence under one `commit_id` — the shape of a command rerun, where no
-`content_ref` survived the first attempt — is nonetheless safe when the
-request is identical. A client that composes upload and commit must, on
-`commit_id_reuse_conflict`, resolve it as follows before surfacing it.
+**Rust convenience calls.** Both the HTTP client and embedded runtime offer
+`prepare_file_bytes` / `prepare_file_stream`, followed by `put_file_prepared`.
+Retain the prepared content and use the same explicit commit ID, path, and
+options on each publication attempt. Preparation alone does not publish a file
+or extend the completed upload's lifetime.
 
-The proof is the commit's whole semantic identity, not a selection of its
-parts. The conflict reports `details.committed_fingerprint`, the fingerprint
-the server's receipt holds for what landed. The client recomputes the
-fingerprint its own retry would have had if the only difference were the
-fresh content object, and the two values must be equal. Comparing the whole
-value is what makes the check complete: a path, a `behavior`, an
-`expected_revision_no`, a `message`, or an operation count that differs is
-a different mutation, and every field a future request gains is covered the
-day it joins the preimage.
-
-1. Find what that `commit_id` committed. There is no read keyed by commit
-   id, but the error names where it landed: read the change feed once at
-   `details.committed_seq` — cursor `after_seq = committed_seq - 1`, limit 1
-   — and take the row whose `commit_id` matches. If `details.committed_seq`
-   or `details.committed_fingerprint` is absent, or the feed answers
-   `rebootstrap_required` because retention has moved past that sequence, or
-   the row there names some other commit, there is nothing to compare: go
-   straight to rule 5.
-2. Take the committed content reference from that row. The row must carry
-   exactly one content-bearing event — a `file_created` or a
-   `content_changed`. A single put produces exactly one, however many
-   parent directories it also had to create, because directory creations
-   carry no content ref. None, or more than one, means the commit was not
-   this put: go to rule 5.
-3. Recompute the fingerprint of the request just made, with that committed
-   `content_ref` substituted for the freshly uploaded one, and compare it
-   against `details.committed_fingerprint`. Any difference means the two
-   requests are not the same mutation: go to rule 5. The preimage is the
-   one defined in section 5.1, so annotations are compared exactly as the
-   server fingerprints them — an absent message and an empty one are
-   different commits, and a client must not fold both into "no message".
-4. Compare the uploaded bytes with the committed content reference's
-   `checksum`. If the client still has the bytes, it recomputes the required
-   checksum. If it streamed the bytes, it uses the checksum calculated during
-   that stream. The algorithms must match; the client must not compare or
-   convert different algorithms.
-
-   If both the fingerprint and checksum match, report the original commit and
-   its `committed_seq`.
-5. Otherwise, report failure. Preserve `commit_id_reuse_conflict` when the
-   fingerprints or content differ. Also fail when the original commit cannot
-   be found or the client cannot compute the required checksum. An incomplete
-   comparison is never treated as success.
-
-The duplicate content object the rerun uploaded is then referenced by
-nothing. That is by design: it is a completed upload whose content no
-metadata names, and content garbage collection reclaims it once its grace
-passes (format spec, "Garbage collection", rule 11).
-
-This reconciliation is a client obligation, not a server behaviour: the
-server's answer to a reused id with different content is always
-`commit_id_reuse_conflict`.
+Calling `put_file_bytes` or `put_file_stream` again uploads a new object; using
+an already-committed ID therefore returns `commit_id_reuse_conflict`, even for
+identical bytes. The unused upload can be reclaimed after its grace period.
+These helpers do not read the change feed or substitute an earlier content
+reference. To recover across processes, the remote CLI saves the full request
+before submission and resends it directly.
 
 Identical resubmission is the reconciliation mechanism. There is no separate
 commit-status lookup: after `commit_outcome_unknown`, a transport failure, or

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -589,12 +589,12 @@ commit retries; that is the cheapest retry and the one the server can
 answer on its own.
 
 **Rust convenience calls.** Both the HTTP client and embedded runtime offer
-`prepare_file_bytes` / `prepare_file_stream`, followed by `put_file_prepared`.
+`prepare_file_bytes()` / `prepare_file_stream()`, followed by `put_file_prepared()`.
 Retain the prepared content and use the same explicit commit ID, path, and
 options on each publication attempt. Preparation alone does not publish a file
 or extend the completed upload's lifetime.
 
-Calling `put_file_bytes` or `put_file_stream` again uploads a new object; using
+Calling `put_file_bytes()` or `put_file_stream()` again uploads a new object; using
 an already-committed ID therefore returns `commit_id_reuse_conflict`, even for
 identical bytes. The unused upload can be reclaimed after its grace period.
 These helpers do not read the change feed or substitute an earlier content


### PR DESCRIPTION
Fresh-upload reconciliation gave PUT a second identity rule and made retries depend on the change feed; both Rust interfaces now prepare content once and replay publication with the same explicit commit ID and options. Fresh uploads using an already-committed ID return a conflict, including embedded CLI reruns, while the remote CLI retains exact-request recovery from #869. This PR targets main after #869 merged and preserves durable receipt replay and existing storage and HTTP formats. Prior CI passed workspace tests, Clippy, formatting, all three SDK conformance suites, and the container build; the rebased combination with #871 exactly matches the checkout that passed 2,059 tests and unchanged OpenAPI generation.