### PR TITLE
refactor(storage): derive immutable envelopes in one encoding

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -978,39 +978,8 @@ impl<'de> Deserialize<'de> for UploadSessionState {
     }
 }
 
-/// In-memory view of a control object envelope.
-///
-/// This struct is not the durable layout; durable bytes are produced only by
-/// [`encode_control_object`] and validated only by [`decode_control_object`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ControlObjectEnvelope<T> {
-    /// Durable-family discriminator that selects `T` and its independent version.
-    pub kind: ControlObjectKind,
-    /// Family-local format version obtained from `kind`.
-    pub format_version: u32,
-    /// Digest of the payload JSON exactly as stored in the durable document,
-    /// in `sha256:<hex>` form.
-    pub payload_checksum: String,
-    /// Decoded control state protected by `payload_checksum`.
-    pub state: T,
-}
-
-impl<T> ControlObjectEnvelope<T>
-where
-    T: Serialize,
-{
-    /// Builds a family-versioned envelope and computes its checksum from canonical state JSON.
-    ///
-    /// Construction fails when `state` cannot be encoded.
-    pub fn from_state(kind: ControlObjectKind, state: T) -> Result<Self, EnvelopeCodecError> {
-        Ok(Self {
-            kind,
-            format_version: kind.format_version(),
-            payload_checksum: control_payload_checksum(&state)?,
-            state,
-        })
-    }
-}
+/// Control state decoded through its checked durable codec.
+pub type ControlObjectEnvelope<T> = crate::envelope::VerifiedEnvelope<T>;
 
 /// Specializes a control envelope for the authoritative namespace head.
 pub type HeadStateEnvelope = ControlObjectEnvelope<HeadState>;
@@ -1026,43 +995,13 @@ pub type CheckpointRecordEnvelope = ControlObjectEnvelope<CheckpointRecordState>
 /// its staged output.
 pub type MetadataCompactionLeaseEnvelope = ControlObjectEnvelope<MetadataCompactionLeaseState>;
 
-/// Computes the checksum stored beside canonical JSON for a control state.
-///
-/// Computation fails when `state` cannot be serialized.
-pub fn control_payload_checksum<T>(state: &T) -> Result<String, EnvelopeCodecError>
-where
-    T: Serialize,
-{
-    crate::envelope::json_payload_checksum(state)
-}
-
-/// Encodes a control-object envelope as its durable JSON representation.
-///
-/// Encoding fails when the family version is unsupported, the in-memory
-/// checksum is stale, or JSON serialization fails. See
-/// [mutable control-object rules](../../../docs/specs/format.md#17-mutable-control-object-rules).
-pub fn encode_control_object<T>(
-    envelope: &ControlObjectEnvelope<T>,
-) -> Result<Vec<u8>, EnvelopeCodecError>
-where
-    T: Serialize,
-{
-    crate::envelope::encode_json_envelope(
-        envelope.kind.as_str(),
-        envelope.format_version,
-        envelope.kind.format_version(),
-        &envelope.payload_checksum,
-        &envelope.state,
-    )
-}
-
-/// Encodes state in a control-object envelope.
+/// Encodes control state once, deriving its checksum and family version.
 pub fn encode_control_state<T: Serialize>(
     kind: ControlObjectKind,
     state: &T,
 ) -> Result<Vec<u8>, EnvelopeCodecError> {
-    let envelope = ControlObjectEnvelope::from_state(kind, state)?;
-    encode_control_object(&envelope)
+    crate::envelope::encode_json_envelope(kind.as_str(), kind.format_version(), state)
+        .map(crate::envelope::EncodedEnvelope::into_bytes)
 }
 
 /// Decodes and verifies a durable JSON control object of `expected_kind`.
@@ -1094,12 +1033,7 @@ where
         },
     )?;
 
-    Ok(ControlObjectEnvelope {
-        kind: expected_kind,
-        format_version: decoded.format_version,
-        payload_checksum: decoded.payload_checksum,
-        state: decoded.payload,
-    })
+    Ok(decoded)
 }
 
 #[cfg(test)]
@@ -1291,13 +1225,12 @@ mod tests {
 
     #[test]
     fn control_object_codec_round_trips_and_validates() {
-        let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, sample_head())
-            .expect("envelope");
+        let state = sample_head();
 
-        let encoded = encode_control_object(&envelope).expect("encode");
+        let encoded = encode_control_state(ControlObjectKind::WalHead, &state).expect("encode");
         let decoded: HeadStateEnvelope =
             decode_control_object(&encoded, ControlObjectKind::WalHead).expect("decode");
-        assert_eq!(decoded, envelope);
+        assert_eq!(decoded.into_payload(), state);
 
         let mismatch =
             decode_control_object::<MetadataRootState>(&encoded, ControlObjectKind::MetadataRoot)

--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -84,17 +84,6 @@ pub enum EnvelopeCodecError {
         /// Digest recomputed over the exact stored payload bytes.
         actual: String,
     },
-    /// Reports an in-memory payload changed without rebuilding its envelope checksum.
-    #[error(
-        "envelope checksum `{checksum}` does not match its payload `{actual}`: \
-         rebuild the envelope from its payload"
-    )]
-    StalePayloadChecksum {
-        /// Digest retained by the stale in-memory envelope.
-        checksum: String,
-        /// Digest recomputed from the payload about to be encoded.
-        actual: String,
-    },
 }
 
 /// Requires the probed kind to be exactly `expected`.
@@ -136,23 +125,6 @@ pub fn verify_payload_checksum(
     Ok(())
 }
 
-/// Requires an in-memory envelope's recorded checksum to still match its
-/// payload before encoding — a stale checksum means the caller mutated the
-/// payload without rebuilding the envelope.
-pub fn verify_checksum_fresh(
-    checksum: &str,
-    payload_bytes: &[u8],
-) -> Result<(), EnvelopeCodecError> {
-    let actual = sha256_digest(payload_bytes);
-    if actual != checksum {
-        return Err(EnvelopeCodecError::StalePayloadChecksum {
-            checksum: checksum.to_owned(),
-            actual,
-        });
-    }
-    Ok(())
-}
-
 /// Durable layout of a JSON-bodied envelope: the shared fields plus the
 /// payload as a raw JSON fragment, kept inline so the object remains
 /// directly readable JSON while `payload_checksum` covers the exact
@@ -166,46 +138,91 @@ struct JsonEnvelopeDocument {
     payload: Box<RawValue>,
 }
 
-/// The `sha256:<hex>` checksum a JSON payload will carry, computed over its
-/// canonical serialization.
-pub fn json_payload_checksum<T: Serialize>(payload: &T) -> Result<String, EnvelopeCodecError> {
-    let bytes = serde_json::to_vec(payload)
-        .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?;
-    Ok(sha256_digest(&bytes))
+/// An envelope whose framing was verified on read or derived on write.
+///
+/// Payload access is read-only: changing a payload requires a new encoding.
+/// Family codecs apply their own kind, version, and payload validation rules.
+/// Kind and version are checked at the codec boundary, not retained as caller state.
+/// This type has no serde decoder; durable reads must use a checked codec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedEnvelope<T> {
+    pub(crate) payload_checksum: String,
+    pub(crate) payload: T,
 }
 
-/// Encodes one JSON-bodied envelope, validating that the recorded version is
-/// what this build writes for `kind` and that the recorded checksum still
-/// matches the payload.
+impl<T> VerifiedEnvelope<T> {
+    /// Checksum of the exact stored payload bytes.
+    pub fn payload_checksum(&self) -> &str {
+        &self.payload_checksum
+    }
+    /// Payload protected by this framing. Clone it to prepare a changed successor.
+    pub fn payload(&self) -> &T {
+        &self.payload
+    }
+    /// Takes the payload out of its verified framing for reuse or modification.
+    pub fn into_payload(self) -> T {
+        self.payload
+    }
+}
+
+/// One encoding and the envelope derived from those exact bytes.
+///
+/// Only codecs construct this pair. Neither half can be changed in place.
+/// Readers retain just [`VerifiedEnvelope`], without a second copy of the bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodedEnvelope<T> {
+    pub(crate) envelope: VerifiedEnvelope<T>,
+    pub(crate) bytes: Vec<u8>,
+}
+
+impl<T> EncodedEnvelope<T> {
+    /// Envelope derived while encoding, without decoding or serializing again.
+    pub fn envelope(&self) -> &VerifiedEnvelope<T> {
+        &self.envelope
+    }
+    /// Complete durable document, ready to write.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+    /// Takes the complete durable document.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+    /// Discards the encoding and retains its verified envelope.
+    pub fn into_envelope(self) -> VerifiedEnvelope<T> {
+        self.envelope
+    }
+    /// Separates the immutable envelope and its bytes for storage publication.
+    pub fn into_parts(self) -> (VerifiedEnvelope<T>, Vec<u8>) {
+        (self.envelope, self.bytes)
+    }
+}
+
+/// Serializes the payload once and derives framing from those same bytes.
 pub fn encode_json_envelope<T: Serialize>(
     kind: &str,
     format_version: u32,
-    supported_version: u32,
-    payload_checksum: &str,
-    payload: &T,
-) -> Result<Vec<u8>, EnvelopeCodecError> {
-    verify_version(kind, format_version, supported_version)?;
-    let payload_json = serde_json::to_string(payload)
+    payload: T,
+) -> Result<EncodedEnvelope<T>, EnvelopeCodecError> {
+    let payload_json = serde_json::to_string(&payload)
         .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?;
-    verify_checksum_fresh(payload_checksum, payload_json.as_bytes())?;
+    let payload_checksum = sha256_digest(payload_json.as_bytes());
     let document = JsonEnvelopeDocument {
         kind: kind.to_owned(),
         format_version,
-        payload_checksum: payload_checksum.to_owned(),
+        payload_checksum: payload_checksum.clone(),
         payload: RawValue::from_string(payload_json)
             .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?,
     };
-    serde_json::to_vec(&document).map_err(|err| EnvelopeCodecError::EnvelopeEncode(err.to_string()))
-}
-
-/// A decoded JSON-bodied envelope's shared fields plus its parsed payload.
-pub struct DecodedJsonEnvelope<T> {
-    /// Version gate the stored object declared and this build accepted.
-    pub format_version: u32,
-    /// Digest verified against the payload fragment exactly as stored.
-    pub payload_checksum: String,
-    /// The family payload decoded from that verified fragment.
-    pub payload: T,
+    let bytes = serde_json::to_vec(&document)
+        .map_err(|err| EnvelopeCodecError::EnvelopeEncode(err.to_string()))?;
+    Ok(EncodedEnvelope {
+        envelope: VerifiedEnvelope {
+            payload_checksum,
+            payload,
+        },
+        bytes,
+    })
 }
 
 /// Decodes one JSON-bodied envelope, then checks its kind, version, checksum,
@@ -218,7 +235,7 @@ pub fn decode_json_envelope<T: DeserializeOwned>(
     bytes: &[u8],
     supported_version: u32,
     classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
-) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+) -> Result<VerifiedEnvelope<T>, EnvelopeCodecError> {
     let probe: EnvelopeProbe = serde_json::from_slice(bytes)
         .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
     classify_kind(&probe.kind)?;
@@ -230,7 +247,7 @@ pub fn decode_json_envelope<T: DeserializeOwned>(
 
 fn decode_json_envelope_payload<T: DeserializeOwned>(
     document: JsonEnvelopeDocument,
-) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+) -> Result<VerifiedEnvelope<T>, EnvelopeCodecError> {
     verify_payload_checksum(
         &document.payload_checksum,
         document.payload.get().as_bytes(),
@@ -238,9 +255,56 @@ fn decode_json_envelope_payload<T: DeserializeOwned>(
     let payload: T = serde_json::from_str(document.payload.get())
         .map_err(|err| EnvelopeCodecError::PayloadDecode(err.to_string()))?;
 
-    Ok(DecodedJsonEnvelope {
-        format_version: document.format_version,
+    Ok(VerifiedEnvelope {
         payload_checksum: document.payload_checksum,
         payload,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn encoding_serializes_the_payload_once_and_checksums_those_bytes() {
+        struct CountedPayload<'a>(&'a Cell<usize>);
+        impl Serialize for CountedPayload<'_> {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                self.0.set(self.0.get() + 1);
+                serializer.serialize_u64(42)
+            }
+        }
+        let calls = Cell::new(0);
+        let encoded = encode_json_envelope("test", 1, CountedPayload(&calls)).expect("encode");
+        let document: JsonEnvelopeDocument =
+            serde_json::from_slice(encoded.as_bytes()).expect("document");
+        assert_eq!(calls.get(), 1);
+        assert_eq!(document.payload.get(), "42");
+        assert_eq!(encoded.envelope().payload_checksum(), sha256_digest(b"42"));
+        assert_eq!(
+            document.payload_checksum,
+            encoded.envelope().payload_checksum()
+        );
+    }
+
+    #[test]
+    fn decoding_checks_the_stored_payload_including_noncanonical_whitespace() {
+        let payload = r#"{ "value" : 42 }"#;
+        let checksum = sha256_digest(payload.as_bytes());
+        let bytes = format!(
+            r#"{{"kind":"test","format_version":1,"payload_checksum":"{checksum}","payload":{payload}}}"#
+        );
+        let decoded: VerifiedEnvelope<serde_json::Value> =
+            decode_json_envelope(bytes.as_bytes(), 1, |kind| verify_kind("test", kind))
+                .expect("decode exact stored bytes");
+        assert_eq!(decoded.payload_checksum(), checksum);
+        let successor =
+            encode_json_envelope("test", 1, decoded.into_payload()).expect("canonical encoding");
+        assert_ne!(successor.envelope().payload_checksum(), checksum);
+        let reread: VerifiedEnvelope<serde_json::Value> =
+            decode_json_envelope(successor.as_bytes(), 1, |kind| verify_kind("test", kind))
+                .expect("decode canonical bytes");
+        assert_eq!(&reread, successor.envelope());
+    }
 }

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -939,59 +939,17 @@ pub struct NamespaceManifestPayload {
     pub runs: Vec<MetadataRunRef>,
 }
 
-/// In-memory view of a namespace manifest envelope.
-///
-/// This struct is not the durable layout; durable bytes are produced only by
-/// [`encode_namespace_manifest_json`] and validated only by
-/// [`decode_namespace_manifest_json`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct NamespaceManifestEnvelope {
-    /// Durable-family discriminator checked before payload decoding.
-    pub kind: NamespaceManifestKind,
-    /// Family-local format version, which must equal [`NAMESPACE_MANIFEST_FORMAT_VERSION`].
-    pub format_version: u32,
-    /// Digest of the payload JSON exactly as stored in the durable document,
-    /// in `sha256:<hex>` form.
-    pub payload_checksum: String,
-    /// Decoded file-set description protected by `payload_checksum`.
-    pub payload: NamespaceManifestPayload,
-}
+/// A manifest decoded through its checked durable codec.
+pub type NamespaceManifestEnvelope = crate::envelope::VerifiedEnvelope<NamespaceManifestPayload>;
 
-impl NamespaceManifestEnvelope {
-    /// Builds a versioned envelope and computes its checksum from canonical payload JSON.
-    ///
-    /// Construction fails when the payload cannot be encoded.
-    pub fn from_payload(payload: NamespaceManifestPayload) -> Result<Self, EnvelopeCodecError> {
-        Ok(Self {
-            kind: NamespaceManifestKind::NamespaceManifest,
-            format_version: NAMESPACE_MANIFEST_FORMAT_VERSION,
-            payload_checksum: namespace_manifest_payload_checksum(&payload)?,
-            payload,
-        })
-    }
-}
-
-fn namespace_manifest_payload_checksum(
-    payload: &NamespaceManifestPayload,
-) -> Result<String, EnvelopeCodecError> {
-    crate::envelope::json_payload_checksum(payload)
-}
-
-/// Encodes a namespace-manifest envelope as its durable JSON representation.
-///
-/// Encoding fails when the version is unsupported, the in-memory checksum is
-/// stale, or JSON serialization fails. See
-/// [manifest publication](../../../docs/specs/format.md#61-manifest-publication-and-checkpoint-verification).
+/// Encodes a manifest once and returns its immutable framing and durable bytes.
 pub fn encode_namespace_manifest_json(
-    envelope: &NamespaceManifestEnvelope,
-) -> Result<Vec<u8>, EnvelopeCodecError> {
+    payload: NamespaceManifestPayload,
+) -> Result<crate::envelope::EncodedEnvelope<NamespaceManifestPayload>, EnvelopeCodecError> {
     crate::envelope::encode_json_envelope(
-        envelope.kind.as_str(),
-        envelope.format_version,
+        NamespaceManifestKind::NamespaceManifest.as_str(),
         NAMESPACE_MANIFEST_FORMAT_VERSION,
-        &envelope.payload_checksum,
-        &envelope.payload,
+        payload,
     )
 }
 
@@ -1009,20 +967,14 @@ pub fn decode_namespace_manifest_json(
             crate::envelope::verify_kind(expected_kind.as_str(), found)
         })?;
 
-    Ok(NamespaceManifestEnvelope {
-        kind: expected_kind,
-        format_version: decoded.format_version,
-        payload_checksum: decoded.payload_checksum,
-        payload: decoded.payload,
-    })
+    Ok(decoded)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         decode_namespace_manifest_json, encode_namespace_manifest_json, BlockHandle,
-        MetadataRowFamily, MetadataRunRef, MetadataSegmentRef, NamespaceManifestEnvelope,
-        NamespaceManifestPayload, RunTier,
+        MetadataRowFamily, MetadataRunRef, MetadataSegmentRef, NamespaceManifestPayload, RunTier,
     };
     use crate::{
         ChangeSeq, CommitId, InodeId, ManifestNo, ManifestObjectId, MetadataCompactionId,
@@ -1082,7 +1034,7 @@ mod tests {
 
     #[test]
     fn namespace_manifest_codec_round_trips_base_only_materialization() {
-        let envelope = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+        let (envelope, encoded) = encode_namespace_manifest_json(NamespaceManifestPayload {
             namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
             manifest_no: ManifestNo(10),
             manifest_object_id: ManifestObjectId::parse(
@@ -1105,9 +1057,8 @@ mod tests {
                 RunTier::Base,
             )],
         })
-        .expect("manifest");
-
-        let encoded = encode_namespace_manifest_json(&envelope).expect("encode manifest");
+        .expect("manifest")
+        .into_parts();
         let document: serde_json::Value =
             serde_json::from_slice(&encoded).expect("decode manifest document");
         assert!(document["payload"]
@@ -1123,7 +1074,7 @@ mod tests {
 
     #[test]
     fn namespace_manifest_codec_round_trips_inherited_source_segments() {
-        let envelope = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+        let (envelope, encoded) = encode_namespace_manifest_json(NamespaceManifestPayload {
             namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
             manifest_no: ManifestNo(12),
             manifest_object_id: ManifestObjectId::parse(
@@ -1155,9 +1106,8 @@ mod tests {
                 ),
             ],
         })
-        .expect("manifest");
-
-        let encoded = encode_namespace_manifest_json(&envelope).expect("encode manifest");
+        .expect("manifest")
+        .into_parts();
         let decoded = decode_namespace_manifest_json(&encoded).expect("decode manifest");
 
         assert_eq!(decoded, envelope);
@@ -1177,7 +1127,7 @@ mod tests {
         let mut staged = metadata_segment_ref("demo", "seg_00000000000000000000000000000001");
         staged.compaction_job_id = Some(compaction_job_id.clone());
         let flushed = metadata_segment_ref("demo", "seg_00000000000000000000000000000002");
-        let envelope = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+        let (envelope, encoded) = encode_namespace_manifest_json(NamespaceManifestPayload {
             namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
             manifest_no: ManifestNo(14),
             manifest_object_id: ManifestObjectId::parse(
@@ -1207,9 +1157,8 @@ mod tests {
                 },
             ],
         })
-        .expect("manifest");
-
-        let encoded = encode_namespace_manifest_json(&envelope).expect("encode manifest");
+        .expect("manifest")
+        .into_parts();
         let decoded = decode_namespace_manifest_json(&encoded).expect("decode manifest");
 
         assert_eq!(decoded, envelope);

--- a/crates/loonfs-api/src/wal.rs
+++ b/crates/loonfs-api/src/wal.rs
@@ -198,38 +198,10 @@ pub struct WalSegmentPayload {
     pub records: Vec<WalCommitPayload>,
 }
 
-/// In-memory view of a WAL segment envelope.
-///
-/// This struct is not the durable layout; durable bytes are produced only by
-/// [`encode_wal_segment_envelope_zstd`] and validated only by
-/// [`decode_wal_segment_envelope_zstd`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct WalSegmentEnvelope {
-    /// Durable-family discriminator checked before payload decoding.
-    pub kind: WalEnvelopeKind,
-    /// Family-local format version, which must equal [`WAL_FORMAT_VERSION`].
-    pub format_version: u32,
-    /// Digest of the encoded payload bytes exactly as stored in the durable
-    /// document, in `sha256:<hex>` form.
-    pub payload_checksum: String,
-    /// Decoded namespace segment content protected by `payload_checksum`.
-    pub payload: WalSegmentPayload,
-}
+/// A WAL segment decoded through its checked durable codec.
+pub type WalSegmentEnvelope = crate::envelope::VerifiedEnvelope<WalSegmentPayload>;
 
 impl WalSegmentEnvelope {
-    /// Builds a versioned envelope and computes its checksum from canonical CBOR payload bytes.
-    ///
-    /// Construction fails when the payload cannot be encoded.
-    pub fn from_payload(payload: WalSegmentPayload) -> Result<Self, EnvelopeCodecError> {
-        Ok(Self {
-            kind: WalEnvelopeKind::NamespaceWalSegment,
-            format_version: WAL_FORMAT_VERSION,
-            payload_checksum: wal_payload_checksum(&payload)?,
-            payload,
-        })
-    }
-
     /// Projects the identity, integrity, and sequence metadata needed to link this segment.
     pub fn pointer(&self) -> WalSegmentPointer {
         WalSegmentPointer {
@@ -256,12 +228,6 @@ struct WalSegmentDocument {
     payload: Vec<u8>,
 }
 
-pub(crate) fn wal_payload_checksum(
-    payload: &WalSegmentPayload,
-) -> Result<String, EnvelopeCodecError> {
-    Ok(sha256_digest(&encode_wal_payload_cbor(payload)?))
-}
-
 pub(crate) fn encode_wal_payload_cbor(
     payload: &WalSegmentPayload,
 ) -> Result<Vec<u8>, EnvelopeCodecError> {
@@ -271,33 +237,30 @@ pub(crate) fn encode_wal_payload_cbor(
     Ok(encoded)
 }
 
-/// Encodes a WAL envelope as its durable zstd-compressed CBOR representation.
-///
-/// Encoding fails when the version is unsupported, the in-memory checksum is
-/// stale, CBOR serialization fails, or zstd cannot compress the document. See
-/// [WAL segment rules](../../../docs/specs/format.md#15-wal-segment-rules).
+/// Encodes a WAL payload once, then checksums and compresses its durable document.
 pub fn encode_wal_segment_envelope_zstd(
-    envelope: &WalSegmentEnvelope,
-) -> Result<Vec<u8>, EnvelopeCodecError> {
-    envelope::verify_version(
-        envelope.kind.as_str(),
-        envelope.format_version,
-        WAL_FORMAT_VERSION,
-    )?;
-    let payload_bytes = encode_wal_payload_cbor(&envelope.payload)?;
-    envelope::verify_checksum_fresh(&envelope.payload_checksum, &payload_bytes)?;
-
+    payload: WalSegmentPayload,
+) -> Result<crate::envelope::EncodedEnvelope<WalSegmentPayload>, EnvelopeCodecError> {
+    let payload_bytes = encode_wal_payload_cbor(&payload)?;
+    let payload_checksum = sha256_digest(&payload_bytes);
     let document = WalSegmentDocument {
-        kind: envelope.kind.as_str().to_owned(),
-        format_version: envelope.format_version,
-        payload_checksum: envelope.payload_checksum.clone(),
+        kind: WalEnvelopeKind::NamespaceWalSegment.as_str().to_owned(),
+        format_version: WAL_FORMAT_VERSION,
+        payload_checksum: payload_checksum.clone(),
         payload: payload_bytes,
     };
     let mut encoded = Vec::new();
     into_writer(&document, &mut encoded)
         .map_err(|err| EnvelopeCodecError::EnvelopeEncode(err.to_string()))?;
-    zstd::stream::encode_all(encoded.as_slice(), crate::sst_blocks::ZSTD_LEVEL)
-        .map_err(|err| EnvelopeCodecError::Compress(err.to_string()))
+    let bytes = zstd::stream::encode_all(encoded.as_slice(), crate::sst_blocks::ZSTD_LEVEL)
+        .map_err(|err| EnvelopeCodecError::Compress(err.to_string()))?;
+    Ok(crate::envelope::EncodedEnvelope {
+        envelope: crate::envelope::VerifiedEnvelope {
+            payload_checksum,
+            payload,
+        },
+        bytes,
+    })
 }
 
 /// Decodes and verifies a durable zstd-compressed WAL segment envelope.
@@ -326,8 +289,6 @@ pub fn decode_wal_segment_envelope_zstd(
         .map_err(EnvelopeCodecError::PayloadDecode)?;
 
     Ok(WalSegmentEnvelope {
-        kind: expected_kind,
-        format_version: document.format_version,
         payload_checksum: document.payload_checksum,
         payload,
     })

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -19,22 +19,21 @@
 //!   decoding could erase a field introduced by an unsupported writer.
 
 use loonfs_api::wire::control::{
-    decode_control_object, encode_control_object, CheckpointOwner, CheckpointRecordState,
-    CheckpointStatus, CompactionLeaseStatus, ControlObjectEnvelope, ControlObjectKind, ForkBasis,
-    HeadState, ManifestRef, MetadataCompactionLeaseState, MetadataRootState, NamespaceStatus,
-    ProxiedStaging, UploadSessionMode, UploadSessionRecordStatus, UploadSessionState,
-    WalFloorState, WalSegmentPointer, WriterBlock,
+    decode_control_object, CheckpointOwner, CheckpointRecordState, CheckpointStatus,
+    CompactionLeaseStatus, ControlObjectEnvelope, ControlObjectKind, ForkBasis, HeadState,
+    ManifestRef, MetadataCompactionLeaseState, MetadataRootState, NamespaceStatus, ProxiedStaging,
+    UploadSessionMode, UploadSessionRecordStatus, UploadSessionState, WalFloorState,
+    WalSegmentPointer, WriterBlock,
 };
 use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::wire::manifest::{
     decode_namespace_manifest_json, encode_namespace_manifest_json, ActiveDeletionRowAction,
     DeletedDirentry, MetadataFamilyGroup, MetadataRow, MetadataRowFamily, MetadataRunRef,
-    MetadataSegmentRef, NamespaceManifestEnvelope, NamespaceManifestPayload, RunTier,
-    TombstoneGeneration, TombstoneRowAction,
+    MetadataSegmentRef, NamespaceManifestPayload, RunTier, TombstoneGeneration, TombstoneRowAction,
 };
 use loonfs_api::wire::wal::{
     decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, WalCommitDelta,
-    WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload,
+    WalCommitPayload, WalDelta, WalSegmentPayload,
 };
 use loonfs_api::{
     sha256_digest, ActorId, ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue,
@@ -231,7 +230,7 @@ fn sample_wal_pointer() -> WalSegmentPointer {
     }
 }
 
-fn sample_wal_envelope() -> WalSegmentEnvelope {
+fn sample_wal_payload() -> WalSegmentPayload {
     let deltas = vec![
         WalCommitDelta {
             semantic_op_index: 0,
@@ -296,7 +295,7 @@ fn sample_wal_envelope() -> WalSegmentEnvelope {
             },
         },
     ];
-    WalSegmentEnvelope::from_payload(WalSegmentPayload {
+    WalSegmentPayload {
         namespace_id: namespace_id(),
         segment_id: WalSegmentId::parse("wal_00000000000000000002-0123456789abcdef")
             .expect("valid segment id"),
@@ -317,12 +316,11 @@ fn sample_wal_envelope() -> WalSegmentEnvelope {
             message: Some("golden commit".to_owned()),
             deltas,
         }],
-    })
-    .expect("wal envelope")
+    }
 }
 
-fn sample_manifest_envelope() -> NamespaceManifestEnvelope {
-    NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+fn sample_manifest_payload() -> NamespaceManifestPayload {
+    NamespaceManifestPayload {
         namespace_id: namespace_id(),
         manifest_no: ManifestNo(2),
         manifest_object_id: manifest_object_id(2, "0123456789abcdef"),
@@ -365,8 +363,7 @@ fn sample_manifest_envelope() -> NamespaceManifestEnvelope {
                 object_checksum: sha256_digest(b"sst payload"),
             }],
         }],
-    })
-    .expect("manifest envelope")
+    }
 }
 
 /// Returns a manifest reference owned by the sample namespace.
@@ -434,7 +431,9 @@ fn sample_fork_head_state() -> HeadState {
 
 #[test]
 fn wal_segment_document_matches_golden_bytes() {
-    let encoded = encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("encode wal");
+    let encoded = encode_wal_segment_envelope_zstd(sample_wal_payload())
+        .expect("encode wal")
+        .into_bytes();
     // Compare the decompressed document: zstd frames may differ across zstd
     // versions, the document bytes (which the checksum covers) may not.
     assert_matches_golden("wal_segment.v1.cbor", &unzstd(&encoded));
@@ -444,16 +443,18 @@ fn wal_segment_document_matches_golden_bytes() {
 fn wal_segment_golden_decodes_to_sample() {
     let decoded = decode_wal_segment_envelope_zstd(&rezstd(&read_golden("wal_segment.v1.cbor")))
         .expect("decode golden wal segment");
-    assert_eq!(decoded, sample_wal_envelope());
+    assert_eq!(decoded.into_payload(), sample_wal_payload());
 }
 
 #[test]
 fn wal_segments_reject_an_id_that_disagrees_with_its_start_seq() {
-    let agreeing = encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("encode wal");
+    let agreeing = encode_wal_segment_envelope_zstd(sample_wal_payload())
+        .expect("encode wal")
+        .into_bytes();
     decode_wal_segment_envelope_zstd(&agreeing)
         .expect("a segment whose id encodes its start seq decodes");
 
-    let mut payload = sample_wal_envelope().payload;
+    let mut payload = sample_wal_payload();
     payload.segment_id =
         WalSegmentId::parse("wal_00000000000000000009-0123456789abcdef").expect("valid segment id");
     let message = assert_wal_segment_is_corrupt(payload);
@@ -463,7 +464,7 @@ fn wal_segments_reject_an_id_that_disagrees_with_its_start_seq() {
         "the rejection should name both values: {message}"
     );
 
-    let mut payload = sample_wal_envelope().payload;
+    let mut payload = sample_wal_payload();
     let mut link = sample_wal_pointer();
     link.segment_id =
         WalSegmentId::parse("wal_00000000000000000004-fedcba9876543210").expect("valid segment id");
@@ -479,8 +480,9 @@ fn wal_segments_reject_an_id_that_disagrees_with_its_start_seq() {
 /// Stores `payload` through the real codec and returns why decoding refused
 /// it.
 fn assert_wal_segment_is_corrupt(payload: WalSegmentPayload) -> String {
-    let envelope = WalSegmentEnvelope::from_payload(payload).expect("rebuild the wal envelope");
-    let encoded = encode_wal_segment_envelope_zstd(&envelope).expect("encode wal");
+    let encoded = encode_wal_segment_envelope_zstd(payload)
+        .expect("encode wal")
+        .into_bytes();
     let error =
         decode_wal_segment_envelope_zstd(&encoded).expect_err("the stored segment is corrupt");
     assert!(
@@ -492,7 +494,9 @@ fn assert_wal_segment_is_corrupt(payload: WalSegmentPayload) -> String {
 
 #[test]
 fn namespace_manifest_matches_golden_bytes() {
-    let encoded = encode_namespace_manifest_json(&sample_manifest_envelope()).expect("encode");
+    let encoded = encode_namespace_manifest_json(sample_manifest_payload())
+        .expect("encode")
+        .into_bytes();
     assert_matches_golden("namespace_manifest.v4.json", &encoded);
     let document: serde_json::Value = serde_json::from_slice(&encoded).expect("manifest json");
     let payload = document["payload"].as_object().expect("manifest payload");
@@ -504,20 +508,20 @@ fn namespace_manifest_matches_golden_bytes() {
 fn namespace_manifest_golden_decodes_to_sample() {
     let decoded = decode_namespace_manifest_json(&read_golden("namespace_manifest.v4.json"))
         .expect("decode golden manifest");
-    assert_eq!(decoded, sample_manifest_envelope());
+    assert_eq!(decoded.into_payload(), sample_manifest_payload());
 }
 
 fn check_control_golden<T>(fixture: &str, kind: ControlObjectKind, state: T)
 where
     T: Serialize + DeserializeOwned + PartialEq + Debug,
 {
-    let envelope = ControlObjectEnvelope::from_state(kind, state).expect("control envelope");
-    let encoded = encode_control_object(&envelope).expect("encode control object");
+    let encoded = loonfs_api::wire::control::encode_control_state(kind, &state)
+        .expect("encode control object");
     assert_matches_golden(fixture, &encoded);
 
     let decoded: ControlObjectEnvelope<T> =
         decode_control_object(&read_golden(fixture), kind).expect("decode golden control object");
-    assert_eq!(decoded, envelope);
+    assert_eq!(decoded.into_payload(), state);
 }
 
 fn control_document_with_payload_edit(
@@ -1383,8 +1387,8 @@ fn control_object_decoders_reject_wrong_format_version_without_fallback() {
         ),
     ];
     for (kind, state) in cases {
-        let envelope = ControlObjectEnvelope::from_state(kind, state).expect("control envelope");
-        let encoded = encode_control_object(&envelope).expect("encode control");
+        let encoded =
+            loonfs_api::wire::control::encode_control_state(kind, &state).expect("encode control");
         let mut document: serde_json::Value =
             serde_json::from_slice(&encoded).expect("decode document");
         document["format_version"] = serde_json::Value::from(7);
@@ -1445,10 +1449,14 @@ fn content_store_id() -> ContentStoreId {
 
 /// Edits a WAL payload and updates its checksum.
 fn wal_document_with_payload_edit(
-    envelope: &WalSegmentEnvelope,
+    payload: &WalSegmentPayload,
     edit: impl FnOnce(&mut ciborium::Value),
 ) -> Vec<u8> {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(envelope).expect("wal"));
+    let document = unzstd(
+        &encode_wal_segment_envelope_zstd(payload.clone())
+            .expect("wal")
+            .into_bytes(),
+    );
     let document_value: ciborium::Value =
         ciborium::de::from_reader(document.as_slice()).expect("decode document map");
     let payload_bytes = document_value
@@ -1502,10 +1510,10 @@ fn commit_delta(payload: &mut ciborium::Value, position: usize) -> &mut ciborium
 }
 
 /// Builds a sample segment with the supplied deltas.
-fn wal_envelope_with_deltas(deltas: Vec<WalCommitDelta>) -> WalSegmentEnvelope {
-    let mut payload = sample_wal_envelope().payload;
+fn wal_payload_with_deltas(deltas: Vec<WalCommitDelta>) -> WalSegmentPayload {
+    let mut payload = sample_wal_payload();
     payload.records[0].deltas = deltas;
-    WalSegmentEnvelope::from_payload(payload).expect("wal envelope")
+    payload
 }
 
 /// Rewrites one top-level entry of a CBOR document map.
@@ -1556,7 +1564,11 @@ fn wal_delta_decode_rejects_invalid_name_key() {
 
 #[test]
 fn wal_decode_rejects_wrong_format_version_cleanly() {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let document = unzstd(
+        &encode_wal_segment_envelope_zstd(sample_wal_payload())
+            .expect("wal")
+            .into_bytes(),
+    );
     let wrong_version = with_cbor_document_entry(&document, "format_version", |value| {
         *value = ciborium::Value::from(7);
     });
@@ -1578,7 +1590,11 @@ fn wal_decode_rejects_wrong_format_version_cleanly() {
 
 #[test]
 fn wal_decode_rejects_unknown_kind_cleanly() {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let document = unzstd(
+        &encode_wal_segment_envelope_zstd(sample_wal_payload())
+            .expect("wal")
+            .into_bytes(),
+    );
     let rekinded = with_cbor_document_entry(&document, "kind", |value| {
         *value = ciborium::Value::from("namespace_wal_index");
     });
@@ -1593,7 +1609,11 @@ fn wal_decode_rejects_unknown_kind_cleanly() {
 
 #[test]
 fn wal_decode_rejects_tampered_payload_bytes_as_checksum_mismatch() {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let document = unzstd(
+        &encode_wal_segment_envelope_zstd(sample_wal_payload())
+            .expect("wal")
+            .into_bytes(),
+    );
     let tampered = with_cbor_document_entry(&document, "payload", |value| {
         let bytes = match value {
             ciborium::Value::Bytes(bytes) => bytes,
@@ -1614,7 +1634,7 @@ fn wal_decode_rejects_tampered_payload_bytes_as_checksum_mismatch() {
 #[test]
 fn wal_decode_rejects_unknown_payload_fields() {
     // A valid checksum does not authorize unknown payload fields.
-    let envelope = sample_wal_envelope();
+    let envelope = sample_wal_payload();
     let document = wal_document_with_payload_edit(&envelope, with_future_field);
 
     let error = decode_wal_segment_envelope_zstd(&document)
@@ -1625,7 +1645,7 @@ fn wal_decode_rejects_unknown_payload_fields() {
 
 #[test]
 fn wal_decode_rejects_unknown_predecessor_fields() {
-    let envelope = sample_wal_envelope();
+    let envelope = sample_wal_payload();
     let document = wal_document_with_payload_edit(&envelope, |payload| {
         with_future_field(cbor_entry(payload, "prev_visible_segment"));
     });
@@ -1638,7 +1658,7 @@ fn wal_decode_rejects_unknown_predecessor_fields() {
 
 #[test]
 fn wal_decode_rejects_unknown_fields_inside_tombstone_deltas() {
-    let envelope = wal_envelope_with_deltas(vec![
+    let envelope = wal_payload_with_deltas(vec![
         WalCommitDelta {
             semantic_op_index: 0,
             delta: WalDelta::TombstoneSubtree {
@@ -1677,7 +1697,7 @@ fn wal_decode_rejects_unknown_fields_inside_tombstone_deltas() {
 
 #[test]
 fn wal_decode_rejects_an_additive_field_inside_the_commit_attribution() {
-    let document = wal_document_with_payload_edit(&sample_wal_envelope(), |payload| {
+    let document = wal_document_with_payload_edit(&sample_wal_payload(), |payload| {
         with_future_field(cbor_entry(payload_commit(payload), "committed_by"));
     });
 
@@ -1692,7 +1712,7 @@ fn wal_decode_rejects_an_additive_field_inside_the_commit_attribution() {
 
 #[test]
 fn wal_decode_rejects_a_version_one_commit_without_committed_by() {
-    let document = wal_document_with_payload_edit(&sample_wal_envelope(), |payload| {
+    let document = wal_document_with_payload_edit(&sample_wal_payload(), |payload| {
         cbor_map_of(payload_commit(payload))
             .retain(|(key, _)| key.as_text() != Some("committed_by"));
     });
@@ -1707,10 +1727,10 @@ fn wal_decode_rejects_a_version_one_commit_without_committed_by() {
 
 #[test]
 fn control_object_decode_rejects_tampered_payload_as_checksum_mismatch() {
-    let envelope =
-        ControlObjectEnvelope::from_state(ControlObjectKind::WalHead, sample_head_state())
-            .expect("control envelope");
-    let encoded = encode_control_object(&envelope).expect("encode control object");
+    let envelope = sample_head_state();
+    let encoded =
+        loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &envelope)
+            .expect("encode control object");
     let mut document: serde_json::Value =
         serde_json::from_slice(&encoded).expect("decode document");
     document["payload"]["seq"] = serde_json::Value::from(999);
@@ -1726,7 +1746,9 @@ fn control_object_decode_rejects_tampered_payload_as_checksum_mismatch() {
 
 #[test]
 fn namespace_manifest_decode_rejects_wrong_format_version_cleanly() {
-    let encoded = encode_namespace_manifest_json(&sample_manifest_envelope()).expect("manifest");
+    let encoded = encode_namespace_manifest_json(sample_manifest_payload())
+        .expect("manifest")
+        .into_bytes();
     let mut document: serde_json::Value =
         serde_json::from_slice(&encoded).expect("decode document");
     for version in [1, 2, 3, 7] {
@@ -1750,7 +1772,9 @@ fn namespace_manifest_decode_rejects_wrong_format_version_cleanly() {
 
 #[test]
 fn namespace_manifest_decode_rejects_tampered_payload_as_checksum_mismatch() {
-    let encoded = encode_namespace_manifest_json(&sample_manifest_envelope()).expect("manifest");
+    let encoded = encode_namespace_manifest_json(sample_manifest_payload())
+        .expect("manifest")
+        .into_bytes();
     let mut document: serde_json::Value =
         serde_json::from_slice(&encoded).expect("decode document");
     document["payload"]["head_seq"] = serde_json::Value::from(999);
@@ -1766,8 +1790,10 @@ fn namespace_manifest_decode_rejects_tampered_payload_as_checksum_mismatch() {
 
 #[test]
 fn namespace_manifest_decode_rejects_unknown_fields_at_every_level() {
-    let envelope = sample_manifest_envelope();
-    let encoded = encode_namespace_manifest_json(&envelope).expect("manifest");
+    let payload = sample_manifest_payload();
+    let encoded = encode_namespace_manifest_json(payload)
+        .expect("manifest")
+        .into_bytes();
     for path in [
         "",
         "/runs/0",
@@ -1797,14 +1823,19 @@ fn namespace_manifest_decode_rejects_unknown_fields_at_every_level() {
 
 #[test]
 fn immutable_envelopes_reject_unknown_fields() {
-    let mut manifest =
-        encode_namespace_manifest_json(&sample_manifest_envelope()).expect("manifest");
+    let mut manifest = encode_namespace_manifest_json(sample_manifest_payload())
+        .expect("manifest")
+        .into_bytes();
     assert_eq!(manifest.pop(), Some(b'}'));
     manifest.extend_from_slice(br#", "field_from_the_future": true}"#);
     assert!(matches!(decode_namespace_manifest_json(&manifest),
         Err(EnvelopeCodecError::EnvelopeDecode(message)) if message.contains("field_from_the_future")));
 
-    let encoded = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let encoded = unzstd(
+        &encode_wal_segment_envelope_zstd(sample_wal_payload())
+            .expect("wal")
+            .into_bytes(),
+    );
     let mut document: ciborium::Value =
         ciborium::de::from_reader(encoded.as_slice()).expect("document");
     with_future_field(&mut document);

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -33,9 +33,7 @@ use crate::wal::{
     ensure_replayed_head_matches, load_wal_chain, project_validated_wal_tail, WalChainLoadRequest,
 };
 use loonfs_api::wire::control::{HeadState, ManifestRef};
-use loonfs_api::wire::manifest::{
-    MetadataRunRef, NamespaceManifestEnvelope, NamespaceManifestPayload, RunTier,
-};
+use loonfs_api::wire::manifest::{MetadataRunRef, NamespaceManifestPayload, RunTier};
 use loonfs_api::{
     ChangeSeq, CommitId, FlushWalOutcome, FlushWalResponse, ManifestNo, ManifestObjectId,
     NamespaceId, RunNo, MAX_PUBLIC_INTEGER,
@@ -146,7 +144,7 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
     // checkpoint record can pin only its own.
     let basis_manifest = projection.basis.manifest();
     if projection.basis.is_owned_by(namespace_id)
-        && projection.manifest_segments.manifest().payload.head_seq == head_seq
+        && projection.manifest_segments.manifest().payload().head_seq == head_seq
     {
         let basis_manifest = basis_manifest.expect("an owned basis names a manifest");
         return Ok(TryFlushWal::Settled(Box::new(FlushedBasis {
@@ -171,7 +169,7 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
         ManifestObjectId::generate(manifest_no),
     )
     .await?;
-    write_namespace_manifest(store, &manifest)
+    let manifest = write_namespace_manifest(store, manifest)
         .await
         .map_err(manifest_write_failure)?;
     // The publication budget gates the root compare-and-swap: past it, the
@@ -189,7 +187,7 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
             projection
                 .manifest_segments
                 .manifest()
-                .payload
+                .payload()
                 .manifest_object_id
                 .clone()
         }),
@@ -199,8 +197,8 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
     {
         ManifestPublicationOutcome::Published(_) => (
             FlushWalOutcome::Published,
-            manifest.payload.manifest_no,
-            manifest.payload.head_seq,
+            manifest.payload().manifest_no,
+            manifest.payload().head_seq,
         ),
         // The candidate's head sequence is this flush's target, so a root
         // that covers the candidate covers the target too.
@@ -402,7 +400,7 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
     projection: &RootProjection<'_, S>,
     manifest_no: ManifestNo,
     manifest_object_id: ManifestObjectId,
-) -> Result<NamespaceManifestEnvelope> {
+) -> Result<NamespaceManifestPayload> {
     let head_seq = projection.head.seq;
     // A WAL flush keeps existing runs and writes the WAL delta as one new delta
     // run. Reorganization merges delta runs into the base separately.
@@ -435,10 +433,10 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
         let previous_manifest = projection.manifest_segments.manifest();
         // The manifest that first names a run allocates its number. A flush
         // takes one number for its delta, or none when the head is unchanged.
-        let run_no = previous_manifest.payload.next_run_no;
-        let mut runs = previous_manifest.payload.runs.clone();
+        let run_no = previous_manifest.payload().next_run_no;
+        let mut runs = previous_manifest.payload().runs.clone();
         let mut next_run_no = run_no;
-        if previous_manifest.payload.head_seq < head_seq {
+        if previous_manifest.payload().head_seq < head_seq {
             runs.push(MetadataRunRef {
                 run_no,
                 run_seq: head_seq,
@@ -447,7 +445,7 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
                     build_manifest_delta_run_segments(
                         store,
                         namespace_id,
-                        previous_manifest.payload.head_seq,
+                        previous_manifest.payload().head_seq,
                         &projection.tail_state,
                         MetadataLsmPolicy::default(),
                     )
@@ -456,10 +454,10 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
             });
             next_run_no = next_run_no_after(run_no)?;
         }
-        (previous_manifest.payload.base_seq, runs, next_run_no)
+        (previous_manifest.payload().base_seq, runs, next_run_no)
     };
 
-    NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    Ok(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no,
         manifest_object_id,
@@ -471,11 +469,6 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
         next_run_no,
         retention_floor_seq: projection.floor_seq,
         runs,
-    })
-    .map_err(|err| {
-        CoreError::Internal(format!(
-            "failed to build namespace manifest envelope: {err}"
-        ))
     })
 }
 

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -50,7 +50,7 @@ pub(crate) fn ensure_manifest_reference_matches(
     reference: &ManifestRef,
     manifest: &NamespaceManifestEnvelope,
 ) -> crate::error::Result<()> {
-    let payload = &manifest.payload;
+    let payload = &manifest.payload();
     let mismatch = if reference.owner_namespace_id != payload.namespace_id {
         Some((
             "owner_namespace_id",
@@ -75,11 +75,11 @@ pub(crate) fn ensure_manifest_reference_matches(
             reference.manifest_head_seq.to_string(),
             payload.head_seq.to_string(),
         ))
-    } else if reference.manifest_payload_checksum != manifest.payload_checksum {
+    } else if reference.manifest_payload_checksum != manifest.payload_checksum() {
         Some((
             "manifest_payload_checksum",
             reference.manifest_payload_checksum.clone(),
-            manifest.payload_checksum.clone(),
+            manifest.payload_checksum().to_owned(),
         ))
     } else {
         None
@@ -144,7 +144,7 @@ pub(crate) async fn load_basis_metadata_segments<'a, S: ObjectStore + ?Sized>(
         });
     };
     let segments = load_manifest_segments(store, segment_cache, manifest).await?;
-    let manifest_head_seq = segments.manifest().payload.head_seq;
+    let manifest_head_seq = segments.manifest().payload().head_seq;
     Ok(LoadedMetadataBasis {
         identity: MetadataBasisIdentity::from_verified_basis(basis.clone(), manifest_head_seq),
         segments,
@@ -238,13 +238,13 @@ pub(crate) async fn load_manifest_segments_for_inspection<'a, S: ObjectStore + ?
         })?;
         validate_namespace_manifest(
             namespace_id,
-            manifest.payload.manifest_no,
+            manifest.payload().manifest_no,
             manifest_object_id,
             &manifest_key,
             &manifest,
         )?;
-        validate_manifest(&manifest_key, &manifest.payload)?;
-        let scan_runs = Arc::new(runs_in_reorganization_order(&manifest.payload));
+        validate_manifest(&manifest_key, manifest.payload())?;
+        let scan_runs = Arc::new(runs_in_reorganization_order(manifest.payload()));
         Ok(DecodedMetadataSegmentBlock::Manifest {
             manifest: (Arc::new(manifest), scan_runs),
             // The entry retains the envelope plus its scan-ordered run list.
@@ -283,13 +283,13 @@ pub(crate) fn head_from_manifest(
         content_store_id: current_head.content_store_id.clone(),
         created_at_ms: current_head.created_at_ms,
         fork_basis: current_head.fork_basis.clone(),
-        seq: manifest.payload.head_seq,
-        head_commit_id: manifest.payload.head_commit_id.clone(),
+        seq: manifest.payload().head_seq,
+        head_commit_id: manifest.payload().head_commit_id.clone(),
         // The manifest records the manifest-time writer epoch. That may lag the
         // live head if writer takeover advanced the epoch without WAL replay.
-        writer_epoch: manifest.payload.writer_epoch,
+        writer_epoch: manifest.payload().writer_epoch,
         writer: current_head.writer.clone(),
-        next_inode_id: manifest.payload.next_inode_id,
+        next_inode_id: manifest.payload().next_inode_id,
         visible_wal_tip: None,
         recent_segments: Vec::new(),
         status: current_head.status,
@@ -325,7 +325,7 @@ pub(crate) async fn load_namespace_manifest_envelope_if_present<S: ObjectStore +
     })?;
     validate_namespace_manifest(
         namespace_id,
-        manifest.payload.manifest_no,
+        manifest.payload().manifest_no,
         manifest_object_id,
         manifest_key,
         &manifest,

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -10,7 +10,9 @@ use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_state, ControlObjectKind, ManifestRef, MetadataRootState,
 };
-use loonfs_api::wire::manifest::{encode_namespace_manifest_json, NamespaceManifestEnvelope};
+use loonfs_api::wire::manifest::{
+    encode_namespace_manifest_json, NamespaceManifestEnvelope, NamespaceManifestPayload,
+};
 use loonfs_api::{ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_manifest_object, metadata_root};
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
@@ -37,29 +39,29 @@ pub(super) enum ManifestPublicationOutcome {
 )]
 pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
     store: &S,
-    manifest: &NamespaceManifestEnvelope,
-) -> std::result::Result<(), MetadataProjectionLoadError> {
-    let manifest_key = metadata_manifest_object(
-        &manifest.payload.namespace_id,
-        &manifest.payload.manifest_object_id,
-    );
-    let manifest_bytes = Bytes::from(encode_namespace_manifest_json(manifest).map_err(|err| {
-        MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestCodec {
-            object_key: manifest_key.clone(),
-            message: err.to_string(),
-        })
-    })?);
+    payload: NamespaceManifestPayload,
+) -> std::result::Result<NamespaceManifestEnvelope, MetadataProjectionLoadError> {
+    let manifest_key = metadata_manifest_object(&payload.namespace_id, &payload.manifest_object_id);
+    let (manifest, bytes) = encode_namespace_manifest_json(payload)
+        .map_err(|err| {
+            MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestCodec {
+                object_key: manifest_key.clone(),
+                message: err.to_string(),
+            })
+        })?
+        .into_parts();
+    let manifest_bytes = Bytes::from(bytes);
     // Immutable format objects use verified writes so identical bytes are an idempotent success
     // and different bytes are corruption.
     match store
         .put_immutable_verified(&manifest_key, manifest_bytes)
         .await
     {
-        Ok(_) => Ok(()),
+        Ok(_) => Ok(manifest),
         Err(ImmutableWriteError::DifferentObject { .. }) => Err(
             MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestObjectConflict {
                 object_key: manifest_key,
-                manifest_no: manifest.payload.manifest_no,
+                manifest_no: manifest.payload().manifest_no,
             }),
         ),
         Err(ImmutableWriteError::Transport { source, .. }) => Err(
@@ -299,10 +301,10 @@ pub(super) fn manifest_ref_for(
 ) -> ManifestRef {
     ManifestRef {
         owner_namespace_id: namespace_id.clone(),
-        manifest_no: manifest.payload.manifest_no,
-        manifest_object_id: manifest.payload.manifest_object_id.clone(),
-        manifest_head_seq: manifest.payload.head_seq,
-        manifest_payload_checksum: manifest.payload_checksum.clone(),
+        manifest_no: manifest.payload().manifest_no,
+        manifest_object_id: manifest.payload().manifest_object_id.clone(),
+        manifest_head_seq: manifest.payload().head_seq,
+        manifest_payload_checksum: manifest.payload_checksum().to_owned(),
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/read_basis.rs
+++ b/crates/loonfs-core/src/checkpoint/read_basis.rs
@@ -89,7 +89,7 @@ pub(crate) async fn load_checkpoint_read_basis_from_record<S: ObjectStore + ?Siz
     let envelope = segments.manifest();
     Ok(CheckpointReadBasis {
         head: head_from_manifest(live_head, envelope),
-        head_etag: envelope.payload_checksum.clone(),
+        head_etag: envelope.payload_checksum().to_owned(),
         basis: MetadataBasis::Manifest(manifest),
     })
 }

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -33,7 +33,6 @@ use loonfs_api::wire::manifest::{
     RunTier,
 };
 use loonfs_api::{ChangeSeq, ManifestNo, ManifestObjectId, NamespaceId, RunNo};
-use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
 
@@ -161,9 +160,9 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let segments = load_manifest_segments(store, None, &root.manifest).await?;
     let previous = segments.manifest();
 
-    let delta_runs = delta_run_count(&previous.payload);
+    let delta_runs = delta_run_count(previous.payload());
     if !manifest_has_reorganization_work(
-        &previous.payload,
+        previous.payload(),
         segments.scan_runs.as_ref(),
         policy,
         compaction_policy,
@@ -176,7 +175,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let Some(group) = select_family_group(
         store,
         namespace_id,
-        &previous.payload,
+        previous.payload(),
         context.now_ms,
         compaction_policy,
         policy,
@@ -236,7 +235,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     .await?;
 
     let surviving = previous
-        .payload
+        .payload()
         .runs
         .iter()
         .filter_map(|run| {
@@ -279,7 +278,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
                 input_runs: input.runs.len(),
                 decoded_input_rows: input.decoded_rows,
                 decoded_input_bytes: input.decoded_bytes,
-                manifest_no: manifest.payload.manifest_no,
+                manifest_no: manifest.payload().manifest_no,
                 bottom_anchored_merge_blocked,
             },
         )),
@@ -328,7 +327,7 @@ pub async fn metadata_maintenance_due<S: ObjectStore + ?Sized>(
     };
     let segments = load_manifest_segments(store, segment_cache, &root.state.manifest).await?;
     Ok(manifest_has_reorganization_work(
-        &segments.manifest().payload,
+        segments.manifest().payload(),
         segments.scan_runs.as_ref(),
         MetadataLsmPolicy::default(),
         compaction_policy,
@@ -575,7 +574,7 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
         let placement = merge_placement(
             bottom_anchored,
             &window.runs,
-            segments.manifest().payload.head_seq,
+            segments.manifest().payload().head_seq,
         );
         ReorganizationPlan::BoundedMerge(ReorganizationInput {
             run_nos: window.runs.iter().map(|run| run.run_no).collect(),
@@ -597,7 +596,11 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 .flat_map(|run| group_run_descriptors(run, group))
                 .map(|d| d.row_count)
                 .sum(),
-            merge_placement(bottom_anchored, &runs, segments.manifest().payload.head_seq),
+            merge_placement(
+                bottom_anchored,
+                &runs,
+                segments.manifest().payload().head_seq,
+            ),
             frozen_floor_seq,
         ))
     };
@@ -847,14 +850,14 @@ pub(super) async fn write_replacement_manifest<S: ObjectStore + ?Sized>(
     floor_seq: ChangeSeq,
 ) -> Result<NamespaceManifestEnvelope> {
     let next_run_no = if output.segments.is_empty() {
-        previous.payload.next_run_no
+        previous.payload().next_run_no
     } else {
-        next_run_no_after(previous.payload.next_run_no)?
+        next_run_no_after(previous.payload().next_run_no)?
     };
     let mut runs = surviving;
     if !output.segments.is_empty() {
         runs.push(MetadataRunRef {
-            run_no: previous.payload.next_run_no,
+            run_no: previous.payload().next_run_no,
             run_seq: output.placement.output_seq(),
             tier: output.placement.output_tier(),
             segments: output.segments,
@@ -865,34 +868,30 @@ pub(super) async fn write_replacement_manifest<S: ObjectStore + ?Sized>(
         .map(|run| run.run_seq)
         .min()
         .expect("a replacement manifest should hold at least one run");
-    let retention_floor_seq = previous.payload.retention_floor_seq.max(floor_seq);
+    let retention_floor_seq = previous.payload().retention_floor_seq.max(floor_seq);
     // One generated object id, one write. The generated id ends in 16 random
     // hex characters, so the key is this unit's alone and a conflict under it
     // is corruption rather than contention.
-    let manifest_no = next_manifest_no_after(previous.payload.manifest_no)?;
+    let manifest_no = next_manifest_no_after(previous.payload().manifest_no)?;
     let manifest_object_id = ManifestObjectId::generate(manifest_no);
-    let object_key = metadata_manifest_object(namespace_id, &manifest_object_id);
-    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
-        namespace_id: namespace_id.clone(),
-        manifest_no,
-        manifest_object_id,
-        head_seq: previous.payload.head_seq,
-        head_commit_id: previous.payload.head_commit_id.clone(),
-        base_seq,
-        writer_epoch: previous.payload.writer_epoch,
-        next_inode_id: previous.payload.next_inode_id,
-        next_run_no,
-        retention_floor_seq,
-        runs,
-    })
-    .map_err(|error| CoreError::Codec {
-        object_key,
-        message: error.to_string(),
-    })?;
-    write_namespace_manifest(store, &manifest)
-        .await
-        .map_err(manifest_write_failure)?;
-    Ok(manifest)
+    write_namespace_manifest(
+        store,
+        NamespaceManifestPayload {
+            namespace_id: namespace_id.clone(),
+            manifest_no,
+            manifest_object_id,
+            head_seq: previous.payload().head_seq,
+            head_commit_id: previous.payload().head_commit_id.clone(),
+            base_seq,
+            writer_epoch: previous.payload().writer_epoch,
+            next_inode_id: previous.payload().next_inode_id,
+            next_run_no,
+            retention_floor_seq,
+            runs,
+        },
+    )
+    .await
+    .map_err(manifest_write_failure)
 }
 
 #[cfg(test)]
@@ -908,7 +907,7 @@ mod planning_tests {
             "../../../loonfs-api/tests/golden/namespace_manifest.v4.json"
         ))
         .expect("manifest fixture");
-        let mut template = runs_in_reorganization_order(&manifest.payload).remove(0);
+        let mut template = runs_in_reorganization_order(manifest.payload()).remove(0);
         template
             .segments
             .retain(|family| family.family == MetadataRowFamily::Inodes);

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -26,7 +26,7 @@ async fn verify_manifest_segments_exist<S: ObjectStore + ?Sized>(
     manifest: &NamespaceManifestEnvelope,
 ) -> std::result::Result<(), ManifestLoadError> {
     let object_keys = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -107,7 +107,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     let manifest_segments = load_manifest_segments(store, None, &root.manifest).await?;
     // Grep tolerates retention gaps by checkpointed rebootstrap, so its
     // independent watermark never holds the core WAL floor back.
-    let target_floor = manifest_segments.manifest().payload.head_seq;
+    let target_floor = manifest_segments.manifest().payload().head_seq;
     let initial_floor = match load_wal_floor_object(store, namespace_id).await {
         Ok(loaded) => Some(loaded),
         Err(ControlObjectLoadError::MissingObject { .. }) => None,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -544,7 +544,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
 
         let previous = segments.manifest();
         let surviving = previous
-            .payload
+            .payload()
             .runs
             .iter()
             .filter_map(|run| {
@@ -586,7 +586,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         let lost_to = match published {
             ManifestPublicationOutcome::Published(_) => {
                 return Ok(MetadataCompactionJobOutcome::Published {
-                    manifest_no: manifest.payload.manifest_no,
+                    manifest_no: manifest.payload().manifest_no,
                     rows_read,
                     rows_written,
                     input_bytes,

--- a/crates/loonfs-core/src/checkpoint/tests/attributes.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/attributes.rs
@@ -289,7 +289,7 @@ async fn publish_manifest_with_segments<S: ObjectStore + ?Sized>(
     segments: Vec<MetadataSegmentRef>,
 ) -> ManifestObjectId {
     let manifest_object_id = ManifestObjectId::generate(manifest_no);
-    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    let manifest = encode_namespace_manifest_json(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no,
         manifest_object_id: manifest_object_id.clone(),
@@ -307,8 +307,9 @@ async fn publish_manifest_with_segments<S: ObjectStore + ?Sized>(
             segments,
         }],
     })
-    .expect("manifest envelope");
-    write_namespace_manifest(store, &manifest)
+    .expect("manifest envelope")
+    .into_envelope();
+    write_namespace_manifest(store, manifest.payload().clone())
         .await
         .expect("write manifest");
     manifest_object_id

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -267,7 +267,7 @@ async fn cached_manifest_carries_its_scan_order_runs() {
     );
     assert_eq!(
         *first.scan_runs,
-        runs_in_reorganization_order(&first.manifest().payload),
+        runs_in_reorganization_order(first.manifest().payload()),
         "the cached run list must equal the manifest's reorganization-order grouping"
     );
     assert!(
@@ -568,7 +568,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
             .expect("load segments");
     let direntry_descriptors: Vec<_> = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -585,7 +585,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
     let materialized = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,
-        segments.manifest().payload.manifest_no,
+        segments.manifest().payload().manifest_no,
     )
     .await
     .expect("materialize manifest");
@@ -622,7 +622,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
     // The same lookup against the same manifest with the inline copies
     // stripped must return the same rows through fetched filter blocks —
     // the inline copy is an accelerator, never an answer of its own.
-    let mut stripped_payload = segments.manifest().payload.clone();
+    let mut stripped_payload = segments.manifest().payload().clone();
     stripped_payload.manifest_no = ManifestNo(stripped_payload.manifest_no.0 + 1);
     stripped_payload.manifest_object_id = ManifestObjectId::generate(stripped_payload.manifest_no);
     for descriptor in stripped_payload
@@ -633,9 +633,10 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
         descriptor.filter_inline = None;
     }
     let stripped_object_id = stripped_payload.manifest_object_id.clone();
-    let stripped = NamespaceManifestEnvelope::from_payload(stripped_payload)
-        .expect("stripped manifest envelope");
-    write_namespace_manifest(&store, &stripped)
+    let stripped = encode_namespace_manifest_json(stripped_payload)
+        .expect("stripped manifest envelope")
+        .into_envelope();
+    write_namespace_manifest(&store, stripped.payload().clone())
         .await
         .expect("write stripped manifest");
     let stripped_segments =
@@ -688,7 +689,7 @@ async fn corrupt_inline_filter_fails_the_lookup() {
             .expect("load segments");
     let descriptor = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -759,7 +760,7 @@ async fn checkpointed_direntry_segment() -> (
             .expect("load segments");
     let mut descriptor = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -1027,7 +1028,7 @@ async fn multi_block_direntry_segment() -> (
             .expect("load segments");
     let mut descriptor = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -40,13 +40,11 @@ impl ManifestSwapOnCasConflictStore {
         // Same-seq replacement referencing a different manifest: the shape a
         // pure compaction publishes.
         root.manifest.manifest_no = ManifestNo(root.manifest.manifest_no.0 + 1);
-        let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+        let bytes = loonfs_api::wire::control::encode_control_state(
             loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-            root,
+            &root,
         )
-        .expect("root envelope");
-        let bytes =
-            loonfs_api::wire::control::encode_control_object(&envelope).expect("root bytes");
+        .expect("root bytes");
         self.inner
             .put(
                 &loonfs_objectstore::keys::metadata_root(&self.namespace_id),
@@ -135,13 +133,11 @@ impl FloorRaiseOnCasConflictStore {
             },
         };
         floor.floor_seq = ChangeSeq(5);
-        let envelope = loonfs_api::wire::control::WalFloorEnvelope::from_state(
+        let bytes = loonfs_api::wire::control::encode_control_state(
             loonfs_api::wire::control::ControlObjectKind::WalFloor,
-            floor,
+            &floor,
         )
-        .expect("floor envelope");
-        let bytes =
-            loonfs_api::wire::control::encode_control_object(&envelope).expect("floor bytes");
+        .expect("floor bytes");
         self.inner
             .put(
                 &loonfs_objectstore::keys::wal_floor(&self.namespace_id),
@@ -379,14 +375,12 @@ impl RootCasTransportAfterCompetingRootStore {
     }
 
     async fn install_competing_root(&self, root: MetadataRootState) {
-        let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
-            loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-            root,
-        )
-        .expect("metadata root envelope");
         let bytes = Bytes::from(
-            loonfs_api::wire::control::encode_control_object(&envelope)
-                .expect("encode metadata root"),
+            loonfs_api::wire::control::encode_control_state(
+                loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
+                &root,
+            )
+            .expect("encode metadata root"),
         );
         self.inner
             .put(&self.root_key, bytes, PutMode::Overwrite)
@@ -583,18 +577,18 @@ async fn same_root_publications_keep_the_first_candidate() {
     )
     .await;
     assert_eq!(
-        first_manifest.payload.manifest_no,
-        second_manifest.payload.manifest_no
+        first_manifest.payload().manifest_no,
+        second_manifest.payload().manifest_no
     );
     assert_ne!(
-        first_manifest.payload.manifest_object_id,
-        second_manifest.payload.manifest_object_id
+        first_manifest.payload().manifest_object_id,
+        second_manifest.payload().manifest_object_id
     );
 
-    write_namespace_manifest(&store, &first_manifest)
+    write_namespace_manifest(&store, first_manifest.payload().clone())
         .await
         .expect("write first manifest");
-    write_namespace_manifest(&store, &second_manifest)
+    write_namespace_manifest(&store, second_manifest.payload().clone())
         .await
         .expect("write second manifest");
 
@@ -611,7 +605,7 @@ async fn same_root_publications_keep_the_first_candidate() {
         ManifestPublicationOutcome::Published(root) => {
             assert_eq!(
                 root.manifest.manifest_object_id,
-                first_manifest.payload.manifest_object_id
+                first_manifest.payload().manifest_object_id
             );
         }
         other => panic!("expected first publication to win, got {other:?}"),
@@ -630,7 +624,7 @@ async fn same_root_publications_keep_the_first_candidate() {
         ManifestPublicationOutcome::CoveredByCurrent(root) => {
             assert_eq!(
                 root.manifest.manifest_object_id,
-                first_manifest.payload.manifest_object_id
+                first_manifest.payload().manifest_object_id
             );
         }
         other => panic!("expected the second publication to be covered, got {other:?}"),
@@ -669,17 +663,17 @@ async fn flush_retries_when_a_same_seq_replacement_wins_behind_its_target() {
         ManifestNo(basis.root.manifest.manifest_no.0 + 1),
     )
     .await;
-    write_namespace_manifest(&inner, &replacement)
+    write_namespace_manifest(&inner, replacement.payload().clone())
         .await
         .expect("write replacement manifest");
     let competing_root = MetadataRootState {
         namespace_id: namespace_id.clone(),
         manifest: ManifestRef {
             owner_namespace_id: namespace_id.clone(),
-            manifest_no: replacement.payload.manifest_no,
-            manifest_object_id: replacement.payload.manifest_object_id.clone(),
-            manifest_head_seq: replacement.payload.head_seq,
-            manifest_payload_checksum: replacement.payload_checksum.clone(),
+            manifest_no: replacement.payload().manifest_no,
+            manifest_object_id: replacement.payload().manifest_object_id.clone(),
+            manifest_head_seq: replacement.payload().head_seq,
+            manifest_payload_checksum: replacement.payload_checksum().to_owned(),
         },
         updated_at_ms: context.now_ms + 1,
     };
@@ -701,7 +695,7 @@ async fn flush_retries_when_a_same_seq_replacement_wins_behind_its_target() {
         .expect("load target head")
         .state
         .seq;
-    assert!(replacement.payload.head_seq < target);
+    assert!(replacement.payload().head_seq < target);
 
     let store = RootCasTransportAfterCompetingRootStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -753,7 +747,7 @@ async fn lower_seq_root_publication_yields_to_the_newer_root() {
     )
     .await
     .expect("build metadata segments");
-    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    let manifest = encode_namespace_manifest_json(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no: ManifestNo(materialization_before.head.seq.0),
         manifest_object_id: manifest_object_id(ManifestNo(materialization_before.head.seq.0)),
@@ -771,8 +765,9 @@ async fn lower_seq_root_publication_yields_to_the_newer_root() {
             segments: flatten_manifest_segments(segments),
         }],
     })
-    .expect("build manifest");
-    write_namespace_manifest(&store, &manifest)
+    .expect("build manifest")
+    .into_envelope();
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("write manifest");
 
@@ -856,7 +851,7 @@ async fn root_cas_conflict_reports_a_race() {
     )
     .await
     .expect("build manifest");
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("write manifest");
 
@@ -913,7 +908,7 @@ async fn root_cas_transport_error_recovers_when_candidate_was_published() {
     )
     .await
     .expect("build manifest");
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("write manifest");
 
@@ -930,10 +925,10 @@ async fn root_cas_transport_error_recovers_when_candidate_was_published() {
 
     match outcome {
         ManifestPublicationOutcome::Published(root) => {
-            assert_eq!(root.manifest.manifest_no, manifest.payload.manifest_no);
+            assert_eq!(root.manifest.manifest_no, manifest.payload().manifest_no);
             assert_eq!(
                 root.manifest.manifest_object_id,
-                manifest.payload.manifest_object_id
+                manifest.payload().manifest_object_id
             );
         }
         other => panic!("expected the candidate to be found current, got {other:?}"),
@@ -978,10 +973,10 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
         ManifestNo(candidate_manifest_no.0 + 1),
     )
     .await;
-    write_namespace_manifest(&raw_store, &candidate_manifest)
+    write_namespace_manifest(&raw_store, candidate_manifest.payload().clone())
         .await
         .expect("write candidate manifest");
-    write_namespace_manifest(&raw_store, &competing_manifest)
+    write_namespace_manifest(&raw_store, competing_manifest.payload().clone())
         .await
         .expect("write competing manifest");
 
@@ -989,10 +984,10 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
         namespace_id: namespace_id.clone(),
         manifest: ManifestRef {
             owner_namespace_id: namespace_id.clone(),
-            manifest_no: competing_manifest.payload.manifest_no,
-            manifest_object_id: competing_manifest.payload.manifest_object_id.clone(),
-            manifest_head_seq: competing_manifest.payload.head_seq,
-            manifest_payload_checksum: competing_manifest.payload_checksum.clone(),
+            manifest_no: competing_manifest.payload().manifest_no,
+            manifest_object_id: competing_manifest.payload().manifest_object_id.clone(),
+            manifest_head_seq: competing_manifest.payload().head_seq,
+            manifest_payload_checksum: competing_manifest.payload_checksum().to_owned(),
         },
         updated_at_ms: context.now_ms + 1,
     };
@@ -1016,11 +1011,11 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
         ManifestPublicationOutcome::CoveredByCurrent(root) => {
             assert_eq!(
                 root.manifest.manifest_no,
-                competing_manifest.payload.manifest_no
+                competing_manifest.payload().manifest_no
             );
             assert_eq!(
                 root.manifest.manifest_object_id,
-                competing_manifest.payload.manifest_object_id
+                competing_manifest.payload().manifest_object_id
             );
         }
         other => panic!("expected a covering root after an ambiguous CAS, got {other:?}"),
@@ -1065,20 +1060,20 @@ async fn root_cas_permission_error_surfaces_when_a_newer_root_was_published() {
         ManifestNo(candidate_manifest_no.0 + 1),
     )
     .await;
-    write_namespace_manifest(&raw_store, &candidate_manifest)
+    write_namespace_manifest(&raw_store, candidate_manifest.payload().clone())
         .await
         .expect("write candidate manifest");
-    write_namespace_manifest(&raw_store, &competing_manifest)
+    write_namespace_manifest(&raw_store, competing_manifest.payload().clone())
         .await
         .expect("write competing manifest");
     let competing_root = MetadataRootState {
         namespace_id: namespace_id.clone(),
         manifest: ManifestRef {
             owner_namespace_id: namespace_id.clone(),
-            manifest_no: competing_manifest.payload.manifest_no,
-            manifest_object_id: competing_manifest.payload.manifest_object_id.clone(),
-            manifest_head_seq: competing_manifest.payload.head_seq,
-            manifest_payload_checksum: competing_manifest.payload_checksum.clone(),
+            manifest_no: competing_manifest.payload().manifest_no,
+            manifest_object_id: competing_manifest.payload().manifest_object_id.clone(),
+            manifest_head_seq: competing_manifest.payload().head_seq,
+            manifest_payload_checksum: competing_manifest.payload_checksum().to_owned(),
         },
         updated_at_ms: context.now_ms + 1,
     };
@@ -1107,13 +1102,11 @@ async fn root_cas_permission_error_surfaces_when_a_newer_root_was_published() {
         ),
         async {
             store.wait_until_blocked().await;
-            let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+            let bytes = loonfs_api::wire::control::encode_control_state(
                 loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-                competing_root,
+                &competing_root,
             )
-            .expect("metadata root envelope");
-            let bytes = loonfs_api::wire::control::encode_control_object(&envelope)
-                .expect("encode metadata root");
+            .expect("encode metadata root");
             raw_store
                 .put(&root_key, Bytes::from(bytes), PutMode::Overwrite)
                 .await
@@ -1364,10 +1357,10 @@ async fn same_seq_root_replacement_publishes_a_compacted_manifest() {
     .await
     .expect("build compacted manifest");
     assert_eq!(
-        compacted.payload.head_seq,
+        compacted.payload().head_seq,
         materialization.root.manifest.manifest_head_seq
     );
-    write_namespace_manifest(&store, &compacted)
+    write_namespace_manifest(&store, compacted.payload().clone())
         .await
         .expect("write compacted manifest");
 
@@ -1382,7 +1375,7 @@ async fn same_seq_root_replacement_publishes_a_compacted_manifest() {
     .expect("same-seq replacement publishes");
     match outcome {
         ManifestPublicationOutcome::Published(root) => {
-            assert_eq!(root.manifest.manifest_no, compacted.payload.manifest_no);
+            assert_eq!(root.manifest.manifest_no, compacted.payload().manifest_no);
             assert_eq!(
                 root.manifest.manifest_head_seq,
                 materialization.root.manifest.manifest_head_seq
@@ -1396,7 +1389,7 @@ async fn same_seq_root_replacement_publishes_a_compacted_manifest() {
         .expect("materialization after compaction");
     assert_eq!(
         after.root.manifest.manifest_no,
-        compacted.payload.manifest_no
+        compacted.payload().manifest_no
     );
     assert!(metadata_states_equivalent(
         &materialization.metadata_state,
@@ -1653,11 +1646,11 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
         ManifestNo(stale_basis.root.manifest.manifest_no.0 + 1),
     )
     .await;
-    assert!(stale_higher_head.payload.head_seq > sibling.payload.head_seq);
-    write_namespace_manifest(&store, &sibling)
+    assert!(stale_higher_head.payload().head_seq > sibling.payload().head_seq);
+    write_namespace_manifest(&store, sibling.payload().clone())
         .await
         .expect("write sibling manifest");
-    write_namespace_manifest(&store, &stale_higher_head)
+    write_namespace_manifest(&store, stale_higher_head.payload().clone())
         .await
         .expect("write stale manifest");
 
@@ -1687,7 +1680,8 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
     match stale_outcome {
         ManifestPublicationOutcome::PredecessorChanged(root) => {
             assert_eq!(
-                root.manifest.manifest_object_id, sibling.payload.manifest_object_id,
+                root.manifest.manifest_object_id,
+                sibling.payload().manifest_object_id,
                 "the sibling's acknowledged publication must survive"
             );
         }
@@ -1700,6 +1694,6 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
         .state;
     assert_eq!(
         root_after.manifest.manifest_object_id,
-        sibling.payload.manifest_object_id
+        sibling.payload().manifest_object_id
     );
 }

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -90,7 +90,7 @@ async fn revision_test_materialization(
     );
     assert!(!revision_rows.is_empty());
     (
-        materialized.manifest.payload.manifest_no,
+        materialized.manifest.payload().manifest_no,
         materialized.manifest,
         revision_rows,
     )
@@ -102,9 +102,9 @@ async fn rewrite_revision_segment(
     manifest: &mut NamespaceManifestEnvelope,
     mut rows: Vec<MetadataRow>,
 ) {
+    let mut payload = manifest.payload().clone();
     rows.sort_by_key(|row| row.row_key_for_family(ApiMetadataRowFamily::Revisions));
-    let descriptor = manifest
-        .payload
+    let descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -114,13 +114,16 @@ async fn rewrite_revision_segment(
     rewrite_manifest_segment(
         store,
         namespace_id,
-        manifest.payload.head_seq,
+        payload.head_seq,
         ApiMetadataRowFamily::Revisions,
         descriptor,
         rows,
         default_target_block_bytes(),
     )
     .await;
+    *manifest = encode_namespace_manifest_json(payload)
+        .expect("encode changed manifest")
+        .into_envelope();
 }
 
 fn default_target_block_bytes() -> NonZeroUsize {
@@ -132,13 +135,14 @@ pub(super) async fn overwrite_manifest(
     namespace_id: &NamespaceId,
     manifest: NamespaceManifestEnvelope,
 ) {
-    let manifest_key = metadata_manifest_object(namespace_id, &manifest.payload.manifest_object_id);
-    let manifest_no = manifest.payload.manifest_no;
-    let manifest_object_id = manifest.payload.manifest_object_id.clone();
-    let updated_manifest =
-        NamespaceManifestEnvelope::from_payload(manifest.payload).expect("updated manifest");
-    let manifest_bytes =
-        encode_namespace_manifest_json(&updated_manifest).expect("encode updated manifest");
+    let manifest_key =
+        metadata_manifest_object(namespace_id, &manifest.payload().manifest_object_id);
+    let manifest_no = manifest.payload().manifest_no;
+    let manifest_object_id = manifest.payload().manifest_object_id.clone();
+    let (updated_manifest, manifest_bytes) =
+        encode_namespace_manifest_json(manifest.into_payload())
+            .expect("updated manifest")
+            .into_parts();
     store
         .put_overwrite(&manifest_key, Bytes::from(manifest_bytes))
         .await
@@ -152,14 +156,12 @@ pub(super) async fn overwrite_manifest(
     if loaded_root.state.manifest.manifest_no == manifest_no {
         let mut root = loaded_root.state;
         root.manifest.manifest_object_id = manifest_object_id;
-        root.manifest.manifest_payload_checksum = updated_manifest.payload_checksum.clone();
-        let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+        root.manifest.manifest_payload_checksum = updated_manifest.payload_checksum().to_owned();
+        let bytes = loonfs_api::wire::control::encode_control_state(
             loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-            root,
+            &root,
         )
-        .expect("root envelope");
-        let bytes =
-            loonfs_api::wire::control::encode_control_object(&envelope).expect("root bytes");
+        .expect("root bytes");
         store
             .put_overwrite(
                 &loonfs_objectstore::keys::metadata_root(namespace_id),
@@ -181,9 +183,10 @@ async fn load_perturbed_manifest(
     payload.manifest_no = ManifestNo(payload.manifest_no.0 + id_offset);
     payload.manifest_object_id = ManifestObjectId::generate(payload.manifest_no);
     let manifest_object_id = payload.manifest_object_id.clone();
-    let envelope =
-        NamespaceManifestEnvelope::from_payload(payload).expect("perturbed manifest envelope");
-    write_namespace_manifest(store, &envelope)
+    let envelope = encode_namespace_manifest_json(payload)
+        .expect("perturbed manifest envelope")
+        .into_envelope();
+    write_namespace_manifest(store, envelope.payload().clone())
         .await
         .expect("write perturbed manifest");
     load_manifest_segments_for_inspection(store, None, namespace_id, &manifest_object_id)
@@ -208,7 +211,7 @@ fn base_segment_of_family(
     family: ApiMetadataRowFamily,
 ) -> MetadataSegmentRef {
     manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| run.tier == RunTier::Base)
@@ -544,21 +547,28 @@ async fn manifest_load_rejects_unequal_index_descriptor_counts() {
 
     // Tamper only the descriptor's row_count for the child-bind index family;
     // the per-run count-equality check must reject the manifest at load.
-    let mut manifest =
+    let manifest =
         load_manifest_materialization_for_inspection(&store, &namespace_id, checkpoint.manifest_no)
             .await
             .expect("load manifest")
             .manifest;
-    let descriptor = manifest
-        .payload
+    let mut payload = manifest.payload().clone();
+    let descriptor = payload
         .runs
         .iter_mut()
         .flat_map(|run| &mut run.segments)
         .find(|descriptor| descriptor.family == ApiMetadataRowFamily::DirentryChildBinds)
         .expect("child-bind index descriptor");
     descriptor.row_count += 1;
-    let manifest_object_id = manifest.payload.manifest_object_id.clone();
-    overwrite_manifest(&store, &namespace_id, manifest).await;
+    let manifest_object_id = payload.manifest_object_id.clone();
+    overwrite_manifest(
+        &store,
+        &namespace_id,
+        encode_namespace_manifest_json(payload)
+            .expect("encode changed manifest")
+            .into_envelope(),
+    )
+    .await;
 
     match load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
         .await
@@ -603,9 +613,9 @@ async fn manifest_rejects_segment_whose_index_fails_its_descriptor_checksum() {
     )
     .await
     .expect("load manifest");
-    let mut manifest = materialized.manifest;
-    let descriptor = manifest
-        .payload
+    let manifest = materialized.manifest;
+    let mut payload = manifest.payload().clone();
+    let descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -616,13 +626,11 @@ async fn manifest_rejects_segment_whose_index_fails_its_descriptor_checksum() {
     // is what binds the manifest to the object's exact bytes.
     descriptor.index_block.crc32c ^= 0xffff_ffff;
 
-    let manifest_key =
-        metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id);
-    let manifest_no = manifest.payload.manifest_no;
-    let updated_manifest =
-        NamespaceManifestEnvelope::from_payload(manifest.payload).expect("updated manifest");
-    let manifest_bytes =
-        encode_namespace_manifest_json(&updated_manifest).expect("encode manifest");
+    let manifest_key = metadata_manifest_object(&namespace_id, &payload.manifest_object_id);
+    let manifest_no = payload.manifest_no;
+    let manifest_bytes = encode_namespace_manifest_json(payload)
+        .expect("updated manifest")
+        .into_bytes();
     store
         .put_overwrite(&manifest_key, Bytes::from(manifest_bytes))
         .await
@@ -661,7 +669,7 @@ async fn manifest_load_names_the_segment_codec_for_a_pre_commit_id_row() {
     let checkpoint = create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("checkpoint");
-    let mut materialized =
+    let materialized =
         load_manifest_materialization_for_inspection(&store, &namespace_id, checkpoint.manifest_no)
             .await
             .expect("load manifest before replacing a row");
@@ -682,9 +690,8 @@ async fn manifest_load_names_the_segment_codec_for_a_pre_commit_id_row() {
         )
         .expect("encode pre-change row");
     let built = builder.finish().expect("finish pre-change segment");
-    let descriptor = materialized
-        .manifest
-        .payload
+    let mut payload = materialized.manifest.payload().clone();
+    let descriptor = payload
         .runs
         .iter_mut()
         .flat_map(|run| &mut run.segments)
@@ -712,8 +719,15 @@ async fn manifest_load_names_the_segment_codec_for_a_pre_commit_id_row() {
     descriptor.filter_block = built.filter;
     descriptor.object_checksum = loonfs_api::sha256_digest(&built.bytes);
     let segment_key = metadata_segment_object_key(descriptor);
-    let manifest_no = materialized.manifest.payload.manifest_no;
-    overwrite_manifest(&store, &namespace_id, materialized.manifest).await;
+    let manifest_no = payload.manifest_no;
+    overwrite_manifest(
+        &store,
+        &namespace_id,
+        encode_namespace_manifest_json(payload)
+            .expect("encode changed manifest")
+            .into_envelope(),
+    )
+    .await;
 
     match load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no).await {
         Err(ManifestLoadError::SegmentCodec {
@@ -828,7 +842,7 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
         load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no)
             .await
             .expect("load manifest before corruption");
-    let mut manifest = materialized.manifest;
+    let manifest = materialized.manifest;
     let mut child_index_rows = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::DirentryChildBinds,
@@ -838,8 +852,8 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
     child_index_rows
         .sort_by_key(|row| row.row_key_for_family(ApiMetadataRowFamily::DirentryChildBinds));
 
-    let child_descriptor = manifest
-        .payload
+    let mut payload = manifest.payload().clone();
+    let child_descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -849,7 +863,7 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
     rewrite_manifest_segment(
         &store,
         &namespace_id,
-        manifest.payload.head_seq,
+        payload.head_seq,
         ApiMetadataRowFamily::DirentryChildBinds,
         child_descriptor,
         child_index_rows,
@@ -857,13 +871,11 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
     )
     .await;
 
-    let manifest_key =
-        metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id);
-    let manifest_no = manifest.payload.manifest_no;
-    let updated_manifest =
-        NamespaceManifestEnvelope::from_payload(manifest.payload).expect("updated manifest");
-    let manifest_bytes =
-        encode_namespace_manifest_json(&updated_manifest).expect("encode updated manifest");
+    let manifest_key = metadata_manifest_object(&namespace_id, &payload.manifest_object_id);
+    let manifest_no = payload.manifest_no;
+    let manifest_bytes = encode_namespace_manifest_json(payload)
+        .expect("updated manifest")
+        .into_bytes();
     store
         .put_overwrite(&manifest_key, Bytes::from(manifest_bytes))
         .await
@@ -924,7 +936,7 @@ async fn unreferenced_manifest_run_is_ignored_by_current_projection_load() {
     )
     .await
     .expect("build orphan manifest");
-    write_namespace_manifest(&store, &orphan_manifest)
+    write_namespace_manifest(&store, orphan_manifest.payload().clone())
         .await
         .expect("write orphan manifest");
 
@@ -937,7 +949,7 @@ async fn unreferenced_manifest_run_is_ignored_by_current_projection_load() {
     );
     assert_eq!(
         materialization_after.head.seq,
-        orphan_manifest.payload.head_seq
+        orphan_manifest.payload().head_seq
     );
     assert!(metadata_states_equivalent(
         &materialization_before.metadata_state,
@@ -978,7 +990,7 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
         load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no)
             .await
             .expect("load manifest before the rewrite");
-    let mut manifest = materialized.manifest;
+    let manifest = materialized.manifest;
     let mut inode_rows =
         manifest_rows_for_family(&materialized.metadata_state, ApiMetadataRowFamily::Inodes);
     inode_rows.sort_by_key(|row| row.row_key_for_family(ApiMetadataRowFamily::Inodes));
@@ -992,7 +1004,7 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
         .row_key_for_family(ApiMetadataRowFamily::Inodes);
 
     let base_inode_segments = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| run.tier == RunTier::Base)
@@ -1003,8 +1015,8 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
         base_inode_segments, 1,
         "the folded base should hold one inode segment"
     );
-    let descriptor = manifest
-        .payload
+    let mut payload = manifest.payload().clone();
+    let descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -1017,7 +1029,7 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
     rewrite_manifest_segment(
         &store,
         &namespace_id,
-        manifest.payload.head_seq,
+        payload.head_seq,
         ApiMetadataRowFamily::Inodes,
         descriptor,
         inode_rows.clone(),
@@ -1028,7 +1040,14 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
         descriptor.max_row_key, last_inode_key,
         "the descriptor must carry the segment's last row key"
     );
-    overwrite_manifest(&store, &namespace_id, manifest).await;
+    overwrite_manifest(
+        &store,
+        &namespace_id,
+        encode_namespace_manifest_json(payload)
+            .expect("encode changed manifest")
+            .into_envelope(),
+    )
+    .await;
 
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let segments =
@@ -1075,7 +1094,7 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
         load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
             .await
             .expect("load segments");
-    let payload = segments.manifest().payload.clone();
+    let payload = segments.manifest().payload().clone();
 
     // The read path assumes the filter block directly precedes the index
     // block, that an inline copy matches its handle's length, and that a
@@ -1146,14 +1165,14 @@ async fn a_manifest_whose_group_base_fragmented_does_not_load() {
         "the seed must leave the group in one base run"
     );
 
-    let mut fragmented = manifest.payload.clone();
+    let mut fragmented = manifest.payload().clone();
     // A second base run, not a second segment of the one already there, so
     // the copy takes a run number of its own out of the allocator.
     let second_base_run_no = fragmented.next_run_no;
     fragmented.next_run_no = RunNo(second_base_run_no.0 + 1);
     fragmented.runs.push(MetadataRunRef {
         run_no: second_base_run_no,
-        run_seq: manifest.payload.head_seq,
+        run_seq: manifest.payload().head_seq,
         tier: RunTier::Base,
         segments: vec![segment_modelled_on(&base_segment_of_family(
             &manifest,
@@ -1184,7 +1203,7 @@ async fn a_manifest_that_numbers_one_family_twice_in_one_run_does_not_load() {
     let existing = base_segment_of_family(&manifest, ApiMetadataRowFamily::Inodes);
     assert_eq!(existing.segment_index, 0);
 
-    let mut repeated = manifest.payload.clone();
+    let mut repeated = manifest.payload().clone();
     repeated
         .runs
         .iter_mut()
@@ -1222,7 +1241,7 @@ async fn a_manifest_whose_run_segments_overlap_in_key_range_does_not_load() {
     let existing = base_segment_of_family(&manifest, ApiMetadataRowFamily::Inodes);
     assert_eq!(existing.segment_index, 0);
 
-    let mut overlapping = manifest.payload.clone();
+    let mut overlapping = manifest.payload().clone();
     let mut second = segment_modelled_on(&existing);
     // Index one keeps the numbering valid, leaving the overlapping range as
     // the only error.

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -131,8 +131,8 @@ pub(crate) async fn load_manifest_metadata_state_for_inspection_from_manifest<
     manifest: &NamespaceManifestEnvelope,
 ) -> Result<MetadataState, ManifestLoadError> {
     let mut metadata_state = MetadataStateBuilder::default();
-    validate_manifest_materialization_ranges(manifest_object_key, &manifest.payload)?;
-    for run in runs_in_materialization_order(&manifest.payload) {
+    validate_manifest_materialization_ranges(manifest_object_key, manifest.payload())?;
+    for run in runs_in_materialization_order(manifest.payload()) {
         append_manifest_segments_to_metadata(
             store,
             namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -62,18 +62,18 @@ async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
             .expect("load folded manifest");
     let delta = materialized
         .manifest
-        .payload
+        .payload()
         .runs
         .last()
         .expect("folded manifest has a delta run");
     assert_eq!(delta.tier, RunTier::Delta);
-    let delta_manifest = runs_in_materialization_order(&materialized.manifest.payload)
+    let delta_manifest = runs_in_materialization_order(materialized.manifest.payload())
         .into_iter()
         .find(|run| run.run_no == delta.run_no)
         .expect("folded delta run is valid");
     let manifest_key = metadata_manifest_object(
         &namespace_id,
-        &materialized.manifest.payload.manifest_object_id,
+        &materialized.manifest.payload().manifest_object_id,
     );
     let mut actual_tail = MetadataStateBuilder::default();
     inspection_materialization::append_manifest_segments_to_metadata(
@@ -257,10 +257,10 @@ async fn manifest_round_trip_supports_empty_namespace() {
         load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestNo(1))
             .await
             .expect("first manifest is valid");
-    assert_eq!(published.manifest.payload.next_run_no, RunNo(1));
-    assert_eq!(published.manifest.payload.runs.len(), 1);
-    assert_eq!(published.manifest.payload.runs[0].run_no, RunNo(0));
-    assert_eq!(published.manifest.payload.runs[0].tier, RunTier::Base);
+    assert_eq!(published.manifest.payload().next_run_no, RunNo(1));
+    assert_eq!(published.manifest.payload().runs.len(), 1);
+    assert_eq!(published.manifest.payload().runs[0].run_no, RunNo(0));
+    assert_eq!(published.manifest.payload().runs[0].tier, RunTier::Base);
     assert!(metadata_states_equivalent(
         &published.metadata_state,
         &genesis.base_state
@@ -333,13 +333,11 @@ async fn recovery_rejects_a_root_head_seq_that_disagrees_with_its_manifest() {
     assert_eq!(loaded_root.state.manifest.manifest_head_seq, ChangeSeq(1));
     let mut root = loaded_root.state;
     root.manifest.manifest_head_seq = ChangeSeq(0);
-    let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+    let bytes = loonfs_api::wire::control::encode_control_state(
         loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-        root,
+        &root,
     )
-    .expect("root envelope");
-    let bytes = loonfs_api::wire::control::encode_control_object(&envelope)
-        .expect("encode contradictory root");
+    .expect("encode contradictory root");
     store
         .put_overwrite(
             &loonfs_objectstore::keys::metadata_root(&namespace_id),
@@ -720,8 +718,8 @@ async fn manifest_delta_run_materialization_matches_checkpoint_projection() {
     // Checkpoints only append: the base run stays the bootstrap seed's and
     // each checkpoint contributes one delta run.
     assert_eq!(
-        second_materialized.manifest.payload.base_seq,
-        first_materialized.manifest.payload.base_seq
+        second_materialized.manifest.payload().base_seq,
+        first_materialized.manifest.payload().base_seq
     );
     assert_eq!(
         base_tier(&second_materialized.manifest),
@@ -768,7 +766,7 @@ async fn manifest_delta_run_materialization_matches_checkpoint_projection() {
             .await
             .expect("load chained manifest");
     assert_eq!(
-        latest_materialized.manifest.payload.base_seq,
+        latest_materialized.manifest.payload().base_seq,
         ChangeSeq(0),
         "always-append checkpoints keep the first published base"
     );
@@ -893,7 +891,7 @@ async fn manifest_run_rejects_rows_after_run_seq() {
     )
     .await
     .expect("write empty metadata run segments");
-    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    let manifest = encode_namespace_manifest_json(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no: manifest_no(materialization.head.seq),
         manifest_object_id: manifest_object_id(manifest_no(materialization.head.seq)),
@@ -919,12 +917,13 @@ async fn manifest_run_rejects_rows_after_run_seq() {
             },
         ],
     })
-    .expect("build malformed manifest");
+    .expect("build malformed manifest")
+    .into_envelope();
 
     match load_manifest_metadata_state_for_inspection_from_manifest(
         &store,
         &namespace_id,
-        &metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id),
+        &metadata_manifest_object(&namespace_id, &manifest.payload().manifest_object_id),
         &manifest,
     )
     .await
@@ -1026,10 +1025,10 @@ async fn write_namespace_manifest_conflict_same_payload_is_idempotent() {
     .await
     .expect("build manifest");
 
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("first manifest write");
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("same manifest write is idempotent");
 }
@@ -1061,15 +1060,16 @@ async fn write_namespace_manifest_conflict_different_payload_is_error() {
     )
     .await
     .expect("build manifest");
-    let mut conflicting_payload = manifest.payload.clone();
+    let mut conflicting_payload = manifest.payload().clone();
     conflicting_payload.next_inode_id = InodeId(conflicting_payload.next_inode_id.0 + 1);
-    let conflicting_manifest = NamespaceManifestEnvelope::from_payload(conflicting_payload)
-        .expect("build conflicting manifest");
+    let conflicting_manifest = encode_namespace_manifest_json(conflicting_payload)
+        .expect("build conflicting manifest")
+        .into_envelope();
 
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("first manifest write");
-    let error = write_namespace_manifest(&store, &conflicting_manifest)
+    let error = write_namespace_manifest(&store, conflicting_manifest.payload().clone())
         .await
         .expect_err("different same-id manifest must conflict");
 
@@ -1126,7 +1126,7 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
     )
     .await
     .expect("build manifest");
-    write_namespace_manifest(&store, &manifest_without_checkpoint)
+    write_namespace_manifest(&store, manifest_without_checkpoint.payload().clone())
         .await
         .expect("write manifest");
     publish_metadata_root(
@@ -1155,7 +1155,7 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
     assert_eq!(record.manifest.manifest_no, covering_manifest_no);
     assert_eq!(
         record.manifest.manifest_payload_checksum,
-        manifest_without_checkpoint.payload_checksum
+        manifest_without_checkpoint.payload_checksum()
     );
 }
 
@@ -1204,7 +1204,7 @@ async fn manifest_without_checkpoint_record_reconstructs_manifest_head_commit() 
 
     assert_eq!(
         reconstructed.head_commit_id,
-        manifest.payload.head_commit_id
+        manifest.payload().head_commit_id
     );
     assert_ne!(reconstructed.head_commit_id, newer_live_head.head_commit_id);
 }

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -487,7 +487,7 @@ pub(crate) async fn staged_keys_of_the_current_manifest<S: ObjectStore + ?Sized>
             .await
             .expect("load the published manifest")
             .manifest()
-            .payload
+            .payload()
             .runs
             .iter()
             .flat_map(|run| &run.segments)
@@ -567,7 +567,7 @@ pub(crate) async fn load_current_projection<S: ObjectStore + ?Sized>(
 /// as many base runs as it has rebuilt groups. A caller asking about "the
 /// base" means all of them.
 fn base_tier(manifest: &NamespaceManifestEnvelope) -> Vec<MetadataFamilySegments> {
-    let base_runs = runs_in_reorganization_order(&manifest.payload)
+    let base_runs = runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .filter(|run| run.tier == RunTier::Base)
         .collect::<Vec<_>>();
@@ -587,7 +587,7 @@ fn base_tier(manifest: &NamespaceManifestEnvelope) -> Vec<MetadataFamilySegments
 }
 
 fn delta_runs(manifest: &NamespaceManifestEnvelope) -> Vec<MetadataRunManifest> {
-    runs_in_materialization_order(&manifest.payload)
+    runs_in_materialization_order(manifest.payload())
         .into_iter()
         .filter(|run| run.tier == RunTier::Delta)
         .collect()
@@ -598,7 +598,7 @@ fn group_runs(
     manifest: &NamespaceManifestEnvelope,
     group: &[ApiMetadataRowFamily],
 ) -> Vec<MetadataRunManifest> {
-    runs_in_reorganization_order(&manifest.payload)
+    runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .filter(|run| {
             run.segments.iter().any(|family_segments| {
@@ -776,14 +776,17 @@ impl ObjectStore for ConflictOnManifestCreateStore {
                     ManifestConflictReplacement::MutateCandidateNextInode => {
                         let candidate = decode_namespace_manifest_json(&bytes)
                             .map_err(|error| ObjectStoreError::transport(key, error.to_string()))?;
-                        let mut payload = candidate.payload;
+                        let mut payload = candidate.into_payload();
                         payload.next_inode_id = InodeId(payload.next_inode_id.0 + 1);
-                        let mutated = NamespaceManifestEnvelope::from_payload(payload)
+                        let mutated = encode_namespace_manifest_json(payload)
+                            .map(|encoded| encoded.into_envelope())
                             .map_err(|error| ObjectStoreError::transport(key, error.to_string()))?;
                         Bytes::from(
-                            encode_namespace_manifest_json(&mutated).map_err(|error| {
-                                ObjectStoreError::transport(key, error.to_string())
-                            })?,
+                            encode_namespace_manifest_json(mutated.payload().clone())
+                                .map(|encoded| encoded.into_bytes())
+                                .map_err(|error| {
+                                    ObjectStoreError::transport(key, error.to_string())
+                                })?,
                         )
                     }
                 };
@@ -853,10 +856,10 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
     // the counter alone.
     let run_no = previous_manifest
         .as_ref()
-        .map_or(RunNo(0), |previous| previous.manifest.payload.next_run_no);
+        .map_or(RunNo(0), |previous| previous.manifest.payload().next_run_no);
     let mut next_run_no = next_run_no_after(run_no)?;
     let (base_seq, runs) = match previous_manifest {
-        Some(previous) if is_bootstrap_seed_manifest(&previous.manifest.payload) => {
+        Some(previous) if is_bootstrap_seed_manifest(previous.manifest.payload()) => {
             let run_segments =
                 build_manifest_segments(store, namespace_id, metadata_state, policy).await?;
             debug_assert_manifest_segments_do_not_overlap(&run_segments);
@@ -871,10 +874,10 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
             )
         }
         Some(previous)
-            if delta_run_count(&previous.manifest.payload) < policy.max_delta_runs.get() =>
+            if delta_run_count(previous.manifest.payload()) < policy.max_delta_runs.get() =>
         {
-            let mut runs = previous.manifest.payload.runs.clone();
-            if previous.manifest.payload.head_seq < head_seq {
+            let mut runs = previous.manifest.payload().runs.clone();
+            if previous.manifest.payload().head_seq < head_seq {
                 runs.push(MetadataRunRef {
                     run_no,
                     run_seq: head_seq,
@@ -883,7 +886,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
                         build_manifest_delta_run_segments(
                             store,
                             namespace_id,
-                            previous.manifest.payload.head_seq,
+                            previous.manifest.payload().head_seq,
                             metadata_state,
                             policy,
                         )
@@ -893,7 +896,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
             } else {
                 next_run_no = run_no;
             }
-            (previous.manifest.payload.base_seq, runs)
+            (previous.manifest.payload().base_seq, runs)
         }
         Some(_) => {
             let run_segments =
@@ -924,7 +927,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
         }
     };
 
-    NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    encode_namespace_manifest_json(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no,
         manifest_object_id,
@@ -937,6 +940,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
         retention_floor_seq: source.retention_floor_seq,
         runs,
     })
+    .map(|encoded| encoded.into_envelope())
     .map_err(|err| {
         CoreError::Internal(format!(
             "failed to build namespace manifest envelope: {err}"

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -114,7 +114,7 @@ async fn current_manifest_no<S: ObjectStore + ?Sized>(
 }
 
 fn run_segment_object_keys(manifest: &NamespaceManifestEnvelope) -> Vec<String> {
-    runs_in_reorganization_order(&manifest.payload)
+    runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .flat_map(|run| {
             run.segments.into_iter().flat_map(|family_segments| {
@@ -216,7 +216,7 @@ type FamilyRunShape = (ApiMetadataRowFamily, u64, usize);
 type ManifestRunShape = (ChangeSeq, RunTier, Vec<FamilyRunShape>);
 
 fn manifest_run_shape(manifest: &NamespaceManifestEnvelope) -> Vec<ManifestRunShape> {
-    runs_in_reorganization_order(&manifest.payload)
+    runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .map(|run| {
             let segments = run
@@ -345,7 +345,7 @@ async fn retention_advancement_uses_published_manifest_and_updates_floor_only() 
     .await
     .expect("load current manifest")
     .manifest()
-    .payload
+    .payload()
     .runs
     .iter()
     .flat_map(|run| &run.segments)
@@ -424,7 +424,7 @@ async fn retention_floor_does_not_advance_past_a_missing_basis_segment() {
     .expect("load current manifest");
     let missing_key = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -489,7 +489,7 @@ async fn retention_floor_does_not_advance_when_a_basis_segment_cannot_be_checked
     .expect("load current manifest");
     let selected_key = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -1093,15 +1093,18 @@ async fn checkpoint_checksum_disagreement_is_terminal_corruption_and_releases_re
         .expect("read manifest")
         .expect("current manifest exists");
     let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
-    let record_checksum = manifest.payload_checksum.clone();
-    let mut mismatched_payload = manifest.payload;
+    let record_checksum = manifest.payload_checksum().to_owned();
+    let mut mismatched_payload = manifest.into_payload();
     mismatched_payload.next_inode_id = InodeId(mismatched_payload.next_inode_id.0 + 1);
-    let mismatched_manifest = NamespaceManifestEnvelope::from_payload(mismatched_payload)
-        .expect("build mismatched manifest");
-    let manifest_checksum = mismatched_manifest.payload_checksum.clone();
+    let mismatched_manifest = encode_namespace_manifest_json(mismatched_payload)
+        .expect("build mismatched manifest")
+        .into_envelope();
+    let manifest_checksum = mismatched_manifest.payload_checksum().to_owned();
     assert_ne!(record_checksum, manifest_checksum);
     let mismatched_bytes = Bytes::from(
-        encode_namespace_manifest_json(&mismatched_manifest).expect("encode mismatched manifest"),
+        encode_namespace_manifest_json(mismatched_manifest.payload().clone())
+            .expect("encode mismatched manifest")
+            .into_bytes(),
     );
     let store = ManifestChecksumMismatchOnceStore::new(
         setup_store,
@@ -1282,7 +1285,7 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     .expect("load appended manifest");
     assert_eq!(delta_runs(&appended.manifest).len(), rounds);
     assert!(delta_runs(&appended.manifest).len() > DEFAULT_MAX_CHECKPOINT_DELTA_RUNS);
-    assert_eq!(appended.manifest.payload.base_seq, ChangeSeq(0));
+    assert_eq!(appended.manifest.payload().base_seq, ChangeSeq(0));
 
     // Reorganization folds one family group per unit, each publishing its
     // own manifest — the manifest chain is the progress record.
@@ -1329,7 +1332,7 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
         .expect("materialization");
     assert!(delta_runs(&drained.manifest).is_empty());
     assert_eq!(
-        drained.manifest.payload.base_seq,
+        drained.manifest.payload().base_seq,
         ChangeSeq(u64::try_from(rounds).expect("round count fits"))
     );
     assert!(metadata_states_equivalent(
@@ -1653,7 +1656,7 @@ async fn whole_run_compaction_rewrites_base_segments() {
     );
 
     assert_eq!(
-        compacted_materialized.manifest.payload.base_seq,
+        compacted_materialized.manifest.payload().base_seq,
         compacted.checkpoint_seq
     );
     assert!(delta_runs(&compacted_materialized.manifest).is_empty());
@@ -1755,7 +1758,7 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_delta_runs(
     // Groups untouched since the first fold keep their older base run, so
     // several base runs may coexist; what matters is that no delta remains.
     assert!(
-        runs_in_reorganization_order(&compacted_materialized.manifest.payload)
+        runs_in_reorganization_order(compacted_materialized.manifest.payload())
             .iter()
             .all(|run| run.tier == RunTier::Base)
     );
@@ -2026,7 +2029,7 @@ async fn select_reorganization_window<S: ObjectStore + ?Sized>(
     let group = super::reorganize::select_family_group(
         store,
         namespace_id,
-        &segments.manifest().payload,
+        segments.manifest().payload(),
         0,
         MetadataCompactionPolicy::default(),
         policy,

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -503,7 +503,7 @@ async fn policy_that_starves_the_group<S: ObjectStore + ?Sized>(
     group: MetadataFamilyGroup,
 ) -> MetadataLsmPolicy {
     let segments = load_current_manifest_segments(store, namespace_id).await;
-    let base_rows: u64 = runs_in_reorganization_order(&segments.manifest().payload)
+    let base_rows: u64 = runs_in_reorganization_order(segments.manifest().payload())
         .iter()
         .filter(|run| run.tier == RunTier::Base)
         .flat_map(|run| run.segments.iter())
@@ -552,7 +552,7 @@ fn snapshot_runs_for_group(
     manifest: &NamespaceManifestEnvelope,
     group: MetadataFamilyGroup,
 ) -> Vec<MetadataRunManifest> {
-    runs_in_reorganization_order(&manifest.payload)
+    runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .filter(|run| {
             run.segments.iter().any(|family_segments| {
@@ -1464,10 +1464,10 @@ async fn rewrite_base_segment(
     family: ApiMetadataRowFamily,
     mut rows: Vec<MetadataRow>,
 ) {
+    let mut payload = manifest.payload().clone();
     rows.sort_by_key(|row| row.row_key_for_family(family));
-    let head_seq = manifest.payload.head_seq;
-    let descriptor = manifest
-        .payload
+    let head_seq = payload.head_seq;
+    let descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -1484,6 +1484,9 @@ async fn rewrite_base_segment(
         NonZeroUsize::new(DEFAULT_TARGET_BLOCK_BYTES).expect("the default target is positive"),
     )
     .await;
+    *manifest = encode_namespace_manifest_json(payload)
+        .expect("encode changed manifest")
+        .into_envelope();
 }
 
 #[tokio::test]
@@ -1846,14 +1849,14 @@ async fn install_synthetic_bindings_base(
         ));
     }
 
-    let mut manifest = load_current_manifest_segments(store, namespace_id)
+    let manifest = load_current_manifest_segments(store, namespace_id)
         .await
         .manifest()
         .clone();
     // The synthetic segments replace this run's bindings, so they join the
     // run that already holds the group's other families.
     let base_run = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .find(|run| {
@@ -1889,8 +1892,8 @@ async fn install_synthetic_bindings_base(
 
     // Only the base tier is replaced: the delta run above it is what gives a
     // bottom-anchored window something to fold.
-    let base_run = manifest
-        .payload
+    let mut payload = manifest.payload().clone();
+    let base_run = payload
         .runs
         .iter_mut()
         .find(|run| run.run_no == base_run_no)
@@ -1906,8 +1909,7 @@ async fn install_synthetic_bindings_base(
     // What the probe cache would have to hold to serve every probe without
     // refetching: the decoded data blocks of the unbind family.
     let mut unbind_decoded_bytes = 0u64;
-    for descriptor in manifest
-        .payload
+    for descriptor in payload
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -1926,7 +1928,14 @@ async fn install_synthetic_bindings_base(
             .map(|entry| u64::from(entry.block.decoded_len))
             .sum::<u64>();
     }
-    super::index_parity::overwrite_manifest(store, namespace_id, manifest).await;
+    super::index_parity::overwrite_manifest(
+        store,
+        namespace_id,
+        encode_namespace_manifest_json(payload)
+            .expect("encode changed manifest")
+            .into_envelope(),
+    )
+    .await;
     unbind_decoded_bytes
 }
 
@@ -1951,7 +1960,7 @@ async fn a_step_contained_merge_reads_its_window_once() {
     let segments = load_current_manifest_segments(&store, &namespace_id).await;
     let descriptors: Vec<MetadataSegmentRef> = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| run.segments.iter().cloned())
@@ -2239,7 +2248,7 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
     let manifest_keys: BTreeSet<String> = load_current_manifest_segments(&store, &namespace_id)
         .await
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -2921,7 +2930,7 @@ async fn group_segments_outside_the_job<S: ObjectStore + ?Sized>(
     load_current_manifest_segments(store, namespace_id)
         .await
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| !inputs.contains(&run.run_no))
@@ -2939,7 +2948,7 @@ async fn referenced_segment_keys<S: ObjectStore + ?Sized>(
     load_current_manifest_segments(store, namespace_id)
         .await
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -3389,7 +3398,7 @@ async fn a_flush_landing_during_finalization_is_retried_over() {
     );
 
     let segments = load_current_manifest_segments(&store, &namespace_id).await;
-    assert_eq!(segments.manifest().payload.manifest_no, manifest_no);
+    assert_eq!(segments.manifest().payload().manifest_no, manifest_no);
     let runs = snapshot_runs_for_group(segments.manifest(), group);
     drop(segments);
     // Two runs: the base run the job built, and the delta run the flush

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -24,36 +24,37 @@ pub(super) fn validate_namespace_manifest(
     object_key: &str,
     manifest: &NamespaceManifestEnvelope,
 ) -> Result<(), ManifestLoadError> {
-    if manifest.payload.namespace_id != *namespace_id {
+    if manifest.payload().namespace_id != *namespace_id {
         return Err(ManifestLoadError::ManifestNamespaceMismatch {
             object_key: object_key.to_owned(),
             expected: namespace_id.clone(),
-            actual: manifest.payload.namespace_id.clone(),
+            actual: manifest.payload().namespace_id.clone(),
         });
     }
-    if manifest.payload.manifest_no != manifest_no {
+    if manifest.payload().manifest_no != manifest_no {
         return Err(ManifestLoadError::ManifestNoMismatch {
             object_key: object_key.to_owned(),
             expected: manifest_no,
-            actual: manifest.payload.manifest_no,
+            actual: manifest.payload().manifest_no,
         });
     }
-    if manifest_object_id_manifest_no(manifest.payload.manifest_object_id.as_str())
-        != Some(manifest.payload.manifest_no)
+    if manifest_object_id_manifest_no(manifest.payload().manifest_object_id.as_str())
+        != Some(manifest.payload().manifest_no)
     {
         return Err(ManifestLoadError::RunManifestMismatch {
             object_key: object_key.to_owned(),
             message: format!(
                 "manifest object id `{}` does not encode manifest number `{}`",
-                manifest.payload.manifest_object_id, manifest.payload.manifest_no
+                manifest.payload().manifest_object_id,
+                manifest.payload().manifest_no
             ),
         });
     }
-    if manifest.payload.manifest_object_id != *manifest_object_id {
+    if manifest.payload().manifest_object_id != *manifest_object_id {
         return Err(ManifestLoadError::ManifestObjectIdMismatch {
             object_key: object_key.to_owned(),
             expected: manifest_object_id.clone(),
-            actual: manifest.payload.manifest_object_id.clone(),
+            actual: manifest.payload().manifest_object_id.clone(),
         });
     }
     Ok(())

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -27,7 +27,7 @@ pub(crate) fn prepare_commit_head_publish(
     plan: &CommitPlan,
     wal: &PreparedWalSegment,
 ) -> Result<PreparedCommitHeadPublish, CommitHeadPublishError> {
-    let wal_payload = &wal.envelope.payload;
+    let wal_payload = &wal.envelope().payload();
     ensure_segment_connects(
         "writer_epoch",
         current_head.writer_epoch,
@@ -47,7 +47,7 @@ pub(crate) fn prepare_commit_head_publish(
     ensure_segment_connects("end_seq", plan.assigned_seq, wal_payload.end_seq)?;
 
     let object_key = wal_head(&current_head.namespace_id);
-    let new_tip = wal.envelope.pointer();
+    let new_tip = wal.envelope().pointer();
     let resulting_head = HeadState {
         seq: plan.assigned_seq,
         head_commit_id: plan.commit_id.clone(),
@@ -135,7 +135,6 @@ fn map_object_store_error(object_key: &str, err: ObjectStoreError) -> CommitHead
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_api::wire::control::{encode_control_object, HeadStateEnvelope};
 
     #[test]
     fn head_cas_transport_failure_maps_to_unknown_outcome_not_failure() {
@@ -170,7 +169,7 @@ mod tests {
         ));
     }
     use loonfs_api::wire::control::{NamespaceStatus, WriterBlock};
-    use loonfs_api::wire::wal::{WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload};
+    use loonfs_api::wire::wal::{WalCommitPayload, WalSegmentPayload};
     use loonfs_api::{CommitId, InodeId, NamespaceId, WalSegmentId, WriterEpoch, MAX_ID_BYTES};
 
     fn head(namespace_id: NamespaceId, seq: ChangeSeq) -> HeadState {
@@ -252,11 +251,7 @@ mod tests {
             end_seq,
             records,
         };
-        let envelope = WalSegmentEnvelope::from_payload(payload).expect("wal envelope");
-        PreparedWalSegment {
-            envelope,
-            encoded_bytes: Vec::new(),
-        }
+        loonfs_api::wire::wal::encode_wal_segment_envelope_zstd(payload).expect("wal encoding")
     }
 
     #[test]
@@ -272,20 +267,20 @@ mod tests {
         assert_eq!(prepared.resulting_head.seq, ChangeSeq(9));
         assert_eq!(
             prepared.resulting_head.visible_wal_tip,
-            Some(wal.envelope.pointer())
+            Some(wal.envelope().pointer())
         );
         assert_eq!(
             prepared.object_key,
             wal_head(&prepared.resulting_head.namespace_id),
         );
-        let expected_envelope = HeadStateEnvelope::from_state(
-            ControlObjectKind::WalHead,
-            prepared.resulting_head.clone(),
-        )
-        .expect("head envelope");
+        let expected_envelope = prepared.resulting_head.clone();
         assert_eq!(
             prepared.encoded_bytes,
-            encode_control_object(&expected_envelope).expect("encoded head"),
+            loonfs_api::wire::control::encode_control_state(
+                ControlObjectKind::WalHead,
+                &expected_envelope
+            )
+            .expect("encoded head"),
         );
     }
 
@@ -352,7 +347,7 @@ mod tests {
             ChangeSeq(7),
             2,
         );
-        let prior_tip = prior.envelope.pointer();
+        let prior_tip = prior.envelope().pointer();
         current_head.visible_wal_tip = Some(prior_tip.clone());
         current_head.recent_segments = Vec::new();
         let plan = plan(namespace_id.clone(), ChangeSeq(9));
@@ -361,7 +356,7 @@ mod tests {
         let prepared =
             prepare_commit_head_publish(&current_head, &plan, &wal).expect("prepare head publish");
 
-        let new_tip = wal.envelope.pointer();
+        let new_tip = wal.envelope().pointer();
         assert_eq!(prepared.resulting_head.recent_segments, vec![prior_tip]);
         assert_eq!(prepared.resulting_head.visible_wal_tip, Some(new_tip));
     }
@@ -379,7 +374,7 @@ mod tests {
                 ChangeSeq(index + 1),
                 1,
             );
-            segment.envelope.pointer()
+            segment.envelope().pointer()
         };
         let old_tip = filler(limit);
         current_head.visible_wal_tip = Some(old_tip.clone());
@@ -407,7 +402,7 @@ mod tests {
         assert_eq!(recent[0], old_tip);
         assert_eq!(
             prepared.resulting_head.visible_wal_tip,
-            Some(wal.envelope.pointer())
+            Some(wal.envelope().pointer())
         );
         assert!(!recent.contains(&oldest), "oldest hint must fall off");
     }
@@ -511,9 +506,10 @@ mod tests {
         state.visible_wal_tip = segments.first().cloned();
         state.recent_segments = segments.into_iter().skip(1).collect();
 
-        let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, state)
-            .expect("head envelope");
-        encode_control_object(&envelope).expect("encode head").len()
+        let envelope = state;
+        loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &envelope)
+            .expect("encode head")
+            .len()
     }
 
     #[test]

--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -60,12 +60,12 @@ where
         .ok_or_else(|| classify(&object_key, ControlLoadFailure::MissingEtag))?;
     let envelope = decode_control_object(&body.bytes, kind)
         .map_err(|error| classify(&object_key, ControlLoadFailure::Decode(error)))?;
-    validate_identity(&envelope.state)
+    validate_identity(envelope.payload())
         .map_err(|error| classify(&object_key, ControlLoadFailure::EmbeddedIdentity(error)))?;
     Ok(LoadedControl {
         object_key,
         etag,
-        state: envelope.state,
+        state: envelope.into_payload(),
     })
 }
 
@@ -180,7 +180,7 @@ mod tests {
     use super::*;
     use crate::error::StoreFailureClass;
     use bytes::Bytes;
-    use loonfs_api::wire::control::{encode_control_object, HeadState, HeadStateEnvelope};
+    use loonfs_api::wire::control::HeadState;
     use loonfs_api::{ContentStoreId, NamespaceId};
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -203,9 +203,9 @@ mod tests {
 
     fn encoded_head(namespace_id: &NamespaceId) -> (HeadState, Vec<u8>) {
         let state = HeadState::initial(namespace_id.clone(), ContentStoreId::generate(), 1_000);
-        let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, state.clone())
-            .expect("head envelope");
-        let bytes = encode_control_object(&envelope).expect("head bytes");
+        let bytes =
+            loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &state)
+                .expect("head bytes");
         (state, bytes)
     }
 

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -318,7 +318,7 @@ async fn load_upload_session_object<S: ObjectStore + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
+    use loonfs_api::wire::control::ControlObjectKind;
     use loonfs_api::NamespaceId;
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -329,16 +329,14 @@ mod tests {
     use tempfile::tempdir;
 
     async fn write_initial_head(store: &LocalFsStore, namespace_id: &NamespaceId) {
-        let envelope = HeadStateEnvelope::from_state(
-            ControlObjectKind::WalHead,
-            HeadState::initial(
-                namespace_id.clone(),
-                loonfs_api::ContentStoreId::generate(),
-                1_000,
-            ),
-        )
-        .expect("head envelope");
-        let bytes = encode_control_object(&envelope).expect("head bytes");
+        let envelope = HeadState::initial(
+            namespace_id.clone(),
+            loonfs_api::ContentStoreId::generate(),
+            1_000,
+        );
+        let bytes =
+            loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &envelope)
+                .expect("head bytes");
         store
             .put_if_absent(&wal_head(namespace_id), Bytes::from(bytes))
             .await

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -446,7 +446,7 @@ async fn collect_manifest_segments<S: ObjectStore + ?Sized>(
         {
             Ok(Some(manifest)) => live.segments.extend(
                 manifest
-                    .payload
+                    .payload()
                     .runs
                     .iter()
                     .flat_map(|run| &run.segments)
@@ -721,13 +721,13 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
         };
         manifest_object_ids.insert(manifest_object_id);
         head_seq = Some(
-            head_seq.map_or(manifest.payload.head_seq, |current: ChangeSeq| {
-                current.min(manifest.payload.head_seq)
+            head_seq.map_or(manifest.payload().head_seq, |current: ChangeSeq| {
+                current.min(manifest.payload().head_seq)
             }),
         );
         segments.extend(
             manifest
-                .payload
+                .payload()
                 .runs
                 .iter()
                 .flat_map(|run| &run.segments)

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -200,7 +200,7 @@ impl BlockingControlCasTarget {
                 ) else {
                     return false;
                 };
-                matches!(envelope.state.status, CheckpointStatus::Released { .. })
+                matches!(envelope.payload().status, CheckpointStatus::Released { .. })
             }
             BlockingControlCasTarget::UploadCompleted | BlockingControlCasTarget::UploadAborted => {
                 let Ok(envelope) = decode_control_object::<UploadSessionState>(
@@ -211,12 +211,12 @@ impl BlockingControlCasTarget {
                 };
                 match self {
                     BlockingControlCasTarget::UploadCompleted => matches!(
-                        envelope.state.status,
+                        envelope.payload().status,
                         UploadSessionRecordStatus::Completed { .. }
                     ),
                     BlockingControlCasTarget::UploadAborted => {
                         matches!(
-                            envelope.state.status,
+                            envelope.payload().status,
                             UploadSessionRecordStatus::Aborted { .. }
                         )
                     }
@@ -409,13 +409,11 @@ async fn write_upload_session(store: &LocalFsStore, namespace_id: &NamespaceId) 
             expires_at_ms: 1_000 + UPLOAD_SESSION_LEASE_MS,
         },
     };
-    let envelope = loonfs_api::wire::control::UploadSessionEnvelope::from_state(
+    let bytes = loonfs_api::wire::control::encode_control_state(
         loonfs_api::wire::control::ControlObjectKind::UploadSession,
-        state,
+        &state,
     )
-    .expect("session envelope");
-    let bytes =
-        loonfs_api::wire::control::encode_control_object(&envelope).expect("encode session");
+    .expect("encode session");
     let key = loonfs_objectstore::keys::upload_session(namespace_id, &upload_id);
     store
         .put_if_absent(&key, bytes::Bytes::from(bytes))
@@ -462,7 +460,7 @@ async fn read_upload_session<S: ObjectStore + ?Sized>(
     Some(
         decode_control_object::<UploadSessionState>(&body, ControlObjectKind::UploadSession)
             .expect("decode upload session")
-            .state,
+            .into_payload(),
     )
 }
 
@@ -2158,7 +2156,7 @@ async fn an_old_unpublished_manifest_cannot_replace_the_published_grace_anchor()
         .await
         .expect("load current projection");
     let next_manifest_no = ManifestNo(projection.root.manifest.manifest_no.0 + 1);
-    let mut orphan = build_namespace_manifest_from_metadata_state(
+    let orphan = build_namespace_manifest_from_metadata_state(
         &inner,
         &namespace_id,
         ManifestMetadataSource {
@@ -2175,12 +2173,14 @@ async fn an_old_unpublished_manifest_cannot_replace_the_published_grace_anchor()
     )
     .await
     .expect("build unpublished manifest");
-    orphan.payload.manifest_object_id =
+    let mut orphan_payload = orphan.into_payload();
+    orphan_payload.manifest_object_id =
         ManifestObjectId::parse(format!("man_{:020}-0000000000000000", next_manifest_no.0))
             .expect("ordered orphan manifest id");
-    orphan = loonfs_api::wire::manifest::NamespaceManifestEnvelope::from_payload(orphan.payload)
-        .expect("re-envelope orphan manifest");
-    crate::checkpoint::write_namespace_manifest(&inner, &orphan)
+    let orphan = loonfs_api::wire::manifest::encode_namespace_manifest_json(orphan_payload)
+        .expect("re-envelope orphan manifest")
+        .into_envelope();
+    crate::checkpoint::write_namespace_manifest(&inner, orphan.payload().clone())
         .await
         .expect("write unpublished manifest");
 
@@ -2294,21 +2294,20 @@ async fn write_compaction_lease_in_state<S: ObjectStore + ?Sized>(
     expires_at_ms: u64,
     status: loonfs_api::wire::control::CompactionLeaseStatus,
 ) {
-    let envelope = loonfs_api::wire::control::MetadataCompactionLeaseEnvelope::from_state(
+    let envelope = loonfs_api::wire::control::MetadataCompactionLeaseState {
+        job_id: metadata_compaction_id.clone(),
+        namespace_id: namespace_id.clone(),
+        group,
+        writer_id: loonfs_api::WriterId::parse("writer").expect("writer id"),
+        status,
+        started_at_ms: 1_000,
+        expires_at_ms,
+    };
+    let bytes = loonfs_api::wire::control::encode_control_state(
         loonfs_api::wire::control::ControlObjectKind::CompactionLease,
-        loonfs_api::wire::control::MetadataCompactionLeaseState {
-            job_id: metadata_compaction_id.clone(),
-            namespace_id: namespace_id.clone(),
-            group,
-            writer_id: loonfs_api::WriterId::parse("writer").expect("writer id"),
-            status,
-            started_at_ms: 1_000,
-            expires_at_ms,
-        },
+        &envelope,
     )
-    .expect("build a lease");
-    let bytes =
-        loonfs_api::wire::control::encode_control_object(&envelope).expect("encode a lease");
+    .expect("encode a lease");
     store
         .put(
             &metadata_compaction_lease(namespace_id, group),
@@ -3158,7 +3157,7 @@ async fn assert_record_reaped_and_basis_kept(
     )
     .await
     .expect("the basis manifest survives its record");
-    for descriptor in basis.payload.runs.iter().flat_map(|run| &run.segments) {
+    for descriptor in basis.payload().runs.iter().flat_map(|run| &run.segments) {
         assert!(
             store
                 .head(&metadata_segment_object_key(descriptor))
@@ -4011,7 +4010,7 @@ async fn read_fork_record(store: &LocalFsStore, source: &NamespaceId) -> Checkpo
             ControlObjectKind::CheckpointRecord,
         )
         .expect("decode record")
-        .state;
+        .into_payload();
         if matches!(record.owner, CheckpointOwner::Fork { .. }) {
             return record;
         }
@@ -4136,17 +4135,19 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         ControlObjectKind::WalHead,
     )
     .expect("decode target head")
-    .state;
+    .into_payload();
     let basis = head.fork_basis.as_mut().expect("a fork target has a basis");
     basis.manifest.manifest_no = ManifestNo(basis.manifest.manifest_no.0 + 1);
-    let drifted =
-        loonfs_api::wire::control::HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head)
-            .expect("drifted head envelope");
+    let drifted = head;
     store
         .put_overwrite(
             &head_key,
             Bytes::from(
-                loonfs_api::wire::control::encode_control_object(&drifted).expect("encode head"),
+                loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &drifted,
+                )
+                .expect("encode head"),
             ),
         )
         .await

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -79,7 +79,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             writer_id: context.writer_id.clone(),
             acquired_at_ms: context.now_ms,
         }),
-        next_inode_id: source_manifest.payload.next_inode_id,
+        next_inode_id: source_manifest.payload().next_inode_id,
         visible_wal_tip: None,
         recent_segments: Vec::new(),
         status: NamespaceStatus::Active {},

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -189,8 +189,7 @@ mod tests {
     }
     use bytes::Bytes;
     use loonfs_api::wire::control::{
-        decode_control_object, encode_control_object, ControlObjectKind, HeadStateEnvelope,
-        NamespaceStatus,
+        decode_control_object, ControlObjectKind, HeadStateEnvelope, NamespaceStatus,
     };
     use loonfs_api::{ChangeSeq, CommitId, NamespaceId, MAX_PUBLIC_INTEGER};
     use loonfs_objectstore::keys::wal_head;
@@ -229,9 +228,9 @@ mod tests {
     }
 
     async fn write_head(store: &LocalFsStore, namespace_id: &NamespaceId, head: HeadState) {
-        let envelope =
-            HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
-        let bytes = encode_control_object(&envelope).expect("head bytes");
+        let bytes =
+            loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &head)
+                .expect("head bytes");
         store
             .put_if_absent(&wal_head(namespace_id), Bytes::from(bytes))
             .await
@@ -538,15 +537,17 @@ mod tests {
                 let envelope: HeadStateEnvelope =
                     decode_control_object(&body.bytes, ControlObjectKind::WalHead)
                         .expect("decode head");
-                let mut head = envelope.state;
+                let mut head = envelope.into_payload();
                 head.writer_epoch = WriterEpoch(head.writer_epoch.0 + 1);
                 head.writer = Some(WriterBlock {
                     writer_id: loonfs_api::WriterId::parse("writer-b").expect("writer id"),
                     acquired_at_ms: 1_500,
                 });
-                let next = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head)
-                    .expect("head envelope");
-                let bytes = encode_control_object(&next).expect("head bytes");
+                let bytes = loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &head,
+                )
+                .expect("head bytes");
                 inner
                     .put(&head_key, Bytes::from(bytes), PutMode::Overwrite)
                     .await
@@ -608,9 +609,11 @@ mod tests {
             let namespace_id = winner_namespace_id.clone();
             Box::pin(async move {
                 let winner = head_owned_by(&namespace_id, "writer-b", WriterEpoch(8));
-                let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, winner)
-                    .expect("head envelope");
-                let bytes = encode_control_object(&envelope).expect("head bytes");
+                let bytes = loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &winner,
+                )
+                .expect("head bytes");
                 inner
                     .put(
                         &wal_head(&namespace_id),

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -929,7 +929,7 @@ mod tests {
     use crate::namespace::control::load_head_object;
     use crate::path::write::{CommitRequest, FilesystemOperation};
     use bytes::Bytes;
-    use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
+    use loonfs_api::wire::control::ControlObjectKind;
     use loonfs_api::{AttributeRevisionNo, AttributeValue, CommitId, ErrorCode};
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -1020,12 +1020,17 @@ mod tests {
             .expect("load head")
             .state;
         head.next_inode_id = InodeId(head.next_inode_id.0 + 1);
-        let envelope =
-            HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
+        let envelope = head;
         store
             .put_overwrite(
                 &wal_head(&namespace_id),
-                Bytes::from(encode_control_object(&envelope).expect("encode head")),
+                Bytes::from(
+                    loonfs_api::wire::control::encode_control_state(
+                        ControlObjectKind::WalHead,
+                        &envelope,
+                    )
+                    .expect("encode head"),
+                ),
             )
             .await
             .expect("rewrite head");

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -239,7 +239,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         Err(error) => return abort_batch(slots, &error),
     };
 
-    let wal_records = wal.envelope.payload.records.clone();
+    let wal_records = wal.envelope().payload().records.clone();
     assert_eq!(
         slots
             .iter()
@@ -311,11 +311,11 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
         )
         .map_err(|error| CoreError::Internal(format!("wal build failed: {error}")))?;
         let object_key = wal_segment(
-            &wal.envelope.payload.namespace_id,
-            &wal.envelope.payload.segment_id,
+            &wal.envelope().payload().namespace_id,
+            &wal.envelope().payload().segment_id,
         );
         store
-            .put_immutable_verified(&object_key, Bytes::copy_from_slice(&wal.encoded_bytes))
+            .put_immutable_verified(&object_key, Bytes::copy_from_slice(wal.as_bytes()))
             .await
             .map_err(wal_immutable_write_error)?;
         Ok(wal)

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -2,17 +2,15 @@
 //! replay paths.
 
 use loonfs_api::wire::control::{HeadState, WalSegmentPointer};
-use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalSegmentEnvelope};
+use loonfs_api::wire::wal::{
+    WalCommitDelta, WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload,
+};
 use loonfs_api::{ChangeSeq, CommitId, NamespaceId, WriterEpoch};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct PreparedWalSegment {
-    pub envelope: WalSegmentEnvelope,
-    pub encoded_bytes: Vec<u8>,
-}
+pub(crate) type PreparedWalSegment = loonfs_api::wire::envelope::EncodedEnvelope<WalSegmentPayload>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum WalSegmentError {
@@ -70,7 +68,7 @@ pub(crate) struct WalChainLoadRequest<'a> {
     pub(crate) recent_segments: &'a [WalSegmentPointer],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ValidatedWalSegment {
     object_key: String,
     envelope: WalSegmentEnvelope,
@@ -106,7 +104,7 @@ impl ValidatedWalSegment {
     }
 
     pub(crate) fn records(&self) -> &[WalCommitPayload] {
-        &self.envelope.payload.records
+        &self.envelope.payload().records
     }
 
     pub(crate) fn pointer(&self) -> WalSegmentPointer {
@@ -114,10 +112,10 @@ impl ValidatedWalSegment {
     }
 
     pub(crate) fn decoded_records(&self) -> impl Iterator<Item = DecodedWalRecord<'_>> {
-        let namespace_id = &self.envelope.payload.namespace_id;
-        let writer_epoch = self.envelope.payload.writer_epoch;
+        let namespace_id = &self.envelope.payload().namespace_id;
+        let writer_epoch = self.envelope.payload().writer_epoch;
         self.envelope
-            .payload
+            .payload()
             .records
             .iter()
             .map(move |record| DecodedWalRecord {
@@ -134,7 +132,7 @@ impl ValidatedWalSegment {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ValidatedWalChain {
     segments: Vec<ValidatedWalSegment>,
 }

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -244,8 +244,8 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
             .map_err(|err| WalSegmentError::Codec(err.to_string()))?;
         validate_pointer_matches_envelope(&pointer, &object_key, &envelope)?;
 
-        let reached_stop = envelope.payload.base_head_seq <= stop_after_seq;
-        let prev = envelope.payload.prev_visible_segment.clone();
+        let reached_stop = envelope.payload().base_head_seq <= stop_after_seq;
+        let prev = envelope.payload().prev_visible_segment.clone();
         reversed.push(ValidatedWalSegment::new(object_key.clone(), envelope));
 
         if reached_stop {
@@ -275,14 +275,14 @@ fn finish_chain(
         return Ok(ValidatedWalChain::empty());
     };
     if let Some(after_seq) = request.stop_after_seq {
-        if first_segment.envelope().payload.base_head_seq > after_seq
-            || first_segment.envelope().payload.end_seq <= after_seq
+        if first_segment.envelope().payload().base_head_seq > after_seq
+            || first_segment.envelope().payload().end_seq <= after_seq
         {
             return Err(WalChainLoadError::CursorNotCovered { after_seq });
         }
     }
 
-    let mut expected_base_seq = first_segment.envelope().payload.base_head_seq;
+    let mut expected_base_seq = first_segment.envelope().payload().base_head_seq;
     if request.stop_after_seq.is_none() && expected_base_seq != request.chain_base_seq {
         return Err(WalChainLoadError::HeadSeqMismatch {
             expected: request.chain_base_seq,
@@ -295,7 +295,7 @@ fn finish_chain(
             expected_base_seq,
             segment.envelope(),
         )?;
-        expected_base_seq = segment.envelope().payload.end_seq;
+        expected_base_seq = segment.envelope().payload().end_seq;
     }
 
     if expected_base_seq != request.head_seq {

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -126,17 +126,17 @@ pub(super) fn validate_wal_segment_for_replay(
     expected_base_head_seq: ChangeSeq,
     envelope: &WalSegmentEnvelope,
 ) -> Result<(), WalSegmentError> {
-    if &envelope.payload.namespace_id != expected_namespace_id {
+    if &envelope.payload().namespace_id != expected_namespace_id {
         return Err(WalSegmentError::NamespaceMismatch {
             expected: expected_namespace_id.clone(),
-            actual: envelope.payload.namespace_id.clone(),
+            actual: envelope.payload().namespace_id.clone(),
         });
     }
 
-    if envelope.payload.base_head_seq != expected_base_head_seq {
+    if envelope.payload().base_head_seq != expected_base_head_seq {
         return Err(WalSegmentError::BaseHeadSeqMismatch {
             expected: expected_base_head_seq,
-            actual: envelope.payload.base_head_seq,
+            actual: envelope.payload().base_head_seq,
         });
     }
 
@@ -144,24 +144,25 @@ pub(super) fn validate_wal_segment_for_replay(
         .successor()
         .map_err(|_| WalSegmentError::SeqOverflow)?;
 
-    if envelope.payload.start_seq != expected_start {
+    if envelope.payload().start_seq != expected_start {
         return Err(WalSegmentError::NonContiguousSeq {
             expected: expected_start,
-            actual: envelope.payload.start_seq,
+            actual: envelope.payload().start_seq,
         });
     }
-    if envelope.payload.records.is_empty() {
+    if envelope.payload().records.is_empty() {
         return Err(WalSegmentError::EmptySegment);
     }
-    if envelope.payload.records.first().map(|record| record.seq) != Some(envelope.payload.start_seq)
-        || envelope.payload.records.last().map(|record| record.seq)
-            != Some(envelope.payload.end_seq)
+    if envelope.payload().records.first().map(|record| record.seq)
+        != Some(envelope.payload().start_seq)
+        || envelope.payload().records.last().map(|record| record.seq)
+            != Some(envelope.payload().end_seq)
     {
         return Err(WalSegmentError::SegmentSummaryMismatch);
     }
-    for (offset, record) in envelope.payload.records.iter().enumerate() {
+    for (offset, record) in envelope.payload().records.iter().enumerate() {
         let expected = envelope
-            .payload
+            .payload()
             .start_seq
             .0
             .checked_add(offset as u64)

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -10,7 +10,7 @@ use crate::commit::{
 };
 use bytes::Bytes;
 use loonfs_api::wire::control::WalSegmentPointer;
-use loonfs_api::wire::wal::{encode_wal_segment_envelope_zstd, WalSegmentEnvelope};
+use loonfs_api::wire::wal::{encode_wal_segment_envelope_zstd, WalSegmentPayload};
 use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey, NamespaceId, WalSegmentId, WriterEpoch};
 use loonfs_objectstore::keys::{wal_segment, wal_segment_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -66,7 +66,7 @@ async fn build_wal_record_payload_matches_segment_record_payload() {
     .expect("prepare wal segment");
     let payload = wal_payload_from_materialized_commit(&record);
 
-    assert_eq!(payload, segment.envelope.payload.records[0]);
+    assert_eq!(payload, segment.envelope().payload().records[0]);
 }
 
 #[tokio::test]
@@ -95,8 +95,8 @@ async fn prepared_wal_segments_use_unique_segment_ids_and_derived_object_keys() 
     )
     .expect("prepare second wal segment");
 
-    let first_id = &first.envelope.payload.segment_id;
-    let second_id = &second.envelope.payload.segment_id;
+    let first_id = &first.envelope().payload().segment_id;
+    let second_id = &second.envelope().payload().segment_id;
     assert_ne!(first_id, second_id);
     assert_ne!(prepared_segment_key(&first), prepared_segment_key(&second));
     WalSegmentId::parse(first_id.as_str()).expect("first segment id shape");
@@ -151,7 +151,7 @@ async fn validated_wal_chain_loads_visible_segments_in_ascending_order() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(1),
-            visible_tip: Some(segment.envelope.pointer()),
+            visible_tip: Some(segment.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &[],
@@ -188,8 +188,8 @@ fn canonical_replay_advances_head_and_applies_metadata_rows() {
     );
     base_head.writer_epoch = WriterEpoch(1);
     let record = segment
-        .envelope
-        .payload
+        .envelope()
+        .payload()
         .records
         .first()
         .expect("wal record");
@@ -201,7 +201,7 @@ fn canonical_replay_advances_head_and_applies_metadata_rows() {
         [DecodedWalRecord {
             namespace_id: &namespace_id,
             seq: record.seq,
-            writer_epoch: segment.envelope.payload.writer_epoch,
+            writer_epoch: segment.envelope().payload().writer_epoch,
             commit_id: &record.commit_id,
             committed_by: &record.committed_by,
             committed_at_ms: record.committed_at_ms,
@@ -249,8 +249,8 @@ fn canonical_replay_rejects_writer_epoch_above_expected_bound() {
     );
     base_head.writer_epoch = WriterEpoch(1);
     let record = segment
-        .envelope
-        .payload
+        .envelope()
+        .payload()
         .records
         .first()
         .expect("wal record");
@@ -262,7 +262,7 @@ fn canonical_replay_rejects_writer_epoch_above_expected_bound() {
         [DecodedWalRecord {
             namespace_id: &namespace_id,
             seq: record.seq,
-            writer_epoch: segment.envelope.payload.writer_epoch,
+            writer_epoch: segment.envelope().payload().writer_epoch,
             commit_id: &record.commit_id,
             committed_by: &record.committed_by,
             committed_at_ms: record.committed_at_ms,
@@ -300,7 +300,7 @@ async fn validated_wal_chain_can_load_cursor_suffix_without_full_base() {
     let second = write_create_directory_segment(
         &store,
         &namespace_id,
-        Some(first.envelope.pointer()),
+        Some(first.envelope().pointer()),
         "c_wal_suffix_b",
         "beta",
         ChangeSeq(1),
@@ -314,7 +314,7 @@ async fn validated_wal_chain_can_load_cursor_suffix_without_full_base() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(second.envelope.pointer()),
+            visible_tip: Some(second.envelope().pointer()),
             stop_after_seq: Some(ChangeSeq(1)),
             max_segment_fetches: None,
             recent_segments: &[],
@@ -349,7 +349,7 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(segment.envelope.pointer()),
+            visible_tip: Some(segment.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &[],
@@ -360,7 +360,7 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
 
     let message = error.to_string();
     assert!(
-        message.contains(segment.envelope.payload.segment_id.as_str()),
+        message.contains(segment.envelope().payload().segment_id.as_str()),
         "the error names the segment: {message}"
     );
     assert!(
@@ -371,55 +371,47 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
 
 #[tokio::test]
 async fn validated_wal_chain_rejects_corrupt_visible_segments() {
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        envelope.payload.namespace_id = NamespaceId::parse("other").expect("valid namespace id");
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        payload.namespace_id = NamespaceId::parse("other").expect("valid namespace id");
+        *pointer = pointer_for_payload(payload);
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, _pointer| {
-        envelope.payload.segment_id =
-            WalSegmentId::parse("wal_00000000000000000001-bbbbbbbbbbbbbbbb")
-                .expect("valid segment id");
-        rewrap_envelope(envelope);
+    assert_wal_chain_corruption_rejected(|payload, _pointer| {
+        payload.segment_id = WalSegmentId::parse("wal_00000000000000000001-bbbbbbbbbbbbbbbb")
+            .expect("valid segment id");
     })
     .await;
-    assert_wal_chain_corruption_rejected(|_envelope, pointer| {
+    assert_wal_chain_corruption_rejected(|_payload, pointer| {
         pointer.payload_checksum = "sha256:not-the-payload".to_owned();
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        envelope.payload.records.clear();
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        payload.records.clear();
+        *pointer = pointer_for_payload(payload);
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        envelope.payload.end_seq = ChangeSeq(2);
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        payload.end_seq = ChangeSeq(2);
+        *pointer = pointer_for_payload(payload);
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        let mut skipped = envelope.payload.records[0].clone();
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        let mut skipped = payload.records[0].clone();
         skipped.seq = ChangeSeq(3);
-        envelope.payload.records.push(skipped);
-        envelope.payload.end_seq = ChangeSeq(3);
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+        payload.records.push(skipped);
+        payload.end_seq = ChangeSeq(3);
+        *pointer = pointer_for_payload(payload);
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        envelope.payload.base_head_seq = ChangeSeq(1);
-        envelope.payload.start_seq = ChangeSeq(2);
-        envelope.payload.end_seq = ChangeSeq(2);
-        envelope.payload.records[0].seq = ChangeSeq(2);
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        payload.base_head_seq = ChangeSeq(1);
+        payload.start_seq = ChangeSeq(2);
+        payload.end_seq = ChangeSeq(2);
+        payload.records[0].seq = ChangeSeq(2);
         // Keep the id consistent so this test reaches the chain validation.
-        envelope.payload.segment_id =
-            WalSegmentId::parse("wal_00000000000000000002-cccccccccccccccc")
-                .expect("valid segment id");
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+        payload.segment_id = WalSegmentId::parse("wal_00000000000000000002-cccccccccccccccc")
+            .expect("valid segment id");
+        *pointer = pointer_for_payload(payload);
     })
     .await;
 }
@@ -455,8 +447,15 @@ fn materialized_create_directory(
     materialize_commit(plan, 4_200)
 }
 
+fn pointer_for_payload(payload: &WalSegmentPayload) -> WalSegmentPointer {
+    encode_wal_segment_envelope_zstd(payload.clone())
+        .expect("encode WAL pointer")
+        .envelope()
+        .pointer()
+}
+
 async fn assert_wal_chain_corruption_rejected(
-    corrupt: impl FnOnce(&mut WalSegmentEnvelope, &mut WalSegmentPointer),
+    corrupt: impl FnOnce(&mut WalSegmentPayload, &mut WalSegmentPointer),
 ) {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -474,12 +473,14 @@ async fn assert_wal_chain_corruption_rejected(
         )],
     )
     .expect("prepare wal segment");
-    let mut envelope = segment.envelope;
-    let mut pointer = envelope.pointer();
+    let mut pointer = segment.envelope().pointer();
+    let mut payload = segment.into_envelope().into_payload();
 
-    corrupt(&mut envelope, &mut pointer);
+    corrupt(&mut payload, &mut pointer);
 
-    let encoded = encode_wal_segment_envelope_zstd(&envelope).expect("encode corrupted envelope");
+    let encoded = encode_wal_segment_envelope_zstd(payload)
+        .expect("encode corrupted envelope")
+        .into_bytes();
     let object_key = wal_segment(&namespace_id, &pointer.segment_id);
     store
         .put_if_absent(&object_key, Bytes::from(encoded))
@@ -520,7 +521,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
     let second = write_create_directory_segment(
         &store,
         &namespace_id,
-        Some(first.envelope.pointer()),
+        Some(first.envelope().pointer()),
         "c_wal_hint_b",
         "beta",
         ChangeSeq(1),
@@ -533,7 +534,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(second.envelope.pointer()),
+            visible_tip: Some(second.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &[],
@@ -543,14 +544,14 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
     .expect("unhinted chain");
 
     // Accurate predecessor hints prefetch the gap together with the tip.
-    let accurate = [first.envelope.pointer()];
+    let accurate = [first.envelope().pointer()];
     let hinted = load_complete_wal_chain(
         &store,
         WalChainLoadRequest {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(second.envelope.pointer()),
+            visible_tip: Some(second.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &accurate,
@@ -562,7 +563,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
 
     // Garbage hints (missing objects, lying seq ranges) cost fallback
     // fetches, never correctness: chain links stay the authority.
-    let mut lying_tip = second.envelope.pointer();
+    let mut lying_tip = second.envelope().pointer();
     lying_tip.end_seq = ChangeSeq(999);
     let missing_segment_id =
         WalSegmentId::parse("wal_00000000000000000001-00000000deadbeef").expect("valid segment id");
@@ -581,7 +582,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(second.envelope.pointer()),
+            visible_tip: Some(second.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &garbage,
@@ -611,7 +612,7 @@ async fn write_linked_chain(
             ChangeSeq(index + 1),
         )
         .await;
-        pointers.push(segment.envelope.pointer());
+        pointers.push(segment.envelope().pointer());
     }
     pointers
 }
@@ -855,7 +856,7 @@ async fn write_create_directory_segment(
     .expect("prepare wal segment");
     let object_key = prepared_segment_key(&segment);
     store
-        .put_if_absent(&object_key, Bytes::copy_from_slice(&segment.encoded_bytes))
+        .put_if_absent(&object_key, Bytes::copy_from_slice(segment.as_bytes()))
         .await
         .expect("write wal segment");
     segment
@@ -863,14 +864,9 @@ async fn write_create_directory_segment(
 
 fn prepared_segment_key(segment: &PreparedWalSegment) -> String {
     wal_segment(
-        &segment.envelope.payload.namespace_id,
-        &segment.envelope.payload.segment_id,
+        &segment.envelope().payload().namespace_id,
+        &segment.envelope().payload().segment_id,
     )
-}
-
-fn rewrap_envelope(envelope: &mut WalSegmentEnvelope) {
-    *envelope =
-        WalSegmentEnvelope::from_payload(envelope.payload.clone()).expect("rewrap wal envelope");
 }
 
 fn prepared_create_directory_segment(
@@ -901,7 +897,7 @@ fn prepared_create_directory_segment(
 fn prepared_unstored_chain(namespace_id: &NamespaceId, len: u64) -> Vec<PreparedWalSegment> {
     let mut chain: Vec<PreparedWalSegment> = Vec::new();
     for seq in 1..=len {
-        let prev = chain.last().map(|segment| segment.envelope.pointer());
+        let prev = chain.last().map(|segment| segment.envelope().pointer());
         chain.push(prepared_create_directory_segment(
             namespace_id,
             prev,
@@ -918,7 +914,7 @@ fn newest_first_pointers(chain: &[PreparedWalSegment]) -> Vec<WalSegmentPointer>
     chain
         .iter()
         .rev()
-        .map(|segment| segment.envelope.pointer())
+        .map(|segment| segment.envelope().pointer())
         .collect()
 }
 
@@ -926,7 +922,7 @@ async fn store_chain<S: ObjectStore + ?Sized>(store: &S, chain: &[PreparedWalSeg
     for segment in chain {
         let object_key = prepared_segment_key(segment);
         store
-            .put_if_absent(&object_key, Bytes::copy_from_slice(&segment.encoded_bytes))
+            .put_if_absent(&object_key, Bytes::copy_from_slice(segment.as_bytes()))
             .await
             .expect("write wal segment");
     }
@@ -1199,14 +1195,17 @@ async fn a_corrupt_segment_inside_the_hinted_set_is_still_rejected() {
     // Rewrite the middle segment's body at its own key: it decodes, but its
     // payload no longer matches the checksum its successor's chain link
     // recorded.
-    let mut tampered = chain[1].envelope.clone();
-    tampered.payload.records[0].committed_at_ms += 1;
-    rewrap_envelope(&mut tampered);
+    let mut tampered = chain[1].envelope().payload().clone();
+    tampered.records[0].committed_at_ms += 1;
     let tampered_key = prepared_segment_key(&chain[1]);
     store
         .put_overwrite(
             &tampered_key,
-            Bytes::from(encode_wal_segment_envelope_zstd(&tampered).expect("encode tampered")),
+            Bytes::from(
+                encode_wal_segment_envelope_zstd(tampered)
+                    .expect("encode tampered")
+                    .into_bytes(),
+            ),
         )
         .await
         .expect("overwrite middle wal segment");

--- a/crates/loonfs-core/src/wal/writer.rs
+++ b/crates/loonfs-core/src/wal/writer.rs
@@ -5,7 +5,7 @@ use super::{PreparedWalSegment, WalSegmentError};
 use crate::commit::{wal_payload_from_materialized_commit, MaterializedCommit};
 use loonfs_api::wire::control::WalSegmentPointer;
 use loonfs_api::wire::wal::{
-    encode_wal_segment_envelope_zstd, WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload,
+    encode_wal_segment_envelope_zstd, WalCommitPayload, WalSegmentPayload,
 };
 use loonfs_api::{ChangeSeq, NamespaceId, WalSegmentId, WriterEpoch};
 
@@ -72,12 +72,5 @@ pub(crate) fn prepare_wal_segment(
         end_seq,
         records: payload_records,
     };
-    let envelope = WalSegmentEnvelope::from_payload(payload)
-        .map_err(|err| WalSegmentError::Codec(err.to_string()))?;
-    let encoded_bytes = encode_wal_segment_envelope_zstd(&envelope)
-        .map_err(|err| WalSegmentError::Codec(err.to_string()))?;
-    Ok(PreparedWalSegment {
-        envelope,
-        encoded_bytes,
-    })
+    encode_wal_segment_envelope_zstd(payload).map_err(|err| WalSegmentError::Codec(err.to_string()))
 }

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -216,7 +216,7 @@ fn ack_lost_head_cas_store(
                 _ => return false,
             };
             decode_control_object::<HeadState>(bytes, ControlObjectKind::WalHead)
-                .is_ok_and(|envelope| envelope.state.seq > ChangeSeq(0))
+                .is_ok_and(|envelope| envelope.payload().seq > ChangeSeq(0))
         },
         InjectedError::Transport("response lost after head compare-and-swap".to_owned()),
     )
@@ -340,7 +340,7 @@ async fn head_cas_advances_seq(
         decode_control_object(&existing_bytes, ControlObjectKind::WalHead).map_err(|err| {
             ObjectStoreError::transport(key, format!("decode existing head: {err}"))
         })?;
-    Ok(candidate.state.seq > existing.state.seq)
+    Ok(candidate.payload().seq > existing.payload().seq)
 }
 
 #[tokio::test]
@@ -464,13 +464,13 @@ async fn batch_commit_writes_one_segment_and_expands_change_feed() {
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.start_seq, ChangeSeq(1));
-    assert_eq!(segment.payload.end_seq, ChangeSeq(2));
-    assert_eq!(segment.payload.records.len(), 2);
-    assert_eq!(segment.payload.records[0].deltas.len(), 2);
-    assert_eq!(segment.payload.records[0].deltas[0].semantic_op_index, 0);
-    assert_eq!(segment.payload.records[0].deltas[1].semantic_op_index, 0);
-    match &segment.payload.records[0].deltas[1].delta {
+    assert_eq!(segment.payload().start_seq, ChangeSeq(1));
+    assert_eq!(segment.payload().end_seq, ChangeSeq(2));
+    assert_eq!(segment.payload().records.len(), 2);
+    assert_eq!(segment.payload().records[0].deltas.len(), 2);
+    assert_eq!(segment.payload().records[0].deltas[0].semantic_op_index, 0);
+    assert_eq!(segment.payload().records[0].deltas[1].semantic_op_index, 0);
+    match &segment.payload().records[0].deltas[1].delta {
         WalDelta::BindDirentry {
             name_key,
             display_name,
@@ -658,11 +658,11 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
         .expect("visible wal exists");
     let visible_segment =
         decode_wal_segment_envelope_zstd(&visible_wal).expect("decode visible segment");
-    assert_eq!(visible_segment.payload.start_seq, ChangeSeq(1));
-    assert_eq!(visible_segment.payload.end_seq, ChangeSeq(1));
-    assert_eq!(visible_segment.payload.records.len(), 1);
+    assert_eq!(visible_segment.payload().start_seq, ChangeSeq(1));
+    assert_eq!(visible_segment.payload().end_seq, ChangeSeq(1));
+    assert_eq!(visible_segment.payload().records.len(), 1);
     assert_eq!(
-        visible_segment.payload.records[0].commit_id,
+        visible_segment.payload().records[0].commit_id,
         CommitId::parse("retry-after-orphan").expect("valid commit id")
     );
     let orphan_wal = store
@@ -672,7 +672,7 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
         .expect("orphan wal exists");
     let orphan_segment =
         decode_wal_segment_envelope_zstd(&orphan_wal).expect("decode orphan segment");
-    let visible_created_ids = visible_segment.payload.records[0]
+    let visible_created_ids = visible_segment.payload().records[0]
         .deltas
         .iter()
         .filter_map(|delta| match &delta.delta {
@@ -680,7 +680,7 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
             _ => None,
         })
         .collect::<Vec<_>>();
-    let orphan_created_ids = orphan_segment.payload.records[0]
+    let orphan_created_ids = orphan_segment.payload().records[0]
         .deltas
         .iter()
         .filter_map(|delta| match &delta.delta {
@@ -1159,7 +1159,7 @@ async fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.records.len(), 1);
+    assert_eq!(segment.payload().records.len(), 1);
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0))
         .await
@@ -1563,7 +1563,7 @@ async fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.records.len(), 1);
+    assert_eq!(segment.payload().records.len(), 1);
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0))
         .await

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -12,12 +12,10 @@ use crate::common::namespace_engine;
 use bytes::Bytes;
 use loonfs_api::{
     wire::control::{
-        decode_control_object, encode_control_object, CheckpointOwner, CheckpointStatus,
-        ControlObjectKind, HeadState, HeadStateEnvelope,
+        decode_control_object, CheckpointOwner, CheckpointStatus, ControlObjectKind, HeadState,
     },
     wire::manifest::{
         decode_namespace_manifest_json, encode_namespace_manifest_json, MetadataRowFamily,
-        NamespaceManifestEnvelope,
     },
     AbsolutePath, ChangeSeq, CommitId, DestinationBehavior, ManifestNo, NamespaceId,
 };
@@ -545,7 +543,7 @@ async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
         decode_namespace_manifest_json(&clone_manifest_bytes).expect("decode clone manifest");
     assert!(
         clone_manifest
-            .payload
+            .payload()
             .runs
             .iter()
             .flat_map(|run| &run.segments)
@@ -648,12 +646,17 @@ async fn a_fork_basis_checksum_mismatch_is_corruption() {
     let fork_basis = head.fork_basis.as_mut().expect("fork basis");
     fork_basis.manifest.manifest_payload_checksum =
         loonfs_api::sha256_digest(b"not-the-source-manifest-payload");
-    let envelope =
-        HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
+    let envelope = head;
     store
         .put_overwrite(
             &wal_head(&clone),
-            Bytes::from(encode_control_object(&envelope).expect("encode head")),
+            Bytes::from(
+                loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &envelope,
+                )
+                .expect("encode head"),
+            ),
         )
         .await
         .expect("rewrite clone head");
@@ -802,15 +805,19 @@ async fn fork_namespace_rejects_corrupt_source_manifest_descriptors() {
         .await
         .expect("read source manifest")
         .expect("source manifest exists");
-    let mut manifest =
-        decode_namespace_manifest_json(&manifest_bytes).expect("decode source manifest");
-    manifest.payload.runs.iter_mut().for_each(|run| {
+    let mut manifest = decode_namespace_manifest_json(&manifest_bytes)
+        .expect("decode source manifest")
+        .into_payload();
+    manifest.runs.iter_mut().for_each(|run| {
         run.segments
             .retain(|descriptor| descriptor.family != MetadataRowFamily::DirentryChildBinds);
     });
-    let manifest = NamespaceManifestEnvelope::from_payload(manifest.payload)
-        .expect("rebuild manifest checksum");
-    let corrupted = encode_namespace_manifest_json(&manifest).expect("encode corrupt manifest");
+    let manifest = loonfs_api::wire::manifest::encode_namespace_manifest_json(manifest)
+        .expect("rebuild manifest checksum")
+        .into_envelope();
+    let corrupted = encode_namespace_manifest_json(manifest.payload().clone())
+        .expect("encode corrupt manifest")
+        .into_bytes();
     store
         .put_overwrite(&manifest_key, Bytes::from(corrupted))
         .await
@@ -874,11 +881,9 @@ async fn a_create_losing_to_a_foreign_head_reports_the_id_as_taken() {
         loonfs_api::ContentStoreId::generate(),
         1_000,
     );
-    let foreign_bytes = encode_control_object(
-        &HeadStateEnvelope::from_state(ControlObjectKind::WalHead, foreign)
-            .expect("foreign head envelope"),
-    )
-    .expect("encode foreign head");
+    let foreign_bytes =
+        loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &foreign)
+            .expect("encode foreign head");
     let store = InjectCreateFailureStore::new(
         inner,
         KeyMatcher::Exact(wal_head(&namespace_id)),
@@ -1083,19 +1088,21 @@ impl ReleasePinBeforeRenewalStore {
             ControlObjectKind::CheckpointRecord,
         )
         .expect("decode record")
-        .state;
+        .into_payload();
         record.status = CheckpointStatus::Released {
             released_at_ms: 2_000,
         };
-        let released = loonfs_api::wire::control::CheckpointRecordEnvelope::from_state(
-            ControlObjectKind::CheckpointRecord,
-            record,
-        )
-        .expect("released record envelope");
+        let released = record;
         self.inner
             .put_overwrite(
                 key,
-                Bytes::from(encode_control_object(&released).expect("encode record")),
+                Bytes::from(
+                    loonfs_api::wire::control::encode_control_state(
+                        ControlObjectKind::CheckpointRecord,
+                        &released,
+                    )
+                    .expect("encode record"),
+                ),
             )
             .await
             .expect("release record");

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -1082,12 +1082,12 @@ async fn name_key_stays_typed_through_planning_and_fingerprint() {
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.records.len(), 1);
+    assert_eq!(segment.payload().records.len(), 1);
     assert_eq!(
-        segment.payload.records[0].semantic_commit_fingerprint,
+        segment.payload().records[0].semantic_commit_fingerprint,
         expected_fingerprint
     );
-    assert!(segment.payload.records[0]
+    assert!(segment.payload().records[0]
         .deltas
         .iter()
         .any(|delta| matches!(
@@ -1173,7 +1173,7 @@ async fn path_intents_in_one_batch_see_tentative_state_and_continue_the_seq_ladd
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.records.len(), 2);
+    assert_eq!(segment.payload().records.len(), 2);
 
     let copied = copy_file_path(
         &store,

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -525,7 +525,7 @@ mod direct_multipart {
             .expect("session exists");
         decode_control_object::<UploadSessionState>(&bytes, ControlObjectKind::UploadSession)
             .expect("decode session")
-            .state
+            .into_payload()
     }
 
     /// Uploads every part, the way a client would after asking for the

--- a/crates/loonfs-grep/src/root/codec.rs
+++ b/crates/loonfs-grep/src/root/codec.rs
@@ -1,14 +1,9 @@
-//! Grep's two durable families, parameterized over the shared envelope codec.
-//!
-//! Grep owns its kinds, its versions, and its payload invariants; the probe,
-//! the checksum rules, and the failure vocabulary are the ones every other
-//! LoonFS durable family reads and writes through.
+//! Grep's durable families share framing and checksum rules with the filesystem.
 
 use super::error::GrepEnvelopeCodecError;
 use super::state::{GrepManifestState, GrepRootPointer};
 use loonfs_api::wire::envelope::{
-    decode_json_envelope, encode_json_envelope, json_payload_checksum, verify_kind,
-    DecodedJsonEnvelope,
+    decode_json_envelope, encode_json_envelope, verify_kind, EncodedEnvelope, VerifiedEnvelope,
 };
 
 /// Durable kind string for a grep root-pointer envelope.
@@ -21,126 +16,51 @@ pub const GREP_ROOT_FORMAT_VERSION: u32 = 1;
 pub const GREP_MANIFEST_FORMAT_VERSION: u32 = 1;
 
 /// Verified in-memory representation of one grep root-pointer envelope.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GrepRootEnvelope {
-    format_version: u32,
-    payload_checksum: String,
-    pointer: GrepRootPointer,
-}
-
-impl GrepRootEnvelope {
-    /// Builds a fresh root-pointer envelope over its canonical payload bytes.
-    pub fn from_pointer(pointer: GrepRootPointer) -> Result<Self, GrepEnvelopeCodecError> {
-        Ok(Self {
-            format_version: GREP_ROOT_FORMAT_VERSION,
-            payload_checksum: json_payload_checksum(&pointer)?,
-            pointer,
-        })
-    }
-
-    pub fn format_version(&self) -> u32 {
-        self.format_version
-    }
-
-    pub fn payload_checksum(&self) -> &str {
-        &self.payload_checksum
-    }
-
-    pub fn pointer(&self) -> &GrepRootPointer {
-        &self.pointer
-    }
-}
-
+pub type GrepRootEnvelope = VerifiedEnvelope<GrepRootPointer>;
 /// Verified in-memory representation of one immutable grep manifest.
-///
-/// The envelope describes the bytes and nothing about which object holds
-/// them: a manifest's identity is the key it was written under, which the
-/// root pointer names.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GrepManifestEnvelope {
-    format_version: u32,
-    payload_checksum: String,
-    state: GrepManifestState,
-}
+/// Its identity is the key named by the root pointer.
+pub type GrepManifestEnvelope = VerifiedEnvelope<GrepManifestState>;
 
-impl GrepManifestEnvelope {
-    /// Builds a manifest envelope over its canonical payload bytes.
-    pub fn from_state(state: GrepManifestState) -> Result<Self, GrepEnvelopeCodecError> {
-        state.validate()?;
-        Ok(Self {
-            format_version: GREP_MANIFEST_FORMAT_VERSION,
-            payload_checksum: json_payload_checksum(&state)?,
-            state,
-        })
-    }
-
-    pub fn format_version(&self) -> u32 {
-        self.format_version
-    }
-
-    pub fn payload_checksum(&self) -> &str {
-        &self.payload_checksum
-    }
-
-    pub fn manifest_state(&self) -> &GrepManifestState {
-        &self.state
-    }
-}
-
-/// Encodes a root pointer after rechecking its version and checksum.
-pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepEnvelopeCodecError> {
+/// Encodes a root pointer and derives its framing from the exact payload bytes.
+pub fn encode_grep_root(
+    pointer: GrepRootPointer,
+) -> Result<EncodedEnvelope<GrepRootPointer>, GrepEnvelopeCodecError> {
     Ok(encode_json_envelope(
         GREP_ROOT_KIND,
-        envelope.format_version,
         GREP_ROOT_FORMAT_VERSION,
-        &envelope.payload_checksum,
-        &envelope.pointer,
+        pointer,
     )?)
 }
 
 /// Decodes only the current root-pointer format and verifies exact payload bytes.
-///
-/// The pointer is a mutable control object, so unknown envelope and payload
-/// fields are corruption: a tolerant read followed by the publication rewrite
-/// would erase what this binary does not understand.
+/// Unknown fields are rejected because publication writes successor pointers.
 pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepEnvelopeCodecError> {
-    let decoded: DecodedJsonEnvelope<GrepRootPointer> =
-        decode_json_envelope(bytes, GREP_ROOT_FORMAT_VERSION, |found| {
-            verify_kind(GREP_ROOT_KIND, found)
-        })?;
-    Ok(GrepRootEnvelope {
-        format_version: decoded.format_version,
-        payload_checksum: decoded.payload_checksum,
-        pointer: decoded.payload,
-    })
+    Ok(decode_json_envelope(
+        bytes,
+        GREP_ROOT_FORMAT_VERSION,
+        |found| verify_kind(GREP_ROOT_KIND, found),
+    )?)
 }
 
-/// Encodes an immutable manifest after rechecking every boundary invariant.
+/// Validates a manifest and derives framing from one payload encoding.
 pub fn encode_grep_manifest(
-    envelope: &GrepManifestEnvelope,
-) -> Result<Vec<u8>, GrepEnvelopeCodecError> {
-    envelope.state.validate()?;
+    state: GrepManifestState,
+) -> Result<EncodedEnvelope<GrepManifestState>, GrepEnvelopeCodecError> {
+    state.validate()?;
     Ok(encode_json_envelope(
         GREP_MANIFEST_KIND,
-        envelope.format_version,
         GREP_MANIFEST_FORMAT_VERSION,
-        &envelope.payload_checksum,
-        &envelope.state,
+        state,
     )?)
 }
 
 /// Decodes only the current manifest format and verifies it.
-///
-/// Unknown fields are rejected because indexing and compaction write successor manifests.
+/// Unknown fields are rejected because indexing and compaction write successors.
 pub fn decode_grep_manifest(bytes: &[u8]) -> Result<GrepManifestEnvelope, GrepEnvelopeCodecError> {
-    let decoded: DecodedJsonEnvelope<GrepManifestState> =
+    let decoded: GrepManifestEnvelope =
         decode_json_envelope(bytes, GREP_MANIFEST_FORMAT_VERSION, |found| {
             verify_kind(GREP_MANIFEST_KIND, found)
         })?;
-    decoded.payload.validate()?;
-    Ok(GrepManifestEnvelope {
-        format_version: decoded.format_version,
-        payload_checksum: decoded.payload_checksum,
-        state: decoded.payload,
-    })
+    decoded.payload().validate()?;
+    Ok(decoded)
 }

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -35,7 +35,7 @@ impl LoadedGrepRootPointer {
     }
 
     pub fn pointer(&self) -> &GrepRootPointer {
-        self.envelope.pointer()
+        self.envelope.payload()
     }
 
     pub fn etag(&self) -> &str {
@@ -69,7 +69,7 @@ impl LoadedGrepRoot {
     }
 
     pub fn manifest_state(&self) -> &GrepManifestState {
-        self.manifest.manifest_state()
+        self.manifest.payload()
     }
 }
 
@@ -88,11 +88,11 @@ pub async fn load_grep_root_pointer<S: ObjectStore + ?Sized>(
     };
     let etag = required_etag(&object_key, body.metadata.etag)?;
     let envelope = decode_grep_root(&body.bytes).map_err(|error| corrupt(&object_key, error))?;
-    if envelope.pointer().namespace_id() != namespace_id {
+    if envelope.payload().namespace_id() != namespace_id {
         return Err(GrepRootError::IdentityMismatch {
             object_key,
             expected: namespace_id.clone(),
-            actual: envelope.pointer().namespace_id().clone(),
+            actual: envelope.payload().namespace_id().clone(),
         });
     }
     Ok(Some(LoadedGrepRootPointer {
@@ -132,11 +132,11 @@ pub async fn load_grep_manifest<S: ObjectStore + ?Sized>(
             ),
         });
     }
-    if envelope.manifest_state().namespace_id() != namespace_id {
+    if envelope.payload().namespace_id() != namespace_id {
         return Err(GrepRootError::IdentityMismatch {
             object_key,
             expected: namespace_id.clone(),
-            actual: envelope.manifest_state().namespace_id().clone(),
+            actual: envelope.payload().namespace_id().clone(),
         });
     }
     Ok(Some(envelope))
@@ -170,13 +170,13 @@ pub async fn seed_grep_root<S: ObjectStore + ?Sized>(
     let written = write_grep_manifest(store, state).await?;
     let manifest = written.envelope;
     let object_key = root_key(state.namespace_id());
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let (envelope, bytes) = encode_grep_root(GrepRootPointer::new(
         state.namespace_id().clone(),
         written.manifest_object_id,
         manifest.payload_checksum().to_owned(),
     ))
-    .map_err(|error| corrupt(&object_key, error))?;
-    let bytes = encode_grep_root(&envelope).map_err(|error| corrupt(&object_key, error))?;
+    .map_err(|error| corrupt(&object_key, error))?
+    .into_parts();
     let metadata = match store
         .put(&object_key, Bytes::from(bytes), PutMode::CreateIfAbsent)
         .await
@@ -222,14 +222,13 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
         });
     }
     let written = write_grep_manifest(store, next).await?;
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let (envelope, bytes) = encode_grep_root(GrepRootPointer::new(
         next.namespace_id().clone(),
         written.manifest_object_id,
         written.envelope.payload_checksum().to_owned(),
     ))
-    .map_err(|error| corrupt(&current.pointer.object_key, error))?;
-    let bytes =
-        encode_grep_root(&envelope).map_err(|error| corrupt(&current.pointer.object_key, error))?;
+    .map_err(|error| corrupt(&current.pointer.object_key, error))?
+    .into_parts();
     let metadata = match store
         .put(
             &current.pointer.object_key,
@@ -274,12 +273,12 @@ async fn write_grep_manifest<S: ObjectStore + ?Sized>(
     store: &S,
     state: &GrepManifestState,
 ) -> Result<WrittenGrepManifest> {
-    let envelope = GrepManifestEnvelope::from_state(state.clone())
-        .map_err(|error| corrupt(&root_key(state.namespace_id()), error))?;
     let manifest_object_id = GrepManifestObjectId::generate();
     let object_key = manifest_key(state.namespace_id(), &manifest_object_id);
-    let bytes =
-        Bytes::from(encode_grep_manifest(&envelope).map_err(|error| corrupt(&object_key, error))?);
+    let (envelope, bytes) = encode_grep_manifest(state.clone())
+        .map_err(|error| corrupt(&object_key, error))?
+        .into_parts();
+    let bytes = Bytes::from(bytes);
     // Create-only plus the byte check stay on this write even though a
     // random id cannot collide: an occupied key here is corruption, and it
     // must fail loudly rather than be overwritten.

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -116,11 +116,11 @@ impl GrepService {
                             manifest_key(namespace_id, manifest_object_id)
                         ),
                     })?;
-                let state = Arc::new(manifest.manifest_state().clone());
+                let state = Arc::new(manifest.payload().clone());
                 // As with the metadata manifest cache, JSON-backed decoded
                 // state is weighted at twice its canonical payload bytes to
                 // cover both owned strings and decoded structure overhead.
-                let decoded_bytes = serde_json::to_vec(manifest.manifest_state())
+                let decoded_bytes = serde_json::to_vec(manifest.payload())
                     .map_err(|error| {
                         CoreError::Internal(format!(
                             "failed to size decoded grep manifest `{}`: {error}",

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -206,7 +206,7 @@ pub(crate) mod control {
             .expect("namespace head exists");
         decode_control_object::<HeadState>(&bytes, ControlObjectKind::WalHead)
             .expect("decode namespace head")
-            .state
+            .into_payload()
     }
 
     pub(crate) async fn metadata_root(
@@ -218,7 +218,7 @@ pub(crate) mod control {
             .expect("metadata root exists");
         decode_control_object::<MetadataRootState>(&bytes, ControlObjectKind::MetadataRoot)
             .expect("decode metadata root")
-            .state
+            .into_payload()
     }
 
     pub(crate) async fn checkpoint_record(
@@ -234,7 +234,7 @@ pub(crate) mod control {
                 ControlObjectKind::CheckpointRecord,
             )
             .expect("decode checkpoint record")
-            .state,
+            .into_payload(),
         )
     }
 }

--- a/crates/loonfs-grep/tests/it/golden_formats.rs
+++ b/crates/loonfs-grep/tests/it/golden_formats.rs
@@ -28,8 +28,8 @@ use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, InodeId, RevisionNo, R
 use loonfs_grep::codec::{Gram, GramPosting, IndexRow};
 use loonfs_grep::root::{
     decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root, GrepIndexState,
-    GrepIndexStatus, GrepManifestEnvelope, GrepManifestObjectId, GrepManifestState,
-    GrepReorganizeState, GrepRootEnvelope, GrepRootPointer, GrepSegmentRef,
+    GrepIndexStatus, GrepManifestObjectId, GrepManifestState, GrepReorganizeState, GrepRootPointer,
+    GrepSegmentRef,
 };
 use loonfs_test_support::ids::namespace_id;
 use std::path::{Path, PathBuf};
@@ -186,8 +186,9 @@ pub(crate) fn sample_disabled_manifest() -> GrepManifestState {
 /// [`ACTIVE_MANIFEST_FIXTURE`] pins. Its digest is that manifest envelope's
 /// own `payload_checksum`.
 fn sample_root_pointer() -> GrepRootPointer {
-    let manifest = GrepManifestEnvelope::from_state(sample_active_manifest(ChangeSeq(11), 5))
-        .expect("build a grep manifest envelope");
+    let manifest = encode_grep_manifest(sample_active_manifest(ChangeSeq(11), 5))
+        .expect("manifest")
+        .into_envelope();
     GrepRootPointer::new(
         namespace_id("docs"),
         GrepManifestObjectId::parse(ACTIVE_MANIFEST_OBJECT_ID).expect("valid manifest object id"),
@@ -297,29 +298,33 @@ fn decode_golden_data_block(name: &str) -> DecodedDataBlock<IndexRow> {
 // ---------------------------------------------------------------------------
 
 fn assert_manifest_matches_golden(fixture: &str, state: GrepManifestState) {
-    let envelope = GrepManifestEnvelope::from_state(state).expect("build a grep manifest envelope");
-    let encoded = encode_grep_manifest(&envelope).expect("encode a grep manifest");
+    let encoded = encode_grep_manifest(state)
+        .expect("build a grep manifest envelope")
+        .into_bytes();
     assert_matches_golden(fixture, &encoded);
 }
 
 fn assert_manifest_golden_decodes(fixture: &str, state: GrepManifestState) {
-    let expected = GrepManifestEnvelope::from_state(state).expect("build a grep manifest envelope");
+    let expected = encode_grep_manifest(state)
+        .expect("build a grep manifest envelope")
+        .into_envelope();
     let decoded = decode_grep_manifest(&read_golden(fixture)).expect("decode the golden manifest");
     assert_eq!(decoded, expected);
 }
 
 #[test]
 fn grep_root_matches_golden_bytes() {
-    let envelope =
-        GrepRootEnvelope::from_pointer(sample_root_pointer()).expect("build a grep root envelope");
-    let encoded = encode_grep_root(&envelope).expect("encode a grep root pointer");
+    let encoded = encode_grep_root(sample_root_pointer())
+        .expect("build a grep root envelope")
+        .into_bytes();
     assert_matches_golden(ROOT_POINTER_FIXTURE, &encoded);
 }
 
 #[test]
 fn grep_root_golden_decodes_to_sample() {
-    let expected =
-        GrepRootEnvelope::from_pointer(sample_root_pointer()).expect("build a grep root envelope");
+    let expected = encode_grep_root(sample_root_pointer())
+        .expect("build a grep root envelope")
+        .into_envelope();
     let decoded =
         decode_grep_root(&read_golden(ROOT_POINTER_FIXTURE)).expect("decode the golden pointer");
     assert_eq!(decoded, expected);
@@ -333,7 +338,7 @@ fn grep_root_golden_carries_the_manifest_golden_checksum() {
         .expect("decode the golden manifest");
 
     assert_eq!(
-        pointer.pointer().manifest_payload_checksum(),
+        pointer.payload().manifest_payload_checksum(),
         manifest.payload_checksum()
     );
 }

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -20,7 +20,7 @@ use loonfs_grep::keyspace::{
 };
 use loonfs_grep::root::{
     advance_grep_root, encode_grep_root, load_grep_root, GrepIndexState, GrepIndexStatus,
-    GrepManifestObjectId, GrepManifestState, GrepRootEnvelope, GrepRootPointer,
+    GrepManifestObjectId, GrepManifestState, GrepRootPointer,
 };
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepGcOptions, GrepGcReport,
@@ -887,16 +887,16 @@ async fn an_expired_but_unreleased_backfill_pin_keeps_enumerating() {
         panic!("the backfill pin is user-owned");
     };
     *expires_at_ms = Some(record.created_at_ms);
-    let expired = loonfs_api::wire::control::CheckpointRecordEnvelope::from_state(
-        loonfs_api::wire::control::ControlObjectKind::CheckpointRecord,
-        record,
-    )
-    .expect("expired record envelope");
+    let expired = record;
     store
         .put_overwrite(
             &key,
             Bytes::from(
-                loonfs_api::wire::control::encode_control_object(&expired).expect("encode record"),
+                loonfs_api::wire::control::encode_control_state(
+                    loonfs_api::wire::control::ControlObjectKind::CheckpointRecord,
+                    &expired,
+                )
+                .expect("encode record"),
             ),
         )
         .await
@@ -1582,16 +1582,21 @@ async fn write_pointer(
     manifest_object_id: GrepManifestObjectId,
     manifest_payload_checksum: String,
 ) {
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let envelope = encode_grep_root(GrepRootPointer::new(
         namespace_id.clone(),
         manifest_object_id,
         manifest_payload_checksum,
     ))
-    .expect("build pointer");
+    .expect("build pointer")
+    .into_envelope();
     store
         .put_overwrite(
             &root_key(namespace_id),
-            Bytes::from(encode_grep_root(&envelope).expect("encode pointer")),
+            Bytes::from(
+                encode_grep_root(envelope.payload().clone())
+                    .expect("encode pointer")
+                    .into_bytes(),
+            ),
         )
         .await
         .expect("write pointer");

--- a/crates/loonfs-grep/tests/it/root_format.rs
+++ b/crates/loonfs-grep/tests/it/root_format.rs
@@ -16,8 +16,8 @@ use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::{ChangeSeq, RunNo};
 use loonfs_grep::root::{
     decode_grep_manifest, decode_grep_root, encode_grep_manifest, GrepEnvelopeCodecError,
-    GrepIndexState, GrepIndexStatus, GrepManifestEnvelope, GrepManifestState,
-    GrepManifestStateError, GrepReorganizeState,
+    GrepIndexState, GrepIndexStatus, GrepManifestState, GrepManifestStateError,
+    GrepReorganizeState,
 };
 use loonfs_test_support::ids::namespace_id;
 
@@ -55,10 +55,9 @@ fn every_status_round_trips_carrying_only_its_own_position() {
         (sample_active_manifest(ChangeSeq(11), 0), "target_seq"),
         (sample_disabled_manifest(), "built_through_seq"),
     ] {
-        let encoded = encode_grep_manifest(
-            &GrepManifestEnvelope::from_state(state.clone()).expect("build manifest envelope"),
-        )
-        .expect("encode grep manifest");
+        let encoded = encode_grep_manifest(state.clone())
+            .expect("encode grep manifest")
+            .into_bytes();
         assert!(
             !String::from_utf8(encoded.clone())
                 .expect("manifest JSON is UTF-8")
@@ -69,7 +68,7 @@ fn every_status_round_trips_carrying_only_its_own_position() {
         assert_eq!(
             decode_grep_manifest(&encoded)
                 .expect("decode grep manifest")
-                .manifest_state(),
+                .payload(),
             &state
         );
     }

--- a/crates/loonfs-grep/tests/it/root_store.rs
+++ b/crates/loonfs-grep/tests/it/root_store.rs
@@ -8,8 +8,8 @@ use loonfs_api::{ChangeSeq, NamespaceId, RunNo};
 use loonfs_grep::keyspace::{manifest_key, manifests_prefix, root_key};
 use loonfs_grep::root::{
     advance_grep_root, encode_grep_manifest, encode_grep_root, load_grep_root, seed_grep_root,
-    GrepIndexState, GrepIndexStatus, GrepManifestEnvelope, GrepManifestObjectId, GrepManifestState,
-    GrepRootEnvelope, GrepRootError, GrepRootPointer,
+    GrepIndexState, GrepIndexStatus, GrepManifestObjectId, GrepManifestState, GrepRootError,
+    GrepRootPointer,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectStore, PutMode};
@@ -22,9 +22,10 @@ async fn load_rejects_namespace_identity_mismatch() {
     let store = LocalFsStore::new(temp_dir.path()).expect("local store");
     let requested = namespace_id("requested");
     let wrong = root(namespace_id("other"), ChangeSeq(0));
-    let manifest = GrepManifestEnvelope::from_state(wrong).expect("manifest envelope");
     let manifest_object_id = GrepManifestObjectId::generate();
-    let manifest_bytes = encode_grep_manifest(&manifest).expect("encode manifest");
+    let (manifest, manifest_bytes) = encode_grep_manifest(wrong)
+        .expect("encode manifest")
+        .into_parts();
     store
         .put(
             &manifest_key(&requested, &manifest_object_id),
@@ -33,13 +34,13 @@ async fn load_rejects_namespace_identity_mismatch() {
         )
         .await
         .expect("write mismatched manifest");
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let bytes = encode_grep_root(GrepRootPointer::new(
         requested.clone(),
         manifest_object_id,
         manifest.payload_checksum().to_owned(),
     ))
-    .expect("pointer envelope");
-    let bytes = encode_grep_root(&envelope).expect("encode pointer");
+    .expect("pointer envelope")
+    .into_bytes();
     let key = root_key(&requested);
     store
         .put(&key, Bytes::from(bytes), PutMode::CreateIfAbsent)
@@ -125,8 +126,9 @@ async fn identical_state_publishes_a_fresh_manifest_object() {
             .await
             .expect("read a published manifest")
             .expect("a published manifest is durable at the key the pointer names");
-        let expected =
-            encode_grep_manifest(published.manifest_envelope()).expect("encode manifest");
+        let expected = encode_grep_manifest(published.manifest_envelope().payload().clone())
+            .expect("encode manifest")
+            .into_bytes();
         assert_eq!(
             stored,
             Bytes::from(expected),

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -29,9 +29,7 @@ use loonfs_api::{
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MoveOptions, NamespacePath};
 use loonfs_grep::keyspace::{manifest_key as grep_manifest_key, root_key as grep_root_key};
-use loonfs_grep::root::{
-    encode_grep_root, load_grep_root, GrepManifestObjectId, GrepRootEnvelope, GrepRootPointer,
-};
+use loonfs_grep::root::{encode_grep_root, load_grep_root, GrepManifestObjectId, GrepRootPointer};
 use loonfs_grep::{GrepWorker, NamespaceReads};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -3491,7 +3489,7 @@ async fn write_grep_pointer(
 ) {
     // Every caller here injects a fault the load hits before it compares
     // digests, so any well-formed digest stands in for the real one.
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let envelope = encode_grep_root(GrepRootPointer::new(
         pointer_namespace_id,
         manifest_object_id,
         loonfs_api::sha256_digest(b"a manifest these tests never reach"),
@@ -3500,7 +3498,7 @@ async fn write_grep_pointer(
     store
         .put_overwrite(
             &grep_root_key(stored_namespace_id),
-            Bytes::from(encode_grep_root(&envelope).expect("encode grep pointer")),
+            Bytes::from(envelope.into_bytes()),
         )
         .await
         .expect("write grep pointer");

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -343,7 +343,7 @@ async fn current_manifest_payload<S: ObjectStore + ?Sized>(
         .expect("the manifest exists");
     decode_namespace_manifest_json(&bytes)
         .expect("decode the manifest")
-        .payload
+        .into_payload()
 }
 
 /// The runs the bindings group holds right now, and the rows in them.

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -1631,8 +1631,8 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
             .expect("read WAL segment")
             .expect("WAL segment exists");
         let segment = decode_wal_segment_envelope_zstd(&bytes).expect("decode WAL segment");
-        if segment.payload.records.len() == 2 {
-            for record in segment.payload.records {
+        if segment.payload().records.len() == 2 {
+            for record in segment.into_payload().records {
                 batched_actors.insert(record.commit_id.to_string(), record.committed_by);
             }
         }
@@ -1780,7 +1780,7 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
             .expect("read wal")
             .expect("wal exists");
         let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode wal segment");
-        record_counts.push(segment.payload.records.len());
+        record_counts.push(segment.payload().records.len());
     }
     record_counts.sort_unstable();
     // The warmup published alone; the concurrent pair shares a segment.

--- a/crates/loonfs/tests/it/bulk_file_reads.rs
+++ b/crates/loonfs/tests/it/bulk_file_reads.rs
@@ -512,7 +512,7 @@ async fn foreign_metadata_segment_owners(
         .expect("manifest object exists");
     loonfs_api::wire::manifest::decode_namespace_manifest_json(&bytes)
         .expect("decode manifest")
-        .payload
+        .into_payload()
         .runs
         .into_iter()
         .flat_map(|run| run.segments)

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -155,7 +155,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .expect("manifest exists");
     let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
     let direntry_delta_runs: BTreeSet<_> = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| {
@@ -174,7 +174,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
     );
     assert!(
         manifest
-            .payload
+            .payload()
             .runs
             .iter()
             .filter(|run| run.tier == loonfs_api::wire::manifest::RunTier::Delta)
@@ -183,7 +183,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         "every delta segment should carry an inline filter"
     );
     let filter_offsets: BTreeSet<(String, u64)> = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -195,7 +195,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         })
         .collect();
     let segment_keys: BTreeSet<String> = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -12,7 +12,7 @@ use loonfs::{
     ErrorCode, FsWriter, NamespaceId, PutFileOptions, RevisionNo, RuntimeError, SharedObjectStore,
     CONTENT_READ_CHUNK_BYTES,
 };
-use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
+use loonfs_api::wire::control::ControlObjectKind;
 use loonfs_api::{ContentId, ContentStoreId};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -177,12 +177,17 @@ async fn bind_namespace_to_content_store(
         .expect("load namespace head")
         .state;
     head.content_store_id = content_store_id;
-    let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head)
-        .expect("build namespace head");
+    let envelope = head;
     store
         .put_overwrite(
             &wal_head(namespace_id),
-            Bytes::from(encode_control_object(&envelope).expect("encode namespace head")),
+            Bytes::from(
+                loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &envelope,
+                )
+                .expect("encode namespace head"),
+            ),
         )
         .await
         .expect("rebind the namespace head to the shared content store");

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -12,8 +12,7 @@ use loonfs::{
     RunMaintenanceRequest, RunMaintenanceResponse, SharedObjectStore, WalFlushStepOutcome,
 };
 use loonfs_api::wire::control::{
-    decode_control_object, encode_control_object, ControlObjectEnvelope, ControlObjectKind,
-    HeadState, HeadStateEnvelope,
+    decode_control_object, ControlObjectEnvelope, ControlObjectKind, HeadState,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_api::{AdvanceRetentionRequest, GcRequest, MetadataCompactionRequest};
@@ -169,15 +168,15 @@ fn truncate_recent_segments(store: &SharedObjectStore, namespace_id: &NamespaceI
         .expect("head exists");
     let envelope: ControlObjectEnvelope<HeadState> =
         decode_control_object(&bytes, ControlObjectKind::WalHead).expect("decode head");
-    let mut state = envelope.state;
+    let mut state = envelope.into_payload();
     assert!(
         state.recent_segments.len() > keep,
         "the fixture must publish more pointers than the legacy window held"
     );
     state.recent_segments.truncate(keep);
-    let truncated =
-        HeadStateEnvelope::from_state(ControlObjectKind::WalHead, state).expect("head envelope");
-    let encoded = encode_control_object(&truncated).expect("encode head");
+    let encoded =
+        loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &state)
+            .expect("encode head");
     block_on(store.put_overwrite(&key, bytes::Bytes::from(encoded))).expect("rewrite head");
 }
 
@@ -594,9 +593,9 @@ fn maintenance_step_after_existing_manifest_writes_delta_manifest() {
     let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
     // A WAL flush only appends: the base marker stays where the first
     // published manifest put it until reorganization folds the delta runs.
-    assert_eq!(manifest.payload.base_seq, ChangeSeq(1));
+    assert_eq!(manifest.payload().base_seq, ChangeSeq(1));
     let delta_files = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| run.tier == loonfs_api::wire::manifest::RunTier::Delta)

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -41,7 +41,7 @@ async fn segment_map(store: &SharedObjectStore, namespace_id: &NamespaceId) -> S
         .expect("manifest exists");
     let manifest = decode_namespace_manifest_json(&bytes).expect("decode manifest");
     manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| {


### PR DESCRIPTION
Envelope writers could change a payload independently of its checksum, then serialize that payload again before storage. Derive the checksum and durable bytes in one encoding, expose checked payloads through read-only accessors, and use the same envelope types for controls, manifests, WAL segments, and grep. This removes unchecked serde construction and keeps cached reads free of encoded-byte copies; Rust callers now edit an owned payload before encoding a successor. Durable formats and HTTP schemas are unchanged. Workspace tests pass (2,061 passed; 19 ignored), full Clippy passes, and existing durable goldens and regenerated OpenAPI documents are unchanged.
