### PR TITLE
fix: stream file reads and directory listings across clients

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -626,7 +626,7 @@ Behavior notes
   Existing files are not overwritten unless --force is set. Downloads stream
   without buffering the entire file. The CLI writes to a temporary file and
   moves it into place after verification, so a failed download does not leave
-  a partial destination. When streaming to stdout with `-`, written bytes
+  a partial destination. For `cat` and streaming to stdout with `get ... -`, written bytes
   cannot be taken back; check the exit status to confirm verification
 
   A recursive put, get, or cp works file by file with bounded concurrency,
@@ -636,12 +636,10 @@ Behavior notes
 
   `loonfs mv` moves a directory in one commit and takes no -r
 
-  How much of a transfer is watchable follows how it travels. A streamed or
-  direct download reports bytes as they land, and so does a streamed
-  upload; a proxied download and a small buffered upload are one request
-  each, so they go from nothing to done in one step. A tree is the same
-  file by file: its byte count moves through a large file as that file is
-  read, and advances a whole file at a time over the small ones
+  Downloads report bytes as they arrive for current, historical, and snapshot
+  reads, through either direct or proxied transport. Streamed uploads report
+  incremental progress too; small buffered uploads report completion in one
+  step. Recursive transfers use those same paths for each file
 
   Embedded profiles do not run continuous maintenance. Run
   `loonfs maintenance loop --namespaces <ns>` for ongoing maintenance,

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -255,101 +255,78 @@ impl ResolvedTarget {
         }
     }
 
-    /// Reads file content from a revision or snapshot.
-    pub(crate) async fn get_file_bytes_with_options(
-        &self,
-        spec: &NamespacePath,
-        options: &ReadFileOptions,
-    ) -> Result<Vec<u8>, CliError> {
-        match self {
-            Self::Embedded(target) => {
-                target
-                    .backend
-                    .get_file_bytes_with_options(spec, options)
-                    .await
-            }
-            Self::Remote(target) => Ok(target.client.get_file_bytes(spec, options).await?),
-        }
-    }
-
-    /// Opens a file download using the selected profile's best available path.
-    ///
-    /// Embedded profiles stream from their object store. Remote profiles use
-    /// direct object-store downloads above the proxy limit and buffer smaller
-    /// proxied responses. Every path verifies the complete file.
-    ///
-    /// `start_offset` resumes streaming downloads. Buffered responses and
-    /// retained revisions restart at zero; [`FileDownload::resumed_from`]
-    /// reports the offset actually used.
+    /// Opens a bounded download of the requested current, retained, or snapshot content.
+    /// Direct object-store access is preferred whenever the server offers it.
     pub(crate) async fn open_file_download(
         &self,
         spec: &NamespacePath,
         revision_no: Option<RevisionNo>,
         snapshot_id: Option<&CheckpointId>,
-        size_bytes: Option<u64>,
         start_offset: u64,
     ) -> Result<FileDownload, CliError> {
-        if let (Self::Remote(target), Some(size_bytes)) = (self, size_bytes) {
-            if target.client.offers_direct_download(size_bytes).await? {
-                let grant = target
-                    .client
-                    .create_download(
-                        spec,
-                        &DownloadOptions {
-                            revision_no,
-                            snapshot_id: snapshot_id.cloned(),
-                        },
-                    )
-                    .await?;
-                return Ok(FileDownload::Direct {
-                    stream: Box::new(
-                        target
-                            .client
-                            .open_direct_download_at(&grant, start_offset)
-                            .await?,
-                    ),
-                    resumed_from: start_offset,
-                });
-            }
-        }
-        if revision_no.is_some() || snapshot_id.is_some() {
-            return Ok(FileDownload::Whole(
-                self.get_file_bytes_with_options(
-                    spec,
-                    &ReadFileOptions {
-                        revision_no,
-                        snapshot_id: snapshot_id.cloned(),
-                    },
-                )
-                .await?,
-            ));
-        }
         match self {
-            Self::Embedded(target) => Ok(FileDownload::Streamed {
-                namespace_id: spec.namespace().clone(),
-                stream: Box::new(
-                    target
-                        .backend
-                        .reader
-                        .read_file_stream(
-                            spec.namespace(),
-                            spec.absolute_path().as_str(),
-                            ReadFileStreamOptions {
-                                start_offset,
-                                ..ReadFileStreamOptions::default()
-                            },
-                        )
+            Self::Embedded(target) => {
+                let options = ReadFileStreamOptions {
+                    revision_no,
+                    start_offset,
+                    ..ReadFileStreamOptions::default()
+                };
+                let reader = &target.backend.reader;
+                let stream = match snapshot_id {
+                    Some(snapshot_id) => reader
+                        .pin_namespace_at_snapshot(spec.namespace(), snapshot_id)
+                        .await
+                        .scoped(spec.namespace())?
+                        .read_file_stream(spec.absolute_path().as_str(), options)
                         .await
                         .scoped(spec.namespace())?,
-                ),
-                resumed_from: start_offset,
-            }),
-            Self::Remote(target) => Ok(FileDownload::Whole(
-                target
-                    .client
-                    .get_file_bytes(spec, &ReadFileOptions::default())
-                    .await?,
-            )),
+                    None => reader
+                        .read_file_stream(spec.namespace(), spec.absolute_path().as_str(), options)
+                        .await
+                        .scoped(spec.namespace())?,
+                };
+                Ok(FileDownload::Streamed {
+                    namespace_id: spec.namespace().clone(),
+                    stream: Box::new(stream),
+                    resumed_from: start_offset,
+                })
+            }
+            Self::Remote(target) => {
+                if target.client.offers_direct_download().await? {
+                    let grant = target
+                        .client
+                        .create_download(
+                            spec,
+                            &DownloadOptions {
+                                revision_no,
+                                snapshot_id: snapshot_id.cloned(),
+                            },
+                        )
+                        .await?;
+                    return Ok(FileDownload::Direct {
+                        revision_no: grant.revision_no,
+                        stream: Box::new(
+                            target
+                                .client
+                                .open_direct_download_at(&grant, start_offset)
+                                .await?,
+                        ),
+                        resumed_from: start_offset,
+                    });
+                }
+                Ok(FileDownload::Proxied(
+                    target
+                        .client
+                        .read_file_stream(
+                            spec,
+                            &ReadFileOptions {
+                                revision_no,
+                                snapshot_id: snapshot_id.cloned(),
+                            },
+                        )
+                        .await?,
+                ))
+            }
         }
     }
 

--- a/crates/loonfs-cli/src/backend/download.rs
+++ b/crates/loonfs-cli/src/backend/download.rs
@@ -3,13 +3,14 @@
 use crate::backend_error::map_namespace_scoped_runtime_error;
 use crate::error::CliError;
 use bytes::Bytes;
+use futures::StreamExt;
 use loonfs::{FileContentStream, RuntimeError, SharedObjectStore};
-use loonfs_api::NamespaceId;
-use loonfs_client::DirectDownloadStream;
+use loonfs_api::{ContentRef, NamespaceId, RevisionNo};
+use loonfs_client::{DirectDownloadStream, PayloadStream};
 
 /// File content returned by either profile type.
 ///
-/// The result may be an embedded stream, a remote stream, or buffered bytes.
+/// The result is an embedded, direct, or service-proxied stream.
 /// [`FileDownload::next_chunk`] presents all three as a sequence of chunks.
 pub(crate) enum FileDownload {
     /// A bounded stream from the embedded runtime.
@@ -22,18 +23,34 @@ pub(crate) enum FileDownload {
     /// against the content reference in its download grant.
     Direct {
         stream: Box<DirectDownloadStream>,
+        revision_no: RevisionNo,
         resumed_from: u64,
     },
-    /// A complete response already held in memory.
-    Whole(Vec<u8>),
+    /// A server response whose successful completion follows verification.
+    Proxied(PayloadStream),
 }
 
 impl FileDownload {
+    /// Authoritative metadata for transports that can resume.
+    pub(crate) fn resume_identity(&self) -> Option<(&ContentRef, RevisionNo)> {
+        match self {
+            Self::Streamed { stream, .. } => {
+                Some((stream.content_ref(), stream.entry()?.revision_no()?))
+            }
+            Self::Direct {
+                stream,
+                revision_no,
+                ..
+            } => Some((stream.content_ref(), *revision_no)),
+            Self::Proxied(_) => None,
+        }
+    }
+
     /// Returns the next chunk, or `None` after full verification.
     ///
     /// Streamed downloads verify length and checksum when the final call reaches
-    /// the end. Stopping early does not complete verification. Buffered bytes
-    /// were verified before this method receives them.
+    /// the end. Stopping early does not complete verification. Proxied streams
+    /// rely on the server aborting the response on a verification failure.
     pub(crate) async fn next_chunk(&mut self) -> Result<Option<Bytes>, CliError> {
         match self {
             Self::Streamed {
@@ -44,27 +61,26 @@ impl FileDownload {
                 map_namespace_scoped_runtime_error(namespace_id, RuntimeError::Core(error))
             }),
             Self::Direct { stream, .. } => stream.next_chunk().await.map_err(CliError::from),
-            Self::Whole(bytes) if bytes.is_empty() => Ok(None),
-            Self::Whole(bytes) => Ok(Some(Bytes::from(std::mem::take(bytes)))),
+            Self::Proxied(stream) => stream.next().await.transpose().map_err(CliError::io),
         }
     }
 
     /// Returns the offset where this response starts.
     ///
-    /// Buffered responses cannot resume, so they always start at zero.
+    /// Proxied responses cannot resume, so they always start at zero.
     pub(crate) fn resumed_from(&self) -> u64 {
         match self {
             Self::Streamed { resumed_from, .. } | Self::Direct { resumed_from, .. } => {
                 *resumed_from
             }
-            Self::Whole(_) => 0,
+            Self::Proxied(_) => 0,
         }
     }
 
     /// Adds the existing prefix to a resumed download's checksum.
     ///
     /// Streaming downloads verify the complete object, including bytes read
-    /// by an earlier attempt. Buffered responses do not resume and ignore the
+    /// by an earlier attempt. Proxied responses do not resume and ignore the
     /// prefix.
     pub(crate) fn fold_resumed_prefix(&mut self, bytes: &[u8]) -> Result<(), CliError> {
         match self {
@@ -79,7 +95,7 @@ impl FileDownload {
                 stream.fold_resumed_prefix(bytes);
                 Ok(())
             }
-            Self::Whole(_) => Ok(()),
+            Self::Proxied(_) => Ok(()),
         }
     }
 }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -25,7 +25,7 @@ use loonfs_api::{
     ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse, Namespace, NamespaceId,
     PaginationPolicy, PathEntry, RevisionNo, RunMaintenanceRequest, RunMaintenanceResponse,
 };
-use loonfs_client::{NamespacePath, ReadFileOptions};
+use loonfs_client::NamespacePath;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBlockCache, GrepDisableOutcome, GrepEnableOutcome, GrepError,
     GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
@@ -234,44 +234,6 @@ impl EmbeddedBackend {
             )
             .await
             .scoped(spec.namespace())
-    }
-
-    pub(super) async fn get_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError> {
-        let result = self
-            .reader
-            .get_file_bytes(spec.namespace(), spec.absolute_path().as_str())
-            .await
-            .scoped(spec.namespace())?;
-        Ok(result.bytes)
-    }
-
-    pub(super) async fn get_file_bytes_with_options(
-        &self,
-        spec: &NamespacePath,
-        options: &ReadFileOptions,
-    ) -> Result<Vec<u8>, CliError> {
-        if options.revision_no.is_some() && options.snapshot_id.is_some() {
-            return Err(CliError::invalid_request(
-                "revision_no cannot be combined with snapshot_id",
-            )
-            .with_param("revision_no"));
-        }
-        if let Some(snapshot_id) = &options.snapshot_id {
-            let snapshot = self
-                .reader
-                .pin_namespace_at_snapshot(spec.namespace(), snapshot_id)
-                .await
-                .scoped(spec.namespace())?;
-            return snapshot
-                .get_file_bytes(spec.absolute_path().as_str())
-                .await
-                .map(|file| file.bytes)
-                .scoped(spec.namespace());
-        }
-        match options.revision_no {
-            Some(revision_no) => self.get_file_revision_bytes(spec, revision_no).await,
-            None => self.get_file_bytes(spec).await,
-        }
     }
 
     pub(super) async fn grep(
@@ -510,19 +472,6 @@ impl EmbeddedBackend {
                 },
             )),
         }
-    }
-
-    pub(super) async fn get_file_revision_bytes(
-        &self,
-        spec: &NamespacePath,
-        revision_no: RevisionNo,
-    ) -> Result<Vec<u8>, CliError> {
-        let result = self
-            .reader
-            .get_file_revision_bytes(spec.namespace(), spec.absolute_path().as_str(), revision_no)
-            .await
-            .scoped(spec.namespace())?;
-        Ok(result.bytes)
     }
 
     pub(super) async fn list_trash(

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -12,7 +12,7 @@ use super::output::{
     TrashListing,
 };
 use super::pagination::{
-    collect_or_stream_pages, collect_pages, write_jsonl_page, PagePlan, PagedListing,
+    collect_or_stream_pages, visit_pages, write_jsonl_page, PagePlan, PagedListing,
 };
 use super::partial::{self, PartialDownload, PartialMeta};
 use super::recursive;
@@ -32,12 +32,12 @@ use crate::uploads::{SourceIdentity, UploadJournal};
 use loonfs_api::v0::UploadSessionStatus;
 use loonfs_api::{
     AbsolutePath, ActorRef, AttributeKey, AttributeRevisionNo, AttributeValue, ChangeSeq,
-    CheckpointId, CommitId, CommitResponse, ContentRef, DeleteDirectoryBehavior,
-    DestinationBehavior, InodeKind, ListPathEntriesResponse, NamespaceId, RevisionNo,
+    CheckpointId, CommitId, CommitResponse, DeleteDirectoryBehavior, DestinationBehavior,
+    InodeKind, ListPathEntriesResponse, NamespaceId, RevisionNo,
 };
 use loonfs_client::{
     CommitOptions, CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions,
-    ReadFileOptions, UpdateAttributesOptions,
+    UpdateAttributesOptions,
 };
 use std::collections::BTreeMap;
 use std::fs;
@@ -95,7 +95,8 @@ async fn follow_path_entry_pages(
     mut visit: impl FnMut(Vec<loonfs_api::PathEntry>) -> Result<(), CliError>,
 ) -> Result<FollowedPathEntryPages, CommandFailure> {
     let mut heads = ListingHeadObservation::default();
-    let page = collect_pages(
+    let mut followed = None;
+    visit_pages(
         PagePlan::new(pagination),
         cursor.map(ToOwned::to_owned),
         async |cursor, limit| {
@@ -104,27 +105,21 @@ async fn follow_path_entry_pages(
                 .list_path_entries_page(spec, limit, cursor.as_deref(), snapshot_id)
                 .await
         },
-        |page: &ListPathEntriesResponse| heads.observe(page.head_seq),
+        |page: ListPathEntriesResponse| {
+            heads.observe(page.head_seq);
+            followed = Some(FollowedPathEntryPages {
+                namespace_id: page.namespace_id,
+                path: page.path,
+                head_seq: page.head_seq,
+                head_drift: heads.drift(),
+                next_cursor: page.next_cursor,
+            });
+            visit(page.entries)
+        },
     )
     .await
     .map_err(|error| context.fail(kind, error))?;
-    let ListPathEntriesResponse {
-        namespace_id,
-        path,
-        entries,
-        next_cursor,
-        ..
-    } = page;
-    visit(entries).map_err(|error| context.fail(kind, error))?;
-    Ok(FollowedPathEntryPages {
-        namespace_id,
-        path,
-        head_seq: heads
-            .last()
-            .expect("a listing should observe its first page"),
-        head_drift: heads.drift(),
-        next_cursor,
-    })
+    Ok(followed.expect("a listing should observe its first page"))
 }
 
 pub(crate) async fn run_filesystem_ls(
@@ -427,19 +422,15 @@ pub(crate) async fn run_filesystem_cat(
         .map_err(|error| context.fail(kind, error))?;
     let snapshot_id = parse_snapshot_id_arg(args.snapshot_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
-    let bytes = context
+    let mut download = context
         .target
-        .get_file_bytes_with_options(
-            &spec,
-            &ReadFileOptions {
-                revision_no,
-                snapshot_id,
-            },
-        )
+        .open_file_download(&spec, revision_no, snapshot_id.as_ref(), 0)
         .await
         .map_err(|error| context.fail(kind, error))?;
-
-    Ok(context.output(kind, CommandData::StreamBytes(bytes)))
+    stream_download_to_stdout(&mut download)
+        .await
+        .map_err(|error| context.fail(kind, error))?;
+    Ok(context.output(kind, CommandData::StreamedToStdout))
 }
 
 pub(crate) async fn run_filesystem_get(
@@ -535,13 +526,7 @@ pub(crate) async fn run_filesystem_get(
         // and bytes already piped onward are somewhere this CLI cannot see.
         let mut download = context
             .target
-            .open_file_download(
-                &spec,
-                revision_no,
-                snapshot_id.as_ref(),
-                entry.size_bytes(),
-                0,
-            )
+            .open_file_download(&spec, revision_no, snapshot_id.as_ref(), 0)
             .await
             .map_err(|error| context.fail(kind, error))?;
         stream_download_to_stdout(&mut download)
@@ -561,9 +546,7 @@ pub(crate) async fn run_filesystem_get(
         &spec,
         revision_no,
         snapshot_id.as_ref(),
-        entry.size_bytes(),
         &destination,
-        entry.content_ref(),
     )
     .await
     .map_err(|error| context.fail(kind, error))?;
@@ -573,8 +556,11 @@ pub(crate) async fn run_filesystem_get(
         ProgressOp::Get,
         spec.absolute_path().as_str(),
     ));
-    progress.expect(entry.size_bytes(), Some(1));
-    progress.file_started(spec.absolute_path().as_str(), entry.size_bytes());
+    let size_bytes = download
+        .resume_identity()
+        .map(|(claim, _)| claim.size_bytes);
+    progress.expect(size_bytes, Some(1));
+    progress.file_started(spec.absolute_path().as_str(), size_bytes);
     // The local working copy is the one thing this CLI touches that has no
     // revision history behind it, so clobbering it is opt-in.
     // `persist_noclobber` closes the race between checking and installing
@@ -608,18 +594,36 @@ pub(super) async fn open_resumable_download(
     spec: &NamespacePath,
     revision_no: Option<RevisionNo>,
     snapshot_id: Option<&CheckpointId>,
-    size_bytes: Option<u64>,
     destination: &Path,
-    content_ref: Option<&ContentRef>,
 ) -> Result<(FileDownload, Option<PartialMeta>), CliError> {
-    let meta = content_ref.map(|content_ref| PartialMeta::describe(content_ref, revision_no));
+    let mut download = context
+        .target
+        .open_file_download(spec, revision_no, snapshot_id, 0)
+        .await?;
+    let identity = download.resume_identity();
+    let resolved_revision = identity.map(|(_, revision)| revision);
+    let meta = identity.map(|(claim, _)| PartialMeta::describe(claim, revision_no));
     let start_offset = meta
         .as_ref()
         .map_or(0, |meta| partial::resumable_bytes(destination, meta));
-    let download = context
-        .target
-        .open_file_download(spec, revision_no, snapshot_id, size_bytes, start_offset)
-        .await?;
+    if start_offset > 0 {
+        // Pin the content revision resolved by the first stream. A snapshot
+        // already pins its revision and cannot also take a revision selector.
+        drop(download);
+        download = context
+            .target
+            .open_file_download(
+                spec,
+                if snapshot_id.is_some() {
+                    None
+                } else {
+                    resolved_revision
+                },
+                snapshot_id,
+                start_offset,
+            )
+            .await?;
+    }
     Ok((download, meta))
 }
 

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -34,10 +34,6 @@ impl ListingHeadObservation {
         self.last_head_seq = Some(head_seq);
     }
 
-    pub(crate) fn last(&self) -> Option<ChangeSeq> {
-        self.last_head_seq
-    }
-
     pub(crate) fn drift(&self) -> Option<ListingHeadDrift> {
         let first_head_seq = self.first_head_seq?;
         let last_head_seq = self.last_head_seq?;
@@ -352,7 +348,6 @@ pub(crate) enum CommandData {
     },
     /// A generated shell completion script, rendered byte-for-byte.
     CompletionScript(Vec<u8>),
-    StreamBytes(Vec<u8>),
     /// The payload already went to standard output as it arrived, so there is
     /// nothing left to render. `get -` reports this: a download that is
     /// written chunk by chunk cannot also be handed to the renderer at the
@@ -415,7 +410,6 @@ mod tests {
     fn listing_head_drift_serializes_only_after_the_head_moves() {
         let mut heads = ListingHeadObservation::default();
         heads.observe(ChangeSeq(5));
-        assert_eq!(heads.last(), Some(ChangeSeq(5)));
         assert_eq!(heads.drift(), None);
 
         let settled = serde_json::to_value(path_entries(heads.drift())).expect("serialize listing");

--- a/crates/loonfs-cli/src/commands/pagination.rs
+++ b/crates/loonfs-cli/src/commands/pagination.rs
@@ -19,11 +19,35 @@ pub(super) enum PagedListing<P> {
     Collected(P),
 }
 
+/// Visits and releases each page before requesting the next one.
+pub(super) async fn visit_pages<P, F, Fut, V>(
+    mut plan: PagePlan,
+    mut cursor: Option<P::Cursor>,
+    mut fetch: F,
+    mut visit: V,
+) -> Result<(), CliError>
+where
+    P: PagedResponse,
+    F: FnMut(Option<P::Cursor>, Option<u32>) -> Fut,
+    Fut: Future<Output = Result<P, CliError>>,
+    V: FnMut(P) -> Result<(), CliError>,
+{
+    loop {
+        let page = fetch(cursor, plan.request_size()).await?;
+        plan.record(page.items().len());
+        cursor = page.next_cursor();
+        visit(page)?;
+        if !plan.should_continue(cursor.is_some()) {
+            return Ok(());
+        }
+    }
+}
+
 /// Fetches pages until the plan is satisfied and returns them as one response.
 pub(super) async fn collect_pages<P, F, Fut, O>(
-    mut plan: PagePlan,
+    plan: PagePlan,
     cursor: Option<P::Cursor>,
-    mut fetch: F,
+    fetch: F,
     mut observe: O,
 ) -> Result<P, CliError>
 where
@@ -32,28 +56,26 @@ where
     Fut: Future<Output = Result<P, CliError>>,
     O: FnMut(&P),
 {
-    let mut collected = fetch(cursor, plan.request_size()).await?;
-    observe(&collected);
-    plan.record(collected.items().len());
-    loop {
-        let cursor = collected.next_cursor();
-        if !plan.should_continue(cursor.is_some()) {
-            return Ok(collected);
-        }
-        let page = fetch(cursor, plan.request_size()).await?;
+    let mut collected: Option<P> = None;
+    visit_pages(plan, cursor, fetch, |page| {
         observe(&page);
-        plan.record(page.items().len());
-        collected.absorb(page);
-    }
+        match &mut collected {
+            Some(collected) => collected.absorb(page),
+            None => collected = Some(page),
+        }
+        Ok(())
+    })
+    .await?;
+    Ok(collected.expect("pagination should fetch at least one page"))
 }
 
 /// Writes each page to stdout as JSON lines when `jsonl` is set, and
 /// collects the pages otherwise.
 pub(super) async fn collect_or_stream_pages<P, F, Fut, O>(
-    mut plan: PagePlan,
+    plan: PagePlan,
     cursor: Option<P::Cursor>,
     jsonl: bool,
-    mut fetch: F,
+    fetch: F,
     mut observe: O,
 ) -> Result<PagedListing<P>, CliError>
 where
@@ -70,19 +92,12 @@ where
     }
     let stdout = io::stdout();
     let mut stdout = io::BufWriter::with_capacity(64 * 1024, stdout.lock());
-    let mut page = fetch(cursor, plan.request_size()).await?;
-    observe(&page);
-    plan.record(page.items().len());
-    loop {
-        write_jsonl_page(&mut stdout, page.items()).map_err(CliError::io)?;
-        let cursor = page.next_cursor();
-        if !plan.should_continue(cursor.is_some()) {
-            return Ok(PagedListing::Streamed);
-        }
-        page = fetch(cursor, plan.request_size()).await?;
+    visit_pages(plan, cursor, fetch, |page| {
         observe(&page);
-        plan.record(page.items().len());
-    }
+        write_jsonl_page(&mut stdout, page.items()).map_err(CliError::io)
+    })
+    .await?;
+    Ok(PagedListing::Streamed)
 }
 
 /// Writes one JSON item per line and flushes the page before the next request.
@@ -146,6 +161,37 @@ impl PagePlan {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use loonfs_api::{AbsolutePath, ChangeSeq, ListPathEntriesResponse, NamespaceId};
+    use std::cell::Cell;
+
+    #[tokio::test]
+    async fn pages_are_delivered_before_the_next_fetch_even_if_it_fails() {
+        let delivered = Cell::new(false);
+        let result = visit_pages(
+            PagePlan::new(&args(None, Some(1), true)),
+            None,
+            async |cursor: Option<String>, _| {
+                if cursor.is_some() {
+                    assert!(delivered.get(), "the first page must already be delivered");
+                    return Err(CliError::invalid_request("second page failed"));
+                }
+                Ok(ListPathEntriesResponse {
+                    namespace_id: NamespaceId::parse("demo").expect("namespace"),
+                    path: AbsolutePath::parse("/").expect("root path"),
+                    head_seq: ChangeSeq(1),
+                    entries: Vec::new(),
+                    next_cursor: Some("next".to_owned()),
+                })
+            },
+            |_| {
+                delivered.set(true);
+                Ok(())
+            },
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(delivered.get());
+    }
 
     fn args(limit: Option<u32>, page_size: Option<u32>, all: bool) -> PaginationArgs {
         PaginationArgs {

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -31,8 +31,6 @@ struct FileJob {
     remote: String,
     /// File length, used for transfer selection and progress totals.
     size_bytes: Option<u64>,
-    /// Remote content identity used to resume downloads.
-    content_ref: Option<loonfs_api::ContentRef>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -301,20 +299,13 @@ pub(crate) async fn run_get_tree(
                 Ok(spec) => spec,
                 Err(error) => return (job.remote, Err(error)),
             };
-            let (mut download, meta) = match super::fs::open_resumable_download(
-                context,
-                &spec,
-                None,
-                snapshot_id,
-                job.size_bytes,
-                &local,
-                job.content_ref.as_ref(),
-            )
-            .await
-            {
-                Ok(opened) => opened,
-                Err(error) => return (job.remote, Err(error)),
-            };
+            let (mut download, meta) =
+                match super::fs::open_resumable_download(context, &spec, None, snapshot_id, &local)
+                    .await
+                {
+                    Ok(opened) => opened,
+                    Err(error) => return (job.remote, Err(error)),
+                };
             progress.file_started(&job.remote, job.size_bytes);
             let derived_name = false;
             let written = super::fs::stream_download_to_file(
@@ -549,7 +540,6 @@ fn collect_local_tree(
                 // The upload retries metadata lookup if this first lookup
                 // fails.
                 size_bytes: entry.metadata().ok().map(|metadata| metadata.len()),
-                content_ref: None,
             });
         } else {
             tally.fail(
@@ -643,15 +633,10 @@ async fn walk_remote_tree(
                             child_components,
                         ));
                     }
-                    PathEntryKind::File {
-                        size_bytes,
-                        content_ref,
-                        ..
-                    } => tree.files.push(FileJob {
+                    PathEntryKind::File { size_bytes, .. } => tree.files.push(FileJob {
                         local: PathBuf::from(child_components.join("/")),
                         remote: format!("{remote_dir}/{name}", name = name.as_str()),
                         size_bytes: Some(size_bytes),
-                        content_ref: Some(content_ref),
                     }),
                 }
             }
@@ -781,13 +766,17 @@ mod tests {
         );
 
         let spec = NamespacePath::parse("demo", "/up/docs/big.bin").expect("valid namespace path");
+        let mut download = context
+            .target
+            .open_file_download(&spec, None, None, 0)
+            .await
+            .expect("open uploaded file");
+        let mut read = Vec::new();
+        while let Some(chunk) = download.next_chunk().await.expect("read uploaded chunk") {
+            read.extend_from_slice(&chunk);
+        }
         assert_eq!(
-            context
-                .target
-                .get_file_bytes_with_options(&spec, &loonfs_client::ReadFileOptions::default())
-                .await
-                .expect("read the uploaded file back"),
-            large,
+            read, large,
             "the file that landed is the file that was walked"
         );
     }

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -129,9 +129,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             human_config_show_degraded(error, config_toml)
         }
         CommandData::Version { version } => version.clone(),
-        CommandData::CompletionScript(_)
-        | CommandData::StreamBytes(_)
-        | CommandData::StreamedToStdout => String::new(),
+        CommandData::CompletionScript(_) | CommandData::StreamedToStdout => String::new(),
     }
 }
 

--- a/crates/loonfs-cli/src/render/json.rs
+++ b/crates/loonfs-cli/src/render/json.rs
@@ -21,9 +21,7 @@ where
 
 pub(crate) fn json_success(output: &CommandOutput) -> io::Result<String> {
     match &output.data {
-        CommandData::CompletionScript(_)
-        | CommandData::StreamBytes(_)
-        | CommandData::StreamedToStdout => Err(io::Error::new(
+        CommandData::CompletionScript(_) | CommandData::StreamedToStdout => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "raw output does not support json rendering",
         )),

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -41,7 +41,7 @@ pub(crate) fn render_success(output: &CommandOutput, format: OutputFormat) -> io
     }
 
     match &output.data {
-        CommandData::CompletionScript(bytes) | CommandData::StreamBytes(bytes) => {
+        CommandData::CompletionScript(bytes) => {
             let mut stdout = io::stdout().lock();
             stdout.write_all(bytes)?;
         }

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -2090,3 +2090,40 @@ fn a_remote_put_replays_its_exact_request_after_the_upload_session_is_gone() {
     );
     assert_eq!(download(&harness, "/file", "readback"), b"retained request");
 }
+
+#[test]
+fn a_historical_download_resumes_using_its_own_content_identity() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = streaming_payload();
+    let source = harness.temp_dir.path().join("source.bin");
+    fs::write(&source, &payload).expect("payload");
+    assert_success(&harness.run(&["put", source.to_str().expect("path"), "/big.bin"]));
+    let destination = harness.temp_dir.path().join("historical.bin");
+    let held = 3 * 1024 * 1024;
+    leave_a_partial_download(&harness, "/big.bin", &destination, &payload, held);
+    let (_, meta_path) = partial_paths(&destination);
+    let mut meta: Value =
+        serde_json::from_slice(&fs::read(&meta_path).expect("meta")).expect("json");
+    meta["revision_no"] = Value::from(1);
+    fs::write(&meta_path, serde_json::to_vec(&meta).expect("json")).expect("historical meta");
+    fs::write(&source, b"tiny current revision").expect("replacement");
+    assert_success(&harness.run(&["put", source.to_str().expect("path"), "/big.bin", "--force"]));
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "/big.bin",
+        destination.to_str().expect("path"),
+        "--revision",
+        "1",
+    ]);
+    assert_success(&get);
+    assert_eq!(fs::read(&destination).expect("download"), payload);
+    let resuming = events_of_kind(&get, "phase")
+        .into_iter()
+        .find(|event| event["phase"] == "resuming")
+        .expect("resume event");
+    assert_eq!(resuming["bytes_done"], held as u64);
+}

--- a/crates/loonfs-cli/tests/it/output.rs
+++ b/crates/loonfs-cli/tests/it/output.rs
@@ -775,3 +775,30 @@ fn ls_limit_bounds_the_whole_listing_and_json_rejects_all() {
     assert_eq!(conflicting_json.status.code(), Some(2));
     assert!(conflicting_json.stdout.is_empty());
 }
+
+#[test]
+fn ls_emits_completed_pages_even_when_a_later_page_fails() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["mkdir", "/first-page"]));
+    let listing = harness.run(&["--json", "ls", "/"]);
+    assert_success(&listing);
+    let mut first_page = json_data(&listing).clone();
+    first_page["next_cursor"] = Value::from("second-page");
+    for flag in ["--jsonl", "--all"] {
+        let (url, server) = json_response_server(vec![
+            first_page.clone(),
+            serde_json::json!({"invalid": "second page"}),
+        ]);
+        harness.write_remote_listing_config(&url);
+        let output = harness.run(&["ls", "/", flag]);
+        assert!(!output.status.success(), "the second page failed");
+        assert!(
+            stdout_string(&output).contains("first-page"),
+            "the first page remains visible"
+        );
+        server.join().expect("listing server");
+    }
+}

--- a/crates/loonfs-client/src/downloads.rs
+++ b/crates/loonfs-client/src/downloads.rs
@@ -32,6 +32,11 @@ pub struct DirectDownloadStream {
 }
 
 impl DirectDownloadStream {
+    /// The immutable content claim this stream verifies.
+    pub fn content_ref(&self) -> &ContentRef {
+        &self.expected
+    }
+
     /// Adds existing prefix bytes to the checksum for a resumed download.
     ///
     /// The caller must provide bytes in order from the start of the object.
@@ -108,19 +113,13 @@ impl DirectDownloadStream {
 }
 
 impl Client {
-    /// Returns whether this file should use a direct download.
-    ///
-    /// Files within the proxy limit use the simpler proxied path. Larger files
-    /// use direct object-store access when the deployment advertises it.
-    ///
-    /// If the server advertises no proxy limit, this keeps the proxied path.
-    pub async fn offers_direct_download(&self, size_bytes: u64) -> Result<bool> {
-        let capabilities = self.get_capabilities().await?;
-        Ok(capabilities.supports(FEATURE_DOWNLOADS_DIRECT_GET)
-            && capabilities
-                .limits
-                .get(LIMIT_DOWNLOAD_MAX_CONTENT_BYTES)
-                .is_some_and(|proxy_cap| size_bytes > *proxy_cap))
+    /// Returns whether the deployment offers direct object-store downloads.
+    /// Selection does not depend on the size of a different, current revision.
+    pub async fn offers_direct_download(&self) -> Result<bool> {
+        Ok(self
+            .get_capabilities()
+            .await?
+            .supports(FEATURE_DOWNLOADS_DIRECT_GET))
     }
 
     /// Requests short-lived direct access to a revision or snapshot.

--- a/crates/loonfs-client/src/downloads/tests.rs
+++ b/crates/loonfs-client/src/downloads/tests.rs
@@ -1,20 +1,18 @@
 //! Direct-download selection and verification tests.
 //!
-//! A file uses direct object-store access only when it exceeds the server's
-//! proxy limit and the deployment advertises direct downloads.
+//! Direct access is preferred whenever the deployment advertises it.
 
 use super::*;
 use crate::transport::test_transport::{self, Outcome};
 use loonfs_api::v0::ObjectTransferAccess;
 use loonfs_api::{
-    CapabilityDocument, ContentId, ContentRef, API_GROUP_FILESYSTEM_V0, PROTOCOL_VERSION,
+    CapabilityDocument, ContentId, ContentRef, API_GROUP_FILESYSTEM_V0,
+    LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, PROTOCOL_VERSION,
 };
 use std::collections::BTreeMap;
 
 /// Default maximum size of a proxied read response.
 const DEFAULT_PROXY_CAP_BYTES: u64 = 256 * 1024 * 1024;
-/// Test file larger than the default proxy limit.
-const AUDIT_FILE_BYTES: u64 = 300 * 1024 * 1024;
 
 fn client() -> Client {
     Client::new(ClientConfig {
@@ -41,21 +39,12 @@ fn capabilities(direct_get: bool, proxy_cap_bytes: Option<u64>) -> Outcome {
 }
 
 #[tokio::test]
-async fn a_file_past_the_default_proxy_cap_takes_the_grant() {
+async fn direct_download_selection_uses_the_cached_capability() {
     let client = client();
     let _guard = test_transport::script([capabilities(true, Some(DEFAULT_PROXY_CAP_BYTES))]);
-
+    assert!(client.offers_direct_download().await.expect("capabilities"));
     assert!(client
-        .offers_direct_download(AUDIT_FILE_BYTES)
-        .await
-        .expect("capabilities"));
-    // Cached document, so no second scripted response is needed.
-    assert!(!client
-        .offers_direct_download(DEFAULT_PROXY_CAP_BYTES)
-        .await
-        .expect("cached capabilities"));
-    assert!(!client
-        .offers_direct_download(1)
+        .offers_direct_download()
         .await
         .expect("cached capabilities"));
 }
@@ -65,21 +54,15 @@ async fn a_deployment_without_the_capability_never_takes_the_grant() {
     let client = client();
     let _guard = test_transport::script([capabilities(false, Some(DEFAULT_PROXY_CAP_BYTES))]);
 
-    assert!(!client
-        .offers_direct_download(AUDIT_FILE_BYTES)
-        .await
-        .expect("capabilities"));
+    assert!(!client.offers_direct_download().await.expect("capabilities"));
 }
 
 #[tokio::test]
-async fn a_deployment_that_advertises_no_cap_stays_proxied() {
+async fn direct_downloads_do_not_require_a_proxy_limit() {
     let client = client();
     let _guard = test_transport::script([capabilities(true, None)]);
 
-    assert!(!client
-        .offers_direct_download(AUDIT_FILE_BYTES)
-        .await
-        .expect("capabilities"));
+    assert!(client.offers_direct_download().await.expect("capabilities"));
 }
 
 #[tokio::test]
@@ -87,7 +70,7 @@ async fn a_capability_failure_is_not_reported_as_no_direct_download() {
     let client = client();
     let transport = test_transport::script([Outcome::Success(b"not json".to_vec())]);
 
-    let result = client.offers_direct_download(AUDIT_FILE_BYTES).await;
+    let result = client.offers_direct_download().await;
 
     assert!(matches!(result, Err(ClientError::Json(_))), "{result:?}");
     assert_eq!(transport.attempts(), 1);

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -44,8 +44,7 @@ use loonfs_api::{
     NamespaceDiagnostics, NamespaceId, PathEntry, ReleaseCheckpointResponse, RevisionNo,
     RunMaintenanceRequest, RunMaintenanceResponse, SecretString, StreamingChecksum, UploadId,
     FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
-    LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES,
-    LIMIT_UPLOAD_MAX_CONTENT_BYTES,
+    LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
 use payload::PartReader;
 use std::sync::{Arc, OnceLock};

--- a/crates/loonfs-client/src/reads.rs
+++ b/crates/loonfs-client/src/reads.rs
@@ -455,6 +455,23 @@ impl Client {
         spec: &NamespacePath,
         options: &ReadFileOptions,
     ) -> Result<Vec<u8>> {
+        self.request_bytes(&self.file_content_url(spec, options))
+            .await
+    }
+
+    /// Streams content through the server. Successful completion means the server
+    /// verified the whole object; a late verification failure aborts the body.
+    /// Bytes already consumed remain provisional until the stream ends cleanly.
+    pub async fn read_file_stream(
+        &self,
+        spec: &NamespacePath,
+        options: &ReadFileOptions,
+    ) -> Result<PayloadStream> {
+        self.call_for_response_stream(&self.get(&self.file_content_url(spec, options)))
+            .await
+    }
+
+    fn file_content_url(&self, spec: &NamespacePath, options: &ReadFileOptions) -> String {
         let mut query = QueryBuilder::new(format!(
             "{}/v0/namespaces/{}/filesystem/content",
             self.base_url,
@@ -467,8 +484,7 @@ impl Client {
         if let Some(snapshot_id) = &options.snapshot_id {
             query.push("snapshot_id", snapshot_id.as_str());
         }
-        let url = query.finish();
-        self.request_bytes(&url).await
+        query.finish()
     }
 
     /// Reads and verifies one retained file revision by inode identity.

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -287,6 +287,7 @@ impl<S: ObjectStore, M> NamespaceEngine<S, M> {
         &self,
         path: impl AsRef<str>,
         context: &RuntimeReadContext,
+        revision_no: Option<RevisionNo>,
         chunk_bytes: NonZeroU64,
         start_offset: u64,
     ) -> Result<FileContentStream<S>>
@@ -294,7 +295,9 @@ impl<S: ObjectStore, M> NamespaceEngine<S, M> {
         S: Clone,
     {
         let view = self.load_read_view(context).await?;
-        let (entry, content_ref) = view.resolve_file_content(path.as_ref()).await?;
+        let (entry, content_ref) = view
+            .resolve_file_content(path.as_ref(), revision_no)
+            .await?;
         if start_offset > content_ref.size_bytes {
             return Err(CoreError::ResumeOffsetOutOfRange {
                 start_offset,
@@ -308,6 +311,32 @@ impl<S: ObjectStore, M> NamespaceEngine<S, M> {
             content_ref,
             chunk_bytes,
             start_offset,
+        )
+        .await?)
+    }
+
+    /// Streams one retained inode revision without requiring a visible path.
+    pub async fn read_file_revision_stream_by_inode(
+        &self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        context: &RuntimeReadContext,
+    ) -> Result<FileContentStream<S>>
+    where
+        S: Clone,
+    {
+        let view = self.load_read_view(context).await?;
+        let target = view
+            .direct_download_target_by_inode(inode_id, revision_no)
+            .await?;
+        Ok(FileContentStream::open_inner(
+            self.store.clone(),
+            view.content_store_id(),
+            None,
+            target.content_ref,
+            NonZeroU64::new(crate::CONTENT_READ_CHUNK_BYTES)
+                .expect("content read chunk size should be nonzero"),
+            0,
         )
         .await?)
     }

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -312,7 +312,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         absolute_path: &str,
         max_content_bytes: Option<u64>,
     ) -> Result<FileBytes> {
-        let (entry, content_ref) = self.resolve_file_content(absolute_path).await?;
+        let (entry, content_ref) = self.resolve_file_content(absolute_path, None).await?;
         ensure_within_read_limit(content_ref.size_bytes, max_content_bytes)?;
         let bytes = get_durable_content_bytes(store, &self.content_store_id, &content_ref).await?;
         Ok(FileBytes { entry, bytes })
@@ -325,8 +325,9 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
     pub(crate) async fn resolve_file_content(
         &self,
         absolute_path: &str,
+        revision_no: Option<RevisionNo>,
     ) -> Result<(PathEntry, ContentRef)> {
-        let entry = self
+        let mut entry = self
             .resolve_path(absolute_path, AttributeInclusion::Omit)
             .await?;
         let content_ref = match &entry.kind {
@@ -338,6 +339,17 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 });
             }
         };
+        if let Some(revision_no) = revision_no {
+            let revision = self.revision_for_inode(entry.inode_id, revision_no).await?;
+            entry.kind = PathEntryKind::File {
+                revision_no: revision.revision_no,
+                size_bytes: revision.content_ref.size_bytes,
+                content_ref: revision.content_ref.clone(),
+                revision_committed_by: revision.committed_by,
+                revision_committed_at_ms: revision.committed_at_ms,
+            };
+            return Ok((entry, revision.content_ref));
+        }
         Ok((entry, content_ref))
     }
 
@@ -554,26 +566,11 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         revision_no: RevisionNo,
         max_content_bytes: Option<u64>,
     ) -> Result<FileBytes> {
-        let mut entry = self
-            .resolve_path(absolute_path, AttributeInclusion::Omit)
+        let (entry, content_ref) = self
+            .resolve_file_content(absolute_path, Some(revision_no))
             .await?;
-        if matches!(entry.kind, PathEntryKind::Directory {}) {
-            return Err(CoreError::ExpectedFile {
-                target: entry.path.to_string(),
-                kind: InodeKind::Directory,
-            });
-        }
-        let revision = self.revision_for_inode(entry.inode_id, revision_no).await?;
-        entry.kind = PathEntryKind::File {
-            revision_no: revision.revision_no,
-            size_bytes: revision.content_ref.size_bytes,
-            content_ref: revision.content_ref.clone(),
-            revision_committed_by: revision.committed_by,
-            revision_committed_at_ms: revision.committed_at_ms,
-        };
-        ensure_within_read_limit(revision.content_ref.size_bytes, max_content_bytes)?;
-        let bytes =
-            get_durable_content_bytes(store, &self.content_store_id, &revision.content_ref).await?;
+        ensure_within_read_limit(content_ref.size_bytes, max_content_bytes)?;
+        let bytes = get_durable_content_bytes(store, &self.content_store_id, &content_ref).await?;
         Ok(FileBytes { entry, bytes })
     }
 

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -355,7 +355,7 @@ impl<S: ObjectStore> FileContentStream<S> {
         .await
     }
 
-    async fn open_inner(
+    pub(crate) async fn open_inner(
         store: S,
         content_store_id: &ContentStoreId,
         entry: Option<PathEntry>,
@@ -413,11 +413,15 @@ impl<S: ObjectStore> FileContentStream<S> {
         Ok(())
     }
 
-    /// The authoritative metadata entry the path resolved to.
-    pub fn entry(&self) -> &PathEntry {
-        self.entry
-            .as_ref()
-            .expect("path content stream should carry its metadata entry")
+    /// The authoritative metadata entry for a path read. Inode-only reads
+    /// have no path entry, including when the file has been deleted.
+    pub fn entry(&self) -> Option<&PathEntry> {
+        self.entry.as_ref()
+    }
+
+    /// The immutable content claim this stream verifies.
+    pub fn content_ref(&self) -> &ContentRef {
+        &self.content_ref
     }
 
     /// Complete length of the content this stream reads.

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -37,7 +37,7 @@ writer_id = "loonfs-server-local"
 # `upload.max_content_bytes` capability limit. Defaults to 256 MiB.
 #max_upload_bytes = 268435456
 
-# Largest file content a service-proxied read will buffer and return, in
+# Largest file content a service-proxied read will stream and return, in
 # bytes; over-limit reads answer `content_too_large`. Advertised to clients
 # as the `download.max_content_bytes` capability limit. Defaults to 256 MiB.
 #max_download_bytes = 268435456
@@ -49,7 +49,7 @@ writer_id = "loonfs-server-local"
 #snapshot_max_live_per_namespace = 16
 
 # How many proxied upload bodies the server will stream at once and how many
-# content reads it will buffer at once. Requests past a cap answer 503
+# content streams it will serve at once. Requests past a cap answer 503
 # `server_busy`. Upload memory tracks one transfer part per admitted body.
 # Download memory tracks the bounded file size of each admitted read.
 #max_concurrent_uploads = 8

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -301,14 +301,15 @@ Start with enough memory for:
 
 ```text
 max_concurrent_uploads × 8 MiB
-+ max_concurrent_downloads × max_download_bytes
++ max_concurrent_downloads × 8 MiB
 + local_cache.memory_bytes
 + memory for metadata maintenance and the server
 ```
 
 The defaults allow 8 concurrent uploads, 16 concurrent downloads, and
-256 MiB per download. Set a memory limit comfortably above the calculated
-minimum.
+a 256 MiB transfer limit per proxied download. Content reads use 8 MiB chunks;
+the transfer limit does not reserve that much memory. Set a memory limit
+comfortably above the calculated minimum to allow for HTTP and store buffers.
 
 `max_writer_sessions` defaults to 10,000. A request that needs another writer
 session answers `writer_capacity_exceeded`; raise the limit if the deployment

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -127,8 +127,8 @@ pub struct ServerConfig {
     #[serde(default = "default_max_upload_bytes")]
     pub max_upload_bytes: u64,
     /// Largest file content a service-proxied read (`GET .../filesystem/
-    /// content` and inode revision content) will buffer and return. Checked
-    /// against resolved metadata before any content fetch; over-limit reads
+    /// content` and inode revision content) will stream and return. Checked
+    /// against resolved metadata before fetching content bytes; over-limit reads
     /// answer `content_too_large`. Advertised to clients as the
     /// `download.max_content_bytes` capability limit.
     #[serde(default = "default_max_download_bytes")]
@@ -152,9 +152,11 @@ pub struct ServerConfig {
     /// bodies forward to the store incrementally instead of buffering.
     #[serde(default = "default_max_concurrent_uploads")]
     pub max_concurrent_uploads: usize,
-    /// How many proxied content reads the server will materialize at once;
+    /// How many proxied content streams the server will serve at once;
     /// requests past the cap answer `server_busy` before any fetch.
-    /// Worst-case download memory is this times `max_download_bytes`.
+    /// Content memory follows this count times the internal read chunk size,
+    /// independent of `max_download_bytes`. Admission lasts until the body
+    /// finishes or is dropped.
     #[serde(default = "default_max_concurrent_downloads")]
     pub max_concurrent_downloads: usize,
     /// How many runner-scheduled maintenance runs may execute at once across

--- a/crates/loonfs-server/src/http/download_body.rs
+++ b/crates/loonfs-server/src/http/download_body.rs
@@ -1,41 +1,45 @@
-//! Buffered download response bodies and their admission permits.
+//! Streaming download response bodies and their admission permits.
 
+use super::error::ApiResponseError;
 use axum::body::Body;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use futures::Stream;
-use std::convert::Infallible;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use loonfs::{FileContentStream, SharedObjectStore};
+use loonfs_api::NamespaceId;
 use tokio::sync::OwnedSemaphorePermit;
 
-/// One materialized download plus the permit accounting for its memory.
-///
-/// The stream owns the permit even after yielding its only chunk, so the
-/// response body releases admission only when it is fully consumed or
-/// abandoned and dropped.
-struct DownloadBodyStream {
-    bytes: Option<bytes::Bytes>,
-    _permit: OwnedSemaphorePermit,
-}
-
-pub(super) fn buffered_download_response(bytes: Vec<u8>, permit: OwnedSemaphorePermit) -> Response {
-    let body = Body::from_stream(DownloadBodyStream {
-        bytes: Some(bytes.into()),
-        _permit: permit,
+/// Keeps admission until the stream finishes or is abandoned. No Content-Length
+/// is sent: successful HTTP completion follows checksum verification, not merely
+/// delivery of the expected number of bytes. A late failure aborts the body.
+pub(super) fn streamed_download_response(
+    stream: FileContentStream<SharedObjectStore>,
+    permit: OwnedSemaphorePermit,
+    max_content_bytes: u64,
+    namespace_id: &NamespaceId,
+) -> Result<Response, ApiResponseError> {
+    if stream.size_bytes() > max_content_bytes {
+        return Err(ApiResponseError::runtime_for_namespace(
+            namespace_id,
+            loonfs::RuntimeError::Core(loonfs::CoreError::ContentTooLarge {
+                size_bytes: stream.size_bytes(),
+                max_bytes: max_content_bytes,
+            }),
+        ));
+    }
+    let body = futures::stream::try_unfold((stream, permit), |(mut stream, permit)| async move {
+        match stream.next_chunk().await {
+            Ok(Some(bytes)) => Ok(Some((bytes, (stream, permit)))),
+            Ok(None) => Ok(None),
+            Err(error) => {
+                tracing::warn!(code = %error.code(), error = %error, "download body failed verification or transfer");
+                Err(std::io::Error::other(error))
+            }
+        }
     });
-    (
+    Ok((
         StatusCode::OK,
         [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
-        body,
+        Body::from_stream(body),
     )
-        .into_response()
-}
-
-impl Stream for DownloadBodyStream {
-    type Item = Result<bytes::Bytes, Infallible>;
-
-    fn poll_next(mut self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Poll::Ready(self.bytes.take().map(Ok))
-    }
+        .into_response())
 }

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -28,7 +28,7 @@ const DIRECT_GET_URL_TTL: Duration = Duration::from_secs(15 * 60);
 
 /// Issues a short-lived download URL for a file.
 ///
-/// This endpoint reads metadata but does not proxy the file bytes, so buffered
+/// This endpoint reads metadata but does not proxy the file bytes, so service-proxied
 /// download limits do not apply.
 #[cfg_attr(
     feature = "openapi",

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -2,7 +2,7 @@
 //! reads, revision listings, filesystem mutations, and the committed-change
 //! feed.
 
-use super::download_body::buffered_download_response;
+use super::download_body::streamed_download_response;
 use super::error::ApiResponseError;
 use super::handlers_uploads::{
     content_preparation_for_puts, current_unix_ms, ContentTokenVerifier, PutContentPreparation,
@@ -140,24 +140,21 @@ impl ReadTarget {
         }
     }
 
-    pub(super) async fn get_file_bytes(
+    pub(super) async fn read_file_stream(
         &self,
         path: &str,
         revision_no: Option<RevisionNo>,
-    ) -> loonfs::Result<loonfs::FileBytes> {
+    ) -> loonfs::Result<loonfs::FileContentStream<loonfs::SharedObjectStore>> {
+        let options = loonfs::ReadFileStreamOptions {
+            revision_no,
+            ..Default::default()
+        };
         match self {
-            Self::Snapshot(snapshot) => snapshot.get_file_bytes(path).await,
+            Self::Snapshot(snapshot) => snapshot.read_file_stream(path, options).await,
             Self::Live {
                 reader,
                 namespace_id,
-            } => match revision_no {
-                Some(revision_no) => {
-                    reader
-                        .get_file_revision_bytes(namespace_id, path, revision_no)
-                        .await
-                }
-                None => reader.get_file_bytes(namespace_id, path).await,
-            },
+            } => reader.read_file_stream(namespace_id, path, options).await,
         }
     }
 
@@ -333,14 +330,19 @@ pub(super) async fn get_file_bytes(
     reject_snapshot_with_revision(snapshot_id.as_ref(), revision_no)?;
     let target = pin_requested_snapshot(&state, &namespace_id, snapshot_id).await?;
     let permit = acquire_download_permit(&state)?;
-    let file = target
-        .get_file_bytes(&path, revision_no)
+    let stream = target
+        .read_file_stream(&path, revision_no)
         .await
         .map_err(|error| {
             ApiResponseError::runtime_for_namespace(&namespace_id, error)
                 .with_invalid_request_param("path")
         })?;
-    Ok(buffered_download_response(file.bytes, permit))
+    streamed_download_response(
+        stream,
+        permit,
+        state.config.max_download_bytes,
+        &namespace_id,
+    )
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -1,6 +1,6 @@
 //! HTTP reads addressed by inode ID.
 
-use super::download_body::buffered_download_response;
+use super::download_body::streamed_download_response;
 use super::error::ApiResponseError;
 use super::handlers_filesystem::PageQuery;
 use super::query_params::{
@@ -248,10 +248,15 @@ pub(super) async fn get_file_revision_bytes_by_inode(
     let inode_id = parse_inode_id(&path.inode_id)?;
     let revision_no = parse_revision_no(&path.revision_no)?;
     let permit = acquire_download_permit(&state)?;
-    let bytes = state
+    let stream = state
         .reader
-        .get_file_revision_bytes_by_inode(&namespace_id, inode_id, revision_no)
+        .read_file_revision_stream_by_inode(&namespace_id, inode_id, revision_no)
         .await
         .map_err(ApiResponseError::for_namespace(&namespace_id))?;
-    Ok(buffered_download_response(bytes, permit))
+    streamed_download_response(
+        stream,
+        permit,
+        state.config.max_download_bytes,
+        &namespace_id,
+    )
 }

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -162,9 +162,8 @@ pub struct AppState {
     /// streamed part. Requests past the cap answer 503 `server_busy` before
     /// any transfer.
     pub(super) upload_permits: Arc<Semaphore>,
-    /// Bounds concurrently materialized proxied content reads the same way:
-    /// worst-case download memory is
-    /// `max_concurrent_downloads * max_download_bytes`.
+    /// Bounds live proxied download bodies until completion or cancellation.
+    /// Content memory follows this count times the internal read chunk size.
     pub(super) download_permits: Arc<Semaphore>,
     /// Shared recorder for runtime and request-level metrics. `GET /metrics`
     /// renders its snapshot. It is always installed.

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -4471,3 +4471,103 @@ mod direct_download {
         }
     }
 }
+
+#[tokio::test]
+async fn download_body_streams_one_chunk_and_aborts_on_late_corruption() {
+    use futures::StreamExt;
+    use tower::ServiceExt;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let plain = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let ns = namespace_id("demo");
+    let seed_writer = bootstrap_namespace(&plain, "runtime-writer", &ns).await;
+    let payload = vec![42; loonfs::CONTENT_READ_CHUNK_BYTES as usize * 3 + 17];
+    write_file_bytes(
+        &seed_writer,
+        &ns,
+        "/large.bin",
+        &payload,
+        "download-stream-seed",
+    )
+    .await;
+    let watched = Arc::new(BufferWatchStore::watching_content(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+    ));
+    let (router, state) = app(
+        test_config(temp_dir.path(), "server-writer"),
+        options_with_store(watched.clone()),
+    )
+    .await
+    .expect("app");
+
+    for corrupt in [false, true] {
+        let response = router
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/v0/namespaces/demo/filesystem/content?path=%2Flarge.bin")
+                    .header(axum::http::header::AUTHORIZATION, "Bearer test-token")
+                    .body(axum::body::Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert!(response
+            .headers()
+            .get(axum::http::header::CONTENT_LENGTH)
+            .is_none());
+        if !corrupt {
+            assert_eq!(
+                watched.peaks().total_bytes,
+                0,
+                "opening the response must not fetch the file"
+            );
+        }
+        let mut body = response.into_body().into_data_stream();
+        let first = body
+            .next()
+            .await
+            .expect("first chunk")
+            .expect("valid chunk");
+        assert!(first.len() as u64 <= loonfs::CONTENT_READ_CHUNK_BYTES);
+        drop(first);
+        if corrupt {
+            let reader = loonfs::FsReader::builder_with_store(plain.clone())
+                .build()
+                .await
+                .expect("reader");
+            let entry = reader
+                .get_path_entry(&ns, "/large.bin", Default::default())
+                .await
+                .expect("entry");
+            let catalog = loonfs::control::load_namespace_catalog_entry(&plain, &ns)
+                .await
+                .expect("catalog");
+            let key = loonfs_objectstore::keys::content_blob(
+                catalog.content_store_id(),
+                &entry.content_ref().expect("file").content_id,
+            );
+            let mut changed = payload.clone();
+            changed[loonfs::CONTENT_READ_CHUNK_BYTES as usize] ^= 1;
+            plain
+                .put_overwrite(&key, changed.into())
+                .await
+                .expect("corrupt unread bytes");
+        }
+        let mut failed = false;
+        while let Some(chunk) = body.next().await {
+            if chunk.is_err() {
+                failed = true;
+                break;
+            }
+        }
+        assert_eq!(failed, corrupt, "corruption must abort the HTTP body");
+        drop(body);
+        assert_eq!(
+            state.download_permits.available_permits(),
+            state.config.max_concurrent_downloads
+        );
+        assert!(watched.peaks().peak_live_bytes <= loonfs::CONTENT_READ_CHUNK_BYTES);
+    }
+}

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -175,6 +175,31 @@ impl FsReadSnapshot {
             .await?)
     }
 
+    /// Streams the file selected by this snapshot in bounded chunks.
+    /// Complete verification requires consuming the stream to its end.
+    pub async fn read_file_stream(
+        &self,
+        absolute_path: &str,
+        options: ReadFileStreamOptions,
+    ) -> Result<FileContentStream<SharedObjectStore>> {
+        if options.revision_no.is_some() {
+            return Err(CoreError::InvalidCheckpointRequest(
+                "revision_no cannot be combined with a snapshot read".to_owned(),
+            )
+            .into());
+        }
+        Ok(self
+            .engine
+            .read_file_stream(
+                absolute_path,
+                &self.context,
+                None,
+                options.chunk_bytes,
+                options.start_offset,
+            )
+            .await?)
+    }
+
     /// Resolves the file selected by this snapshot for a direct download.
     pub async fn create_download(&self, absolute_path: &str) -> Result<DirectDownloadTarget> {
         Ok(self
@@ -625,6 +650,7 @@ impl FsReader {
             .read_file_stream(
                 absolute_path,
                 &read_context,
+                options.revision_no,
                 options.chunk_bytes,
                 options.start_offset,
             )
@@ -998,6 +1024,34 @@ impl FsReader {
             )
             .await?;
         Ok(read)
+    }
+
+    /// Streams a retained inode revision, including content without a visible path.
+    /// Complete verification requires consuming the stream to its end.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.get_file_revision_bytes_by_inode",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "get_file_revision_bytes_by_inode",
+            method = "read_file_revision_stream_by_inode",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn read_file_revision_stream_by_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<FileContentStream<SharedObjectStore>> {
+        self.core.record_trace_context(&tracing::Span::current());
+        let (engine, context) = self.core.pinned_metadata_read(namespace_id).await?;
+        Ok(engine
+            .read_file_revision_stream_by_inode(inode_id, revision_no, &context)
+            .await?)
     }
 
     /// Reads and verifies one retained file revision by inode identity.

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -129,6 +129,8 @@ pub struct ListChangesOptions {
 /// Options for a streaming file read.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReadFileStreamOptions {
+    /// Read this retained revision instead of the current content.
+    pub revision_no: Option<loonfs_api::RevisionNo>,
     /// Bytes one ranged read fetches, which is the most of the file the read
     /// holds at once. Defaults to
     /// [`CONTENT_READ_CHUNK_BYTES`](loonfs_core::CONTENT_READ_CHUNK_BYTES);
@@ -151,6 +153,7 @@ pub struct ReadFileStreamOptions {
 impl Default for ReadFileStreamOptions {
     fn default() -> Self {
         Self {
+            revision_no: None,
             chunk_bytes: const { NonZeroU64::new(loonfs_core::CONTENT_READ_CHUNK_BYTES).unwrap() },
             start_offset: 0,
         }

--- a/crates/loonfs/tests/it/streamed_read.rs
+++ b/crates/loonfs/tests/it/streamed_read.rs
@@ -92,7 +92,7 @@ async fn a_streamed_read_holds_one_chunk_of_its_file() {
         .await
         .expect("open stream");
     assert_eq!(stream.size_bytes(), PAYLOAD_BYTES as u64);
-    assert_eq!(stream.entry().path.as_str(), PATH);
+    assert_eq!(stream.entry().expect("path metadata").path.as_str(), PATH);
 
     let mut read = Vec::with_capacity(PAYLOAD_BYTES);
     let mut chunks = 0u64;
@@ -185,4 +185,89 @@ async fn a_streamed_read_rejects_content_that_stopped_matching_its_reference() {
     }
     .expect("corrupted content must not report a verified end");
     assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+}
+
+#[tokio::test]
+async fn historical_and_snapshot_reads_stream_the_selected_revision() {
+    use loonfs::{CreateSnapshotOptions, RevisionNo};
+
+    let temp_dir = tempdir().expect("tempdir");
+    let payload = payload(PAYLOAD_BYTES);
+    let (namespace_id, watched, reader) = written_file(temp_dir.path(), &payload).await;
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-b").await;
+    let snapshot = runtime
+        .writer
+        .create_snapshot(
+            &namespace_id,
+            CreateSnapshotOptions {
+                name: "before-replace".to_owned(),
+                expires_at_ms: u64::MAX,
+            },
+        )
+        .await
+        .expect("snapshot");
+    runtime
+        .writer
+        .put_file_bytes(
+            &namespace_id,
+            PATH,
+            b"tiny",
+            PutFileOptions {
+                behavior: DestinationBehavior::Replace,
+                ..PutFileOptions::new(loonfs_test_support::test_actor())
+            },
+        )
+        .await
+        .expect("replace");
+
+    let historical = reader
+        .read_file_stream(
+            &namespace_id,
+            PATH,
+            ReadFileStreamOptions {
+                revision_no: Some(RevisionNo(1)),
+                ..chunked()
+            },
+        )
+        .await
+        .expect("historical stream");
+    let pinned = reader
+        .pin_namespace_at_snapshot(&namespace_id, &snapshot.checkpoint_id)
+        .await
+        .expect("pin snapshot");
+    let snapshot_stream = pinned
+        .read_file_stream(PATH, chunked())
+        .await
+        .expect("snapshot stream");
+    for mut stream in [historical, snapshot_stream] {
+        assert_eq!(stream.size_bytes(), payload.len() as u64);
+        assert_eq!(
+            stream
+                .entry()
+                .expect("path metadata")
+                .content_ref()
+                .expect("file")
+                .size_bytes,
+            payload.len() as u64
+        );
+        let mut read = Vec::new();
+        while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
+            read.extend_from_slice(&chunk);
+        }
+        assert_eq!(read, payload);
+    }
+    assert!(watched.peaks().peak_live_bytes <= CHUNK_BYTES);
+    assert!(
+        pinned
+            .read_file_stream(
+                PATH,
+                ReadFileStreamOptions {
+                    revision_no: Some(RevisionNo(1)),
+                    ..chunked()
+                }
+            )
+            .await
+            .is_err(),
+        "snapshot and revision cannot be combined"
+    );
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -131,9 +131,9 @@ Registered limit keys:
 | `upload.max_content_bytes` | Largest request body accepted for service-proxied upload content (`PUT .../uploads/{upload_id}/content`). Clients may use `direct_put` for larger content only when `filesystem.uploads.direct_put` is advertised; otherwise they must stay within this limit. |
 | `upload.direct_put_max_content_bytes` | Largest object this deployment's provider accepts in one presigned `direct_put` request. Unrelated to `upload.max_content_bytes`, which bounds service-proxied uploads. A size hint above this limit returns `content_too_large` at begin, and completion checks the actual stored size. Advertised only alongside `filesystem.uploads.direct_put`. |
 | `upload.completion_max_body_bytes` | Largest JSON body accepted by `POST .../uploads/{upload_id}/complete`. Larger requests return `content_too_large`. |
-| `download.max_content_bytes` | Largest file content a service-proxied read (`GET .../filesystem/content` or `GET .../inodes/{inode_id}/revisions/{revision_no}/content`) will buffer and return in one response. Over-limit reads answer `content_too_large`; v0 has no proxied streaming or range reads. A file past this limit is read through the corresponding path or inode download grant when `filesystem.downloads.direct_get` is advertised — which it is on exactly the deployments that could have let a client create such a file. |
-| `upload.max_concurrent` | How many service-proxied upload bodies the deployment buffers at once; requests past the cap answer `server_busy`. |
-| `download.max_concurrent` | How many service-proxied content reads the deployment materializes at once; requests past the cap answer `server_busy`. |
+| `download.max_content_bytes` | Largest file content a service-proxied read (`GET .../filesystem/content` or `GET .../inodes/{inode_id}/revisions/{revision_no}/content`) will stream and return in one response. Over-limit reads answer `content_too_large`; proxied reads use bounded chunks but do not support range reads. A file past this limit is read through the corresponding path or inode download grant when `filesystem.downloads.direct_get` is advertised — which it is on exactly the deployments that could have let a client create such a file. |
+| `upload.max_concurrent` | How many service-proxied upload streams the deployment accepts at once; requests past the cap answer `server_busy`. |
+| `download.max_concurrent` | How many service-proxied content streams the deployment serves at once; requests past the cap answer `server_busy`. |
 | `commit.max_operations` | Most path operations one commit may carry. A longer list answers `invalid_request` before planning, on every transport. |
 | `commit.max_content_tokens` | Most content tokens one commit may carry. Over-limit requests answer `invalid_request` before planning. |
 | `commit.max_external_content_refs` | Most distinct external content refs one commit's operations may name. Over-limit requests answer `invalid_request` before planning. |
@@ -1636,11 +1636,18 @@ Those rows represent current state and are not removed when the retention floor 
 The response body is the authoritative file bytes. Metadata may be exposed in
 headers, but the body itself is raw content rather than JSON.
 
-The server buffers the whole file for one response, so a file past
-`download.max_content_bytes` answers `content_too_large` here. That is not the
-end of the road: the download transport in section 6.10 reads the same bytes
-without the server holding them, and every deployment that could have let a
-client create such a file offers it.
+The server streams and verifies content in bounded chunks. A file past
+`download.max_content_bytes` answers `content_too_large` before content bytes
+are fetched; clients may use a download grant when direct GET is advertised.
+The limit is a transfer policy, not an allocation size.
+
+A successful end of the response body means length and checksum verification
+completed. The server omits `Content-Length` so receiving the expected byte
+count alone cannot signal success before verification. An I/O or verification
+failure after headers aborts the body instead of returning a JSON error.
+Consumers must require successful stream completion; file downloads should
+publish their temporary output only after that completion. Streaming to stdout
+can expose a partial or unverified prefix before a later error.
 
 Revision listings return newest revisions first and use the standard
 `limit`/`cursor` pattern. The path route resolves the current inode first; the
@@ -2196,9 +2203,8 @@ Representative complete-upload response:
 A deployment must be able to serve back whatever it let a client create.
 That is the whole rule, and it is why this exists: `direct_put` and
 `direct_multipart` let a client write an object of any size, while a proxied
-read buffers the file for one response and refuses anything past
-`download.max_content_bytes`. Without a read that does not buffer, a
-deployment could hold a file it had no way to return. So
+read enforces the transfer limit `download.max_content_bytes`. Direct reads
+bypass that service limit and keep object traffic off the server. So
 `filesystem.downloads.direct_get` is advertised by every deployment that offers
 any direct write — the read is not a separate decision, and a deployment
 that offers none of them cannot have created such a file in the first place.

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -2885,3 +2885,34 @@ func TestProxyForwardsEveryDocumentedRoute(t *testing.T) {
 		t.Errorf("stub observed %d requests for excluded server routes", observedAfter-observedBefore)
 	}
 }
+
+func TestProxyPreservesAnAbortedUpstreamBody(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(bytes.Repeat([]byte("provisional"), 8192))
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
+	}))
+	defer upstream.Close()
+	handler, err := loonfsproxy.NewHandler(loonfsproxy.Config{
+		ServerBaseURL: upstream.URL, Token: "test-token", NamespaceAliases: map[string]string{"app": "demo"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+	response, err := http.Get(proxy.URL + "/v0/namespace-aliases/app/filesystem/content?path=%2Ffile")
+	if err != nil {
+		t.Fatalf("read response headers: %v", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err == nil {
+		t.Fatalf("aborted upstream became successful EOF after %d bytes", len(body))
+	}
+	if len(body) == 0 {
+		t.Fatal("expected a provisional prefix before the failure")
+	}
+}

--- a/sdk/proxy/go/proxy/proxy.go
+++ b/sdk/proxy/go/proxy/proxy.go
@@ -171,7 +171,11 @@ func (h *handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	responseHeaders.Del("Set-Cookie")
 	copyHeaders(responseWriter.Header(), responseHeaders)
 	responseWriter.WriteHeader(response.StatusCode)
-	_, _ = io.Copy(responseWriter, response.Body)
+	if _, err := io.Copy(responseWriter, response.Body); err != nil {
+		// A truncated or unverified upstream body must not become a successful
+		// downstream EOF. net/http aborts the response for this sentinel.
+		panic(http.ErrAbortHandler)
+	}
 }
 
 func (h *handler) rewritePath(method, path string) (string, bool) {


### PR DESCRIPTION
File reads and listings currently have different memory and failure behavior depending on transport and revision selection. Stream CLI and proxied server reads through bounded chunks, resolve resume metadata from the selected revision, and emit completed listing pages before fetching the next page. Keep checksum verification as the success boundary and preserve aborted upstream bodies through the Go proxy.

All CI checks pass, including the workspace suite, OpenAPI checks, Clippy, formatting, and SDK conformance; local workspace tests and a separate doctest rerun also pass.
