### PR TITLE
feat(sdk): expose prepared upload publication

### DIFF
--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -588,18 +588,26 @@ Keep the `content_ref` a completed upload returned and reuse it across
 commit retries; that is the cheapest retry and the one the server can
 answer on its own.
 
-**Rust convenience calls.** Both the HTTP client and embedded runtime offer
-`prepare_file_bytes()` / `prepare_file_stream()`, followed by `put_file_prepared()`.
-Retain the prepared content and use the same explicit commit ID, path, and
-options on each publication attempt. Preparation alone does not publish a file
-or extend the completed upload's lifetime.
+**Prepared content.** Prepare bytes once, retain the returned content, then publish
+with the same explicit commit ID, path, actor, and options on each attempt.
+Preparation alone does not publish a file or extend the completed upload's
+lifetime.
 
-Calling `put_file_bytes()` or `put_file_stream()` again uploads a new object; using
-an already-committed ID therefore returns `commit_id_reuse_conflict`, even for
-identical bytes. The unused upload can be reclaimed after its grace period.
-These helpers do not read the change feed or substitute an earlier content
-reference. To recover across processes, the remote CLI saves the full request
-before submission and resends it directly.
+| Client | Prepare content | Publish retained content |
+| --- | --- | --- |
+| Rust HTTP and embedded runtime | `prepare_file_bytes()` / `prepare_file_stream()` | `put_file_prepared()` |
+| Python synchronous client | `files.prepare_file_bytes()` | `files.put_file_prepared()` |
+| Go | `Files.PrepareFileBytes()` | `Files.PutFilePrepared()` |
+| TypeScript server and browser clients | `files.prepareFileBytes()` | `files.putFilePrepared()` |
+
+The whole-file convenience calls (`upload` / `Upload` in generated SDKs,
+`put_file_bytes()` / `put_file_stream()` in Rust) prepare a new object on each
+invocation. Reusing an already-committed ID with fresh content therefore returns
+`commit_id_reuse_conflict`, even for identical bytes. The unused upload can be
+reclaimed after its grace period. These helpers do not read the change feed or
+substitute an earlier content reference. To recover across processes, retain the
+complete publication request; the remote CLI saves that request before
+submission and resends it directly.
 
 Identical resubmission is the reconciliation mechanism. There is no separate
 commit-status lookup: after `commit_outcome_unknown`, a transport failure, or

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -338,7 +338,7 @@ source = source.replace(
     generated_import,
     "    from .client import AsyncLoonFS\n"
     "    from .core.api_error import ApiError\n"
-    "    from .transfers import FileDownloadResult, FileUploadResult, LoonFS\n",
+    "    from .transfers import FileDownloadResult, FileUploadResult, PreparedFileContent, LoonFS\n",
 )
 generated_mapping = '    "LoonFS": ".client",\n'
 assert source.count(generated_mapping) == 1, "generated server.py client mapping not found"
@@ -346,6 +346,7 @@ source = source.replace(generated_mapping, '    "LoonFS": ".transfers",\n')
 for anchor, insertion, label in (
     ('    "AsyncLoonFS": ".client",\n', '    "ApiError": ".core.api_error",\n', "ApiError mapping"),
     ('    "FileRevision": ".types",\n', '    "FileDownloadResult": ".transfers",\n', "FileDownloadResult mapping"),
+    ('    "FileRevision": ".types",\n', '    "PreparedFileContent": ".transfers",\n', "PreparedFileContent mapping"),
     ('    "FilesystemChange": ".types",\n', '    "FileUploadResult": ".transfers",\n', "FileUploadResult mapping"),
 ):
     assert source.count(anchor) == 1, f"generated server.py anchor for {label} not found exactly once"
@@ -353,6 +354,7 @@ for anchor, insertion, label in (
 for anchor, insertion, label in (
     ('    "AsyncLoonFS",\n', '    "ApiError",\n', "ApiError __all__ entry"),
     ('    "FileRevision",\n', '    "FileDownloadResult",\n', "FileDownloadResult __all__ entry"),
+    ('    "FileRevision",\n', '    "PreparedFileContent",\n', "PreparedFileContent __all__ entry"),
     ('    "FilesystemChange",\n', '    "FileUploadResult",\n', "FileUploadResult __all__ entry"),
 ):
     assert source.count(anchor) == 1, f"generated server.py anchor for {label} not found exactly once"
@@ -454,6 +456,8 @@ source = replace_once(
     '    FileDownloadResult,\n'
     '    FileUploadInput,\n'
     '    FileUploadResult,\n'
+    '    PreparedFileContent,\n'
+    '    PreparedFileUploadInput,\n'
     '} from "./transfers.js";\n',
 )
 index_path.write_text(source)

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -294,6 +294,64 @@ func runCommitReplay(t *testing.T, h *harness, testCase conformanceCase) {
 		replayed.NamespaceID != first.NamespaceID {
 		t.Errorf("replayed commit = %#v, want %#v", replayed, first)
 	}
+	prepared, err := h.client.Files.PrepareFileBytes(context.Background(), loonfs.NamespaceID(request.NamespaceID), []byte("original bytes"))
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	input := files.PreparedUploadInput{NamespaceID: loonfs.NamespaceID(request.NamespaceID), Path: "/prepared", Prepared: prepared,
+		Actor: &request.Actor, CommitID: "prepared-put"}
+	published, err := h.client.Files.PutFilePrepared(context.Background(), input)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	_, err = h.client.Commits.Create(context.Background(), &loonfs.CommitRequest{
+		NamespaceID: request.NamespaceID, Actor: &request.Actor, CommitID: "prepared-rename",
+		Operations: []*loonfs.FilesystemOperation{{MovePath: &loonfs.FilesystemOperationMovePath{FromPath: input.Path, ToPath: "/renamed"}}},
+	})
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	replay, err := h.client.Files.PutFilePrepared(context.Background(), input)
+	if err != nil || replay == nil || *replay != *published {
+		t.Fatalf("replay = %#v, %v; want %#v", replay, err, published)
+	}
+	message := "changed"
+	changed := input
+	changed.Message = &message
+	_, err = h.client.Files.PutFilePrepared(context.Background(), changed)
+	var conflict *loonfs.ConflictError
+	if !errors.As(err, &conflict) || conflict.Body.Code != "commit_id_reuse_conflict" {
+		t.Fatalf("changed publication: %v", err)
+	}
+	fresh, err := h.client.Files.PrepareFileBytes(context.Background(), input.NamespaceID, []byte("original bytes"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed = input
+	changed.Prepared = fresh
+	_, err = h.client.Files.PutFilePrepared(context.Background(), changed)
+	if !errors.As(err, &conflict) {
+		t.Fatalf("fresh content reused a committed id: %v", err)
+	}
+	entry, err := h.client.Files.Retrieve(context.Background(), &loonfs.GetPathEntryRequest{NamespaceID: request.NamespaceID, Path: "/renamed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inode := string(entry.File.InodeID)
+	input.Path = "/renamed"
+	input.CommitID = "prepared-replace"
+	input.Behavior = loonfs.DestinationBehaviorReplace
+	input.ExpectedInodeID = &inode
+	input.ExpectedRevisionNo = &entry.File.RevisionNo
+	published, err = h.client.Files.PutFilePrepared(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replay, err = h.client.Files.PutFilePrepared(context.Background(), input)
+	if err != nil || replay == nil || *replay != *published {
+		t.Fatalf("guarded replay: %#v, %v", replay, err)
+	}
+
 }
 
 type directPutRequest struct {

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -1677,6 +1677,36 @@ def test_download(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     assert downloaded.content == payload
 
 
+def test_prepared_upload_replays_after_a_rename(harness: Harness) -> None:
+    from loonfs.server import PreparedFileContent
+
+    client = harness.client
+    namespace_id = "conf-python-prepared"
+    client.namespaces.create(namespace_id=namespace_id)
+    prepared = client.files.prepare_file_bytes(namespace_id, content=b"original bytes")
+    assert isinstance(prepared, PreparedFileContent)
+    inputs = dict(path="/original", prepared=prepared,
+                  actor=ActorRef(kind="user", id="prepared-user"), commit_id="prepared-put")
+    with pytest.raises(NotFoundError):
+        client.files.retrieve(namespace_id, path="/original")
+    first = client.files.put_file_prepared(namespace_id, **inputs)
+    _apply(client, namespace_id, "prepared-rename", inputs["actor"],
+           FilesystemOperation_MovePath(from_path="/original", to_path="/renamed"))
+    assert client.files.put_file_prepared(namespace_id, **inputs) == first
+    for changed in [dict(message="changed"), dict(path="/renamed"), dict(behavior="replace")]:
+        with pytest.raises(ConflictError) as conflict:
+            client.files.put_file_prepared(namespace_id, **(inputs | changed))
+        assert conflict.value.body.code == "commit_id_reuse_conflict"
+    fresh = client.files.prepare_file_bytes(namespace_id, content=b"original bytes")
+    with pytest.raises(ConflictError):
+        client.files.put_file_prepared(namespace_id, **(inputs | dict(prepared=fresh)))
+    entry = client.files.retrieve(namespace_id, path="/renamed")
+    guarded = inputs | dict(path="/renamed", commit_id="prepared-replace", behavior="replace",
+                           expected_inode_id=entry.inode_id, expected_revision_no=entry.revision_no)
+    replaced = client.files.put_file_prepared(namespace_id, **guarded)
+    assert client.files.put_file_prepared(namespace_id, **guarded) == replaced
+
+
 def test_end_to_end(cases: dict[str, ConformanceCase], harness: Harness) -> None:
     request, expected = _decode(
         cases["end_to_end"], EndToEndRequest, EndToEndExpected

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -7,7 +7,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { test } from "node:test";
 
-import { LoonFS, LoonFSClient } from "../../../generated/typescript/index.js";
+import { LoonFS, LoonFSClient, type PreparedFileContent } from "../../../generated/typescript/index.js";
 import {
     LoonFS as BrowserLoonFS,
     LoonFSClient as BrowserLoonFSClient,
@@ -1192,6 +1192,32 @@ conformanceTest("commit_replay", async (activeHarness, testCase) => {
     assert.equal(first.commit_id, request.commit_id);
     assert.equal(replayed.committed_seq, first.committed_seq);
     assert.deepEqual(replayed, first);
+    const prepared: PreparedFileContent = await activeHarness.client.files.prepareFileBytes({
+        namespace_id: request.namespace_id, content: new TextEncoder().encode("original bytes"),
+    });
+    const input = { namespace_id: request.namespace_id, path: "/prepared", prepared,
+        actor: request.actor, commit_id: "prepared-put" };
+    const published = await activeHarness.client.files.putFilePrepared(input);
+    await activeHarness.client.commits.create({namespace_id: request.namespace_id,
+        actor: request.actor, commit_id: "prepared-rename",
+        operations: [{kind: "move_path", from_path: input.path, to_path: "/renamed"}],
+    });
+    assert.deepEqual(await activeHarness.client.files.putFilePrepared(input), published);
+    for (const changed of [{message: "changed"}, {path: "/renamed"}, {behavior: "replace" as const}]) {
+        await assert.rejects(activeHarness.client.files.putFilePrepared({...input, ...changed}),
+            (error: unknown) => error instanceof LoonFS.ConflictError && error.body.code === "commit_id_reuse_conflict");
+    }
+    const fresh = await activeHarness.client.files.prepareFileBytes({namespace_id: request.namespace_id,
+        content: new TextEncoder().encode("original bytes")});
+    await assert.rejects(activeHarness.client.files.putFilePrepared({...input, prepared: fresh}),
+        (error: unknown) => error instanceof LoonFS.ConflictError);
+    const entry = await activeHarness.client.files.retrieve({namespace_id: request.namespace_id, path: "/renamed"});
+    if (entry.inode_kind !== "file") throw new Error("expected file");
+    const guarded = {...input, path: "/renamed", commit_id: "prepared-replace", behavior: "replace" as const,
+        expected_inode_id: entry.inode_id, expected_revision_no: entry.revision_no};
+    const replaced = await activeHarness.client.files.putFilePrepared(guarded);
+    assert.deepEqual(await activeHarness.client.files.putFilePrepared(guarded), replaced);
+
 });
 
 conformanceTest("pagination", async (activeHarness, testCase) => {
@@ -2036,6 +2062,20 @@ test("proxy", { skip: environmentSkip }, async (context) => {
         "browser multipart transfer",
     );
     assert.deepEqual(beginModes, ["service_proxied", "direct_put", "direct_multipart"]);
+
+    const prepared = await browserClient.files.prepareFileBytes({namespace_alias: request.namespace_alias, content: payload});
+    const input = {namespace_alias: request.namespace_alias, path: "/browser-prepared", prepared,
+        actor: request.actor, commit_id: "browser-prepared-put"};
+    const published = await browserClient.files.putFilePrepared(input);
+    assert.deepEqual(await browserClient.files.putFilePrepared(input), published);
+    await assert.rejects(browserClient.files.putFilePrepared({...input, message: "changed"}),
+        (error: unknown) => error instanceof BrowserLoonFS.ConflictError);
+    const entry = await browserClient.files.retrieve({namespace_alias: request.namespace_alias, path: input.path});
+    if (entry.inode_kind !== "file") throw new Error("expected file");
+    const guarded = {...input, commit_id: "browser-prepared-replace", behavior: "replace" as const,
+        expected_inode_id: entry.inode_id, expected_revision_no: entry.revision_no};
+    const replaced = await browserClient.files.putFilePrepared(guarded);
+    assert.deepEqual(await browserClient.files.putFilePrepared(guarded), replaced);
 
     // The rig fails only at begin. No session exists then, so mid-flow cleanup is not covered.
     await assert.rejects(

--- a/sdk/overlays/go/README.md
+++ b/sdk/overlays/go/README.md
@@ -53,6 +53,14 @@ The Go SDK makes one HTTP attempt by default. You can opt into retries with
 `option.WithMaxAttempts`, but only do so for operations your application can
 safely repeat.
 
+For publication retries, call `client.Files.PrepareFileBytes(ctx, namespaceID,
+payload)` once and retain the returned `*files.PreparedFileContent`. Publish it
+with `client.Files.PutFilePrepared(ctx, files.PreparedUploadInput{...})`, keeping
+the prepared content, commit ID, path, actor, and options identical on every
+attempt. Preparation does not create a visible file or extend the upload
+lifetime. Calling `Upload` again starts a fresh upload and cannot replay a
+previously committed ID.
+
 ## Generated code
 
 This SDK is generated from the LoonFS OpenAPI specification. Please report SDK

--- a/sdk/overlays/python/README.md
+++ b/sdk/overlays/python/README.md
@@ -42,6 +42,14 @@ Operations that LoonFS classifies as non-idempotent are never retried
 automatically. Use the `max_retries` client or request option to tune retries for
 safe operations.
 
+For publication retries, call `client.files.prepare_file_bytes(namespace_id,
+content=payload)` once and retain its `PreparedFileContent`. Pass it to
+`client.files.put_file_prepared(namespace_id, path=path, prepared=prepared,
+actor=actor, commit_id=commit_id)` on each attempt, keeping all publication
+inputs identical. Preparation does not create a visible file or extend the
+upload lifetime. Calling `upload` again starts a fresh upload and cannot replay
+a previously committed ID.
+
 ## Generated code
 
 This SDK is generated from the LoonFS OpenAPI specification. Please report SDK

--- a/sdk/transfers/go/files/transfers.go
+++ b/sdk/transfers/go/files/transfers.go
@@ -55,6 +55,27 @@ type UploadInput struct {
 	ExpectedRevisionNo *loonfs.RevisionNo
 }
 
+// PreparedFileContent is a completed upload retained for publication retries.
+// Preparation does not publish a file or extend the upload lifetime.
+// Treat its reference and token as immutable.
+type PreparedFileContent struct {
+	ContentRef   *loonfs.ContentRef
+	ContentToken *loonfs.ContentToken
+}
+
+// PreparedUploadInput publishes completed content without uploading again.
+type PreparedUploadInput struct {
+	NamespaceID        loonfs.NamespaceID
+	Path               loonfs.AbsolutePath
+	Prepared           *PreparedFileContent
+	Actor              *loonfs.ActorRef
+	CommitID           loonfs.CommitID
+	Message            *string
+	Behavior           loonfs.DestinationBehavior
+	ExpectedInodeID    *string
+	ExpectedRevisionNo *loonfs.RevisionNo
+}
+
 // UploadResult identifies the commit that made the new revision visible.
 type UploadResult struct {
 	NamespaceID  loonfs.NamespaceID
@@ -78,8 +99,8 @@ type DownloadResult struct {
 	ContentRef  *loonfs.ContentRef
 }
 
-// Upload uploads bytes, completes the upload, and commits the content to a path.
-// Streaming and resume are follow-ups.
+// Upload uploads fresh content and publishes it. For publication retries,
+// retain PrepareFileBytes output and use PutFilePrepared with unchanged inputs.
 func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, error) {
 	if c == nil {
 		return nil, fmt.Errorf("transfers: client is nil")
@@ -88,14 +109,32 @@ func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, err
 		return nil, fmt.Errorf("transfers: actor is required")
 	}
 
+	if in.CommitID == "" {
+		return nil, fmt.Errorf("transfers: commit id is required")
+	}
+	prepared, err := c.PrepareFileBytes(ctx, in.NamespaceID, in.Content)
+	if err != nil {
+		return nil, err
+	}
+	return c.PutFilePrepared(ctx, PreparedUploadInput{
+		NamespaceID: in.NamespaceID, Path: in.Path, Prepared: prepared, Actor: in.Actor,
+		CommitID: in.CommitID, Message: in.Message, Behavior: in.Behavior,
+		ExpectedInodeID: in.ExpectedInodeID, ExpectedRevisionNo: in.ExpectedRevisionNo,
+	})
+}
+
+// PrepareFileBytes uploads once without publishing; retain the result for retries.
+func (c *Client) PrepareFileBytes(ctx context.Context, namespaceID loonfs.NamespaceID, content []byte) (*PreparedFileContent, error) {
+	if c == nil {
+		return nil, fmt.Errorf("transfers: client is nil")
+	}
 	capabilitiesClient := capabilities.NewClient(c.options)
 	uploadsClient := uploads.NewClient(c.options)
-	commitsClient := commits.NewClient(c.options)
 	capabilities, err := capabilitiesClient.Retrieve(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
 	}
-	createRequest, err := createUploadRequest(capabilities, in.NamespaceID, int64(len(in.Content)))
+	createRequest, err := createUploadRequest(capabilities, namespaceID, int64(len(content)))
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +143,7 @@ func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, err
 		return nil, fmt.Errorf("transfers: begin upload: %w", err)
 	}
 
-	completed, err := transferAndComplete(ctx, uploadsClient, in.NamespaceID, in.Content, begin)
+	completed, err := transferAndComplete(ctx, uploadsClient, namespaceID, content, begin)
 	if err != nil {
 		return nil, err
 	}
@@ -112,17 +151,32 @@ func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, err
 	if err != nil {
 		return nil, err
 	}
+	return &PreparedFileContent{ContentRef: status.ContentRef, ContentToken: status.ContentToken}, nil
+}
 
-	if in.CommitID == "" {
-		return nil, fmt.Errorf("transfers: commit id is required; a caller that keeps its commit id can replay a lost response safely")
+// PutFilePrepared publishes retained content without starting another upload.
+// Reuse unchanged inputs to retry the same commit.
+func (c *Client) PutFilePrepared(ctx context.Context, in PreparedUploadInput) (*UploadResult, error) {
+	if c == nil {
+		return nil, fmt.Errorf("transfers: client is nil")
 	}
+	if in.Actor == nil {
+		return nil, fmt.Errorf("transfers: actor is required")
+	}
+	if in.CommitID == "" {
+		return nil, fmt.Errorf("transfers: commit id is required")
+	}
+	if in.Prepared == nil || in.Prepared.ContentRef == nil {
+		return nil, fmt.Errorf("transfers: prepared content is required")
+	}
+	commitsClient := commits.NewClient(c.options)
 	behavior := in.Behavior
 	if behavior == "" {
 		behavior = loonfs.DestinationBehaviorNoReplace
 	}
 	contentTokens := []*loonfs.ContentToken(nil)
-	if status.ContentToken != nil {
-		contentTokens = []*loonfs.ContentToken{status.ContentToken}
+	if in.Prepared.ContentToken != nil {
+		contentTokens = []*loonfs.ContentToken{in.Prepared.ContentToken}
 	}
 	committed, err := commitsClient.Create(ctx, &loonfs.CommitRequest{
 		NamespaceID:   string(in.NamespaceID),
@@ -134,7 +188,7 @@ func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, err
 			{
 				PutFile: &loonfs.FilesystemOperationPutFile{
 					Behavior:           &behavior,
-					ContentRef:         status.ContentRef,
+					ContentRef:         in.Prepared.ContentRef,
 					ExpectedInodeID:    in.ExpectedInodeID,
 					ExpectedRevisionNo: in.ExpectedRevisionNo,
 					Path:               in.Path,

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -79,7 +79,13 @@ class FileDownloadResult:
 
 
 @dataclass(frozen=True)
-class _StagedContent:
+class PreparedFileContent:
+    """Completed content retained for repeated publication of the same request.
+
+    Preparation does not publish a file or extend the upload lifetime.
+    Treat the content reference and token as immutable.
+    """
+
     content_ref: ContentRef
     content_token: str | None
 
@@ -105,8 +111,35 @@ class FilesClient(_GeneratedFilesClient):
         expected_revision_no: RevisionNo | None = None,
         http_client: httpx.Client | None = None,
     ) -> FileUploadResult:
-        """Upload in-memory bytes, complete the upload, and commit the file."""
+        """Upload fresh content and publish it.
 
+        For publication retries, retain prepare_file_bytes() output and call
+        put_file_prepared() with unchanged inputs.
+        """
+
+        prepared = self.prepare_file_bytes(
+            namespace_id, content=content, http_client=http_client
+        )
+        return self.put_file_prepared(
+            namespace_id,
+            path=path,
+            prepared=prepared,
+            actor=actor,
+            commit_id=commit_id,
+            message=message,
+            behavior=behavior,
+            expected_inode_id=expected_inode_id,
+            expected_revision_no=expected_revision_no,
+        )
+
+    def prepare_file_bytes(
+        self,
+        namespace_id: str,
+        *,
+        content: bytes,
+        http_client: httpx.Client | None = None,
+    ) -> PreparedFileContent:
+        """Upload bytes once without publishing; retain the result for retries."""
         begin = _create_upload(self._root, namespace_id, content)
         if http_client is None:
             with httpx.Client() as transfer_client:
@@ -118,7 +151,23 @@ class FilesClient(_GeneratedFilesClient):
                 self._root, http_client, namespace_id, begin, content
             )
 
-        operation_arguments = {"path": path, "content_ref": staged.content_ref}
+        return staged
+
+    def put_file_prepared(
+        self,
+        namespace_id: str,
+        *,
+        path: str,
+        prepared: PreparedFileContent,
+        actor: ActorRef,
+        commit_id: str,
+        message: str | None = None,
+        behavior: DestinationBehavior | None = None,
+        expected_inode_id: str | None = None,
+        expected_revision_no: RevisionNo | None = None,
+    ) -> FileUploadResult:
+        """Publish retained content; reuse it with identical inputs to retry safely."""
+        operation_arguments = {"path": path, "content_ref": prepared.content_ref}
         if behavior is not None:
             operation_arguments["behavior"] = behavior
         if expected_inode_id is not None:
@@ -130,8 +179,8 @@ class FilesClient(_GeneratedFilesClient):
             "actor": actor,
             "commit_id": commit_id,
             "operations": [operation],
-            "content_tokens": [staged.content_token]
-            if staged.content_token is not None
+            "content_tokens": [prepared.content_token]
+            if prepared.content_token is not None
             else [],
         }
         if message is not None:
@@ -207,7 +256,13 @@ class LoonFS(_GeneratedLoonFS):
         return self._transfer_files
 
 
-__all__ = ["FileDownloadResult", "FileUploadResult", "FilesClient", "LoonFS"]
+__all__ = [
+    "FileDownloadResult",
+    "FileUploadResult",
+    "PreparedFileContent",
+    "FilesClient",
+    "LoonFS",
+]
 
 
 def _get_file_proxied(
@@ -298,7 +353,7 @@ def _stage_upload(
     namespace_id: str,
     begin,
     content: bytes,
-) -> _StagedContent:
+) -> PreparedFileContent:
     if begin.mode == "service_proxied":
         try:
             client.uploads.put_content(namespace_id, begin.upload_id, request=content)
@@ -354,7 +409,7 @@ def _stage_multipart(
     part_size_bytes: int,
     checksum_algorithm: str,
     content: bytes,
-) -> _StagedContent:
+) -> PreparedFileContent:
     if part_size_bytes <= 0:
         raise RuntimeError("multipart response returned a non-positive part size")
     parts = [
@@ -439,13 +494,13 @@ def _send_presigned(
     return response
 
 
-def _completed_content(response: UploadSession) -> _StagedContent:
+def _completed_content(response: UploadSession) -> PreparedFileContent:
     if response.status != "completed":
         raise RuntimeError(
             f"upload {response.upload_id!r} completed with status "
             f"{response.status!r}"
         )
-    return _StagedContent(
+    return PreparedFileContent(
         content_ref=response.content_ref,
         content_token=response.content_token,
     )

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -27,7 +27,12 @@ export interface FileUploadInput {
     commit_id: LoonFS.CommitId;
     message?: string | null;
     behavior?: LoonFS.DestinationBehavior;
+    expected_inode_id?: string;
     expected_revision_no?: LoonFS.RevisionNo;
+}
+
+export interface PreparedFileUploadInput extends Omit<FileUploadInput, "content"> {
+    prepared: PreparedFileContent;
 }
 
 export interface FileUploadResult {
@@ -50,9 +55,10 @@ export interface FileDownloadResult {
     content: Uint8Array;
 }
 
-interface StagedContent {
-    contentRef: LoonFS.ContentRef;
-    contentToken?: LoonFS.ContentToken;
+/** Completed content; preparation does not publish or extend the upload lifetime. */
+export interface PreparedFileContent {
+    readonly contentRef: LoonFS.ContentRef;
+    readonly contentToken?: LoonFS.ContentToken;
 }
 
 interface DirectPutBody {
@@ -83,20 +89,32 @@ export class FilesClient extends GeneratedFilesClient {
         super(options);
     }
 
-    /** Uploads in-memory bytes and commits them at one path. Streaming and resume are follow-ups. */
+    /** Uploads fresh content and publishes it. For publication retries, retain prepareFileBytes() output and use putFilePrepared(). */
     public async upload(input: FileUploadInput): Promise<FileUploadResult> {
-        const staged = await stageBytes(this.root, input.namespace_alias, input.content);
+        const { content, ...publication } = input;
+        const prepared = await this.prepareFileBytes({ namespace_alias: input.namespace_alias, content });
+        return this.putFilePrepared({ ...publication, prepared });
+    }
+
+    /** Upload once without publishing; retain the result for publication retries. */
+    public async prepareFileBytes(input: Pick<FileUploadInput, "namespace_alias" | "content">): Promise<PreparedFileContent> {
+        return stageBytes(this.root, input.namespace_alias, input.content);
+    }
+
+    /** Reuse prepared content and identical publication inputs to retry the same commit. */
+    public async putFilePrepared(input: PreparedFileUploadInput): Promise<FileUploadResult> {
         const request: LoonFS.CommitRequest = {
             namespace_alias: input.namespace_alias,
             actor: input.actor,
             commit_id: input.commit_id,
-            content_tokens: staged.contentToken === undefined ? [] : [staged.contentToken],
+            content_tokens: input.prepared.contentToken === undefined ? [] : [input.prepared.contentToken],
             operations: [
                 {
                     kind: "put_file",
                     path: input.path,
-                    content_ref: staged.contentRef,
+                    content_ref: input.prepared.contentRef,
                     behavior: input.behavior ?? "no_replace",
+                    expected_inode_id: input.expected_inode_id,
                     expected_revision_no: input.expected_revision_no,
                 },
             ],
@@ -214,7 +232,7 @@ async function stageBytes(
     client: GeneratedLoonFSClient,
     namespaceAlias: string,
     bytes: Uint8Array,
-): Promise<StagedContent> {
+): Promise<PreparedFileContent> {
     const capabilities = await client.capabilities.retrieve();
     const beginRequest = selectBeginRequest(capabilities, bytes);
     const begin = await client.uploads.create({
@@ -269,7 +287,7 @@ async function stageServiceProxied(
     namespaceAlias: string,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.ServiceProxied,
-): Promise<StagedContent> {
+): Promise<PreparedFileContent> {
     try {
         await client.uploads.putContent(arrayBuffer(bytes), namespaceAlias, begin.upload_id);
         return stagedContent(
@@ -290,7 +308,7 @@ async function stageDirectPut(
     namespaceAlias: string,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectPut,
-): Promise<StagedContent> {
+): Promise<PreparedFileContent> {
     let upload: DirectPutBody;
     try {
         requirePresignedMethod(begin.access, "PUT", "direct PUT");
@@ -320,7 +338,7 @@ async function stageMultipart(
     namespaceAlias: string,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectMultipart,
-): Promise<StagedContent> {
+): Promise<PreparedFileContent> {
     const { checksum_algorithm: algorithm, part_size_bytes: partSize } = begin;
     if (!Number.isSafeInteger(partSize) || partSize <= 0) {
         throw new Error(`invalid multipart part size ${partSize}`);
@@ -397,7 +415,7 @@ function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
     return parts;
 }
 
-function stagedContent(response: LoonFS.UploadSession): StagedContent {
+function stagedContent(response: LoonFS.UploadSession): PreparedFileContent {
     if (response.status !== "completed") {
         throw new Error(`upload ${response.upload_id} completed with status ${response.status}`);
     }

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -28,6 +28,10 @@ export interface FileUploadInput {
     expected_revision_no?: LoonFS.RevisionNo;
 }
 
+export interface PreparedFileUploadInput extends Omit<FileUploadInput, "content"> {
+    prepared: PreparedFileContent;
+}
+
 export interface FileUploadResult {
     namespace_id: LoonFS.NamespaceId;
     commit_id: LoonFS.CommitId;
@@ -48,9 +52,10 @@ export interface FileDownloadResult {
     content: Uint8Array;
 }
 
-interface StagedContent {
-    contentRef: LoonFS.ContentRef;
-    contentToken?: LoonFS.ContentToken;
+/** Completed content; preparation does not publish or extend the upload lifetime. */
+export interface PreparedFileContent {
+    readonly contentRef: LoonFS.ContentRef;
+    readonly contentToken?: LoonFS.ContentToken;
 }
 
 interface DirectPutBody {
@@ -81,19 +86,30 @@ export class FilesClient extends GeneratedFilesClient {
         super(options);
     }
 
-    /** Uploads in-memory bytes and commits them at one path. Streaming and resume are follow-ups. */
+    /** Uploads fresh content and publishes it. For publication retries, retain prepareFileBytes() output and use putFilePrepared(). */
     public async upload(input: FileUploadInput): Promise<FileUploadResult> {
-        const staged = await stageBytes(this.root, input.namespace_id, input.content);
+        const { content, ...publication } = input;
+        const prepared = await this.prepareFileBytes({ namespace_id: input.namespace_id, content });
+        return this.putFilePrepared({ ...publication, prepared });
+    }
+
+    /** Upload once without publishing; retain the result for publication retries. */
+    public async prepareFileBytes(input: Pick<FileUploadInput, "namespace_id" | "content">): Promise<PreparedFileContent> {
+        return stageBytes(this.root, input.namespace_id, input.content);
+    }
+
+    /** Reuse prepared content and identical publication inputs to retry the same commit. */
+    public async putFilePrepared(input: PreparedFileUploadInput): Promise<FileUploadResult> {
         const request: LoonFS.CommitRequest = {
             namespace_id: input.namespace_id,
             actor: input.actor,
             commit_id: input.commit_id,
-            content_tokens: staged.contentToken === undefined ? [] : [staged.contentToken],
+            content_tokens: input.prepared.contentToken === undefined ? [] : [input.prepared.contentToken],
             operations: [
                 {
                     kind: "put_file",
                     path: input.path,
-                    content_ref: staged.contentRef,
+                    content_ref: input.prepared.contentRef,
                     behavior: input.behavior ?? "no_replace",
                     expected_inode_id: input.expected_inode_id,
                     expected_revision_no: input.expected_revision_no,
@@ -213,7 +229,7 @@ async function stageBytes(
     client: GeneratedLoonFSClient,
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
-): Promise<StagedContent> {
+): Promise<PreparedFileContent> {
     const capabilities = await client.capabilities.retrieve();
     const beginRequest = selectBeginRequest(capabilities, bytes);
     const begin = await client.uploads.create({
@@ -268,7 +284,7 @@ async function stageServiceProxied(
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.ServiceProxied,
-): Promise<StagedContent> {
+): Promise<PreparedFileContent> {
     try {
         await client.uploads.putContent(arrayBuffer(bytes), namespaceId, begin.upload_id);
         return stagedContent(
@@ -289,7 +305,7 @@ async function stageDirectPut(
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectPut,
-): Promise<StagedContent> {
+): Promise<PreparedFileContent> {
     let upload: DirectPutBody;
     try {
         requirePresignedMethod(begin.access, "PUT", "direct PUT");
@@ -319,7 +335,7 @@ async function stageMultipart(
     namespaceId: LoonFS.NamespaceId,
     bytes: Uint8Array,
     begin: LoonFS.BeginUploadResponse.DirectMultipart,
-): Promise<StagedContent> {
+): Promise<PreparedFileContent> {
     const { checksum_algorithm: algorithm, part_size_bytes: partSize } = begin;
     if (!Number.isSafeInteger(partSize) || partSize <= 0) {
         throw new Error(`invalid multipart part size ${partSize}`);
@@ -396,7 +412,7 @@ function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
     return parts;
 }
 
-function stagedContent(response: LoonFS.UploadSession): StagedContent {
+function stagedContent(response: LoonFS.UploadSession): PreparedFileContent {
     if (response.status !== "completed") {
         throw new Error(`upload ${response.upload_id} completed with status ${response.status}`);
     }


### PR DESCRIPTION
Generated SDK callers need to retain completed content to retry the same publication, matching the prepared-content contract already used by Rust. Expose prepare-file-bytes and put-file-prepared methods in Python, Go, TypeScript, and the browser client, keep whole-file upload calls as fresh preparation followed by publication, and add the missing browser inode guard.

Regenerated all four SDK targets and verified their retry policies; Go, Python, and TypeScript conformance pass, including prepared retries after rename, guarded replacement, and conflicts for changed inputs or fresh content. Preparation still uses the existing in-memory transfer path and does not publish a file or extend the upload lifetime.
