### PR TITLE
fix(maintenance): probe debt with the configured policy

### DIFF
--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -162,9 +162,12 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let previous = segments.manifest();
 
     let delta_runs = delta_run_count(&previous.payload);
-    if compaction_policy != MetadataCompactionPolicy::CompactImmediately
-        && !manifest_has_reorganization_work(&previous.payload, segments.scan_runs.as_ref(), policy)
-    {
+    if !manifest_has_reorganization_work(
+        &previous.payload,
+        segments.scan_runs.as_ref(),
+        policy,
+        compaction_policy,
+    ) {
         return Ok(report(
             namespace_id,
             MetadataReorganizeOutcome::NotNeeded { delta_runs },
@@ -294,6 +297,7 @@ pub async fn metadata_maintenance_due<S: ObjectStore + ?Sized>(
     segment_cache: Option<&super::cache::MetadataSegmentCache>,
     namespace_id: &NamespaceId,
     max_wal_tail_segments: u64,
+    compaction_policy: MetadataCompactionPolicy,
 ) -> Result<bool> {
     let snapshot = load_control_snapshot(store, namespace_id)
         .await
@@ -327,6 +331,7 @@ pub async fn metadata_maintenance_due<S: ObjectStore + ?Sized>(
         &segments.manifest().payload,
         segments.scan_runs.as_ref(),
         MetadataLsmPolicy::default(),
+        compaction_policy,
     ))
 }
 
@@ -710,16 +715,18 @@ fn manifest_has_reorganization_work(
     payload: &NamespaceManifestPayload,
     runs: &[MetadataRunManifest],
     policy: MetadataLsmPolicy,
+    compaction_policy: MetadataCompactionPolicy,
 ) -> bool {
-    let has_group_rows = !ranked_family_groups(payload).is_empty();
-    let triggered = (delta_run_count(payload) >= policy.max_delta_runs.get() && has_group_rows)
+    let groups = ranked_family_groups(payload);
+    let triggered = compaction_policy == MetadataCompactionPolicy::CompactImmediately
+        || (delta_run_count(payload) >= policy.max_delta_runs.get() && !groups.is_empty())
         || manifest_has_partial_reorganization(runs);
     triggered
-        && REORGANIZE_FAMILY_GROUPS.into_iter().any(|group| {
+        && groups.into_iter().any(|group| {
             select_merge_window(
                 &group_candidates(runs, group),
                 group,
-                MetadataCompactionPolicy::SizeTiered,
+                compaction_policy,
                 policy.small_run_bytes.get() as u64,
             )
             .is_some()

--- a/crates/loonfs-server/tests/it/http_snapshots.rs
+++ b/crates/loonfs-server/tests/it/http_snapshots.rs
@@ -323,7 +323,7 @@ async fn http_snapshots_keep_owner_operations_and_listings_separate() {
         .create_namespace(&namespace)
         .await
         .expect("create namespace");
-    let snapshot = create_snapshot(&harness.server_url, namespace.as_str(), "brief", 500)
+    let snapshot = create_snapshot(&harness.server_url, namespace.as_str(), "brief", 60_000)
         .expect("create snapshot");
     let checkpoint = harness
         .client

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -296,17 +296,24 @@ impl FsMaintenance {
         Ok(response)
     }
 
-    /// Whether the WAL tail or metadata manifest has bounded work waiting.
-    pub async fn metadata_probe(&self, namespace_id: &NamespaceId) -> Result<MaintenanceProbe> {
-        let threshold = MetadataMaintenanceOptions::default()
-            .max_wal_tail_segments
-            .get();
+    /// Whether the WAL tail or metadata manifest has work under these options.
+    ///
+    /// Use the same options as [`Self::maintain_metadata`] so recovery probes
+    /// and scheduled steps agree on when work is due. Active leases may still
+    /// prevent an eligible merge from running until their expiry.
+    pub async fn metadata_probe(
+        &self,
+        namespace_id: &NamespaceId,
+        options: &MetadataMaintenanceOptions,
+    ) -> Result<MaintenanceProbe> {
+        let threshold = options.max_wal_tail_segments.get();
         let cache = self.core.metadata_segment_cache();
         loonfs_core::cache::metadata_maintenance_due(
             self.core.store(),
             Some(cache.as_ref()),
             namespace_id,
             threshold,
+            options.compaction_policy,
         )
         .await
         .map(|due| {

--- a/crates/loonfs/src/maintenance/metadata.rs
+++ b/crates/loonfs/src/maintenance/metadata.rs
@@ -65,7 +65,11 @@ impl MaintenanceJob for MetadataMaintenanceJob {
     }
 
     async fn probe(&self, namespace_id: &NamespaceId) -> Result<MaintenanceProbe> {
-        match self.maintenance.metadata_probe(namespace_id).await {
+        match self
+            .maintenance
+            .metadata_probe(namespace_id, &self.options)
+            .await
+        {
             Ok(probe) => Ok(probe),
             Err(error) if metadata_has_nothing_to_maintain(&error) => Ok(MaintenanceProbe::Idle),
             Err(error) => Err(error),

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -802,3 +802,119 @@ async fn fork_recovers_an_ambiguously_landed_checkpoint_renewal() {
         .expect("fork checkpoint remains installed");
     assert_eq!(fork_checkpoint.namespace_id, source);
 }
+
+#[tokio::test]
+async fn a_cold_metadata_job_probes_with_its_configured_options() {
+    use loonfs::{
+        MaintenanceCancellation, MaintenanceJob, MaintenanceProbe, MetadataMaintenanceJob,
+    };
+    use loonfs::{MetadataCompactionPolicy, MetadataMaintenanceOptions};
+    use std::num::NonZeroU64;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace = namespace_id("probe-options");
+    runtime
+        .create_namespace(&namespace, CreateNamespaceOptions::default())
+        .await
+        .expect("namespace");
+    runtime
+        .put_file_bytes(
+            &namespace,
+            "/one.txt",
+            b"one",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("write one WAL segment");
+    drop(runtime);
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-b").await;
+    let defaults = MetadataMaintenanceJob::new(runtime.maintenance.clone());
+    let eager_flush = MetadataMaintenanceJob::new(runtime.maintenance.clone()).options(
+        MetadataMaintenanceOptions {
+            max_wal_tail_segments: NonZeroU64::MIN,
+            ..MetadataMaintenanceOptions::default()
+        },
+    );
+    assert_eq!(
+        defaults.probe(&namespace).await.expect("default probe"),
+        MaintenanceProbe::Idle
+    );
+    assert_eq!(
+        eager_flush.probe(&namespace).await.expect("custom probe"),
+        MaintenanceProbe::Due
+    );
+    runtime
+        .create_checkpoint(&namespace)
+        .await
+        .expect("flush the first run");
+    runtime
+        .put_file_bytes(
+            &namespace,
+            "/two.txt",
+            b"two",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("write another segment");
+    runtime
+        .create_checkpoint(&namespace)
+        .await
+        .expect("flush a delta below the default trigger");
+    drop(runtime);
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-c").await;
+    let defaults = MetadataMaintenanceJob::new(runtime.maintenance.clone());
+    let immediate = MetadataMaintenanceJob::new(runtime.maintenance.clone()).options(
+        MetadataMaintenanceOptions {
+            compaction_policy: MetadataCompactionPolicy::CompactImmediately,
+            ..MetadataMaintenanceOptions::default()
+        },
+    );
+    assert_eq!(
+        defaults
+            .probe(&namespace)
+            .await
+            .expect("default merge probe"),
+        MaintenanceProbe::Idle
+    );
+    assert_eq!(
+        immediate
+            .probe(&namespace)
+            .await
+            .expect("immediate merge probe"),
+        MaintenanceProbe::Due
+    );
+    for _ in 0..16 {
+        immediate
+            .run(&namespace, None, &MaintenanceCancellation::new())
+            .await
+            .expect("run configured maintenance");
+        if immediate
+            .probe(&namespace)
+            .await
+            .expect("probe after progress")
+            == MaintenanceProbe::Idle
+        {
+            assert_eq!(
+                runtime
+                    .reader
+                    .get_file_bytes(&namespace, "/one.txt")
+                    .await
+                    .expect("first file")
+                    .bytes,
+                b"one"
+            );
+            assert_eq!(
+                runtime
+                    .reader
+                    .get_file_bytes(&namespace, "/two.txt")
+                    .await
+                    .expect("second file")
+                    .bytes,
+                b"two"
+            );
+            return;
+        }
+    }
+    panic!("configured maintenance must finish its finite work");
+}

--- a/docs/design/maintenance-hosting.md
+++ b/docs/design/maintenance-hosting.md
@@ -1,0 +1,33 @@
+# Maintenance hosting and recovery
+
+The hosting layer assigns namespace/job pairs explicitly. On startup and at a
+regular interval, it nudges every assigned pair. The embedded CLI host does this
+immediately and every 60 seconds by default. A replacement host repeats that
+assignment from its own configuration; it does not need the old process's hints
+or runner state. Writer namespace assignment and handoff remain separate from
+maintenance scheduling.
+
+A nudge is a scheduling hint. The runner coalesces hints, limits concurrency,
+retries failures with backoff, and probes admitted keys periodically. Idle keys
+can leave the admitted set. Those probes do not enumerate namespaces or replace
+the hosting layer's assignment loop. GC and compaction jobs have no cheap
+standalone debt probe, so periodic assignment runs them to inspect durable state.
+
+Metadata probes inspect the WAL and manifest descriptors using the same WAL
+threshold and compaction policy as the job's execution. A probe can report work
+while a lease still prevents that work from running. The next assigned pass
+checks the lease again; a remembered deadline is not required for correctness or
+recovery.
+
+After a compaction worker stops, its incomplete output remains unpublished.
+Once its lease expires, maintenance plans a fresh job from the current manifest.
+It repeats the abandoned work rather than resuming partial segments. GC removes
+unreferenced staged output under its lease-claim rules. Successful jobs also
+retain their lease until expiry to protect published output from older GC scans.
+This protection can delay the next compaction window for the same family group.
+
+GC cursors currently resume candidate enumeration only. Every invocation rebuilds
+reachability, so a budget too small to finish that work can still prevent
+progress. Periodic assignment and restart recovery do not solve resumable marking.
+A safe marking continuation needs a protocol for protecting its basis while new
+checkpoints, forks, and manifests are published.

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -211,8 +211,8 @@ The implementation is validated with the following tests:
 - Leave the final lease after publication and verify that an older collection pass cannot remove the published output.
 - Reclaim staged output after a lease expires, is already marked `reaping`, or is missing.
 - Reject malformed leases and leases whose namespace or group disagrees with their key.
-- Exercise continuous delta creation and verify that metadata maintenance requests full compaction after two published delta merges.
-- Verify that explicit compaction selects full compaction immediately for a frozen base.
+- Exercise continuous delta creation and verify that size-based selection eventually merges an eligible base within the eight-run fan-in limit.
+- Verify that explicit compaction bypasses the size ratio and automatic trigger while preserving the fan-in limit.
 - Process large attribute histories and heavily reused binding slots while holding at most one row in retention state.
 - Reject canonical-family and secondary-index mismatches before publication.
 - Reject a metadata family whose merge input repeats a row key.
@@ -222,4 +222,4 @@ The implementation is validated with the following tests:
 
 Durable resume may be added later if measured restart cost justifies the additional state. Resume state would be owned by the compactor and would record completed segment boundaries without changing the reader-visible namespace manifest. The job lease is not resume state and never records progress.
 
-Support for multiple concurrent compactions in one namespace remains deferred. The process-wide concurrency limit is fixed at two rather than exposed as configuration.
+The built-in job defaults to two concurrent compactions per process; `MetadataCompactionJob::max_concurrent` sets another limit. Each family group has its own durable lease. A completed job retains that lease until expiry to protect its published output from an older GC scan, so another window for that group may wait.


### PR DESCRIPTION
Metadata recovery probes used defaults even when their job had a different WAL threshold or compaction policy, so quiet namespaces could be marked idle with eligible work remaining. Probes now use the job's options and the planner's group selection; a restart regression verifies custom thresholds and immediate compaction through completion. Rust callers pass probe options explicitly, and the hosting documentation explains periodic namespace assignment and lease-expiry recovery while retaining completed-output protection. Workspace tests, Clippy, formatting, all three SDK conformance suites, and the container build pass in CI; the combined checkout with #869 and #870 passes 2,059 tests and unchanged OpenAPI generation.