### PR TITLE
fix(compaction): release groups without dropping output protection

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -33,17 +33,20 @@ pub enum ControlObjectKind {
     /// Marks one streaming metadata compaction's output as owned by a job
     /// that is still running.
     CompactionLease,
+    /// Protects sealed compaction output across publication and later group owners.
+    CompactionOutputProtection,
 }
 
 impl ControlObjectKind {
     /// Lists every registered control-object family in stable registry order.
-    pub const ALL: [Self; 6] = [
+    pub const ALL: [Self; 7] = [
         Self::WalHead,
         Self::WalFloor,
         Self::MetadataRoot,
         Self::CheckpointRecord,
         Self::UploadSession,
         Self::CompactionLease,
+        Self::CompactionOutputProtection,
     ];
 
     /// Durable format version for this control object kind.
@@ -59,7 +62,8 @@ impl ControlObjectKind {
             Self::MetadataRoot => 1,
             Self::CheckpointRecord => 1,
             Self::UploadSession => 1,
-            Self::CompactionLease => 2,
+            Self::CompactionLease => 3,
+            Self::CompactionOutputProtection => 1,
         }
     }
 
@@ -72,6 +76,7 @@ impl ControlObjectKind {
             Self::CheckpointRecord => "checkpoint_record",
             Self::UploadSession => "upload_session",
             Self::CompactionLease => "compaction_lease",
+            Self::CompactionOutputProtection => "compaction_output_protection",
         }
     }
 
@@ -152,6 +157,9 @@ pub enum CompactionLeaseStatus {
     /// The braces make serde reject a stray field; a unit variant would
     /// silently accept and discard one.
     Active {},
+    /// The job has finished every output write and publication attempt. The
+    /// group is available; the output protection record retains its deadline.
+    Completed {},
     /// Garbage collection owns the prefix and the job is fenced.
     Reaping {},
 }
@@ -160,6 +168,7 @@ impl fmt::Display for CompactionLeaseStatus {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
             Self::Active {} => "active",
+            Self::Completed {} => "completed",
             Self::Reaping {} => "reaping",
         })
     }
@@ -192,6 +201,22 @@ pub struct MetadataCompactionLeaseState {
     pub started_at_ms: u64,
     /// Unix-millisecond expiry written when the job creates or refreshes the
     /// lease, and the only input to whether an `active` lease has expired.
+    pub expires_at_ms: u64,
+}
+
+/// Protects a job's sealed output from collectors predating publication.
+///
+/// The job extends this deadline before each root publication attempt. It
+/// writes no further output after creating this record. GC removes the record
+/// only after its deadline and after the output prefix is empty.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompactionOutputProtectionState {
+    /// Namespace that owns the output.
+    pub namespace_id: NamespaceId,
+    /// Job whose sealed output is protected.
+    pub job_id: MetadataCompactionId,
+    /// Last publication lease deadline; collectors use their fixed pass clock.
     pub expires_at_ms: u64,
 }
 

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -978,39 +978,8 @@ impl<'de> Deserialize<'de> for UploadSessionState {
     }
 }
 
-/// In-memory view of a control object envelope.
-///
-/// This struct is not the durable layout; durable bytes are produced only by
-/// [`encode_control_object`] and validated only by [`decode_control_object`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ControlObjectEnvelope<T> {
-    /// Durable-family discriminator that selects `T` and its independent version.
-    pub kind: ControlObjectKind,
-    /// Family-local format version obtained from `kind`.
-    pub format_version: u32,
-    /// Digest of the payload JSON exactly as stored in the durable document,
-    /// in `sha256:<hex>` form.
-    pub payload_checksum: String,
-    /// Decoded control state protected by `payload_checksum`.
-    pub state: T,
-}
-
-impl<T> ControlObjectEnvelope<T>
-where
-    T: Serialize,
-{
-    /// Builds a family-versioned envelope and computes its checksum from canonical state JSON.
-    ///
-    /// Construction fails when `state` cannot be encoded.
-    pub fn from_state(kind: ControlObjectKind, state: T) -> Result<Self, EnvelopeCodecError> {
-        Ok(Self {
-            kind,
-            format_version: kind.format_version(),
-            payload_checksum: control_payload_checksum(&state)?,
-            state,
-        })
-    }
-}
+/// Control state decoded through its checked durable codec.
+pub type ControlObjectEnvelope<T> = crate::envelope::VerifiedEnvelope<T>;
 
 /// Specializes a control envelope for the authoritative namespace head.
 pub type HeadStateEnvelope = ControlObjectEnvelope<HeadState>;
@@ -1026,43 +995,13 @@ pub type CheckpointRecordEnvelope = ControlObjectEnvelope<CheckpointRecordState>
 /// its staged output.
 pub type MetadataCompactionLeaseEnvelope = ControlObjectEnvelope<MetadataCompactionLeaseState>;
 
-/// Computes the checksum stored beside canonical JSON for a control state.
-///
-/// Computation fails when `state` cannot be serialized.
-pub fn control_payload_checksum<T>(state: &T) -> Result<String, EnvelopeCodecError>
-where
-    T: Serialize,
-{
-    crate::envelope::json_payload_checksum(state)
-}
-
-/// Encodes a control-object envelope as its durable JSON representation.
-///
-/// Encoding fails when the family version is unsupported, the in-memory
-/// checksum is stale, or JSON serialization fails. See
-/// [mutable control-object rules](../../../docs/specs/format.md#17-mutable-control-object-rules).
-pub fn encode_control_object<T>(
-    envelope: &ControlObjectEnvelope<T>,
-) -> Result<Vec<u8>, EnvelopeCodecError>
-where
-    T: Serialize,
-{
-    crate::envelope::encode_json_envelope(
-        envelope.kind.as_str(),
-        envelope.format_version,
-        envelope.kind.format_version(),
-        &envelope.payload_checksum,
-        &envelope.state,
-    )
-}
-
-/// Encodes state in a control-object envelope.
+/// Encodes control state once, deriving its checksum and family version.
 pub fn encode_control_state<T: Serialize>(
     kind: ControlObjectKind,
     state: &T,
 ) -> Result<Vec<u8>, EnvelopeCodecError> {
-    let envelope = ControlObjectEnvelope::from_state(kind, state)?;
-    encode_control_object(&envelope)
+    crate::envelope::encode_json_envelope(kind.as_str(), kind.format_version(), state)
+        .map(crate::envelope::EncodedEnvelope::into_bytes)
 }
 
 /// Decodes and verifies a durable JSON control object of `expected_kind`.
@@ -1094,12 +1033,7 @@ where
         },
     )?;
 
-    Ok(ControlObjectEnvelope {
-        kind: expected_kind,
-        format_version: decoded.format_version,
-        payload_checksum: decoded.payload_checksum,
-        state: decoded.payload,
-    })
+    Ok(decoded)
 }
 
 #[cfg(test)]
@@ -1291,13 +1225,12 @@ mod tests {
 
     #[test]
     fn control_object_codec_round_trips_and_validates() {
-        let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, sample_head())
-            .expect("envelope");
+        let state = sample_head();
 
-        let encoded = encode_control_object(&envelope).expect("encode");
+        let encoded = encode_control_state(ControlObjectKind::WalHead, &state).expect("encode");
         let decoded: HeadStateEnvelope =
             decode_control_object(&encoded, ControlObjectKind::WalHead).expect("decode");
-        assert_eq!(decoded, envelope);
+        assert_eq!(decoded.into_payload(), state);
 
         let mismatch =
             decode_control_object::<MetadataRootState>(&encoded, ControlObjectKind::MetadataRoot)

--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -84,17 +84,6 @@ pub enum EnvelopeCodecError {
         /// Digest recomputed over the exact stored payload bytes.
         actual: String,
     },
-    /// Reports an in-memory payload changed without rebuilding its envelope checksum.
-    #[error(
-        "envelope checksum `{checksum}` does not match its payload `{actual}`: \
-         rebuild the envelope from its payload"
-    )]
-    StalePayloadChecksum {
-        /// Digest retained by the stale in-memory envelope.
-        checksum: String,
-        /// Digest recomputed from the payload about to be encoded.
-        actual: String,
-    },
 }
 
 /// Requires the probed kind to be exactly `expected`.
@@ -136,23 +125,6 @@ pub fn verify_payload_checksum(
     Ok(())
 }
 
-/// Requires an in-memory envelope's recorded checksum to still match its
-/// payload before encoding — a stale checksum means the caller mutated the
-/// payload without rebuilding the envelope.
-pub fn verify_checksum_fresh(
-    checksum: &str,
-    payload_bytes: &[u8],
-) -> Result<(), EnvelopeCodecError> {
-    let actual = sha256_digest(payload_bytes);
-    if actual != checksum {
-        return Err(EnvelopeCodecError::StalePayloadChecksum {
-            checksum: checksum.to_owned(),
-            actual,
-        });
-    }
-    Ok(())
-}
-
 /// Durable layout of a JSON-bodied envelope: the shared fields plus the
 /// payload as a raw JSON fragment, kept inline so the object remains
 /// directly readable JSON while `payload_checksum` covers the exact
@@ -166,46 +138,91 @@ struct JsonEnvelopeDocument {
     payload: Box<RawValue>,
 }
 
-/// The `sha256:<hex>` checksum a JSON payload will carry, computed over its
-/// canonical serialization.
-pub fn json_payload_checksum<T: Serialize>(payload: &T) -> Result<String, EnvelopeCodecError> {
-    let bytes = serde_json::to_vec(payload)
-        .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?;
-    Ok(sha256_digest(&bytes))
+/// An envelope whose framing was verified on read or derived on write.
+///
+/// Payload access is read-only: changing a payload requires a new encoding.
+/// Family codecs apply their own kind, version, and payload validation rules.
+/// Kind and version are checked at the codec boundary, not retained as caller state.
+/// This type has no serde decoder; durable reads must use a checked codec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedEnvelope<T> {
+    pub(crate) payload_checksum: String,
+    pub(crate) payload: T,
 }
 
-/// Encodes one JSON-bodied envelope, validating that the recorded version is
-/// what this build writes for `kind` and that the recorded checksum still
-/// matches the payload.
+impl<T> VerifiedEnvelope<T> {
+    /// Checksum of the exact stored payload bytes.
+    pub fn payload_checksum(&self) -> &str {
+        &self.payload_checksum
+    }
+    /// Payload protected by this framing. Clone it to prepare a changed successor.
+    pub fn payload(&self) -> &T {
+        &self.payload
+    }
+    /// Takes the payload out of its verified framing for reuse or modification.
+    pub fn into_payload(self) -> T {
+        self.payload
+    }
+}
+
+/// One encoding and the envelope derived from those exact bytes.
+///
+/// Only codecs construct this pair. Neither half can be changed in place.
+/// Readers retain just [`VerifiedEnvelope`], without a second copy of the bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodedEnvelope<T> {
+    pub(crate) envelope: VerifiedEnvelope<T>,
+    pub(crate) bytes: Vec<u8>,
+}
+
+impl<T> EncodedEnvelope<T> {
+    /// Envelope derived while encoding, without decoding or serializing again.
+    pub fn envelope(&self) -> &VerifiedEnvelope<T> {
+        &self.envelope
+    }
+    /// Complete durable document, ready to write.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+    /// Takes the complete durable document.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+    /// Discards the encoding and retains its verified envelope.
+    pub fn into_envelope(self) -> VerifiedEnvelope<T> {
+        self.envelope
+    }
+    /// Separates the immutable envelope and its bytes for storage publication.
+    pub fn into_parts(self) -> (VerifiedEnvelope<T>, Vec<u8>) {
+        (self.envelope, self.bytes)
+    }
+}
+
+/// Serializes the payload once and derives framing from those same bytes.
 pub fn encode_json_envelope<T: Serialize>(
     kind: &str,
     format_version: u32,
-    supported_version: u32,
-    payload_checksum: &str,
-    payload: &T,
-) -> Result<Vec<u8>, EnvelopeCodecError> {
-    verify_version(kind, format_version, supported_version)?;
-    let payload_json = serde_json::to_string(payload)
+    payload: T,
+) -> Result<EncodedEnvelope<T>, EnvelopeCodecError> {
+    let payload_json = serde_json::to_string(&payload)
         .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?;
-    verify_checksum_fresh(payload_checksum, payload_json.as_bytes())?;
+    let payload_checksum = sha256_digest(payload_json.as_bytes());
     let document = JsonEnvelopeDocument {
         kind: kind.to_owned(),
         format_version,
-        payload_checksum: payload_checksum.to_owned(),
+        payload_checksum: payload_checksum.clone(),
         payload: RawValue::from_string(payload_json)
             .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?,
     };
-    serde_json::to_vec(&document).map_err(|err| EnvelopeCodecError::EnvelopeEncode(err.to_string()))
-}
-
-/// A decoded JSON-bodied envelope's shared fields plus its parsed payload.
-pub struct DecodedJsonEnvelope<T> {
-    /// Version gate the stored object declared and this build accepted.
-    pub format_version: u32,
-    /// Digest verified against the payload fragment exactly as stored.
-    pub payload_checksum: String,
-    /// The family payload decoded from that verified fragment.
-    pub payload: T,
+    let bytes = serde_json::to_vec(&document)
+        .map_err(|err| EnvelopeCodecError::EnvelopeEncode(err.to_string()))?;
+    Ok(EncodedEnvelope {
+        envelope: VerifiedEnvelope {
+            payload_checksum,
+            payload,
+        },
+        bytes,
+    })
 }
 
 /// Decodes one JSON-bodied envelope, then checks its kind, version, checksum,
@@ -218,7 +235,7 @@ pub fn decode_json_envelope<T: DeserializeOwned>(
     bytes: &[u8],
     supported_version: u32,
     classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
-) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+) -> Result<VerifiedEnvelope<T>, EnvelopeCodecError> {
     let probe: EnvelopeProbe = serde_json::from_slice(bytes)
         .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
     classify_kind(&probe.kind)?;
@@ -230,7 +247,7 @@ pub fn decode_json_envelope<T: DeserializeOwned>(
 
 fn decode_json_envelope_payload<T: DeserializeOwned>(
     document: JsonEnvelopeDocument,
-) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+) -> Result<VerifiedEnvelope<T>, EnvelopeCodecError> {
     verify_payload_checksum(
         &document.payload_checksum,
         document.payload.get().as_bytes(),
@@ -238,9 +255,56 @@ fn decode_json_envelope_payload<T: DeserializeOwned>(
     let payload: T = serde_json::from_str(document.payload.get())
         .map_err(|err| EnvelopeCodecError::PayloadDecode(err.to_string()))?;
 
-    Ok(DecodedJsonEnvelope {
-        format_version: document.format_version,
+    Ok(VerifiedEnvelope {
         payload_checksum: document.payload_checksum,
         payload,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn encoding_serializes_the_payload_once_and_checksums_those_bytes() {
+        struct CountedPayload<'a>(&'a Cell<usize>);
+        impl Serialize for CountedPayload<'_> {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                self.0.set(self.0.get() + 1);
+                serializer.serialize_u64(42)
+            }
+        }
+        let calls = Cell::new(0);
+        let encoded = encode_json_envelope("test", 1, CountedPayload(&calls)).expect("encode");
+        let document: JsonEnvelopeDocument =
+            serde_json::from_slice(encoded.as_bytes()).expect("document");
+        assert_eq!(calls.get(), 1);
+        assert_eq!(document.payload.get(), "42");
+        assert_eq!(encoded.envelope().payload_checksum(), sha256_digest(b"42"));
+        assert_eq!(
+            document.payload_checksum,
+            encoded.envelope().payload_checksum()
+        );
+    }
+
+    #[test]
+    fn decoding_checks_the_stored_payload_including_noncanonical_whitespace() {
+        let payload = r#"{ "value" : 42 }"#;
+        let checksum = sha256_digest(payload.as_bytes());
+        let bytes = format!(
+            r#"{{"kind":"test","format_version":1,"payload_checksum":"{checksum}","payload":{payload}}}"#
+        );
+        let decoded: VerifiedEnvelope<serde_json::Value> =
+            decode_json_envelope(bytes.as_bytes(), 1, |kind| verify_kind("test", kind))
+                .expect("decode exact stored bytes");
+        assert_eq!(decoded.payload_checksum(), checksum);
+        let successor =
+            encode_json_envelope("test", 1, decoded.into_payload()).expect("canonical encoding");
+        assert_ne!(successor.envelope().payload_checksum(), checksum);
+        let reread: VerifiedEnvelope<serde_json::Value> =
+            decode_json_envelope(successor.as_bytes(), 1, |kind| verify_kind("test", kind))
+                .expect("decode canonical bytes");
+        assert_eq!(&reread, successor.envelope());
+    }
 }

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -939,59 +939,17 @@ pub struct NamespaceManifestPayload {
     pub runs: Vec<MetadataRunRef>,
 }
 
-/// In-memory view of a namespace manifest envelope.
-///
-/// This struct is not the durable layout; durable bytes are produced only by
-/// [`encode_namespace_manifest_json`] and validated only by
-/// [`decode_namespace_manifest_json`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct NamespaceManifestEnvelope {
-    /// Durable-family discriminator checked before payload decoding.
-    pub kind: NamespaceManifestKind,
-    /// Family-local format version, which must equal [`NAMESPACE_MANIFEST_FORMAT_VERSION`].
-    pub format_version: u32,
-    /// Digest of the payload JSON exactly as stored in the durable document,
-    /// in `sha256:<hex>` form.
-    pub payload_checksum: String,
-    /// Decoded file-set description protected by `payload_checksum`.
-    pub payload: NamespaceManifestPayload,
-}
+/// A manifest decoded through its checked durable codec.
+pub type NamespaceManifestEnvelope = crate::envelope::VerifiedEnvelope<NamespaceManifestPayload>;
 
-impl NamespaceManifestEnvelope {
-    /// Builds a versioned envelope and computes its checksum from canonical payload JSON.
-    ///
-    /// Construction fails when the payload cannot be encoded.
-    pub fn from_payload(payload: NamespaceManifestPayload) -> Result<Self, EnvelopeCodecError> {
-        Ok(Self {
-            kind: NamespaceManifestKind::NamespaceManifest,
-            format_version: NAMESPACE_MANIFEST_FORMAT_VERSION,
-            payload_checksum: namespace_manifest_payload_checksum(&payload)?,
-            payload,
-        })
-    }
-}
-
-fn namespace_manifest_payload_checksum(
-    payload: &NamespaceManifestPayload,
-) -> Result<String, EnvelopeCodecError> {
-    crate::envelope::json_payload_checksum(payload)
-}
-
-/// Encodes a namespace-manifest envelope as its durable JSON representation.
-///
-/// Encoding fails when the version is unsupported, the in-memory checksum is
-/// stale, or JSON serialization fails. See
-/// [manifest publication](../../../docs/specs/format.md#61-manifest-publication-and-checkpoint-verification).
+/// Encodes a manifest once and returns its immutable framing and durable bytes.
 pub fn encode_namespace_manifest_json(
-    envelope: &NamespaceManifestEnvelope,
-) -> Result<Vec<u8>, EnvelopeCodecError> {
+    payload: NamespaceManifestPayload,
+) -> Result<crate::envelope::EncodedEnvelope<NamespaceManifestPayload>, EnvelopeCodecError> {
     crate::envelope::encode_json_envelope(
-        envelope.kind.as_str(),
-        envelope.format_version,
+        NamespaceManifestKind::NamespaceManifest.as_str(),
         NAMESPACE_MANIFEST_FORMAT_VERSION,
-        &envelope.payload_checksum,
-        &envelope.payload,
+        payload,
     )
 }
 
@@ -1009,20 +967,14 @@ pub fn decode_namespace_manifest_json(
             crate::envelope::verify_kind(expected_kind.as_str(), found)
         })?;
 
-    Ok(NamespaceManifestEnvelope {
-        kind: expected_kind,
-        format_version: decoded.format_version,
-        payload_checksum: decoded.payload_checksum,
-        payload: decoded.payload,
-    })
+    Ok(decoded)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         decode_namespace_manifest_json, encode_namespace_manifest_json, BlockHandle,
-        MetadataRowFamily, MetadataRunRef, MetadataSegmentRef, NamespaceManifestEnvelope,
-        NamespaceManifestPayload, RunTier,
+        MetadataRowFamily, MetadataRunRef, MetadataSegmentRef, NamespaceManifestPayload, RunTier,
     };
     use crate::{
         ChangeSeq, CommitId, InodeId, ManifestNo, ManifestObjectId, MetadataCompactionId,
@@ -1082,7 +1034,7 @@ mod tests {
 
     #[test]
     fn namespace_manifest_codec_round_trips_base_only_materialization() {
-        let envelope = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+        let (envelope, encoded) = encode_namespace_manifest_json(NamespaceManifestPayload {
             namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
             manifest_no: ManifestNo(10),
             manifest_object_id: ManifestObjectId::parse(
@@ -1105,9 +1057,8 @@ mod tests {
                 RunTier::Base,
             )],
         })
-        .expect("manifest");
-
-        let encoded = encode_namespace_manifest_json(&envelope).expect("encode manifest");
+        .expect("manifest")
+        .into_parts();
         let document: serde_json::Value =
             serde_json::from_slice(&encoded).expect("decode manifest document");
         assert!(document["payload"]
@@ -1123,7 +1074,7 @@ mod tests {
 
     #[test]
     fn namespace_manifest_codec_round_trips_inherited_source_segments() {
-        let envelope = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+        let (envelope, encoded) = encode_namespace_manifest_json(NamespaceManifestPayload {
             namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
             manifest_no: ManifestNo(12),
             manifest_object_id: ManifestObjectId::parse(
@@ -1155,9 +1106,8 @@ mod tests {
                 ),
             ],
         })
-        .expect("manifest");
-
-        let encoded = encode_namespace_manifest_json(&envelope).expect("encode manifest");
+        .expect("manifest")
+        .into_parts();
         let decoded = decode_namespace_manifest_json(&encoded).expect("decode manifest");
 
         assert_eq!(decoded, envelope);
@@ -1177,7 +1127,7 @@ mod tests {
         let mut staged = metadata_segment_ref("demo", "seg_00000000000000000000000000000001");
         staged.compaction_job_id = Some(compaction_job_id.clone());
         let flushed = metadata_segment_ref("demo", "seg_00000000000000000000000000000002");
-        let envelope = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+        let (envelope, encoded) = encode_namespace_manifest_json(NamespaceManifestPayload {
             namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
             manifest_no: ManifestNo(14),
             manifest_object_id: ManifestObjectId::parse(
@@ -1207,9 +1157,8 @@ mod tests {
                 },
             ],
         })
-        .expect("manifest");
-
-        let encoded = encode_namespace_manifest_json(&envelope).expect("encode manifest");
+        .expect("manifest")
+        .into_parts();
         let decoded = decode_namespace_manifest_json(&encoded).expect("decode manifest");
 
         assert_eq!(decoded, envelope);

--- a/crates/loonfs-api/src/wal.rs
+++ b/crates/loonfs-api/src/wal.rs
@@ -198,38 +198,10 @@ pub struct WalSegmentPayload {
     pub records: Vec<WalCommitPayload>,
 }
 
-/// In-memory view of a WAL segment envelope.
-///
-/// This struct is not the durable layout; durable bytes are produced only by
-/// [`encode_wal_segment_envelope_zstd`] and validated only by
-/// [`decode_wal_segment_envelope_zstd`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct WalSegmentEnvelope {
-    /// Durable-family discriminator checked before payload decoding.
-    pub kind: WalEnvelopeKind,
-    /// Family-local format version, which must equal [`WAL_FORMAT_VERSION`].
-    pub format_version: u32,
-    /// Digest of the encoded payload bytes exactly as stored in the durable
-    /// document, in `sha256:<hex>` form.
-    pub payload_checksum: String,
-    /// Decoded namespace segment content protected by `payload_checksum`.
-    pub payload: WalSegmentPayload,
-}
+/// A WAL segment decoded through its checked durable codec.
+pub type WalSegmentEnvelope = crate::envelope::VerifiedEnvelope<WalSegmentPayload>;
 
 impl WalSegmentEnvelope {
-    /// Builds a versioned envelope and computes its checksum from canonical CBOR payload bytes.
-    ///
-    /// Construction fails when the payload cannot be encoded.
-    pub fn from_payload(payload: WalSegmentPayload) -> Result<Self, EnvelopeCodecError> {
-        Ok(Self {
-            kind: WalEnvelopeKind::NamespaceWalSegment,
-            format_version: WAL_FORMAT_VERSION,
-            payload_checksum: wal_payload_checksum(&payload)?,
-            payload,
-        })
-    }
-
     /// Projects the identity, integrity, and sequence metadata needed to link this segment.
     pub fn pointer(&self) -> WalSegmentPointer {
         WalSegmentPointer {
@@ -256,12 +228,6 @@ struct WalSegmentDocument {
     payload: Vec<u8>,
 }
 
-pub(crate) fn wal_payload_checksum(
-    payload: &WalSegmentPayload,
-) -> Result<String, EnvelopeCodecError> {
-    Ok(sha256_digest(&encode_wal_payload_cbor(payload)?))
-}
-
 pub(crate) fn encode_wal_payload_cbor(
     payload: &WalSegmentPayload,
 ) -> Result<Vec<u8>, EnvelopeCodecError> {
@@ -271,33 +237,30 @@ pub(crate) fn encode_wal_payload_cbor(
     Ok(encoded)
 }
 
-/// Encodes a WAL envelope as its durable zstd-compressed CBOR representation.
-///
-/// Encoding fails when the version is unsupported, the in-memory checksum is
-/// stale, CBOR serialization fails, or zstd cannot compress the document. See
-/// [WAL segment rules](../../../docs/specs/format.md#15-wal-segment-rules).
+/// Encodes a WAL payload once, then checksums and compresses its durable document.
 pub fn encode_wal_segment_envelope_zstd(
-    envelope: &WalSegmentEnvelope,
-) -> Result<Vec<u8>, EnvelopeCodecError> {
-    envelope::verify_version(
-        envelope.kind.as_str(),
-        envelope.format_version,
-        WAL_FORMAT_VERSION,
-    )?;
-    let payload_bytes = encode_wal_payload_cbor(&envelope.payload)?;
-    envelope::verify_checksum_fresh(&envelope.payload_checksum, &payload_bytes)?;
-
+    payload: WalSegmentPayload,
+) -> Result<crate::envelope::EncodedEnvelope<WalSegmentPayload>, EnvelopeCodecError> {
+    let payload_bytes = encode_wal_payload_cbor(&payload)?;
+    let payload_checksum = sha256_digest(&payload_bytes);
     let document = WalSegmentDocument {
-        kind: envelope.kind.as_str().to_owned(),
-        format_version: envelope.format_version,
-        payload_checksum: envelope.payload_checksum.clone(),
+        kind: WalEnvelopeKind::NamespaceWalSegment.as_str().to_owned(),
+        format_version: WAL_FORMAT_VERSION,
+        payload_checksum: payload_checksum.clone(),
         payload: payload_bytes,
     };
     let mut encoded = Vec::new();
     into_writer(&document, &mut encoded)
         .map_err(|err| EnvelopeCodecError::EnvelopeEncode(err.to_string()))?;
-    zstd::stream::encode_all(encoded.as_slice(), crate::sst_blocks::ZSTD_LEVEL)
-        .map_err(|err| EnvelopeCodecError::Compress(err.to_string()))
+    let bytes = zstd::stream::encode_all(encoded.as_slice(), crate::sst_blocks::ZSTD_LEVEL)
+        .map_err(|err| EnvelopeCodecError::Compress(err.to_string()))?;
+    Ok(crate::envelope::EncodedEnvelope {
+        envelope: crate::envelope::VerifiedEnvelope {
+            payload_checksum,
+            payload,
+        },
+        bytes,
+    })
 }
 
 /// Decodes and verifies a durable zstd-compressed WAL segment envelope.
@@ -326,8 +289,6 @@ pub fn decode_wal_segment_envelope_zstd(
         .map_err(EnvelopeCodecError::PayloadDecode)?;
 
     Ok(WalSegmentEnvelope {
-        kind: expected_kind,
-        format_version: document.format_version,
         payload_checksum: document.payload_checksum,
         payload,
     })

--- a/crates/loonfs-api/tests/golden/control_compaction_completed_lease.v3.json
+++ b/crates/loonfs-api/tests/golden/control_compaction_completed_lease.v3.json
@@ -1,0 +1,1 @@
+{"kind":"compaction_lease","format_version":3,"payload_checksum":"sha256:86ea3d6d5e619228124bd05e629e1315b4ee8fb5ada7ea504246a626e4fb3802","payload":{"job_id":"cmp_0123456789abcdef0123456789abcdef","namespace_id":"demo","group":"bindings","writer_id":"writer-1","status":{"kind":"completed"},"started_at_ms":1000,"expires_at_ms":1503000}}

--- a/crates/loonfs-api/tests/golden/control_compaction_lease.v2.json
+++ b/crates/loonfs-api/tests/golden/control_compaction_lease.v2.json
@@ -1,1 +1,0 @@
-{"kind":"compaction_lease","format_version":2,"payload_checksum":"sha256:7a5726ff3c492c298dcf6f6254851d79928d76370bd9d4dcb37d186cc2fea113","payload":{"job_id":"cmp_0123456789abcdef0123456789abcdef","namespace_id":"demo","group":"bindings","writer_id":"writer-1","status":{"kind":"active"},"started_at_ms":1000,"expires_at_ms":1503000}}

--- a/crates/loonfs-api/tests/golden/control_compaction_lease.v3.json
+++ b/crates/loonfs-api/tests/golden/control_compaction_lease.v3.json
@@ -1,0 +1,1 @@
+{"kind":"compaction_lease","format_version":3,"payload_checksum":"sha256:7a5726ff3c492c298dcf6f6254851d79928d76370bd9d4dcb37d186cc2fea113","payload":{"job_id":"cmp_0123456789abcdef0123456789abcdef","namespace_id":"demo","group":"bindings","writer_id":"writer-1","status":{"kind":"active"},"started_at_ms":1000,"expires_at_ms":1503000}}

--- a/crates/loonfs-api/tests/golden/control_compaction_output_protection.v1.json
+++ b/crates/loonfs-api/tests/golden/control_compaction_output_protection.v1.json
@@ -1,0 +1,1 @@
+{"kind":"compaction_output_protection","format_version":1,"payload_checksum":"sha256:1f19759d120cea27b37085b82bdc43146fd19791b10e231113329c17e7e2ac15","payload":{"namespace_id":"demo","job_id":"cmp_0123456789abcdef0123456789abcdef","expires_at_ms":1503000}}

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -19,22 +19,21 @@
 //!   decoding could erase a field introduced by an unsupported writer.
 
 use loonfs_api::wire::control::{
-    decode_control_object, encode_control_object, CheckpointOwner, CheckpointRecordState,
-    CheckpointStatus, CompactionLeaseStatus, ControlObjectEnvelope, ControlObjectKind, ForkBasis,
-    HeadState, ManifestRef, MetadataCompactionLeaseState, MetadataRootState, NamespaceStatus,
-    ProxiedStaging, UploadSessionMode, UploadSessionRecordStatus, UploadSessionState,
-    WalFloorState, WalSegmentPointer, WriterBlock,
+    decode_control_object, CheckpointOwner, CheckpointRecordState, CheckpointStatus,
+    CompactionLeaseStatus, ControlObjectEnvelope, ControlObjectKind, ForkBasis, HeadState,
+    ManifestRef, MetadataCompactionLeaseState, MetadataRootState, NamespaceStatus, ProxiedStaging,
+    UploadSessionMode, UploadSessionRecordStatus, UploadSessionState, WalFloorState,
+    WalSegmentPointer, WriterBlock,
 };
 use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::wire::manifest::{
     decode_namespace_manifest_json, encode_namespace_manifest_json, ActiveDeletionRowAction,
     DeletedDirentry, MetadataFamilyGroup, MetadataRow, MetadataRowFamily, MetadataRunRef,
-    MetadataSegmentRef, NamespaceManifestEnvelope, NamespaceManifestPayload, RunTier,
-    TombstoneGeneration, TombstoneRowAction,
+    MetadataSegmentRef, NamespaceManifestPayload, RunTier, TombstoneGeneration, TombstoneRowAction,
 };
 use loonfs_api::wire::wal::{
     decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, WalCommitDelta,
-    WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload,
+    WalCommitPayload, WalDelta, WalSegmentPayload,
 };
 use loonfs_api::{
     sha256_digest, ActorId, ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue,
@@ -231,7 +230,7 @@ fn sample_wal_pointer() -> WalSegmentPointer {
     }
 }
 
-fn sample_wal_envelope() -> WalSegmentEnvelope {
+fn sample_wal_payload() -> WalSegmentPayload {
     let deltas = vec![
         WalCommitDelta {
             semantic_op_index: 0,
@@ -296,7 +295,7 @@ fn sample_wal_envelope() -> WalSegmentEnvelope {
             },
         },
     ];
-    WalSegmentEnvelope::from_payload(WalSegmentPayload {
+    WalSegmentPayload {
         namespace_id: namespace_id(),
         segment_id: WalSegmentId::parse("wal_00000000000000000002-0123456789abcdef")
             .expect("valid segment id"),
@@ -317,12 +316,11 @@ fn sample_wal_envelope() -> WalSegmentEnvelope {
             message: Some("golden commit".to_owned()),
             deltas,
         }],
-    })
-    .expect("wal envelope")
+    }
 }
 
-fn sample_manifest_envelope() -> NamespaceManifestEnvelope {
-    NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+fn sample_manifest_payload() -> NamespaceManifestPayload {
+    NamespaceManifestPayload {
         namespace_id: namespace_id(),
         manifest_no: ManifestNo(2),
         manifest_object_id: manifest_object_id(2, "0123456789abcdef"),
@@ -365,8 +363,7 @@ fn sample_manifest_envelope() -> NamespaceManifestEnvelope {
                 object_checksum: sha256_digest(b"sst payload"),
             }],
         }],
-    })
-    .expect("manifest envelope")
+    }
 }
 
 /// Returns a manifest reference owned by the sample namespace.
@@ -434,7 +431,9 @@ fn sample_fork_head_state() -> HeadState {
 
 #[test]
 fn wal_segment_document_matches_golden_bytes() {
-    let encoded = encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("encode wal");
+    let encoded = encode_wal_segment_envelope_zstd(sample_wal_payload())
+        .expect("encode wal")
+        .into_bytes();
     // Compare the decompressed document: zstd frames may differ across zstd
     // versions, the document bytes (which the checksum covers) may not.
     assert_matches_golden("wal_segment.v1.cbor", &unzstd(&encoded));
@@ -444,16 +443,18 @@ fn wal_segment_document_matches_golden_bytes() {
 fn wal_segment_golden_decodes_to_sample() {
     let decoded = decode_wal_segment_envelope_zstd(&rezstd(&read_golden("wal_segment.v1.cbor")))
         .expect("decode golden wal segment");
-    assert_eq!(decoded, sample_wal_envelope());
+    assert_eq!(decoded.into_payload(), sample_wal_payload());
 }
 
 #[test]
 fn wal_segments_reject_an_id_that_disagrees_with_its_start_seq() {
-    let agreeing = encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("encode wal");
+    let agreeing = encode_wal_segment_envelope_zstd(sample_wal_payload())
+        .expect("encode wal")
+        .into_bytes();
     decode_wal_segment_envelope_zstd(&agreeing)
         .expect("a segment whose id encodes its start seq decodes");
 
-    let mut payload = sample_wal_envelope().payload;
+    let mut payload = sample_wal_payload();
     payload.segment_id =
         WalSegmentId::parse("wal_00000000000000000009-0123456789abcdef").expect("valid segment id");
     let message = assert_wal_segment_is_corrupt(payload);
@@ -463,7 +464,7 @@ fn wal_segments_reject_an_id_that_disagrees_with_its_start_seq() {
         "the rejection should name both values: {message}"
     );
 
-    let mut payload = sample_wal_envelope().payload;
+    let mut payload = sample_wal_payload();
     let mut link = sample_wal_pointer();
     link.segment_id =
         WalSegmentId::parse("wal_00000000000000000004-fedcba9876543210").expect("valid segment id");
@@ -479,8 +480,9 @@ fn wal_segments_reject_an_id_that_disagrees_with_its_start_seq() {
 /// Stores `payload` through the real codec and returns why decoding refused
 /// it.
 fn assert_wal_segment_is_corrupt(payload: WalSegmentPayload) -> String {
-    let envelope = WalSegmentEnvelope::from_payload(payload).expect("rebuild the wal envelope");
-    let encoded = encode_wal_segment_envelope_zstd(&envelope).expect("encode wal");
+    let encoded = encode_wal_segment_envelope_zstd(payload)
+        .expect("encode wal")
+        .into_bytes();
     let error =
         decode_wal_segment_envelope_zstd(&encoded).expect_err("the stored segment is corrupt");
     assert!(
@@ -492,7 +494,9 @@ fn assert_wal_segment_is_corrupt(payload: WalSegmentPayload) -> String {
 
 #[test]
 fn namespace_manifest_matches_golden_bytes() {
-    let encoded = encode_namespace_manifest_json(&sample_manifest_envelope()).expect("encode");
+    let encoded = encode_namespace_manifest_json(sample_manifest_payload())
+        .expect("encode")
+        .into_bytes();
     assert_matches_golden("namespace_manifest.v4.json", &encoded);
     let document: serde_json::Value = serde_json::from_slice(&encoded).expect("manifest json");
     let payload = document["payload"].as_object().expect("manifest payload");
@@ -504,20 +508,20 @@ fn namespace_manifest_matches_golden_bytes() {
 fn namespace_manifest_golden_decodes_to_sample() {
     let decoded = decode_namespace_manifest_json(&read_golden("namespace_manifest.v4.json"))
         .expect("decode golden manifest");
-    assert_eq!(decoded, sample_manifest_envelope());
+    assert_eq!(decoded.into_payload(), sample_manifest_payload());
 }
 
 fn check_control_golden<T>(fixture: &str, kind: ControlObjectKind, state: T)
 where
     T: Serialize + DeserializeOwned + PartialEq + Debug,
 {
-    let envelope = ControlObjectEnvelope::from_state(kind, state).expect("control envelope");
-    let encoded = encode_control_object(&envelope).expect("encode control object");
+    let encoded = loonfs_api::wire::control::encode_control_state(kind, &state)
+        .expect("encode control object");
     assert_matches_golden(fixture, &encoded);
 
     let decoded: ControlObjectEnvelope<T> =
         decode_control_object(&read_golden(fixture), kind).expect("decode golden control object");
-    assert_eq!(decoded, envelope);
+    assert_eq!(decoded.into_payload(), state);
 }
 
 fn control_document_with_payload_edit(
@@ -1383,8 +1387,8 @@ fn control_object_decoders_reject_wrong_format_version_without_fallback() {
         ),
     ];
     for (kind, state) in cases {
-        let envelope = ControlObjectEnvelope::from_state(kind, state).expect("control envelope");
-        let encoded = encode_control_object(&envelope).expect("encode control");
+        let encoded =
+            loonfs_api::wire::control::encode_control_state(kind, &state).expect("encode control");
         let mut document: serde_json::Value =
             serde_json::from_slice(&encoded).expect("decode document");
         document["format_version"] = serde_json::Value::from(7);
@@ -1445,10 +1449,14 @@ fn content_store_id() -> ContentStoreId {
 
 /// Edits a WAL payload and updates its checksum.
 fn wal_document_with_payload_edit(
-    envelope: &WalSegmentEnvelope,
+    payload: &WalSegmentPayload,
     edit: impl FnOnce(&mut ciborium::Value),
 ) -> Vec<u8> {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(envelope).expect("wal"));
+    let document = unzstd(
+        &encode_wal_segment_envelope_zstd(payload.clone())
+            .expect("wal")
+            .into_bytes(),
+    );
     let document_value: ciborium::Value =
         ciborium::de::from_reader(document.as_slice()).expect("decode document map");
     let payload_bytes = document_value
@@ -1502,10 +1510,10 @@ fn commit_delta(payload: &mut ciborium::Value, position: usize) -> &mut ciborium
 }
 
 /// Builds a sample segment with the supplied deltas.
-fn wal_envelope_with_deltas(deltas: Vec<WalCommitDelta>) -> WalSegmentEnvelope {
-    let mut payload = sample_wal_envelope().payload;
+fn wal_payload_with_deltas(deltas: Vec<WalCommitDelta>) -> WalSegmentPayload {
+    let mut payload = sample_wal_payload();
     payload.records[0].deltas = deltas;
-    WalSegmentEnvelope::from_payload(payload).expect("wal envelope")
+    payload
 }
 
 /// Rewrites one top-level entry of a CBOR document map.
@@ -1556,7 +1564,11 @@ fn wal_delta_decode_rejects_invalid_name_key() {
 
 #[test]
 fn wal_decode_rejects_wrong_format_version_cleanly() {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let document = unzstd(
+        &encode_wal_segment_envelope_zstd(sample_wal_payload())
+            .expect("wal")
+            .into_bytes(),
+    );
     let wrong_version = with_cbor_document_entry(&document, "format_version", |value| {
         *value = ciborium::Value::from(7);
     });
@@ -1578,7 +1590,11 @@ fn wal_decode_rejects_wrong_format_version_cleanly() {
 
 #[test]
 fn wal_decode_rejects_unknown_kind_cleanly() {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let document = unzstd(
+        &encode_wal_segment_envelope_zstd(sample_wal_payload())
+            .expect("wal")
+            .into_bytes(),
+    );
     let rekinded = with_cbor_document_entry(&document, "kind", |value| {
         *value = ciborium::Value::from("namespace_wal_index");
     });
@@ -1593,7 +1609,11 @@ fn wal_decode_rejects_unknown_kind_cleanly() {
 
 #[test]
 fn wal_decode_rejects_tampered_payload_bytes_as_checksum_mismatch() {
-    let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let document = unzstd(
+        &encode_wal_segment_envelope_zstd(sample_wal_payload())
+            .expect("wal")
+            .into_bytes(),
+    );
     let tampered = with_cbor_document_entry(&document, "payload", |value| {
         let bytes = match value {
             ciborium::Value::Bytes(bytes) => bytes,
@@ -1614,7 +1634,7 @@ fn wal_decode_rejects_tampered_payload_bytes_as_checksum_mismatch() {
 #[test]
 fn wal_decode_rejects_unknown_payload_fields() {
     // A valid checksum does not authorize unknown payload fields.
-    let envelope = sample_wal_envelope();
+    let envelope = sample_wal_payload();
     let document = wal_document_with_payload_edit(&envelope, with_future_field);
 
     let error = decode_wal_segment_envelope_zstd(&document)
@@ -1625,7 +1645,7 @@ fn wal_decode_rejects_unknown_payload_fields() {
 
 #[test]
 fn wal_decode_rejects_unknown_predecessor_fields() {
-    let envelope = sample_wal_envelope();
+    let envelope = sample_wal_payload();
     let document = wal_document_with_payload_edit(&envelope, |payload| {
         with_future_field(cbor_entry(payload, "prev_visible_segment"));
     });
@@ -1638,7 +1658,7 @@ fn wal_decode_rejects_unknown_predecessor_fields() {
 
 #[test]
 fn wal_decode_rejects_unknown_fields_inside_tombstone_deltas() {
-    let envelope = wal_envelope_with_deltas(vec![
+    let envelope = wal_payload_with_deltas(vec![
         WalCommitDelta {
             semantic_op_index: 0,
             delta: WalDelta::TombstoneSubtree {
@@ -1677,7 +1697,7 @@ fn wal_decode_rejects_unknown_fields_inside_tombstone_deltas() {
 
 #[test]
 fn wal_decode_rejects_an_additive_field_inside_the_commit_attribution() {
-    let document = wal_document_with_payload_edit(&sample_wal_envelope(), |payload| {
+    let document = wal_document_with_payload_edit(&sample_wal_payload(), |payload| {
         with_future_field(cbor_entry(payload_commit(payload), "committed_by"));
     });
 
@@ -1692,7 +1712,7 @@ fn wal_decode_rejects_an_additive_field_inside_the_commit_attribution() {
 
 #[test]
 fn wal_decode_rejects_a_version_one_commit_without_committed_by() {
-    let document = wal_document_with_payload_edit(&sample_wal_envelope(), |payload| {
+    let document = wal_document_with_payload_edit(&sample_wal_payload(), |payload| {
         cbor_map_of(payload_commit(payload))
             .retain(|(key, _)| key.as_text() != Some("committed_by"));
     });
@@ -1707,10 +1727,10 @@ fn wal_decode_rejects_a_version_one_commit_without_committed_by() {
 
 #[test]
 fn control_object_decode_rejects_tampered_payload_as_checksum_mismatch() {
-    let envelope =
-        ControlObjectEnvelope::from_state(ControlObjectKind::WalHead, sample_head_state())
-            .expect("control envelope");
-    let encoded = encode_control_object(&envelope).expect("encode control object");
+    let envelope = sample_head_state();
+    let encoded =
+        loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &envelope)
+            .expect("encode control object");
     let mut document: serde_json::Value =
         serde_json::from_slice(&encoded).expect("decode document");
     document["payload"]["seq"] = serde_json::Value::from(999);
@@ -1726,7 +1746,9 @@ fn control_object_decode_rejects_tampered_payload_as_checksum_mismatch() {
 
 #[test]
 fn namespace_manifest_decode_rejects_wrong_format_version_cleanly() {
-    let encoded = encode_namespace_manifest_json(&sample_manifest_envelope()).expect("manifest");
+    let encoded = encode_namespace_manifest_json(sample_manifest_payload())
+        .expect("manifest")
+        .into_bytes();
     let mut document: serde_json::Value =
         serde_json::from_slice(&encoded).expect("decode document");
     for version in [1, 2, 3, 7] {
@@ -1750,7 +1772,9 @@ fn namespace_manifest_decode_rejects_wrong_format_version_cleanly() {
 
 #[test]
 fn namespace_manifest_decode_rejects_tampered_payload_as_checksum_mismatch() {
-    let encoded = encode_namespace_manifest_json(&sample_manifest_envelope()).expect("manifest");
+    let encoded = encode_namespace_manifest_json(sample_manifest_payload())
+        .expect("manifest")
+        .into_bytes();
     let mut document: serde_json::Value =
         serde_json::from_slice(&encoded).expect("decode document");
     document["payload"]["head_seq"] = serde_json::Value::from(999);
@@ -1766,8 +1790,10 @@ fn namespace_manifest_decode_rejects_tampered_payload_as_checksum_mismatch() {
 
 #[test]
 fn namespace_manifest_decode_rejects_unknown_fields_at_every_level() {
-    let envelope = sample_manifest_envelope();
-    let encoded = encode_namespace_manifest_json(&envelope).expect("manifest");
+    let payload = sample_manifest_payload();
+    let encoded = encode_namespace_manifest_json(payload)
+        .expect("manifest")
+        .into_bytes();
     for path in [
         "",
         "/runs/0",
@@ -1797,14 +1823,19 @@ fn namespace_manifest_decode_rejects_unknown_fields_at_every_level() {
 
 #[test]
 fn immutable_envelopes_reject_unknown_fields() {
-    let mut manifest =
-        encode_namespace_manifest_json(&sample_manifest_envelope()).expect("manifest");
+    let mut manifest = encode_namespace_manifest_json(sample_manifest_payload())
+        .expect("manifest")
+        .into_bytes();
     assert_eq!(manifest.pop(), Some(b'}'));
     manifest.extend_from_slice(br#", "field_from_the_future": true}"#);
     assert!(matches!(decode_namespace_manifest_json(&manifest),
         Err(EnvelopeCodecError::EnvelopeDecode(message)) if message.contains("field_from_the_future")));
 
-    let encoded = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
+    let encoded = unzstd(
+        &encode_wal_segment_envelope_zstd(sample_wal_payload())
+            .expect("wal")
+            .into_bytes(),
+    );
     let mut document: ciborium::Value =
         ciborium::de::from_reader(encoded.as_slice()).expect("document");
     with_future_field(&mut document);

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -710,7 +710,7 @@ fn control_objects_match_golden_bytes() {
     // like every other family's so a field rename cannot silently change what
     // either party reads that claim out of.
     check_control_golden(
-        "control_compaction_lease.v2.json",
+        "control_compaction_lease.v3.json",
         ControlObjectKind::CompactionLease,
         MetadataCompactionLeaseState {
             job_id: MetadataCompactionId::parse("cmp_0123456789abcdef0123456789abcdef")
@@ -720,6 +720,30 @@ fn control_objects_match_golden_bytes() {
             writer_id: WriterId::parse("writer-1").expect("writer id"),
             status: CompactionLeaseStatus::Active {},
             started_at_ms: 1_000,
+            expires_at_ms: 1_503_000,
+        },
+    );
+    check_control_golden(
+        "control_compaction_completed_lease.v3.json",
+        ControlObjectKind::CompactionLease,
+        MetadataCompactionLeaseState {
+            job_id: MetadataCompactionId::parse("cmp_0123456789abcdef0123456789abcdef")
+                .expect("valid compaction id"),
+            namespace_id: namespace_id(),
+            group: MetadataFamilyGroup::Bindings,
+            writer_id: WriterId::parse("writer-1").expect("writer id"),
+            status: CompactionLeaseStatus::Completed {},
+            started_at_ms: 1_000,
+            expires_at_ms: 1_503_000,
+        },
+    );
+    check_control_golden(
+        "control_compaction_output_protection.v1.json",
+        ControlObjectKind::CompactionOutputProtection,
+        loonfs_api::wire::control::CompactionOutputProtectionState {
+            namespace_id: namespace_id(),
+            job_id: MetadataCompactionId::parse("cmp_0123456789abcdef0123456789abcdef")
+                .expect("job id"),
             expires_at_ms: 1_503_000,
         },
     );
@@ -866,7 +890,7 @@ fn every_durable_status_is_a_kind_tagged_object() {
         "control_checkpoint_record.v1.json",
         "control_checkpoint_record_released.v1.json",
         "control_upload_session.v1.json",
-        "control_compaction_lease.v2.json",
+        "control_compaction_lease.v3.json",
     ];
     for fixture in fixtures {
         let document: serde_json::Value =
@@ -924,7 +948,7 @@ fn every_mutable_control_payload_rejects_unknown_fields_as_corruption() {
         add_unknown,
     );
     assert_control_payload_edit_is_corrupt::<MetadataCompactionLeaseState>(
-        "control_compaction_lease.v2.json",
+        "control_compaction_lease.v3.json",
         ControlObjectKind::CompactionLease,
         add_unknown,
     );
@@ -940,7 +964,7 @@ fn compaction_leases_reject_the_retired_refresh_instant_field() {
     let retired_field = ["heart", "beat_at_ms"].concat();
     let field_for_edit = retired_field.clone();
     let message = assert_control_payload_edit_is_corrupt::<MetadataCompactionLeaseState>(
-        "control_compaction_lease.v2.json",
+        "control_compaction_lease.v3.json",
         ControlObjectKind::CompactionLease,
         move |payload| {
             let fields = payload.as_object_mut().expect("lease payload");
@@ -2727,4 +2751,15 @@ fn every_metadata_row_rejects_unknown_fields() {
             );
         }
     }
+}
+
+#[test]
+fn compaction_output_protection_rejects_unknown_payload_fields() {
+    assert_control_payload_edit_is_corrupt::<
+        loonfs_api::wire::control::CompactionOutputProtectionState,
+    >(
+        "control_compaction_output_protection.v1.json",
+        ControlObjectKind::CompactionOutputProtection,
+        |payload| payload["unknown"] = serde_json::json!(true),
+    );
 }

--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -4,9 +4,10 @@
 //! Garbage collection may claim an expired lease by changing it to `Reaping`.
 //! A failed refresh then prevents the job from publishing.
 //!
-//! Completed jobs leave the lease in place so a collection pass that started
-//! before publication cannot mistake old output for garbage. Malformed leases
-//! stop collection because ownership cannot be verified.
+//! Before publishing, a job records a protection deadline beside its sealed
+//! output. That record remains until every output object is gone, even after
+//! the group admits another job. Paused collectors keep their fixed clock.
+//! Malformed leases stop collection because ownership cannot be verified.
 
 use super::streaming_compaction::MetadataCompactionSpec;
 use crate::control_object::{
@@ -19,28 +20,25 @@ use crate::limits::{
 use crate::time::MonotonicTimer;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
-    encode_control_state, CompactionLeaseStatus, ControlObjectKind, MetadataCompactionLeaseState,
+    encode_control_state, CompactionLeaseStatus, CompactionOutputProtectionState,
+    ControlObjectKind, MetadataCompactionLeaseState,
 };
 use loonfs_api::{MetadataCompactionId, MetadataFamilyGroup, NamespaceId, WriterId};
-use loonfs_objectstore::keys::metadata_compaction_lease;
+use loonfs_objectstore::keys::{metadata_compaction_lease, metadata_compaction_output_protection};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 
 /// Who owns the objects under one job's prefix, as a collector reads it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompactionPrefixOwner {
-    /// A job owns it: its lease is `Active` and unexpired, or it refreshed
-    /// out from under this pass's claim. Nothing about the objects' age
-    /// matters.
-    LiveJob,
-    /// This pass claimed the prefix, or found a claim someone else won. The
-    /// job that wrote the objects is fenced, so they are orphans — and the
-    /// lease is deleted after them, once nothing unreferenced is left under
-    /// the prefix.
-    ThisCollector,
+    /// A live job or publication deadline protects this output, regardless
+    /// of object age. A lost fencing CAS also retains output for this pass.
+    Protected,
+    /// This pass or another collector fenced the job. Unreferenced output
+    /// can be collected; the group slot remains available for replacement.
+    Fenced,
     /// There is no lease to own anything. Whatever sits under the prefix is
-    /// an ordinary unreferenced orphan and there is no claim to release
-    /// afterwards.
-    NoOne,
+    /// an ordinary unreferenced orphan.
+    Unclaimed,
 }
 
 /// Returns the current prefix owner, claiming its expired group lease when possible.
@@ -53,7 +51,7 @@ pub(crate) async fn claim_group_lease<S: ObjectStore + ?Sized>(
     now_ms: u64,
 ) -> Result<CompactionPrefixOwner> {
     let Some(loaded) = load_group_lease(store, namespace_id, group).await? else {
-        return Ok(CompactionPrefixOwner::NoOne);
+        return Ok(CompactionPrefixOwner::Unclaimed);
     };
     claim_loaded_group_lease(store, namespace_id, metadata_compaction_id, loaded, now_ms).await
 }
@@ -87,6 +85,29 @@ pub(crate) async fn load_group_lease<S: ObjectStore + ?Sized>(
     }
 }
 
+/// Reads the sealed output's publication deadline independently of the group.
+pub(crate) async fn load_output_protection<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    job_id: &MetadataCompactionId,
+) -> Result<Option<crate::control_object::LoadedControl<CompactionOutputProtectionState>>> {
+    let loaded = load_control_object(
+        store,
+        metadata_compaction_output_protection(namespace_id, job_id),
+        ControlObjectKind::CompactionOutputProtection,
+        |state: &CompactionOutputProtectionState| {
+            expect_namespace(namespace_id, &state.namespace_id)?;
+            expect_identity_field("compaction job", job_id.as_str(), state.job_id.as_str())
+        },
+    )
+    .await;
+    match loaded {
+        Ok(loaded) => Ok(Some(loaded)),
+        Err(ControlObjectLoadError::MissingObject { .. }) => Ok(None),
+        Err(error) => Err(CoreError::ControlObjectLoad(error)),
+    }
+}
+
 pub(crate) async fn claim_loaded_group_lease<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -99,15 +120,19 @@ pub(crate) async fn claim_loaded_group_lease<S: ObjectStore + ?Sized>(
     let state = loaded.state;
     // A group lease protects only the staged objects written by the job id it names.
     if state.job_id != *metadata_compaction_id {
-        return Ok(CompactionPrefixOwner::NoOne);
+        return Ok(CompactionPrefixOwner::Unclaimed);
+    }
+    // Publication has ended. Its separate record protects older collectors.
+    if state.status == (CompactionLeaseStatus::Completed {}) {
+        return Ok(CompactionPrefixOwner::Unclaimed);
     }
     // Terminal: somebody already fenced this job, so the reap goes on from
     // wherever the pass that started it stopped.
     if state.status == (CompactionLeaseStatus::Reaping {}) {
-        return Ok(CompactionPrefixOwner::ThisCollector);
+        return Ok(CompactionPrefixOwner::Fenced);
     }
     if active_lease_is_unexpired(&state, now_ms) {
-        return Ok(CompactionPrefixOwner::LiveJob);
+        return Ok(CompactionPrefixOwner::Protected);
     }
 
     // Expired. Nothing is decided until the claim lands.
@@ -128,12 +153,12 @@ pub(crate) async fn claim_loaded_group_lease<S: ObjectStore + ?Sized>(
                 "a streaming metadata compaction lease expired; garbage collection claimed the \
                  group lease and the job that wrote it can no longer publish"
             );
-            Ok(CompactionPrefixOwner::ThisCollector)
+            Ok(CompactionPrefixOwner::Fenced)
         }
         // The job wrote the lease between this pass's read and its claim, so
         // the job is alive and owns its prefix. This pass keeps every object
         // under it.
-        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CompactionPrefixOwner::LiveJob),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(CompactionPrefixOwner::Protected),
         // An ambiguous claim is left to a later collector, which reads the
         // lease afresh and finishes whatever landed.
         Err(error) => Err(CoreError::store(&object_key, &error)),
@@ -143,12 +168,10 @@ pub(crate) async fn claim_loaded_group_lease<S: ObjectStore + ?Sized>(
 /// Availability of one family group's deterministic lease.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum GroupLeaseState {
-    /// No lease exists.
-    Free,
-    /// An unexpired job or a collector holds the lease.
+    /// No unexpired job owns the group.
+    Available,
+    /// An unexpired job holds the lease.
     Held,
-    /// The active lease may be taken over.
-    Expired,
 }
 
 /// Reads one family group's lease for planning.
@@ -159,17 +182,13 @@ pub(super) async fn group_lease_state<S: ObjectStore + ?Sized>(
     now_ms: u64,
 ) -> Result<GroupLeaseState> {
     let Some(loaded) = load_group_lease(store, namespace_id, group).await? else {
-        return Ok(GroupLeaseState::Free);
+        return Ok(GroupLeaseState::Available);
     };
-    Ok(
-        if active_lease_is_unexpired(&loaded.state, now_ms)
-            || loaded.state.status == (CompactionLeaseStatus::Reaping {})
-        {
-            GroupLeaseState::Held
-        } else {
-            GroupLeaseState::Expired
-        },
-    )
+    Ok(if active_lease_is_unexpired(&loaded.state, now_ms) {
+        GroupLeaseState::Held
+    } else {
+        GroupLeaseState::Available
+    })
 }
 
 fn active_lease_is_unexpired(state: &MetadataCompactionLeaseState, now_ms: u64) -> bool {
@@ -191,7 +210,7 @@ pub(super) enum LeaseHold {
 pub(super) enum LeaseAcquire<'a> {
     /// This job owns the lease.
     Acquired(CompactionLease<'a>),
-    /// Another job or a collector holds the lease.
+    /// Another unexpired job holds the lease.
     Held,
 }
 
@@ -227,7 +246,7 @@ impl<'a> CompactionLease<'a> {
         let loaded = load_group_lease(store, namespace_id, spec.group()).await?;
         let etag = match loaded {
             Some(loaded) => {
-                return Self::take_over_expired(
+                return Self::replace_available(
                     store,
                     loaded,
                     object_key,
@@ -245,7 +264,7 @@ impl<'a> CompactionLease<'a> {
                     else {
                         return Ok(LeaseAcquire::Held);
                     };
-                    return Self::take_over_expired(
+                    return Self::replace_available(
                         store,
                         loaded,
                         object_key,
@@ -264,7 +283,7 @@ impl<'a> CompactionLease<'a> {
                     if loaded.state == state {
                         loaded.etag
                     } else {
-                        return Self::take_over_expired(
+                        return Self::replace_available(
                             store,
                             loaded,
                             object_key,
@@ -289,7 +308,7 @@ impl<'a> CompactionLease<'a> {
         }))
     }
 
-    async fn take_over_expired<S: ObjectStore + ?Sized>(
+    async fn replace_available<S: ObjectStore + ?Sized>(
         store: &S,
         loaded: LoadedCompactionLease,
         object_key: String,
@@ -298,12 +317,10 @@ impl<'a> CompactionLease<'a> {
         timer: &'a dyn MonotonicTimer,
         started_monotonic_ms: u64,
     ) -> Result<LeaseAcquire<'a>> {
-        if active_lease_is_unexpired(&loaded.state, state.started_at_ms)
-            || loaded.state.status == (CompactionLeaseStatus::Reaping {})
-        {
+        if active_lease_is_unexpired(&loaded.state, state.started_at_ms) {
             return Ok(LeaseAcquire::Held);
         }
-        // Replacing the complete expired lease in one CAS fences the previous job's next refresh.
+        // Replacing the complete slot in one CAS fences the previous job's next refresh.
         let etag = match store
             .compare_and_swap(&object_key, &loaded.etag, encoded)
             .await
@@ -333,6 +350,74 @@ impl<'a> CompactionLease<'a> {
             started_monotonic_ms,
             next_refresh_monotonic_ms: started_monotonic_ms,
         }))
+    }
+
+    /// Confirms output protection before a root publication can make old output live.
+    /// No further output writes are permitted after the first call.
+    pub(super) async fn protect_output<S: ObjectStore + ?Sized>(&self, store: &S) -> Result<()> {
+        let key =
+            metadata_compaction_output_protection(&self.state.namespace_id, &self.state.job_id);
+        let existing =
+            load_output_protection(store, &self.state.namespace_id, &self.state.job_id).await?;
+        let state = CompactionOutputProtectionState {
+            namespace_id: self.state.namespace_id.clone(),
+            job_id: self.state.job_id.clone(),
+            expires_at_ms: existing
+                .as_ref()
+                .map_or(self.state.expires_at_ms, |loaded| {
+                    loaded.state.expires_at_ms.max(self.state.expires_at_ms)
+                }),
+        };
+        if existing
+            .as_ref()
+            .is_some_and(|loaded| loaded.state == state)
+        {
+            return Ok(());
+        }
+        let bytes = encode_control_state(ControlObjectKind::CompactionOutputProtection, &state)
+            .map(Bytes::from)
+            .map_err(|error| CoreError::Codec {
+                object_key: key.clone(),
+                message: error.to_string(),
+            })?;
+        let result = match existing {
+            Some(loaded) => store.compare_and_swap(&key, &loaded.etag, bytes).await,
+            None => store.put_if_absent(&key, bytes).await,
+        };
+        match result {
+            Ok(_) => Ok(()),
+            Err(
+                error @ (ObjectStoreError::PreconditionFailed { .. }
+                | ObjectStoreError::Transport { .. }),
+            ) => {
+                let confirmed =
+                    load_output_protection(store, &state.namespace_id, &state.job_id).await?;
+                if confirmed.is_some_and(|loaded| loaded.state == state) {
+                    Ok(())
+                } else {
+                    Err(CoreError::store(&key, &error))
+                }
+            }
+            Err(error) => Err(CoreError::store(&key, &error)),
+        }
+    }
+
+    /// Releases the group after the last publication attempt. The separate
+    /// output protection was confirmed before publication, so a pause here
+    /// cannot leave published output dependent on the group slot.
+    pub(super) async fn complete<S: ObjectStore + ?Sized>(&self, store: &S) -> Result<()> {
+        let mut completed = self.state.clone();
+        completed.status = CompactionLeaseStatus::Completed {};
+        match store
+            .compare_and_swap(&self.object_key, &self.etag, encode_lease(&completed)?)
+            .await
+        {
+            Ok(_)
+            | Err(
+                ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::NotFound { .. },
+            ) => Ok(()),
+            Err(error) => Err(CoreError::store(&self.object_key, &error)),
+        }
     }
 
     /// The clock the job paces itself by. One clock for the job's refresh

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -33,9 +33,7 @@ use crate::wal::{
     ensure_replayed_head_matches, load_wal_chain, project_validated_wal_tail, WalChainLoadRequest,
 };
 use loonfs_api::wire::control::{HeadState, ManifestRef};
-use loonfs_api::wire::manifest::{
-    MetadataRunRef, NamespaceManifestEnvelope, NamespaceManifestPayload, RunTier,
-};
+use loonfs_api::wire::manifest::{MetadataRunRef, NamespaceManifestPayload, RunTier};
 use loonfs_api::{
     ChangeSeq, CommitId, FlushWalOutcome, FlushWalResponse, ManifestNo, ManifestObjectId,
     NamespaceId, RunNo, MAX_PUBLIC_INTEGER,
@@ -146,7 +144,7 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
     // checkpoint record can pin only its own.
     let basis_manifest = projection.basis.manifest();
     if projection.basis.is_owned_by(namespace_id)
-        && projection.manifest_segments.manifest().payload.head_seq == head_seq
+        && projection.manifest_segments.manifest().payload().head_seq == head_seq
     {
         let basis_manifest = basis_manifest.expect("an owned basis names a manifest");
         return Ok(TryFlushWal::Settled(Box::new(FlushedBasis {
@@ -171,7 +169,7 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
         ManifestObjectId::generate(manifest_no),
     )
     .await?;
-    write_namespace_manifest(store, &manifest)
+    let manifest = write_namespace_manifest(store, manifest)
         .await
         .map_err(manifest_write_failure)?;
     // The publication budget gates the root compare-and-swap: past it, the
@@ -189,7 +187,7 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
             projection
                 .manifest_segments
                 .manifest()
-                .payload
+                .payload()
                 .manifest_object_id
                 .clone()
         }),
@@ -199,8 +197,8 @@ async fn try_flush_wal_projection<S: ObjectStore + ?Sized>(
     {
         ManifestPublicationOutcome::Published(_) => (
             FlushWalOutcome::Published,
-            manifest.payload.manifest_no,
-            manifest.payload.head_seq,
+            manifest.payload().manifest_no,
+            manifest.payload().head_seq,
         ),
         // The candidate's head sequence is this flush's target, so a root
         // that covers the candidate covers the target too.
@@ -402,7 +400,7 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
     projection: &RootProjection<'_, S>,
     manifest_no: ManifestNo,
     manifest_object_id: ManifestObjectId,
-) -> Result<NamespaceManifestEnvelope> {
+) -> Result<NamespaceManifestPayload> {
     let head_seq = projection.head.seq;
     // A WAL flush keeps existing runs and writes the WAL delta as one new delta
     // run. Reorganization merges delta runs into the base separately.
@@ -435,10 +433,10 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
         let previous_manifest = projection.manifest_segments.manifest();
         // The manifest that first names a run allocates its number. A flush
         // takes one number for its delta, or none when the head is unchanged.
-        let run_no = previous_manifest.payload.next_run_no;
-        let mut runs = previous_manifest.payload.runs.clone();
+        let run_no = previous_manifest.payload().next_run_no;
+        let mut runs = previous_manifest.payload().runs.clone();
         let mut next_run_no = run_no;
-        if previous_manifest.payload.head_seq < head_seq {
+        if previous_manifest.payload().head_seq < head_seq {
             runs.push(MetadataRunRef {
                 run_no,
                 run_seq: head_seq,
@@ -447,7 +445,7 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
                     build_manifest_delta_run_segments(
                         store,
                         namespace_id,
-                        previous_manifest.payload.head_seq,
+                        previous_manifest.payload().head_seq,
                         &projection.tail_state,
                         MetadataLsmPolicy::default(),
                     )
@@ -456,10 +454,10 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
             });
             next_run_no = next_run_no_after(run_no)?;
         }
-        (previous_manifest.payload.base_seq, runs, next_run_no)
+        (previous_manifest.payload().base_seq, runs, next_run_no)
     };
 
-    NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    Ok(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no,
         manifest_object_id,
@@ -471,11 +469,6 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
         next_run_no,
         retention_floor_seq: projection.floor_seq,
         runs,
-    })
-    .map_err(|err| {
-        CoreError::Internal(format!(
-            "failed to build namespace manifest envelope: {err}"
-        ))
     })
 }
 

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -50,7 +50,7 @@ pub(crate) fn ensure_manifest_reference_matches(
     reference: &ManifestRef,
     manifest: &NamespaceManifestEnvelope,
 ) -> crate::error::Result<()> {
-    let payload = &manifest.payload;
+    let payload = &manifest.payload();
     let mismatch = if reference.owner_namespace_id != payload.namespace_id {
         Some((
             "owner_namespace_id",
@@ -75,11 +75,11 @@ pub(crate) fn ensure_manifest_reference_matches(
             reference.manifest_head_seq.to_string(),
             payload.head_seq.to_string(),
         ))
-    } else if reference.manifest_payload_checksum != manifest.payload_checksum {
+    } else if reference.manifest_payload_checksum != manifest.payload_checksum() {
         Some((
             "manifest_payload_checksum",
             reference.manifest_payload_checksum.clone(),
-            manifest.payload_checksum.clone(),
+            manifest.payload_checksum().to_owned(),
         ))
     } else {
         None
@@ -144,7 +144,7 @@ pub(crate) async fn load_basis_metadata_segments<'a, S: ObjectStore + ?Sized>(
         });
     };
     let segments = load_manifest_segments(store, segment_cache, manifest).await?;
-    let manifest_head_seq = segments.manifest().payload.head_seq;
+    let manifest_head_seq = segments.manifest().payload().head_seq;
     Ok(LoadedMetadataBasis {
         identity: MetadataBasisIdentity::from_verified_basis(basis.clone(), manifest_head_seq),
         segments,
@@ -238,13 +238,13 @@ pub(crate) async fn load_manifest_segments_for_inspection<'a, S: ObjectStore + ?
         })?;
         validate_namespace_manifest(
             namespace_id,
-            manifest.payload.manifest_no,
+            manifest.payload().manifest_no,
             manifest_object_id,
             &manifest_key,
             &manifest,
         )?;
-        validate_manifest(&manifest_key, &manifest.payload)?;
-        let scan_runs = Arc::new(runs_in_reorganization_order(&manifest.payload));
+        validate_manifest(&manifest_key, manifest.payload())?;
+        let scan_runs = Arc::new(runs_in_reorganization_order(manifest.payload()));
         Ok(DecodedMetadataSegmentBlock::Manifest {
             manifest: (Arc::new(manifest), scan_runs),
             // The entry retains the envelope plus its scan-ordered run list.
@@ -283,13 +283,13 @@ pub(crate) fn head_from_manifest(
         content_store_id: current_head.content_store_id.clone(),
         created_at_ms: current_head.created_at_ms,
         fork_basis: current_head.fork_basis.clone(),
-        seq: manifest.payload.head_seq,
-        head_commit_id: manifest.payload.head_commit_id.clone(),
+        seq: manifest.payload().head_seq,
+        head_commit_id: manifest.payload().head_commit_id.clone(),
         // The manifest records the manifest-time writer epoch. That may lag the
         // live head if writer takeover advanced the epoch without WAL replay.
-        writer_epoch: manifest.payload.writer_epoch,
+        writer_epoch: manifest.payload().writer_epoch,
         writer: current_head.writer.clone(),
-        next_inode_id: manifest.payload.next_inode_id,
+        next_inode_id: manifest.payload().next_inode_id,
         visible_wal_tip: None,
         recent_segments: Vec::new(),
         status: current_head.status,
@@ -325,7 +325,7 @@ pub(crate) async fn load_namespace_manifest_envelope_if_present<S: ObjectStore +
     })?;
     validate_namespace_manifest(
         namespace_id,
-        manifest.payload.manifest_no,
+        manifest.payload().manifest_no,
         manifest_object_id,
         manifest_key,
         &manifest,

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -65,7 +65,8 @@ pub use self::streaming_compaction::{
 };
 
 pub(crate) use self::compaction_lease::{
-    claim_loaded_group_lease, load_group_lease, CompactionPrefixOwner, LoadedCompactionLease,
+    claim_loaded_group_lease, load_group_lease, load_output_protection, CompactionPrefixOwner,
+    LoadedCompactionLease,
 };
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::data_block_load::DecodedRowWeight;

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -10,7 +10,9 @@ use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_state, ControlObjectKind, ManifestRef, MetadataRootState,
 };
-use loonfs_api::wire::manifest::{encode_namespace_manifest_json, NamespaceManifestEnvelope};
+use loonfs_api::wire::manifest::{
+    encode_namespace_manifest_json, NamespaceManifestEnvelope, NamespaceManifestPayload,
+};
 use loonfs_api::{ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_manifest_object, metadata_root};
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
@@ -37,29 +39,29 @@ pub(super) enum ManifestPublicationOutcome {
 )]
 pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
     store: &S,
-    manifest: &NamespaceManifestEnvelope,
-) -> std::result::Result<(), MetadataProjectionLoadError> {
-    let manifest_key = metadata_manifest_object(
-        &manifest.payload.namespace_id,
-        &manifest.payload.manifest_object_id,
-    );
-    let manifest_bytes = Bytes::from(encode_namespace_manifest_json(manifest).map_err(|err| {
-        MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestCodec {
-            object_key: manifest_key.clone(),
-            message: err.to_string(),
-        })
-    })?);
+    payload: NamespaceManifestPayload,
+) -> std::result::Result<NamespaceManifestEnvelope, MetadataProjectionLoadError> {
+    let manifest_key = metadata_manifest_object(&payload.namespace_id, &payload.manifest_object_id);
+    let (manifest, bytes) = encode_namespace_manifest_json(payload)
+        .map_err(|err| {
+            MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestCodec {
+                object_key: manifest_key.clone(),
+                message: err.to_string(),
+            })
+        })?
+        .into_parts();
+    let manifest_bytes = Bytes::from(bytes);
     // Immutable format objects use verified writes so identical bytes are an idempotent success
     // and different bytes are corruption.
     match store
         .put_immutable_verified(&manifest_key, manifest_bytes)
         .await
     {
-        Ok(_) => Ok(()),
+        Ok(_) => Ok(manifest),
         Err(ImmutableWriteError::DifferentObject { .. }) => Err(
             MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestObjectConflict {
                 object_key: manifest_key,
-                manifest_no: manifest.payload.manifest_no,
+                manifest_no: manifest.payload().manifest_no,
             }),
         ),
         Err(ImmutableWriteError::Transport { source, .. }) => Err(
@@ -299,10 +301,10 @@ pub(super) fn manifest_ref_for(
 ) -> ManifestRef {
     ManifestRef {
         owner_namespace_id: namespace_id.clone(),
-        manifest_no: manifest.payload.manifest_no,
-        manifest_object_id: manifest.payload.manifest_object_id.clone(),
-        manifest_head_seq: manifest.payload.head_seq,
-        manifest_payload_checksum: manifest.payload_checksum.clone(),
+        manifest_no: manifest.payload().manifest_no,
+        manifest_object_id: manifest.payload().manifest_object_id.clone(),
+        manifest_head_seq: manifest.payload().head_seq,
+        manifest_payload_checksum: manifest.payload_checksum().to_owned(),
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/read_basis.rs
+++ b/crates/loonfs-core/src/checkpoint/read_basis.rs
@@ -89,7 +89,7 @@ pub(crate) async fn load_checkpoint_read_basis_from_record<S: ObjectStore + ?Siz
     let envelope = segments.manifest();
     Ok(CheckpointReadBasis {
         head: head_from_manifest(live_head, envelope),
-        head_etag: envelope.payload_checksum.clone(),
+        head_etag: envelope.payload_checksum().to_owned(),
         basis: MetadataBasis::Manifest(manifest),
     })
 }

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -33,7 +33,6 @@ use loonfs_api::wire::manifest::{
     RunTier,
 };
 use loonfs_api::{ChangeSeq, ManifestNo, ManifestObjectId, NamespaceId, RunNo};
-use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
 
@@ -161,9 +160,9 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let segments = load_manifest_segments(store, None, &root.manifest).await?;
     let previous = segments.manifest();
 
-    let delta_runs = delta_run_count(&previous.payload);
+    let delta_runs = delta_run_count(previous.payload());
     if !manifest_has_reorganization_work(
-        &previous.payload,
+        previous.payload(),
         segments.scan_runs.as_ref(),
         policy,
         compaction_policy,
@@ -176,7 +175,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let Some(group) = select_family_group(
         store,
         namespace_id,
-        &previous.payload,
+        previous.payload(),
         context.now_ms,
         compaction_policy,
         policy,
@@ -236,7 +235,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     .await?;
 
     let surviving = previous
-        .payload
+        .payload()
         .runs
         .iter()
         .filter_map(|run| {
@@ -279,7 +278,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
                 input_runs: input.runs.len(),
                 decoded_input_rows: input.decoded_rows,
                 decoded_input_bytes: input.decoded_bytes,
-                manifest_no: manifest.payload.manifest_no,
+                manifest_no: manifest.payload().manifest_no,
                 bottom_anchored_merge_blocked,
             },
         )),
@@ -328,7 +327,7 @@ pub async fn metadata_maintenance_due<S: ObjectStore + ?Sized>(
     };
     let segments = load_manifest_segments(store, segment_cache, &root.state.manifest).await?;
     Ok(manifest_has_reorganization_work(
-        &segments.manifest().payload,
+        segments.manifest().payload(),
         segments.scan_runs.as_ref(),
         MetadataLsmPolicy::default(),
         compaction_policy,
@@ -575,7 +574,7 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
         let placement = merge_placement(
             bottom_anchored,
             &window.runs,
-            segments.manifest().payload.head_seq,
+            segments.manifest().payload().head_seq,
         );
         ReorganizationPlan::BoundedMerge(ReorganizationInput {
             run_nos: window.runs.iter().map(|run| run.run_no).collect(),
@@ -597,7 +596,11 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 .flat_map(|run| group_run_descriptors(run, group))
                 .map(|d| d.row_count)
                 .sum(),
-            merge_placement(bottom_anchored, &runs, segments.manifest().payload.head_seq),
+            merge_placement(
+                bottom_anchored,
+                &runs,
+                segments.manifest().payload().head_seq,
+            ),
             frozen_floor_seq,
         ))
     };
@@ -847,14 +850,14 @@ pub(super) async fn write_replacement_manifest<S: ObjectStore + ?Sized>(
     floor_seq: ChangeSeq,
 ) -> Result<NamespaceManifestEnvelope> {
     let next_run_no = if output.segments.is_empty() {
-        previous.payload.next_run_no
+        previous.payload().next_run_no
     } else {
-        next_run_no_after(previous.payload.next_run_no)?
+        next_run_no_after(previous.payload().next_run_no)?
     };
     let mut runs = surviving;
     if !output.segments.is_empty() {
         runs.push(MetadataRunRef {
-            run_no: previous.payload.next_run_no,
+            run_no: previous.payload().next_run_no,
             run_seq: output.placement.output_seq(),
             tier: output.placement.output_tier(),
             segments: output.segments,
@@ -865,34 +868,30 @@ pub(super) async fn write_replacement_manifest<S: ObjectStore + ?Sized>(
         .map(|run| run.run_seq)
         .min()
         .expect("a replacement manifest should hold at least one run");
-    let retention_floor_seq = previous.payload.retention_floor_seq.max(floor_seq);
+    let retention_floor_seq = previous.payload().retention_floor_seq.max(floor_seq);
     // One generated object id, one write. The generated id ends in 16 random
     // hex characters, so the key is this unit's alone and a conflict under it
     // is corruption rather than contention.
-    let manifest_no = next_manifest_no_after(previous.payload.manifest_no)?;
+    let manifest_no = next_manifest_no_after(previous.payload().manifest_no)?;
     let manifest_object_id = ManifestObjectId::generate(manifest_no);
-    let object_key = metadata_manifest_object(namespace_id, &manifest_object_id);
-    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
-        namespace_id: namespace_id.clone(),
-        manifest_no,
-        manifest_object_id,
-        head_seq: previous.payload.head_seq,
-        head_commit_id: previous.payload.head_commit_id.clone(),
-        base_seq,
-        writer_epoch: previous.payload.writer_epoch,
-        next_inode_id: previous.payload.next_inode_id,
-        next_run_no,
-        retention_floor_seq,
-        runs,
-    })
-    .map_err(|error| CoreError::Codec {
-        object_key,
-        message: error.to_string(),
-    })?;
-    write_namespace_manifest(store, &manifest)
-        .await
-        .map_err(manifest_write_failure)?;
-    Ok(manifest)
+    write_namespace_manifest(
+        store,
+        NamespaceManifestPayload {
+            namespace_id: namespace_id.clone(),
+            manifest_no,
+            manifest_object_id,
+            head_seq: previous.payload().head_seq,
+            head_commit_id: previous.payload().head_commit_id.clone(),
+            base_seq,
+            writer_epoch: previous.payload().writer_epoch,
+            next_inode_id: previous.payload().next_inode_id,
+            next_run_no,
+            retention_floor_seq,
+            runs,
+        },
+    )
+    .await
+    .map_err(manifest_write_failure)
 }
 
 #[cfg(test)]
@@ -908,7 +907,7 @@ mod planning_tests {
             "../../../loonfs-api/tests/golden/namespace_manifest.v4.json"
         ))
         .expect("manifest fixture");
-        let mut template = runs_in_reorganization_order(&manifest.payload).remove(0);
+        let mut template = runs_in_reorganization_order(manifest.payload()).remove(0);
         template
             .segments
             .retain(|family| family.family == MetadataRowFamily::Inodes);

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -26,7 +26,7 @@ async fn verify_manifest_segments_exist<S: ObjectStore + ?Sized>(
     manifest: &NamespaceManifestEnvelope,
 ) -> std::result::Result<(), ManifestLoadError> {
     let object_keys = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -107,7 +107,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     let manifest_segments = load_manifest_segments(store, None, &root.manifest).await?;
     // Grep tolerates retention gaps by checkpointed rebootstrap, so its
     // independent watermark never holds the core WAL floor back.
-    let target_floor = manifest_segments.manifest().payload.head_seq;
+    let target_floor = manifest_segments.manifest().payload().head_seq;
     let initial_floor = match load_wal_floor_object(store, namespace_id).await {
         Ok(loaded) => Some(loaded),
         Err(ControlObjectLoadError::MissingObject { .. }) => None,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -434,6 +434,7 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
         }
         Err(stopped) => stopped,
     };
+    lease.complete(store).await?;
     log_metadata_compaction_outcome(namespace_id, spec, &outcome);
     Ok(outcome)
 }
@@ -567,6 +568,8 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
             spec.frozen_floor_seq(),
         )
         .await?;
+
+        lease.protect_output(store).await?;
 
         // The last check before the swap that makes this output reader
         // truth. Everything above it is reads and objects nothing references.

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -544,7 +544,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
 
         let previous = segments.manifest();
         let surviving = previous
-            .payload
+            .payload()
             .runs
             .iter()
             .filter_map(|run| {
@@ -586,7 +586,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         let lost_to = match published {
             ManifestPublicationOutcome::Published(_) => {
                 return Ok(MetadataCompactionJobOutcome::Published {
-                    manifest_no: manifest.payload.manifest_no,
+                    manifest_no: manifest.payload().manifest_no,
                     rows_read,
                     rows_written,
                     input_bytes,

--- a/crates/loonfs-core/src/checkpoint/tests/attributes.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/attributes.rs
@@ -289,7 +289,7 @@ async fn publish_manifest_with_segments<S: ObjectStore + ?Sized>(
     segments: Vec<MetadataSegmentRef>,
 ) -> ManifestObjectId {
     let manifest_object_id = ManifestObjectId::generate(manifest_no);
-    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    let manifest = encode_namespace_manifest_json(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no,
         manifest_object_id: manifest_object_id.clone(),
@@ -307,8 +307,9 @@ async fn publish_manifest_with_segments<S: ObjectStore + ?Sized>(
             segments,
         }],
     })
-    .expect("manifest envelope");
-    write_namespace_manifest(store, &manifest)
+    .expect("manifest envelope")
+    .into_envelope();
+    write_namespace_manifest(store, manifest.payload().clone())
         .await
         .expect("write manifest");
     manifest_object_id

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -267,7 +267,7 @@ async fn cached_manifest_carries_its_scan_order_runs() {
     );
     assert_eq!(
         *first.scan_runs,
-        runs_in_reorganization_order(&first.manifest().payload),
+        runs_in_reorganization_order(first.manifest().payload()),
         "the cached run list must equal the manifest's reorganization-order grouping"
     );
     assert!(
@@ -568,7 +568,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
             .expect("load segments");
     let direntry_descriptors: Vec<_> = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -585,7 +585,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
     let materialized = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,
-        segments.manifest().payload.manifest_no,
+        segments.manifest().payload().manifest_no,
     )
     .await
     .expect("materialize manifest");
@@ -622,7 +622,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
     // The same lookup against the same manifest with the inline copies
     // stripped must return the same rows through fetched filter blocks —
     // the inline copy is an accelerator, never an answer of its own.
-    let mut stripped_payload = segments.manifest().payload.clone();
+    let mut stripped_payload = segments.manifest().payload().clone();
     stripped_payload.manifest_no = ManifestNo(stripped_payload.manifest_no.0 + 1);
     stripped_payload.manifest_object_id = ManifestObjectId::generate(stripped_payload.manifest_no);
     for descriptor in stripped_payload
@@ -633,9 +633,10 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
         descriptor.filter_inline = None;
     }
     let stripped_object_id = stripped_payload.manifest_object_id.clone();
-    let stripped = NamespaceManifestEnvelope::from_payload(stripped_payload)
-        .expect("stripped manifest envelope");
-    write_namespace_manifest(&store, &stripped)
+    let stripped = encode_namespace_manifest_json(stripped_payload)
+        .expect("stripped manifest envelope")
+        .into_envelope();
+    write_namespace_manifest(&store, stripped.payload().clone())
         .await
         .expect("write stripped manifest");
     let stripped_segments =
@@ -688,7 +689,7 @@ async fn corrupt_inline_filter_fails_the_lookup() {
             .expect("load segments");
     let descriptor = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -759,7 +760,7 @@ async fn checkpointed_direntry_segment() -> (
             .expect("load segments");
     let mut descriptor = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -1027,7 +1028,7 @@ async fn multi_block_direntry_segment() -> (
             .expect("load segments");
     let mut descriptor = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -40,13 +40,11 @@ impl ManifestSwapOnCasConflictStore {
         // Same-seq replacement referencing a different manifest: the shape a
         // pure compaction publishes.
         root.manifest.manifest_no = ManifestNo(root.manifest.manifest_no.0 + 1);
-        let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+        let bytes = loonfs_api::wire::control::encode_control_state(
             loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-            root,
+            &root,
         )
-        .expect("root envelope");
-        let bytes =
-            loonfs_api::wire::control::encode_control_object(&envelope).expect("root bytes");
+        .expect("root bytes");
         self.inner
             .put(
                 &loonfs_objectstore::keys::metadata_root(&self.namespace_id),
@@ -135,13 +133,11 @@ impl FloorRaiseOnCasConflictStore {
             },
         };
         floor.floor_seq = ChangeSeq(5);
-        let envelope = loonfs_api::wire::control::WalFloorEnvelope::from_state(
+        let bytes = loonfs_api::wire::control::encode_control_state(
             loonfs_api::wire::control::ControlObjectKind::WalFloor,
-            floor,
+            &floor,
         )
-        .expect("floor envelope");
-        let bytes =
-            loonfs_api::wire::control::encode_control_object(&envelope).expect("floor bytes");
+        .expect("floor bytes");
         self.inner
             .put(
                 &loonfs_objectstore::keys::wal_floor(&self.namespace_id),
@@ -379,14 +375,12 @@ impl RootCasTransportAfterCompetingRootStore {
     }
 
     async fn install_competing_root(&self, root: MetadataRootState) {
-        let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
-            loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-            root,
-        )
-        .expect("metadata root envelope");
         let bytes = Bytes::from(
-            loonfs_api::wire::control::encode_control_object(&envelope)
-                .expect("encode metadata root"),
+            loonfs_api::wire::control::encode_control_state(
+                loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
+                &root,
+            )
+            .expect("encode metadata root"),
         );
         self.inner
             .put(&self.root_key, bytes, PutMode::Overwrite)
@@ -583,18 +577,18 @@ async fn same_root_publications_keep_the_first_candidate() {
     )
     .await;
     assert_eq!(
-        first_manifest.payload.manifest_no,
-        second_manifest.payload.manifest_no
+        first_manifest.payload().manifest_no,
+        second_manifest.payload().manifest_no
     );
     assert_ne!(
-        first_manifest.payload.manifest_object_id,
-        second_manifest.payload.manifest_object_id
+        first_manifest.payload().manifest_object_id,
+        second_manifest.payload().manifest_object_id
     );
 
-    write_namespace_manifest(&store, &first_manifest)
+    write_namespace_manifest(&store, first_manifest.payload().clone())
         .await
         .expect("write first manifest");
-    write_namespace_manifest(&store, &second_manifest)
+    write_namespace_manifest(&store, second_manifest.payload().clone())
         .await
         .expect("write second manifest");
 
@@ -611,7 +605,7 @@ async fn same_root_publications_keep_the_first_candidate() {
         ManifestPublicationOutcome::Published(root) => {
             assert_eq!(
                 root.manifest.manifest_object_id,
-                first_manifest.payload.manifest_object_id
+                first_manifest.payload().manifest_object_id
             );
         }
         other => panic!("expected first publication to win, got {other:?}"),
@@ -630,7 +624,7 @@ async fn same_root_publications_keep_the_first_candidate() {
         ManifestPublicationOutcome::CoveredByCurrent(root) => {
             assert_eq!(
                 root.manifest.manifest_object_id,
-                first_manifest.payload.manifest_object_id
+                first_manifest.payload().manifest_object_id
             );
         }
         other => panic!("expected the second publication to be covered, got {other:?}"),
@@ -669,17 +663,17 @@ async fn flush_retries_when_a_same_seq_replacement_wins_behind_its_target() {
         ManifestNo(basis.root.manifest.manifest_no.0 + 1),
     )
     .await;
-    write_namespace_manifest(&inner, &replacement)
+    write_namespace_manifest(&inner, replacement.payload().clone())
         .await
         .expect("write replacement manifest");
     let competing_root = MetadataRootState {
         namespace_id: namespace_id.clone(),
         manifest: ManifestRef {
             owner_namespace_id: namespace_id.clone(),
-            manifest_no: replacement.payload.manifest_no,
-            manifest_object_id: replacement.payload.manifest_object_id.clone(),
-            manifest_head_seq: replacement.payload.head_seq,
-            manifest_payload_checksum: replacement.payload_checksum.clone(),
+            manifest_no: replacement.payload().manifest_no,
+            manifest_object_id: replacement.payload().manifest_object_id.clone(),
+            manifest_head_seq: replacement.payload().head_seq,
+            manifest_payload_checksum: replacement.payload_checksum().to_owned(),
         },
         updated_at_ms: context.now_ms + 1,
     };
@@ -701,7 +695,7 @@ async fn flush_retries_when_a_same_seq_replacement_wins_behind_its_target() {
         .expect("load target head")
         .state
         .seq;
-    assert!(replacement.payload.head_seq < target);
+    assert!(replacement.payload().head_seq < target);
 
     let store = RootCasTransportAfterCompetingRootStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -753,7 +747,7 @@ async fn lower_seq_root_publication_yields_to_the_newer_root() {
     )
     .await
     .expect("build metadata segments");
-    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    let manifest = encode_namespace_manifest_json(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no: ManifestNo(materialization_before.head.seq.0),
         manifest_object_id: manifest_object_id(ManifestNo(materialization_before.head.seq.0)),
@@ -771,8 +765,9 @@ async fn lower_seq_root_publication_yields_to_the_newer_root() {
             segments: flatten_manifest_segments(segments),
         }],
     })
-    .expect("build manifest");
-    write_namespace_manifest(&store, &manifest)
+    .expect("build manifest")
+    .into_envelope();
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("write manifest");
 
@@ -856,7 +851,7 @@ async fn root_cas_conflict_reports_a_race() {
     )
     .await
     .expect("build manifest");
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("write manifest");
 
@@ -913,7 +908,7 @@ async fn root_cas_transport_error_recovers_when_candidate_was_published() {
     )
     .await
     .expect("build manifest");
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("write manifest");
 
@@ -930,10 +925,10 @@ async fn root_cas_transport_error_recovers_when_candidate_was_published() {
 
     match outcome {
         ManifestPublicationOutcome::Published(root) => {
-            assert_eq!(root.manifest.manifest_no, manifest.payload.manifest_no);
+            assert_eq!(root.manifest.manifest_no, manifest.payload().manifest_no);
             assert_eq!(
                 root.manifest.manifest_object_id,
-                manifest.payload.manifest_object_id
+                manifest.payload().manifest_object_id
             );
         }
         other => panic!("expected the candidate to be found current, got {other:?}"),
@@ -978,10 +973,10 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
         ManifestNo(candidate_manifest_no.0 + 1),
     )
     .await;
-    write_namespace_manifest(&raw_store, &candidate_manifest)
+    write_namespace_manifest(&raw_store, candidate_manifest.payload().clone())
         .await
         .expect("write candidate manifest");
-    write_namespace_manifest(&raw_store, &competing_manifest)
+    write_namespace_manifest(&raw_store, competing_manifest.payload().clone())
         .await
         .expect("write competing manifest");
 
@@ -989,10 +984,10 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
         namespace_id: namespace_id.clone(),
         manifest: ManifestRef {
             owner_namespace_id: namespace_id.clone(),
-            manifest_no: competing_manifest.payload.manifest_no,
-            manifest_object_id: competing_manifest.payload.manifest_object_id.clone(),
-            manifest_head_seq: competing_manifest.payload.head_seq,
-            manifest_payload_checksum: competing_manifest.payload_checksum.clone(),
+            manifest_no: competing_manifest.payload().manifest_no,
+            manifest_object_id: competing_manifest.payload().manifest_object_id.clone(),
+            manifest_head_seq: competing_manifest.payload().head_seq,
+            manifest_payload_checksum: competing_manifest.payload_checksum().to_owned(),
         },
         updated_at_ms: context.now_ms + 1,
     };
@@ -1016,11 +1011,11 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
         ManifestPublicationOutcome::CoveredByCurrent(root) => {
             assert_eq!(
                 root.manifest.manifest_no,
-                competing_manifest.payload.manifest_no
+                competing_manifest.payload().manifest_no
             );
             assert_eq!(
                 root.manifest.manifest_object_id,
-                competing_manifest.payload.manifest_object_id
+                competing_manifest.payload().manifest_object_id
             );
         }
         other => panic!("expected a covering root after an ambiguous CAS, got {other:?}"),
@@ -1065,20 +1060,20 @@ async fn root_cas_permission_error_surfaces_when_a_newer_root_was_published() {
         ManifestNo(candidate_manifest_no.0 + 1),
     )
     .await;
-    write_namespace_manifest(&raw_store, &candidate_manifest)
+    write_namespace_manifest(&raw_store, candidate_manifest.payload().clone())
         .await
         .expect("write candidate manifest");
-    write_namespace_manifest(&raw_store, &competing_manifest)
+    write_namespace_manifest(&raw_store, competing_manifest.payload().clone())
         .await
         .expect("write competing manifest");
     let competing_root = MetadataRootState {
         namespace_id: namespace_id.clone(),
         manifest: ManifestRef {
             owner_namespace_id: namespace_id.clone(),
-            manifest_no: competing_manifest.payload.manifest_no,
-            manifest_object_id: competing_manifest.payload.manifest_object_id.clone(),
-            manifest_head_seq: competing_manifest.payload.head_seq,
-            manifest_payload_checksum: competing_manifest.payload_checksum.clone(),
+            manifest_no: competing_manifest.payload().manifest_no,
+            manifest_object_id: competing_manifest.payload().manifest_object_id.clone(),
+            manifest_head_seq: competing_manifest.payload().head_seq,
+            manifest_payload_checksum: competing_manifest.payload_checksum().to_owned(),
         },
         updated_at_ms: context.now_ms + 1,
     };
@@ -1107,13 +1102,11 @@ async fn root_cas_permission_error_surfaces_when_a_newer_root_was_published() {
         ),
         async {
             store.wait_until_blocked().await;
-            let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+            let bytes = loonfs_api::wire::control::encode_control_state(
                 loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-                competing_root,
+                &competing_root,
             )
-            .expect("metadata root envelope");
-            let bytes = loonfs_api::wire::control::encode_control_object(&envelope)
-                .expect("encode metadata root");
+            .expect("encode metadata root");
             raw_store
                 .put(&root_key, Bytes::from(bytes), PutMode::Overwrite)
                 .await
@@ -1364,10 +1357,10 @@ async fn same_seq_root_replacement_publishes_a_compacted_manifest() {
     .await
     .expect("build compacted manifest");
     assert_eq!(
-        compacted.payload.head_seq,
+        compacted.payload().head_seq,
         materialization.root.manifest.manifest_head_seq
     );
-    write_namespace_manifest(&store, &compacted)
+    write_namespace_manifest(&store, compacted.payload().clone())
         .await
         .expect("write compacted manifest");
 
@@ -1382,7 +1375,7 @@ async fn same_seq_root_replacement_publishes_a_compacted_manifest() {
     .expect("same-seq replacement publishes");
     match outcome {
         ManifestPublicationOutcome::Published(root) => {
-            assert_eq!(root.manifest.manifest_no, compacted.payload.manifest_no);
+            assert_eq!(root.manifest.manifest_no, compacted.payload().manifest_no);
             assert_eq!(
                 root.manifest.manifest_head_seq,
                 materialization.root.manifest.manifest_head_seq
@@ -1396,7 +1389,7 @@ async fn same_seq_root_replacement_publishes_a_compacted_manifest() {
         .expect("materialization after compaction");
     assert_eq!(
         after.root.manifest.manifest_no,
-        compacted.payload.manifest_no
+        compacted.payload().manifest_no
     );
     assert!(metadata_states_equivalent(
         &materialization.metadata_state,
@@ -1653,11 +1646,11 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
         ManifestNo(stale_basis.root.manifest.manifest_no.0 + 1),
     )
     .await;
-    assert!(stale_higher_head.payload.head_seq > sibling.payload.head_seq);
-    write_namespace_manifest(&store, &sibling)
+    assert!(stale_higher_head.payload().head_seq > sibling.payload().head_seq);
+    write_namespace_manifest(&store, sibling.payload().clone())
         .await
         .expect("write sibling manifest");
-    write_namespace_manifest(&store, &stale_higher_head)
+    write_namespace_manifest(&store, stale_higher_head.payload().clone())
         .await
         .expect("write stale manifest");
 
@@ -1687,7 +1680,8 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
     match stale_outcome {
         ManifestPublicationOutcome::PredecessorChanged(root) => {
             assert_eq!(
-                root.manifest.manifest_object_id, sibling.payload.manifest_object_id,
+                root.manifest.manifest_object_id,
+                sibling.payload().manifest_object_id,
                 "the sibling's acknowledged publication must survive"
             );
         }
@@ -1700,6 +1694,6 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
         .state;
     assert_eq!(
         root_after.manifest.manifest_object_id,
-        sibling.payload.manifest_object_id
+        sibling.payload().manifest_object_id
     );
 }

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -90,7 +90,7 @@ async fn revision_test_materialization(
     );
     assert!(!revision_rows.is_empty());
     (
-        materialized.manifest.payload.manifest_no,
+        materialized.manifest.payload().manifest_no,
         materialized.manifest,
         revision_rows,
     )
@@ -102,9 +102,9 @@ async fn rewrite_revision_segment(
     manifest: &mut NamespaceManifestEnvelope,
     mut rows: Vec<MetadataRow>,
 ) {
+    let mut payload = manifest.payload().clone();
     rows.sort_by_key(|row| row.row_key_for_family(ApiMetadataRowFamily::Revisions));
-    let descriptor = manifest
-        .payload
+    let descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -114,13 +114,16 @@ async fn rewrite_revision_segment(
     rewrite_manifest_segment(
         store,
         namespace_id,
-        manifest.payload.head_seq,
+        payload.head_seq,
         ApiMetadataRowFamily::Revisions,
         descriptor,
         rows,
         default_target_block_bytes(),
     )
     .await;
+    *manifest = encode_namespace_manifest_json(payload)
+        .expect("encode changed manifest")
+        .into_envelope();
 }
 
 fn default_target_block_bytes() -> NonZeroUsize {
@@ -132,13 +135,14 @@ pub(super) async fn overwrite_manifest(
     namespace_id: &NamespaceId,
     manifest: NamespaceManifestEnvelope,
 ) {
-    let manifest_key = metadata_manifest_object(namespace_id, &manifest.payload.manifest_object_id);
-    let manifest_no = manifest.payload.manifest_no;
-    let manifest_object_id = manifest.payload.manifest_object_id.clone();
-    let updated_manifest =
-        NamespaceManifestEnvelope::from_payload(manifest.payload).expect("updated manifest");
-    let manifest_bytes =
-        encode_namespace_manifest_json(&updated_manifest).expect("encode updated manifest");
+    let manifest_key =
+        metadata_manifest_object(namespace_id, &manifest.payload().manifest_object_id);
+    let manifest_no = manifest.payload().manifest_no;
+    let manifest_object_id = manifest.payload().manifest_object_id.clone();
+    let (updated_manifest, manifest_bytes) =
+        encode_namespace_manifest_json(manifest.into_payload())
+            .expect("updated manifest")
+            .into_parts();
     store
         .put_overwrite(&manifest_key, Bytes::from(manifest_bytes))
         .await
@@ -152,14 +156,12 @@ pub(super) async fn overwrite_manifest(
     if loaded_root.state.manifest.manifest_no == manifest_no {
         let mut root = loaded_root.state;
         root.manifest.manifest_object_id = manifest_object_id;
-        root.manifest.manifest_payload_checksum = updated_manifest.payload_checksum.clone();
-        let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+        root.manifest.manifest_payload_checksum = updated_manifest.payload_checksum().to_owned();
+        let bytes = loonfs_api::wire::control::encode_control_state(
             loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-            root,
+            &root,
         )
-        .expect("root envelope");
-        let bytes =
-            loonfs_api::wire::control::encode_control_object(&envelope).expect("root bytes");
+        .expect("root bytes");
         store
             .put_overwrite(
                 &loonfs_objectstore::keys::metadata_root(namespace_id),
@@ -181,9 +183,10 @@ async fn load_perturbed_manifest(
     payload.manifest_no = ManifestNo(payload.manifest_no.0 + id_offset);
     payload.manifest_object_id = ManifestObjectId::generate(payload.manifest_no);
     let manifest_object_id = payload.manifest_object_id.clone();
-    let envelope =
-        NamespaceManifestEnvelope::from_payload(payload).expect("perturbed manifest envelope");
-    write_namespace_manifest(store, &envelope)
+    let envelope = encode_namespace_manifest_json(payload)
+        .expect("perturbed manifest envelope")
+        .into_envelope();
+    write_namespace_manifest(store, envelope.payload().clone())
         .await
         .expect("write perturbed manifest");
     load_manifest_segments_for_inspection(store, None, namespace_id, &manifest_object_id)
@@ -208,7 +211,7 @@ fn base_segment_of_family(
     family: ApiMetadataRowFamily,
 ) -> MetadataSegmentRef {
     manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| run.tier == RunTier::Base)
@@ -544,21 +547,28 @@ async fn manifest_load_rejects_unequal_index_descriptor_counts() {
 
     // Tamper only the descriptor's row_count for the child-bind index family;
     // the per-run count-equality check must reject the manifest at load.
-    let mut manifest =
+    let manifest =
         load_manifest_materialization_for_inspection(&store, &namespace_id, checkpoint.manifest_no)
             .await
             .expect("load manifest")
             .manifest;
-    let descriptor = manifest
-        .payload
+    let mut payload = manifest.payload().clone();
+    let descriptor = payload
         .runs
         .iter_mut()
         .flat_map(|run| &mut run.segments)
         .find(|descriptor| descriptor.family == ApiMetadataRowFamily::DirentryChildBinds)
         .expect("child-bind index descriptor");
     descriptor.row_count += 1;
-    let manifest_object_id = manifest.payload.manifest_object_id.clone();
-    overwrite_manifest(&store, &namespace_id, manifest).await;
+    let manifest_object_id = payload.manifest_object_id.clone();
+    overwrite_manifest(
+        &store,
+        &namespace_id,
+        encode_namespace_manifest_json(payload)
+            .expect("encode changed manifest")
+            .into_envelope(),
+    )
+    .await;
 
     match load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
         .await
@@ -603,9 +613,9 @@ async fn manifest_rejects_segment_whose_index_fails_its_descriptor_checksum() {
     )
     .await
     .expect("load manifest");
-    let mut manifest = materialized.manifest;
-    let descriptor = manifest
-        .payload
+    let manifest = materialized.manifest;
+    let mut payload = manifest.payload().clone();
+    let descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -616,13 +626,11 @@ async fn manifest_rejects_segment_whose_index_fails_its_descriptor_checksum() {
     // is what binds the manifest to the object's exact bytes.
     descriptor.index_block.crc32c ^= 0xffff_ffff;
 
-    let manifest_key =
-        metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id);
-    let manifest_no = manifest.payload.manifest_no;
-    let updated_manifest =
-        NamespaceManifestEnvelope::from_payload(manifest.payload).expect("updated manifest");
-    let manifest_bytes =
-        encode_namespace_manifest_json(&updated_manifest).expect("encode manifest");
+    let manifest_key = metadata_manifest_object(&namespace_id, &payload.manifest_object_id);
+    let manifest_no = payload.manifest_no;
+    let manifest_bytes = encode_namespace_manifest_json(payload)
+        .expect("updated manifest")
+        .into_bytes();
     store
         .put_overwrite(&manifest_key, Bytes::from(manifest_bytes))
         .await
@@ -661,7 +669,7 @@ async fn manifest_load_names_the_segment_codec_for_a_pre_commit_id_row() {
     let checkpoint = create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("checkpoint");
-    let mut materialized =
+    let materialized =
         load_manifest_materialization_for_inspection(&store, &namespace_id, checkpoint.manifest_no)
             .await
             .expect("load manifest before replacing a row");
@@ -682,9 +690,8 @@ async fn manifest_load_names_the_segment_codec_for_a_pre_commit_id_row() {
         )
         .expect("encode pre-change row");
     let built = builder.finish().expect("finish pre-change segment");
-    let descriptor = materialized
-        .manifest
-        .payload
+    let mut payload = materialized.manifest.payload().clone();
+    let descriptor = payload
         .runs
         .iter_mut()
         .flat_map(|run| &mut run.segments)
@@ -712,8 +719,15 @@ async fn manifest_load_names_the_segment_codec_for_a_pre_commit_id_row() {
     descriptor.filter_block = built.filter;
     descriptor.object_checksum = loonfs_api::sha256_digest(&built.bytes);
     let segment_key = metadata_segment_object_key(descriptor);
-    let manifest_no = materialized.manifest.payload.manifest_no;
-    overwrite_manifest(&store, &namespace_id, materialized.manifest).await;
+    let manifest_no = payload.manifest_no;
+    overwrite_manifest(
+        &store,
+        &namespace_id,
+        encode_namespace_manifest_json(payload)
+            .expect("encode changed manifest")
+            .into_envelope(),
+    )
+    .await;
 
     match load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no).await {
         Err(ManifestLoadError::SegmentCodec {
@@ -828,7 +842,7 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
         load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no)
             .await
             .expect("load manifest before corruption");
-    let mut manifest = materialized.manifest;
+    let manifest = materialized.manifest;
     let mut child_index_rows = manifest_rows_for_family(
         &materialized.metadata_state,
         ApiMetadataRowFamily::DirentryChildBinds,
@@ -838,8 +852,8 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
     child_index_rows
         .sort_by_key(|row| row.row_key_for_family(ApiMetadataRowFamily::DirentryChildBinds));
 
-    let child_descriptor = manifest
-        .payload
+    let mut payload = manifest.payload().clone();
+    let child_descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -849,7 +863,7 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
     rewrite_manifest_segment(
         &store,
         &namespace_id,
-        manifest.payload.head_seq,
+        payload.head_seq,
         ApiMetadataRowFamily::DirentryChildBinds,
         child_descriptor,
         child_index_rows,
@@ -857,13 +871,11 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
     )
     .await;
 
-    let manifest_key =
-        metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id);
-    let manifest_no = manifest.payload.manifest_no;
-    let updated_manifest =
-        NamespaceManifestEnvelope::from_payload(manifest.payload).expect("updated manifest");
-    let manifest_bytes =
-        encode_namespace_manifest_json(&updated_manifest).expect("encode updated manifest");
+    let manifest_key = metadata_manifest_object(&namespace_id, &payload.manifest_object_id);
+    let manifest_no = payload.manifest_no;
+    let manifest_bytes = encode_namespace_manifest_json(payload)
+        .expect("updated manifest")
+        .into_bytes();
     store
         .put_overwrite(&manifest_key, Bytes::from(manifest_bytes))
         .await
@@ -924,7 +936,7 @@ async fn unreferenced_manifest_run_is_ignored_by_current_projection_load() {
     )
     .await
     .expect("build orphan manifest");
-    write_namespace_manifest(&store, &orphan_manifest)
+    write_namespace_manifest(&store, orphan_manifest.payload().clone())
         .await
         .expect("write orphan manifest");
 
@@ -937,7 +949,7 @@ async fn unreferenced_manifest_run_is_ignored_by_current_projection_load() {
     );
     assert_eq!(
         materialization_after.head.seq,
-        orphan_manifest.payload.head_seq
+        orphan_manifest.payload().head_seq
     );
     assert!(metadata_states_equivalent(
         &materialization_before.metadata_state,
@@ -978,7 +990,7 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
         load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_no)
             .await
             .expect("load manifest before the rewrite");
-    let mut manifest = materialized.manifest;
+    let manifest = materialized.manifest;
     let mut inode_rows =
         manifest_rows_for_family(&materialized.metadata_state, ApiMetadataRowFamily::Inodes);
     inode_rows.sort_by_key(|row| row.row_key_for_family(ApiMetadataRowFamily::Inodes));
@@ -992,7 +1004,7 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
         .row_key_for_family(ApiMetadataRowFamily::Inodes);
 
     let base_inode_segments = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| run.tier == RunTier::Base)
@@ -1003,8 +1015,8 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
         base_inode_segments, 1,
         "the folded base should hold one inode segment"
     );
-    let descriptor = manifest
-        .payload
+    let mut payload = manifest.payload().clone();
+    let descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -1017,7 +1029,7 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
     rewrite_manifest_segment(
         &store,
         &namespace_id,
-        manifest.payload.head_seq,
+        payload.head_seq,
         ApiMetadataRowFamily::Inodes,
         descriptor,
         inode_rows.clone(),
@@ -1028,7 +1040,14 @@ async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
         descriptor.max_row_key, last_inode_key,
         "the descriptor must carry the segment's last row key"
     );
-    overwrite_manifest(&store, &namespace_id, manifest).await;
+    overwrite_manifest(
+        &store,
+        &namespace_id,
+        encode_namespace_manifest_json(payload)
+            .expect("encode changed manifest")
+            .into_envelope(),
+    )
+    .await;
 
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let segments =
@@ -1075,7 +1094,7 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
         load_manifest_segments_for_inspection(&store, None, &namespace_id, &manifest_object_id)
             .await
             .expect("load segments");
-    let payload = segments.manifest().payload.clone();
+    let payload = segments.manifest().payload().clone();
 
     // The read path assumes the filter block directly precedes the index
     // block, that an inline copy matches its handle's length, and that a
@@ -1146,14 +1165,14 @@ async fn a_manifest_whose_group_base_fragmented_does_not_load() {
         "the seed must leave the group in one base run"
     );
 
-    let mut fragmented = manifest.payload.clone();
+    let mut fragmented = manifest.payload().clone();
     // A second base run, not a second segment of the one already there, so
     // the copy takes a run number of its own out of the allocator.
     let second_base_run_no = fragmented.next_run_no;
     fragmented.next_run_no = RunNo(second_base_run_no.0 + 1);
     fragmented.runs.push(MetadataRunRef {
         run_no: second_base_run_no,
-        run_seq: manifest.payload.head_seq,
+        run_seq: manifest.payload().head_seq,
         tier: RunTier::Base,
         segments: vec![segment_modelled_on(&base_segment_of_family(
             &manifest,
@@ -1184,7 +1203,7 @@ async fn a_manifest_that_numbers_one_family_twice_in_one_run_does_not_load() {
     let existing = base_segment_of_family(&manifest, ApiMetadataRowFamily::Inodes);
     assert_eq!(existing.segment_index, 0);
 
-    let mut repeated = manifest.payload.clone();
+    let mut repeated = manifest.payload().clone();
     repeated
         .runs
         .iter_mut()
@@ -1222,7 +1241,7 @@ async fn a_manifest_whose_run_segments_overlap_in_key_range_does_not_load() {
     let existing = base_segment_of_family(&manifest, ApiMetadataRowFamily::Inodes);
     assert_eq!(existing.segment_index, 0);
 
-    let mut overlapping = manifest.payload.clone();
+    let mut overlapping = manifest.payload().clone();
     let mut second = segment_modelled_on(&existing);
     // Index one keeps the numbering valid, leaving the overlapping range as
     // the only error.

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -131,8 +131,8 @@ pub(crate) async fn load_manifest_metadata_state_for_inspection_from_manifest<
     manifest: &NamespaceManifestEnvelope,
 ) -> Result<MetadataState, ManifestLoadError> {
     let mut metadata_state = MetadataStateBuilder::default();
-    validate_manifest_materialization_ranges(manifest_object_key, &manifest.payload)?;
-    for run in runs_in_materialization_order(&manifest.payload) {
+    validate_manifest_materialization_ranges(manifest_object_key, manifest.payload())?;
+    for run in runs_in_materialization_order(manifest.payload()) {
         append_manifest_segments_to_metadata(
             store,
             namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -62,18 +62,18 @@ async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
             .expect("load folded manifest");
     let delta = materialized
         .manifest
-        .payload
+        .payload()
         .runs
         .last()
         .expect("folded manifest has a delta run");
     assert_eq!(delta.tier, RunTier::Delta);
-    let delta_manifest = runs_in_materialization_order(&materialized.manifest.payload)
+    let delta_manifest = runs_in_materialization_order(materialized.manifest.payload())
         .into_iter()
         .find(|run| run.run_no == delta.run_no)
         .expect("folded delta run is valid");
     let manifest_key = metadata_manifest_object(
         &namespace_id,
-        &materialized.manifest.payload.manifest_object_id,
+        &materialized.manifest.payload().manifest_object_id,
     );
     let mut actual_tail = MetadataStateBuilder::default();
     inspection_materialization::append_manifest_segments_to_metadata(
@@ -257,10 +257,10 @@ async fn manifest_round_trip_supports_empty_namespace() {
         load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestNo(1))
             .await
             .expect("first manifest is valid");
-    assert_eq!(published.manifest.payload.next_run_no, RunNo(1));
-    assert_eq!(published.manifest.payload.runs.len(), 1);
-    assert_eq!(published.manifest.payload.runs[0].run_no, RunNo(0));
-    assert_eq!(published.manifest.payload.runs[0].tier, RunTier::Base);
+    assert_eq!(published.manifest.payload().next_run_no, RunNo(1));
+    assert_eq!(published.manifest.payload().runs.len(), 1);
+    assert_eq!(published.manifest.payload().runs[0].run_no, RunNo(0));
+    assert_eq!(published.manifest.payload().runs[0].tier, RunTier::Base);
     assert!(metadata_states_equivalent(
         &published.metadata_state,
         &genesis.base_state
@@ -333,13 +333,11 @@ async fn recovery_rejects_a_root_head_seq_that_disagrees_with_its_manifest() {
     assert_eq!(loaded_root.state.manifest.manifest_head_seq, ChangeSeq(1));
     let mut root = loaded_root.state;
     root.manifest.manifest_head_seq = ChangeSeq(0);
-    let envelope = loonfs_api::wire::control::MetadataRootEnvelope::from_state(
+    let bytes = loonfs_api::wire::control::encode_control_state(
         loonfs_api::wire::control::ControlObjectKind::MetadataRoot,
-        root,
+        &root,
     )
-    .expect("root envelope");
-    let bytes = loonfs_api::wire::control::encode_control_object(&envelope)
-        .expect("encode contradictory root");
+    .expect("encode contradictory root");
     store
         .put_overwrite(
             &loonfs_objectstore::keys::metadata_root(&namespace_id),
@@ -720,8 +718,8 @@ async fn manifest_delta_run_materialization_matches_checkpoint_projection() {
     // Checkpoints only append: the base run stays the bootstrap seed's and
     // each checkpoint contributes one delta run.
     assert_eq!(
-        second_materialized.manifest.payload.base_seq,
-        first_materialized.manifest.payload.base_seq
+        second_materialized.manifest.payload().base_seq,
+        first_materialized.manifest.payload().base_seq
     );
     assert_eq!(
         base_tier(&second_materialized.manifest),
@@ -768,7 +766,7 @@ async fn manifest_delta_run_materialization_matches_checkpoint_projection() {
             .await
             .expect("load chained manifest");
     assert_eq!(
-        latest_materialized.manifest.payload.base_seq,
+        latest_materialized.manifest.payload().base_seq,
         ChangeSeq(0),
         "always-append checkpoints keep the first published base"
     );
@@ -893,7 +891,7 @@ async fn manifest_run_rejects_rows_after_run_seq() {
     )
     .await
     .expect("write empty metadata run segments");
-    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    let manifest = encode_namespace_manifest_json(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no: manifest_no(materialization.head.seq),
         manifest_object_id: manifest_object_id(manifest_no(materialization.head.seq)),
@@ -919,12 +917,13 @@ async fn manifest_run_rejects_rows_after_run_seq() {
             },
         ],
     })
-    .expect("build malformed manifest");
+    .expect("build malformed manifest")
+    .into_envelope();
 
     match load_manifest_metadata_state_for_inspection_from_manifest(
         &store,
         &namespace_id,
-        &metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id),
+        &metadata_manifest_object(&namespace_id, &manifest.payload().manifest_object_id),
         &manifest,
     )
     .await
@@ -1026,10 +1025,10 @@ async fn write_namespace_manifest_conflict_same_payload_is_idempotent() {
     .await
     .expect("build manifest");
 
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("first manifest write");
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("same manifest write is idempotent");
 }
@@ -1061,15 +1060,16 @@ async fn write_namespace_manifest_conflict_different_payload_is_error() {
     )
     .await
     .expect("build manifest");
-    let mut conflicting_payload = manifest.payload.clone();
+    let mut conflicting_payload = manifest.payload().clone();
     conflicting_payload.next_inode_id = InodeId(conflicting_payload.next_inode_id.0 + 1);
-    let conflicting_manifest = NamespaceManifestEnvelope::from_payload(conflicting_payload)
-        .expect("build conflicting manifest");
+    let conflicting_manifest = encode_namespace_manifest_json(conflicting_payload)
+        .expect("build conflicting manifest")
+        .into_envelope();
 
-    write_namespace_manifest(&store, &manifest)
+    write_namespace_manifest(&store, manifest.payload().clone())
         .await
         .expect("first manifest write");
-    let error = write_namespace_manifest(&store, &conflicting_manifest)
+    let error = write_namespace_manifest(&store, conflicting_manifest.payload().clone())
         .await
         .expect_err("different same-id manifest must conflict");
 
@@ -1126,7 +1126,7 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
     )
     .await
     .expect("build manifest");
-    write_namespace_manifest(&store, &manifest_without_checkpoint)
+    write_namespace_manifest(&store, manifest_without_checkpoint.payload().clone())
         .await
         .expect("write manifest");
     publish_metadata_root(
@@ -1155,7 +1155,7 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
     assert_eq!(record.manifest.manifest_no, covering_manifest_no);
     assert_eq!(
         record.manifest.manifest_payload_checksum,
-        manifest_without_checkpoint.payload_checksum
+        manifest_without_checkpoint.payload_checksum()
     );
 }
 
@@ -1204,7 +1204,7 @@ async fn manifest_without_checkpoint_record_reconstructs_manifest_head_commit() 
 
     assert_eq!(
         reconstructed.head_commit_id,
-        manifest.payload.head_commit_id
+        manifest.payload().head_commit_id
     );
     assert_ne!(reconstructed.head_commit_id, newer_live_head.head_commit_id);
 }

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -487,7 +487,7 @@ pub(crate) async fn staged_keys_of_the_current_manifest<S: ObjectStore + ?Sized>
             .await
             .expect("load the published manifest")
             .manifest()
-            .payload
+            .payload()
             .runs
             .iter()
             .flat_map(|run| &run.segments)
@@ -567,7 +567,7 @@ pub(crate) async fn load_current_projection<S: ObjectStore + ?Sized>(
 /// as many base runs as it has rebuilt groups. A caller asking about "the
 /// base" means all of them.
 fn base_tier(manifest: &NamespaceManifestEnvelope) -> Vec<MetadataFamilySegments> {
-    let base_runs = runs_in_reorganization_order(&manifest.payload)
+    let base_runs = runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .filter(|run| run.tier == RunTier::Base)
         .collect::<Vec<_>>();
@@ -587,7 +587,7 @@ fn base_tier(manifest: &NamespaceManifestEnvelope) -> Vec<MetadataFamilySegments
 }
 
 fn delta_runs(manifest: &NamespaceManifestEnvelope) -> Vec<MetadataRunManifest> {
-    runs_in_materialization_order(&manifest.payload)
+    runs_in_materialization_order(manifest.payload())
         .into_iter()
         .filter(|run| run.tier == RunTier::Delta)
         .collect()
@@ -598,7 +598,7 @@ fn group_runs(
     manifest: &NamespaceManifestEnvelope,
     group: &[ApiMetadataRowFamily],
 ) -> Vec<MetadataRunManifest> {
-    runs_in_reorganization_order(&manifest.payload)
+    runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .filter(|run| {
             run.segments.iter().any(|family_segments| {
@@ -776,14 +776,17 @@ impl ObjectStore for ConflictOnManifestCreateStore {
                     ManifestConflictReplacement::MutateCandidateNextInode => {
                         let candidate = decode_namespace_manifest_json(&bytes)
                             .map_err(|error| ObjectStoreError::transport(key, error.to_string()))?;
-                        let mut payload = candidate.payload;
+                        let mut payload = candidate.into_payload();
                         payload.next_inode_id = InodeId(payload.next_inode_id.0 + 1);
-                        let mutated = NamespaceManifestEnvelope::from_payload(payload)
+                        let mutated = encode_namespace_manifest_json(payload)
+                            .map(|encoded| encoded.into_envelope())
                             .map_err(|error| ObjectStoreError::transport(key, error.to_string()))?;
                         Bytes::from(
-                            encode_namespace_manifest_json(&mutated).map_err(|error| {
-                                ObjectStoreError::transport(key, error.to_string())
-                            })?,
+                            encode_namespace_manifest_json(mutated.payload().clone())
+                                .map(|encoded| encoded.into_bytes())
+                                .map_err(|error| {
+                                    ObjectStoreError::transport(key, error.to_string())
+                                })?,
                         )
                     }
                 };
@@ -853,10 +856,10 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
     // the counter alone.
     let run_no = previous_manifest
         .as_ref()
-        .map_or(RunNo(0), |previous| previous.manifest.payload.next_run_no);
+        .map_or(RunNo(0), |previous| previous.manifest.payload().next_run_no);
     let mut next_run_no = next_run_no_after(run_no)?;
     let (base_seq, runs) = match previous_manifest {
-        Some(previous) if is_bootstrap_seed_manifest(&previous.manifest.payload) => {
+        Some(previous) if is_bootstrap_seed_manifest(previous.manifest.payload()) => {
             let run_segments =
                 build_manifest_segments(store, namespace_id, metadata_state, policy).await?;
             debug_assert_manifest_segments_do_not_overlap(&run_segments);
@@ -871,10 +874,10 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
             )
         }
         Some(previous)
-            if delta_run_count(&previous.manifest.payload) < policy.max_delta_runs.get() =>
+            if delta_run_count(previous.manifest.payload()) < policy.max_delta_runs.get() =>
         {
-            let mut runs = previous.manifest.payload.runs.clone();
-            if previous.manifest.payload.head_seq < head_seq {
+            let mut runs = previous.manifest.payload().runs.clone();
+            if previous.manifest.payload().head_seq < head_seq {
                 runs.push(MetadataRunRef {
                     run_no,
                     run_seq: head_seq,
@@ -883,7 +886,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
                         build_manifest_delta_run_segments(
                             store,
                             namespace_id,
-                            previous.manifest.payload.head_seq,
+                            previous.manifest.payload().head_seq,
                             metadata_state,
                             policy,
                         )
@@ -893,7 +896,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
             } else {
                 next_run_no = run_no;
             }
-            (previous.manifest.payload.base_seq, runs)
+            (previous.manifest.payload().base_seq, runs)
         }
         Some(_) => {
             let run_segments =
@@ -924,7 +927,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
         }
     };
 
-    NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+    encode_namespace_manifest_json(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_no,
         manifest_object_id,
@@ -937,6 +940,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
         retention_floor_seq: source.retention_floor_seq,
         runs,
     })
+    .map(|encoded| encoded.into_envelope())
     .map_err(|err| {
         CoreError::Internal(format!(
             "failed to build namespace manifest envelope: {err}"

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -114,7 +114,7 @@ async fn current_manifest_no<S: ObjectStore + ?Sized>(
 }
 
 fn run_segment_object_keys(manifest: &NamespaceManifestEnvelope) -> Vec<String> {
-    runs_in_reorganization_order(&manifest.payload)
+    runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .flat_map(|run| {
             run.segments.into_iter().flat_map(|family_segments| {
@@ -216,7 +216,7 @@ type FamilyRunShape = (ApiMetadataRowFamily, u64, usize);
 type ManifestRunShape = (ChangeSeq, RunTier, Vec<FamilyRunShape>);
 
 fn manifest_run_shape(manifest: &NamespaceManifestEnvelope) -> Vec<ManifestRunShape> {
-    runs_in_reorganization_order(&manifest.payload)
+    runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .map(|run| {
             let segments = run
@@ -345,7 +345,7 @@ async fn retention_advancement_uses_published_manifest_and_updates_floor_only() 
     .await
     .expect("load current manifest")
     .manifest()
-    .payload
+    .payload()
     .runs
     .iter()
     .flat_map(|run| &run.segments)
@@ -424,7 +424,7 @@ async fn retention_floor_does_not_advance_past_a_missing_basis_segment() {
     .expect("load current manifest");
     let missing_key = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -489,7 +489,7 @@ async fn retention_floor_does_not_advance_when_a_basis_segment_cannot_be_checked
     .expect("load current manifest");
     let selected_key = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -1093,15 +1093,18 @@ async fn checkpoint_checksum_disagreement_is_terminal_corruption_and_releases_re
         .expect("read manifest")
         .expect("current manifest exists");
     let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
-    let record_checksum = manifest.payload_checksum.clone();
-    let mut mismatched_payload = manifest.payload;
+    let record_checksum = manifest.payload_checksum().to_owned();
+    let mut mismatched_payload = manifest.into_payload();
     mismatched_payload.next_inode_id = InodeId(mismatched_payload.next_inode_id.0 + 1);
-    let mismatched_manifest = NamespaceManifestEnvelope::from_payload(mismatched_payload)
-        .expect("build mismatched manifest");
-    let manifest_checksum = mismatched_manifest.payload_checksum.clone();
+    let mismatched_manifest = encode_namespace_manifest_json(mismatched_payload)
+        .expect("build mismatched manifest")
+        .into_envelope();
+    let manifest_checksum = mismatched_manifest.payload_checksum().to_owned();
     assert_ne!(record_checksum, manifest_checksum);
     let mismatched_bytes = Bytes::from(
-        encode_namespace_manifest_json(&mismatched_manifest).expect("encode mismatched manifest"),
+        encode_namespace_manifest_json(mismatched_manifest.payload().clone())
+            .expect("encode mismatched manifest")
+            .into_bytes(),
     );
     let store = ManifestChecksumMismatchOnceStore::new(
         setup_store,
@@ -1282,7 +1285,7 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     .expect("load appended manifest");
     assert_eq!(delta_runs(&appended.manifest).len(), rounds);
     assert!(delta_runs(&appended.manifest).len() > DEFAULT_MAX_CHECKPOINT_DELTA_RUNS);
-    assert_eq!(appended.manifest.payload.base_seq, ChangeSeq(0));
+    assert_eq!(appended.manifest.payload().base_seq, ChangeSeq(0));
 
     // Reorganization folds one family group per unit, each publishing its
     // own manifest — the manifest chain is the progress record.
@@ -1329,7 +1332,7 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
         .expect("materialization");
     assert!(delta_runs(&drained.manifest).is_empty());
     assert_eq!(
-        drained.manifest.payload.base_seq,
+        drained.manifest.payload().base_seq,
         ChangeSeq(u64::try_from(rounds).expect("round count fits"))
     );
     assert!(metadata_states_equivalent(
@@ -1653,7 +1656,7 @@ async fn whole_run_compaction_rewrites_base_segments() {
     );
 
     assert_eq!(
-        compacted_materialized.manifest.payload.base_seq,
+        compacted_materialized.manifest.payload().base_seq,
         compacted.checkpoint_seq
     );
     assert!(delta_runs(&compacted_materialized.manifest).is_empty());
@@ -1755,7 +1758,7 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_delta_runs(
     // Groups untouched since the first fold keep their older base run, so
     // several base runs may coexist; what matters is that no delta remains.
     assert!(
-        runs_in_reorganization_order(&compacted_materialized.manifest.payload)
+        runs_in_reorganization_order(compacted_materialized.manifest.payload())
             .iter()
             .all(|run| run.tier == RunTier::Base)
     );
@@ -2026,7 +2029,7 @@ async fn select_reorganization_window<S: ObjectStore + ?Sized>(
     let group = super::reorganize::select_family_group(
         store,
         namespace_id,
-        &segments.manifest().payload,
+        segments.manifest().payload(),
         0,
         MetadataCompactionPolicy::default(),
         policy,

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -1034,9 +1034,9 @@ async fn held_group_leases_are_skipped_and_an_expired_lease_is_available() {
     else {
         panic!("expected another group to merge, got {:?}", reaping.outcome);
     };
-    assert_ne!(
+    assert_eq!(
         reaping_group, group,
-        "the reaping lease excludes its family group"
+        "a fenced job does not hold its family group"
     );
 
     write_active_lease(&expired_store, &namespace_id, &spec, 0).await;
@@ -2265,7 +2265,7 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
 // -------------------------------------------------------------------------
 
 #[tokio::test]
-async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_when_it_publishes() {
+async fn a_job_keeps_published_output_under_its_own_prefix() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -2305,7 +2305,11 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
         "every object a job writes belongs to that job's prefix: {staged:?}"
     );
     assert!(
-        !staged.is_empty() && staged.iter().all(|key| referenced.contains(key)),
+        !staged.is_empty()
+            && staged
+                .iter()
+                .filter(|key| key.ends_with(".sst.zst"))
+                .all(|key| referenced.contains(key)),
         "the manifest must name every segment the job published"
     );
     assert!(
@@ -2314,8 +2318,7 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
             .await
             .expect("head the group lease")
             .is_some(),
-        "a published job leaves its final lease standing for the pass that has not seen the new \
-         root yet"
+        "a completed group slot remains available for the next job's CAS"
     );
 }
 
@@ -2432,7 +2435,7 @@ async fn a_worker_whose_expired_lease_was_claimed_is_fenced_and_publishes_nothin
     .expect("claim the expired prefix");
     assert_eq!(
         owner,
-        CompactionPrefixOwner::ThisCollector,
+        CompactionPrefixOwner::Fenced,
         "an expired lease is claimed, and only the winner may reap the prefix"
     );
 
@@ -2564,7 +2567,7 @@ async fn exactly_one_of_a_refresh_and_a_reaping_claim_wins() {
     );
     assert_eq!(
         claimed.expect("claim the prefix"),
-        CompactionPrefixOwner::LiveJob,
+        CompactionPrefixOwner::Protected,
         "and the claim behind it is refused, so exactly one of the two won"
     );
 
@@ -2580,7 +2583,7 @@ async fn exactly_one_of_a_refresh_and_a_reaping_claim_wins() {
         )
         .await
         .expect("claim the prefix"),
-        CompactionPrefixOwner::ThisCollector
+        CompactionPrefixOwner::Fenced
     );
     assert_eq!(
         lease.refresh(&store).await.expect("refresh the lease"),
@@ -3901,4 +3904,109 @@ async fn a_backlogged_job_limits_input_and_preserves_unselected_runs() {
     assert!(untouched.is_subset(&referenced));
     let after = current_metadata_state(&store, &namespace).await;
     assert!(metadata_states_equivalent(&before, &after));
+}
+
+#[tokio::test]
+async fn completed_output_protection_does_not_hold_the_group() {
+    use super::super::compaction_lease::{load_output_protection, LeaseAcquire};
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let first =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let second =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let timer = StdMonotonicTimer::default();
+    let mut lease = test_lease(&store, &namespace_id, &first, &timer).await;
+    let before = load_group_lease(&store, &namespace_id, first.group())
+        .await
+        .expect("load group")
+        .expect("held group");
+    lease
+        .protect_output(&store)
+        .await
+        .expect("protect sealed output");
+    lease.complete(&store).await.expect("complete job");
+    let protected = load_output_protection(&store, &namespace_id, first.job_id())
+        .await
+        .expect("load protection")
+        .expect("protection exists");
+    assert_eq!(protected.state.expires_at_ms, before.state.expires_at_ms);
+    let acquired = CompactionLease::acquire(
+        &store,
+        &namespace_id,
+        &second,
+        &test_context().writer_id,
+        test_context().now_ms,
+        &timer,
+    )
+    .await
+    .expect("acquire next job");
+    assert!(
+        matches!(acquired, LeaseAcquire::Acquired(_)),
+        "completion must not wait for expiry"
+    );
+    assert_eq!(
+        lease.refresh(&store).await.expect("old lease is fenced"),
+        LeaseHold::Fenced
+    );
+    assert_eq!(
+        load_output_protection(&store, &namespace_id, first.job_id())
+            .await
+            .expect("old output protection")
+            .expect("still present")
+            .state,
+        protected.state
+    );
+}
+
+#[tokio::test]
+async fn output_protection_is_durable_before_the_root_cas() {
+    use super::super::compaction_lease::load_output_protection;
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let spec =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let gated = BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::exact(loonfs_objectstore::keys::metadata_root(&namespace_id)),
+        OperationClass::CompareAndSwap,
+    );
+    gated.block_next();
+    let context = test_context();
+    let cancellation = MetadataCompactionCancellation::default();
+    let (result, ()) = tokio::join!(
+        run_metadata_compaction_job(
+            &gated,
+            &namespace_id,
+            &context,
+            &spec,
+            small_segment_policy(),
+            &cancellation
+        ),
+        async {
+            gated.wait_until_blocked().await;
+            let protection = load_output_protection(&store, &namespace_id, spec.job_id())
+                .await
+                .expect("protection read")
+                .expect("protected before publication");
+            let group = load_group_lease(&store, &namespace_id, spec.group())
+                .await
+                .expect("group read")
+                .expect("active group");
+            assert_eq!(protection.state.expires_at_ms, group.state.expires_at_ms);
+            assert_eq!(
+                group.state.status,
+                loonfs_api::wire::control::CompactionLeaseStatus::Active {}
+            );
+            gated.release();
+        }
+    );
+    assert!(matches!(
+        result.expect("publish"),
+        MetadataCompactionJobOutcome::Published { .. }
+    ));
 }

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -503,7 +503,7 @@ async fn policy_that_starves_the_group<S: ObjectStore + ?Sized>(
     group: MetadataFamilyGroup,
 ) -> MetadataLsmPolicy {
     let segments = load_current_manifest_segments(store, namespace_id).await;
-    let base_rows: u64 = runs_in_reorganization_order(&segments.manifest().payload)
+    let base_rows: u64 = runs_in_reorganization_order(segments.manifest().payload())
         .iter()
         .filter(|run| run.tier == RunTier::Base)
         .flat_map(|run| run.segments.iter())
@@ -552,7 +552,7 @@ fn snapshot_runs_for_group(
     manifest: &NamespaceManifestEnvelope,
     group: MetadataFamilyGroup,
 ) -> Vec<MetadataRunManifest> {
-    runs_in_reorganization_order(&manifest.payload)
+    runs_in_reorganization_order(manifest.payload())
         .into_iter()
         .filter(|run| {
             run.segments.iter().any(|family_segments| {
@@ -1464,10 +1464,10 @@ async fn rewrite_base_segment(
     family: ApiMetadataRowFamily,
     mut rows: Vec<MetadataRow>,
 ) {
+    let mut payload = manifest.payload().clone();
     rows.sort_by_key(|row| row.row_key_for_family(family));
-    let head_seq = manifest.payload.head_seq;
-    let descriptor = manifest
-        .payload
+    let head_seq = payload.head_seq;
+    let descriptor = payload
         .runs
         .iter_mut()
         .filter(|run| run.tier == RunTier::Base)
@@ -1484,6 +1484,9 @@ async fn rewrite_base_segment(
         NonZeroUsize::new(DEFAULT_TARGET_BLOCK_BYTES).expect("the default target is positive"),
     )
     .await;
+    *manifest = encode_namespace_manifest_json(payload)
+        .expect("encode changed manifest")
+        .into_envelope();
 }
 
 #[tokio::test]
@@ -1846,14 +1849,14 @@ async fn install_synthetic_bindings_base(
         ));
     }
 
-    let mut manifest = load_current_manifest_segments(store, namespace_id)
+    let manifest = load_current_manifest_segments(store, namespace_id)
         .await
         .manifest()
         .clone();
     // The synthetic segments replace this run's bindings, so they join the
     // run that already holds the group's other families.
     let base_run = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .find(|run| {
@@ -1889,8 +1892,8 @@ async fn install_synthetic_bindings_base(
 
     // Only the base tier is replaced: the delta run above it is what gives a
     // bottom-anchored window something to fold.
-    let base_run = manifest
-        .payload
+    let mut payload = manifest.payload().clone();
+    let base_run = payload
         .runs
         .iter_mut()
         .find(|run| run.run_no == base_run_no)
@@ -1906,8 +1909,7 @@ async fn install_synthetic_bindings_base(
     // What the probe cache would have to hold to serve every probe without
     // refetching: the decoded data blocks of the unbind family.
     let mut unbind_decoded_bytes = 0u64;
-    for descriptor in manifest
-        .payload
+    for descriptor in payload
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -1926,7 +1928,14 @@ async fn install_synthetic_bindings_base(
             .map(|entry| u64::from(entry.block.decoded_len))
             .sum::<u64>();
     }
-    super::index_parity::overwrite_manifest(store, namespace_id, manifest).await;
+    super::index_parity::overwrite_manifest(
+        store,
+        namespace_id,
+        encode_namespace_manifest_json(payload)
+            .expect("encode changed manifest")
+            .into_envelope(),
+    )
+    .await;
     unbind_decoded_bytes
 }
 
@@ -1951,7 +1960,7 @@ async fn a_step_contained_merge_reads_its_window_once() {
     let segments = load_current_manifest_segments(&store, &namespace_id).await;
     let descriptors: Vec<MetadataSegmentRef> = segments
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| run.segments.iter().cloned())
@@ -2239,7 +2248,7 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
     let manifest_keys: BTreeSet<String> = load_current_manifest_segments(&store, &namespace_id)
         .await
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -2921,7 +2930,7 @@ async fn group_segments_outside_the_job<S: ObjectStore + ?Sized>(
     load_current_manifest_segments(store, namespace_id)
         .await
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| !inputs.contains(&run.run_no))
@@ -2939,7 +2948,7 @@ async fn referenced_segment_keys<S: ObjectStore + ?Sized>(
     load_current_manifest_segments(store, namespace_id)
         .await
         .manifest()
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -3389,7 +3398,7 @@ async fn a_flush_landing_during_finalization_is_retried_over() {
     );
 
     let segments = load_current_manifest_segments(&store, &namespace_id).await;
-    assert_eq!(segments.manifest().payload.manifest_no, manifest_no);
+    assert_eq!(segments.manifest().payload().manifest_no, manifest_no);
     let runs = snapshot_runs_for_group(segments.manifest(), group);
     drop(segments);
     // Two runs: the base run the job built, and the delta run the flush

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -24,36 +24,37 @@ pub(super) fn validate_namespace_manifest(
     object_key: &str,
     manifest: &NamespaceManifestEnvelope,
 ) -> Result<(), ManifestLoadError> {
-    if manifest.payload.namespace_id != *namespace_id {
+    if manifest.payload().namespace_id != *namespace_id {
         return Err(ManifestLoadError::ManifestNamespaceMismatch {
             object_key: object_key.to_owned(),
             expected: namespace_id.clone(),
-            actual: manifest.payload.namespace_id.clone(),
+            actual: manifest.payload().namespace_id.clone(),
         });
     }
-    if manifest.payload.manifest_no != manifest_no {
+    if manifest.payload().manifest_no != manifest_no {
         return Err(ManifestLoadError::ManifestNoMismatch {
             object_key: object_key.to_owned(),
             expected: manifest_no,
-            actual: manifest.payload.manifest_no,
+            actual: manifest.payload().manifest_no,
         });
     }
-    if manifest_object_id_manifest_no(manifest.payload.manifest_object_id.as_str())
-        != Some(manifest.payload.manifest_no)
+    if manifest_object_id_manifest_no(manifest.payload().manifest_object_id.as_str())
+        != Some(manifest.payload().manifest_no)
     {
         return Err(ManifestLoadError::RunManifestMismatch {
             object_key: object_key.to_owned(),
             message: format!(
                 "manifest object id `{}` does not encode manifest number `{}`",
-                manifest.payload.manifest_object_id, manifest.payload.manifest_no
+                manifest.payload().manifest_object_id,
+                manifest.payload().manifest_no
             ),
         });
     }
-    if manifest.payload.manifest_object_id != *manifest_object_id {
+    if manifest.payload().manifest_object_id != *manifest_object_id {
         return Err(ManifestLoadError::ManifestObjectIdMismatch {
             object_key: object_key.to_owned(),
             expected: manifest_object_id.clone(),
-            actual: manifest.payload.manifest_object_id.clone(),
+            actual: manifest.payload().manifest_object_id.clone(),
         });
     }
     Ok(())

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -27,7 +27,7 @@ pub(crate) fn prepare_commit_head_publish(
     plan: &CommitPlan,
     wal: &PreparedWalSegment,
 ) -> Result<PreparedCommitHeadPublish, CommitHeadPublishError> {
-    let wal_payload = &wal.envelope.payload;
+    let wal_payload = &wal.envelope().payload();
     ensure_segment_connects(
         "writer_epoch",
         current_head.writer_epoch,
@@ -47,7 +47,7 @@ pub(crate) fn prepare_commit_head_publish(
     ensure_segment_connects("end_seq", plan.assigned_seq, wal_payload.end_seq)?;
 
     let object_key = wal_head(&current_head.namespace_id);
-    let new_tip = wal.envelope.pointer();
+    let new_tip = wal.envelope().pointer();
     let resulting_head = HeadState {
         seq: plan.assigned_seq,
         head_commit_id: plan.commit_id.clone(),
@@ -135,7 +135,6 @@ fn map_object_store_error(object_key: &str, err: ObjectStoreError) -> CommitHead
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_api::wire::control::{encode_control_object, HeadStateEnvelope};
 
     #[test]
     fn head_cas_transport_failure_maps_to_unknown_outcome_not_failure() {
@@ -170,7 +169,7 @@ mod tests {
         ));
     }
     use loonfs_api::wire::control::{NamespaceStatus, WriterBlock};
-    use loonfs_api::wire::wal::{WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload};
+    use loonfs_api::wire::wal::{WalCommitPayload, WalSegmentPayload};
     use loonfs_api::{CommitId, InodeId, NamespaceId, WalSegmentId, WriterEpoch, MAX_ID_BYTES};
 
     fn head(namespace_id: NamespaceId, seq: ChangeSeq) -> HeadState {
@@ -252,11 +251,7 @@ mod tests {
             end_seq,
             records,
         };
-        let envelope = WalSegmentEnvelope::from_payload(payload).expect("wal envelope");
-        PreparedWalSegment {
-            envelope,
-            encoded_bytes: Vec::new(),
-        }
+        loonfs_api::wire::wal::encode_wal_segment_envelope_zstd(payload).expect("wal encoding")
     }
 
     #[test]
@@ -272,20 +267,20 @@ mod tests {
         assert_eq!(prepared.resulting_head.seq, ChangeSeq(9));
         assert_eq!(
             prepared.resulting_head.visible_wal_tip,
-            Some(wal.envelope.pointer())
+            Some(wal.envelope().pointer())
         );
         assert_eq!(
             prepared.object_key,
             wal_head(&prepared.resulting_head.namespace_id),
         );
-        let expected_envelope = HeadStateEnvelope::from_state(
-            ControlObjectKind::WalHead,
-            prepared.resulting_head.clone(),
-        )
-        .expect("head envelope");
+        let expected_envelope = prepared.resulting_head.clone();
         assert_eq!(
             prepared.encoded_bytes,
-            encode_control_object(&expected_envelope).expect("encoded head"),
+            loonfs_api::wire::control::encode_control_state(
+                ControlObjectKind::WalHead,
+                &expected_envelope
+            )
+            .expect("encoded head"),
         );
     }
 
@@ -352,7 +347,7 @@ mod tests {
             ChangeSeq(7),
             2,
         );
-        let prior_tip = prior.envelope.pointer();
+        let prior_tip = prior.envelope().pointer();
         current_head.visible_wal_tip = Some(prior_tip.clone());
         current_head.recent_segments = Vec::new();
         let plan = plan(namespace_id.clone(), ChangeSeq(9));
@@ -361,7 +356,7 @@ mod tests {
         let prepared =
             prepare_commit_head_publish(&current_head, &plan, &wal).expect("prepare head publish");
 
-        let new_tip = wal.envelope.pointer();
+        let new_tip = wal.envelope().pointer();
         assert_eq!(prepared.resulting_head.recent_segments, vec![prior_tip]);
         assert_eq!(prepared.resulting_head.visible_wal_tip, Some(new_tip));
     }
@@ -379,7 +374,7 @@ mod tests {
                 ChangeSeq(index + 1),
                 1,
             );
-            segment.envelope.pointer()
+            segment.envelope().pointer()
         };
         let old_tip = filler(limit);
         current_head.visible_wal_tip = Some(old_tip.clone());
@@ -407,7 +402,7 @@ mod tests {
         assert_eq!(recent[0], old_tip);
         assert_eq!(
             prepared.resulting_head.visible_wal_tip,
-            Some(wal.envelope.pointer())
+            Some(wal.envelope().pointer())
         );
         assert!(!recent.contains(&oldest), "oldest hint must fall off");
     }
@@ -511,9 +506,10 @@ mod tests {
         state.visible_wal_tip = segments.first().cloned();
         state.recent_segments = segments.into_iter().skip(1).collect();
 
-        let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, state)
-            .expect("head envelope");
-        encode_control_object(&envelope).expect("encode head").len()
+        let envelope = state;
+        loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &envelope)
+            .expect("encode head")
+            .len()
     }
 
     #[test]

--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -60,12 +60,12 @@ where
         .ok_or_else(|| classify(&object_key, ControlLoadFailure::MissingEtag))?;
     let envelope = decode_control_object(&body.bytes, kind)
         .map_err(|error| classify(&object_key, ControlLoadFailure::Decode(error)))?;
-    validate_identity(&envelope.state)
+    validate_identity(envelope.payload())
         .map_err(|error| classify(&object_key, ControlLoadFailure::EmbeddedIdentity(error)))?;
     Ok(LoadedControl {
         object_key,
         etag,
-        state: envelope.state,
+        state: envelope.into_payload(),
     })
 }
 
@@ -180,7 +180,7 @@ mod tests {
     use super::*;
     use crate::error::StoreFailureClass;
     use bytes::Bytes;
-    use loonfs_api::wire::control::{encode_control_object, HeadState, HeadStateEnvelope};
+    use loonfs_api::wire::control::HeadState;
     use loonfs_api::{ContentStoreId, NamespaceId};
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -203,9 +203,9 @@ mod tests {
 
     fn encoded_head(namespace_id: &NamespaceId) -> (HeadState, Vec<u8>) {
         let state = HeadState::initial(namespace_id.clone(), ContentStoreId::generate(), 1_000);
-        let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, state.clone())
-            .expect("head envelope");
-        let bytes = encode_control_object(&envelope).expect("head bytes");
+        let bytes =
+            loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &state)
+                .expect("head bytes");
         (state, bytes)
     }
 

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -318,7 +318,7 @@ async fn load_upload_session_object<S: ObjectStore + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
+    use loonfs_api::wire::control::ControlObjectKind;
     use loonfs_api::NamespaceId;
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -329,16 +329,14 @@ mod tests {
     use tempfile::tempdir;
 
     async fn write_initial_head(store: &LocalFsStore, namespace_id: &NamespaceId) {
-        let envelope = HeadStateEnvelope::from_state(
-            ControlObjectKind::WalHead,
-            HeadState::initial(
-                namespace_id.clone(),
-                loonfs_api::ContentStoreId::generate(),
-                1_000,
-            ),
-        )
-        .expect("head envelope");
-        let bytes = encode_control_object(&envelope).expect("head bytes");
+        let envelope = HeadState::initial(
+            namespace_id.clone(),
+            loonfs_api::ContentStoreId::generate(),
+            1_000,
+        );
+        let bytes =
+            loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &envelope)
+                .expect("head bytes");
         store
             .put_if_absent(&wal_head(namespace_id), Bytes::from(bytes))
             .await

--- a/crates/loonfs-core/src/gc/compaction_staging.rs
+++ b/crates/loonfs-core/src/gc/compaction_staging.rs
@@ -5,29 +5,20 @@
 //! job's output, which fences the job from publishing.
 
 use crate::checkpoint::{
-    claim_loaded_group_lease, load_group_lease, CompactionPrefixOwner, LoadedCompactionLease,
+    claim_loaded_group_lease, load_group_lease, load_output_protection, CompactionPrefixOwner,
+    LoadedCompactionLease,
 };
 use crate::error::{CoreError, Result};
-use loonfs_api::wire::control::CompactionLeaseStatus;
 use loonfs_api::{MetadataCompactionId, MetadataFamilyGroup, NamespaceId};
 use loonfs_objectstore::keys::metadata_compaction_job_id_from_key;
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeMap;
 
-/// What the loaded-lease sweep should do with one lease.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum GroupLeaseSweep {
-    Retain,
-    Delete { object_key: String },
-}
-
-/// Tracks the seven group leases and any claim awaiting prefix completion.
+/// Tracks the seven group leases and the last inspected job prefix.
 #[derive(Debug, Default)]
 pub(super) struct CompactionLeases {
     by_job_id: BTreeMap<MetadataCompactionId, LoadedCompactionLease>,
     last_read: Option<LastPrefixRead>,
-    claimed_lease: Option<String>,
-    staging_complete: bool,
     loaded: bool,
 }
 
@@ -82,24 +73,22 @@ impl CompactionLeases {
         let owner = match &self.last_read {
             Some(read) if read.job_id == metadata_compaction_id => read.owner,
             _ => {
-                self.delete_claimed_lease(store).await?;
-                let owner = match self.by_job_id.get(&metadata_compaction_id).cloned() {
-                    Some(loaded) => {
-                        let lease_key = loaded.object_key.clone();
-                        let owner = claim_loaded_group_lease(
-                            store,
-                            namespace_id,
-                            &metadata_compaction_id,
-                            loaded,
-                            now_ms,
-                        )
-                        .await?;
-                        if owner == CompactionPrefixOwner::ThisCollector {
-                            self.claimed_lease = Some(lease_key);
-                        }
-                        owner
-                    }
-                    None => CompactionPrefixOwner::NoOne,
+                let protection =
+                    load_output_protection(store, namespace_id, &metadata_compaction_id).await?;
+                let owner = if protection.is_some_and(|loaded| now_ms <= loaded.state.expires_at_ms)
+                {
+                    CompactionPrefixOwner::Protected
+                } else if let Some(loaded) = self.by_job_id.get(&metadata_compaction_id).cloned() {
+                    claim_loaded_group_lease(
+                        store,
+                        namespace_id,
+                        &metadata_compaction_id,
+                        loaded,
+                        now_ms,
+                    )
+                    .await?
+                } else {
+                    CompactionPrefixOwner::Unclaimed
                 };
                 self.last_read = Some(LastPrefixRead {
                     job_id: metadata_compaction_id,
@@ -109,66 +98,5 @@ impl CompactionLeases {
             }
         };
         Ok(Some(owner))
-    }
-
-    /// Records that the complete staging-prefix listing finished.
-    pub(super) fn staging_finished(&mut self) {
-        self.staging_complete = true;
-    }
-
-    pub(super) fn contains_group(&self, group: MetadataFamilyGroup) -> bool {
-        self.by_job_id
-            .values()
-            .any(|loaded| loaded.state.group == group)
-    }
-
-    /// Decides one loaded lease after the staging prefix has been walked.
-    pub(super) async fn sweep_group_lease<S: ObjectStore + ?Sized>(
-        &mut self,
-        store: &S,
-        namespace_id: &NamespaceId,
-        group: MetadataFamilyGroup,
-        now_ms: u64,
-    ) -> Result<Option<GroupLeaseSweep>> {
-        let Some(loaded) = self
-            .by_job_id
-            .values()
-            .find(|loaded| loaded.state.group == group)
-            .cloned()
-        else {
-            return Ok(None);
-        };
-        if !self.staging_complete
-            || (loaded.state.status == (CompactionLeaseStatus::Active {})
-                && now_ms <= loaded.state.expires_at_ms)
-        {
-            return Ok(Some(GroupLeaseSweep::Retain));
-        }
-        let job_id = loaded.state.job_id.clone();
-        let object_key = loaded.object_key.clone();
-        let owner = claim_loaded_group_lease(store, namespace_id, &job_id, loaded, now_ms).await?;
-        Ok(Some(match owner {
-            CompactionPrefixOwner::ThisCollector => GroupLeaseSweep::Delete { object_key },
-            CompactionPrefixOwner::LiveJob | CompactionPrefixOwner::NoOne => {
-                GroupLeaseSweep::Retain
-            }
-        }))
-    }
-
-    /// Deletes a claimed lease after its job prefix has been processed.
-    pub(super) async fn finish<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
-        self.delete_claimed_lease(store).await
-    }
-
-    async fn delete_claimed_lease<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
-        let Some(object_key) = self.claimed_lease.take() else {
-            return Ok(());
-        };
-        self.by_job_id
-            .retain(|_, loaded| loaded.object_key != object_key);
-        store
-            .delete(&object_key)
-            .await
-            .map_err(|error| CoreError::store(&object_key, &error))
     }
 }

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -62,7 +62,11 @@ impl CandidateFamily {
         match self {
             Self::WalSegments => family == DurableObjectFamily::WalSegment,
             Self::MetadataSegments => family == DurableObjectFamily::MetadataSegment,
-            Self::CompactionStaging => family == DurableObjectFamily::MetadataCompactionStaging,
+            Self::CompactionStaging => matches!(
+                family,
+                DurableObjectFamily::MetadataCompactionStaging
+                    | DurableObjectFamily::CompactionOutputProtection
+            ),
             Self::Manifests => matches!(manifest_object_id_of(key), Some(Ok(_))),
             Self::Checkpoints => family == DurableObjectFamily::CheckpointRecord,
             Self::UploadSessions => family == DurableObjectFamily::UploadSession,

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -446,7 +446,7 @@ async fn collect_manifest_segments<S: ObjectStore + ?Sized>(
         {
             Ok(Some(manifest)) => live.segments.extend(
                 manifest
-                    .payload
+                    .payload()
                     .runs
                     .iter()
                     .flat_map(|run| &run.segments)
@@ -721,13 +721,13 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
         };
         manifest_object_ids.insert(manifest_object_id);
         head_seq = Some(
-            head_seq.map_or(manifest.payload.head_seq, |current: ChangeSeq| {
-                current.min(manifest.payload.head_seq)
+            head_seq.map_or(manifest.payload().head_seq, |current: ChangeSeq| {
+                current.min(manifest.payload().head_seq)
             }),
         );
         segments.extend(
             manifest
-                .payload
+                .payload()
                 .runs
                 .iter()
                 .flat_map(|run| &run.segments)

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -2,7 +2,7 @@
 //! and the bounded, resumable sweep.
 
 use super::budget::PassBudget;
-use super::compaction_staging::{CompactionLeases, GroupLeaseSweep};
+use super::compaction_staging::CompactionLeases;
 use super::config::{GcConfig, GcPolicy};
 use super::cursor::{cursor_after, CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
@@ -109,8 +109,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     };
 
     // A pass exists only after root collection succeeds. From here on it is
-    // the one owner of every mutable sweep concern, including cleanup owed by
-    // an early budget stop or error.
+    // the one owner of every mutable sweep concern, including the budget and cursor.
     let upload_sweep = UploadSweepContext::new(
         store,
         namespace_id,
@@ -139,9 +138,8 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
 /// One initialized garbage-collection pass.
 ///
 /// These fields share a lifecycle rather than merely sharing a call site:
-/// candidate decisions mutate the verifier, reference memo, lease claim,
-/// budget, cursor, and report together, and [`Self::run`] settles all of them
-/// exactly once.
+/// candidate decisions mutate the verifier, reference memo, lease observations,
+/// budget, cursor, and report together.
 struct GcPass<'a, S: ?Sized> {
     store: &'a S,
     namespace_id: &'a NamespaceId,
@@ -170,19 +168,16 @@ enum PassEnd {
 pub(super) const COMPACTION_LEASE_STAGE_UNITS: u64 = MetadataFamilyGroup::ALL.len() as u64;
 
 impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
-    /// Runs and settles the pass. Lease cleanup deliberately happens before
-    /// the walk result is propagated, so no error or budget return can bypass
-    /// a claimed compaction lease.
+    /// Runs the pass. Group slots stay in place and are replaced by CAS, so a
+    /// paused collector can never delete a newer job's lease.
     async fn run(mut self) -> Result<GcResponse> {
-        let walked = self.walk_candidates().await;
-        let leases_finished = self.leases.finish(self.store).await;
-        leases_finished?;
-        self.finish_report(walked?)
+        let end = self.walk_candidates().await?;
+        self.finish_report(end)
     }
 
     async fn walk_candidates(&mut self) -> Result<PassEnd> {
         // The compaction lease stage reads one lease per family group and
-        // settles them after the walk. Every pass pays for those reads here,
+        // keeps terminal group slots for the next CAS. Every pass pays for those reads here,
         // whether or not it reaches the stage, so the budget bounds the pass
         // and a pass that cannot cover the stage decides nothing.
         if self.budget.remaining() < COMPACTION_LEASE_STAGE_UNITS {
@@ -228,11 +223,6 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
                 // retains its session instead of pinning the cursor forever.
                 self.budget.charge();
                 self.position = Some(cursor_after(self.namespace_id, family, key));
-            }
-            if family == CandidateFamily::CompactionStaging {
-                self.leases.staging_finished();
-                self.leases.finish(self.store).await?;
-                self.sweep_compaction_leases().await?;
             }
         }
         Ok(PassEnd::Complete)
@@ -330,6 +320,9 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
     }
 
     async fn process_compaction_staging(&mut self, key: &str) -> Result<()> {
+        if key.ends_with("/protection.json") {
+            return self.process_compaction_output_protection(key).await;
+        }
         if self.sweep.degraded {
             self.report.retain(RetainedReason::DegradedRoots);
             return Ok(());
@@ -344,13 +337,13 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             .owner_of(self.store, self.namespace_id, key, self.mutation.now_ms)
             .await?
         {
-            Some(CompactionPrefixOwner::LiveJob) => {
+            Some(CompactionPrefixOwner::Protected) => {
                 self.report.retain(RetainedReason::WithinGraceWindow);
             }
             None => {
                 self.report.retain(RetainedReason::UnrecognizedKey);
             }
-            Some(CompactionPrefixOwner::ThisCollector | CompactionPrefixOwner::NoOne) => {
+            Some(CompactionPrefixOwner::Fenced | CompactionPrefixOwner::Unclaimed) => {
                 if key.ends_with(".sst.zst")
                     && self
                         .sweep_aged(key, METADATA_COMPACTION_STAGING_GRACE_MS)
@@ -363,29 +356,37 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
         Ok(())
     }
 
-    async fn sweep_compaction_leases(&mut self) -> Result<()> {
-        for group in MetadataFamilyGroup::ALL {
-            if self.sweep.degraded {
-                if self.leases.contains_group(group) {
-                    self.report.retain(RetainedReason::DegradedRoots);
-                }
-                continue;
-            }
-            match self
-                .leases
-                .sweep_group_lease(self.store, self.namespace_id, group, self.mutation.now_ms)
+    /// Output protection stays readable until no output remains. In particular,
+    /// a newer collector must not remove the protection an older one still needs.
+    async fn process_compaction_output_protection(&mut self, key: &str) -> Result<()> {
+        use loonfs_objectstore::layout::parse_object_key;
+        let parsed = parse_object_key(key).expect("recognized output protection");
+        let job_id = loonfs_api::MetadataCompactionId::parse(parsed.identifier().expect("job id"))
+            .map_err(|error| CoreError::NamespaceCorrupt(error.to_string()))?;
+        let Some(loaded) =
+            crate::checkpoint::load_output_protection(self.store, self.namespace_id, &job_id)
                 .await?
-            {
-                Some(GroupLeaseSweep::Delete { object_key }) => {
-                    self.delete_key(&object_key).await?
-                }
-                Some(GroupLeaseSweep::Retain) => {
-                    self.report.retain(RetainedReason::WithinGraceWindow);
-                }
-                None => {}
-            }
+        else {
+            return Ok(());
+        };
+        if self.mutation.now_ms <= loaded.state.expires_at_ms {
+            self.report.retain(RetainedReason::WithinGraceWindow);
+            return Ok(());
         }
-        Ok(())
+        let prefix = format!(
+            "{}segments/",
+            key.strip_suffix("protection.json")
+                .expect("protection suffix")
+        );
+        let mut outputs = self.store.list_prefix_from_stream(&prefix, None);
+        match outputs.next().await {
+            Some(Ok(_)) => {
+                self.report.retain(RetainedReason::Referenced);
+                Ok(())
+            }
+            Some(Err(error)) => Err(CoreError::store(&prefix, &error)),
+            None => self.delete_key(key).await,
+        }
     }
 
     async fn process_missing_basis_checkpoint(&mut self, key: &str) -> Result<()> {

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -2349,8 +2349,8 @@ async fn a_live_jobs_staged_output_survives_however_old_it_is() {
         "a running job's output must not be reaped"
     );
     assert_eq!(
-        report.retained.within_grace_window, 2,
-        "the segment and the lease are both retained by the lease"
+        report.retained.within_grace_window, 1,
+        "the segment is retained by the lease"
     );
     for key in [&staged_key, &lease_key] {
         assert!(store
@@ -2410,13 +2410,16 @@ async fn a_dead_jobs_staged_output_is_reclaimed_after_the_staging_window() {
         report.deleted.metadata_segments, 1,
         "a dead job's orphan must be reaped"
     );
-    for key in [&staged_key, &lease_key] {
-        assert!(store
-            .head(key)
-            .await
-            .expect("head a staged object")
-            .is_none());
-    }
+    assert!(store
+        .head(&staged_key)
+        .await
+        .expect("removed output")
+        .is_none());
+    assert!(store
+        .head(&lease_key)
+        .await
+        .expect("terminal group slot")
+        .is_some());
 }
 
 #[tokio::test]
@@ -2514,7 +2517,7 @@ async fn two_group_leases_naming_the_same_job_are_namespace_corruption() {
 }
 
 #[tokio::test]
-async fn a_candidate_error_still_finishes_the_claimed_compaction_lease() {
+async fn a_candidate_error_leaves_the_terminal_group_slot() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let (inner, staged_key, lease_key) =
@@ -2557,8 +2560,8 @@ async fn a_candidate_error_still_finishes_the_claimed_compaction_lease() {
             .head(&lease_key)
             .await
             .expect("head the claimed lease")
-            .is_none(),
-        "pass settlement deletes the claimed lease on the error path"
+            .is_some(),
+        "a terminal group slot stays available for replacement by CAS"
     );
     assert!(
         store
@@ -2572,7 +2575,7 @@ async fn a_candidate_error_still_finishes_the_claimed_compaction_lease() {
 }
 
 #[tokio::test]
-async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
+async fn a_budget_stop_leaves_the_terminal_group_slot() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let (store, staged_key, lease_key) =
@@ -2616,8 +2619,8 @@ async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
             .head(&lease_key)
             .await
             .expect("head the claimed lease")
-            .is_none(),
-        "pass settlement deletes the claimed lease at the budget boundary"
+            .is_some(),
+        "a terminal group slot stays available for replacement by CAS"
     );
     assert!(
         store
@@ -2679,7 +2682,7 @@ async fn a_budget_short_of_the_lease_stage_reads_no_lease() {
         .expect("head the lease")
         .is_some());
 
-    // Unbounded, the same pass claims the expired lease and settles it.
+    // Unbounded, the same pass claims the expired lease and keeps its slot.
     gc_namespace(&store, &namespace_id, &config(), &reclaimable)
         .await
         .expect("unbounded rerun");
@@ -2688,7 +2691,7 @@ async fn a_budget_short_of_the_lease_stage_reads_no_lease() {
         .head(&lease_key)
         .await
         .expect("head the lease")
-        .is_none());
+        .is_some());
 }
 
 #[tokio::test]
@@ -2819,7 +2822,7 @@ async fn a_publication_during_a_pass_never_costs_the_job_its_segments() {
 }
 
 #[tokio::test]
-async fn a_published_jobs_lease_expires_and_the_pass_removes_only_the_lease() {
+async fn a_published_jobs_group_slot_survives_gc() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -2882,8 +2885,8 @@ async fn a_published_jobs_lease_expires_and_the_pass_removes_only_the_lease() {
             .head(&lease_key)
             .await
             .expect("head the lease")
-            .is_none(),
-        "the expired lease of a published job is what the pass reclaims"
+            .is_some(),
+        "GC retains the group slot for replacement by CAS"
     );
     for key in &staged {
         assert!(
@@ -5077,4 +5080,108 @@ async fn stale_cursor_rebuilds_roots_before_resuming() {
         );
     }
     stat_root(&store, &namespace_id).await;
+}
+
+#[tokio::test]
+async fn output_protection_survives_a_new_group_owner() {
+    use loonfs_api::wire::control::{encode_control_state, CompactionLeaseStatus};
+    use loonfs_objectstore::keys::metadata_compaction_output_protection;
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace");
+    let job_id = test_metadata_compaction_id();
+    let (store, staged_key, _) =
+        namespace_with_staged_output(&temp_dir, &namespace_id, &job_id).await;
+    let now_ms = now_after_newest_object(
+        store.inner(),
+        &namespace_id,
+        METADATA_COMPACTION_STAGING_GRACE_MS + 1,
+    )
+    .await;
+    write_compaction_lease_in_state(
+        &store,
+        &namespace_id,
+        &job_id,
+        loonfs_api::MetadataFamilyGroup::Bindings,
+        now_ms + 10_000,
+        CompactionLeaseStatus::Completed {},
+    )
+    .await;
+    let completed = crate::checkpoint::load_group_lease(
+        &store,
+        &namespace_id,
+        loonfs_api::MetadataFamilyGroup::Bindings,
+    )
+    .await
+    .expect("group")
+    .expect("completed group");
+    let protection_key = metadata_compaction_output_protection(&namespace_id, &job_id);
+    store
+        .put_if_absent(
+            &protection_key,
+            Bytes::from(
+                encode_control_state(
+                    ControlObjectKind::CompactionOutputProtection,
+                    &loonfs_api::wire::control::CompactionOutputProtectionState {
+                        namespace_id: namespace_id.clone(),
+                        job_id: job_id.clone(),
+                        expires_at_ms: completed.state.expires_at_ms,
+                    },
+                )
+                .expect("encode protection"),
+            ),
+        )
+        .await
+        .expect("copy protection");
+    let next_job = loonfs_api::MetadataCompactionId::parse("cmp_abcdef0123456789abcdef0123456789")
+        .expect("next job");
+    write_compaction_lease(&store, &namespace_id, &next_job, now_ms + 20_000).await;
+
+    // This old collector's clock predates completion. A later group owner
+    // must not erase the protection it needs, however old the output is.
+    gc_namespace(&store, &namespace_id, &config(), &context(now_ms))
+        .await
+        .expect("old collector");
+    assert!(store
+        .head(&staged_key)
+        .await
+        .expect("protected output")
+        .is_some());
+    assert!(store
+        .head(&protection_key)
+        .await
+        .expect("protected lease")
+        .is_some());
+
+    // A later pass may remove unreferenced output. It leaves protection
+    // while that output exists, including while deciding this pass.
+    gc_namespace(&store, &namespace_id, &config(), &context(now_ms + 10_001))
+        .await
+        .expect("new collector");
+    assert!(store
+        .head(&staged_key)
+        .await
+        .expect("removed output")
+        .is_none());
+    assert!(store
+        .head(&protection_key)
+        .await
+        .expect("output protection")
+        .is_some());
+    gc_namespace(&store, &namespace_id, &config(), &context(now_ms + 10_001))
+        .await
+        .expect("empty prefix cleanup");
+    assert!(store
+        .head(&protection_key)
+        .await
+        .expect("removed output protection")
+        .is_none());
+    let group = crate::checkpoint::load_group_lease(
+        &store,
+        &namespace_id,
+        loonfs_api::MetadataFamilyGroup::Bindings,
+    )
+    .await
+    .expect("group")
+    .expect("new job remains");
+    assert_eq!(group.state.job_id, next_job);
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -200,7 +200,7 @@ impl BlockingControlCasTarget {
                 ) else {
                     return false;
                 };
-                matches!(envelope.state.status, CheckpointStatus::Released { .. })
+                matches!(envelope.payload().status, CheckpointStatus::Released { .. })
             }
             BlockingControlCasTarget::UploadCompleted | BlockingControlCasTarget::UploadAborted => {
                 let Ok(envelope) = decode_control_object::<UploadSessionState>(
@@ -211,12 +211,12 @@ impl BlockingControlCasTarget {
                 };
                 match self {
                     BlockingControlCasTarget::UploadCompleted => matches!(
-                        envelope.state.status,
+                        envelope.payload().status,
                         UploadSessionRecordStatus::Completed { .. }
                     ),
                     BlockingControlCasTarget::UploadAborted => {
                         matches!(
-                            envelope.state.status,
+                            envelope.payload().status,
                             UploadSessionRecordStatus::Aborted { .. }
                         )
                     }
@@ -409,13 +409,11 @@ async fn write_upload_session(store: &LocalFsStore, namespace_id: &NamespaceId) 
             expires_at_ms: 1_000 + UPLOAD_SESSION_LEASE_MS,
         },
     };
-    let envelope = loonfs_api::wire::control::UploadSessionEnvelope::from_state(
+    let bytes = loonfs_api::wire::control::encode_control_state(
         loonfs_api::wire::control::ControlObjectKind::UploadSession,
-        state,
+        &state,
     )
-    .expect("session envelope");
-    let bytes =
-        loonfs_api::wire::control::encode_control_object(&envelope).expect("encode session");
+    .expect("encode session");
     let key = loonfs_objectstore::keys::upload_session(namespace_id, &upload_id);
     store
         .put_if_absent(&key, bytes::Bytes::from(bytes))
@@ -462,7 +460,7 @@ async fn read_upload_session<S: ObjectStore + ?Sized>(
     Some(
         decode_control_object::<UploadSessionState>(&body, ControlObjectKind::UploadSession)
             .expect("decode upload session")
-            .state,
+            .into_payload(),
     )
 }
 
@@ -2158,7 +2156,7 @@ async fn an_old_unpublished_manifest_cannot_replace_the_published_grace_anchor()
         .await
         .expect("load current projection");
     let next_manifest_no = ManifestNo(projection.root.manifest.manifest_no.0 + 1);
-    let mut orphan = build_namespace_manifest_from_metadata_state(
+    let orphan = build_namespace_manifest_from_metadata_state(
         &inner,
         &namespace_id,
         ManifestMetadataSource {
@@ -2175,12 +2173,14 @@ async fn an_old_unpublished_manifest_cannot_replace_the_published_grace_anchor()
     )
     .await
     .expect("build unpublished manifest");
-    orphan.payload.manifest_object_id =
+    let mut orphan_payload = orphan.into_payload();
+    orphan_payload.manifest_object_id =
         ManifestObjectId::parse(format!("man_{:020}-0000000000000000", next_manifest_no.0))
             .expect("ordered orphan manifest id");
-    orphan = loonfs_api::wire::manifest::NamespaceManifestEnvelope::from_payload(orphan.payload)
-        .expect("re-envelope orphan manifest");
-    crate::checkpoint::write_namespace_manifest(&inner, &orphan)
+    let orphan = loonfs_api::wire::manifest::encode_namespace_manifest_json(orphan_payload)
+        .expect("re-envelope orphan manifest")
+        .into_envelope();
+    crate::checkpoint::write_namespace_manifest(&inner, orphan.payload().clone())
         .await
         .expect("write unpublished manifest");
 
@@ -2294,21 +2294,20 @@ async fn write_compaction_lease_in_state<S: ObjectStore + ?Sized>(
     expires_at_ms: u64,
     status: loonfs_api::wire::control::CompactionLeaseStatus,
 ) {
-    let envelope = loonfs_api::wire::control::MetadataCompactionLeaseEnvelope::from_state(
+    let envelope = loonfs_api::wire::control::MetadataCompactionLeaseState {
+        job_id: metadata_compaction_id.clone(),
+        namespace_id: namespace_id.clone(),
+        group,
+        writer_id: loonfs_api::WriterId::parse("writer").expect("writer id"),
+        status,
+        started_at_ms: 1_000,
+        expires_at_ms,
+    };
+    let bytes = loonfs_api::wire::control::encode_control_state(
         loonfs_api::wire::control::ControlObjectKind::CompactionLease,
-        loonfs_api::wire::control::MetadataCompactionLeaseState {
-            job_id: metadata_compaction_id.clone(),
-            namespace_id: namespace_id.clone(),
-            group,
-            writer_id: loonfs_api::WriterId::parse("writer").expect("writer id"),
-            status,
-            started_at_ms: 1_000,
-            expires_at_ms,
-        },
+        &envelope,
     )
-    .expect("build a lease");
-    let bytes =
-        loonfs_api::wire::control::encode_control_object(&envelope).expect("encode a lease");
+    .expect("encode a lease");
     store
         .put(
             &metadata_compaction_lease(namespace_id, group),
@@ -3158,7 +3157,7 @@ async fn assert_record_reaped_and_basis_kept(
     )
     .await
     .expect("the basis manifest survives its record");
-    for descriptor in basis.payload.runs.iter().flat_map(|run| &run.segments) {
+    for descriptor in basis.payload().runs.iter().flat_map(|run| &run.segments) {
         assert!(
             store
                 .head(&metadata_segment_object_key(descriptor))
@@ -4011,7 +4010,7 @@ async fn read_fork_record(store: &LocalFsStore, source: &NamespaceId) -> Checkpo
             ControlObjectKind::CheckpointRecord,
         )
         .expect("decode record")
-        .state;
+        .into_payload();
         if matches!(record.owner, CheckpointOwner::Fork { .. }) {
             return record;
         }
@@ -4136,17 +4135,19 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         ControlObjectKind::WalHead,
     )
     .expect("decode target head")
-    .state;
+    .into_payload();
     let basis = head.fork_basis.as_mut().expect("a fork target has a basis");
     basis.manifest.manifest_no = ManifestNo(basis.manifest.manifest_no.0 + 1);
-    let drifted =
-        loonfs_api::wire::control::HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head)
-            .expect("drifted head envelope");
+    let drifted = head;
     store
         .put_overwrite(
             &head_key,
             Bytes::from(
-                loonfs_api::wire::control::encode_control_object(&drifted).expect("encode head"),
+                loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &drifted,
+                )
+                .expect("encode head"),
             ),
         )
         .await

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -79,7 +79,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             writer_id: context.writer_id.clone(),
             acquired_at_ms: context.now_ms,
         }),
-        next_inode_id: source_manifest.payload.next_inode_id,
+        next_inode_id: source_manifest.payload().next_inode_id,
         visible_wal_tip: None,
         recent_segments: Vec::new(),
         status: NamespaceStatus::Active {},

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -189,8 +189,7 @@ mod tests {
     }
     use bytes::Bytes;
     use loonfs_api::wire::control::{
-        decode_control_object, encode_control_object, ControlObjectKind, HeadStateEnvelope,
-        NamespaceStatus,
+        decode_control_object, ControlObjectKind, HeadStateEnvelope, NamespaceStatus,
     };
     use loonfs_api::{ChangeSeq, CommitId, NamespaceId, MAX_PUBLIC_INTEGER};
     use loonfs_objectstore::keys::wal_head;
@@ -229,9 +228,9 @@ mod tests {
     }
 
     async fn write_head(store: &LocalFsStore, namespace_id: &NamespaceId, head: HeadState) {
-        let envelope =
-            HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
-        let bytes = encode_control_object(&envelope).expect("head bytes");
+        let bytes =
+            loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &head)
+                .expect("head bytes");
         store
             .put_if_absent(&wal_head(namespace_id), Bytes::from(bytes))
             .await
@@ -538,15 +537,17 @@ mod tests {
                 let envelope: HeadStateEnvelope =
                     decode_control_object(&body.bytes, ControlObjectKind::WalHead)
                         .expect("decode head");
-                let mut head = envelope.state;
+                let mut head = envelope.into_payload();
                 head.writer_epoch = WriterEpoch(head.writer_epoch.0 + 1);
                 head.writer = Some(WriterBlock {
                     writer_id: loonfs_api::WriterId::parse("writer-b").expect("writer id"),
                     acquired_at_ms: 1_500,
                 });
-                let next = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head)
-                    .expect("head envelope");
-                let bytes = encode_control_object(&next).expect("head bytes");
+                let bytes = loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &head,
+                )
+                .expect("head bytes");
                 inner
                     .put(&head_key, Bytes::from(bytes), PutMode::Overwrite)
                     .await
@@ -608,9 +609,11 @@ mod tests {
             let namespace_id = winner_namespace_id.clone();
             Box::pin(async move {
                 let winner = head_owned_by(&namespace_id, "writer-b", WriterEpoch(8));
-                let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, winner)
-                    .expect("head envelope");
-                let bytes = encode_control_object(&envelope).expect("head bytes");
+                let bytes = loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &winner,
+                )
+                .expect("head bytes");
                 inner
                     .put(
                         &wal_head(&namespace_id),

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -929,7 +929,7 @@ mod tests {
     use crate::namespace::control::load_head_object;
     use crate::path::write::{CommitRequest, FilesystemOperation};
     use bytes::Bytes;
-    use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
+    use loonfs_api::wire::control::ControlObjectKind;
     use loonfs_api::{AttributeRevisionNo, AttributeValue, CommitId, ErrorCode};
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -1020,12 +1020,17 @@ mod tests {
             .expect("load head")
             .state;
         head.next_inode_id = InodeId(head.next_inode_id.0 + 1);
-        let envelope =
-            HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
+        let envelope = head;
         store
             .put_overwrite(
                 &wal_head(&namespace_id),
-                Bytes::from(encode_control_object(&envelope).expect("encode head")),
+                Bytes::from(
+                    loonfs_api::wire::control::encode_control_state(
+                        ControlObjectKind::WalHead,
+                        &envelope,
+                    )
+                    .expect("encode head"),
+                ),
             )
             .await
             .expect("rewrite head");

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -239,7 +239,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         Err(error) => return abort_batch(slots, &error),
     };
 
-    let wal_records = wal.envelope.payload.records.clone();
+    let wal_records = wal.envelope().payload().records.clone();
     assert_eq!(
         slots
             .iter()
@@ -311,11 +311,11 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
         )
         .map_err(|error| CoreError::Internal(format!("wal build failed: {error}")))?;
         let object_key = wal_segment(
-            &wal.envelope.payload.namespace_id,
-            &wal.envelope.payload.segment_id,
+            &wal.envelope().payload().namespace_id,
+            &wal.envelope().payload().segment_id,
         );
         store
-            .put_immutable_verified(&object_key, Bytes::copy_from_slice(&wal.encoded_bytes))
+            .put_immutable_verified(&object_key, Bytes::copy_from_slice(wal.as_bytes()))
             .await
             .map_err(wal_immutable_write_error)?;
         Ok(wal)

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -2,17 +2,15 @@
 //! replay paths.
 
 use loonfs_api::wire::control::{HeadState, WalSegmentPointer};
-use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalSegmentEnvelope};
+use loonfs_api::wire::wal::{
+    WalCommitDelta, WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload,
+};
 use loonfs_api::{ChangeSeq, CommitId, NamespaceId, WriterEpoch};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct PreparedWalSegment {
-    pub envelope: WalSegmentEnvelope,
-    pub encoded_bytes: Vec<u8>,
-}
+pub(crate) type PreparedWalSegment = loonfs_api::wire::envelope::EncodedEnvelope<WalSegmentPayload>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum WalSegmentError {
@@ -70,7 +68,7 @@ pub(crate) struct WalChainLoadRequest<'a> {
     pub(crate) recent_segments: &'a [WalSegmentPointer],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ValidatedWalSegment {
     object_key: String,
     envelope: WalSegmentEnvelope,
@@ -106,7 +104,7 @@ impl ValidatedWalSegment {
     }
 
     pub(crate) fn records(&self) -> &[WalCommitPayload] {
-        &self.envelope.payload.records
+        &self.envelope.payload().records
     }
 
     pub(crate) fn pointer(&self) -> WalSegmentPointer {
@@ -114,10 +112,10 @@ impl ValidatedWalSegment {
     }
 
     pub(crate) fn decoded_records(&self) -> impl Iterator<Item = DecodedWalRecord<'_>> {
-        let namespace_id = &self.envelope.payload.namespace_id;
-        let writer_epoch = self.envelope.payload.writer_epoch;
+        let namespace_id = &self.envelope.payload().namespace_id;
+        let writer_epoch = self.envelope.payload().writer_epoch;
         self.envelope
-            .payload
+            .payload()
             .records
             .iter()
             .map(move |record| DecodedWalRecord {
@@ -134,7 +132,7 @@ impl ValidatedWalSegment {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ValidatedWalChain {
     segments: Vec<ValidatedWalSegment>,
 }

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -244,8 +244,8 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
             .map_err(|err| WalSegmentError::Codec(err.to_string()))?;
         validate_pointer_matches_envelope(&pointer, &object_key, &envelope)?;
 
-        let reached_stop = envelope.payload.base_head_seq <= stop_after_seq;
-        let prev = envelope.payload.prev_visible_segment.clone();
+        let reached_stop = envelope.payload().base_head_seq <= stop_after_seq;
+        let prev = envelope.payload().prev_visible_segment.clone();
         reversed.push(ValidatedWalSegment::new(object_key.clone(), envelope));
 
         if reached_stop {
@@ -275,14 +275,14 @@ fn finish_chain(
         return Ok(ValidatedWalChain::empty());
     };
     if let Some(after_seq) = request.stop_after_seq {
-        if first_segment.envelope().payload.base_head_seq > after_seq
-            || first_segment.envelope().payload.end_seq <= after_seq
+        if first_segment.envelope().payload().base_head_seq > after_seq
+            || first_segment.envelope().payload().end_seq <= after_seq
         {
             return Err(WalChainLoadError::CursorNotCovered { after_seq });
         }
     }
 
-    let mut expected_base_seq = first_segment.envelope().payload.base_head_seq;
+    let mut expected_base_seq = first_segment.envelope().payload().base_head_seq;
     if request.stop_after_seq.is_none() && expected_base_seq != request.chain_base_seq {
         return Err(WalChainLoadError::HeadSeqMismatch {
             expected: request.chain_base_seq,
@@ -295,7 +295,7 @@ fn finish_chain(
             expected_base_seq,
             segment.envelope(),
         )?;
-        expected_base_seq = segment.envelope().payload.end_seq;
+        expected_base_seq = segment.envelope().payload().end_seq;
     }
 
     if expected_base_seq != request.head_seq {

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -126,17 +126,17 @@ pub(super) fn validate_wal_segment_for_replay(
     expected_base_head_seq: ChangeSeq,
     envelope: &WalSegmentEnvelope,
 ) -> Result<(), WalSegmentError> {
-    if &envelope.payload.namespace_id != expected_namespace_id {
+    if &envelope.payload().namespace_id != expected_namespace_id {
         return Err(WalSegmentError::NamespaceMismatch {
             expected: expected_namespace_id.clone(),
-            actual: envelope.payload.namespace_id.clone(),
+            actual: envelope.payload().namespace_id.clone(),
         });
     }
 
-    if envelope.payload.base_head_seq != expected_base_head_seq {
+    if envelope.payload().base_head_seq != expected_base_head_seq {
         return Err(WalSegmentError::BaseHeadSeqMismatch {
             expected: expected_base_head_seq,
-            actual: envelope.payload.base_head_seq,
+            actual: envelope.payload().base_head_seq,
         });
     }
 
@@ -144,24 +144,25 @@ pub(super) fn validate_wal_segment_for_replay(
         .successor()
         .map_err(|_| WalSegmentError::SeqOverflow)?;
 
-    if envelope.payload.start_seq != expected_start {
+    if envelope.payload().start_seq != expected_start {
         return Err(WalSegmentError::NonContiguousSeq {
             expected: expected_start,
-            actual: envelope.payload.start_seq,
+            actual: envelope.payload().start_seq,
         });
     }
-    if envelope.payload.records.is_empty() {
+    if envelope.payload().records.is_empty() {
         return Err(WalSegmentError::EmptySegment);
     }
-    if envelope.payload.records.first().map(|record| record.seq) != Some(envelope.payload.start_seq)
-        || envelope.payload.records.last().map(|record| record.seq)
-            != Some(envelope.payload.end_seq)
+    if envelope.payload().records.first().map(|record| record.seq)
+        != Some(envelope.payload().start_seq)
+        || envelope.payload().records.last().map(|record| record.seq)
+            != Some(envelope.payload().end_seq)
     {
         return Err(WalSegmentError::SegmentSummaryMismatch);
     }
-    for (offset, record) in envelope.payload.records.iter().enumerate() {
+    for (offset, record) in envelope.payload().records.iter().enumerate() {
         let expected = envelope
-            .payload
+            .payload()
             .start_seq
             .0
             .checked_add(offset as u64)

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -10,7 +10,7 @@ use crate::commit::{
 };
 use bytes::Bytes;
 use loonfs_api::wire::control::WalSegmentPointer;
-use loonfs_api::wire::wal::{encode_wal_segment_envelope_zstd, WalSegmentEnvelope};
+use loonfs_api::wire::wal::{encode_wal_segment_envelope_zstd, WalSegmentPayload};
 use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey, NamespaceId, WalSegmentId, WriterEpoch};
 use loonfs_objectstore::keys::{wal_segment, wal_segment_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -66,7 +66,7 @@ async fn build_wal_record_payload_matches_segment_record_payload() {
     .expect("prepare wal segment");
     let payload = wal_payload_from_materialized_commit(&record);
 
-    assert_eq!(payload, segment.envelope.payload.records[0]);
+    assert_eq!(payload, segment.envelope().payload().records[0]);
 }
 
 #[tokio::test]
@@ -95,8 +95,8 @@ async fn prepared_wal_segments_use_unique_segment_ids_and_derived_object_keys() 
     )
     .expect("prepare second wal segment");
 
-    let first_id = &first.envelope.payload.segment_id;
-    let second_id = &second.envelope.payload.segment_id;
+    let first_id = &first.envelope().payload().segment_id;
+    let second_id = &second.envelope().payload().segment_id;
     assert_ne!(first_id, second_id);
     assert_ne!(prepared_segment_key(&first), prepared_segment_key(&second));
     WalSegmentId::parse(first_id.as_str()).expect("first segment id shape");
@@ -151,7 +151,7 @@ async fn validated_wal_chain_loads_visible_segments_in_ascending_order() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(1),
-            visible_tip: Some(segment.envelope.pointer()),
+            visible_tip: Some(segment.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &[],
@@ -188,8 +188,8 @@ fn canonical_replay_advances_head_and_applies_metadata_rows() {
     );
     base_head.writer_epoch = WriterEpoch(1);
     let record = segment
-        .envelope
-        .payload
+        .envelope()
+        .payload()
         .records
         .first()
         .expect("wal record");
@@ -201,7 +201,7 @@ fn canonical_replay_advances_head_and_applies_metadata_rows() {
         [DecodedWalRecord {
             namespace_id: &namespace_id,
             seq: record.seq,
-            writer_epoch: segment.envelope.payload.writer_epoch,
+            writer_epoch: segment.envelope().payload().writer_epoch,
             commit_id: &record.commit_id,
             committed_by: &record.committed_by,
             committed_at_ms: record.committed_at_ms,
@@ -249,8 +249,8 @@ fn canonical_replay_rejects_writer_epoch_above_expected_bound() {
     );
     base_head.writer_epoch = WriterEpoch(1);
     let record = segment
-        .envelope
-        .payload
+        .envelope()
+        .payload()
         .records
         .first()
         .expect("wal record");
@@ -262,7 +262,7 @@ fn canonical_replay_rejects_writer_epoch_above_expected_bound() {
         [DecodedWalRecord {
             namespace_id: &namespace_id,
             seq: record.seq,
-            writer_epoch: segment.envelope.payload.writer_epoch,
+            writer_epoch: segment.envelope().payload().writer_epoch,
             commit_id: &record.commit_id,
             committed_by: &record.committed_by,
             committed_at_ms: record.committed_at_ms,
@@ -300,7 +300,7 @@ async fn validated_wal_chain_can_load_cursor_suffix_without_full_base() {
     let second = write_create_directory_segment(
         &store,
         &namespace_id,
-        Some(first.envelope.pointer()),
+        Some(first.envelope().pointer()),
         "c_wal_suffix_b",
         "beta",
         ChangeSeq(1),
@@ -314,7 +314,7 @@ async fn validated_wal_chain_can_load_cursor_suffix_without_full_base() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(second.envelope.pointer()),
+            visible_tip: Some(second.envelope().pointer()),
             stop_after_seq: Some(ChangeSeq(1)),
             max_segment_fetches: None,
             recent_segments: &[],
@@ -349,7 +349,7 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(segment.envelope.pointer()),
+            visible_tip: Some(segment.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &[],
@@ -360,7 +360,7 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
 
     let message = error.to_string();
     assert!(
-        message.contains(segment.envelope.payload.segment_id.as_str()),
+        message.contains(segment.envelope().payload().segment_id.as_str()),
         "the error names the segment: {message}"
     );
     assert!(
@@ -371,55 +371,47 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
 
 #[tokio::test]
 async fn validated_wal_chain_rejects_corrupt_visible_segments() {
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        envelope.payload.namespace_id = NamespaceId::parse("other").expect("valid namespace id");
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        payload.namespace_id = NamespaceId::parse("other").expect("valid namespace id");
+        *pointer = pointer_for_payload(payload);
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, _pointer| {
-        envelope.payload.segment_id =
-            WalSegmentId::parse("wal_00000000000000000001-bbbbbbbbbbbbbbbb")
-                .expect("valid segment id");
-        rewrap_envelope(envelope);
+    assert_wal_chain_corruption_rejected(|payload, _pointer| {
+        payload.segment_id = WalSegmentId::parse("wal_00000000000000000001-bbbbbbbbbbbbbbbb")
+            .expect("valid segment id");
     })
     .await;
-    assert_wal_chain_corruption_rejected(|_envelope, pointer| {
+    assert_wal_chain_corruption_rejected(|_payload, pointer| {
         pointer.payload_checksum = "sha256:not-the-payload".to_owned();
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        envelope.payload.records.clear();
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        payload.records.clear();
+        *pointer = pointer_for_payload(payload);
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        envelope.payload.end_seq = ChangeSeq(2);
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        payload.end_seq = ChangeSeq(2);
+        *pointer = pointer_for_payload(payload);
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        let mut skipped = envelope.payload.records[0].clone();
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        let mut skipped = payload.records[0].clone();
         skipped.seq = ChangeSeq(3);
-        envelope.payload.records.push(skipped);
-        envelope.payload.end_seq = ChangeSeq(3);
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+        payload.records.push(skipped);
+        payload.end_seq = ChangeSeq(3);
+        *pointer = pointer_for_payload(payload);
     })
     .await;
-    assert_wal_chain_corruption_rejected(|envelope, pointer| {
-        envelope.payload.base_head_seq = ChangeSeq(1);
-        envelope.payload.start_seq = ChangeSeq(2);
-        envelope.payload.end_seq = ChangeSeq(2);
-        envelope.payload.records[0].seq = ChangeSeq(2);
+    assert_wal_chain_corruption_rejected(|payload, pointer| {
+        payload.base_head_seq = ChangeSeq(1);
+        payload.start_seq = ChangeSeq(2);
+        payload.end_seq = ChangeSeq(2);
+        payload.records[0].seq = ChangeSeq(2);
         // Keep the id consistent so this test reaches the chain validation.
-        envelope.payload.segment_id =
-            WalSegmentId::parse("wal_00000000000000000002-cccccccccccccccc")
-                .expect("valid segment id");
-        rewrap_envelope(envelope);
-        *pointer = envelope.pointer();
+        payload.segment_id = WalSegmentId::parse("wal_00000000000000000002-cccccccccccccccc")
+            .expect("valid segment id");
+        *pointer = pointer_for_payload(payload);
     })
     .await;
 }
@@ -455,8 +447,15 @@ fn materialized_create_directory(
     materialize_commit(plan, 4_200)
 }
 
+fn pointer_for_payload(payload: &WalSegmentPayload) -> WalSegmentPointer {
+    encode_wal_segment_envelope_zstd(payload.clone())
+        .expect("encode WAL pointer")
+        .envelope()
+        .pointer()
+}
+
 async fn assert_wal_chain_corruption_rejected(
-    corrupt: impl FnOnce(&mut WalSegmentEnvelope, &mut WalSegmentPointer),
+    corrupt: impl FnOnce(&mut WalSegmentPayload, &mut WalSegmentPointer),
 ) {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -474,12 +473,14 @@ async fn assert_wal_chain_corruption_rejected(
         )],
     )
     .expect("prepare wal segment");
-    let mut envelope = segment.envelope;
-    let mut pointer = envelope.pointer();
+    let mut pointer = segment.envelope().pointer();
+    let mut payload = segment.into_envelope().into_payload();
 
-    corrupt(&mut envelope, &mut pointer);
+    corrupt(&mut payload, &mut pointer);
 
-    let encoded = encode_wal_segment_envelope_zstd(&envelope).expect("encode corrupted envelope");
+    let encoded = encode_wal_segment_envelope_zstd(payload)
+        .expect("encode corrupted envelope")
+        .into_bytes();
     let object_key = wal_segment(&namespace_id, &pointer.segment_id);
     store
         .put_if_absent(&object_key, Bytes::from(encoded))
@@ -520,7 +521,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
     let second = write_create_directory_segment(
         &store,
         &namespace_id,
-        Some(first.envelope.pointer()),
+        Some(first.envelope().pointer()),
         "c_wal_hint_b",
         "beta",
         ChangeSeq(1),
@@ -533,7 +534,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(second.envelope.pointer()),
+            visible_tip: Some(second.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &[],
@@ -543,14 +544,14 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
     .expect("unhinted chain");
 
     // Accurate predecessor hints prefetch the gap together with the tip.
-    let accurate = [first.envelope.pointer()];
+    let accurate = [first.envelope().pointer()];
     let hinted = load_complete_wal_chain(
         &store,
         WalChainLoadRequest {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(second.envelope.pointer()),
+            visible_tip: Some(second.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &accurate,
@@ -562,7 +563,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
 
     // Garbage hints (missing objects, lying seq ranges) cost fallback
     // fetches, never correctness: chain links stay the authority.
-    let mut lying_tip = second.envelope.pointer();
+    let mut lying_tip = second.envelope().pointer();
     lying_tip.end_seq = ChangeSeq(999);
     let missing_segment_id =
         WalSegmentId::parse("wal_00000000000000000001-00000000deadbeef").expect("valid segment id");
@@ -581,7 +582,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(2),
-            visible_tip: Some(second.envelope.pointer()),
+            visible_tip: Some(second.envelope().pointer()),
             stop_after_seq: None,
             max_segment_fetches: None,
             recent_segments: &garbage,
@@ -611,7 +612,7 @@ async fn write_linked_chain(
             ChangeSeq(index + 1),
         )
         .await;
-        pointers.push(segment.envelope.pointer());
+        pointers.push(segment.envelope().pointer());
     }
     pointers
 }
@@ -855,7 +856,7 @@ async fn write_create_directory_segment(
     .expect("prepare wal segment");
     let object_key = prepared_segment_key(&segment);
     store
-        .put_if_absent(&object_key, Bytes::copy_from_slice(&segment.encoded_bytes))
+        .put_if_absent(&object_key, Bytes::copy_from_slice(segment.as_bytes()))
         .await
         .expect("write wal segment");
     segment
@@ -863,14 +864,9 @@ async fn write_create_directory_segment(
 
 fn prepared_segment_key(segment: &PreparedWalSegment) -> String {
     wal_segment(
-        &segment.envelope.payload.namespace_id,
-        &segment.envelope.payload.segment_id,
+        &segment.envelope().payload().namespace_id,
+        &segment.envelope().payload().segment_id,
     )
-}
-
-fn rewrap_envelope(envelope: &mut WalSegmentEnvelope) {
-    *envelope =
-        WalSegmentEnvelope::from_payload(envelope.payload.clone()).expect("rewrap wal envelope");
 }
 
 fn prepared_create_directory_segment(
@@ -901,7 +897,7 @@ fn prepared_create_directory_segment(
 fn prepared_unstored_chain(namespace_id: &NamespaceId, len: u64) -> Vec<PreparedWalSegment> {
     let mut chain: Vec<PreparedWalSegment> = Vec::new();
     for seq in 1..=len {
-        let prev = chain.last().map(|segment| segment.envelope.pointer());
+        let prev = chain.last().map(|segment| segment.envelope().pointer());
         chain.push(prepared_create_directory_segment(
             namespace_id,
             prev,
@@ -918,7 +914,7 @@ fn newest_first_pointers(chain: &[PreparedWalSegment]) -> Vec<WalSegmentPointer>
     chain
         .iter()
         .rev()
-        .map(|segment| segment.envelope.pointer())
+        .map(|segment| segment.envelope().pointer())
         .collect()
 }
 
@@ -926,7 +922,7 @@ async fn store_chain<S: ObjectStore + ?Sized>(store: &S, chain: &[PreparedWalSeg
     for segment in chain {
         let object_key = prepared_segment_key(segment);
         store
-            .put_if_absent(&object_key, Bytes::copy_from_slice(&segment.encoded_bytes))
+            .put_if_absent(&object_key, Bytes::copy_from_slice(segment.as_bytes()))
             .await
             .expect("write wal segment");
     }
@@ -1199,14 +1195,17 @@ async fn a_corrupt_segment_inside_the_hinted_set_is_still_rejected() {
     // Rewrite the middle segment's body at its own key: it decodes, but its
     // payload no longer matches the checksum its successor's chain link
     // recorded.
-    let mut tampered = chain[1].envelope.clone();
-    tampered.payload.records[0].committed_at_ms += 1;
-    rewrap_envelope(&mut tampered);
+    let mut tampered = chain[1].envelope().payload().clone();
+    tampered.records[0].committed_at_ms += 1;
     let tampered_key = prepared_segment_key(&chain[1]);
     store
         .put_overwrite(
             &tampered_key,
-            Bytes::from(encode_wal_segment_envelope_zstd(&tampered).expect("encode tampered")),
+            Bytes::from(
+                encode_wal_segment_envelope_zstd(tampered)
+                    .expect("encode tampered")
+                    .into_bytes(),
+            ),
         )
         .await
         .expect("overwrite middle wal segment");

--- a/crates/loonfs-core/src/wal/writer.rs
+++ b/crates/loonfs-core/src/wal/writer.rs
@@ -5,7 +5,7 @@ use super::{PreparedWalSegment, WalSegmentError};
 use crate::commit::{wal_payload_from_materialized_commit, MaterializedCommit};
 use loonfs_api::wire::control::WalSegmentPointer;
 use loonfs_api::wire::wal::{
-    encode_wal_segment_envelope_zstd, WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload,
+    encode_wal_segment_envelope_zstd, WalCommitPayload, WalSegmentPayload,
 };
 use loonfs_api::{ChangeSeq, NamespaceId, WalSegmentId, WriterEpoch};
 
@@ -72,12 +72,5 @@ pub(crate) fn prepare_wal_segment(
         end_seq,
         records: payload_records,
     };
-    let envelope = WalSegmentEnvelope::from_payload(payload)
-        .map_err(|err| WalSegmentError::Codec(err.to_string()))?;
-    let encoded_bytes = encode_wal_segment_envelope_zstd(&envelope)
-        .map_err(|err| WalSegmentError::Codec(err.to_string()))?;
-    Ok(PreparedWalSegment {
-        envelope,
-        encoded_bytes,
-    })
+    encode_wal_segment_envelope_zstd(payload).map_err(|err| WalSegmentError::Codec(err.to_string()))
 }

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -216,7 +216,7 @@ fn ack_lost_head_cas_store(
                 _ => return false,
             };
             decode_control_object::<HeadState>(bytes, ControlObjectKind::WalHead)
-                .is_ok_and(|envelope| envelope.state.seq > ChangeSeq(0))
+                .is_ok_and(|envelope| envelope.payload().seq > ChangeSeq(0))
         },
         InjectedError::Transport("response lost after head compare-and-swap".to_owned()),
     )
@@ -340,7 +340,7 @@ async fn head_cas_advances_seq(
         decode_control_object(&existing_bytes, ControlObjectKind::WalHead).map_err(|err| {
             ObjectStoreError::transport(key, format!("decode existing head: {err}"))
         })?;
-    Ok(candidate.state.seq > existing.state.seq)
+    Ok(candidate.payload().seq > existing.payload().seq)
 }
 
 #[tokio::test]
@@ -464,13 +464,13 @@ async fn batch_commit_writes_one_segment_and_expands_change_feed() {
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.start_seq, ChangeSeq(1));
-    assert_eq!(segment.payload.end_seq, ChangeSeq(2));
-    assert_eq!(segment.payload.records.len(), 2);
-    assert_eq!(segment.payload.records[0].deltas.len(), 2);
-    assert_eq!(segment.payload.records[0].deltas[0].semantic_op_index, 0);
-    assert_eq!(segment.payload.records[0].deltas[1].semantic_op_index, 0);
-    match &segment.payload.records[0].deltas[1].delta {
+    assert_eq!(segment.payload().start_seq, ChangeSeq(1));
+    assert_eq!(segment.payload().end_seq, ChangeSeq(2));
+    assert_eq!(segment.payload().records.len(), 2);
+    assert_eq!(segment.payload().records[0].deltas.len(), 2);
+    assert_eq!(segment.payload().records[0].deltas[0].semantic_op_index, 0);
+    assert_eq!(segment.payload().records[0].deltas[1].semantic_op_index, 0);
+    match &segment.payload().records[0].deltas[1].delta {
         WalDelta::BindDirentry {
             name_key,
             display_name,
@@ -658,11 +658,11 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
         .expect("visible wal exists");
     let visible_segment =
         decode_wal_segment_envelope_zstd(&visible_wal).expect("decode visible segment");
-    assert_eq!(visible_segment.payload.start_seq, ChangeSeq(1));
-    assert_eq!(visible_segment.payload.end_seq, ChangeSeq(1));
-    assert_eq!(visible_segment.payload.records.len(), 1);
+    assert_eq!(visible_segment.payload().start_seq, ChangeSeq(1));
+    assert_eq!(visible_segment.payload().end_seq, ChangeSeq(1));
+    assert_eq!(visible_segment.payload().records.len(), 1);
     assert_eq!(
-        visible_segment.payload.records[0].commit_id,
+        visible_segment.payload().records[0].commit_id,
         CommitId::parse("retry-after-orphan").expect("valid commit id")
     );
     let orphan_wal = store
@@ -672,7 +672,7 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
         .expect("orphan wal exists");
     let orphan_segment =
         decode_wal_segment_envelope_zstd(&orphan_wal).expect("decode orphan segment");
-    let visible_created_ids = visible_segment.payload.records[0]
+    let visible_created_ids = visible_segment.payload().records[0]
         .deltas
         .iter()
         .filter_map(|delta| match &delta.delta {
@@ -680,7 +680,7 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
             _ => None,
         })
         .collect::<Vec<_>>();
-    let orphan_created_ids = orphan_segment.payload.records[0]
+    let orphan_created_ids = orphan_segment.payload().records[0]
         .deltas
         .iter()
         .filter_map(|delta| match &delta.delta {
@@ -1159,7 +1159,7 @@ async fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.records.len(), 1);
+    assert_eq!(segment.payload().records.len(), 1);
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0))
         .await
@@ -1563,7 +1563,7 @@ async fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.records.len(), 1);
+    assert_eq!(segment.payload().records.len(), 1);
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0))
         .await

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -12,12 +12,10 @@ use crate::common::namespace_engine;
 use bytes::Bytes;
 use loonfs_api::{
     wire::control::{
-        decode_control_object, encode_control_object, CheckpointOwner, CheckpointStatus,
-        ControlObjectKind, HeadState, HeadStateEnvelope,
+        decode_control_object, CheckpointOwner, CheckpointStatus, ControlObjectKind, HeadState,
     },
     wire::manifest::{
         decode_namespace_manifest_json, encode_namespace_manifest_json, MetadataRowFamily,
-        NamespaceManifestEnvelope,
     },
     AbsolutePath, ChangeSeq, CommitId, DestinationBehavior, ManifestNo, NamespaceId,
 };
@@ -545,7 +543,7 @@ async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
         decode_namespace_manifest_json(&clone_manifest_bytes).expect("decode clone manifest");
     assert!(
         clone_manifest
-            .payload
+            .payload()
             .runs
             .iter()
             .flat_map(|run| &run.segments)
@@ -648,12 +646,17 @@ async fn a_fork_basis_checksum_mismatch_is_corruption() {
     let fork_basis = head.fork_basis.as_mut().expect("fork basis");
     fork_basis.manifest.manifest_payload_checksum =
         loonfs_api::sha256_digest(b"not-the-source-manifest-payload");
-    let envelope =
-        HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
+    let envelope = head;
     store
         .put_overwrite(
             &wal_head(&clone),
-            Bytes::from(encode_control_object(&envelope).expect("encode head")),
+            Bytes::from(
+                loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &envelope,
+                )
+                .expect("encode head"),
+            ),
         )
         .await
         .expect("rewrite clone head");
@@ -802,15 +805,19 @@ async fn fork_namespace_rejects_corrupt_source_manifest_descriptors() {
         .await
         .expect("read source manifest")
         .expect("source manifest exists");
-    let mut manifest =
-        decode_namespace_manifest_json(&manifest_bytes).expect("decode source manifest");
-    manifest.payload.runs.iter_mut().for_each(|run| {
+    let mut manifest = decode_namespace_manifest_json(&manifest_bytes)
+        .expect("decode source manifest")
+        .into_payload();
+    manifest.runs.iter_mut().for_each(|run| {
         run.segments
             .retain(|descriptor| descriptor.family != MetadataRowFamily::DirentryChildBinds);
     });
-    let manifest = NamespaceManifestEnvelope::from_payload(manifest.payload)
-        .expect("rebuild manifest checksum");
-    let corrupted = encode_namespace_manifest_json(&manifest).expect("encode corrupt manifest");
+    let manifest = loonfs_api::wire::manifest::encode_namespace_manifest_json(manifest)
+        .expect("rebuild manifest checksum")
+        .into_envelope();
+    let corrupted = encode_namespace_manifest_json(manifest.payload().clone())
+        .expect("encode corrupt manifest")
+        .into_bytes();
     store
         .put_overwrite(&manifest_key, Bytes::from(corrupted))
         .await
@@ -874,11 +881,9 @@ async fn a_create_losing_to_a_foreign_head_reports_the_id_as_taken() {
         loonfs_api::ContentStoreId::generate(),
         1_000,
     );
-    let foreign_bytes = encode_control_object(
-        &HeadStateEnvelope::from_state(ControlObjectKind::WalHead, foreign)
-            .expect("foreign head envelope"),
-    )
-    .expect("encode foreign head");
+    let foreign_bytes =
+        loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &foreign)
+            .expect("encode foreign head");
     let store = InjectCreateFailureStore::new(
         inner,
         KeyMatcher::Exact(wal_head(&namespace_id)),
@@ -1083,19 +1088,21 @@ impl ReleasePinBeforeRenewalStore {
             ControlObjectKind::CheckpointRecord,
         )
         .expect("decode record")
-        .state;
+        .into_payload();
         record.status = CheckpointStatus::Released {
             released_at_ms: 2_000,
         };
-        let released = loonfs_api::wire::control::CheckpointRecordEnvelope::from_state(
-            ControlObjectKind::CheckpointRecord,
-            record,
-        )
-        .expect("released record envelope");
+        let released = record;
         self.inner
             .put_overwrite(
                 key,
-                Bytes::from(encode_control_object(&released).expect("encode record")),
+                Bytes::from(
+                    loonfs_api::wire::control::encode_control_state(
+                        ControlObjectKind::CheckpointRecord,
+                        &released,
+                    )
+                    .expect("encode record"),
+                ),
             )
             .await
             .expect("release record");

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -1082,12 +1082,12 @@ async fn name_key_stays_typed_through_planning_and_fingerprint() {
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.records.len(), 1);
+    assert_eq!(segment.payload().records.len(), 1);
     assert_eq!(
-        segment.payload.records[0].semantic_commit_fingerprint,
+        segment.payload().records[0].semantic_commit_fingerprint,
         expected_fingerprint
     );
-    assert!(segment.payload.records[0]
+    assert!(segment.payload().records[0]
         .deltas
         .iter()
         .any(|delta| matches!(
@@ -1173,7 +1173,7 @@ async fn path_intents_in_one_batch_see_tentative_state_and_continue_the_seq_ladd
         .expect("read wal")
         .expect("wal exists");
     let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
-    assert_eq!(segment.payload.records.len(), 2);
+    assert_eq!(segment.payload().records.len(), 2);
 
     let copied = copy_file_path(
         &store,

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -525,7 +525,7 @@ mod direct_multipart {
             .expect("session exists");
         decode_control_object::<UploadSessionState>(&bytes, ControlObjectKind::UploadSession)
             .expect("decode session")
-            .state
+            .into_payload()
     }
 
     /// Uploads every part, the way a client would after asking for the

--- a/crates/loonfs-grep/src/root/codec.rs
+++ b/crates/loonfs-grep/src/root/codec.rs
@@ -1,14 +1,9 @@
-//! Grep's two durable families, parameterized over the shared envelope codec.
-//!
-//! Grep owns its kinds, its versions, and its payload invariants; the probe,
-//! the checksum rules, and the failure vocabulary are the ones every other
-//! LoonFS durable family reads and writes through.
+//! Grep's durable families share framing and checksum rules with the filesystem.
 
 use super::error::GrepEnvelopeCodecError;
 use super::state::{GrepManifestState, GrepRootPointer};
 use loonfs_api::wire::envelope::{
-    decode_json_envelope, encode_json_envelope, json_payload_checksum, verify_kind,
-    DecodedJsonEnvelope,
+    decode_json_envelope, encode_json_envelope, verify_kind, EncodedEnvelope, VerifiedEnvelope,
 };
 
 /// Durable kind string for a grep root-pointer envelope.
@@ -21,126 +16,51 @@ pub const GREP_ROOT_FORMAT_VERSION: u32 = 1;
 pub const GREP_MANIFEST_FORMAT_VERSION: u32 = 1;
 
 /// Verified in-memory representation of one grep root-pointer envelope.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GrepRootEnvelope {
-    format_version: u32,
-    payload_checksum: String,
-    pointer: GrepRootPointer,
-}
-
-impl GrepRootEnvelope {
-    /// Builds a fresh root-pointer envelope over its canonical payload bytes.
-    pub fn from_pointer(pointer: GrepRootPointer) -> Result<Self, GrepEnvelopeCodecError> {
-        Ok(Self {
-            format_version: GREP_ROOT_FORMAT_VERSION,
-            payload_checksum: json_payload_checksum(&pointer)?,
-            pointer,
-        })
-    }
-
-    pub fn format_version(&self) -> u32 {
-        self.format_version
-    }
-
-    pub fn payload_checksum(&self) -> &str {
-        &self.payload_checksum
-    }
-
-    pub fn pointer(&self) -> &GrepRootPointer {
-        &self.pointer
-    }
-}
-
+pub type GrepRootEnvelope = VerifiedEnvelope<GrepRootPointer>;
 /// Verified in-memory representation of one immutable grep manifest.
-///
-/// The envelope describes the bytes and nothing about which object holds
-/// them: a manifest's identity is the key it was written under, which the
-/// root pointer names.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GrepManifestEnvelope {
-    format_version: u32,
-    payload_checksum: String,
-    state: GrepManifestState,
-}
+/// Its identity is the key named by the root pointer.
+pub type GrepManifestEnvelope = VerifiedEnvelope<GrepManifestState>;
 
-impl GrepManifestEnvelope {
-    /// Builds a manifest envelope over its canonical payload bytes.
-    pub fn from_state(state: GrepManifestState) -> Result<Self, GrepEnvelopeCodecError> {
-        state.validate()?;
-        Ok(Self {
-            format_version: GREP_MANIFEST_FORMAT_VERSION,
-            payload_checksum: json_payload_checksum(&state)?,
-            state,
-        })
-    }
-
-    pub fn format_version(&self) -> u32 {
-        self.format_version
-    }
-
-    pub fn payload_checksum(&self) -> &str {
-        &self.payload_checksum
-    }
-
-    pub fn manifest_state(&self) -> &GrepManifestState {
-        &self.state
-    }
-}
-
-/// Encodes a root pointer after rechecking its version and checksum.
-pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepEnvelopeCodecError> {
+/// Encodes a root pointer and derives its framing from the exact payload bytes.
+pub fn encode_grep_root(
+    pointer: GrepRootPointer,
+) -> Result<EncodedEnvelope<GrepRootPointer>, GrepEnvelopeCodecError> {
     Ok(encode_json_envelope(
         GREP_ROOT_KIND,
-        envelope.format_version,
         GREP_ROOT_FORMAT_VERSION,
-        &envelope.payload_checksum,
-        &envelope.pointer,
+        pointer,
     )?)
 }
 
 /// Decodes only the current root-pointer format and verifies exact payload bytes.
-///
-/// The pointer is a mutable control object, so unknown envelope and payload
-/// fields are corruption: a tolerant read followed by the publication rewrite
-/// would erase what this binary does not understand.
+/// Unknown fields are rejected because publication writes successor pointers.
 pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepEnvelopeCodecError> {
-    let decoded: DecodedJsonEnvelope<GrepRootPointer> =
-        decode_json_envelope(bytes, GREP_ROOT_FORMAT_VERSION, |found| {
-            verify_kind(GREP_ROOT_KIND, found)
-        })?;
-    Ok(GrepRootEnvelope {
-        format_version: decoded.format_version,
-        payload_checksum: decoded.payload_checksum,
-        pointer: decoded.payload,
-    })
+    Ok(decode_json_envelope(
+        bytes,
+        GREP_ROOT_FORMAT_VERSION,
+        |found| verify_kind(GREP_ROOT_KIND, found),
+    )?)
 }
 
-/// Encodes an immutable manifest after rechecking every boundary invariant.
+/// Validates a manifest and derives framing from one payload encoding.
 pub fn encode_grep_manifest(
-    envelope: &GrepManifestEnvelope,
-) -> Result<Vec<u8>, GrepEnvelopeCodecError> {
-    envelope.state.validate()?;
+    state: GrepManifestState,
+) -> Result<EncodedEnvelope<GrepManifestState>, GrepEnvelopeCodecError> {
+    state.validate()?;
     Ok(encode_json_envelope(
         GREP_MANIFEST_KIND,
-        envelope.format_version,
         GREP_MANIFEST_FORMAT_VERSION,
-        &envelope.payload_checksum,
-        &envelope.state,
+        state,
     )?)
 }
 
 /// Decodes only the current manifest format and verifies it.
-///
-/// Unknown fields are rejected because indexing and compaction write successor manifests.
+/// Unknown fields are rejected because indexing and compaction write successors.
 pub fn decode_grep_manifest(bytes: &[u8]) -> Result<GrepManifestEnvelope, GrepEnvelopeCodecError> {
-    let decoded: DecodedJsonEnvelope<GrepManifestState> =
+    let decoded: GrepManifestEnvelope =
         decode_json_envelope(bytes, GREP_MANIFEST_FORMAT_VERSION, |found| {
             verify_kind(GREP_MANIFEST_KIND, found)
         })?;
-    decoded.payload.validate()?;
-    Ok(GrepManifestEnvelope {
-        format_version: decoded.format_version,
-        payload_checksum: decoded.payload_checksum,
-        state: decoded.payload,
-    })
+    decoded.payload().validate()?;
+    Ok(decoded)
 }

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -35,7 +35,7 @@ impl LoadedGrepRootPointer {
     }
 
     pub fn pointer(&self) -> &GrepRootPointer {
-        self.envelope.pointer()
+        self.envelope.payload()
     }
 
     pub fn etag(&self) -> &str {
@@ -69,7 +69,7 @@ impl LoadedGrepRoot {
     }
 
     pub fn manifest_state(&self) -> &GrepManifestState {
-        self.manifest.manifest_state()
+        self.manifest.payload()
     }
 }
 
@@ -88,11 +88,11 @@ pub async fn load_grep_root_pointer<S: ObjectStore + ?Sized>(
     };
     let etag = required_etag(&object_key, body.metadata.etag)?;
     let envelope = decode_grep_root(&body.bytes).map_err(|error| corrupt(&object_key, error))?;
-    if envelope.pointer().namespace_id() != namespace_id {
+    if envelope.payload().namespace_id() != namespace_id {
         return Err(GrepRootError::IdentityMismatch {
             object_key,
             expected: namespace_id.clone(),
-            actual: envelope.pointer().namespace_id().clone(),
+            actual: envelope.payload().namespace_id().clone(),
         });
     }
     Ok(Some(LoadedGrepRootPointer {
@@ -132,11 +132,11 @@ pub async fn load_grep_manifest<S: ObjectStore + ?Sized>(
             ),
         });
     }
-    if envelope.manifest_state().namespace_id() != namespace_id {
+    if envelope.payload().namespace_id() != namespace_id {
         return Err(GrepRootError::IdentityMismatch {
             object_key,
             expected: namespace_id.clone(),
-            actual: envelope.manifest_state().namespace_id().clone(),
+            actual: envelope.payload().namespace_id().clone(),
         });
     }
     Ok(Some(envelope))
@@ -170,13 +170,13 @@ pub async fn seed_grep_root<S: ObjectStore + ?Sized>(
     let written = write_grep_manifest(store, state).await?;
     let manifest = written.envelope;
     let object_key = root_key(state.namespace_id());
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let (envelope, bytes) = encode_grep_root(GrepRootPointer::new(
         state.namespace_id().clone(),
         written.manifest_object_id,
         manifest.payload_checksum().to_owned(),
     ))
-    .map_err(|error| corrupt(&object_key, error))?;
-    let bytes = encode_grep_root(&envelope).map_err(|error| corrupt(&object_key, error))?;
+    .map_err(|error| corrupt(&object_key, error))?
+    .into_parts();
     let metadata = match store
         .put(&object_key, Bytes::from(bytes), PutMode::CreateIfAbsent)
         .await
@@ -222,14 +222,13 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
         });
     }
     let written = write_grep_manifest(store, next).await?;
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let (envelope, bytes) = encode_grep_root(GrepRootPointer::new(
         next.namespace_id().clone(),
         written.manifest_object_id,
         written.envelope.payload_checksum().to_owned(),
     ))
-    .map_err(|error| corrupt(&current.pointer.object_key, error))?;
-    let bytes =
-        encode_grep_root(&envelope).map_err(|error| corrupt(&current.pointer.object_key, error))?;
+    .map_err(|error| corrupt(&current.pointer.object_key, error))?
+    .into_parts();
     let metadata = match store
         .put(
             &current.pointer.object_key,
@@ -274,12 +273,12 @@ async fn write_grep_manifest<S: ObjectStore + ?Sized>(
     store: &S,
     state: &GrepManifestState,
 ) -> Result<WrittenGrepManifest> {
-    let envelope = GrepManifestEnvelope::from_state(state.clone())
-        .map_err(|error| corrupt(&root_key(state.namespace_id()), error))?;
     let manifest_object_id = GrepManifestObjectId::generate();
     let object_key = manifest_key(state.namespace_id(), &manifest_object_id);
-    let bytes =
-        Bytes::from(encode_grep_manifest(&envelope).map_err(|error| corrupt(&object_key, error))?);
+    let (envelope, bytes) = encode_grep_manifest(state.clone())
+        .map_err(|error| corrupt(&object_key, error))?
+        .into_parts();
+    let bytes = Bytes::from(bytes);
     // Create-only plus the byte check stay on this write even though a
     // random id cannot collide: an occupied key here is corruption, and it
     // must fail loudly rather than be overwritten.

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -116,11 +116,11 @@ impl GrepService {
                             manifest_key(namespace_id, manifest_object_id)
                         ),
                     })?;
-                let state = Arc::new(manifest.manifest_state().clone());
+                let state = Arc::new(manifest.payload().clone());
                 // As with the metadata manifest cache, JSON-backed decoded
                 // state is weighted at twice its canonical payload bytes to
                 // cover both owned strings and decoded structure overhead.
-                let decoded_bytes = serde_json::to_vec(manifest.manifest_state())
+                let decoded_bytes = serde_json::to_vec(manifest.payload())
                     .map_err(|error| {
                         CoreError::Internal(format!(
                             "failed to size decoded grep manifest `{}`: {error}",

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -206,7 +206,7 @@ pub(crate) mod control {
             .expect("namespace head exists");
         decode_control_object::<HeadState>(&bytes, ControlObjectKind::WalHead)
             .expect("decode namespace head")
-            .state
+            .into_payload()
     }
 
     pub(crate) async fn metadata_root(
@@ -218,7 +218,7 @@ pub(crate) mod control {
             .expect("metadata root exists");
         decode_control_object::<MetadataRootState>(&bytes, ControlObjectKind::MetadataRoot)
             .expect("decode metadata root")
-            .state
+            .into_payload()
     }
 
     pub(crate) async fn checkpoint_record(
@@ -234,7 +234,7 @@ pub(crate) mod control {
                 ControlObjectKind::CheckpointRecord,
             )
             .expect("decode checkpoint record")
-            .state,
+            .into_payload(),
         )
     }
 }

--- a/crates/loonfs-grep/tests/it/golden_formats.rs
+++ b/crates/loonfs-grep/tests/it/golden_formats.rs
@@ -28,8 +28,8 @@ use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, InodeId, RevisionNo, R
 use loonfs_grep::codec::{Gram, GramPosting, IndexRow};
 use loonfs_grep::root::{
     decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root, GrepIndexState,
-    GrepIndexStatus, GrepManifestEnvelope, GrepManifestObjectId, GrepManifestState,
-    GrepReorganizeState, GrepRootEnvelope, GrepRootPointer, GrepSegmentRef,
+    GrepIndexStatus, GrepManifestObjectId, GrepManifestState, GrepReorganizeState, GrepRootPointer,
+    GrepSegmentRef,
 };
 use loonfs_test_support::ids::namespace_id;
 use std::path::{Path, PathBuf};
@@ -186,8 +186,9 @@ pub(crate) fn sample_disabled_manifest() -> GrepManifestState {
 /// [`ACTIVE_MANIFEST_FIXTURE`] pins. Its digest is that manifest envelope's
 /// own `payload_checksum`.
 fn sample_root_pointer() -> GrepRootPointer {
-    let manifest = GrepManifestEnvelope::from_state(sample_active_manifest(ChangeSeq(11), 5))
-        .expect("build a grep manifest envelope");
+    let manifest = encode_grep_manifest(sample_active_manifest(ChangeSeq(11), 5))
+        .expect("manifest")
+        .into_envelope();
     GrepRootPointer::new(
         namespace_id("docs"),
         GrepManifestObjectId::parse(ACTIVE_MANIFEST_OBJECT_ID).expect("valid manifest object id"),
@@ -297,29 +298,33 @@ fn decode_golden_data_block(name: &str) -> DecodedDataBlock<IndexRow> {
 // ---------------------------------------------------------------------------
 
 fn assert_manifest_matches_golden(fixture: &str, state: GrepManifestState) {
-    let envelope = GrepManifestEnvelope::from_state(state).expect("build a grep manifest envelope");
-    let encoded = encode_grep_manifest(&envelope).expect("encode a grep manifest");
+    let encoded = encode_grep_manifest(state)
+        .expect("build a grep manifest envelope")
+        .into_bytes();
     assert_matches_golden(fixture, &encoded);
 }
 
 fn assert_manifest_golden_decodes(fixture: &str, state: GrepManifestState) {
-    let expected = GrepManifestEnvelope::from_state(state).expect("build a grep manifest envelope");
+    let expected = encode_grep_manifest(state)
+        .expect("build a grep manifest envelope")
+        .into_envelope();
     let decoded = decode_grep_manifest(&read_golden(fixture)).expect("decode the golden manifest");
     assert_eq!(decoded, expected);
 }
 
 #[test]
 fn grep_root_matches_golden_bytes() {
-    let envelope =
-        GrepRootEnvelope::from_pointer(sample_root_pointer()).expect("build a grep root envelope");
-    let encoded = encode_grep_root(&envelope).expect("encode a grep root pointer");
+    let encoded = encode_grep_root(sample_root_pointer())
+        .expect("build a grep root envelope")
+        .into_bytes();
     assert_matches_golden(ROOT_POINTER_FIXTURE, &encoded);
 }
 
 #[test]
 fn grep_root_golden_decodes_to_sample() {
-    let expected =
-        GrepRootEnvelope::from_pointer(sample_root_pointer()).expect("build a grep root envelope");
+    let expected = encode_grep_root(sample_root_pointer())
+        .expect("build a grep root envelope")
+        .into_envelope();
     let decoded =
         decode_grep_root(&read_golden(ROOT_POINTER_FIXTURE)).expect("decode the golden pointer");
     assert_eq!(decoded, expected);
@@ -333,7 +338,7 @@ fn grep_root_golden_carries_the_manifest_golden_checksum() {
         .expect("decode the golden manifest");
 
     assert_eq!(
-        pointer.pointer().manifest_payload_checksum(),
+        pointer.payload().manifest_payload_checksum(),
         manifest.payload_checksum()
     );
 }

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -20,7 +20,7 @@ use loonfs_grep::keyspace::{
 };
 use loonfs_grep::root::{
     advance_grep_root, encode_grep_root, load_grep_root, GrepIndexState, GrepIndexStatus,
-    GrepManifestObjectId, GrepManifestState, GrepRootEnvelope, GrepRootPointer,
+    GrepManifestObjectId, GrepManifestState, GrepRootPointer,
 };
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepGcOptions, GrepGcReport,
@@ -887,16 +887,16 @@ async fn an_expired_but_unreleased_backfill_pin_keeps_enumerating() {
         panic!("the backfill pin is user-owned");
     };
     *expires_at_ms = Some(record.created_at_ms);
-    let expired = loonfs_api::wire::control::CheckpointRecordEnvelope::from_state(
-        loonfs_api::wire::control::ControlObjectKind::CheckpointRecord,
-        record,
-    )
-    .expect("expired record envelope");
+    let expired = record;
     store
         .put_overwrite(
             &key,
             Bytes::from(
-                loonfs_api::wire::control::encode_control_object(&expired).expect("encode record"),
+                loonfs_api::wire::control::encode_control_state(
+                    loonfs_api::wire::control::ControlObjectKind::CheckpointRecord,
+                    &expired,
+                )
+                .expect("encode record"),
             ),
         )
         .await
@@ -1582,16 +1582,21 @@ async fn write_pointer(
     manifest_object_id: GrepManifestObjectId,
     manifest_payload_checksum: String,
 ) {
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let envelope = encode_grep_root(GrepRootPointer::new(
         namespace_id.clone(),
         manifest_object_id,
         manifest_payload_checksum,
     ))
-    .expect("build pointer");
+    .expect("build pointer")
+    .into_envelope();
     store
         .put_overwrite(
             &root_key(namespace_id),
-            Bytes::from(encode_grep_root(&envelope).expect("encode pointer")),
+            Bytes::from(
+                encode_grep_root(envelope.payload().clone())
+                    .expect("encode pointer")
+                    .into_bytes(),
+            ),
         )
         .await
         .expect("write pointer");

--- a/crates/loonfs-grep/tests/it/root_format.rs
+++ b/crates/loonfs-grep/tests/it/root_format.rs
@@ -16,8 +16,8 @@ use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::{ChangeSeq, RunNo};
 use loonfs_grep::root::{
     decode_grep_manifest, decode_grep_root, encode_grep_manifest, GrepEnvelopeCodecError,
-    GrepIndexState, GrepIndexStatus, GrepManifestEnvelope, GrepManifestState,
-    GrepManifestStateError, GrepReorganizeState,
+    GrepIndexState, GrepIndexStatus, GrepManifestState, GrepManifestStateError,
+    GrepReorganizeState,
 };
 use loonfs_test_support::ids::namespace_id;
 
@@ -55,10 +55,9 @@ fn every_status_round_trips_carrying_only_its_own_position() {
         (sample_active_manifest(ChangeSeq(11), 0), "target_seq"),
         (sample_disabled_manifest(), "built_through_seq"),
     ] {
-        let encoded = encode_grep_manifest(
-            &GrepManifestEnvelope::from_state(state.clone()).expect("build manifest envelope"),
-        )
-        .expect("encode grep manifest");
+        let encoded = encode_grep_manifest(state.clone())
+            .expect("encode grep manifest")
+            .into_bytes();
         assert!(
             !String::from_utf8(encoded.clone())
                 .expect("manifest JSON is UTF-8")
@@ -69,7 +68,7 @@ fn every_status_round_trips_carrying_only_its_own_position() {
         assert_eq!(
             decode_grep_manifest(&encoded)
                 .expect("decode grep manifest")
-                .manifest_state(),
+                .payload(),
             &state
         );
     }

--- a/crates/loonfs-grep/tests/it/root_store.rs
+++ b/crates/loonfs-grep/tests/it/root_store.rs
@@ -8,8 +8,8 @@ use loonfs_api::{ChangeSeq, NamespaceId, RunNo};
 use loonfs_grep::keyspace::{manifest_key, manifests_prefix, root_key};
 use loonfs_grep::root::{
     advance_grep_root, encode_grep_manifest, encode_grep_root, load_grep_root, seed_grep_root,
-    GrepIndexState, GrepIndexStatus, GrepManifestEnvelope, GrepManifestObjectId, GrepManifestState,
-    GrepRootEnvelope, GrepRootError, GrepRootPointer,
+    GrepIndexState, GrepIndexStatus, GrepManifestObjectId, GrepManifestState, GrepRootError,
+    GrepRootPointer,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectStore, PutMode};
@@ -22,9 +22,10 @@ async fn load_rejects_namespace_identity_mismatch() {
     let store = LocalFsStore::new(temp_dir.path()).expect("local store");
     let requested = namespace_id("requested");
     let wrong = root(namespace_id("other"), ChangeSeq(0));
-    let manifest = GrepManifestEnvelope::from_state(wrong).expect("manifest envelope");
     let manifest_object_id = GrepManifestObjectId::generate();
-    let manifest_bytes = encode_grep_manifest(&manifest).expect("encode manifest");
+    let (manifest, manifest_bytes) = encode_grep_manifest(wrong)
+        .expect("encode manifest")
+        .into_parts();
     store
         .put(
             &manifest_key(&requested, &manifest_object_id),
@@ -33,13 +34,13 @@ async fn load_rejects_namespace_identity_mismatch() {
         )
         .await
         .expect("write mismatched manifest");
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let bytes = encode_grep_root(GrepRootPointer::new(
         requested.clone(),
         manifest_object_id,
         manifest.payload_checksum().to_owned(),
     ))
-    .expect("pointer envelope");
-    let bytes = encode_grep_root(&envelope).expect("encode pointer");
+    .expect("pointer envelope")
+    .into_bytes();
     let key = root_key(&requested);
     store
         .put(&key, Bytes::from(bytes), PutMode::CreateIfAbsent)
@@ -125,8 +126,9 @@ async fn identical_state_publishes_a_fresh_manifest_object() {
             .await
             .expect("read a published manifest")
             .expect("a published manifest is durable at the key the pointer names");
-        let expected =
-            encode_grep_manifest(published.manifest_envelope()).expect("encode manifest");
+        let expected = encode_grep_manifest(published.manifest_envelope().payload().clone())
+            .expect("encode manifest")
+            .into_bytes();
         assert_eq!(
             stored,
             Bytes::from(expected),

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -109,6 +109,14 @@ pub fn metadata_compaction_lease(namespace_id: &NamespaceId, group: MetadataFami
     format!("namespaces/{namespace_id}/metadata/compaction_leases/{group}.json")
 }
 
+/// Builds the publication-protection key beside one job's sealed output.
+pub fn metadata_compaction_output_protection(
+    namespace_id: &NamespaceId,
+    job_id: &MetadataCompactionId,
+) -> String {
+    format!("namespaces/{namespace_id}/metadata/compactions/{job_id}/protection.json")
+}
+
 /// Extracts the family group from a current-format compaction lease key.
 pub fn metadata_compaction_lease_group_from_key(key: &str) -> Option<MetadataFamilyGroup> {
     parse_metadata_compaction_lease_group(key)
@@ -156,7 +164,8 @@ pub fn content_blob(content_store_id: &ContentStoreId, content_id: &ContentId) -
 #[cfg(test)]
 mod tests {
     use super::{
-        checkpoint_record, content_blob, metadata_compaction_lease, metadata_compaction_prefix,
+        checkpoint_record, content_blob, metadata_compaction_lease,
+        metadata_compaction_output_protection, metadata_compaction_prefix,
         metadata_compaction_segment, metadata_manifest_object, metadata_root, metadata_segment,
         metadata_segment_object_key, upload_session, wal_floor, wal_head, wal_segment,
         wal_segment_id_from_key, wal_segment_prefix,
@@ -297,6 +306,10 @@ mod tests {
             (
                 "Compaction leases",
                 metadata_compaction_lease(&namespace_id(), MetadataFamilyGroup::Bindings),
+            ),
+            (
+                "Compaction output protection",
+                metadata_compaction_output_protection(&namespace_id(), &metadata_compaction_id()),
             ),
             (
                 "Upload sessions",

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -23,6 +23,8 @@ pub enum DurableObjectFamily {
     MetadataCompactionStaging,
     /// Classifies the mutable lease for one metadata family group.
     MetadataCompactionLease,
+    /// Classifies the publication-protection record beside sealed job output.
+    CompactionOutputProtection,
     /// Classifies a mutable checkpoint lifecycle record.
     CheckpointRecord,
     /// Classifies a mutable upload-session lifecycle record.
@@ -111,6 +113,13 @@ pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
         {
             Some(parsed(
                 DurableObjectFamily::MetadataCompactionStaging,
+                Some(namespace),
+                Some(job_id),
+            ))
+        }
+        ["namespaces", namespace, "metadata", "compactions", job_id, "protection.json"] => {
+            Some(parsed(
+                DurableObjectFamily::CompactionOutputProtection,
                 Some(namespace),
                 Some(job_id),
             ))

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -752,7 +752,8 @@ fn classify_key(key: &str) -> KeyClass {
         }
         DurableObjectFamily::CheckpointRecord
         | DurableObjectFamily::WalFloor
-        | DurableObjectFamily::MetadataCompactionLease => KeyClass::GcControl,
+        | DurableObjectFamily::MetadataCompactionLease
+        | DurableObjectFamily::CompactionOutputProtection => KeyClass::GcControl,
         DurableObjectFamily::UploadSession => KeyClass::Metadata,
     }
 }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -29,9 +29,7 @@ use loonfs_api::{
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MoveOptions, NamespacePath};
 use loonfs_grep::keyspace::{manifest_key as grep_manifest_key, root_key as grep_root_key};
-use loonfs_grep::root::{
-    encode_grep_root, load_grep_root, GrepManifestObjectId, GrepRootEnvelope, GrepRootPointer,
-};
+use loonfs_grep::root::{encode_grep_root, load_grep_root, GrepManifestObjectId, GrepRootPointer};
 use loonfs_grep::{GrepWorker, NamespaceReads};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -3491,7 +3489,7 @@ async fn write_grep_pointer(
 ) {
     // Every caller here injects a fault the load hits before it compares
     // digests, so any well-formed digest stands in for the real one.
-    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+    let envelope = encode_grep_root(GrepRootPointer::new(
         pointer_namespace_id,
         manifest_object_id,
         loonfs_api::sha256_digest(b"a manifest these tests never reach"),
@@ -3500,7 +3498,7 @@ async fn write_grep_pointer(
     store
         .put_overwrite(
             &grep_root_key(stored_namespace_id),
-            Bytes::from(encode_grep_root(&envelope).expect("encode grep pointer")),
+            Bytes::from(envelope.into_bytes()),
         )
         .await
         .expect("write grep pointer");

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -61,6 +61,7 @@ pub async fn summarize_namespace_objects<S: ObjectStore + ?Sized>(
                 DurableObjectFamily::WalFloor
                 | DurableObjectFamily::MetadataRoot
                 | DurableObjectFamily::CheckpointRecord
+                | DurableObjectFamily::CompactionOutputProtection
                 | DurableObjectFamily::MetadataCompactionLease
                 | DurableObjectFamily::UploadSession
                 | DurableObjectFamily::ContentBlob => {}

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -343,7 +343,7 @@ async fn current_manifest_payload<S: ObjectStore + ?Sized>(
         .expect("the manifest exists");
     decode_namespace_manifest_json(&bytes)
         .expect("decode the manifest")
-        .payload
+        .into_payload()
 }
 
 /// The runs the bindings group holds right now, and the rows in them.

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -1631,8 +1631,8 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
             .expect("read WAL segment")
             .expect("WAL segment exists");
         let segment = decode_wal_segment_envelope_zstd(&bytes).expect("decode WAL segment");
-        if segment.payload.records.len() == 2 {
-            for record in segment.payload.records {
+        if segment.payload().records.len() == 2 {
+            for record in segment.into_payload().records {
                 batched_actors.insert(record.commit_id.to_string(), record.committed_by);
             }
         }
@@ -1780,7 +1780,7 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
             .expect("read wal")
             .expect("wal exists");
         let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode wal segment");
-        record_counts.push(segment.payload.records.len());
+        record_counts.push(segment.payload().records.len());
     }
     record_counts.sort_unstable();
     // The warmup published alone; the concurrent pair shares a segment.

--- a/crates/loonfs/tests/it/bulk_file_reads.rs
+++ b/crates/loonfs/tests/it/bulk_file_reads.rs
@@ -512,7 +512,7 @@ async fn foreign_metadata_segment_owners(
         .expect("manifest object exists");
     loonfs_api::wire::manifest::decode_namespace_manifest_json(&bytes)
         .expect("decode manifest")
-        .payload
+        .into_payload()
         .runs
         .into_iter()
         .flat_map(|run| run.segments)

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -155,7 +155,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .expect("manifest exists");
     let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
     let direntry_delta_runs: BTreeSet<_> = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| {
@@ -174,7 +174,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
     );
     assert!(
         manifest
-            .payload
+            .payload()
             .runs
             .iter()
             .filter(|run| run.tier == loonfs_api::wire::manifest::RunTier::Delta)
@@ -183,7 +183,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         "every delta segment should carry an inline filter"
     );
     let filter_offsets: BTreeSet<(String, u64)> = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)
@@ -195,7 +195,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         })
         .collect();
     let segment_keys: BTreeSet<String> = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| &run.segments)

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -12,7 +12,7 @@ use loonfs::{
     ErrorCode, FsWriter, NamespaceId, PutFileOptions, RevisionNo, RuntimeError, SharedObjectStore,
     CONTENT_READ_CHUNK_BYTES,
 };
-use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
+use loonfs_api::wire::control::ControlObjectKind;
 use loonfs_api::{ContentId, ContentStoreId};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -177,12 +177,17 @@ async fn bind_namespace_to_content_store(
         .expect("load namespace head")
         .state;
     head.content_store_id = content_store_id;
-    let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head)
-        .expect("build namespace head");
+    let envelope = head;
     store
         .put_overwrite(
             &wal_head(namespace_id),
-            Bytes::from(encode_control_object(&envelope).expect("encode namespace head")),
+            Bytes::from(
+                loonfs_api::wire::control::encode_control_state(
+                    ControlObjectKind::WalHead,
+                    &envelope,
+                )
+                .expect("encode namespace head"),
+            ),
         )
         .await
         .expect("rebind the namespace head to the shared content store");

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -12,8 +12,7 @@ use loonfs::{
     RunMaintenanceRequest, RunMaintenanceResponse, SharedObjectStore, WalFlushStepOutcome,
 };
 use loonfs_api::wire::control::{
-    decode_control_object, encode_control_object, ControlObjectEnvelope, ControlObjectKind,
-    HeadState, HeadStateEnvelope,
+    decode_control_object, ControlObjectEnvelope, ControlObjectKind, HeadState,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_api::{AdvanceRetentionRequest, GcRequest, MetadataCompactionRequest};
@@ -169,15 +168,15 @@ fn truncate_recent_segments(store: &SharedObjectStore, namespace_id: &NamespaceI
         .expect("head exists");
     let envelope: ControlObjectEnvelope<HeadState> =
         decode_control_object(&bytes, ControlObjectKind::WalHead).expect("decode head");
-    let mut state = envelope.state;
+    let mut state = envelope.into_payload();
     assert!(
         state.recent_segments.len() > keep,
         "the fixture must publish more pointers than the legacy window held"
     );
     state.recent_segments.truncate(keep);
-    let truncated =
-        HeadStateEnvelope::from_state(ControlObjectKind::WalHead, state).expect("head envelope");
-    let encoded = encode_control_object(&truncated).expect("encode head");
+    let encoded =
+        loonfs_api::wire::control::encode_control_state(ControlObjectKind::WalHead, &state)
+            .expect("encode head");
     block_on(store.put_overwrite(&key, bytes::Bytes::from(encoded))).expect("rewrite head");
 }
 
@@ -594,9 +593,9 @@ fn maintenance_step_after_existing_manifest_writes_delta_manifest() {
     let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
     // A WAL flush only appends: the base marker stays where the first
     // published manifest put it until reorganization folds the delta runs.
-    assert_eq!(manifest.payload.base_seq, ChangeSeq(1));
+    assert_eq!(manifest.payload().base_seq, ChangeSeq(1));
     let delta_files = manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .filter(|run| run.tier == loonfs_api::wire::manifest::RunTier::Delta)

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -41,7 +41,7 @@ async fn segment_map(store: &SharedObjectStore, namespace_id: &NamespaceId) -> S
         .expect("manifest exists");
     let manifest = decode_namespace_manifest_json(&bytes).expect("decode manifest");
     manifest
-        .payload
+        .payload()
         .runs
         .iter()
         .flat_map(|run| {

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -103,7 +103,7 @@ The planner tries to execute an eligible prefix within the step's row, byte, and
 
 `MetadataCompactionPolicy::SizeTiered` is the automatic policy. `CompactImmediately` bypasses size thresholds for an explicit request, while retaining the input limit. Explicit compaction performs one window per call and may require repeated calls to drain a backlog. Small workloads consolidate promptly. For large workloads, delaying a base rewrite reduces write amplification but leaves obsolete metadata until enough newer data accumulates or an operator requests compaction.
 
-The bounded pass reports `compaction_required`; the `metadata_compaction` job runs the streaming compaction under its own two-permit limit. The planner considers family groups in ranked order and reads each selected group's lease by key, skipping an `active` unexpired or `reaping` lease while unrelated groups remain available. Runner shutdown cancels running jobs.
+The bounded pass reports `compaction_required`; the `metadata_compaction` job runs the streaming compaction under its own two-permit limit. The planner considers family groups in ranked order and reads each selected group's lease by key, skipping an `active` unexpired lease while unrelated groups remain available. Runner shutdown cancels running jobs.
 
 Runs published after the snapshot was captured are not part of the compaction input. Final publication preserves those runs.
 
@@ -159,17 +159,17 @@ Step budgets therefore price the selected logical input, and a step-contained me
 
 ## Job leases and garbage collection
 
-Each family group has one lease at `metadata/compaction_leases/{group}.json`, and its payload names the job whose output under `metadata/compactions/{job_id}/segments/` it protects. An `active` unexpired or `reaping` group lease excludes every other job for that group.
+Each family group has one lease at `metadata/compaction_leases/{group}.json`, and its payload names the job whose output under `metadata/compactions/{job_id}/segments/` it protects. An `active` unexpired group lease excludes every other job for that group.
 
 The lease records the job ID, namespace ID, writer ID, status, start time, and absolute expiry. It does not contain a cursor, output descriptors, offsets, or progress, so it cannot be used to resume a failed job.
 
-The job creates a missing lease with `active` status and create-if-absent semantics before writing the first output segment. It takes over an expired `active` lease with one compare-and-swap that replaces the job, writer, start, and expiry fields; a held unexpired or `reaping` lease supersedes the new job. Every refresh uses compare-and-swap with the ETag returned by the preceding lease write and stores the current time plus the 25-minute lease lifetime in `expires_at_ms`. Refreshes occur every five minutes while the job runs and at the start of every finalization attempt. Readers compare their current time directly with `expires_at_ms`; the lifetime constant is only the writer's policy.
+The job creates a missing lease with `active` status and create-if-absent semantics before writing the first output segment. It takes over an expired or terminal lease with one compare-and-swap that replaces the job, writer, start, and expiry fields; a held unexpired active lease supersedes the new job. Every refresh uses compare-and-swap with the ETag returned by the preceding lease write and stores the current time plus the 25-minute lease lifetime in `expires_at_ms`. Refreshes occur every five minutes while the job runs and at the start of every finalization attempt. Readers compare their current time directly with `expires_at_ms`; the lifetime constant is only the writer's policy.
 
 Garbage collection reads the seven group lease keys once per namespace per pass and maps each named job to its lease. A fresh active lease keeps only that job's objects regardless of age. For an expired active lease, the collector uses compare-and-swap to change the status to `reaping`. If a concurrent refresh wins, the collector retains the job's objects. If the collector wins, the job's next refresh fails, the job returns a fenced outcome without publishing, and its unreferenced objects become eligible for collection. The `reaping` status is terminal, so a later pass can continue an interrupted cleanup without repeating the ownership decision.
 
 A missing lease or a lease naming another job provides no ownership claim. An invalid lease fails the pass. Unreferenced objects in that prefix become eligible after a staging grace period derived from the lease expiry and the normal publication grace. Unrecognized keys under the compaction prefix are retained because ownership cannot be established safely.
 
-After publication, the job stops refreshing but leaves its final active lease in place. This also delays another streaming window for that group until the lease expires (currently up to 25 minutes); a large backlog can require several such windows. This protects the output from a collection pass that captured its live references before the manifest update. After the lease expires, a later pass reads the updated manifest, retains the referenced output segments, claims the lease, and deletes it after processing the named job's prefix. Failed, cancelled, abandoned, superseded, and fenced jobs leave unreferenced output that is eventually collected.
+Before each publication attempt, the job confirms its refreshed lease deadline in `metadata/compactions/{job_id}/protection.json`. This is a separate control record containing namespace, job ID, and expiry; it is created only after output writing ends and updated by CAS. Confirming it before root publication covers a crash immediately after publication. After the final attempt, the job changes its group slot to `completed`, allowing the next job immediately. GC checks the protection deadline before group ownership, and removes that record only after its deadline and after the output prefix is empty. Group slots remain in place and are only replaced by CAS, so a paused collector cannot delete a newer job's claim. A failed completion write may leave the group held until expiry.
 
 ## Finalization
 
@@ -222,4 +222,4 @@ The implementation is validated with the following tests:
 
 Durable resume may be added later if measured restart cost justifies the additional state. Resume state would be owned by the compactor and would record completed segment boundaries without changing the reader-visible namespace manifest. The job lease is not resume state and never records progress.
 
-The built-in job defaults to two concurrent compactions per process; `MetadataCompactionJob::max_concurrent` sets another limit. Each family group has its own durable lease. A completed job retains that lease until expiry to protect its published output from an older GC scan, so another window for that group may wait.
+The built-in job defaults to two concurrent compactions per process; `MetadataCompactionJob::max_concurrent` sets another limit. Each family group has its own durable lease. A completed job retains its separate output protection and immediately releases the group for another window.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -93,7 +93,8 @@ The required durable object families and standard key patterns are:
 | **Checkpoint records** | Mutable lifecycle | Durable stable-view pins to a metadata manifest, each carrying a required owner (user, fork target, or snapshot). The record's `status` is monotonic: a record is created `active` under a generated id, released once by compare-and-swap, and deleted a grace window after that release. | `namespaces/{namespace_id}/checkpoints/{checkpoint_id}.json` |
 | **Metadata segments** | Immutable | Store metadata rows referenced by manifests. Segments may be owned by the namespace itself or by a fork source namespace. | `namespaces/{owner_namespace_id}/metadata/segments/{segment_id}.sst.zst` |
 | **Compaction staging** | Immutable | Holds segments written by a streaming compaction before publication. The descriptor stores the job id used to derive this key. | `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/segments/{segment_id}.sst.zst` |
-| **Compaction leases** | Mutable lifecycle | Record ownership of one family group's active compaction output. A job creates or takes over and refreshes an `active` lease. Garbage collection may change an expired lease to terminal `reaping` before reclaiming the named job's output. | `namespaces/{owner_namespace_id}/metadata/compaction_leases/{group}.json` |
+| **Compaction leases** | Mutable group slot | An `active` lease owns a running job's output. `completed` and `reaping` jobs release the group. Slots are replaced by CAS and never deleted. | `namespaces/{owner_namespace_id}/metadata/compaction_leases/{group}.json` |
+| **Compaction output protection** | Mutable deadline | Before each publication attempt, a job records its lease deadline beside the sealed output. This record remains until the output prefix is empty. | `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/protection.json` |
 | **Upload sessions** | Mutable lifecycle | Track one staged-content upload. The record's `status` is monotonic: a session is created `open` under a lease, and moves once to `completed` or `aborted`, both terminal. | `namespaces/{namespace_id}/uploads/{upload_id}.json` |
 | **Metadata root** | Mutable | Cold pointer to the best known materialized metadata root; monotonic CAS. | `namespaces/{namespace_id}/metadata/root.json` |
 | **WAL floor** | Mutable | Cold lower bound of retained WAL/change history; monotonic CAS. | `namespaces/{namespace_id}/wal/floor.json` |
@@ -338,7 +339,7 @@ practical.
 
 Six control-object kinds are registered: `wal_head`, `wal_floor`,
 `metadata_root`, `checkpoint_record`, `upload_session`, and
-`compaction_lease`. A control-object envelope carrying any other kind string
+`compaction_lease`, and `compaction_output_protection`. A control-object envelope carrying any other kind string
 is rejected, not skipped.
 
 The WAL floor and the metadata root are the only control objects that carry
@@ -1886,7 +1887,8 @@ and absent, and no schema language states it, so no durable encoding writes one.
 | Control objects (head, metadata root, WAL floor) | per-kind snake_case names | JSON, uncompressed | 1 (tracked per kind) |
 | Checkpoint record | `checkpoint_record` | JSON, uncompressed | 1 |
 | Upload session | `upload_session` | JSON, uncompressed | 1 |
-| Compaction lease | `compaction_lease` | JSON, uncompressed | 2 |
+| Compaction lease | `compaction_lease` | JSON, uncompressed | 3 |
+| Compaction output protection | `compaction_output_protection` | JSON, uncompressed | 1 |
 
 JSON families keep their payload inline as raw JSON so manifests and control
 objects stay directly readable with generic tooling; CBOR families carry the
@@ -2294,7 +2296,7 @@ because that makes "the newest at the floor" arbitrary and the drop unsafe.
 
 A rebuild that cannot fit within one bounded maintenance pass runs as a streaming compaction. The job merges every run in the group and writes output segments as they fill. These segments use `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/segments/{segment_id}.sst.zst` instead of `metadata/segments/`.
 
-The separate prefix prevents GC from treating unfinished output as abandoned metadata. Each family group has one lease at `namespaces/{owner_namespace_id}/metadata/compaction_leases/{group}.json`, and an `active` unexpired or `reaping` lease excludes every other job for that group. A job acquires a missing lease with create-if-absent before its first output object, or takes over an expired `active` lease with one compare-and-swap that replaces the job, writer, start, and expiry fields. Garbage collection changes an expired `active` lease to terminal `reaping` with compare-and-swap before reclaiming output belonging to the job id the lease names. A group lease never protects objects written by another job id. Collection passes are shorter than `METADATA_COMPACTION_LEASE_EXPIRY_MS`, so a pass does not mistake a lease that it observed as live for one that expired during the pass. A published manifest references the segments in place, so publication does not move them. Each descriptor stores `compaction_job_id`, and readers use it to derive the key (section 4.2.1).
+Each family group has one lease at `namespaces/{owner_namespace_id}/metadata/compaction_leases/{group}.json`. An unexpired `active` lease excludes another job for that group. An expired, `completed`, or `reaping` slot can be replaced with one compare-and-swap; the old job's refresh then fails. Before each publication attempt, the job confirms its current lease deadline at `metadata/compactions/{job_id}/protection.json`. No output is written after this record is created. After the final publication attempt, the group slot becomes `completed`. The protection record remains until the job's output prefix is empty. An older collector therefore retains its protection even after a newer job takes over the group. A published manifest references the segments in place. Each descriptor stores `compaction_job_id`, and readers use it to derive the key (section 4.2.1).
 
 The rules a rebuild applies are the same however it runs them. A bounded
 merge holds every row of its window and decides them together. A streaming
@@ -2542,7 +2544,7 @@ publishing CAS) — under these rules:
    while it runs and at the top of every finalization attempt. Creation and
    every refresh store the job's current time plus
    `METADATA_COMPACTION_LEASE_EXPIRY_MS` in `expires_at_ms`. An `active`
-   unexpired or `reaping` lease excludes every other job for the group.
+   unexpired lease excludes every other job for the group.
 
    The lease is a fence, not a timestamp. An expired lease alone proves
    nothing — the job may be resuming from a long stall — so a pass claims one
@@ -2556,16 +2558,29 @@ publishing CAS) — under these rules:
                              pass's to reclaim
    ```
 
-   `reaping` is terminal. Nothing returns a lease to `active`, so a job that
-   lost ownership never regains it, and a `reaping` lease a later pass finds
-   means an unfinished reap to carry on with.
+   `reaping` fences that job permanently. The group slot can be replaced by
+   a new job with a new identity; a replaced job never regains ownership.
 
-   A published job stops refreshing and leaves its final lease in place; it
-   never deletes it. Deleting it would open the hole the lease exists to
-   close: a pass that collected its live set before the publication would find
-   output objects far older than any grace window and no lease saying who
-   owns them. The fresh lease covers that pass, a later pass reads a root that
-   already references the objects, and that pass removes the expired lease.
+   Before each root publication attempt, after refreshing the group lease,
+   the job confirms an output-protection record at
+   `metadata/compactions/{job_id}/protection.json`. It contains `namespace_id`,
+   `job_id`, and `expires_at_ms`, and its deadline only advances by CAS. No
+   output writes follow the first protection record. Confirming protection
+   before the root CAS also covers a crash immediately after publication.
+
+   After the final publication attempt, the job changes its group slot to
+   `completed` by CAS, immediately admitting the next job. A failed completion
+   write leaves the group held until expiry; a lost CAS cannot change a newer
+   job's claim. Output protection is already independent of that slot.
+
+   GC checks output protection before the group slot. A deadline at or after
+   the pass's fixed clock retains the output. An expired deadline still
+   requires the normal group-lease ownership check: a publisher may have
+   refreshed its group lease and be about to extend output protection.
+   GC removes protection only after its deadline and after the output prefix
+   is empty. Thus a newer collector cannot erase the protection needed by
+   one paused before publication. Removing the record may take one additional
+   pass after the last output is removed.
 
    A pass reads the seven group lease keys once and decides one staged object
    as follows. An object the manifest references is live, like every other
@@ -2591,16 +2606,13 @@ publishing CAS) — under these rules:
    at the top of an attempt cannot have its prefix claimed before that
    attempt's root compare-and-swap.
 
-   Deletion processes a claimed job's staged prefix before its group lease,
-   for the same reason deletion runs data before records everywhere else: a
-   pass that stops in between leaves a `reaping` lease saying the reap is
-   unfinished, rather than nothing at all. A pass also claims and deletes an
-   expired `active` lease after confirming its named job has no staged object
-   left.
+   Group slots are never deleted by GC. They stay available for replacement
+   by CAS, which prevents a paused collector from deleting a newer job's
+   lease. This retains at most one small slot per family group.
 
    The lease is a mutable control object and decodes strictly like every
-   other. A lease that does not decode, or whose namespace or group disagrees
-   with its key, fails the pass and is reported: nothing else reads the object,
+   other. A lease that does not decode, or whose namespace, group, job identity, or terminal status disagrees
+   with its location, fails the pass and is reported: nothing else reads the object,
    so believing a corrupt one would keep its named job's output alive forever
    and nothing would ever say why. Every other rule — the reference anchor,
    delete-time re-verification, degraded roots — applies here exactly as it


### PR DESCRIPTION
Let the next compaction use a family group as soon as the previous job finishes. Each publication first confirms a separate output-protection deadline, which survives later group owners and remains until the output is gone. Group slots are replaced only by CAS, preventing a paused collector from deleting a newer job's lease.

This retains one small protection record per finalizing job and at most seven group slots per namespace, with an extra read/write before publication. Wire format change; goldens regenerated. Workspace tests pass (2,135 passed, 19 ignored), along with all-feature Clippy and tests for publication ordering, immediate group reuse, and old-collector protection. Builds on #872.
