### PR TITLE
refactor(grep): keep merge policy in engine defaults

### DIFF
--- a/crates/loonfs-grep/src/config.rs
+++ b/crates/loonfs-grep/src/config.rs
@@ -10,7 +10,8 @@ use serde::Deserialize;
 use std::num::{NonZeroU64, NonZeroUsize};
 use thiserror::Error;
 
-/// Bounded-work policy shared by every host that runs grep steps.
+/// Operator-facing work budgets shared by hosts that run grep steps.
+/// Segment layout and merge policy remain engine defaults.
 ///
 /// Project-wide, zero may disable an explicitly documented cache. Work
 /// budgets instead reject zero at their construction boundaries.
@@ -21,14 +22,6 @@ pub struct GrepWorkerConfig {
     pub max_files_per_step: usize,
     /// Content bytes read per build step.
     pub max_content_bytes_per_step: u64,
-    /// Rows per written grep segment.
-    pub max_rows_per_segment: usize,
-    /// Delta-level runs that trigger a reorganization into a mid run.
-    pub max_delta_runs: usize,
-    /// Mid-level runs that trigger a reorganization into the base run.
-    pub max_mid_runs: usize,
-    /// Rows merged by one reorganize step.
-    pub max_decoded_input_rows_per_step: usize,
 }
 
 impl GrepWorkerConfig {
@@ -40,13 +33,7 @@ impl GrepWorkerConfig {
                 "max_content_bytes_per_step",
                 self.max_content_bytes_per_step,
             )?,
-            max_rows_per_segment: nonzero_usize("max_rows_per_segment", self.max_rows_per_segment)?,
-            max_delta_runs: nonzero_usize("max_delta_runs", self.max_delta_runs)?,
-            max_mid_runs: nonzero_usize("max_mid_runs", self.max_mid_runs)?,
-            max_decoded_input_rows_per_step: nonzero_usize(
-                "max_decoded_input_rows_per_step",
-                self.max_decoded_input_rows_per_step,
-            )?,
+            ..GramIndexBuildPolicy::default()
         })
     }
 
@@ -63,10 +50,6 @@ impl Default for GrepWorkerConfig {
         Self {
             max_files_per_step: policy.max_files_per_step.get(),
             max_content_bytes_per_step: policy.max_content_bytes_per_step.get(),
-            max_rows_per_segment: policy.max_rows_per_segment.get(),
-            max_delta_runs: policy.max_delta_runs.get(),
-            max_mid_runs: policy.max_mid_runs.get(),
-            max_decoded_input_rows_per_step: policy.max_decoded_input_rows_per_step.get(),
         }
     }
 }
@@ -117,34 +100,6 @@ mod tests {
                 "max_content_bytes_per_step",
                 GrepWorkerConfig {
                     max_content_bytes_per_step: 0,
-                    ..GrepWorkerConfig::default()
-                },
-            ),
-            (
-                "max_rows_per_segment",
-                GrepWorkerConfig {
-                    max_rows_per_segment: 0,
-                    ..GrepWorkerConfig::default()
-                },
-            ),
-            (
-                "max_delta_runs",
-                GrepWorkerConfig {
-                    max_delta_runs: 0,
-                    ..GrepWorkerConfig::default()
-                },
-            ),
-            (
-                "max_mid_runs",
-                GrepWorkerConfig {
-                    max_mid_runs: 0,
-                    ..GrepWorkerConfig::default()
-                },
-            ),
-            (
-                "max_decoded_input_rows_per_step",
-                GrepWorkerConfig {
-                    max_decoded_input_rows_per_step: 0,
                     ..GrepWorkerConfig::default()
                 },
             ),

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -110,14 +110,11 @@ writer_id = "loonfs-server-local"
 # turns both off again.
 #[grep]
 #mode = "serve_and_maintain"
-# Bounded build/fold budgets; every value must be greater than zero. How many
+# Bounded indexing input budgets; every value must be greater than zero. How many
 # maintenance passes run at once — grep's included — is `max_concurrent_maintenance`.
 #max_files_per_step = 256
 #max_content_bytes_per_step = 67108864
-#max_rows_per_segment = 65536
-#max_delta_runs = 8
-#max_mid_runs = 8
-#max_decoded_input_rows_per_step = 131072
+# Segment layout and merge policy use engine defaults.
 
 # The server's TLS identity, read once at startup: a file that is missing or
 # is not the PEM it claims to be fails the process rather than falling back

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -295,6 +295,19 @@ The server writes JSON logs to standard output.
 
 The server rejects unsupported `LOONFS_TRACE` values instead of guessing.
 
+## Grep indexing
+
+Set `[grep].mode` to choose whether this server serves searches, maintains the
+index, or does both. Omit the table to disable grep. The optional
+`max_files_per_step` and `max_content_bytes_per_step` bound input work per
+indexing step; their defaults are 256 files and 64 MiB, and both must be positive.
+Indexing shares `max_concurrent_maintenance` with other maintenance work.
+
+Segment sizes, merge thresholds, and reorganization step sizes use engine
+defaults, like metadata compaction. The former `max_rows_per_segment`,
+`max_delta_runs`, `max_mid_runs`, and `max_decoded_input_rows_per_step` settings
+are rejected; remove them from existing pre-release configurations.
+
 ## Resource sizing
 
 Start with enough memory for:

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -1383,7 +1383,7 @@ writer_id = "loonfs-server"
 
 [grep]
 mode = "serve_and_maintain"
-max_decoded_input_rows_per_step = 0
+max_content_bytes_per_step = 0
 
 [store]
 kind = "local-fs"
@@ -1979,10 +1979,6 @@ writer_id = "loonfs-server"
 mode = "serve_only"
 max_files_per_step = 4096
 max_content_bytes_per_step = 536870912
-max_rows_per_segment = 131072
-max_delta_runs = 4
-max_mid_runs = 6
-max_decoded_input_rows_per_step = 262144
 
 [store]
 kind = "local-fs"
@@ -1998,16 +1994,20 @@ root = "/tmp/loonfs-server"
             .expect("valid configured grep policy");
         assert_eq!(policy.max_files_per_step.get(), 4096);
         assert_eq!(policy.max_content_bytes_per_step.get(), 536_870_912);
-        assert_eq!(policy.max_rows_per_segment.get(), 131_072);
-        assert_eq!(policy.max_delta_runs.get(), 4);
-        assert_eq!(policy.max_mid_runs.get(), 6);
-        assert_eq!(policy.max_decoded_input_rows_per_step.get(), 262_144);
+        let defaults = loonfs_grep::GramIndexBuildPolicy::default();
+        assert_eq!(policy.max_rows_per_segment, defaults.max_rows_per_segment);
+        assert_eq!(policy.max_delta_runs, defaults.max_delta_runs);
+        assert_eq!(policy.max_mid_runs, defaults.max_mid_runs);
+        assert_eq!(
+            policy.max_decoded_input_rows_per_step,
+            defaults.max_decoded_input_rows_per_step
+        );
     }
 
     #[test]
-    fn grep_policy_overrides_apply_verbatim() {
-        // The policy handed to the worker is exactly the configured one:
-        // zero budgets are rejected by validation, never rewritten.
+    fn grep_work_budget_overrides_preserve_engine_defaults() {
+        // Operators control input work; the engine controls segment and merge
+        // shape. A work override must not change the merge policy.
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"
@@ -2017,7 +2017,6 @@ writer_id = "loonfs-server"
 [grep]
 mode = "serve_and_maintain"
 max_files_per_step = 1024
-max_delta_runs = 3
 
 [store]
 kind = "local-fs"
@@ -2034,8 +2033,34 @@ root = "/tmp/loonfs-server"
         assert_eq!(
             policy.max_mid_runs,
             loonfs_grep::GramIndexBuildPolicy::default().max_mid_runs,
-            "untouched budgets keep their defaults"
+            "merge policy remains an engine default"
         );
+    }
+
+    #[test]
+    fn grep_rejects_retired_engine_tuning_keys() {
+        for key in [
+            "max_rows_per_segment",
+            "max_delta_runs",
+            "max_mid_runs",
+            "max_decoded_input_rows_per_step",
+        ] {
+            let path = write_config(&format!(
+                r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+[grep]
+mode = "serve_and_maintain"
+{key} = 1
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#
+            ));
+            let error = load_server_config(&path).expect_err("engine tuning keys must be rejected");
+            assert!(error.to_string().contains(key), "{error}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Grep exposes segment and merge tuning in server configuration even though those choices belong to the engine, as they do for metadata compaction. Retain the positive file-count and content-byte work budgets, take segment layout and merge policy from the existing engine defaults, and reject the four retired configuration keys. Document the reduced settings and the migration for pre-release configurations.

All 364 grep/server tests pass, including retired-key rejection and preservation of engine defaults under work-budget overrides; full all-target/all-feature Clippy and formatting checks pass.
