### PR TITLE
feat(sdk): add verified streaming downloads

### DIFF
--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2791,3 +2791,27 @@ New client-visible operations arrive as API group ops or named features here;
 new durable state arrives in `format.md`; new scheduling machinery is
 implementation freedom. Cross-store discovery — naming authority, search,
 ownership, quotas — is out of scope for this specification.
+
+### SDK streaming downloads
+
+The handwritten transfer helpers expose verified download streams in every SDK:
+
+| SDK | Open a stream | Cancel or release it |
+| --- | --- | --- |
+| Go | `client.Files.DownloadStream(ctx, input)` | Close `Content` or cancel `ctx` |
+| Python (synchronous) | `client.files.download_stream(namespace_id, path=path, request_options=options)` | Use a `with` block or call `close()` |
+| TypeScript server/browser | `client.files.downloadStream(input, requestOptions)` | Cancel the `content` reader or abort `requestOptions.abortSignal` |
+
+The existing buffered download helpers collect these streams. Streams verify size
+and checksum incrementally and report a verification error on the same iterator,
+reader, or stream that carries the bytes. Only successful exhaustion verifies the
+file; cancellation and early close do not. Consumers must handle late errors even
+after some bytes have been delivered. A failed body is never automatically replayed.
+
+Both direct and proxied downloads propagate the caller's transport controls.
+Go respects a caller context deadline, with a 60-second operation deadline when
+none is supplied. TypeScript uses `timeoutInSeconds` (client default, otherwise
+60 seconds) across metadata and the body, plus `abortSignal`. Python uses the
+request/client HTTPX timeout for I/O waits on both transports; its synchronous
+iterator closes the response on early exit from a `with` block. API authorization,
+cookies and API headers are not copied into presigned object-store requests.

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -16,6 +16,9 @@ cd "$(dirname "$0")/../sdk"
 npx --yes "fern-api@${FERN_CLI_VERSION}" check
 
 overlay_handwritten() {
+    case "$1" in
+        typescript|typescript-client) cp transfers/typescript-shared/*.ts "generated/$1/" ;;
+    esac
     if [ -d "transfers/$1" ]; then
         cp -R "transfers/$1/." "generated/$1/"
     fi
@@ -338,14 +341,14 @@ source = source.replace(
     generated_import,
     "    from .client import AsyncLoonFS\n"
     "    from .core.api_error import ApiError\n"
-    "    from .transfers import FileDownloadResult, FileUploadResult, PreparedFileContent, LoonFS\n",
+    "    from .transfers import FileDownloadResult, FileDownloadStream, FileUploadResult, PreparedFileContent, LoonFS\n",
 )
 generated_mapping = '    "LoonFS": ".client",\n'
 assert source.count(generated_mapping) == 1, "generated server.py client mapping not found"
 source = source.replace(generated_mapping, '    "LoonFS": ".transfers",\n')
 for anchor, insertion, label in (
     ('    "AsyncLoonFS": ".client",\n', '    "ApiError": ".core.api_error",\n', "ApiError mapping"),
-    ('    "FileRevision": ".types",\n', '    "FileDownloadResult": ".transfers",\n', "FileDownloadResult mapping"),
+    ('    "FileRevision": ".types",\n', '    "FileDownloadResult": ".transfers",\n    "FileDownloadStream": ".transfers",\n', "FileDownloadResult mapping"),
     ('    "FileRevision": ".types",\n', '    "PreparedFileContent": ".transfers",\n', "PreparedFileContent mapping"),
     ('    "FilesystemChange": ".types",\n', '    "FileUploadResult": ".transfers",\n', "FileUploadResult mapping"),
 ):
@@ -353,7 +356,7 @@ for anchor, insertion, label in (
     source = source.replace(anchor, insertion + anchor)
 for anchor, insertion, label in (
     ('    "AsyncLoonFS",\n', '    "ApiError",\n', "ApiError __all__ entry"),
-    ('    "FileRevision",\n', '    "FileDownloadResult",\n', "FileDownloadResult __all__ entry"),
+    ('    "FileRevision",\n', '    "FileDownloadResult",\n    "FileDownloadStream",\n', "FileDownloadResult __all__ entry"),
     ('    "FileRevision",\n', '    "PreparedFileContent",\n', "PreparedFileContent __all__ entry"),
     ('    "FilesystemChange",\n', '    "FileUploadResult",\n', "FileUploadResult __all__ entry"),
 ):
@@ -454,6 +457,7 @@ source = replace_once(
     'export type {\n'
     '    FileDownloadInput,\n'
     '    FileDownloadResult,\n'
+    '    FileDownloadStream,\n'
     '    FileUploadInput,\n'
     '    FileUploadResult,\n'
     '    PreparedFileContent,\n'

--- a/scripts/run-sdk-conformance.sh
+++ b/scripts/run-sdk-conformance.sh
@@ -79,7 +79,7 @@ case "$LANGUAGE" in
         fi
         "$PYTHON_HARNESS/.venv/bin/pip" install -q -r "$PYTHON_HARNESS/requirements.txt"
         PYTHONPATH="$PYTHON_HARNESS" \
-            "$PYTHON_HARNESS/.venv/bin/python" -m pytest "$PYTHON_HARNESS/test_conformance.py"
+            "$PYTHON_HARNESS/.venv/bin/python" -m pytest "$PYTHON_HARNESS"/test_*.py
         ;;
     typescript)
         TYPESCRIPT_HARNESS="$REPO_ROOT/sdk/conformance/typescript"

--- a/sdk/conformance/fixtures/streaming_downloads.json
+++ b/sdk/conformance/fixtures/streaming_downloads.json
@@ -1,0 +1,67 @@
+[
+  {
+    "name": "sha256",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": false
+  },
+  {
+    "name": "crc32c",
+    "content": "123456789",
+    "algorithm": "crc32c",
+    "checksum": "e3069283",
+    "size_bytes": 9,
+    "error": false
+  },
+  {
+    "name": "crc64nvme",
+    "content": "123456789",
+    "algorithm": "crc64nvme",
+    "checksum": "ae8b14860a799888",
+    "size_bytes": 9,
+    "error": false
+  },
+  {
+    "name": "truncated",
+    "content": "12345678",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true
+  },
+  {
+    "name": "too_long",
+    "content": "123456789x",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true
+  },
+  {
+    "name": "corrupt",
+    "content": "12345678x",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true
+  },
+  {
+    "name": "empty",
+    "content": "",
+    "algorithm": "sha256",
+    "checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size_bytes": 0,
+    "error": false
+  },
+  {
+    "name": "transport_failure_after_last_byte",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "transport_error": true
+  }
+]

--- a/sdk/conformance/go/streaming_test.go
+++ b/sdk/conformance/go/streaming_test.go
@@ -1,0 +1,143 @@
+package conformance_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	loonfs "github.com/loonfs/loonfs-sdk-go"
+	"github.com/loonfs/loonfs-sdk-go/files"
+	"github.com/loonfs/loonfs-sdk-go/option"
+	"github.com/loonfs/loonfs-sdk-go/server"
+)
+
+type streamCase struct {
+	Name           string `json:"name"`
+	Content        string `json:"content"`
+	Algorithm      string `json:"algorithm"`
+	Checksum       string `json:"checksum"`
+	SizeBytes      int    `json:"size_bytes"`
+	Error          bool   `json:"error"`
+	TransportError bool   `json:"transport_error"`
+}
+
+func streamingCases(t *testing.T) []streamCase {
+	t.Helper()
+	data, err := os.ReadFile("../fixtures/streaming_downloads.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cases []streamCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatal(err)
+	}
+	return cases
+}
+
+func streamTestServer(t *testing.T, fixture streamCase, direct bool, content func(http.ResponseWriter, *http.Request)) *httptest.Server {
+	t.Helper()
+	var host *httptest.Server
+	claim := map[string]any{"kind": "blob", "content_id": "cnt_00000000000000000000000000000001", "size_bytes": fixture.SizeBytes, "checksum": map[string]any{"algorithm": fixture.Algorithm, "value": fixture.Checksum}}
+	host = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/object" {
+			if r.Header.Get("Authorization") != "" || r.Header.Get("X-Private") != "" {
+				t.Error("API credentials leaked to object store")
+			}
+			content(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer private-token" {
+			t.Error("API authorization missing")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/capabilities"):
+			json.NewEncoder(w).Encode(map[string]any{"protocol_version": "v0", "api_groups": []string{"filesystem/v0"}, "features": map[string]bool{"filesystem.downloads.direct_get": direct}})
+		case strings.HasSuffix(r.URL.Path, "/downloads"):
+			json.NewEncoder(w).Encode(map[string]any{"namespace_id": "demo", "path": "/file", "revision_no": 1, "content_ref": claim, "access": map[string]any{"kind": "presigned_url", "url": host.URL + "/object", "method": "GET", "expires_at_ms": 2000000000000}})
+		case strings.HasSuffix(r.URL.Path, "/entry"):
+			json.NewEncoder(w).Encode(map[string]any{"inode_kind": "file", "namespace_id": "demo", "path": "/file", "revision_no": 1, "content_ref": claim})
+		case strings.HasSuffix(r.URL.Path, "/content"):
+			if r.URL.Query().Get("revision_no") != "1" {
+				t.Error("proxy read is not pinned to its revision")
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			content(w, r)
+		default:
+			t.Errorf("unexpected request %s", r.URL)
+			http.NotFound(w, r)
+		}
+	}))
+	return host
+}
+
+func TestStreamingDownloadConformance(t *testing.T) {
+	for _, direct := range []bool{false, true} {
+		for _, fixture := range streamingCases(t) {
+			t.Run(fixture.Name+map[bool]string{false: "_proxy", true: "_direct"}[direct], func(t *testing.T) {
+				host := streamTestServer(t, fixture, direct, func(w http.ResponseWriter, r *http.Request) {
+					if fixture.TransportError {
+						w.Header().Set("Content-Length", "10")
+					}
+					io.WriteString(w, fixture.Content)
+				})
+				defer host.Close()
+				client := server.NewClient(option.WithBaseURL(host.URL), option.WithToken("private-token"), option.WithHTTPHeader(http.Header{"X-Private": {"secret"}}), option.WithHTTPClient(host.Client()))
+				opened, err := client.Files.DownloadStream(context.Background(), files.DownloadInput{NamespaceID: loonfs.NamespaceID("demo"), Path: loonfs.AbsolutePath("/file")})
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer opened.Content.Close()
+				data, err := io.ReadAll(opened.Content)
+				if fixture.Error {
+					if err == nil {
+						t.Fatal("invalid body passed verification")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(data) != fixture.Content {
+					t.Fatalf("got %q", data)
+				}
+			})
+		}
+	}
+}
+
+func TestStreamingDownloadsStartBeforeEOFAndCancelPendingReads(t *testing.T) {
+	fixture := streamingCases(t)[0]
+	for _, direct := range []bool{false, true} {
+		host := streamTestServer(t, fixture, direct, func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, "1")
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		})
+		client := server.NewClient(option.WithBaseURL(host.URL), option.WithToken("private-token"))
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		opened, err := client.Files.DownloadStream(ctx, files.DownloadInput{NamespaceID: "demo", Path: "/file"})
+		if err != nil {
+			cancel()
+			host.Close()
+			t.Fatal(err)
+		}
+		first := make([]byte, 1)
+		if _, err := io.ReadFull(opened.Content, first); err != nil {
+			t.Fatal(err)
+		}
+		cancel()
+		if _, err := opened.Content.Read(first); !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected cancellation, got %v", err)
+		}
+		opened.Content.Close()
+		host.Close()
+	}
+}

--- a/sdk/conformance/python/test_streaming.py
+++ b/sdk/conformance/python/test_streaming.py
@@ -1,0 +1,140 @@
+import hashlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from loonfs.server import LoonFS
+
+CASES = json.loads(
+    (Path(__file__).parents[1] / "fixtures/streaming_downloads.json").read_text()
+)
+
+
+class Chunks(httpx.SyncByteStream):
+    def __init__(self, chunks, transport_error=False):
+        self.transport_error = transport_error
+        self.chunks = chunks
+        self.reads = 0
+        self.closed = False
+
+    def __iter__(self):
+        for chunk in self.chunks:
+            self.reads += 1
+            yield chunk
+        if self.transport_error:
+            raise httpx.ReadError("body interrupted after its last byte")
+
+    def close(self):
+        self.closed = True
+
+
+def stream_client(fixture, direct, body):
+    claim = {
+        "kind": "blob",
+        "content_id": "cnt_00000000000000000000000000000001",
+        "size_bytes": fixture["size_bytes"],
+        "checksum": {"algorithm": fixture["algorithm"], "value": fixture["checksum"]},
+    }
+    requests = []
+
+    def handle(request):
+        requests.append(request)
+        assert request.extensions["timeout"]["read"] == 7
+        path = request.url.path
+        if path == "/object":
+            assert "authorization" not in request.headers
+            assert "x-private" not in request.headers
+            assert "cookie" not in request.headers
+            return httpx.Response(200, stream=body)
+        assert request.headers["authorization"] == "Bearer private-token"
+        if path.endswith("/capabilities"):
+            value = {
+                "protocol_version": "v0",
+                "api_groups": ["filesystem/v0"],
+                "features": {"filesystem.downloads.direct_get": direct},
+            }
+        elif path.endswith("/downloads"):
+            value = {
+                "namespace_id": "demo",
+                "path": "/file",
+                "revision_no": 1,
+                "content_ref": claim,
+                "access": {
+                    "kind": "presigned_url",
+                    "method": "GET",
+                    "url": "http://objects.test/object",
+                    "expires_at_ms": 2000000000000,
+                },
+            }
+        elif path.endswith("/entry"):
+            actor = {"kind": "system", "id": "test"}
+            value = {
+                "inode_kind": "file",
+                "namespace_id": "demo",
+                "path": "/file",
+                "inode_id": "ino_2",
+                "head_seq": 1,
+                "created_at_ms": 0,
+                "created_by": actor,
+                "revision_committed_at_ms": 0,
+                "revision_committed_by": actor,
+                "revision_no": 1,
+                "content_ref": claim,
+                "size_bytes": claim["size_bytes"],
+            }
+        elif path.endswith("/content"):
+            assert request.url.params["revision_no"] == "1"
+            return httpx.Response(200, stream=body)
+        else:
+            raise AssertionError(str(request.url))
+        return httpx.Response(200, json=value)
+
+    http = httpx.Client(
+        transport=httpx.MockTransport(handle),
+        headers={"X-Private": "secret"},
+        cookies={"private": "secret"},
+    )
+    return (
+        LoonFS(base_url="http://api.test", token="private-token", httpx_client=http),
+        http,
+        requests,
+    )
+
+
+@pytest.mark.parametrize("direct", [False, True])
+@pytest.mark.parametrize("fixture", CASES, ids=lambda case: case["name"])
+def test_streaming_download_conformance(fixture, direct):
+    body = Chunks([fixture["content"].encode()], fixture.get("transport_error", False))
+    client, http, requests = stream_client(fixture, direct, body)
+    with http:
+        with client.files.download_stream(
+            "demo", path="/file", request_options={"timeout": 7}
+        ) as stream:
+            assert body.reads == 0, "opening the download must not consume its body"
+            if fixture["error"]:
+                with pytest.raises((RuntimeError, httpx.ReadError)):
+                    b"".join(stream)
+            else:
+                assert b"".join(stream) == fixture["content"].encode()
+        assert body.closed
+
+
+@pytest.mark.parametrize("direct", [False, True])
+def test_streaming_download_backpressure_and_early_close(direct):
+    chunk = b"x" * 65536
+    fixture = {
+        "size_bytes": len(chunk) * 3,
+        "algorithm": "sha256",
+        "checksum": hashlib.sha256(chunk * 3).hexdigest(),
+    }
+    body = Chunks([chunk] * 3)
+    client, http, _ = stream_client(fixture, direct, body)
+    with http:
+        with client.files.download_stream(
+            "demo", path="/file", request_options={"timeout": 7}
+        ) as stream:
+            assert next(stream) == chunk
+            assert body.reads == 1, "the next chunk must wait for the consumer"
+        assert body.closed
+        assert body.reads == 1

--- a/sdk/conformance/typescript/package.json
+++ b/sdk/conformance/typescript/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "test": "node --test dist/conformance/typescript/src/conformance.test.js"
+    "test": "node --test dist/conformance/typescript/src/*.test.js"
   },
   "devDependencies": {
     "@types/node": "^18.19.0",

--- a/sdk/conformance/typescript/src/streaming.test.ts
+++ b/sdk/conformance/typescript/src/streaming.test.ts
@@ -1,0 +1,210 @@
+import * as assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import { LoonFSClient } from "../../../generated/typescript/transfers.js";
+import { LoonFSClient as BrowserClient } from "../../../generated/typescript-client/transfers.js";
+import {
+    IncrementalChecksum,
+    TransferScope,
+    verifiedDownload,
+} from "../../../generated/typescript/transfer-runtime.js";
+
+type Fixture = {
+    name: string;
+    content: string;
+    algorithm: "sha256" | "crc32c" | "crc64nvme";
+    checksum: string;
+    size_bytes: number;
+    error: boolean;
+    transport_error?: boolean;
+};
+const fixtures: Fixture[] = JSON.parse(
+    readFileSync(join(__dirname, "../../../../../fixtures/streaming_downloads.json"), "utf8"),
+);
+
+function fakeFetch(fixture: Fixture, direct: boolean, body: ReadableStream<Uint8Array>): typeof fetch {
+    const claim = {
+        kind: "blob",
+        content_id: "cnt_00000000000000000000000000000001",
+        size_bytes: fixture.size_bytes,
+        checksum: { algorithm: fixture.algorithm, value: fixture.checksum },
+    };
+    return (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input.toString());
+        const headers = new Headers(init?.headers);
+        if (url.pathname === "/object") {
+            assert.equal(headers.has("Authorization"), false);
+            assert.equal(headers.has("X-Private"), false);
+            assert.ok(init?.signal, "direct bytes must use the operation's cancellation signal");
+            return new Response(body);
+        }
+        if (url.pathname.endsWith("/capabilities"))
+            return Response.json({
+                protocol_version: "v0",
+                api_groups: ["filesystem/v0"],
+                features: { "filesystem.downloads.direct_get": direct },
+            });
+        if (url.pathname.endsWith("/downloads"))
+            return Response.json({
+                namespace_id: "demo",
+                namespace_alias: "demo",
+                path: "/file",
+                revision_no: 1,
+                content_ref: claim,
+                access: {
+                    kind: "presigned_url",
+                    method: "GET",
+                    url: "http://objects.test/object",
+                    expires_at_ms: 2000000000000,
+                },
+            });
+        if (url.pathname.endsWith("/entry"))
+            return Response.json({
+                inode_kind: "file",
+                namespace_id: "demo",
+                path: "/file",
+                revision_no: 1,
+                content_ref: claim,
+            });
+        if (url.pathname.endsWith("/content")) {
+            assert.equal(url.searchParams.get("revision_no"), "1");
+            assert.ok(init?.signal, "proxy bytes must use the operation's cancellation signal");
+            return new Response(body);
+        }
+        throw new Error(`unexpected request ${url}`);
+    }) as typeof fetch;
+}
+
+for (const browser of [false, true])
+    for (const direct of [false, true])
+        for (const fixture of fixtures) {
+            test(`verified streaming ${browser ? "browser" : "server"} ${direct ? "direct" : "proxy"} ${fixture.name}`, async () => {
+                let reads = 0;
+                const body = new ReadableStream<Uint8Array>(
+                    {
+                        pull(controller) {
+                            reads++;
+                            if (reads === 1) controller.enqueue(new TextEncoder().encode(fixture.content));
+                            else if (fixture.transport_error) controller.error(new Error("body interrupted after its last byte"));
+                        else controller.close();
+                        },
+                    },
+                    { highWaterMark: 0 },
+                );
+                const options = {
+                    baseUrl: "http://api.test",
+                    token: "private-token",
+                    headers: { "X-Private": "secret" },
+                    fetch: fakeFetch(fixture, direct, body),
+                };
+                const stream = browser
+                    ? await new BrowserClient(options).files.downloadStream({
+                          namespace_alias: "demo",
+                          path: "/file",
+                      })
+                    : await new LoonFSClient(options).files.downloadStream({
+                          namespace_id: "demo",
+                          path: "/file",
+                      });
+                assert.equal(reads, 0, "opening must not consume the response body");
+                const collected = new Response(stream.content).text();
+                if (fixture.error) await assert.rejects(collected);
+                else assert.equal(await collected, fixture.content);
+            });
+        }
+
+test("incremental SHA-256 agrees with the native implementation across block boundaries", () => {
+    for (const length of [0, 1, 55, 56, 63, 64, 65, 127, 128, 129, 4096, 65537, 1000000]) {
+        const bytes = Uint8Array.from({ length }, (_, i) => (i * 29) % 251);
+        const expected = createHash("sha256").update(bytes).digest("hex");
+        for (const stride of [1, 7, 63, 64, 65536]) {
+            const digest = new IncrementalChecksum("sha256");
+            for (let offset = 0; offset < bytes.length; offset += stride)
+                digest.update(bytes.subarray(offset, offset + stride));
+            assert.equal(digest.finish().value, expected, `length=${length} stride=${stride}`);
+        }
+    }
+});
+
+for (const direct of [false, true]) {
+    test(`streaming ${direct ? "direct" : "proxy"} cancellation releases a stalled body`, async () => {
+        let cancelled = false;
+        const body = new ReadableStream<Uint8Array>(
+            {
+                cancel() {
+                    cancelled = true;
+                },
+            },
+            { highWaterMark: 0 },
+        );
+        const controller = new AbortController();
+        const client = new LoonFSClient({
+            baseUrl: "http://api.test",
+            token: "private-token",
+            fetch: fakeFetch(fixtures[0]!, direct, body),
+        });
+        const stream = await client.files.downloadStream(
+            { namespace_id: "demo", path: "/file" },
+            { abortSignal: controller.signal },
+        );
+        const read = stream.content.getReader().read();
+        controller.abort(new Error("caller cancelled"));
+        await assert.rejects(read, /caller cancelled/);
+        assert.ok(cancelled);
+    });
+    test(`streaming ${direct ? "direct" : "proxy"} deadline remains active after headers`, async () => {
+        let cancelled = false;
+        const body = new ReadableStream<Uint8Array>(
+            {
+                cancel() {
+                    cancelled = true;
+                },
+            },
+            { highWaterMark: 0 },
+        );
+        const client = new LoonFSClient({
+            baseUrl: "http://api.test",
+            token: "private-token",
+            fetch: fakeFetch(fixtures[0]!, direct, body),
+        });
+        const stream = await client.files.downloadStream(
+            { namespace_id: "demo", path: "/file" },
+            { timeoutInSeconds: 0.05 },
+        );
+        await assert.rejects(stream.content.getReader().read(), { name: "TimeoutError" });
+        assert.ok(cancelled);
+    });
+}
+
+test("verified streams bound chunks and stop reading when the consumer closes", async () => {
+    const bytes = new Uint8Array(3 * 65536);
+    const digest = new IncrementalChecksum("sha256");
+    digest.update(bytes);
+    let reads = 0,
+        cancelled = false;
+    const body = new ReadableStream<Uint8Array>(
+        {
+            pull(controller) {
+                reads++;
+                controller.enqueue(bytes);
+            },
+            cancel() {
+                cancelled = true;
+            },
+        },
+        { highWaterMark: 0 },
+    );
+    const stream = verifiedDownload(
+        body,
+        { size_bytes: bytes.length, checksum: digest.finish() },
+        new TransferScope(),
+    );
+    const reader = stream.getReader();
+    assert.equal((await reader.read()).value?.length, 65536);
+    assert.equal(reads, 1);
+    await reader.cancel();
+    assert.ok(cancelled);
+    assert.equal(reads, 1);
+});

--- a/sdk/overlays/go/README.md
+++ b/sdk/overlays/go/README.md
@@ -39,8 +39,17 @@ func main() {
 }
 ```
 
-`client.Files.Upload` and `client.Files.Download` transfer whole files in memory. See
-[reference.md](./reference.md) for the generated API reference.
+`client.Files.DownloadStream(ctx, input)` opens a live, verified `io.ReadCloser`
+in its `Content` field. Consume it through successful EOF to verify size and
+checksum, and always close it. Closing early or cancelling the context releases
+the response without claiming verification. A caller deadline covers metadata
+and body reads; without one, the operation has a 60-second deadline. Direct and
+proxied transfers use the configured HTTP client and the same context. Direct
+requests carry only the presigned headers, and do not follow redirects.
+
+`client.Files.Download` collects that stream into memory. `client.Files.Upload`
+accepts an in-memory byte slice. See [reference.md](./reference.md) for the
+generated API reference.
 
 ## Proxy
 

--- a/sdk/overlays/python/README.md
+++ b/sdk/overlays/python/README.md
@@ -26,7 +26,25 @@ client = LoonFS(
 capabilities = client.capabilities.retrieve()
 ```
 
-`client.files.upload` and `client.files.download` transfer whole files in memory. `AsyncLoonFS` provides the same generated API for async applications; it does not have the transfer methods yet.
+Use `client.files.download_stream` in a `with` block for bounded download memory:
+
+```python
+with client.files.download_stream("demo", path="/large.bin", request_options={"timeout": 60}) as download:
+    for chunk in download:
+        destination.write(chunk)
+```
+
+Successful exhaustion verifies both size and checksum. Leaving the block early
+closes the response without claiming verification; bytes already consumed cannot
+be recalled if a later check fails. The request's `timeout` (or the client default)
+applies to metadata and payload HTTP I/O for direct and proxied reads. Python's
+synchronous HTTPX timeout bounds I/O waits, not the time spent processing chunks.
+Direct requests do not inherit API authorization, cookies or API headers, and
+never follow redirects. Closing the stream or interrupting its `with` block is
+the synchronous cancellation mechanism.
+
+`client.files.download` collects the same verified stream into memory.
+`client.files.upload` accepts in-memory bytes. `AsyncLoonFS` provides the same generated API for async applications; it does not have the transfer methods yet.
 
 ## Proxy
 

--- a/sdk/transfers/go/files/streaming.go
+++ b/sdk/transfers/go/files/streaming.go
@@ -1,0 +1,239 @@
+package files
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"hash/crc64"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	loonfs "github.com/loonfs/loonfs-sdk-go"
+	"github.com/loonfs/loonfs-sdk-go/capabilities"
+	"github.com/loonfs/loonfs-sdk-go/core"
+	"github.com/loonfs/loonfs-sdk-go/internal"
+)
+
+const defaultTransferTimeout = 60 * time.Second
+const transferChunkBytes = 64 * 1024
+
+// FileDownloadStream holds a live response. Read Content to successful EOF to
+// verify the size and checksum; Close releases it without asserting verification.
+type FileDownloadStream struct {
+	Content     io.ReadCloser
+	NamespaceID loonfs.NamespaceID
+	Path        loonfs.AbsolutePath
+	RevisionNo  loonfs.RevisionNo
+	ContentRef  *loonfs.ContentRef
+}
+
+func transferContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, defaultTransferTimeout)
+}
+
+// DownloadStream opens a verified stream with backpressure. The caller's context
+// covers discovery and the body; without a deadline the operation has 60 seconds.
+// Closing Content also cancels the operation. No failed body is replayed.
+func (c *Client) DownloadStream(ctx context.Context, in DownloadInput) (*FileDownloadStream, error) {
+	if c == nil {
+		return nil, fmt.Errorf("transfers: client is nil")
+	}
+	ctx, cancel := transferContext(ctx)
+	opened := false
+	defer func() {
+		if !opened {
+			cancel()
+		}
+	}()
+	capabilities, err := capabilities.NewClient(c.options).Retrieve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var result *FileDownloadStream
+	if capabilities != nil && capabilities.Features[featureDirectGet] {
+		grant, err := c.CreateDownload(ctx, &loonfs.BeginDownloadRequest{NamespaceID: string(in.NamespaceID), Path: in.Path, RevisionNo: in.RevisionNo})
+		if err != nil {
+			return nil, err
+		}
+		if grant == nil || grant.ContentRef == nil {
+			return nil, fmt.Errorf("transfers: download grant has no content reference")
+		}
+		response, err := sendPresignedWithClient(ctx, c.transferHTTPClient(), grant.Access, http.MethodGet, nil, 0)
+		if err != nil {
+			return nil, err
+		}
+		if response.StatusCode < 200 || response.StatusCode >= 300 {
+			defer response.Body.Close()
+			return nil, responseStatusError(response)
+		}
+		result = &FileDownloadStream{Content: response.Body, NamespaceID: grant.NamespaceID, Path: grant.Path, RevisionNo: grant.RevisionNo, ContentRef: grant.ContentRef}
+	} else {
+		result, err = c.downloadProxiedStream(ctx, in)
+		if err != nil {
+			return nil, err
+		}
+	}
+	verified, err := newVerifiedReader(ctx, result.Content, result.ContentRef, cancel)
+	if err != nil {
+		result.Content.Close()
+		return nil, err
+	}
+	result.Content = verified
+	opened = true
+	return result, nil
+}
+
+func (c *Client) transferHTTPClient() core.HTTPClient {
+	if c.options.HTTPClient != nil {
+		if configured, ok := c.options.HTTPClient.(*http.Client); ok {
+			copied := *configured
+			copied.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+			return &copied
+		}
+		return c.options.HTTPClient
+	}
+	return presignedHTTPClient
+}
+
+func (c *Client) downloadProxiedStream(ctx context.Context, in DownloadInput) (*FileDownloadStream, error) {
+	revisionNo := in.RevisionNo
+	var claim *loonfs.ContentRef
+	if revisionNo == nil {
+		entry, err := c.Retrieve(ctx, &loonfs.GetPathEntryRequest{NamespaceID: string(in.NamespaceID), Path: string(in.Path)})
+		if err != nil {
+			return nil, err
+		}
+		file, err := fileProjection(entry)
+		if err != nil {
+			return nil, err
+		}
+		revision := file.RevisionNo
+		revisionNo, claim = &revision, file.ContentRef
+	} else {
+		page, err := c.ListRevisions(ctx, &loonfs.ListFileRevisionsRequest{NamespaceID: string(in.NamespaceID), Path: string(in.Path)})
+		if err != nil {
+			return nil, err
+		}
+		iterator := page.Iterator()
+		for iterator.Next(ctx) {
+			revision := iterator.Current()
+			if revision.RevisionNo == *revisionNo {
+				claim = revision.ContentRef
+				break
+			}
+		}
+		if err := iterator.Err(); err != nil {
+			return nil, err
+		}
+	}
+	if claim == nil {
+		return nil, fmt.Errorf("transfers: revision not found for %s", in.Path)
+	}
+	query := url.Values{"path": {string(in.Path)}, "revision_no": {strconv.FormatInt(int64(*revisionNo), 10)}}
+	endpoint := strings.TrimRight(c.baseURL, "/") + "/v0/namespaces/" + url.PathEscape(string(in.NamespaceID)) + "/filesystem/content?" + query.Encode()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header = c.options.ToHeader()
+	response, err := c.transferHTTPClient().Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		defer response.Body.Close()
+		return nil, internal.NewErrorDecoder(loonfs.ErrorCodes)(response.StatusCode, response.Header, io.LimitReader(response.Body, 64*1024))
+	}
+	return &FileDownloadStream{Content: response.Body, NamespaceID: in.NamespaceID, Path: in.Path, RevisionNo: *revisionNo, ContentRef: claim}, nil
+}
+
+func newChecksum(algorithm loonfs.ChecksumAlgorithm) (hash.Hash, error) {
+	switch algorithm {
+	case loonfs.ChecksumAlgorithmSha256:
+		return sha256.New(), nil
+	case loonfs.ChecksumAlgorithmCrc32C:
+		return crc32.New(crc32CTable), nil
+	case loonfs.ChecksumAlgorithmCrc64Nvme:
+		return crc64.New(crc64NVMeTable), nil
+	default:
+		return nil, fmt.Errorf("unsupported checksum algorithm %q", algorithm)
+	}
+}
+
+type verifiedReader struct {
+	ctx      context.Context
+	body     io.ReadCloser
+	cancel   context.CancelFunc
+	hash     hash.Hash
+	expected *loonfs.ContentRef
+	count    int64
+	terminal error
+	closed   bool
+}
+
+func newVerifiedReader(ctx context.Context, body io.ReadCloser, expected *loonfs.ContentRef, cancel context.CancelFunc) (*verifiedReader, error) {
+	if expected == nil || expected.Checksum == nil || expected.SizeBytes < 0 {
+		return nil, fmt.Errorf("transfers: invalid content reference")
+	}
+	digest, err := newChecksum(expected.Checksum.Algorithm)
+	if err != nil {
+		return nil, err
+	}
+	return &verifiedReader{ctx: ctx, body: body, cancel: cancel, hash: digest, expected: expected}, nil
+}
+
+func (r *verifiedReader) Read(buffer []byte) (int, error) {
+	if r.terminal != nil {
+		return 0, r.terminal
+	}
+	if r.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if err := r.ctx.Err(); err != nil {
+		r.terminal = err
+		r.Close()
+		return 0, err
+	}
+	if len(buffer) > transferChunkBytes {
+		buffer = buffer[:transferChunkBytes]
+	}
+	n, err := r.body.Read(buffer)
+	r.count += int64(n)
+	if r.count > r.expected.SizeBytes {
+		r.terminal = fmt.Errorf("transfers: download exceeded expected size %d", r.expected.SizeBytes)
+		r.Close()
+		return 0, r.terminal
+	}
+	r.hash.Write(buffer[:n])
+	if err == io.EOF {
+		if r.count != r.expected.SizeBytes {
+			err = fmt.Errorf("transfers: download returned %d bytes, expected %d", r.count, r.expected.SizeBytes)
+		} else if hex.EncodeToString(r.hash.Sum(nil)) != r.expected.Checksum.Value {
+			err = fmt.Errorf("transfers: download checksum mismatch")
+		}
+	}
+	if err != nil {
+		r.terminal = err
+		r.Close()
+	}
+	return n, err
+}
+
+func (r *verifiedReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	r.cancel()
+	return r.body.Close()
+}

--- a/sdk/transfers/go/files/transfers.go
+++ b/sdk/transfers/go/files/transfers.go
@@ -15,6 +15,7 @@ import (
 	loonfs "github.com/loonfs/loonfs-sdk-go"
 	"github.com/loonfs/loonfs-sdk-go/capabilities"
 	"github.com/loonfs/loonfs-sdk-go/commits"
+	"github.com/loonfs/loonfs-sdk-go/core"
 	"github.com/loonfs/loonfs-sdk-go/option"
 	"github.com/loonfs/loonfs-sdk-go/uploads"
 )
@@ -206,131 +207,18 @@ func (c *Client) PutFilePrepared(ctx context.Context, in PreparedUploadInput) (*
 	}, nil
 }
 
-// Download reads one revision into memory and verifies its content claim.
-// Streaming and resume are follow-ups.
+// Download collects DownloadStream for callers that want a whole byte slice.
 func (c *Client) Download(ctx context.Context, in DownloadInput) (*DownloadResult, error) {
-	if c == nil {
-		return nil, fmt.Errorf("transfers: client is nil")
-	}
-	capabilitiesClient := capabilities.NewClient(c.options)
-	capabilities, err := capabilitiesClient.Retrieve(ctx)
+	stream, err := c.DownloadStream(ctx, in)
 	if err != nil {
-		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
+		return nil, err
 	}
-	if capabilities == nil || !capabilities.Features[featureDirectGet] {
-		return downloadProxied(ctx, c, in)
-	}
-	grant, err := c.CreateDownload(ctx, &loonfs.BeginDownloadRequest{
-		NamespaceID: string(in.NamespaceID),
-		Path:        in.Path,
-		RevisionNo:  in.RevisionNo,
-	})
+	defer stream.Content.Close()
+	content, err := io.ReadAll(stream.Content)
 	if err != nil {
-		return nil, fmt.Errorf("transfers: begin download: %w", err)
+		return nil, err
 	}
-	if grant.ContentRef == nil {
-		return nil, fmt.Errorf("transfers: download grant has no content reference")
-	}
-
-	payload, err := getPresigned(ctx, grant.Access)
-	if err != nil {
-		return nil, fmt.Errorf("transfers: download content: %w", err)
-	}
-	if int64(len(payload)) != grant.ContentRef.SizeBytes {
-		return nil, fmt.Errorf(
-			"transfers: downloaded %d bytes, expected %d",
-			len(payload),
-			grant.ContentRef.SizeBytes,
-		)
-	}
-	if err := verifyChecksum(grant.ContentRef.Checksum, payload); err != nil {
-		return nil, fmt.Errorf("transfers: verify download: %w", err)
-	}
-
-	return &DownloadResult{
-		Content:     payload,
-		NamespaceID: grant.NamespaceID,
-		Path:        grant.Path,
-		RevisionNo:  grant.RevisionNo,
-		ContentRef:  grant.ContentRef,
-	}, nil
-}
-
-// downloadProxied reads through LoonFS when direct reads are unavailable.
-// It loads the content reference first, then requests the exact revision so
-// the reference and returned bytes describe the same file version.
-func downloadProxied(ctx context.Context, c *Client, in DownloadInput) (*DownloadResult, error) {
-	revisionNo := in.RevisionNo
-	var claim *loonfs.ContentRef
-	if revisionNo == nil {
-		entry, err := c.Retrieve(ctx, &loonfs.GetPathEntryRequest{
-			NamespaceID: string(in.NamespaceID),
-			Path:        string(in.Path),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("transfers: stat path: %w", err)
-		}
-		file, err := fileProjection(entry)
-		if err != nil {
-			return nil, err
-		}
-		headRevision := file.RevisionNo
-		revisionNo = &headRevision
-		claim = file.ContentRef
-	} else {
-		page, err := c.ListRevisions(ctx, &loonfs.ListFileRevisionsRequest{
-			NamespaceID: string(in.NamespaceID),
-			Path:        string(in.Path),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("transfers: list file revisions: %w", err)
-		}
-		iterator := page.Iterator()
-		for iterator.Next(ctx) {
-			revision := iterator.Current()
-			if revision.RevisionNo == *revisionNo {
-				claim = revision.ContentRef
-				break
-			}
-		}
-		if claim == nil {
-			return nil, fmt.Errorf("transfers: revision %d not found for %s", *revisionNo, in.Path)
-		}
-	}
-	if claim == nil {
-		return nil, fmt.Errorf("transfers: revision has no content reference")
-	}
-
-	reader, err := c.Content(ctx, &loonfs.GetFileBytesRequest{
-		NamespaceID: string(in.NamespaceID),
-		Path:        string(in.Path),
-		RevisionNo:  revisionNo,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("transfers: read content: %w", err)
-	}
-	payload, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, fmt.Errorf("transfers: read content: %w", err)
-	}
-	if int64(len(payload)) != claim.SizeBytes {
-		return nil, fmt.Errorf(
-			"transfers: proxied read returned %d bytes, expected %d",
-			len(payload),
-			claim.SizeBytes,
-		)
-	}
-	if err := verifyChecksum(claim.Checksum, payload); err != nil {
-		return nil, fmt.Errorf("transfers: verify proxied read: %w", err)
-	}
-
-	return &DownloadResult{
-		Content:     payload,
-		NamespaceID: in.NamespaceID,
-		Path:        in.Path,
-		RevisionNo:  *revisionNo,
-		ContentRef:  claim,
-	}, nil
+	return &DownloadResult{Content: content, NamespaceID: stream.NamespaceID, Path: stream.Path, RevisionNo: stream.RevisionNo, ContentRef: stream.ContentRef}, nil
 }
 
 // fileProjection reads the file half of a path entry union.
@@ -606,22 +494,6 @@ func putPresigned(
 	return response.Header.Get("ETag"), nil
 }
 
-func getPresigned(ctx context.Context, access *loonfs.ObjectTransferAccess) ([]byte, error) {
-	response, err := sendPresigned(ctx, access, http.MethodGet, nil, 0)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		return nil, responseStatusError(response)
-	}
-	payload, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read presigned GET response: %w", err)
-	}
-	return payload, nil
-}
-
 func sendPresigned(
 	ctx context.Context,
 	access *loonfs.ObjectTransferAccess,
@@ -629,6 +501,10 @@ func sendPresigned(
 	body io.Reader,
 	contentLength int64,
 ) (*http.Response, error) {
+	return sendPresignedWithClient(ctx, presignedHTTPClient, access, expectedMethod, body, contentLength)
+}
+
+func sendPresignedWithClient(ctx context.Context, client core.HTTPClient, access *loonfs.ObjectTransferAccess, expectedMethod string, body io.Reader, contentLength int64) (*http.Response, error) {
 	if access == nil || access.PresignedURL == nil {
 		return nil, fmt.Errorf("unsupported object transfer access")
 	}
@@ -650,7 +526,7 @@ func sendPresigned(
 		}
 		request.Header.Set(name, value)
 	}
-	response, err := presignedHTTPClient.Do(request)
+	response, err := client.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("send presigned request: %w", err)
 	}
@@ -664,20 +540,6 @@ func responseStatusError(response *http.Response) error {
 		return fmt.Errorf("presigned request returned %s", response.Status)
 	}
 	return fmt.Errorf("presigned request returned %s: %s", response.Status, detail)
-}
-
-func verifyChecksum(expected *loonfs.Checksum, payload []byte) error {
-	if expected == nil {
-		return fmt.Errorf("content reference has no checksum")
-	}
-	actual, err := computeChecksum(expected.Algorithm, payload)
-	if err != nil {
-		return err
-	}
-	if actual.Value != expected.Value {
-		return fmt.Errorf("checksum mismatch: got %s, expected %s", actual.Value, expected.Value)
-	}
-	return nil
 }
 
 func computeChecksum(algorithm loonfs.ChecksumAlgorithm, payload []byte) (*loonfs.Checksum, error) {

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -1,8 +1,4 @@
-"""Synchronous, in-memory file transfer orchestration.
-
-Streaming and resume are follow-ups. The async client does not have these
-methods yet.
-"""
+"""Synchronous file transfers with verified streaming downloads."""
 
 from __future__ import annotations
 
@@ -14,6 +10,7 @@ import httpx
 
 from .client import LoonFS as _GeneratedLoonFS
 from .files.client import FilesClient as _GeneratedFilesClient
+from .core.request_options import RequestOptions
 from .types import (
     ActorRef,
     BeginUploadRequest_DirectMultipart,
@@ -88,6 +85,118 @@ class PreparedFileContent:
 
     content_ref: ContentRef
     content_token: str | None
+
+
+_TRANSFER_CHUNK_BYTES = 64 * 1024
+
+
+class _IncrementalChecksum:
+    def __init__(self, algorithm: str):
+        self.algorithm = algorithm
+        self.sha = hashlib.sha256() if algorithm == "sha256" else None
+        if algorithm == "crc32c":
+            self.value, self.table, self.mask = (
+                _CRC32C_MASK,
+                _CRC32C_TABLE,
+                _CRC32C_MASK,
+            )
+        elif algorithm == "crc64nvme":
+            self.value, self.table, self.mask = (
+                _CRC64_NVME_MASK,
+                _CRC64_NVME_TABLE,
+                _CRC64_NVME_MASK,
+            )
+        elif algorithm != "sha256":
+            raise ValueError(f"unsupported checksum algorithm {algorithm!r}")
+
+    def update(self, content: bytes) -> None:
+        if self.sha is not None:
+            self.sha.update(content)
+        else:
+            for byte in content:
+                self.value = self.table[(self.value ^ byte) & 0xFF] ^ (self.value >> 8)
+
+    def finish(self) -> Checksum:
+        value = (
+            self.sha.hexdigest()
+            if self.sha is not None
+            else format(
+                self.value ^ self.mask, "08x" if self.algorithm == "crc32c" else "016x"
+            )
+        )
+        return Checksum(algorithm=self.algorithm, value=value)
+
+
+class FileDownloadStream(typing.Iterator[bytes]):
+    """A single-use verified iterator. Close or leave its with block to cancel.
+
+    A caller that stops early has not verified the complete file. Bytes already
+    consumed cannot be recalled if a checksum or transport error occurs later.
+    """
+
+    def __init__(self, chunks, close, namespace_id, path, revision_no, content_ref):
+        self._chunks, self._close = iter(chunks), close
+        self.namespace_id, self.path, self.revision_no = namespace_id, path, revision_no
+        self.content_ref = content_ref
+        self._checksum = _IncrementalChecksum(content_ref.checksum.algorithm)
+        self._expected_checksum = content_ref.checksum.value
+        self._expected_size = content_ref.size_bytes
+        self._count = 0
+        self._closed = False
+        self._verified = False
+        self._terminal_error = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> bytes:
+        if self._terminal_error is not None:
+            raise self._terminal_error
+        if self._closed:
+            if self._verified:
+                raise StopIteration
+            raise ValueError("download stream was closed before verification")
+        try:
+            chunk = next(self._chunks)
+            self._count += len(chunk)
+            if self._count > self._expected_size:
+                raise RuntimeError(
+                    f"download exceeded expected size {self._expected_size}"
+                )
+            self._checksum.update(chunk)
+            return chunk
+        except StopIteration:
+            try:
+                if self._count != self._expected_size:
+                    raise RuntimeError(
+                        f"download returned {self._count} bytes, expected {self._expected_size}"
+                    )
+                if self._checksum.finish().value != self._expected_checksum:
+                    raise RuntimeError(
+                        "download checksum did not match its content reference"
+                    )
+                self._verified = True
+            except BaseException as error:
+                self._terminal_error = error
+                raise
+            finally:
+                self.close()
+            raise
+        except BaseException as error:
+            self._terminal_error = error
+            self.close()
+            raise
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._close()
 
 
 class FilesClient(_GeneratedFilesClient):
@@ -192,6 +301,72 @@ class FilesClient(_GeneratedFilesClient):
             committed_seq=committed.committed_seq,
         )
 
+    def download_stream(
+        self,
+        namespace_id: str,
+        *,
+        path: str,
+        revision_no: RevisionNo | None = None,
+        http_client: httpx.Client | None = None,
+        request_options: RequestOptions | None = None,
+    ) -> FileDownloadStream:
+        """Open a verified stream; use a with block to close on early exit.
+
+        Size and checksum verification complete only at successful exhaustion.
+        Request timeouts apply to metadata and payload I/O on either transport.
+        """
+        capabilities = self._root.capabilities.retrieve(request_options=request_options)
+        if not (capabilities.features or {}).get(_DIRECT_GET_FEATURE, False):
+            claim, revision_no = _proxied_claim(
+                self._root, namespace_id, path, revision_no, request_options
+            )
+            chunks = self._root.files.content(
+                namespace_id,
+                path=path,
+                revision_no=revision_no,
+                request_options={
+                    **(request_options or {}),
+                    "chunk_size": _TRANSFER_CHUNK_BYTES,
+                },
+            )
+            return FileDownloadStream(
+                chunks, chunks.close, namespace_id, path, revision_no, claim
+            )
+        grant = self.create_download(
+            namespace_id,
+            path=path,
+            revision_no=revision_no,
+            request_options=request_options,
+        )
+        if grant.access.method.upper() != "GET":
+            raise RuntimeError("download grant must use GET")
+        client = http_client or self._root._client_wrapper.httpx_client.httpx_client
+        timeout = (request_options or {}).get(
+            "timeout", self._root._client_wrapper.get_timeout()
+        )
+        # Construct a fresh request: SDK authorization, cookies and custom
+        # API headers must never be forwarded to the object-store capability.
+        request = httpx.Request(
+            "GET",
+            grant.access.url,
+            headers=grant.access.headers or {},
+            extensions={"timeout": httpx.Timeout(timeout).as_dict()},
+        )
+        response = client.send(request, stream=True, auth=None, follow_redirects=False)
+        try:
+            response.raise_for_status()
+            return FileDownloadStream(
+                response.iter_bytes(chunk_size=_TRANSFER_CHUNK_BYTES),
+                response.close,
+                grant.namespace_id,
+                grant.path,
+                grant.revision_no,
+                grant.content_ref,
+            )
+        except BaseException:
+            response.close()
+            raise
+
     def download(
         self,
         namespace_id: str,
@@ -199,47 +374,24 @@ class FilesClient(_GeneratedFilesClient):
         path: str,
         revision_no: RevisionNo | None = None,
         http_client: httpx.Client | None = None,
+        request_options: RequestOptions | None = None,
     ) -> FileDownloadResult:
-        """Download one file revision into memory and verify its checksum."""
-
-        capabilities = self._root.capabilities.retrieve()
-        if not capabilities.features.get(_DIRECT_GET_FEATURE, False):
-            return _get_file_proxied(
-                self._root,
-                namespace_id=namespace_id,
-                path=path,
-                revision_no=revision_no,
+        """Collect download_stream for callers that want all bytes in memory."""
+        with self.download_stream(
+            namespace_id,
+            path=path,
+            revision_no=revision_no,
+            http_client=http_client,
+            request_options=request_options,
+        ) as stream:
+            content = b"".join(stream)
+            return FileDownloadResult(
+                content=content,
+                namespace_id=stream.namespace_id,
+                path=stream.path,
+                revision_no=stream.revision_no,
+                content_ref=stream.content_ref,
             )
-        if revision_no is None:
-            grant = self.create_download(namespace_id, path=path)
-        else:
-            grant = self.create_download(
-                namespace_id,
-                path=path,
-                revision_no=revision_no,
-            )
-        if http_client is None:
-            with httpx.Client() as transfer_client:
-                response = _send_presigned(transfer_client, grant.access, "GET")
-        else:
-            response = _send_presigned(http_client, grant.access, "GET")
-        content = response.content
-        if len(content) != grant.content_ref.size_bytes:
-            raise RuntimeError(
-                f"download returned {len(content)} bytes, expected {grant.content_ref.size_bytes}"
-            )
-        if (
-            _checksum(grant.content_ref.checksum.algorithm, content)
-            != grant.content_ref.checksum
-        ):
-            raise RuntimeError("download checksum did not match its content reference")
-        return FileDownloadResult(
-            content=content,
-            namespace_id=grant.namespace_id,
-            path=grant.path,
-            revision_no=grant.revision_no,
-            content_ref=grant.content_ref,
-        )
 
 
 class LoonFS(_GeneratedLoonFS):
@@ -258,6 +410,7 @@ class LoonFS(_GeneratedLoonFS):
 
 __all__ = [
     "FileDownloadResult",
+    "FileDownloadStream",
     "FileUploadResult",
     "PreparedFileContent",
     "FilesClient",
@@ -265,56 +418,25 @@ __all__ = [
 ]
 
 
-def _get_file_proxied(
-    client: _GeneratedLoonFS,
-    *,
-    namespace_id: str,
-    path: str,
-    revision_no: RevisionNo | None,
-) -> FileDownloadResult:
-    """Read through LoonFS when direct reads are unavailable.
-
-    Load the content reference first, then request the exact revision so the
-    reference and returned bytes describe the same file version.
-    """
+def _proxied_claim(client, namespace_id, path, revision_no, request_options):
     if revision_no is None:
-        entry = client.files.retrieve(namespace_id, path=path)
+        entry = client.files.retrieve(
+            namespace_id, path=path, request_options=request_options
+        )
         if entry.inode_kind != "file":
             raise RuntimeError(f"path {path!r} is a {entry.inode_kind}, not a file")
-        claim = entry.content_ref
-        revision_no = entry.revision_no
-    else:
-        claim = None
-        cursor = None
-        while True:
-            page = client.files.list_revisions(
-                namespace_id, path=path, cursor=cursor
-            )
-            for revision in page.revisions:
-                if revision.revision_no == revision_no:
-                    claim = revision.content_ref
-                    break
-            if claim is not None or page.next_cursor is None:
-                break
-            cursor = page.next_cursor
-        if claim is None:
-            raise RuntimeError(f"revision {revision_no} not found for {path!r}")
-    content = b"".join(
-        client.files.content(namespace_id, path=path, revision_no=revision_no)
-    )
-    if len(content) != claim.size_bytes:
-        raise RuntimeError(
-            f"proxied read returned {len(content)} bytes, expected {claim.size_bytes}"
+        return entry.content_ref, entry.revision_no
+    cursor = None
+    while True:
+        page = client.files.list_revisions(
+            namespace_id, path=path, cursor=cursor, request_options=request_options
         )
-    if _checksum(claim.checksum.algorithm, content) != claim.checksum:
-        raise RuntimeError("proxied read checksum did not match its content reference")
-    return FileDownloadResult(
-        content=content,
-        namespace_id=namespace_id,
-        path=path,
-        revision_no=revision_no,
-        content_ref=claim,
-    )
+        for revision in page.revisions:
+            if revision.revision_no == revision_no:
+                return revision.content_ref, revision_no
+        if page.next_cursor is None:
+            raise RuntimeError(f"revision {revision_no} not found for {path!r}")
+        cursor = page.next_cursor
 
 
 def _create_upload(client: _GeneratedLoonFS, namespace_id: str, content: bytes):
@@ -497,8 +619,7 @@ def _send_presigned(
 def _completed_content(response: UploadSession) -> PreparedFileContent:
     if response.status != "completed":
         raise RuntimeError(
-            f"upload {response.upload_id!r} completed with status "
-            f"{response.status!r}"
+            f"upload {response.upload_id!r} completed with status {response.status!r}"
         )
     return PreparedFileContent(
         content_ref=response.content_ref,
@@ -506,9 +627,7 @@ def _completed_content(response: UploadSession) -> PreparedFileContent:
     )
 
 
-def _abort_quietly(
-    client: _GeneratedLoonFS, namespace_id: str, upload_id: str
-) -> None:
+def _abort_quietly(client: _GeneratedLoonFS, namespace_id: str, upload_id: str) -> None:
     try:
         client.uploads.abort(namespace_id, upload_id)
     except Exception:

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -1,3 +1,4 @@
+import { TransferScope, verifiedDownload } from "./transfer-runtime.js";
 import { LoonFSClient as GeneratedLoonFSClient } from "./Client.js";
 import { FilesClient as GeneratedFilesClient } from "./api/resources/files/client/Client.js";
 import * as core from "./core/index.js";
@@ -55,6 +56,11 @@ export interface FileDownloadResult {
     content: Uint8Array;
 }
 
+/** A live stream; consume through successful EOF to verify the content. */
+export interface FileDownloadStream extends Omit<FileDownloadResult, "content"> {
+    content: ReadableStream<Uint8Array>;
+}
+
 /** Completed content; preparation does not publish or extend the upload lifetime. */
 export interface PreparedFileContent {
     readonly contentRef: LoonFS.ContentRef;
@@ -97,7 +103,9 @@ export class FilesClient extends GeneratedFilesClient {
     }
 
     /** Upload once without publishing; retain the result for publication retries. */
-    public async prepareFileBytes(input: Pick<FileUploadInput, "namespace_alias" | "content">): Promise<PreparedFileContent> {
+    public async prepareFileBytes(
+        input: Pick<FileUploadInput, "namespace_alias" | "content">,
+    ): Promise<PreparedFileContent> {
         return stageBytes(this.root, input.namespace_alias, input.content);
     }
 
@@ -125,37 +133,54 @@ export class FilesClient extends GeneratedFilesClient {
         return this.root.commits.create(request);
     }
 
-    /** Downloads one revision into memory and verifies its content claim. Streaming and resume are follow-ups. */
-    public async download(input: FileDownloadInput): Promise<FileDownloadResult> {
-        const capabilities = await this.root.capabilities.retrieve();
-        if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
-            return downloadProxied(this.root, input);
+    /** Opens a verified stream; cancel its reader to release an unfinished download. */
+    public async downloadStream(
+        input: FileDownloadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileDownloadStream> {
+        const scope = new TransferScope(requestOptions, this._options.timeoutInSeconds);
+        const options = { ...requestOptions, abortSignal: scope.signal };
+        let body: ReadableStream<Uint8Array> | null | undefined;
+        try {
+            scope.check();
+            const capabilities = await this.root.capabilities.retrieve(options);
+            if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
+                const result = await downloadProxied(this.root, input, options);
+                body = result.content;
+                return { ...result, content: verifiedDownload(body, result.content_ref, scope) };
+            }
+            const grant = await this.createDownload(input, options);
+            requirePresignedMethod(grant.access, "GET", "download");
+            const response = await (this._options.fetch ?? fetch)(grant.access.url, {
+                redirect: "error",
+                method: grant.access.method,
+                headers: grant.access.headers,
+                signal: scope.signal,
+            });
+            body = response.body;
+            requireSuccessfulResponse(response, "download");
+            return {
+                namespace_alias: input.namespace_alias,
+                path: grant.path,
+                revision_no: grant.revision_no,
+                content_ref: grant.content_ref,
+                content: verifiedDownload(body, grant.content_ref, scope),
+            };
+        } catch (error) {
+            scope.close();
+            await body?.cancel(error).catch(() => {});
+            throw error;
         }
-        const grant = await this.createDownload(input);
-        requirePresignedMethod(grant.access, "GET", "download");
-        const response = await fetch(grant.access.url, {
-            redirect: "error",
-            method: grant.access.method,
-            headers: grant.access.headers,
-        });
-        requireSuccessfulResponse(response, "download");
-        const bytes = new Uint8Array(await response.arrayBuffer());
-        if (bytes.byteLength !== grant.content_ref.size_bytes) {
-            throw new Error(
-                `download returned ${bytes.byteLength} bytes, expected ${grant.content_ref.size_bytes}`,
-            );
-        }
-        const actual = await checksum(grant.content_ref.checksum.algorithm, bytes);
-        if (actual.value !== grant.content_ref.checksum.value) {
-            throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
-        }
-        return {
-            namespace_alias: input.namespace_alias,
-            path: grant.path,
-            revision_no: grant.revision_no,
-            content_ref: grant.content_ref,
-            content: bytes,
-        };
+    }
+
+    /** Collects downloadStream for callers that want all bytes in memory. */
+    public async download(
+        input: FileDownloadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileDownloadResult> {
+        const stream = await this.downloadStream(input, requestOptions);
+        const content = new Uint8Array(await new Response(stream.content).arrayBuffer());
+        return { ...stream, content };
     }
 }
 
@@ -178,24 +203,31 @@ export class LoonFSClient extends GeneratedLoonFSClient {
 async function downloadProxied(
     client: GeneratedLoonFSClient,
     input: FileDownloadInput,
-): Promise<FileDownloadResult> {
+    requestOptions: FilesClient.RequestOptions,
+): Promise<FileDownloadStream> {
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;
     if (revisionNo === undefined) {
-        const entry = await client.files.retrieve({
-            namespace_alias: input.namespace_alias,
-            path: input.path,
-        });
+        const entry = await client.files.retrieve(
+            {
+                namespace_alias: input.namespace_alias,
+                path: input.path,
+            },
+            requestOptions,
+        );
         if (entry.inode_kind !== "file") {
             throw new Error(`path ${input.path} is a ${entry.inode_kind}, not a file`);
         }
         claim = entry.content_ref;
         revisionNo = entry.revision_no;
     } else {
-        const page = await client.files.listRevisions({
-            namespace_alias: input.namespace_alias,
-            path: input.path,
-        });
+        const page = await client.files.listRevisions(
+            {
+                namespace_alias: input.namespace_alias,
+                path: input.path,
+            },
+            requestOptions,
+        );
         for await (const revision of page) {
             if (revision.revision_no === revisionNo) {
                 claim = revision.content_ref;
@@ -206,25 +238,26 @@ async function downloadProxied(
             throw new Error(`revision ${revisionNo} not found for ${input.path}`);
         }
     }
-    const body = await client.files.content({
-        namespace_alias: input.namespace_alias,
-        path: input.path,
-        revision_no: revisionNo,
-    });
-    const bytes = new Uint8Array(await body.arrayBuffer());
-    if (bytes.byteLength !== claim.size_bytes) {
-        throw new Error(`proxied read returned ${bytes.byteLength} bytes, expected ${claim.size_bytes}`);
-    }
-    const actual = await checksum(claim.checksum.algorithm, bytes);
-    if (actual.value !== claim.checksum.value) {
-        throw new Error(`proxied read checksum did not match ${claim.checksum.algorithm} claim`);
-    }
+    const body = await client.files.content(
+        {
+            namespace_alias: input.namespace_alias,
+            path: input.path,
+            revision_no: revisionNo,
+        },
+        requestOptions,
+    );
     return {
         namespace_alias: input.namespace_alias,
         path: input.path,
         revision_no: revisionNo,
         content_ref: claim,
-        content: bytes,
+        content:
+            body.stream() ??
+            new ReadableStream({
+                start(controller) {
+                    controller.error(new Error("download response has no body"));
+                },
+            }),
     };
 }
 
@@ -266,11 +299,7 @@ function selectBeginRequest(
     const fitsProxy = proxyLimit === undefined || bytes.byteLength <= proxyLimit;
     const directPutLimit = limits[DIRECT_PUT_MAX_BYTES];
     const fitsDirectPut = directPutLimit === undefined || bytes.byteLength <= directPutLimit;
-    if (
-        features[DIRECT_PUT_FEATURE] === true &&
-        fitsDirectPut &&
-        (worthCutting || !fitsProxy)
-    ) {
+    if (features[DIRECT_PUT_FEATURE] === true && fitsDirectPut && (worthCutting || !fitsProxy)) {
         return {
             mode: "direct_put",
             size_bytes: bytes.byteLength,
@@ -456,10 +485,7 @@ function requireSuccessfulResponse(response: Response, operation: string): void 
     }
 }
 
-async function directPutBody(
-    algorithm: LoonFS.ChecksumAlgorithm,
-    bytes: Uint8Array,
-): Promise<DirectPutBody> {
+async function directPutBody(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): Promise<DirectPutBody> {
     const body = arrayBuffer(bytes);
     const sentBytes = new Uint8Array(body);
     return {
@@ -471,10 +497,7 @@ async function directPutBody(
     };
 }
 
-async function checksum(
-    algorithm: LoonFS.ChecksumAlgorithm,
-    bytes: Uint8Array,
-): Promise<LoonFS.Checksum> {
+async function checksum(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): Promise<LoonFS.Checksum> {
     switch (algorithm) {
         case "sha256": {
             const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer(bytes));

--- a/sdk/transfers/typescript-shared/transfer-runtime.ts
+++ b/sdk/transfers/typescript-shared/transfer-runtime.ts
@@ -1,0 +1,260 @@
+/** Shared by server and browser transfers; no Node-only APIs or whole-file hashing. */
+export type ChecksumAlgorithm = "sha256" | "crc32c" | "crc64nvme";
+export const TRANSFER_CHUNK_BYTES = 64 * 1024;
+
+export interface TransferRequestOptions {
+    timeoutInSeconds?: number;
+    abortSignal?: AbortSignal;
+}
+
+/** One deadline and cancellation signal, retained until the body is finished. */
+export class TransferScope {
+    readonly controller = new AbortController();
+    readonly signal = this.controller.signal;
+    private readonly timer: ReturnType<typeof setTimeout>;
+    private readonly parent?: AbortSignal;
+    private readonly onParentAbort = () => this.controller.abort(this.parent?.reason);
+
+    constructor(options: TransferRequestOptions = {}, defaultTimeout = 60) {
+        const seconds = options.timeoutInSeconds ?? defaultTimeout;
+        if (!Number.isFinite(seconds) || seconds <= 0)
+            throw new Error("transfer timeout must be positive and finite");
+        this.parent = options.abortSignal;
+        if (this.parent?.aborted) this.onParentAbort();
+        else this.parent?.addEventListener("abort", this.onParentAbort, { once: true });
+        this.timer = setTimeout(
+            () => this.controller.abort(new DOMException("transfer timed out", "TimeoutError")),
+            seconds * 1000,
+        );
+    }
+
+    check(): void {
+        if (this.signal.aborted) throw this.signal.reason;
+    }
+    close(): void {
+        clearTimeout(this.timer);
+        this.parent?.removeEventListener("abort", this.onParentAbort);
+    }
+}
+
+const SHA256_K = new Uint32Array([
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+const rotate = (value: number, bits: number) => (value >>> bits) | (value << (32 - bits));
+
+/** SHA-256 compression and padding with a single retained 64-byte block. */
+class Sha256 {
+    private readonly state = new Uint32Array([
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ]);
+    private readonly words = new Uint32Array(64);
+    private readonly block = new Uint8Array(64);
+    private used = 0;
+    private bytes = 0;
+    update(input: Uint8Array): void {
+        this.bytes += input.length;
+        let offset = 0;
+        while (offset < input.length) {
+            const count = Math.min(64 - this.used, input.length - offset);
+            this.block.set(input.subarray(offset, offset + count), this.used);
+            offset += count;
+            this.used += count;
+            if (this.used === 64) {
+                this.compress(this.block);
+                this.used = 0;
+            }
+        }
+    }
+    private compress(block: Uint8Array): void {
+        const w = this.words;
+        const view = new DataView(block.buffer, block.byteOffset, block.byteLength);
+        for (let i = 0; i < 16; i++) w[i] = view.getUint32(i * 4);
+        for (let i = 16; i < 64; i++) {
+            const x = w[i - 15]!,
+                y = w[i - 2]!;
+            w[i] =
+                (w[i - 16]! +
+                    (rotate(x, 7) ^ rotate(x, 18) ^ (x >>> 3)) +
+                    w[i - 7]! +
+                    (rotate(y, 17) ^ rotate(y, 19) ^ (y >>> 10))) >>>
+                0;
+        }
+        let [a, b, c, d, e, f, g, h] = Array.from(this.state) as [
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+        ];
+        for (let i = 0; i < 64; i++) {
+            const t1 =
+                (h +
+                    (rotate(e, 6) ^ rotate(e, 11) ^ rotate(e, 25)) +
+                    ((e & f) ^ (~e & g)) +
+                    SHA256_K[i]! +
+                    w[i]!) >>>
+                0;
+            const t2 = ((rotate(a, 2) ^ rotate(a, 13) ^ rotate(a, 22)) + ((a & b) ^ (a & c) ^ (b & c))) >>> 0;
+            h = g;
+            g = f;
+            f = e;
+            e = (d + t1) >>> 0;
+            d = c;
+            c = b;
+            b = a;
+            a = (t1 + t2) >>> 0;
+        }
+        [a, b, c, d, e, f, g, h].forEach((value, i) => {
+            this.state[i] = (this.state[i]! + value) >>> 0;
+        });
+    }
+    finish(): string {
+        const padding = new Uint8Array(this.used < 56 ? 64 : 128);
+        padding.set(this.block.subarray(0, this.used));
+        padding[this.used] = 0x80;
+        new DataView(padding.buffer).setBigUint64(padding.length - 8, BigInt(this.bytes) * 8n);
+        this.compress(padding.subarray(0, 64));
+        if (padding.length === 128) this.compress(padding.subarray(64));
+        return Array.from(this.state, (value) => value.toString(16).padStart(8, "0")).join("");
+    }
+}
+
+function crcTable(polynomial: bigint): bigint[] {
+    return Array.from({ length: 256 }, (_, byte) => {
+        let value = BigInt(byte);
+        for (let bit = 0; bit < 8; bit++) value = (value >> 1n) ^ (value & 1n ? polynomial : 0n);
+        return value;
+    });
+}
+const CRC32 = crcTable(0x82f63b78n).map(Number);
+const CRC64 = crcTable(0x9a6c9329ac4bc9b5n);
+
+export class IncrementalChecksum {
+    private readonly sha?: Sha256;
+    private crc32 = 0xffffffff;
+    private crc64 = 0xffffffffffffffffn;
+    private result?: string;
+    constructor(readonly algorithm: ChecksumAlgorithm) {
+        if (algorithm === "sha256") this.sha = new Sha256();
+        else if (algorithm !== "crc32c" && algorithm !== "crc64nvme")
+            throw new Error(`unsupported checksum algorithm ${algorithm}`);
+    }
+    update(bytes: Uint8Array): void {
+        if (this.result !== undefined) throw new Error("checksum already finalized");
+        if (this.sha) this.sha.update(bytes);
+        else if (this.algorithm === "crc32c") {
+            for (const byte of bytes) this.crc32 = CRC32[(this.crc32 ^ byte) & 255]! ^ (this.crc32 >>> 8);
+        } else {
+            for (const byte of bytes)
+                this.crc64 = CRC64[Number((this.crc64 ^ BigInt(byte)) & 255n)]! ^ (this.crc64 >> 8n);
+        }
+    }
+    finish(): { algorithm: ChecksumAlgorithm; value: string } {
+        this.result ??= this.sha
+            ? this.sha.finish()
+            : this.algorithm === "crc32c"
+              ? ((this.crc32 ^ 0xffffffff) >>> 0).toString(16).padStart(8, "0")
+              : (this.crc64 ^ 0xffffffffffffffffn).toString(16).padStart(16, "0");
+        return { algorithm: this.algorithm, value: this.result };
+    }
+}
+
+/** Verification belongs to EOF, on the same stream as the bytes it checks. */
+export function verifiedDownload(
+    body: ReadableStream<Uint8Array> | null,
+    claim: { size_bytes: number; checksum: { algorithm: ChecksumAlgorithm; value: string } },
+    scope: TransferScope,
+): ReadableStream<Uint8Array> {
+    if (!body) throw new Error("download response has no body");
+    const digest = new IncrementalChecksum(claim.checksum.algorithm);
+    const expectedSize = claim.size_bytes,
+        expectedChecksum = claim.checksum.value;
+    if (!Number.isSafeInteger(expectedSize) || expectedSize < 0) throw new Error("invalid download size");
+    const reader = body.getReader();
+    let count = 0,
+        offset = 0,
+        closed = false;
+    let pending: Uint8Array | undefined;
+    let onAbort: () => void;
+    const cleanup = () => {
+        scope.signal.removeEventListener("abort", onAbort);
+        scope.close();
+        reader.releaseLock();
+        pending = undefined;
+    };
+    return new ReadableStream<Uint8Array>(
+        {
+            start(controller) {
+                onAbort = () => {
+                    if (closed) return;
+                    closed = true;
+                    controller.error(scope.signal.reason);
+                    void reader
+                        .cancel(scope.signal.reason)
+                        .catch(() => {})
+                        .finally(cleanup);
+                };
+                scope.signal.addEventListener("abort", onAbort, { once: true });
+                if (scope.signal.aborted) onAbort();
+            },
+            async pull(controller) {
+                if (closed) return;
+                try {
+                    scope.check();
+                    while (!pending || offset === pending.length) {
+                        const next = await reader.read();
+                        scope.check();
+                        if (next.done) {
+                            if (count !== expectedSize)
+                                throw new Error(`download returned ${count} bytes, expected ${expectedSize}`);
+                            if (digest.finish().value !== expectedChecksum)
+                                throw new Error("download checksum mismatch");
+                            closed = true;
+                            controller.close();
+                            cleanup();
+                            return;
+                        }
+                        pending = next.value;
+                        offset = 0;
+                    }
+                    const chunk = pending.subarray(offset, offset + TRANSFER_CHUNK_BYTES);
+                    offset += chunk.length;
+                    count += chunk.length;
+                    if (count > expectedSize)
+                        throw new Error(`download exceeded expected size ${expectedSize}`);
+                    digest.update(chunk);
+                    controller.enqueue(chunk);
+                } catch (error) {
+                    if (closed) return;
+                    closed = true;
+                    controller.error(error);
+                    try {
+                        await reader.cancel(error);
+                    } finally {
+                        cleanup();
+                    }
+                }
+            },
+            async cancel(reason) {
+                if (closed) return;
+                closed = true;
+                try {
+                    await reader.cancel(reason);
+                } finally {
+                    cleanup();
+                }
+            },
+        },
+        { highWaterMark: 0 },
+    );
+}

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -1,3 +1,4 @@
+import { TransferScope, verifiedDownload } from "./transfer-runtime.js";
 import { LoonFSClient as GeneratedLoonFSClient } from "./Client.js";
 import { FilesClient as GeneratedFilesClient } from "./api/resources/files/client/Client.js";
 import * as core from "./core/index.js";
@@ -52,6 +53,11 @@ export interface FileDownloadResult {
     content: Uint8Array;
 }
 
+/** A live stream; consume through successful EOF to verify the content. */
+export interface FileDownloadStream extends Omit<FileDownloadResult, "content"> {
+    content: ReadableStream<Uint8Array>;
+}
+
 /** Completed content; preparation does not publish or extend the upload lifetime. */
 export interface PreparedFileContent {
     readonly contentRef: LoonFS.ContentRef;
@@ -94,7 +100,9 @@ export class FilesClient extends GeneratedFilesClient {
     }
 
     /** Upload once without publishing; retain the result for publication retries. */
-    public async prepareFileBytes(input: Pick<FileUploadInput, "namespace_id" | "content">): Promise<PreparedFileContent> {
+    public async prepareFileBytes(
+        input: Pick<FileUploadInput, "namespace_id" | "content">,
+    ): Promise<PreparedFileContent> {
         return stageBytes(this.root, input.namespace_id, input.content);
     }
 
@@ -122,37 +130,54 @@ export class FilesClient extends GeneratedFilesClient {
         return this.root.commits.create(request);
     }
 
-    /** Downloads one revision into memory and verifies its content claim. Streaming and resume are follow-ups. */
-    public async download(input: FileDownloadInput): Promise<FileDownloadResult> {
-        const capabilities = await this.root.capabilities.retrieve();
-        if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
-            return downloadProxied(this.root, input);
+    /** Opens a verified stream; cancel its reader to release an unfinished download. */
+    public async downloadStream(
+        input: FileDownloadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileDownloadStream> {
+        const scope = new TransferScope(requestOptions, this._options.timeoutInSeconds);
+        const options = { ...requestOptions, abortSignal: scope.signal };
+        let body: ReadableStream<Uint8Array> | null | undefined;
+        try {
+            scope.check();
+            const capabilities = await this.root.capabilities.retrieve(options);
+            if ((capabilities.features ?? {})[DIRECT_GET_FEATURE] !== true) {
+                const result = await downloadProxied(this.root, input, options);
+                body = result.content;
+                return { ...result, content: verifiedDownload(body, result.content_ref, scope) };
+            }
+            const grant = await this.createDownload(input, options);
+            requirePresignedMethod(grant.access, "GET", "download");
+            const response = await (this._options.fetch ?? fetch)(grant.access.url, {
+                redirect: "error",
+                method: grant.access.method,
+                headers: grant.access.headers,
+                signal: scope.signal,
+            });
+            body = response.body;
+            requireSuccessfulResponse(response, "download");
+            return {
+                namespace_id: input.namespace_id,
+                path: grant.path,
+                revision_no: grant.revision_no,
+                content_ref: grant.content_ref,
+                content: verifiedDownload(body, grant.content_ref, scope),
+            };
+        } catch (error) {
+            scope.close();
+            await body?.cancel(error).catch(() => {});
+            throw error;
         }
-        const grant = await this.createDownload(input);
-        requirePresignedMethod(grant.access, "GET", "download");
-        const response = await fetch(grant.access.url, {
-            redirect: "error",
-            method: grant.access.method,
-            headers: grant.access.headers,
-        });
-        requireSuccessfulResponse(response, "download");
-        const bytes = new Uint8Array(await response.arrayBuffer());
-        if (bytes.byteLength !== grant.content_ref.size_bytes) {
-            throw new Error(
-                `download returned ${bytes.byteLength} bytes, expected ${grant.content_ref.size_bytes}`,
-            );
-        }
-        const actual = await checksum(grant.content_ref.checksum.algorithm, bytes);
-        if (actual.value !== grant.content_ref.checksum.value) {
-            throw new Error(`download checksum did not match ${grant.content_ref.checksum.algorithm} claim`);
-        }
-        return {
-            namespace_id: input.namespace_id,
-            path: grant.path,
-            revision_no: grant.revision_no,
-            content_ref: grant.content_ref,
-            content: bytes,
-        };
+    }
+
+    /** Collects downloadStream for callers that want all bytes in memory. */
+    public async download(
+        input: FileDownloadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileDownloadResult> {
+        const stream = await this.downloadStream(input, requestOptions);
+        const content = new Uint8Array(await new Response(stream.content).arrayBuffer());
+        return { ...stream, content };
     }
 }
 
@@ -175,24 +200,31 @@ export class LoonFSClient extends GeneratedLoonFSClient {
 async function downloadProxied(
     client: GeneratedLoonFSClient,
     input: FileDownloadInput,
-): Promise<FileDownloadResult> {
+    requestOptions: FilesClient.RequestOptions,
+): Promise<FileDownloadStream> {
     let revisionNo = input.revision_no;
     let claim: LoonFS.ContentRef | undefined;
     if (revisionNo === undefined) {
-        const entry = await client.files.retrieve({
-            namespace_id: input.namespace_id,
-            path: input.path,
-        });
+        const entry = await client.files.retrieve(
+            {
+                namespace_id: input.namespace_id,
+                path: input.path,
+            },
+            requestOptions,
+        );
         if (entry.inode_kind !== "file") {
             throw new Error(`path ${input.path} is a ${entry.inode_kind}, not a file`);
         }
         claim = entry.content_ref;
         revisionNo = entry.revision_no;
     } else {
-        const page = await client.files.listRevisions({
-            namespace_id: input.namespace_id,
-            path: input.path,
-        });
+        const page = await client.files.listRevisions(
+            {
+                namespace_id: input.namespace_id,
+                path: input.path,
+            },
+            requestOptions,
+        );
         for await (const revision of page) {
             if (revision.revision_no === revisionNo) {
                 claim = revision.content_ref;
@@ -203,25 +235,26 @@ async function downloadProxied(
             throw new Error(`revision ${revisionNo} not found for ${input.path}`);
         }
     }
-    const body = await client.files.content({
-        namespace_id: input.namespace_id,
-        path: input.path,
-        revision_no: revisionNo,
-    });
-    const bytes = new Uint8Array(await body.arrayBuffer());
-    if (bytes.byteLength !== claim.size_bytes) {
-        throw new Error(`proxied read returned ${bytes.byteLength} bytes, expected ${claim.size_bytes}`);
-    }
-    const actual = await checksum(claim.checksum.algorithm, bytes);
-    if (actual.value !== claim.checksum.value) {
-        throw new Error(`proxied read checksum did not match ${claim.checksum.algorithm} claim`);
-    }
+    const body = await client.files.content(
+        {
+            namespace_id: input.namespace_id,
+            path: input.path,
+            revision_no: revisionNo,
+        },
+        requestOptions,
+    );
     return {
         namespace_id: input.namespace_id,
         path: input.path,
         revision_no: revisionNo,
         content_ref: claim,
-        content: bytes,
+        content:
+            body.stream() ??
+            new ReadableStream({
+                start(controller) {
+                    controller.error(new Error("download response has no body"));
+                },
+            }),
     };
 }
 
@@ -263,11 +296,7 @@ function selectBeginRequest(
     const fitsProxy = proxyLimit === undefined || bytes.byteLength <= proxyLimit;
     const directPutLimit = limits[DIRECT_PUT_MAX_BYTES];
     const fitsDirectPut = directPutLimit === undefined || bytes.byteLength <= directPutLimit;
-    if (
-        features[DIRECT_PUT_FEATURE] === true &&
-        fitsDirectPut &&
-        (worthCutting || !fitsProxy)
-    ) {
+    if (features[DIRECT_PUT_FEATURE] === true && fitsDirectPut && (worthCutting || !fitsProxy)) {
         return {
             mode: "direct_put",
             size_bytes: bytes.byteLength,
@@ -450,10 +479,7 @@ function requireSuccessfulResponse(response: Response, operation: string): void 
     }
 }
 
-async function directPutBody(
-    algorithm: LoonFS.ChecksumAlgorithm,
-    bytes: Uint8Array,
-): Promise<DirectPutBody> {
+async function directPutBody(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): Promise<DirectPutBody> {
     const body = arrayBuffer(bytes);
     const sentBytes = new Uint8Array(body);
     return {
@@ -465,10 +491,7 @@ async function directPutBody(
     };
 }
 
-async function checksum(
-    algorithm: LoonFS.ChecksumAlgorithm,
-    bytes: Uint8Array,
-): Promise<LoonFS.Checksum> {
+async function checksum(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): Promise<LoonFS.Checksum> {
     switch (algorithm) {
         case "sha256": {
             const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer(bytes));


### PR DESCRIPTION
The high-level Python, Go, and TypeScript download helpers loaded entire files and used different transport controls for direct and proxied reads. Add verified streaming downloads in all SDKs, make buffered downloads collect those streams, and carry cancellation and configured timeout behavior through body consumption without replaying failed bodies or forwarding API credentials to object storage. Document successful-EOF verification, early-close behavior, and each language's native timeout semantics. Validation: regenerated all four SDKs and passed retry-safety checks, all three SDK conformance runners, and a shared streaming fault matrix covering checksums, empty/truncated/oversized bodies, errors after the last byte, backpressure, early close, cancellation, and TypeScript deadlines after headers.
