### PR TITLE
fix(cli): spool recursive failure reports

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -633,8 +633,11 @@ Behavior notes
   eight pending file operations. Discovery pauses when those slots are full.
   Local traversal keeps one directory handle per depth; remote traversal keeps
   up to 64 entries per depth. The existing path-depth limit bounds both.
-  Successful results are counted immediately; the final report retains every
-  failure, so failure-report memory still grows with the number of errors.
+  Successful results are counted immediately. Failures are spooled to a local
+  temporary file and rendered incrementally, preserving every error without
+  keeping the report in memory. Temporary disk usage grows with the error
+  report, and the file is removed when the command exits normally. A report
+  write failure stops the command and is reported as an I/O error.
   Overall totals become known when discovery finishes. Per-file progress starts
   immediately, and traversal order is unspecified. A later listing failure
   preserves completed work and reports the affected directory alongside file

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -13,10 +13,12 @@ mod profile;
 mod profile_config;
 mod recursive;
 mod snapshot;
+mod tree_failures;
+pub(crate) use tree_failures::TreeTransferFailures;
 
 pub(crate) use self::output::{
     CommandData, CommandFailure, CommandOutput, DoctorCheck, DoctorStatus, ListingHeadDrift,
-    MaintenanceKeyReport, MaintenanceRan, TrashListing, TreeTransferFailure,
+    MaintenanceKeyReport, MaintenanceRan, TrashListing,
 };
 
 use crate::args::{Cli, Command, CommandKind, CompletionArgs, RuntimeBehavior};

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -1,5 +1,6 @@
 //! The typed command results the renderer turns into text or JSON.
 
+use super::tree_failures::TreeTransferFailures;
 use crate::args::CommandKind;
 use crate::config::{CliConfig, ConfigSource, ProfileConfig};
 use crate::error::CliError;
@@ -14,7 +15,7 @@ use loonfs_api::{
     FileRevision, GrepMatch, InodeId, ListCheckpointsResponse, Namespace, NamespaceId, PathEntry,
     ReleaseCheckpointResponse, RunMaintenanceResponse,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub(crate) struct ListingHeadDrift {
@@ -45,7 +46,7 @@ impl ListingHeadObservation {
 }
 
 /// One failed item inside a recursive transfer.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct TreeTransferFailure {
     /// The path that failed — remote for uploads and copies, whichever side
     /// failed for downloads.
@@ -169,7 +170,7 @@ impl Serialize for MaintenanceRan {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub(crate) enum CommandData {
     Capabilities(CapabilityDocument),
@@ -294,7 +295,7 @@ pub(crate) enum CommandData {
         /// Heads observed while listing the source tree.
         #[serde(skip_serializing_if = "Option::is_none")]
         head_drift: Option<ListingHeadDrift>,
-        failures: Vec<TreeTransferFailure>,
+        failures: TreeTransferFailures,
     },
     FileMutation {
         target: String,

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -10,6 +10,7 @@ use super::context::{
 use super::output::{
     CommandData, CommandFailure, CommandOutput, ListingHeadObservation, TreeTransferFailure,
 };
+use super::tree_failures::TreeTransferFailures;
 use crate::args::{CommandKind, RuntimeBehavior};
 use crate::error::CliError;
 use crate::payload::LocalPayload;
@@ -54,7 +55,7 @@ impl DirectoryOutcome {
 struct TreeTally {
     files: u64,
     directories: u64,
-    failures: Vec<TreeTransferFailure>,
+    failures: TreeTransferFailures,
     heads: ListingHeadObservation,
 }
 
@@ -63,7 +64,7 @@ impl TreeTally {
         Self {
             files: 0,
             directories: 0,
-            failures: Vec::new(),
+            failures: TreeTransferFailures::default(),
             heads: ListingHeadObservation::default(),
         }
     }
@@ -74,7 +75,7 @@ impl TreeTally {
         result: Result<String, CliError>,
         runtime: RuntimeBehavior,
         verb: &str,
-    ) {
+    ) -> Result<(), CliError> {
         match result {
             Ok(target) => {
                 self.files += 1;
@@ -82,8 +83,9 @@ impl TreeTally {
                     write_stderr_progress(format_args!("{verb} {target}"));
                 }
             }
-            Err(error) => self.fail(path, error),
+            Err(error) => self.fail(path, error)?,
         }
+        Ok(())
     }
 
     fn record_directory(&mut self, outcome: DirectoryOutcome) {
@@ -92,11 +94,18 @@ impl TreeTally {
         }
     }
 
-    fn fail(&mut self, path: impl Into<String>, error: CliError) {
-        self.failures.push(TreeTransferFailure {
-            path: path.into(),
-            error,
-        });
+    fn fail(&mut self, path: impl Into<String>, error: CliError) -> Result<(), CliError> {
+        self.failures
+            .push(TreeTransferFailure {
+                path: path.into(),
+                error,
+            })
+            .map_err(|error| {
+                CliError::new(
+                    "io_error",
+                    format!("could not save recursive failure report: {error}"),
+                )
+            })
     }
 }
 
@@ -131,7 +140,7 @@ async fn transfer_tree<S, F, FF, D, DF>(
     progress: Option<&ProgressReporter>,
     runtime: RuntimeBehavior,
     verb: &str,
-) -> TreeTally
+) -> Result<TreeTally, CliError>
 where
     S: Stream<Item = TreeEntry>,
     F: Fn(FileJob) -> FF,
@@ -150,7 +159,7 @@ where
         tokio::select! {
             biased;
             Some((path, result)) = pending.next(), if !pending.is_empty() => {
-                tally.record_file(path, result, runtime, verb);
+                tally.record_file(path, result, runtime, verb)?;
             }
             entry = entries.next(), if !finished_discovery && pending.len() < TREE_TRANSFER_CONCURRENCY => {
                 match entry {
@@ -169,7 +178,7 @@ where
                             tokio::select! {
                                 biased;
                                 Some((path, result)) = pending.next(), if !pending.is_empty() => {
-                                    tally.record_file(path, result, runtime, verb);
+                                    tally.record_file(path, result, runtime, verb)?;
                                 }
                                 (path, result) = &mut directory => {
                                     match result {
@@ -179,7 +188,7 @@ where
                                                 write_stderr_progress(format_args!("{} {path}", outcome.progress_label()));
                                             }
                                         }
-                                        Err(error) => tally.fail(path, error),
+                                        Err(error) => tally.fail(path, error)?,
                                     }
                                     break;
                                 }
@@ -189,7 +198,7 @@ where
                     Some(TreeEntry::Head(head)) => tally.heads.observe(head),
                     Some(TreeEntry::Failure(path, error)) => {
                         discovery_failed = true;
-                        tally.fail(path, error);
+                        tally.fail(path, error)?;
                     },
                     None => {
                         finished_discovery = true;
@@ -207,7 +216,7 @@ where
     if let Some(progress) = progress {
         progress.finish();
     }
-    tally
+    Ok(tally)
 }
 
 async fn create_remote_directory(
@@ -341,7 +350,8 @@ pub(crate) async fn run_put_tree(
         runtime,
         "stored",
     )
-    .await;
+    .await
+    .map_err(|error| context.fail(kind, error))?;
     Ok(context.output(
         kind,
         CommandData::TreeTransfer {
@@ -420,7 +430,8 @@ pub(crate) async fn run_get_tree(
         runtime,
         "wrote",
     )
-    .await;
+    .await
+    .map_err(|error| context.fail(kind, error))?;
     tally.record_directory(root_outcome);
     warn_drift(&tally, runtime);
     Ok(context.output(
@@ -521,7 +532,8 @@ pub(crate) async fn run_copy_tree(
         runtime,
         "copied",
     )
-    .await;
+    .await
+    .map_err(|error| context.fail(kind, error))?;
     warn_drift(&tally, runtime);
     Ok(context.output(
         kind,
@@ -658,7 +670,8 @@ mod tests {
             unwatched(),
             "stored",
         )
-        .await;
+        .await
+        .expect("transfer report");
         assert_eq!(tally.files, 100);
         assert!(tally.failures.is_empty());
         assert_eq!(completed.get(), 100);
@@ -696,7 +709,8 @@ mod tests {
             unwatched(),
             "stored",
         )
-        .await;
+        .await
+        .expect("transfer report");
         assert_eq!(tally.files, 1);
         assert_eq!(tally.directories, 1);
     }
@@ -743,11 +757,22 @@ mod tests {
             unwatched(),
             "stored",
         )
-        .await;
+        .await
+        .expect("transfer report");
         assert_eq!(tally.files, 2);
         assert_eq!(tally.directories, 1);
         assert_eq!(tally.failures.len(), 1);
-        assert_eq!(tally.failures[0].path, "broken");
+        assert_eq!(
+            tally
+                .failures
+                .iter()
+                .expect("read report")
+                .next()
+                .expect("failure")
+                .expect("decode failure")
+                .path,
+            "broken"
+        );
     }
 
     #[tokio::test]
@@ -801,13 +826,24 @@ mod tests {
             unwatched(),
             "wrote",
         )
-        .await;
+        .await
+        .expect("transfer report");
         assert_eq!(
             tally.files, 132,
             "every root page and the surviving child was visited"
         );
         assert_eq!(tally.failures.len(), 1);
-        assert_eq!(tally.failures[0].path, "/up/broken");
+        assert_eq!(
+            tally
+                .failures
+                .iter()
+                .expect("read report")
+                .next()
+                .expect("failure")
+                .expect("decode failure")
+                .path,
+            "/up/broken"
+        );
         assert!(tally.heads.drift().is_some());
     }
 

--- a/crates/loonfs-cli/src/commands/tree_failures.rs
+++ b/crates/loonfs-cli/src/commands/tree_failures.rs
@@ -1,0 +1,208 @@
+//! A complete failure report backed by a temporary file, never by tree-sized RAM.
+
+use super::output::TreeTransferFailure;
+use serde::ser::{SerializeSeq, Serializer};
+use serde::Serialize;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use tempfile::NamedTempFile;
+
+#[derive(Debug, Default)]
+pub(crate) struct TreeTransferFailures {
+    spool: Option<NamedTempFile>,
+    len: usize,
+}
+
+impl TreeTransferFailures {
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub(crate) fn push(&mut self, failure: TreeTransferFailure) -> io::Result<()> {
+        // Successful transfers need no temporary report at all. File writes
+        // are unbuffered here, so readers never need to flush a hidden buffer.
+        if self.spool.is_none() {
+            self.spool = Some(NamedTempFile::new()?);
+        }
+        let file = self.spool.as_mut().expect("a report file was opened");
+        serde_json::to_writer(file.as_file_mut(), &failure)?;
+        file.write_all(b"\n")?;
+        self.len += 1;
+        Ok(())
+    }
+
+    pub(crate) fn iter(&self) -> io::Result<impl Iterator<Item = io::Result<TreeTransferFailure>>> {
+        // Reopen, rather than clone the descriptor: every reader needs an
+        // independent offset, including repeated human and JSON rendering.
+        let reader: Box<dyn Read> = match &self.spool {
+            Some(file) => Box::new(file.reopen()?),
+            None => Box::new(io::empty()),
+        };
+        Ok(BufReader::new(reader)
+            .lines()
+            .map(|line| serde_json::from_str(&line?).map_err(io::Error::other)))
+    }
+}
+
+impl Serialize for TreeTransferFailures {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::Error;
+        let mut sequence = serializer.serialize_seq(Some(self.len))?;
+        for failure in self.iter().map_err(S::Error::custom)? {
+            sequence.serialize_element(&failure.map_err(S::Error::custom)?)?;
+        }
+        sequence.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::CliError;
+
+    #[test]
+    fn reports_keep_every_failure_and_reopen_from_the_start() {
+        let mut report = TreeTransferFailures::default();
+        assert!(report.spool.is_none());
+        for index in 0..10_000 {
+            report
+                .push(TreeTransferFailure {
+                    path: format!("/file-{index}"),
+                    error: CliError::invalid_request("bad\ninput"),
+                })
+                .expect("append failure");
+        }
+        assert_eq!(report.len(), 10_000);
+        for _ in 0..2 {
+            let mut count = 0;
+            for failure in report.iter().expect("open reader") {
+                let failure = failure.expect("read failure");
+                assert_eq!(failure.path, format!("/file-{count}"));
+                assert_eq!(failure.error.message, "bad\ninput");
+                count += 1;
+            }
+            assert_eq!(count, 10_000);
+        }
+        let path = report.spool.as_ref().expect("spooled").path().to_owned();
+        drop(report);
+        assert!(!path.exists(), "the report is removed on drop");
+    }
+
+    #[test]
+    fn both_renderers_stream_the_report_and_preserve_write_errors() {
+        use crate::args::CommandKind;
+        use crate::commands::{CommandData, CommandOutput};
+        use crate::render::{write_success, OutputFormat};
+        #[derive(Default)]
+        struct CountWrites {
+            total: usize,
+            largest: usize,
+        }
+        impl Write for CountWrites {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.total += bytes.len();
+                self.largest = self.largest.max(bytes.len());
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        struct BrokenOutput;
+        impl Write for BrokenOutput {
+            fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+                Err(io::ErrorKind::BrokenPipe.into())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        let mut failures = TreeTransferFailures::default();
+        for index in 0..10_000 {
+            failures
+                .push(TreeTransferFailure {
+                    path: format!("/file-{index}"),
+                    error: CliError::invalid_request("failed"),
+                })
+                .expect("append");
+        }
+        let output = CommandOutput {
+            kind: CommandKind::FilesystemPut,
+            profile: None,
+            mode: None,
+            data: CommandData::TreeTransfer {
+                source: "local".to_owned(),
+                destination: "/remote".to_owned(),
+                files: 3,
+                directories: 1,
+                head_drift: None,
+                failures,
+            },
+        };
+        assert!(output.data.reports_failures());
+        for format in [OutputFormat::Json, OutputFormat::Human] {
+            let mut count = CountWrites::default();
+            write_success(&output, format, &mut count).expect("render");
+            assert!(count.total > 100_000);
+            assert!(
+                count.largest < 1024,
+                "renderer buffered {} bytes",
+                count.largest
+            );
+            assert_eq!(
+                write_success(&output, format, BrokenOutput)
+                    .expect_err("closed output")
+                    .kind(),
+                io::ErrorKind::BrokenPipe
+            );
+        }
+        let mut json = Vec::new();
+        write_success(&output, OutputFormat::Json, &mut json).expect("json");
+        let json: serde_json::Value = serde_json::from_slice(&json).expect("parse JSON");
+        assert_eq!(
+            json["data"]["failures"].as_array().expect("array").len(),
+            10_000
+        );
+        assert_eq!(json["data"]["failures"][9999]["path"], "/file-9999");
+    }
+
+    #[test]
+    fn report_write_failures_are_returned_without_counting_a_saved_error() {
+        let spool = NamedTempFile::new().expect("spool");
+        let (writer, path) = spool.into_parts();
+        drop(writer);
+        let reader = std::fs::File::open(&path).expect("read-only file");
+        let mut report = TreeTransferFailures {
+            spool: Some(NamedTempFile::from_parts(reader, path)),
+            len: 0,
+        };
+        assert!(report
+            .push(TreeTransferFailure {
+                path: "/file".to_owned(),
+                error: CliError::invalid_request("failed")
+            })
+            .is_err());
+        assert_eq!(report.len(), 0);
+    }
+
+    #[test]
+    fn a_damaged_report_is_an_error_instead_of_a_truncated_success() {
+        let mut report = TreeTransferFailures::default();
+        report
+            .push(TreeTransferFailure {
+                path: "/first".to_owned(),
+                error: CliError::invalid_request("failed"),
+            })
+            .expect("append");
+        report
+            .spool
+            .as_mut()
+            .expect("spooled")
+            .write_all(b"{broken\n")
+            .expect("damage report");
+        assert!(serde_json::to_writer(io::sink(), &report).is_err());
+    }
+}

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -2,7 +2,7 @@
 
 use crate::config::NAMESPACE_ENV;
 use loonfs_api::ErrorCode;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 macro_rules! cli_error_codes {
     (@count) => { 0 };
@@ -60,7 +60,7 @@ cli_error_codes! {
 /// same code. Validation after argument parsing uses `invalid_request`.
 /// Parser errors use the CLI-local `invalid_usage` code. Other local codes are
 /// created by the constructors below.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CliError {
     pub code: String,
     /// Feature key for `not_supported` errors.

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -2,14 +2,41 @@
 
 use super::summaries::*;
 use super::*;
-use crate::commands::{TrashListing, TreeTransferFailure};
+use crate::commands::{TrashListing, TreeTransferFailures};
 use crate::config::{CliConfig, ProfileConfig};
 use crate::profiles::ProfileSummary;
 use loonfs_api::{ChangeSeq, CommitId, FileRevision, GrepMatch, PathEntry};
 
 use super::human_maintenance::*;
 
+#[cfg(test)]
 pub(crate) fn human_success(output: &CommandOutput) -> String {
+    let mut bytes = Vec::new();
+    write_human_success(output, &mut bytes).expect("render human output");
+    String::from_utf8(bytes).expect("human output is UTF-8")
+}
+
+pub(crate) fn write_human_success(
+    output: &CommandOutput,
+    mut writer: impl Write,
+) -> io::Result<bool> {
+    if let CommandData::TreeTransfer { failures, .. } = &output.data {
+        for failure in failures.iter()? {
+            let failure = failure?;
+            writeln!(
+                writer,
+                "failed {}: {}",
+                failure.path,
+                human_error(&failure.error)
+            )?;
+        }
+    }
+    let text = human_success_text(output);
+    writer.write_all(text.as_bytes())?;
+    Ok(text.ends_with('\n'))
+}
+
+fn human_success_text(output: &CommandOutput) -> String {
     match &output.data {
         CommandData::Capabilities(document) => human_capabilities(document),
         CommandData::Doctor { checks } => human_doctor(checks),
@@ -327,18 +354,13 @@ fn human_tree_transfer(
     destination: &str,
     files: u64,
     directories: u64,
-    failures: &[TreeTransferFailure],
+    failures: &TreeTransferFailures,
 ) -> String {
     let verb = match kind {
         CommandKind::FilesystemGet => "downloaded",
         CommandKind::FilesystemCp => "copied",
         _ => "stored",
     };
-    let mut lines = Vec::new();
-    for failure in failures {
-        let rendered = human_error(&failure.error);
-        lines.push(format!("failed {}: {rendered}", failure.path));
-    }
     let directory_noun = if directories == 1 {
         "directory"
     } else {
@@ -350,8 +372,7 @@ fn human_tree_transfer(
     if !failures.is_empty() {
         summary.push_str(&format!("; {} failed", failures.len()));
     }
-    lines.push(summary);
-    lines.join("\n")
+    summary
 }
 
 fn human_file_mutation(

--- a/crates/loonfs-cli/src/render/json.rs
+++ b/crates/loonfs-cli/src/render/json.rs
@@ -19,21 +19,33 @@ where
     error: Option<&'a CliError>,
 }
 
+#[cfg(test)]
 pub(crate) fn json_success(output: &CommandOutput) -> io::Result<String> {
+    let mut bytes = Vec::new();
+    write_json_success(output, &mut bytes)?;
+    String::from_utf8(bytes).map_err(io::Error::other)
+}
+
+pub(crate) fn write_json_success(output: &CommandOutput, writer: impl Write) -> io::Result<()> {
     match &output.data {
         CommandData::CompletionScript(_) | CommandData::StreamedToStdout => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "raw output does not support json rendering",
         )),
-        data => serde_json::to_string_pretty(&JsonEnvelope {
-            kind: output.kind.as_str(),
-            format_version: CLI_JSON_FORMAT_VERSION,
-            profile: output.profile.as_deref(),
-            mode: output.mode.as_deref(),
-            data: Some(data),
-            error: None,
-        })
-        .map_err(io::Error::other),
+        data => serde_json::to_writer_pretty(
+            writer,
+            &JsonEnvelope {
+                kind: output.kind.as_str(),
+                format_version: CLI_JSON_FORMAT_VERSION,
+                profile: output.profile.as_deref(),
+                mode: output.mode.as_deref(),
+                data: Some(data),
+                error: None,
+            },
+        )
+        .map_err(|error| {
+            io::Error::new(error.io_error_kind().unwrap_or(io::ErrorKind::Other), error)
+        }),
     }
 }
 

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -19,8 +19,12 @@ use loonfs_api::{
 use serde::Serialize;
 use std::io::{self, Write};
 
-pub(crate) use human::{human_path_entry, human_success};
-pub(crate) use json::{json_error, json_success, render_parse_error};
+pub(crate) use human::human_path_entry;
+#[cfg(test)]
+use human::human_success;
+#[cfg(test)]
+use json::json_success;
+pub(crate) use json::{json_error, render_parse_error};
 pub(crate) use summaries::{
     gc_pass_line, store_probe_summary_line, store_probe_verdict, StoreProbeVerdict,
 };
@@ -32,27 +36,25 @@ pub(crate) enum OutputFormat {
 }
 
 pub(crate) fn render_success(output: &CommandOutput, format: OutputFormat) -> io::Result<()> {
+    write_success(output, format, io::stdout().lock())
+}
+
+pub(crate) fn write_success(
+    output: &CommandOutput,
+    format: OutputFormat,
+    mut writer: impl Write,
+) -> io::Result<()> {
     if format == OutputFormat::Json {
-        let body = json_success(output)?;
-        let mut stdout = io::stdout().lock();
-        stdout.write_all(body.as_bytes())?;
-        stdout.write_all(b"\n")?;
+        json::write_json_success(output, &mut writer)?;
+        writer.write_all(b"\n")?;
         return Ok(());
     }
-
     match &output.data {
-        CommandData::CompletionScript(bytes) => {
-            let mut stdout = io::stdout().lock();
-            stdout.write_all(bytes)?;
-        }
-        // Already written, chunk by chunk, by the command itself.
+        CommandData::CompletionScript(bytes) => writer.write_all(bytes)?,
         CommandData::StreamedToStdout => {}
         _ => {
-            let rendered = human_success(output);
-            let mut stdout = io::stdout().lock();
-            stdout.write_all(rendered.as_bytes())?;
-            if !rendered.ends_with('\n') {
-                stdout.write_all(b"\n")?;
+            if !human::write_human_success(output, &mut writer)? {
+                writer.write_all(b"\n")?;
             }
         }
     }


### PR DESCRIPTION
Recursive transfers bounded discovery but still retained every failure and rebuilt the complete output in memory. Spool failures to a temporary file and stream both human and JSON rendering, preserving the complete failure list, output shape, and nonzero exit status while keeping report memory independent of the number of failures. Report storage and output errors propagate, and temporary reports are removed when dropped. Validation: full workspace tests, formatting, all-target/all-feature Clippy with warnings denied, and focused coverage for 10,000-error reports, repeat reads, cleanup, damaged reports, read-only report files, and broken output pipes.
