### PR TITLE
feat(sdk): add bounded streaming uploads

### DIFF
--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2815,3 +2815,42 @@ none is supplied. TypeScript uses `timeoutInSeconds` (client default, otherwise
 request/client HTTPX timeout for I/O waits on both transports; its synchronous
 iterator closes the response on early exit from a `with` block. API authorization,
 cookies and API headers are not copied into presigned object-store requests.
+
+### SDK streaming uploads
+
+Streaming preparation accepts a caller-owned `io.Reader` in Go, a binary file
+object in synchronous Python, and a `Blob`, `ReadableStream<Uint8Array>`, or
+`AsyncIterable<Uint8Array>` in TypeScript. It returns the same prepared content
+used by the byte helpers, without publishing a filesystem entry:
+
+| SDK | Prepare once | Prepare and publish once |
+| --- | --- | --- |
+| Go | `Files.PrepareFileStream(ctx, namespaceID, reader, sizeBytes)` | `Files.UploadStream(ctx, files.StreamUploadInput{...})` |
+| Python | `files.prepare_file_stream(namespace_id, content=reader, size_bytes=size)` | `files.upload_stream(namespace_id, content=reader, ...)` |
+| TypeScript server/browser | `files.prepareFileStream({ ...namespace, content, size_bytes }, options)` | `files.uploadStream(input, options)` |
+
+The optional size is checked against the consumed bytes; TypeScript infers it
+for a Blob. Unknown nonempty sources use multipart when advertised, otherwise
+service-proxied uploads. SDK reads are limited to 64 KiB, and multipart uploads
+retain a provider-sized part plus at most 10,000 part descriptors. TypeScript
+retains the caller's current chunk, so callers should also produce bounded
+chunks. Known TypeScript sources up to 8 MiB use a bounded fixed request body to
+preserve browser compatibility; larger or unknown single-request uploads require
+runtime support for streaming request bodies. Multipart sends fixed part bodies
+and does not require that support. Existing byte helpers use these same paths.
+
+Upload preparation and publication use the same caller transport controls as
+downloads. Go and TypeScript deadlines cover the combined `UploadStream` /
+`uploadStream` operation. Python's timeout bounds HTTP I/O waits. A blocking
+caller-owned Go or Python source read must be interrupted by its owner; network
+cancellation cannot interrupt arbitrary source code. Callers close Go/Python
+sources; TypeScript cancels or returns its consumed source on completion or error.
+
+Payloads are consumed once and never automatically replayed. Source errors,
+size mismatches, and failed payload requests prevent completion and trigger a
+best-effort abort with a separate five-second cleanup timeout (an I/O timeout
+in synchronous Python). An ambiguous
+completion failure leaves the session available for inspection. After successful
+preparation, retain the result and retry `PutFilePrepared` / `put_file_prepared` /
+`putFilePrepared` with identical publication inputs; do not reread a stream or
+start a new upload to retry publication.

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -459,6 +459,8 @@ source = replace_once(
     '    FileDownloadResult,\n'
     '    FileDownloadStream,\n'
     '    FileUploadInput,\n'
+    '    FileStreamUploadInput,\n'
+    '    PrepareFileStreamInput,\n'
     '    FileUploadResult,\n'
     '    PreparedFileContent,\n'
     '    PreparedFileUploadInput,\n'

--- a/scripts/verify-sdk-retry-safety.py
+++ b/scripts/verify-sdk-retry-safety.py
@@ -51,7 +51,9 @@ def verify_group(group: str) -> None:
     generated = GENERATED_ROOT / group
 
     if group in {"typescript", "typescript-client"}:
-        actual = count_token(generated, ".ts", "maxRetries: 0,")
+        # Only generated endpoint clients correspond to operations in the spec.
+        # Handwritten transfer helpers independently disable payload retries.
+        actual = count_token(generated / "api" / "resources", ".ts", "maxRetries: 0,")
         if actual != expected:
             raise SystemExit(
                 f"{group} disables retries at {actual} call sites; expected {expected}"

--- a/sdk/conformance/fixtures/streaming_uploads.json
+++ b/sdk/conformance/fixtures/streaming_uploads.json
@@ -1,0 +1,284 @@
+[
+  {
+    "name": "sha256_service_proxied",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "service_proxied",
+    "size": 9
+  },
+  {
+    "name": "sha256_direct_put",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "direct_put",
+    "size": 9
+  },
+  {
+    "name": "sha256_direct_multipart",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "direct_multipart",
+    "size": null
+  },
+  {
+    "name": "crc32c_service_proxied",
+    "content": "123456789",
+    "algorithm": "crc32c",
+    "checksum": "e3069283",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "service_proxied",
+    "size": 9
+  },
+  {
+    "name": "crc32c_direct_put",
+    "content": "123456789",
+    "algorithm": "crc32c",
+    "checksum": "e3069283",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "direct_put",
+    "size": 9
+  },
+  {
+    "name": "crc32c_direct_multipart",
+    "content": "123456789",
+    "algorithm": "crc32c",
+    "checksum": "e3069283",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "direct_multipart",
+    "size": null
+  },
+  {
+    "name": "crc64nvme_service_proxied",
+    "content": "123456789",
+    "algorithm": "crc64nvme",
+    "checksum": "ae8b14860a799888",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "service_proxied",
+    "size": 9
+  },
+  {
+    "name": "crc64nvme_direct_put",
+    "content": "123456789",
+    "algorithm": "crc64nvme",
+    "checksum": "ae8b14860a799888",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "direct_put",
+    "size": 9
+  },
+  {
+    "name": "crc64nvme_direct_multipart",
+    "content": "123456789",
+    "algorithm": "crc64nvme",
+    "checksum": "ae8b14860a799888",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "direct_multipart",
+    "size": null
+  },
+  {
+    "name": "empty_service_proxied",
+    "content": "",
+    "algorithm": "sha256",
+    "checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size_bytes": 0,
+    "error": false,
+    "mode": "service_proxied",
+    "size": 0
+  },
+  {
+    "name": "service_proxied_source_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "service_proxied",
+    "size": 9,
+    "fault": "source_error"
+  },
+  {
+    "name": "service_proxied_payload_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "service_proxied",
+    "size": 9,
+    "fault": "payload_error"
+  },
+  {
+    "name": "service_proxied_completion_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "service_proxied",
+    "size": 9,
+    "fault": "completion_error"
+  },
+  {
+    "name": "service_proxied_size_8",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "service_proxied",
+    "size": 8
+  },
+  {
+    "name": "service_proxied_size_10",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "service_proxied",
+    "size": 10
+  },
+  {
+    "name": "proxy_unknown",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": false,
+    "mode": "service_proxied",
+    "size": null
+  },
+  {
+    "name": "direct_put_source_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_put",
+    "size": 9,
+    "fault": "source_error"
+  },
+  {
+    "name": "direct_put_payload_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_put",
+    "size": 9,
+    "fault": "payload_error"
+  },
+  {
+    "name": "direct_put_completion_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_put",
+    "size": 9,
+    "fault": "completion_error"
+  },
+  {
+    "name": "direct_put_size_8",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_put",
+    "size": 8
+  },
+  {
+    "name": "direct_put_size_10",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_put",
+    "size": 10
+  },
+  {
+    "name": "direct_multipart_source_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_multipart",
+    "size": null,
+    "fault": "source_error"
+  },
+  {
+    "name": "direct_multipart_payload_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_multipart",
+    "size": null,
+    "fault": "payload_error"
+  },
+  {
+    "name": "direct_multipart_completion_error",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_multipart",
+    "size": null,
+    "fault": "completion_error"
+  },
+  {
+    "name": "service_proxied_timeout",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "service_proxied",
+    "size": 9,
+    "fault": "timeout"
+  },
+  {
+    "name": "direct_put_timeout",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_put",
+    "size": 9,
+    "fault": "timeout"
+  },
+  {
+    "name": "direct_multipart_timeout",
+    "content": "123456789",
+    "algorithm": "sha256",
+    "checksum": "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+    "size_bytes": 9,
+    "error": true,
+    "mode": "direct_multipart",
+    "size": null,
+    "fault": "timeout"
+  }
+]

--- a/sdk/conformance/go/conformance_test.go
+++ b/sdk/conformance/go/conformance_test.go
@@ -294,7 +294,7 @@ func runCommitReplay(t *testing.T, h *harness, testCase conformanceCase) {
 		replayed.NamespaceID != first.NamespaceID {
 		t.Errorf("replayed commit = %#v, want %#v", replayed, first)
 	}
-	prepared, err := h.client.Files.PrepareFileBytes(context.Background(), loonfs.NamespaceID(request.NamespaceID), []byte("original bytes"))
+	prepared, err := h.client.Files.PrepareFileStream(context.Background(), loonfs.NamespaceID(request.NamespaceID), strings.NewReader("original bytes"), nil)
 	if err != nil {
 		t.Fatalf("prepare: %v", err)
 	}

--- a/sdk/conformance/go/streaming_uploads_test.go
+++ b/sdk/conformance/go/streaming_uploads_test.go
@@ -1,0 +1,206 @@
+package conformance_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	loonfs "github.com/loonfs/loonfs-sdk-go"
+	"github.com/loonfs/loonfs-sdk-go/option"
+	"github.com/loonfs/loonfs-sdk-go/server"
+)
+
+type uploadCase struct {
+	streamCase
+	Mode  string `json:"mode"`
+	Size  *int64 `json:"size"`
+	Fault string `json:"fault"`
+}
+type uploadSource struct {
+	reader   *strings.Reader
+	fault    bool
+	position atomic.Int64
+	eof      atomic.Bool
+}
+
+func (s *uploadSource) Read(p []byte) (int, error) {
+	if len(p) > 65536 {
+		return 0, fmt.Errorf("unbounded source read: %d", len(p))
+	}
+	n, err := s.reader.Read(p)
+	s.position.Add(int64(n))
+	if err == io.EOF {
+		s.eof.Store(true)
+		if s.fault {
+			err = errors.New("source failed after its last byte")
+		}
+	}
+	return n, err
+}
+
+func TestStreamingUploads(t *testing.T) {
+	data, err := os.ReadFile("../fixtures/streaming_uploads.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cases []uploadCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatal(err)
+	}
+	for _, fixture := range cases {
+		t.Run(fixture.Name, func(t *testing.T) {
+			source := &uploadSource{reader: strings.NewReader(fixture.Content), fault: fixture.Fault == "source_error"}
+			var payload, abort, complete atomic.Int64
+			var bodies bytes.Buffer // server handlers complete before their response is consumed
+			claim := map[string]any{"kind": "blob", "content_id": "cnt_00000000000000000000000000000001", "size_bytes": fixture.SizeBytes, "checksum": map[string]any{"algorithm": fixture.Algorithm, "value": fixture.Checksum}}
+			var host *httptest.Server
+			host = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				path := r.URL.Path
+				if path == "/object" {
+					if r.Header.Get("Authorization") != "" || r.Header.Get("X-Private") != "" {
+						t.Error("API credentials leaked")
+					}
+					if fixture.Mode == "direct_put" && r.ContentLength != *fixture.Size {
+						t.Errorf("content length=%d", r.ContentLength)
+					}
+				} else if r.Header.Get("Authorization") != "Bearer private-token" {
+					t.Error("missing API credentials")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				session := map[string]any{"namespace_id": "demo", "upload_id": "upl_test", "mode": fixture.Mode}
+				access := map[string]any{"kind": "presigned_url", "method": "PUT", "url": host.URL + "/object", "expires_at_ms": 2000000000000}
+				var value any
+				switch {
+				case strings.HasSuffix(path, "/capabilities"):
+					limits := map[string]int{}
+					if fixture.Mode == "direct_put" {
+						limits["upload.max_content_bytes"] = 0
+					}
+					value = map[string]any{"protocol_version": "v0", "api_groups": []string{"filesystem/v0"}, "features": map[string]bool{"filesystem.uploads.direct_put": fixture.Mode == "direct_put", "filesystem.uploads.direct_multipart": fixture.Mode == "direct_multipart"}, "limits": limits}
+				case strings.HasSuffix(path, "/uploads"):
+					var body struct {
+						Mode string `json:"mode"`
+					}
+					json.NewDecoder(r.Body).Decode(&body)
+					if body.Mode != fixture.Mode {
+						t.Errorf("mode %s", body.Mode)
+					}
+					session["checksum_algorithm"] = fixture.Algorithm
+					session["part_size_bytes"] = 4
+					session["access"] = access
+					value = session
+				case strings.HasSuffix(path, "/parts"):
+					var body struct {
+						Parts []struct {
+							PartNumber int `json:"part_number"`
+						} `json:"parts"`
+					}
+					json.NewDecoder(r.Body).Decode(&body)
+					if len(body.Parts) != 1 {
+						t.Error("must sign one part at a time")
+						http.Error(w, "bad parts", 400)
+						return
+					}
+					if source.position.Load() > payload.Load()*4+4 {
+						t.Error("read the next part before sending this one")
+					}
+					value = map[string]any{"namespace_id": "demo", "upload_id": "upl_test", "parts": []any{map[string]any{"part_number": body.Parts[0].PartNumber, "access": access}}}
+				case path == "/object" || strings.HasSuffix(path, "/content"):
+					payload.Add(1)
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						http.Error(w, "body interrupted", 400)
+						return
+					}
+					bodies.Write(body)
+					if fixture.Fault == "timeout" {
+						<-r.Context().Done()
+						return
+					}
+					if fixture.Fault == "payload_error" {
+						http.Error(w, "payload failed", 503)
+						return
+					}
+					w.Header().Set("ETag", "test-etag")
+					session["content_ref"] = claim
+					value = session
+				case strings.HasSuffix(path, "/abort"):
+					abort.Add(1)
+					session["status"] = "aborted"
+					session["aborted_at_ms"] = 0
+					value = session
+				case strings.HasSuffix(path, "/complete"):
+					complete.Add(1)
+					if !source.eof.Load() {
+						t.Error("completed before source EOF")
+					}
+					var body struct {
+						Content *loonfs.UploadContentClaim `json:"content"`
+					}
+					json.NewDecoder(r.Body).Decode(&body)
+					if fixture.Mode != "service_proxied" && (body.Content == nil || body.Content.Checksum.Value != fixture.Checksum || body.Content.SizeBytes != int64(fixture.SizeBytes)) {
+						t.Error("wrong completion checksum/size")
+					}
+					if fixture.Fault == "completion_error" {
+						http.Error(w, "completion unavailable", 503)
+						return
+					}
+					session["status"] = "completed"
+					session["completed_at_ms"] = 0
+					session["content_ref"] = claim
+					session["content_token"] = map[string]any{"token": "retained-token", "content_ref": claim}
+					value = session
+				default:
+					t.Errorf("unexpected %s", path)
+					http.NotFound(w, r)
+					return
+				}
+				json.NewEncoder(w).Encode(value)
+			}))
+			defer host.Close()
+			client := server.NewClient(option.WithBaseURL(host.URL), option.WithToken("private-token"), option.WithHTTPHeader(http.Header{"X-Private": {"secret"}}), option.WithHTTPClient(host.Client()), option.WithMaxAttempts(4))
+			ctx := context.Background()
+			if fixture.Fault == "timeout" {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, 100*time.Millisecond)
+				defer cancel()
+			}
+			prepared, err := client.Files.PrepareFileStream(ctx, "demo", source, fixture.Size)
+			if fixture.Error {
+				if err == nil {
+					t.Fatal("invalid upload succeeded")
+				}
+				expectedAbort, expectedComplete := int64(1), int64(0)
+				if fixture.Fault == "completion_error" {
+					expectedAbort, expectedComplete = 0, 1
+				}
+				if abort.Load() != expectedAbort || complete.Load() != expectedComplete {
+					t.Fatalf("abort=%d complete=%d err=%v", abort.Load(), complete.Load(), err)
+				}
+				if fixture.Fault == "payload_error" && payload.Load() != 1 {
+					t.Error("payload retried")
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if prepared.ContentToken.Token != "retained-token" || bodies.String() != fixture.Content {
+					t.Error("wrong prepared result or bytes")
+				}
+				if complete.Load() != 1 || abort.Load() != 0 {
+					t.Error("unexpected session lifecycle")
+				}
+			}
+		})
+	}
+}

--- a/sdk/conformance/python/test_conformance.py
+++ b/sdk/conformance/python/test_conformance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import os
 import re
@@ -1683,7 +1684,7 @@ def test_prepared_upload_replays_after_a_rename(harness: Harness) -> None:
     client = harness.client
     namespace_id = "conf-python-prepared"
     client.namespaces.create(namespace_id=namespace_id)
-    prepared = client.files.prepare_file_bytes(namespace_id, content=b"original bytes")
+    prepared = client.files.prepare_file_stream(namespace_id, content=io.BytesIO(b"original bytes"))
     assert isinstance(prepared, PreparedFileContent)
     inputs = dict(path="/original", prepared=prepared,
                   actor=ActorRef(kind="user", id="prepared-user"), commit_id="prepared-put")

--- a/sdk/conformance/python/test_streaming_uploads.py
+++ b/sdk/conformance/python/test_streaming_uploads.py
@@ -1,0 +1,162 @@
+import io
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from loonfs.server import LoonFS
+from loonfs.core.api_error import ApiError
+
+CASES = json.loads(
+    (Path(__file__).parents[1] / "fixtures/streaming_uploads.json").read_text()
+)
+
+
+class Source(io.BytesIO):
+    def __init__(self, fixture):
+        super().__init__(fixture["content"].encode())
+        self.fixture = fixture
+        self.eof = False
+
+    def read(self, size=-1):
+        assert 0 < size <= 65536, "source reads must stay bounded"
+        result = super().read(size)
+        if not result:
+            self.eof = True
+            if self.fixture.get("fault") == "source_error":
+                raise OSError("source failed after its last byte")
+        return result
+
+
+@pytest.mark.parametrize("fixture", CASES, ids=lambda c: c["name"])
+def test_streaming_uploads(fixture):
+    source = Source(fixture)
+    mode, fault = fixture["mode"], fixture.get("fault")
+    counts = {"payload": 0, "abort": 0, "complete": 0}
+    bodies = []
+    claim = {
+        "kind": "blob",
+        "content_id": "cnt_00000000000000000000000000000001",
+        "size_bytes": fixture["size_bytes"],
+        "checksum": {"algorithm": fixture["algorithm"], "value": fixture["checksum"]},
+    }
+    session = {"namespace_id": "demo", "upload_id": "upl_test", "mode": mode}
+    access = {
+        "kind": "presigned_url",
+        "method": "PUT",
+        "url": "http://objects.test/object",
+        "expires_at_ms": 2000000000000,
+    }
+
+    def handle(request):
+        path = request.url.path
+        assert request.extensions["timeout"]["read"] == (
+            5 if path.endswith("/abort") else 7
+        )
+        if path == "/object":
+            assert "authorization" not in request.headers
+            assert "x-private" not in request.headers
+            assert "cookie" not in request.headers
+            if mode == "direct_put":
+                assert int(request.headers["content-length"]) == fixture["size"]
+        else:
+            assert request.headers["authorization"] == "Bearer private-token"
+        if path.endswith("/capabilities"):
+            value = {
+                "protocol_version": "v0",
+                "api_groups": ["filesystem/v0"],
+                "features": {
+                    "filesystem.uploads.direct_put": mode == "direct_put",
+                    "filesystem.uploads.direct_multipart": mode == "direct_multipart",
+                },
+                "limits": {"upload.max_content_bytes": 0}
+                if mode == "direct_put"
+                else {},
+            }
+        elif path.endswith("/uploads"):
+            assert json.loads(request.content)["mode"] == mode
+            value = {
+                **session,
+                "checksum_algorithm": fixture["algorithm"],
+                "part_size_bytes": 4,
+                "access": access,
+            }
+        elif path.endswith("/parts"):
+            parts = json.loads(request.content)["parts"]
+            assert len(parts) == 1
+            assert source.tell() <= len(bodies) * 4 + 4, (
+                "must send a part before reading the next"
+            )
+            value = {
+                "namespace_id": "demo",
+                "upload_id": "upl_test",
+                "parts": [{"part_number": parts[0]["part_number"], "access": access}],
+            }
+        elif path == "/object" or path.endswith("/content"):
+            counts["payload"] += 1
+            bodies.append(request.read())
+            if fault == "timeout":
+                raise httpx.WriteTimeout("payload timed out")
+            if fault == "payload_error":
+                return httpx.Response(503)
+            return httpx.Response(
+                200,
+                headers={"ETag": "test-etag"},
+                json={**session, "content_ref": claim},
+            )
+        elif path.endswith("/abort"):
+            counts["abort"] += 1
+            value = {**session, "status": "aborted", "aborted_at_ms": 0}
+        elif path.endswith("/complete"):
+            counts["complete"] += 1
+            assert source.eof
+            completion = json.loads(request.content)
+            if mode != "service_proxied":
+                assert completion["content"] == {
+                    "size_bytes": fixture["size_bytes"],
+                    "checksum": claim["checksum"],
+                }
+            if fault == "completion_error":
+                return httpx.Response(503)
+            value = {
+                **session,
+                "status": "completed",
+                "completed_at_ms": 0,
+                "content_ref": claim,
+                "content_token": {"token": "retained-token", "content_ref": claim},
+            }
+        else:
+            raise AssertionError(str(request.url))
+        return httpx.Response(200, json=value)
+
+    with httpx.Client(
+        transport=httpx.MockTransport(handle),
+        headers={"X-Private": "secret"},
+        cookies={"private": "secret"},
+    ) as http:
+        client = LoonFS(
+            base_url="http://api.test", token="private-token", httpx_client=http
+        )
+
+        def prepare():
+            return client.files.prepare_file_stream(
+                "demo",
+                content=source,
+                size_bytes=fixture["size"],
+                request_options={"timeout": 7, "max_retries": 3},
+            )
+
+        if fixture["error"]:
+            with pytest.raises((OSError, ValueError, httpx.HTTPError, ApiError)):
+                prepare()
+            assert counts["abort"] == (0 if fault == "completion_error" else 1)
+            assert counts["complete"] == (1 if fault == "completion_error" else 0)
+            if fault == "payload_error":
+                assert counts["payload"] == 1
+        else:
+            prepared = prepare()
+            assert prepared.content_ref.size_bytes == len(fixture["content"])
+            assert prepared.content_token.token == "retained-token"
+            assert b"".join(bodies) == fixture["content"].encode()
+            assert counts["complete"] == 1 and counts["abort"] == 0
+        assert not source.closed, "callers own their source"

--- a/sdk/conformance/typescript/src/conformance.test.ts
+++ b/sdk/conformance/typescript/src/conformance.test.ts
@@ -1192,8 +1192,8 @@ conformanceTest("commit_replay", async (activeHarness, testCase) => {
     assert.equal(first.commit_id, request.commit_id);
     assert.equal(replayed.committed_seq, first.committed_seq);
     assert.deepEqual(replayed, first);
-    const prepared: PreparedFileContent = await activeHarness.client.files.prepareFileBytes({
-        namespace_id: request.namespace_id, content: new TextEncoder().encode("original bytes"),
+    const prepared: PreparedFileContent = await activeHarness.client.files.prepareFileStream({
+        namespace_id: request.namespace_id, content: new Blob(["original bytes"]),
     });
     const input = { namespace_id: request.namespace_id, path: "/prepared", prepared,
         actor: request.actor, commit_id: "prepared-put" };
@@ -2063,7 +2063,7 @@ test("proxy", { skip: environmentSkip }, async (context) => {
     );
     assert.deepEqual(beginModes, ["service_proxied", "direct_put", "direct_multipart"]);
 
-    const prepared = await browserClient.files.prepareFileBytes({namespace_alias: request.namespace_alias, content: payload});
+    const prepared = await browserClient.files.prepareFileStream({namespace_alias: request.namespace_alias, content: new Blob([arrayBuffer(payload)])});
     const input = {namespace_alias: request.namespace_alias, path: "/browser-prepared", prepared,
         actor: request.actor, commit_id: "browser-prepared-put"};
     const published = await browserClient.files.putFilePrepared(input);

--- a/sdk/conformance/typescript/src/streaming-uploads.test.ts
+++ b/sdk/conformance/typescript/src/streaming-uploads.test.ts
@@ -1,0 +1,219 @@
+import * as assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import { LoonFSClient } from "../../../generated/typescript/transfers.js";
+import { LoonFSClient as BrowserClient } from "../../../generated/typescript-client/transfers.js";
+import { UploadSource, TransferScope } from "../../../generated/typescript/transfer-runtime.js";
+
+type Fixture = {
+    name: string;
+    content: string;
+    algorithm: string;
+    checksum: string;
+    size_bytes: number;
+    size: number | null;
+    mode: string;
+    fault?: string;
+    error: boolean;
+};
+const cases: Fixture[] = JSON.parse(
+    readFileSync(join(__dirname, "../../../../../fixtures/streaming_uploads.json"), "utf8"),
+);
+for (const browser of [false, true])
+    for (const fixture of cases) {
+        test(`streaming upload ${browser ? "browser" : "server"} ${fixture.name}`, async () => {
+            let position = 0,
+                eof = false,
+                closed = false;
+            const content = new TextEncoder().encode(fixture.content);
+            const source = {
+                async *[Symbol.asyncIterator]() {
+                    try {
+                        while (position < content.length) {
+                            const start = position;
+                            position += Math.min(2, content.length - position);
+                            yield content.subarray(start, position);
+                        }
+                        eof = true;
+                        if (fixture.fault === "source_error")
+                            throw new Error("source failed after its last byte");
+                    } finally {
+                        closed = true;
+                    }
+                },
+            };
+            const counts = { payload: 0, abort: 0, complete: 0 };
+            const bodies: Uint8Array[] = [];
+            const claim = {
+                kind: "blob",
+                content_id: "cnt_00000000000000000000000000000001",
+                size_bytes: fixture.size_bytes,
+                checksum: { algorithm: fixture.algorithm, value: fixture.checksum },
+            };
+            const session = {
+                namespace_id: "demo",
+                namespace_alias: "demo",
+                upload_id: "upl_test",
+                mode: fixture.mode,
+            };
+            const access = {
+                kind: "presigned_url",
+                method: "PUT",
+                url: "http://objects.test/object",
+                expires_at_ms: 2000000000000,
+            };
+            const send: typeof fetch = async (input, init) => {
+                const url = new URL(input instanceof Request ? input.url : input.toString());
+                const path = url.pathname,
+                    headers = new Headers(init?.headers);
+                assert.ok(init?.signal, "every transport needs a signal");
+                if (path === "/object") {
+                    assert.equal(headers.has("authorization"), false);
+                    assert.equal(headers.has("X-Private"), false);
+                } else {
+                    if (!browser) assert.equal(headers.get("authorization"), "Bearer private-token");
+                    if (!path.endsWith("/capabilities"))
+                        assert.ok(
+                            path.startsWith(browser ? "/v0/namespace-aliases/demo/" : "/v0/namespaces/demo/"),
+                        );
+                }
+                // Construct a real Request: Node rejects a stream if duplex was lost.
+                const request = new Request(url, init);
+                let value: unknown;
+                if (path.endsWith("/capabilities"))
+                    value = {
+                        protocol_version: "v0",
+                        api_groups: ["filesystem/v0"],
+                        features: {
+                            "filesystem.uploads.direct_put": fixture.mode === "direct_put",
+                            "filesystem.uploads.direct_multipart": fixture.mode === "direct_multipart",
+                        },
+                        limits: fixture.mode === "direct_put" ? { "upload.max_content_bytes": 0 } : {},
+                    };
+                else if (path.endsWith("/uploads")) {
+                    assert.equal((await request.json()).mode, fixture.mode);
+                    value = { ...session, checksum_algorithm: fixture.algorithm, part_size_bytes: 4, access };
+                } else if (path.endsWith("/parts")) {
+                    const { parts } = await request.json();
+                    assert.equal(parts.length, 1);
+                    assert.ok(position <= bodies.length * 4 + 4, "send a part before reading the next");
+                    value = { ...session, parts: [{ part_number: parts[0].part_number, access }] };
+                } else if (path === "/object" || path.endsWith("/content")) {
+                    counts.payload++;
+                    if (fixture.size !== null)
+                        assert.ok(
+                            !(init?.body instanceof ReadableStream),
+                            "small known bodies must remain portable in browsers",
+                        );
+                    bodies.push(new Uint8Array(await request.arrayBuffer()));
+                    if (fixture.fault === "timeout")
+                        return new Promise<Response>((_, reject) => {
+                            if (init!.signal!.aborted) reject(init!.signal!.reason);
+                            else
+                                init!.signal!.addEventListener("abort", () => reject(init!.signal!.reason), {
+                                    once: true,
+                                });
+                        });
+                    if (fixture.fault === "payload_error") return new Response(null, { status: 503 });
+                    return Response.json(
+                        { ...session, content_ref: claim },
+                        { headers: { ETag: "test-etag" } },
+                    );
+                } else if (path.endsWith("/abort")) {
+                    counts.abort++;
+                    value = { ...session, status: "aborted", aborted_at_ms: 0 };
+                } else if (path.endsWith("/complete")) {
+                    counts.complete++;
+                    assert.ok(eof);
+                    const completion = await request.json();
+                    if (fixture.mode !== "service_proxied")
+                        assert.deepEqual(completion.content, {
+                            size_bytes: fixture.size_bytes,
+                            checksum: claim.checksum,
+                        });
+                    if (fixture.fault === "completion_error") return new Response(null, { status: 503 });
+                    value = {
+                        ...session,
+                        status: "completed",
+                        completed_at_ms: 0,
+                        content_ref: claim,
+                        content_token: { token: "retained-token", content_ref: claim },
+                    };
+                } else throw new Error(`unexpected ${url}`);
+                return Response.json(value);
+            };
+            const options = {
+                baseUrl: "http://api.test",
+                token: "private-token",
+                headers: { "X-Private": "secret" },
+                fetch: send,
+            };
+            const requestOptions = {
+                timeoutInSeconds: fixture.fault === "timeout" ? 0.02 : 7,
+                maxRetries: 3,
+            };
+            const result = browser
+                ? new BrowserClient(options).files.prepareFileStream(
+                      { namespace_alias: "demo", content: source, size_bytes: fixture.size ?? undefined },
+                      requestOptions,
+                  )
+                : new LoonFSClient(options).files.prepareFileStream(
+                      { namespace_id: "demo", content: source, size_bytes: fixture.size ?? undefined },
+                      requestOptions,
+                  );
+            if (fixture.error) {
+                await assert.rejects(result, (error) => !(error instanceof assert.AssertionError));
+                assert.equal(counts.abort, fixture.fault === "completion_error" ? 0 : 1);
+                assert.equal(counts.complete, fixture.fault === "completion_error" ? 1 : 0);
+                if (fixture.fault === "payload_error") assert.equal(counts.payload, 1);
+            } else {
+                const prepared = await result;
+                assert.equal(prepared.contentToken?.token, "retained-token");
+                assert.equal(Buffer.concat(bodies).toString(), fixture.content);
+                assert.equal(counts.complete, 1);
+                assert.equal(counts.abort, 0);
+            }
+            assert.ok(closed, "SDK consumes or returns the source");
+        });
+    }
+
+test("upload cancellation interrupts a stalled source without waiting for its cleanup", async () => {
+    const scope = new TransferScope({ timeoutInSeconds: 0.02 });
+    const source = new UploadSource(
+        {
+            async *[Symbol.asyncIterator]() {
+                await new Promise(() => {});
+                yield new Uint8Array();
+            },
+        },
+        scope,
+    );
+    try {
+        await assert.rejects(source.read());
+    } finally {
+        source.close();
+        scope.close();
+    }
+});
+
+test("upload bounds large caller chunks and validates before locking a stream", async () => {
+    const scope = new TransferScope({});
+    const stream = new ReadableStream<Uint8Array>();
+    assert.throws(() => new UploadSource(stream, scope, -1));
+    assert.equal(stream.locked, false);
+    const source = new UploadSource(
+        {
+            async *[Symbol.asyncIterator]() {
+                yield new Uint8Array(1024 * 1024);
+            },
+        },
+        scope,
+    );
+    try {
+        assert.equal((await source.read())?.length, 65536);
+    } finally {
+        source.close();
+        scope.close();
+    }
+});

--- a/sdk/overlays/go/README.md
+++ b/sdk/overlays/go/README.md
@@ -48,7 +48,14 @@ proxied transfers use the configured HTTP client and the same context. Direct
 requests carry only the presigned headers, and do not follow redirects.
 
 `client.Files.Download` collects that stream into memory. `client.Files.Upload`
-accepts an in-memory byte slice. See [reference.md](./reference.md) for the
+accepts an in-memory byte slice through the same transfer path.
+`client.Files.PrepareFileStream(ctx, namespaceID, reader, sizeBytes)` consumes an
+`io.Reader` once and returns prepared content for publication retries. Pass nil
+for an unknown size; multipart retains one provider-sized part.
+`client.Files.UploadStream(ctx, files.StreamUploadInput{...})` prepares and
+publishes in one operation. The context covers metadata, bytes and publication;
+source and payload failures abort without replaying bytes. The caller owns and
+closes the reader, including interrupting any blocking source read. See [reference.md](./reference.md) for the
 generated API reference.
 
 ## Proxy

--- a/sdk/overlays/python/README.md
+++ b/sdk/overlays/python/README.md
@@ -44,7 +44,23 @@ never follow redirects. Closing the stream or interrupting its `with` block is
 the synchronous cancellation mechanism.
 
 `client.files.download` collects the same verified stream into memory.
-`client.files.upload` accepts in-memory bytes. `AsyncLoonFS` provides the same generated API for async applications; it does not have the transfer methods yet.
+`client.files.upload` accepts in-memory bytes through the same transfer path.
+Use `prepare_file_stream` to retain prepared content for publication retries:
+
+```python
+with open("large.bin", "rb") as source:
+    prepared = client.files.prepare_file_stream("demo", content=source,
+                                                request_options={"timeout": 60})
+```
+
+Pass `size_bytes` when known to validate the source and choose the usual transport.
+Unknown nonempty sources use multipart when available; memory is bounded by a
+provider-sized part. `upload_stream` prepares and publishes in one operation.
+The HTTP I/O timeout applies to both transports. Source and payload failures abort
+without replaying bytes. The caller owns the source and must interrupt any
+blocking source read; an HTTP timeout cannot interrupt arbitrary Python code.
+
+ `AsyncLoonFS` provides the same generated API for async applications; it does not have the transfer methods yet.
 
 ## Proxy
 

--- a/sdk/transfers/go/files/transfers.go
+++ b/sdk/transfers/go/files/transfers.go
@@ -13,10 +13,8 @@ import (
 	"strings"
 
 	loonfs "github.com/loonfs/loonfs-sdk-go"
-	"github.com/loonfs/loonfs-sdk-go/capabilities"
 	"github.com/loonfs/loonfs-sdk-go/commits"
 	"github.com/loonfs/loonfs-sdk-go/core"
-	"github.com/loonfs/loonfs-sdk-go/option"
 	"github.com/loonfs/loonfs-sdk-go/uploads"
 )
 
@@ -103,61 +101,26 @@ type DownloadResult struct {
 // Upload uploads fresh content and publishes it. For publication retries,
 // retain PrepareFileBytes output and use PutFilePrepared with unchanged inputs.
 func (c *Client) Upload(ctx context.Context, in UploadInput) (*UploadResult, error) {
-	if c == nil {
-		return nil, fmt.Errorf("transfers: client is nil")
-	}
-	if in.Actor == nil {
-		return nil, fmt.Errorf("transfers: actor is required")
-	}
-
-	if in.CommitID == "" {
-		return nil, fmt.Errorf("transfers: commit id is required")
-	}
-	prepared, err := c.PrepareFileBytes(ctx, in.NamespaceID, in.Content)
-	if err != nil {
-		return nil, err
-	}
-	return c.PutFilePrepared(ctx, PreparedUploadInput{
-		NamespaceID: in.NamespaceID, Path: in.Path, Prepared: prepared, Actor: in.Actor,
-		CommitID: in.CommitID, Message: in.Message, Behavior: in.Behavior,
+	size := int64(len(in.Content))
+	return c.UploadStream(ctx, StreamUploadInput{
+		NamespaceID: in.NamespaceID, Path: in.Path,
+		Content: bytes.NewReader(in.Content), SizeBytes: &size,
+		Actor: in.Actor, CommitID: in.CommitID, Message: in.Message, Behavior: in.Behavior,
 		ExpectedInodeID: in.ExpectedInodeID, ExpectedRevisionNo: in.ExpectedRevisionNo,
 	})
 }
 
-// PrepareFileBytes uploads once without publishing; retain the result for retries.
+// PrepareFileBytes stages the same streaming path for an existing byte slice.
 func (c *Client) PrepareFileBytes(ctx context.Context, namespaceID loonfs.NamespaceID, content []byte) (*PreparedFileContent, error) {
-	if c == nil {
-		return nil, fmt.Errorf("transfers: client is nil")
-	}
-	capabilitiesClient := capabilities.NewClient(c.options)
-	uploadsClient := uploads.NewClient(c.options)
-	capabilities, err := capabilitiesClient.Retrieve(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("transfers: read capabilities: %w", err)
-	}
-	createRequest, err := createUploadRequest(capabilities, namespaceID, int64(len(content)))
-	if err != nil {
-		return nil, err
-	}
-	begin, err := uploadsClient.Create(ctx, createRequest)
-	if err != nil {
-		return nil, fmt.Errorf("transfers: begin upload: %w", err)
-	}
-
-	completed, err := transferAndComplete(ctx, uploadsClient, namespaceID, content, begin)
-	if err != nil {
-		return nil, err
-	}
-	status, err := completedUploadStatus(completed)
-	if err != nil {
-		return nil, err
-	}
-	return &PreparedFileContent{ContentRef: status.ContentRef, ContentToken: status.ContentToken}, nil
+	size := int64(len(content))
+	return c.PrepareFileStream(ctx, namespaceID, bytes.NewReader(content), &size)
 }
 
 // PutFilePrepared publishes retained content without starting another upload.
 // Reuse unchanged inputs to retry the same commit.
 func (c *Client) PutFilePrepared(ctx context.Context, in PreparedUploadInput) (*UploadResult, error) {
+	ctx, cancel := transferContext(ctx)
+	defer cancel()
 	if c == nil {
 		return nil, fmt.Errorf("transfers: client is nil")
 	}
@@ -269,185 +232,6 @@ func createUploadRequest(
 	}, nil
 }
 
-func transferAndComplete(
-	ctx context.Context,
-	uploadsClient *uploads.Client,
-	namespaceID loonfs.NamespaceID,
-	payload []byte,
-	begin *loonfs.BeginUploadResponse,
-) (*loonfs.UploadSession, error) {
-	if begin == nil {
-		return nil, fmt.Errorf("transfers: begin upload response is nil")
-	}
-	switch {
-	case begin.DirectPut != nil:
-		return transferDirectPut(ctx, uploadsClient, namespaceID, payload, begin.DirectPut)
-	case begin.DirectMultipart != nil:
-		return transferDirectMultipart(ctx, uploadsClient, namespaceID, payload, begin.DirectMultipart)
-	case begin.ServiceProxied != nil:
-		return transferServiceProxied(ctx, uploadsClient, namespaceID, payload, begin.ServiceProxied)
-	default:
-		return nil, fmt.Errorf("transfers: unsupported begin upload mode %q", begin.Mode)
-	}
-}
-
-func transferDirectPut(
-	ctx context.Context,
-	uploadsClient *uploads.Client,
-	namespaceID loonfs.NamespaceID,
-	payload []byte,
-	begin *loonfs.BeginUploadResponseDirectPut,
-) (*loonfs.UploadSession, error) {
-	checksum, err := computeChecksum(begin.ChecksumAlgorithm, payload)
-	if err != nil {
-		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: direct PUT: %w", err)
-	}
-	if _, err := putPresigned(ctx, begin.Access, payload); err != nil {
-		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: direct PUT: %w", err)
-	}
-	content := &loonfs.UploadContentClaim{
-		Checksum:  checksum,
-		SizeBytes: int64(len(payload)),
-	}
-	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadRequest{
-		NamespaceID: string(namespaceID),
-		UploadID:    string(begin.UploadID),
-		Body: &loonfs.UploadCompletion{
-			DirectPut: &loonfs.CompleteUploadDirectPut{Content: content},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("transfers: complete direct PUT: %w", err)
-	}
-	return completed, nil
-}
-
-func transferDirectMultipart(
-	ctx context.Context,
-	uploadsClient *uploads.Client,
-	namespaceID loonfs.NamespaceID,
-	payload []byte,
-	begin *loonfs.BeginUploadResponseDirectMultipart,
-) (*loonfs.UploadSession, error) {
-	partSizeBytes := begin.PartSizeBytes
-	partSize := int(partSizeBytes)
-	if partSizeBytes <= 0 || int64(partSize) != partSizeBytes {
-		return nil, fmt.Errorf("transfers: invalid multipart part size %d", partSizeBytes)
-	}
-	parts := splitParts(payload, partSize)
-	if len(parts) == 0 {
-		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: multipart response selected for an empty payload")
-	}
-	claims := make([]*loonfs.UploadPartChecksumClaim, len(parts))
-	for index, part := range parts {
-		checksum, checksumErr := computeChecksum(begin.ChecksumAlgorithm, part)
-		if checksumErr != nil {
-			abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-			return nil, fmt.Errorf("transfers: checksum part %d: %w", index+1, checksumErr)
-		}
-		claims[index] = &loonfs.UploadPartChecksumClaim{
-			Checksum:   checksum,
-			PartNumber: index + 1,
-		}
-	}
-	signed, err := uploadsClient.SignParts(ctx, &loonfs.SignUploadPartsRequest{
-		NamespaceID: string(namespaceID),
-		UploadID:    string(begin.UploadID),
-		Parts:       claims,
-	})
-	if err != nil {
-		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: sign multipart parts: %w", err)
-	}
-	if signed == nil {
-		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: sign multipart parts returned no response")
-	}
-	accessByPart := make(map[int]*loonfs.SignedUploadPart, len(signed.Parts))
-	for _, signedPart := range signed.Parts {
-		accessByPart[signedPart.PartNumber] = signedPart
-	}
-
-	completedParts := make([]*loonfs.CompletedUploadPart, 0, len(parts))
-	for index, part := range parts {
-		partNumber := index + 1
-		signedPart := accessByPart[partNumber]
-		if signedPart == nil {
-			abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-			return nil, fmt.Errorf("transfers: server did not sign multipart part %d", partNumber)
-		}
-		etag, putErr := putPresigned(ctx, signedPart.Access, part)
-		if putErr != nil {
-			abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-			return nil, fmt.Errorf("transfers: upload part %d: %w", partNumber, putErr)
-		}
-		if etag == "" {
-			abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-			return nil, fmt.Errorf("transfers: upload part %d: presigned PUT response has no ETag", partNumber)
-		}
-		completedParts = append(completedParts, &loonfs.CompletedUploadPart{
-			Checksum:   claims[index].Checksum,
-			Etag:       etag,
-			PartNumber: partNumber,
-		})
-	}
-	wholeChecksum, err := computeChecksum(begin.ChecksumAlgorithm, payload)
-	if err != nil {
-		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: checksum multipart payload: %w", err)
-	}
-	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadRequest{
-		NamespaceID: string(namespaceID),
-		UploadID:    string(begin.UploadID),
-		Body: &loonfs.UploadCompletion{
-			DirectMultipart: &loonfs.CompleteUploadDirectMultipart{
-				Content: &loonfs.UploadContentClaim{
-					Checksum:  wholeChecksum,
-					SizeBytes: int64(len(payload)),
-				},
-				Parts: completedParts,
-			},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("transfers: complete multipart upload: %w", err)
-	}
-	return completed, nil
-}
-
-func transferServiceProxied(
-	ctx context.Context,
-	uploadsClient *uploads.Client,
-	namespaceID loonfs.NamespaceID,
-	payload []byte,
-	begin *loonfs.BeginUploadResponseServiceProxied,
-) (*loonfs.UploadSession, error) {
-	if _, err := uploadsClient.PutContent(
-		ctx,
-		string(namespaceID),
-		string(begin.UploadID),
-		bytes.NewReader(payload),
-		option.WithHTTPHeader(http.Header{"Content-Type": []string{"application/octet-stream"}}),
-	); err != nil {
-		abortUpload(ctx, uploadsClient, namespaceID, begin.UploadID)
-		return nil, fmt.Errorf("transfers: upload proxied content: %w", err)
-	}
-	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadRequest{
-		NamespaceID: string(namespaceID),
-		UploadID:    string(begin.UploadID),
-		Body: &loonfs.UploadCompletion{
-			ServiceProxied: &loonfs.CompleteUploadServiceProxied{},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("transfers: complete proxied upload: %w", err)
-	}
-	return completed, nil
-}
-
 func abortUpload(ctx context.Context, uploadsClient *uploads.Client, namespaceID loonfs.NamespaceID, uploadID loonfs.UploadID) {
 	_, _ = uploadsClient.Abort(ctx, &loonfs.AbortUploadRequest{
 		NamespaceID: string(namespaceID),
@@ -463,45 +247,6 @@ func completedUploadStatus(response *loonfs.UploadSession) (*loonfs.UploadSessio
 		return nil, fmt.Errorf("transfers: upload is %s, not completed", response.Status)
 	}
 	return response.Completed, nil
-}
-
-func splitParts(payload []byte, partSize int) [][]byte {
-	parts := make([][]byte, 0, (len(payload)+partSize-1)/partSize)
-	for offset := 0; offset < len(payload); offset += partSize {
-		end := offset + partSize
-		if end > len(payload) {
-			end = len(payload)
-		}
-		parts = append(parts, payload[offset:end])
-	}
-	return parts
-}
-
-func putPresigned(
-	ctx context.Context,
-	access *loonfs.ObjectTransferAccess,
-	payload []byte,
-) (string, error) {
-	response, err := sendPresigned(ctx, access, http.MethodPut, bytes.NewReader(payload), int64(len(payload)))
-	if err != nil {
-		return "", err
-	}
-	defer response.Body.Close()
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		return "", responseStatusError(response)
-	}
-	_, _ = io.Copy(io.Discard, response.Body)
-	return response.Header.Get("ETag"), nil
-}
-
-func sendPresigned(
-	ctx context.Context,
-	access *loonfs.ObjectTransferAccess,
-	expectedMethod string,
-	body io.Reader,
-	contentLength int64,
-) (*http.Response, error) {
-	return sendPresignedWithClient(ctx, presignedHTTPClient, access, expectedMethod, body, contentLength)
 }
 
 func sendPresignedWithClient(ctx context.Context, client core.HTTPClient, access *loonfs.ObjectTransferAccess, expectedMethod string, body io.Reader, contentLength int64) (*http.Response, error) {

--- a/sdk/transfers/go/files/upload_stream.go
+++ b/sdk/transfers/go/files/upload_stream.go
@@ -1,0 +1,297 @@
+package files
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"time"
+
+	loonfs "github.com/loonfs/loonfs-sdk-go"
+	"github.com/loonfs/loonfs-sdk-go/capabilities"
+	"github.com/loonfs/loonfs-sdk-go/option"
+	"github.com/loonfs/loonfs-sdk-go/uploads"
+)
+
+// StreamUploadInput consumes Content once. SizeBytes is optional; supply it when
+// known to validate the source and select a single PUT for small files.
+// The caller owns Content and is responsible for closing it.
+type StreamUploadInput struct {
+	NamespaceID        loonfs.NamespaceID
+	Path               loonfs.AbsolutePath
+	Content            io.Reader
+	SizeBytes          *int64
+	Actor              *loonfs.ActorRef
+	CommitID           loonfs.CommitID
+	Message            *string
+	Behavior           loonfs.DestinationBehavior
+	ExpectedInodeID    *string
+	ExpectedRevisionNo *loonfs.RevisionNo
+}
+
+func (c *Client) UploadStream(ctx context.Context, in StreamUploadInput) (*UploadResult, error) {
+	if in.Actor == nil || in.CommitID == "" {
+		return nil, fmt.Errorf("transfers: actor and commit id are required")
+	}
+	ctx, cancel := transferContext(ctx)
+	defer cancel()
+	prepared, err := c.PrepareFileStream(ctx, in.NamespaceID, in.Content, in.SizeBytes)
+	if err != nil {
+		return nil, err
+	}
+	return c.PutFilePrepared(ctx, PreparedUploadInput{
+		NamespaceID: in.NamespaceID, Path: in.Path, Prepared: prepared,
+		Actor: in.Actor, CommitID: in.CommitID, Message: in.Message, Behavior: in.Behavior,
+		ExpectedInodeID: in.ExpectedInodeID, ExpectedRevisionNo: in.ExpectedRevisionNo,
+	})
+}
+
+// PrepareFileStream stages a source once with bounded memory and no payload
+// retries. Retain its result for PutFilePrepared publication retries.
+func (c *Client) PrepareFileStream(ctx context.Context, namespaceID loonfs.NamespaceID, source io.Reader, sizeBytes *int64) (*PreparedFileContent, error) {
+	if c == nil {
+		return nil, fmt.Errorf("transfers: client is nil")
+	}
+	if source == nil || (sizeBytes != nil && *sizeBytes < 0) {
+		return nil, fmt.Errorf("transfers: source and nonnegative size are required")
+	}
+	ctx, cancel := transferContext(ctx)
+	defer cancel()
+	capabilities, err := capabilities.NewClient(c.options).Retrieve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if capabilities == nil {
+		return nil, fmt.Errorf("transfers: no capabilities")
+	}
+	if sizeBytes == nil {
+		// Distinguish an empty source before selecting multipart. Retain at
+		// most one byte, not the whole source or every multipart part.
+		var first [1]byte
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		var n int
+		var err error
+		for attempts := 0; attempts < 100 && n == 0 && err == nil; attempts++ {
+			if err = ctx.Err(); err == nil {
+				n, err = source.Read(first[:])
+			}
+		}
+		if n == 0 && err == nil {
+			return nil, io.ErrNoProgress
+		}
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if n == 0 {
+			size := int64(0)
+			sizeBytes = &size
+		} else {
+			source = io.MultiReader(bytes.NewReader(first[:n]), source)
+		}
+	}
+	var request *loonfs.CreateUploadRequest
+	if sizeBytes != nil {
+		request, err = createUploadRequest(capabilities, namespaceID, *sizeBytes)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		body := &loonfs.BeginUploadRequest{}
+		if capabilities.Features[featureDirectMultipart] {
+			body.DirectMultipart = &loonfs.BeginUploadDirectMultipart{}
+		} else {
+			body.ServiceProxied = &loonfs.BeginUploadServiceProxied{}
+		}
+		request = &loonfs.CreateUploadRequest{NamespaceID: string(namespaceID), Body: body}
+	}
+	uploadsClient := uploads.NewClient(c.options)
+	begin, err := uploadsClient.Create(ctx, request, option.WithMaxAttempts(1))
+	if err != nil {
+		return nil, err
+	}
+	if begin == nil {
+		return nil, fmt.Errorf("transfers: no upload session")
+	}
+	reader := &uploadReader{ctx: ctx, source: source, expected: sizeBytes}
+	var uploadID loonfs.UploadID
+	var completion *loonfs.UploadCompletion
+	switch {
+	case begin.ServiceProxied != nil:
+		uploadID = begin.ServiceProxied.UploadID
+		if limit, ok := capabilities.Limits[limitUploadMaximumBytes]; ok {
+			reader.limit = &limit
+		}
+		_, err = uploadsClient.PutContent(ctx, string(namespaceID), string(uploadID), reader,
+			option.WithHTTPHeader(http.Header{"Content-Type": {"application/octet-stream"}}), option.WithMaxAttempts(1))
+		completion = &loonfs.UploadCompletion{ServiceProxied: &loonfs.CompleteUploadServiceProxied{}}
+	case begin.DirectPut != nil:
+		uploadID = begin.DirectPut.UploadID
+		reader.digest, err = newChecksum(begin.DirectPut.ChecksumAlgorithm)
+		if err == nil {
+			length := int64(-1)
+			if sizeBytes != nil {
+				length = *sizeBytes
+			}
+			_, err = c.putStream(ctx, begin.DirectPut.Access, reader, length)
+		}
+		if err == nil {
+			completion = &loonfs.UploadCompletion{DirectPut: &loonfs.CompleteUploadDirectPut{Content: reader.claim(begin.DirectPut.ChecksumAlgorithm)}}
+		}
+	case begin.DirectMultipart != nil:
+		uploadID = begin.DirectMultipart.UploadID
+		completion, err = c.streamMultipart(ctx, uploadsClient, namespaceID, begin.DirectMultipart, reader)
+	default:
+		return nil, fmt.Errorf("transfers: unsupported upload mode %q", begin.Mode)
+	}
+	if err == nil {
+		err = reader.finish()
+	}
+	if err != nil {
+		cleanup, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		abortUpload(cleanup, uploadsClient, namespaceID, uploadID)
+		return nil, err
+	}
+	// A lost completion response may still have completed the upload. Keep
+	// that session available for inspection rather than aborting it.
+	completed, err := uploadsClient.Complete(ctx, &loonfs.CompleteUploadRequest{NamespaceID: string(namespaceID), UploadID: string(uploadID), Body: completion}, option.WithMaxAttempts(1))
+	if err != nil {
+		return nil, fmt.Errorf("transfers: complete upload %s: %w", uploadID, err)
+	}
+	status, err := completedUploadStatus(completed)
+	if err != nil {
+		return nil, err
+	}
+	if status.ContentRef.SizeBytes != reader.count {
+		return nil, fmt.Errorf("transfers: completed upload size mismatch")
+	}
+	return &PreparedFileContent{ContentRef: status.ContentRef, ContentToken: status.ContentToken}, nil
+}
+
+func (c *Client) putStream(ctx context.Context, access *loonfs.ObjectTransferAccess, source io.Reader, length int64) (string, error) {
+	response, err := sendPresignedWithClient(ctx, c.transferHTTPClient(), access, http.MethodPut, source, length)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return "", responseStatusError(response)
+	}
+	if _, err := io.Copy(io.Discard, io.LimitReader(response.Body, 64*1024)); err != nil {
+		return "", err
+	}
+	return response.Header.Get("ETag"), nil
+}
+
+func (c *Client) streamMultipart(ctx context.Context, client *uploads.Client, namespaceID loonfs.NamespaceID, begin *loonfs.BeginUploadResponseDirectMultipart, reader *uploadReader) (*loonfs.UploadCompletion, error) {
+	partSize := int(begin.PartSizeBytes)
+	if partSize <= 0 || int64(partSize) != begin.PartSizeBytes {
+		return nil, fmt.Errorf("transfers: invalid multipart part size")
+	}
+	digest, err := newChecksum(begin.ChecksumAlgorithm)
+	if err != nil {
+		return nil, err
+	}
+	reader.digest = digest
+	buffer := make([]byte, partSize)
+	parts := make([]*loonfs.CompletedUploadPart, 0)
+	for {
+		n, err := io.ReadFull(reader, buffer)
+		if reader.failure != nil {
+			return nil, reader.failure
+		}
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+			return nil, err
+		}
+		if n == 0 {
+			break
+		}
+		if len(parts) == 10000 {
+			return nil, fmt.Errorf("transfers: multipart upload exceeds 10000 parts")
+		}
+		part := buffer[:n]
+		number := len(parts) + 1
+		checksum, err := computeChecksum(begin.ChecksumAlgorithm, part)
+		if err != nil {
+			return nil, err
+		}
+		signed, err := client.SignParts(ctx, &loonfs.SignUploadPartsRequest{NamespaceID: string(namespaceID), UploadID: string(begin.UploadID), Parts: []*loonfs.UploadPartChecksumClaim{{PartNumber: number, Checksum: checksum}}}, option.WithMaxAttempts(1))
+		if err != nil {
+			return nil, err
+		}
+		if signed == nil || len(signed.Parts) != 1 || signed.Parts[0].PartNumber != number {
+			return nil, fmt.Errorf("transfers: server did not sign requested part %d", number)
+		}
+		etag, err := c.putStream(ctx, signed.Parts[0].Access, bytes.NewReader(part), int64(n))
+		if err != nil {
+			return nil, err
+		}
+		if etag == "" {
+			return nil, fmt.Errorf("transfers: part %d has no ETag", number)
+		}
+		parts = append(parts, &loonfs.CompletedUploadPart{PartNumber: number, Checksum: checksum, Etag: etag})
+	}
+	return &loonfs.UploadCompletion{DirectMultipart: &loonfs.CompleteUploadDirectMultipart{Content: reader.claim(begin.ChecksumAlgorithm), Parts: parts}}, nil
+}
+
+type uploadReader struct {
+	ctx             context.Context
+	source          io.Reader
+	expected, limit *int64
+	digest          hash.Hash
+	count           int64
+	ended           bool
+	failure         error
+}
+
+func (r *uploadReader) Read(buffer []byte) (int, error) {
+	if r.ended {
+		return 0, io.EOF
+	}
+	if r.failure != nil {
+		return 0, r.failure
+	}
+	if err := r.ctx.Err(); err != nil {
+		r.failure = err
+		return 0, err
+	}
+	if len(buffer) > transferChunkBytes {
+		buffer = buffer[:transferChunkBytes]
+	}
+	n, err := r.source.Read(buffer)
+	r.count += int64(n)
+	if r.limit != nil && r.count > *r.limit {
+		err = fmt.Errorf("transfers: source exceeds advertised proxy limit")
+	}
+	if r.expected != nil && (r.count > *r.expected || (err == io.EOF && r.count != *r.expected)) {
+		err = fmt.Errorf("transfers: source does not match declared size")
+	}
+	if err != nil && err != io.EOF {
+		r.failure = err
+		return 0, err
+	}
+	if r.digest != nil {
+		r.digest.Write(buffer[:n])
+	}
+	if err == io.EOF {
+		r.ended = true
+	}
+	return n, err
+}
+func (r *uploadReader) finish() error {
+	if r.failure != nil {
+		return r.failure
+	}
+	if !r.ended {
+		return fmt.Errorf("transfers: successful response before source reached EOF")
+	}
+	return nil
+}
+func (r *uploadReader) claim(algorithm loonfs.ChecksumAlgorithm) *loonfs.UploadContentClaim {
+	return &loonfs.UploadContentClaim{SizeBytes: r.count, Checksum: &loonfs.Checksum{Algorithm: algorithm, Value: hex.EncodeToString(r.digest.Sum(nil))}}
+}

--- a/sdk/transfers/python/transfers.py
+++ b/sdk/transfers/python/transfers.py
@@ -1,8 +1,9 @@
-"""Synchronous file transfers with verified streaming downloads."""
+"""Synchronous streaming transfers and buffered convenience methods."""
 
 from __future__ import annotations
 
 import hashlib
+import io
 import typing
 from dataclasses import dataclass
 
@@ -19,6 +20,7 @@ from .types import (
     Checksum,
     CompletedUploadPart,
     ContentRef,
+    ContentToken,
     DestinationBehavior,
     FilesystemOperation_PutFile,
     ObjectTransferAccess,
@@ -84,7 +86,7 @@ class PreparedFileContent:
     """
 
     content_ref: ContentRef
-    content_token: str | None
+    content_token: ContentToken | None
 
 
 _TRANSFER_CHUNK_BYTES = 64 * 1024
@@ -200,7 +202,7 @@ class FileDownloadStream(typing.Iterator[bytes]):
 
 
 class FilesClient(_GeneratedFilesClient):
-    """The files group plus whole-file transfers."""
+    """The files group plus streaming and buffered transfers."""
 
     def __init__(self, *, client_wrapper, root: "LoonFS") -> None:
         super().__init__(client_wrapper=client_wrapper)
@@ -219,15 +221,47 @@ class FilesClient(_GeneratedFilesClient):
         expected_inode_id: str | None = None,
         expected_revision_no: RevisionNo | None = None,
         http_client: httpx.Client | None = None,
+        request_options: RequestOptions | None = None,
     ) -> FileUploadResult:
-        """Upload fresh content and publish it.
+        """Upload fresh bytes through upload_stream."""
+        return self.upload_stream(
+            namespace_id,
+            path=path,
+            content=io.BytesIO(content),
+            size_bytes=len(content),
+            actor=actor,
+            commit_id=commit_id,
+            message=message,
+            behavior=behavior,
+            expected_inode_id=expected_inode_id,
+            expected_revision_no=expected_revision_no,
+            http_client=http_client,
+            request_options=request_options,
+        )
 
-        For publication retries, retain prepare_file_bytes() output and call
-        put_file_prepared() with unchanged inputs.
-        """
-
-        prepared = self.prepare_file_bytes(
-            namespace_id, content=content, http_client=http_client
+    def upload_stream(
+        self,
+        namespace_id: str,
+        *,
+        path: str,
+        content: typing.BinaryIO,
+        size_bytes: int | None = None,
+        actor: ActorRef,
+        commit_id: str,
+        message: str | None = None,
+        behavior: DestinationBehavior | None = None,
+        expected_inode_id: str | None = None,
+        expected_revision_no: RevisionNo | None = None,
+        http_client: httpx.Client | None = None,
+        request_options: RequestOptions | None = None,
+    ) -> FileUploadResult:
+        """Consume a source once and publish it; the caller owns the source."""
+        prepared = self.prepare_file_stream(
+            namespace_id,
+            content=content,
+            size_bytes=size_bytes,
+            http_client=http_client,
+            request_options=request_options,
         )
         return self.put_file_prepared(
             namespace_id,
@@ -239,6 +273,7 @@ class FilesClient(_GeneratedFilesClient):
             behavior=behavior,
             expected_inode_id=expected_inode_id,
             expected_revision_no=expected_revision_no,
+            request_options=request_options,
         )
 
     def prepare_file_bytes(
@@ -247,20 +282,86 @@ class FilesClient(_GeneratedFilesClient):
         *,
         content: bytes,
         http_client: httpx.Client | None = None,
+        request_options: RequestOptions | None = None,
     ) -> PreparedFileContent:
-        """Upload bytes once without publishing; retain the result for retries."""
-        begin = _create_upload(self._root, namespace_id, content)
-        if http_client is None:
-            with httpx.Client() as transfer_client:
-                staged = _stage_upload(
-                    self._root, transfer_client, namespace_id, begin, content
-                )
-        else:
-            staged = _stage_upload(
-                self._root, http_client, namespace_id, begin, content
-            )
+        """Stage the streaming path for an existing byte buffer."""
+        return self.prepare_file_stream(
+            namespace_id,
+            content=io.BytesIO(content),
+            size_bytes=len(content),
+            http_client=http_client,
+            request_options=request_options,
+        )
 
-        return staged
+    def prepare_file_stream(
+        self,
+        namespace_id: str,
+        *,
+        content: typing.BinaryIO,
+        size_bytes: int | None = None,
+        http_client: httpx.Client | None = None,
+        request_options: RequestOptions | None = None,
+    ) -> PreparedFileContent:
+        """Stage once with bounded memory; retain the result for publication retries.
+
+        The caller owns content. Payload requests are never retried. A known
+        size validates the source and selects the usual small-file transport.
+        """
+        if size_bytes is not None and size_bytes < 0:
+            raise ValueError("size_bytes must be nonnegative")
+        capabilities = self._root.capabilities.retrieve(request_options=request_options)
+        first = b""
+        if size_bytes is None:
+            first = content.read(1)
+            if not first:
+                size_bytes = 0
+        source = _UploadSource(content, first, size_bytes)
+        begin = _create_upload(
+            self._root, namespace_id, capabilities, size_bytes, request_options
+        )
+        client = http_client or self._root._client_wrapper.httpx_client.httpx_client
+        timeout = (request_options or {}).get(
+            "timeout", self._root._client_wrapper.get_timeout()
+        )
+        options = {**(request_options or {}), "max_retries": 0}
+        try:
+            if begin.mode == "service_proxied":
+                source.limit = (capabilities.limits or {}).get(_PROXY_UPLOAD_LIMIT)
+                self._root.uploads.put_content(
+                    namespace_id,
+                    begin.upload_id,
+                    request=source.chunks(),
+                    request_options=options,
+                )
+                completion = UploadCompletion_ServiceProxied()
+            elif begin.mode == "direct_put":
+                source.digest = _IncrementalChecksum(begin.checksum_algorithm)
+                _send_stream_presigned(
+                    client, begin.access, source.chunks(), timeout, size_bytes
+                )
+                completion = UploadCompletion_DirectPut(
+                    content=UploadContentClaim(
+                        size_bytes=source.count, checksum=source.digest.finish()
+                    )
+                )
+            elif begin.mode == "direct_multipart":
+                completion = _stream_multipart(
+                    self._root, client, namespace_id, begin, source, timeout, options
+                )
+            else:
+                raise RuntimeError(f"unsupported upload mode {begin.mode!r}")
+            source.finish()
+        except BaseException:
+            _abort_quietly(self._root, namespace_id, begin.upload_id)
+            raise
+        # Keep a session whose completion response was lost available for inspection.
+        completed = self._root.uploads.complete(
+            namespace_id, begin.upload_id, request=completion, request_options=options
+        )
+        result = _completed_content(completed)
+        if result.content_ref.size_bytes != source.count:
+            raise RuntimeError("completed upload size mismatch")
+        return result
 
     def put_file_prepared(
         self,
@@ -274,6 +375,7 @@ class FilesClient(_GeneratedFilesClient):
         behavior: DestinationBehavior | None = None,
         expected_inode_id: str | None = None,
         expected_revision_no: RevisionNo | None = None,
+        request_options: RequestOptions | None = None,
     ) -> FileUploadResult:
         """Publish retained content; reuse it with identical inputs to retry safely."""
         operation_arguments = {"path": path, "content_ref": prepared.content_ref}
@@ -294,7 +396,9 @@ class FilesClient(_GeneratedFilesClient):
         }
         if message is not None:
             commit_arguments["message"] = message
-        committed = self._root.commits.create(namespace_id, **commit_arguments)
+        committed = self._root.commits.create(
+            namespace_id, request_options=request_options, **commit_arguments
+        )
         return FileUploadResult(
             namespace_id=committed.namespace_id,
             commit_id=committed.commit_id,
@@ -439,181 +543,143 @@ def _proxied_claim(client, namespace_id, path, revision_no, request_options):
         cursor = page.next_cursor
 
 
-def _create_upload(client: _GeneratedLoonFS, namespace_id: str, content: bytes):
-    capabilities = client.capabilities.retrieve()
-    features = capabilities.features or {}
-    limits = capabilities.limits or {}
-    size_bytes = len(content)
-    if size_bytes >= _MULTIPART_MIN_BYTES and features.get(
+class _UploadSource:
+    def __init__(self, reader, prefix, expected):
+        self.reader, self.prefix, self.expected = reader, prefix, expected
+        self.count = 0
+        self.ended = False
+        self.limit = None
+        self.digest = None
+
+    def read(self, size):
+        if self.ended:
+            return b""
+        size = min(size, _TRANSFER_CHUNK_BYTES)
+        if self.prefix:
+            chunk, self.prefix = self.prefix[:size], self.prefix[size:]
+        else:
+            chunk = self.reader.read(size)
+        if not isinstance(chunk, bytes):
+            raise TypeError("upload source must return bytes")
+        self.count += len(chunk)
+        if self.limit is not None and self.count > self.limit:
+            raise ValueError("source exceeds advertised proxy upload limit")
+        if self.expected is not None and (
+            self.count > self.expected or (not chunk and self.count != self.expected)
+        ):
+            raise ValueError("source does not match declared size")
+        if self.digest is not None:
+            self.digest.update(chunk)
+        if not chunk:
+            self.ended = True
+        return chunk
+
+    def chunks(self):
+        while True:
+            chunk = self.read(_TRANSFER_CHUNK_BYTES)
+            if not chunk:
+                return
+            yield chunk
+
+    def finish(self):
+        if not self.ended:
+            raise RuntimeError("successful response before upload source reached EOF")
+
+
+def _create_upload(client, namespace_id, capabilities, size_bytes, request_options):
+    features, limits = capabilities.features or {}, capabilities.limits or {}
+    if (size_bytes is None or size_bytes >= _MULTIPART_MIN_BYTES) and features.get(
         _DIRECT_MULTIPART_FEATURE, False
     ):
         request = BeginUploadRequest_DirectMultipart()
     else:
         proxy_limit = limits.get(_PROXY_UPLOAD_LIMIT)
-        fits_proxy = proxy_limit is None or size_bytes <= proxy_limit
-        direct_put_limit = limits.get(_DIRECT_PUT_LIMIT)
-        fits_direct_put = direct_put_limit is None or size_bytes <= direct_put_limit
+        fits_proxy = (
+            size_bytes is None or proxy_limit is None or size_bytes <= proxy_limit
+        )
+        direct_limit = limits.get(_DIRECT_PUT_LIMIT)
+        fits_direct = size_bytes is not None and (
+            direct_limit is None or size_bytes <= direct_limit
+        )
         if (
             features.get(_DIRECT_PUT_FEATURE, False)
-            and fits_direct_put
+            and fits_direct
             and (size_bytes >= _MULTIPART_MIN_BYTES or not fits_proxy)
         ):
             request = BeginUploadRequest_DirectPut(size_bytes=size_bytes)
         elif fits_proxy:
             request = BeginUploadRequest_ServiceProxied()
         else:
-            raise ValueError(
-                f"{size_bytes} bytes exceed the advertised proxy and direct PUT limits, "
-                "and direct multipart is unavailable"
-            )
-    return client.uploads.create(namespace_id, request=request)
-
-
-def _stage_upload(
-    client: _GeneratedLoonFS,
-    transfer_client: httpx.Client,
-    namespace_id: str,
-    begin,
-    content: bytes,
-) -> PreparedFileContent:
-    if begin.mode == "service_proxied":
-        try:
-            client.uploads.put_content(namespace_id, begin.upload_id, request=content)
-            completion = client.uploads.complete(
-                namespace_id,
-                begin.upload_id,
-                request=UploadCompletion_ServiceProxied(),
-            )
-        except Exception:
-            _abort_quietly(client, namespace_id, begin.upload_id)
-            raise
-        return _completed_content(completion)
-    if begin.mode == "direct_put":
-        try:
-            _send_presigned(
-                transfer_client,
-                begin.access,
-                "PUT",
-                content=content,
-            )
-        except Exception:
-            _abort_quietly(client, namespace_id, begin.upload_id)
-            raise
-        completion = client.uploads.complete(
-            namespace_id,
-            begin.upload_id,
-            request=UploadCompletion_DirectPut(
-                content=UploadContentClaim(
-                    size_bytes=len(content),
-                    checksum=_checksum(begin.checksum_algorithm, content),
-                )
-            ),
-        )
-        return _completed_content(completion)
-    if begin.mode == "direct_multipart":
-        return _stage_multipart(
-            client,
-            transfer_client,
-            namespace_id,
-            begin.upload_id,
-            begin.part_size_bytes,
-            begin.checksum_algorithm,
-            content,
-        )
-    raise RuntimeError(f"unsupported upload mode {begin.mode!r}")
-
-
-def _stage_multipart(
-    client: _GeneratedLoonFS,
-    transfer_client: httpx.Client,
-    namespace_id: str,
-    upload_id: str,
-    part_size_bytes: int,
-    checksum_algorithm: str,
-    content: bytes,
-) -> PreparedFileContent:
-    if part_size_bytes <= 0:
-        raise RuntimeError("multipart response returned a non-positive part size")
-    parts = [
-        content[offset : offset + part_size_bytes]
-        for offset in range(0, len(content), part_size_bytes)
-    ]
-    claims = [
-        UploadPartChecksumClaim(
-            part_number=index,
-            checksum=_checksum(checksum_algorithm, part),
-        )
-        for index, part in enumerate(parts, start=1)
-    ]
-    try:
-        signed = client.uploads.sign_parts(
-            namespace_id,
-            upload_id,
-            parts=claims,
-        )
-        access_by_part = {part.part_number: part.access for part in signed.parts}
-        completed_parts = []
-        for claim, part in zip(claims, parts):
-            access = access_by_part.get(claim.part_number)
-            if access is None:
-                raise RuntimeError(
-                    f"server did not sign multipart part {claim.part_number}"
-                )
-            response = _send_presigned(
-                transfer_client,
-                access,
-                "PUT",
-                content=part,
-            )
-            etag = response.headers.get("etag")
-            if etag is None:
-                raise RuntimeError(
-                    f"multipart part {claim.part_number} returned no ETag"
-                )
-            completed_parts.append(
-                CompletedUploadPart(
-                    part_number=claim.part_number,
-                    etag=etag,
-                    checksum=claim.checksum,
-                )
-            )
-    except Exception:
-        _abort_quietly(client, namespace_id, upload_id)
-        raise
-    completion = client.uploads.complete(
-        namespace_id,
-        upload_id,
-        request=UploadCompletion_DirectMultipart(
-            content=UploadContentClaim(
-                size_bytes=len(content),
-                checksum=_checksum(checksum_algorithm, content),
-            ),
-            parts=completed_parts,
-        ),
+            raise ValueError("source fits no advertised upload transport")
+    return client.uploads.create(
+        namespace_id, request=request, request_options=request_options
     )
-    return _completed_content(completion)
 
 
-def _send_presigned(
-    client: httpx.Client,
-    access: ObjectTransferAccess,
-    expected_method: str,
-    *,
-    content: bytes | None = None,
-) -> httpx.Response:
-    if access.method.upper() != expected_method:
-        raise RuntimeError(
-            f"presigned access uses {access.method!r}, expected {expected_method!r}"
-        )
+def _send_stream_presigned(client, access, content, timeout, size_bytes=None):
+    if access.method.upper() != "PUT":
+        raise RuntimeError("upload grant must use PUT")
     headers = httpx.Headers(access.headers or {})
-    response = client.request(
-        expected_method,
+    if size_bytes is not None:
+        headers["Content-Length"] = str(size_bytes)
+    request = httpx.Request(
+        "PUT",
         access.url,
         headers=headers,
         content=content,
+        extensions={"timeout": httpx.Timeout(timeout).as_dict()},
     )
-    response.raise_for_status()
-    return response
+    response = client.send(request, stream=True, auth=None, follow_redirects=False)
+    try:
+        response.raise_for_status()
+        return response.headers.get("etag")
+    finally:
+        response.close()
+
+
+def _stream_multipart(
+    client, http, namespace_id, begin, source, timeout, request_options
+):
+    part_size = begin.part_size_bytes
+    if part_size <= 0:
+        raise RuntimeError("multipart part size must be positive")
+    source.digest = _IncrementalChecksum(begin.checksum_algorithm)
+    completed_parts = []
+    while True:
+        part = bytearray()
+        while len(part) < part_size:
+            chunk = source.read(part_size - len(part))
+            if not chunk:
+                break
+            part.extend(chunk)
+        if not part:
+            break
+        if len(completed_parts) == 10000:
+            raise ValueError("multipart upload exceeds 10000 parts")
+        number = len(completed_parts) + 1
+        checksum = _checksum(begin.checksum_algorithm, part)
+        signed = client.uploads.sign_parts(
+            namespace_id,
+            begin.upload_id,
+            parts=[UploadPartChecksumClaim(part_number=number, checksum=checksum)],
+            request_options=request_options,
+        )
+        if len(signed.parts) != 1 or signed.parts[0].part_number != number:
+            raise RuntimeError(f"server did not sign requested part {number}")
+        etag = _send_stream_presigned(
+            http, signed.parts[0].access, bytes(part), timeout
+        )
+        if not etag:
+            raise RuntimeError(f"part {number} returned no ETag")
+        completed_parts.append(
+            CompletedUploadPart(part_number=number, etag=etag, checksum=checksum)
+        )
+    return UploadCompletion_DirectMultipart(
+        content=UploadContentClaim(
+            size_bytes=source.count, checksum=source.digest.finish()
+        ),
+        parts=completed_parts,
+    )
 
 
 def _completed_content(response: UploadSession) -> PreparedFileContent:
@@ -627,23 +693,16 @@ def _completed_content(response: UploadSession) -> PreparedFileContent:
     )
 
 
-def _abort_quietly(client: _GeneratedLoonFS, namespace_id: str, upload_id: str) -> None:
+def _abort_quietly(client, namespace_id, upload_id):
     try:
-        client.uploads.abort(namespace_id, upload_id)
+        client.uploads.abort(
+            namespace_id, upload_id, request_options={"timeout": 5, "max_retries": 0}
+        )
     except Exception:
         pass
 
 
 def _checksum(algorithm: str, content: bytes) -> Checksum:
-    if algorithm == "sha256":
-        return Checksum(algorithm=algorithm, value=hashlib.sha256(content).hexdigest())
-    if algorithm == "crc64nvme":
-        table, mask, width = _CRC64_NVME_TABLE, _CRC64_NVME_MASK, 16
-    elif algorithm == "crc32c":
-        table, mask, width = _CRC32C_TABLE, _CRC32C_MASK, 8
-    else:
-        raise RuntimeError(f"unsupported checksum algorithm {algorithm!r}")
-    value = mask
-    for byte in content:
-        value = table[(value ^ byte) & 0xFF] ^ (value >> 8)
-    return Checksum(algorithm=algorithm, value=f"{value ^ mask:0{width}x}")
+    digest = _IncrementalChecksum(algorithm)
+    digest.update(content)
+    return digest.finish()

--- a/sdk/transfers/typescript-client/transfers.ts
+++ b/sdk/transfers/typescript-client/transfers.ts
@@ -1,4 +1,13 @@
-import { TransferScope, verifiedDownload } from "./transfer-runtime.js";
+import {
+    TransferScope,
+    verifiedDownload,
+    UploadSource,
+    bytesSource,
+    IncrementalChecksum,
+    type UploadContent,
+    streamingFetch,
+    uploadBody,
+} from "./transfer-runtime.js";
 import { LoonFSClient as GeneratedLoonFSClient } from "./Client.js";
 import { FilesClient as GeneratedFilesClient } from "./api/resources/files/client/Client.js";
 import * as core from "./core/index.js";
@@ -11,15 +20,6 @@ const DIRECT_PUT_MAX_BYTES = "upload.direct_put_max_content_bytes";
 const PROXY_UPLOAD_MAX_BYTES = "upload.max_content_bytes";
 const MULTIPART_MIN_BYTES = 8 * 1024 * 1024;
 
-// The CRC constants, tables, and functions are copied from
-// sdk/transfers/typescript/transfers.ts.
-const CRC32C_POLYNOMIAL = 0x82f63b78;
-const CRC64_NVME_POLYNOMIAL = 0x9a6c9329ac4bc9b5n;
-const CRC64_MASK = 0xffffffffffffffffn;
-
-const CRC32C_TABLE = makeCrc32cTable();
-const CRC64_NVME_TABLE = makeCrc64NvmeTable();
-
 export interface FileUploadInput {
     namespace_alias: string;
     path: LoonFS.AbsolutePath;
@@ -30,6 +30,17 @@ export interface FileUploadInput {
     behavior?: LoonFS.DestinationBehavior;
     expected_inode_id?: string;
     expected_revision_no?: LoonFS.RevisionNo;
+}
+
+export interface FileStreamUploadInput extends Omit<FileUploadInput, "content"> {
+    content: UploadContent;
+    size_bytes?: number;
+}
+
+export interface PrepareFileStreamInput {
+    namespace_alias: string;
+    content: UploadContent;
+    size_bytes?: number;
 }
 
 export interface PreparedFileUploadInput extends Omit<FileUploadInput, "content"> {
@@ -67,11 +78,6 @@ export interface PreparedFileContent {
     readonly contentToken?: LoonFS.ContentToken;
 }
 
-interface DirectPutBody {
-    body: ArrayBuffer;
-    content: LoonFS.UploadContentClaim;
-}
-
 export declare namespace LoonFSClient {
     /** The generated client options with `baseUrl` in place of `environment`. */
     export type Options = Omit<GeneratedLoonFSClient.Options, "environment"> & {
@@ -86,7 +92,7 @@ export declare namespace FilesClient {
     export interface RequestOptions extends GeneratedFilesClient.RequestOptions {}
 }
 
-/** The files group plus whole-file transfers. */
+/** The files group plus streaming and buffered transfers. */
 export class FilesClient extends GeneratedFilesClient {
     constructor(
         options: GeneratedFilesClient.Options,
@@ -95,22 +101,78 @@ export class FilesClient extends GeneratedFilesClient {
         super(options);
     }
 
-    /** Uploads fresh content and publishes it. For publication retries, retain prepareFileBytes() output and use putFilePrepared(). */
-    public async upload(input: FileUploadInput): Promise<FileUploadResult> {
-        const { content, ...publication } = input;
-        const prepared = await this.prepareFileBytes({ namespace_alias: input.namespace_alias, content });
-        return this.putFilePrepared({ ...publication, prepared });
+    /** Upload bytes through the same streaming path. */
+    public async upload(
+        input: FileUploadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileUploadResult> {
+        return this.uploadStream(
+            { ...input, content: bytesSource(input.content), size_bytes: input.content.length },
+            requestOptions,
+        );
     }
 
-    /** Upload once without publishing; retain the result for publication retries. */
+    /** Consume a source once and publish it. For publication retries, prepare separately. */
+    public async uploadStream(
+        input: FileStreamUploadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileUploadResult> {
+        const scope = new TransferScope(requestOptions, this._options.timeoutInSeconds);
+        const options = { ...requestOptions, abortSignal: scope.signal };
+        try {
+            const prepared = await this.prepareFileStream(
+                {
+                    namespace_alias: input.namespace_alias,
+                    content: input.content,
+                    size_bytes: input.size_bytes,
+                },
+                options,
+            );
+            const { content, size_bytes, ...publication } = input;
+            return await this.putFilePrepared({ ...publication, prepared }, options);
+        } finally {
+            scope.close();
+        }
+    }
+
     public async prepareFileBytes(
         input: Pick<FileUploadInput, "namespace_alias" | "content">,
+        requestOptions: FilesClient.RequestOptions = {},
     ): Promise<PreparedFileContent> {
-        return stageBytes(this.root, input.namespace_alias, input.content);
+        return this.prepareFileStream(
+            { ...input, content: bytesSource(input.content), size_bytes: input.content.length },
+            requestOptions,
+        );
+    }
+
+    /** Stage a source once with bounded memory; retain the result for publication retries. */
+    public async prepareFileStream(
+        input: PrepareFileStreamInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<PreparedFileContent> {
+        const scope = new TransferScope(requestOptions, this._options.timeoutInSeconds);
+        let source: UploadSource | undefined;
+        try {
+            source = new UploadSource(input.content, scope, input.size_bytes);
+            return await stageStream(
+                this.root,
+                input.namespace_alias,
+                source,
+                scope,
+                { ...requestOptions, abortSignal: scope.signal, maxRetries: 0 },
+                this._options.fetch ?? fetch,
+            );
+        } finally {
+            source?.close();
+            scope.close();
+        }
     }
 
     /** Reuse prepared content and identical publication inputs to retry the same commit. */
-    public async putFilePrepared(input: PreparedFileUploadInput): Promise<FileUploadResult> {
+    public async putFilePrepared(
+        input: PreparedFileUploadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileUploadResult> {
         const request: LoonFS.CommitRequest = {
             namespace_alias: input.namespace_alias,
             actor: input.actor,
@@ -130,7 +192,7 @@ export class FilesClient extends GeneratedFilesClient {
         if (input.message !== undefined) {
             request.message = input.message;
         }
-        return this.root.commits.create(request);
+        return this.root.commits.create(request, requestOptions);
     }
 
     /** Opens a verified stream; cancel its reader to release an unfinished download. */
@@ -184,12 +246,16 @@ export class FilesClient extends GeneratedFilesClient {
     }
 }
 
-/** The generated client with `files.upload` and `files.download`. */
+/** The generated client with streaming and buffered transfer helpers. */
 export class LoonFSClient extends GeneratedLoonFSClient {
     private _transferFiles: FilesClient | undefined;
 
     constructor(options: LoonFSClient.Options) {
-        super({ ...options, environment: options.baseUrl });
+        super({
+            ...options,
+            environment: options.baseUrl,
+            fetch: streamingFetch(options.fetch ?? globalThis.fetch.bind(globalThis)),
+        });
     }
 
     public override get files(): FilesClient {
@@ -261,211 +327,150 @@ async function downloadProxied(
     };
 }
 
-async function stageBytes(
+async function stageStream(
     client: GeneratedLoonFSClient,
-    namespaceAlias: string,
-    bytes: Uint8Array,
+    namespace: string,
+    source: UploadSource,
+    scope: TransferScope,
+    options: FilesClient.RequestOptions,
+    send: typeof fetch,
 ): Promise<PreparedFileContent> {
-    const capabilities = await client.capabilities.retrieve();
-    const beginRequest = selectBeginRequest(capabilities, bytes);
-    const begin = await client.uploads.create({
-        namespace_alias: namespaceAlias,
-        body: beginRequest,
-    });
-
-    switch (begin.mode) {
-        case "direct_put":
-            return stageDirectPut(client, namespaceAlias, bytes, begin);
-        case "direct_multipart":
-            return stageMultipart(client, namespaceAlias, bytes, begin);
-        case "service_proxied":
-            return stageServiceProxied(client, namespaceAlias, bytes, begin);
+    scope.check();
+    const capabilities = await client.capabilities.retrieve(options);
+    const size = source.expected ?? ((await source.empty()) ? 0 : undefined);
+    const features = capabilities.features ?? {},
+        limits = capabilities.limits ?? {};
+    let request: LoonFS.BeginUploadRequest;
+    if ((size === undefined || size >= MULTIPART_MIN_BYTES) && features[DIRECT_MULTIPART_FEATURE]) {
+        request = { mode: "direct_multipart" };
+    } else {
+        const fitsProxy =
+            size === undefined ||
+            limits[PROXY_UPLOAD_MAX_BYTES] === undefined ||
+            size <= limits[PROXY_UPLOAD_MAX_BYTES]!;
+        const fitsDirect =
+            size !== undefined &&
+            (limits[DIRECT_PUT_MAX_BYTES] === undefined || size <= limits[DIRECT_PUT_MAX_BYTES]!);
+        if (features[DIRECT_PUT_FEATURE] && fitsDirect && (size! >= MULTIPART_MIN_BYTES || !fitsProxy))
+            request = { mode: "direct_put", size_bytes: size };
+        else if (fitsProxy) request = { mode: "service_proxied" };
+        else throw new Error("source fits no advertised upload transport");
     }
-}
-
-function selectBeginRequest(
-    capabilities: LoonFS.CapabilityDocument,
-    bytes: Uint8Array,
-): LoonFS.BeginUploadRequest {
-    const features = capabilities.features ?? {};
-    const limits = capabilities.limits ?? {};
-    const supportsMultipart = features[DIRECT_MULTIPART_FEATURE] === true;
-    const worthCutting = bytes.byteLength >= MULTIPART_MIN_BYTES;
-    if (worthCutting && supportsMultipart) {
-        return { mode: "direct_multipart" };
-    }
-
-    const proxyLimit = limits[PROXY_UPLOAD_MAX_BYTES];
-    const fitsProxy = proxyLimit === undefined || bytes.byteLength <= proxyLimit;
-    const directPutLimit = limits[DIRECT_PUT_MAX_BYTES];
-    const fitsDirectPut = directPutLimit === undefined || bytes.byteLength <= directPutLimit;
-    if (features[DIRECT_PUT_FEATURE] === true && fitsDirectPut && (worthCutting || !fitsProxy)) {
-        return {
-            mode: "direct_put",
-            size_bytes: bytes.byteLength,
-        };
-    }
-    if (fitsProxy) {
-        return { mode: "service_proxied" };
-    }
-    throw new Error(`${bytes.byteLength} bytes fit no advertised upload transport`);
-}
-
-async function stageServiceProxied(
-    client: GeneratedLoonFSClient,
-    namespaceAlias: string,
-    bytes: Uint8Array,
-    begin: LoonFS.BeginUploadResponse.ServiceProxied,
-): Promise<PreparedFileContent> {
+    const begin = await client.uploads.create({ namespace_alias: namespace, body: request }, options);
+    let completion: LoonFS.UploadCompletion;
     try {
-        await client.uploads.putContent(arrayBuffer(bytes), namespaceAlias, begin.upload_id);
-        return stagedContent(
-            await client.uploads.complete({
-                namespace_alias: namespaceAlias,
-                upload_id: begin.upload_id,
-                body: { mode: "service_proxied" },
-            }),
-        );
-    } catch (error) {
-        await abortQuietly(client, namespaceAlias, begin.upload_id);
-        throw error;
-    }
-}
-
-async function stageDirectPut(
-    client: GeneratedLoonFSClient,
-    namespaceAlias: string,
-    bytes: Uint8Array,
-    begin: LoonFS.BeginUploadResponse.DirectPut,
-): Promise<PreparedFileContent> {
-    let upload: DirectPutBody;
-    try {
-        requirePresignedMethod(begin.access, "PUT", "direct PUT");
-        upload = await directPutBody(begin.checksum_algorithm, bytes);
-        const response = await fetch(begin.access.url, {
-            redirect: "error",
-            method: begin.access.method,
-            headers: begin.access.headers,
-            body: upload.body,
-        });
-        requireSuccessfulResponse(response, "direct PUT");
-    } catch (error) {
-        await abortQuietly(client, namespaceAlias, begin.upload_id);
-        throw error;
-    }
-    return stagedContent(
-        await client.uploads.complete({
-            namespace_alias: namespaceAlias,
-            upload_id: begin.upload_id,
-            body: { mode: "direct_put", content: upload.content },
-        }),
-    );
-}
-
-async function stageMultipart(
-    client: GeneratedLoonFSClient,
-    namespaceAlias: string,
-    bytes: Uint8Array,
-    begin: LoonFS.BeginUploadResponse.DirectMultipart,
-): Promise<PreparedFileContent> {
-    const { checksum_algorithm: algorithm, part_size_bytes: partSize } = begin;
-    if (!Number.isSafeInteger(partSize) || partSize <= 0) {
-        throw new Error(`invalid multipart part size ${partSize}`);
-    }
-    if (bytes.byteLength === 0) {
-        throw new Error("direct multipart upload cannot carry an empty payload");
-    }
-
-    const chunks = splitBytes(bytes, partSize);
-    const claims: LoonFS.UploadPartChecksumClaim[] = [];
-    for (const [index, chunk] of chunks.entries()) {
-        claims.push({
-            part_number: index + 1,
-            checksum: await checksum(algorithm, chunk),
-        });
-    }
-    const completedParts: LoonFS.CompletedUploadPart[] = [];
-    try {
-        const signed = await client.uploads.signParts({
-            namespace_alias: namespaceAlias,
-            upload_id: begin.upload_id,
-            parts: claims,
-        });
-        const accessByPart = new Map(signed.parts.map((part) => [part.part_number, part.access]));
-        for (const [index, claim] of claims.entries()) {
-            const access = accessByPart.get(claim.part_number);
-            if (access === undefined) {
-                throw new Error(`server did not sign part ${claim.part_number}`);
-            }
-            requirePresignedMethod(access, "PUT", `part ${claim.part_number}`);
-            const response = await fetch(access.url, {
-                redirect: "error",
-                method: access.method,
-                headers: access.headers,
-                body: arrayBuffer(chunks[index]!),
-            });
-            requireSuccessfulResponse(response, `part ${claim.part_number}`);
-            const etag = response.headers.get("etag");
-            if (etag === null) {
-                throw new Error(`part ${claim.part_number} upload returned no etag`);
-            }
-            completedParts.push({
-                part_number: claim.part_number,
-                checksum: claim.checksum,
-                etag,
-            });
-        }
-    } catch (error) {
-        await abortQuietly(client, namespaceAlias, begin.upload_id);
-        throw error;
-    }
-
-    return stagedContent(
-        await client.uploads.complete({
-            namespace_alias: namespaceAlias,
-            upload_id: begin.upload_id,
-            body: {
-                mode: "direct_multipart",
-                content: {
-                    size_bytes: bytes.byteLength,
-                    checksum: await checksum(algorithm, bytes),
+        if (begin.mode === "service_proxied") {
+            source.limit = limits[PROXY_UPLOAD_MAX_BYTES];
+            const response = await client.fetch(
+                `v0/namespace-aliases/${encodeURIComponent(namespace)}/uploads/${encodeURIComponent(begin.upload_id)}/content`,
+                {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/octet-stream" },
+                    body: await uploadBody(source),
+                    duplex: "half",
+                } as RequestInit,
+                {
+                    timeoutInSeconds: options.timeoutInSeconds,
+                    maxRetries: 0,
+                    abortSignal: options.abortSignal,
+                    headers: await resolvedHeaders(options.headers),
                 },
-                parts: completedParts,
-            },
-        }),
+            );
+            requireSuccessfulResponse(response, "proxied upload");
+            await response.body?.cancel();
+            completion = { mode: "service_proxied" };
+        } else if (begin.mode === "direct_put") {
+            source.digest = new IncrementalChecksum(begin.checksum_algorithm);
+            await putStream(send, begin.access, await uploadBody(source), scope);
+            completion = {
+                mode: "direct_put",
+                content: { size_bytes: source.count, checksum: source.digest.finish() },
+            };
+        } else {
+            const partSize = begin.part_size_bytes;
+            if (!Number.isSafeInteger(partSize) || partSize <= 0)
+                throw new Error("invalid multipart part size");
+            source.digest = new IncrementalChecksum(begin.checksum_algorithm);
+            const parts: LoonFS.CompletedUploadPart[] = [];
+            while (true) {
+                const buffer = new Uint8Array(partSize);
+                let length = 0;
+                while (length < partSize) {
+                    const chunk = await source.read(partSize - length);
+                    if (!chunk) break;
+                    buffer.set(chunk, length);
+                    length += chunk.length;
+                }
+                if (!length) break;
+                if (parts.length === 10000) throw new Error("multipart upload exceeds 10000 parts");
+                const part = buffer.subarray(0, length),
+                    partNumber = parts.length + 1;
+                const digest = new IncrementalChecksum(begin.checksum_algorithm);
+                digest.update(part);
+                const checksum = digest.finish();
+                const signed = await client.uploads.signParts(
+                    {
+                        namespace_alias: namespace,
+                        upload_id: begin.upload_id,
+                        parts: [{ part_number: partNumber, checksum }],
+                    },
+                    options,
+                );
+                if (signed.parts.length !== 1 || signed.parts[0]!.part_number !== partNumber)
+                    throw new Error(`server did not sign requested part ${partNumber}`);
+                const etag = await putStream(send, signed.parts[0]!.access, part, scope);
+                if (!etag) throw new Error(`part ${partNumber} returned no ETag`);
+                parts.push({ part_number: partNumber, checksum, etag });
+            }
+            completion = {
+                mode: "direct_multipart",
+                content: { size_bytes: source.count, checksum: source.digest.finish() },
+                parts,
+            };
+        }
+        source.finish();
+    } catch (error) {
+        try {
+            await client.uploads.abort(
+                { namespace_alias: namespace, upload_id: begin.upload_id },
+                { timeoutInSeconds: 5, maxRetries: 0, abortSignal: AbortSignal.timeout(5000) },
+            );
+        } catch {
+            /* Preserve the transfer error. */
+        }
+        throw error;
+    }
+    // A lost completion response may still have completed the session.
+    const completed = await client.uploads.complete(
+        { namespace_alias: namespace, upload_id: begin.upload_id, body: completion },
+        options,
     );
+    if (completed.status !== "completed") throw new Error(`upload is ${completed.status}, not completed`);
+    if (completed.content_ref.size_bytes !== source.count) throw new Error("completed upload size mismatch");
+    return { contentRef: completed.content_ref, contentToken: completed.content_token ?? undefined };
 }
 
-function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
-    const parts: Uint8Array[] = [];
-    for (let offset = 0; offset < bytes.byteLength; offset += partSize) {
-        parts.push(bytes.subarray(offset, Math.min(offset + partSize, bytes.byteLength)));
-    }
-    return parts;
-}
-
-function stagedContent(response: LoonFS.UploadSession): PreparedFileContent {
-    if (response.status !== "completed") {
-        throw new Error(`upload ${response.upload_id} completed with status ${response.status}`);
-    }
-    return {
-        contentRef: response.content_ref,
-        contentToken: response.content_token,
-    };
-}
-
-async function abortQuietly(
-    client: GeneratedLoonFSClient,
-    namespaceAlias: string,
-    uploadId: LoonFS.UploadId,
-): Promise<void> {
+async function putStream(
+    send: typeof fetch,
+    access: LoonFS.ObjectTransferAccess,
+    body: BodyInit,
+    scope: TransferScope,
+): Promise<string | null> {
+    requirePresignedMethod(access, "PUT", "upload");
+    scope.check();
+    const response = await send(access.url, {
+        redirect: "error",
+        method: "PUT",
+        headers: access.headers,
+        body,
+        signal: scope.signal,
+        duplex: "half",
+    } as RequestInit);
     try {
-        await client.uploads.abort({
-            namespace_alias: namespaceAlias,
-            upload_id: uploadId,
-        });
-    } catch {
-        // Preserve the transfer error.
+        requireSuccessfulResponse(response, "upload");
+        return response.headers.get("etag");
+    } finally {
+        await response.body?.cancel();
     }
 }
 
@@ -474,89 +479,21 @@ function requirePresignedMethod(
     expected: "GET" | "PUT",
     operation: string,
 ): void {
-    if (access.method !== expected) {
+    if (access.method !== expected)
         throw new Error(`${operation} received unsupported presigned method ${access.method}`);
-    }
 }
 
 function requireSuccessfulResponse(response: Response, operation: string): void {
-    if (!response.ok) {
-        throw new Error(`${operation} failed with HTTP ${response.status}`);
+    if (!response.ok) throw new Error(`${operation} failed with HTTP ${response.status}`);
+}
+
+async function resolvedHeaders(
+    headers: FilesClient.RequestOptions["headers"],
+): Promise<Record<string, string>> {
+    const result: Record<string, string> = {};
+    for (const [name, supplier] of Object.entries(headers ?? {})) {
+        const value = await core.Supplier.get(supplier);
+        if (value != null) result[name] = value;
     }
-}
-
-async function directPutBody(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): Promise<DirectPutBody> {
-    const body = arrayBuffer(bytes);
-    const sentBytes = new Uint8Array(body);
-    return {
-        body,
-        content: {
-            size_bytes: sentBytes.byteLength,
-            checksum: await checksum(algorithm, sentBytes),
-        },
-    };
-}
-
-async function checksum(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): Promise<LoonFS.Checksum> {
-    switch (algorithm) {
-        case "sha256": {
-            const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer(bytes));
-            return { algorithm, value: hex(new Uint8Array(digest)) };
-        }
-        case "crc32c":
-            return { algorithm, value: crc32c(bytes).toString(16).padStart(8, "0") };
-        case "crc64nvme":
-            return { algorithm, value: crc64Nvme(bytes).toString(16).padStart(16, "0") };
-    }
-}
-
-function hex(bytes: Uint8Array): string {
-    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
-}
-
-function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
-    const copy = new Uint8Array(bytes.byteLength);
-    copy.set(bytes);
-    return copy.buffer;
-}
-
-function makeCrc32cTable(): Uint32Array {
-    const table = new Uint32Array(256);
-    for (let index = 0; index < table.length; index += 1) {
-        let value = index;
-        for (let bit = 0; bit < 8; bit += 1) {
-            value = (value >>> 1) ^ ((value & 1) === 0 ? 0 : CRC32C_POLYNOMIAL);
-        }
-        table[index] = value >>> 0;
-    }
-    return table;
-}
-
-function crc32c(bytes: Uint8Array): number {
-    let value = 0xffffffff;
-    for (const byte of bytes) {
-        value = CRC32C_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
-    }
-    return (value ^ 0xffffffff) >>> 0;
-}
-
-function makeCrc64NvmeTable(): bigint[] {
-    const table: bigint[] = [];
-    for (let index = 0; index < 256; index += 1) {
-        let value = BigInt(index);
-        for (let bit = 0; bit < 8; bit += 1) {
-            value = (value >> 1n) ^ ((value & 1n) === 0n ? 0n : CRC64_NVME_POLYNOMIAL);
-        }
-        table.push(value & CRC64_MASK);
-    }
-    return table;
-}
-
-function crc64Nvme(bytes: Uint8Array): bigint {
-    let value = CRC64_MASK;
-    for (const byte of bytes) {
-        const index = Number((value ^ BigInt(byte)) & 0xffn);
-        value = CRC64_NVME_TABLE[index]! ^ (value >> 8n);
-    }
-    return (value ^ CRC64_MASK) & CRC64_MASK;
+    return result;
 }

--- a/sdk/transfers/typescript-shared/transfer-runtime.ts
+++ b/sdk/transfers/typescript-shared/transfer-runtime.ts
@@ -258,3 +258,173 @@ export function verifiedDownload(
         { highWaterMark: 0 },
     );
 }
+
+export type UploadContent = Blob | ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>;
+
+function streamIterator(stream: ReadableStream<Uint8Array>): AsyncIterator<Uint8Array> {
+    const reader = stream.getReader();
+    let closed = false;
+    return {
+        async next() {
+            const next = await reader.read();
+            if (next.done) {
+                closed = true;
+                reader.releaseLock();
+            }
+            return next;
+        },
+        async return() {
+            if (!closed) {
+                closed = true;
+                try {
+                    await reader.cancel();
+                } finally {
+                    reader.releaseLock();
+                }
+            }
+            return { done: true, value: undefined };
+        },
+    };
+}
+
+async function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+    if (signal.aborted) throw signal.reason;
+    let abort: () => void;
+    const cancelled = new Promise<never>((_, reject) => {
+        abort = () => reject(signal.reason);
+        signal.addEventListener("abort", abort, { once: true });
+    });
+    try {
+        return await Promise.race([promise, cancelled]);
+    } finally {
+        signal.removeEventListener("abort", abort!);
+    }
+}
+
+/** One source chunk and one bounded consumer chunk; no replay or whole-source copy. */
+export class UploadSource {
+    readonly expected?: number;
+    private readonly iterator: AsyncIterator<Uint8Array>;
+    private pending?: Uint8Array;
+    private offset = 0;
+    private closed = false;
+    count = 0;
+    ended = false;
+    digest?: IncrementalChecksum;
+    limit?: number;
+
+    constructor(
+        content: UploadContent,
+        private readonly scope: TransferScope,
+        size?: number,
+    ) {
+        this.expected = size ?? ("size" in content ? content.size : undefined);
+        if (this.expected !== undefined && (!Number.isSafeInteger(this.expected) || this.expected < 0))
+            throw new Error("upload size must be a nonnegative safe integer");
+        this.iterator =
+            "size" in content && "stream" in content
+                ? streamIterator(content.stream())
+                : "getReader" in content
+                  ? streamIterator(content)
+                  : content[Symbol.asyncIterator]();
+    }
+
+    async empty(): Promise<boolean> {
+        await this.fill();
+        return this.ended;
+    }
+
+    private async fill(): Promise<void> {
+        while (!this.ended && (!this.pending || this.offset === this.pending.length)) {
+            this.scope.check();
+            const next = await withAbort(Promise.resolve(this.iterator.next()), this.scope.signal);
+            if (next.done) {
+                this.ended = true;
+                if (this.expected !== undefined && this.count !== this.expected)
+                    throw new Error("source does not match declared size");
+            } else {
+                if (!(next.value instanceof Uint8Array))
+                    throw new Error("upload source must yield Uint8Array chunks");
+                this.pending = next.value;
+                this.offset = 0;
+            }
+        }
+    }
+
+    async read(maximum = TRANSFER_CHUNK_BYTES): Promise<Uint8Array | undefined> {
+        await this.fill();
+        if (this.ended) return undefined;
+        const chunk = this.pending!.subarray(
+            this.offset,
+            this.offset + Math.min(maximum, TRANSFER_CHUNK_BYTES),
+        );
+        this.offset += chunk.length;
+        this.count += chunk.length;
+        if (this.expected !== undefined && this.count > this.expected)
+            throw new Error("source does not match declared size");
+        if (this.limit !== undefined && this.count > this.limit)
+            throw new Error("source exceeds advertised proxy upload limit");
+        this.digest?.update(chunk);
+        return chunk;
+    }
+
+    stream(): ReadableStream<Uint8Array> {
+        return new ReadableStream(
+            {
+                pull: async (controller) => {
+                    try {
+                        const chunk = await this.read();
+                        if (chunk) controller.enqueue(chunk);
+                        else controller.close();
+                    } catch (error) {
+                        controller.error(error);
+                    }
+                },
+                cancel: () => this.close(),
+            },
+            { highWaterMark: 0 },
+        );
+    }
+
+    finish(): void {
+        if (!this.ended) throw new Error("successful response before upload source reached EOF");
+    }
+    close(): void {
+        if (this.closed) return;
+        this.closed = true;
+        // A caller-owned async iterator may itself be stalled; its cleanup
+        // must not hold up transport cancellation indefinitely.
+        void this.iterator.return?.().catch(() => {});
+        this.pending = undefined;
+    }
+}
+
+export function bytesSource(bytes: Uint8Array): UploadContent {
+    return {
+        async *[Symbol.asyncIterator]() {
+            yield bytes;
+        },
+    };
+}
+
+/** Preserve streaming request bodies through the generated passthrough transport. */
+export function streamingFetch(send: typeof fetch): typeof fetch {
+    return (input, init) =>
+        send(
+            input,
+            init?.body instanceof ReadableStream ? ({ ...init, duplex: "half" } as RequestInit) : init,
+        );
+}
+
+/** Small known sources use a portable fixed body; large/unknown ones stream. */
+export async function uploadBody(source: UploadSource): Promise<BodyInit> {
+    if (source.expected === undefined || source.expected > 8 * 1024 * 1024) return source.stream();
+    const bytes = new Uint8Array(source.expected);
+    let offset = 0;
+    for (;;) {
+        const chunk = await source.read();
+        if (!chunk) return bytes;
+        bytes.set(chunk, offset);
+        offset += chunk.length;
+    }
+}

--- a/sdk/transfers/typescript/transfers.ts
+++ b/sdk/transfers/typescript/transfers.ts
@@ -1,4 +1,13 @@
-import { TransferScope, verifiedDownload } from "./transfer-runtime.js";
+import {
+    TransferScope,
+    verifiedDownload,
+    UploadSource,
+    bytesSource,
+    IncrementalChecksum,
+    type UploadContent,
+    streamingFetch,
+    uploadBody,
+} from "./transfer-runtime.js";
 import { LoonFSClient as GeneratedLoonFSClient } from "./Client.js";
 import { FilesClient as GeneratedFilesClient } from "./api/resources/files/client/Client.js";
 import * as core from "./core/index.js";
@@ -10,13 +19,6 @@ const DIRECT_PUT_FEATURE = "filesystem.uploads.direct_put";
 const DIRECT_PUT_MAX_BYTES = "upload.direct_put_max_content_bytes";
 const PROXY_UPLOAD_MAX_BYTES = "upload.max_content_bytes";
 const MULTIPART_MIN_BYTES = 8 * 1024 * 1024;
-const CRC32C_POLYNOMIAL = 0x82f63b78;
-const CRC64_NVME_POLYNOMIAL = 0x9a6c9329ac4bc9b5n;
-const CRC64_MASK = 0xffffffffffffffffn;
-
-const CRC32C_TABLE = makeCrc32cTable();
-const CRC64_NVME_TABLE = makeCrc64NvmeTable();
-
 export interface FileUploadInput {
     namespace_id: LoonFS.NamespaceId;
     path: LoonFS.AbsolutePath;
@@ -27,6 +29,17 @@ export interface FileUploadInput {
     behavior?: LoonFS.DestinationBehavior;
     expected_inode_id?: string;
     expected_revision_no?: LoonFS.RevisionNo;
+}
+
+export interface FileStreamUploadInput extends Omit<FileUploadInput, "content"> {
+    content: UploadContent;
+    size_bytes?: number;
+}
+
+export interface PrepareFileStreamInput {
+    namespace_id: LoonFS.NamespaceId;
+    content: UploadContent;
+    size_bytes?: number;
 }
 
 export interface PreparedFileUploadInput extends Omit<FileUploadInput, "content"> {
@@ -64,11 +77,6 @@ export interface PreparedFileContent {
     readonly contentToken?: LoonFS.ContentToken;
 }
 
-interface DirectPutBody {
-    body: ArrayBuffer;
-    content: LoonFS.UploadContentClaim;
-}
-
 export declare namespace LoonFSClient {
     /** The generated client options with `baseUrl` in place of `environment`. */
     export type Options = Omit<GeneratedLoonFSClient.Options, "environment"> & {
@@ -83,7 +91,7 @@ export declare namespace FilesClient {
     export interface RequestOptions extends GeneratedFilesClient.RequestOptions {}
 }
 
-/** The files group plus whole-file transfers. */
+/** The files group plus streaming and buffered transfers. */
 export class FilesClient extends GeneratedFilesClient {
     constructor(
         options: GeneratedFilesClient.Options,
@@ -92,22 +100,74 @@ export class FilesClient extends GeneratedFilesClient {
         super(options);
     }
 
-    /** Uploads fresh content and publishes it. For publication retries, retain prepareFileBytes() output and use putFilePrepared(). */
-    public async upload(input: FileUploadInput): Promise<FileUploadResult> {
-        const { content, ...publication } = input;
-        const prepared = await this.prepareFileBytes({ namespace_id: input.namespace_id, content });
-        return this.putFilePrepared({ ...publication, prepared });
+    /** Upload bytes through the same streaming path. */
+    public async upload(
+        input: FileUploadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileUploadResult> {
+        return this.uploadStream(
+            { ...input, content: bytesSource(input.content), size_bytes: input.content.length },
+            requestOptions,
+        );
     }
 
-    /** Upload once without publishing; retain the result for publication retries. */
+    /** Consume a source once and publish it. For publication retries, prepare separately. */
+    public async uploadStream(
+        input: FileStreamUploadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileUploadResult> {
+        const scope = new TransferScope(requestOptions, this._options.timeoutInSeconds);
+        const options = { ...requestOptions, abortSignal: scope.signal };
+        try {
+            const prepared = await this.prepareFileStream(
+                { namespace_id: input.namespace_id, content: input.content, size_bytes: input.size_bytes },
+                options,
+            );
+            const { content, size_bytes, ...publication } = input;
+            return await this.putFilePrepared({ ...publication, prepared }, options);
+        } finally {
+            scope.close();
+        }
+    }
+
     public async prepareFileBytes(
         input: Pick<FileUploadInput, "namespace_id" | "content">,
+        requestOptions: FilesClient.RequestOptions = {},
     ): Promise<PreparedFileContent> {
-        return stageBytes(this.root, input.namespace_id, input.content);
+        return this.prepareFileStream(
+            { ...input, content: bytesSource(input.content), size_bytes: input.content.length },
+            requestOptions,
+        );
+    }
+
+    /** Stage a source once with bounded memory; retain the result for publication retries. */
+    public async prepareFileStream(
+        input: PrepareFileStreamInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<PreparedFileContent> {
+        const scope = new TransferScope(requestOptions, this._options.timeoutInSeconds);
+        let source: UploadSource | undefined;
+        try {
+            source = new UploadSource(input.content, scope, input.size_bytes);
+            return await stageStream(
+                this.root,
+                input.namespace_id,
+                source,
+                scope,
+                { ...requestOptions, abortSignal: scope.signal, maxRetries: 0 },
+                this._options.fetch ?? fetch,
+            );
+        } finally {
+            source?.close();
+            scope.close();
+        }
     }
 
     /** Reuse prepared content and identical publication inputs to retry the same commit. */
-    public async putFilePrepared(input: PreparedFileUploadInput): Promise<FileUploadResult> {
+    public async putFilePrepared(
+        input: PreparedFileUploadInput,
+        requestOptions: FilesClient.RequestOptions = {},
+    ): Promise<FileUploadResult> {
         const request: LoonFS.CommitRequest = {
             namespace_id: input.namespace_id,
             actor: input.actor,
@@ -127,7 +187,7 @@ export class FilesClient extends GeneratedFilesClient {
         if (input.message !== undefined) {
             request.message = input.message;
         }
-        return this.root.commits.create(request);
+        return this.root.commits.create(request, requestOptions);
     }
 
     /** Opens a verified stream; cancel its reader to release an unfinished download. */
@@ -181,12 +241,16 @@ export class FilesClient extends GeneratedFilesClient {
     }
 }
 
-/** The generated client with `files.upload` and `files.download`. */
+/** The generated client with streaming and buffered transfer helpers. */
 export class LoonFSClient extends GeneratedLoonFSClient {
     private _transferFiles: FilesClient | undefined;
 
     constructor(options: LoonFSClient.Options) {
-        super({ ...options, environment: options.baseUrl });
+        super({
+            ...options,
+            environment: options.baseUrl,
+            fetch: streamingFetch(options.fetch ?? globalThis.fetch.bind(globalThis)),
+        });
     }
 
     public override get files(): FilesClient {
@@ -258,208 +322,150 @@ async function downloadProxied(
     };
 }
 
-async function stageBytes(
+async function stageStream(
     client: GeneratedLoonFSClient,
-    namespaceId: LoonFS.NamespaceId,
-    bytes: Uint8Array,
+    namespace: LoonFS.NamespaceId,
+    source: UploadSource,
+    scope: TransferScope,
+    options: FilesClient.RequestOptions,
+    send: typeof fetch,
 ): Promise<PreparedFileContent> {
-    const capabilities = await client.capabilities.retrieve();
-    const beginRequest = selectBeginRequest(capabilities, bytes);
-    const begin = await client.uploads.create({
-        namespace_id: namespaceId,
-        body: beginRequest,
-    });
-
-    switch (begin.mode) {
-        case "direct_put":
-            return stageDirectPut(client, namespaceId, bytes, begin);
-        case "direct_multipart":
-            return stageMultipart(client, namespaceId, bytes, begin);
-        case "service_proxied":
-            return stageServiceProxied(client, namespaceId, bytes, begin);
+    scope.check();
+    const capabilities = await client.capabilities.retrieve(options);
+    const size = source.expected ?? ((await source.empty()) ? 0 : undefined);
+    const features = capabilities.features ?? {},
+        limits = capabilities.limits ?? {};
+    let request: LoonFS.BeginUploadRequest;
+    if ((size === undefined || size >= MULTIPART_MIN_BYTES) && features[DIRECT_MULTIPART_FEATURE]) {
+        request = { mode: "direct_multipart" };
+    } else {
+        const fitsProxy =
+            size === undefined ||
+            limits[PROXY_UPLOAD_MAX_BYTES] === undefined ||
+            size <= limits[PROXY_UPLOAD_MAX_BYTES]!;
+        const fitsDirect =
+            size !== undefined &&
+            (limits[DIRECT_PUT_MAX_BYTES] === undefined || size <= limits[DIRECT_PUT_MAX_BYTES]!);
+        if (features[DIRECT_PUT_FEATURE] && fitsDirect && (size! >= MULTIPART_MIN_BYTES || !fitsProxy))
+            request = { mode: "direct_put", size_bytes: size };
+        else if (fitsProxy) request = { mode: "service_proxied" };
+        else throw new Error("source fits no advertised upload transport");
     }
-}
-
-function selectBeginRequest(
-    capabilities: LoonFS.CapabilityDocument,
-    bytes: Uint8Array,
-): LoonFS.BeginUploadRequest {
-    const features = capabilities.features ?? {};
-    const limits = capabilities.limits ?? {};
-    const supportsMultipart = features[DIRECT_MULTIPART_FEATURE] === true;
-    const worthCutting = bytes.byteLength >= MULTIPART_MIN_BYTES;
-    if (worthCutting && supportsMultipart) {
-        return { mode: "direct_multipart" };
-    }
-
-    const proxyLimit = limits[PROXY_UPLOAD_MAX_BYTES];
-    const fitsProxy = proxyLimit === undefined || bytes.byteLength <= proxyLimit;
-    const directPutLimit = limits[DIRECT_PUT_MAX_BYTES];
-    const fitsDirectPut = directPutLimit === undefined || bytes.byteLength <= directPutLimit;
-    if (features[DIRECT_PUT_FEATURE] === true && fitsDirectPut && (worthCutting || !fitsProxy)) {
-        return {
-            mode: "direct_put",
-            size_bytes: bytes.byteLength,
-        };
-    }
-    if (fitsProxy) {
-        return { mode: "service_proxied" };
-    }
-    throw new Error(`${bytes.byteLength} bytes fit no advertised upload transport`);
-}
-
-async function stageServiceProxied(
-    client: GeneratedLoonFSClient,
-    namespaceId: LoonFS.NamespaceId,
-    bytes: Uint8Array,
-    begin: LoonFS.BeginUploadResponse.ServiceProxied,
-): Promise<PreparedFileContent> {
+    const begin = await client.uploads.create({ namespace_id: namespace, body: request }, options);
+    let completion: LoonFS.UploadCompletion;
     try {
-        await client.uploads.putContent(arrayBuffer(bytes), namespaceId, begin.upload_id);
-        return stagedContent(
-            await client.uploads.complete({
-                namespace_id: namespaceId,
-                upload_id: begin.upload_id,
-                body: { mode: "service_proxied" },
-            }),
-        );
-    } catch (error) {
-        await abortQuietly(client, namespaceId, begin.upload_id);
-        throw error;
-    }
-}
-
-async function stageDirectPut(
-    client: GeneratedLoonFSClient,
-    namespaceId: LoonFS.NamespaceId,
-    bytes: Uint8Array,
-    begin: LoonFS.BeginUploadResponse.DirectPut,
-): Promise<PreparedFileContent> {
-    let upload: DirectPutBody;
-    try {
-        requirePresignedMethod(begin.access, "PUT", "direct PUT");
-        upload = await directPutBody(begin.checksum_algorithm, bytes);
-        const response = await fetch(begin.access.url, {
-            redirect: "error",
-            method: begin.access.method,
-            headers: begin.access.headers,
-            body: upload.body,
-        });
-        requireSuccessfulResponse(response, "direct PUT");
-    } catch (error) {
-        await abortQuietly(client, namespaceId, begin.upload_id);
-        throw error;
-    }
-    return stagedContent(
-        await client.uploads.complete({
-            namespace_id: namespaceId,
-            upload_id: begin.upload_id,
-            body: { mode: "direct_put", content: upload.content },
-        }),
-    );
-}
-
-async function stageMultipart(
-    client: GeneratedLoonFSClient,
-    namespaceId: LoonFS.NamespaceId,
-    bytes: Uint8Array,
-    begin: LoonFS.BeginUploadResponse.DirectMultipart,
-): Promise<PreparedFileContent> {
-    const { checksum_algorithm: algorithm, part_size_bytes: partSize } = begin;
-    if (!Number.isSafeInteger(partSize) || partSize <= 0) {
-        throw new Error(`invalid multipart part size ${partSize}`);
-    }
-    if (bytes.byteLength === 0) {
-        throw new Error("direct multipart upload cannot carry an empty payload");
-    }
-
-    const chunks = splitBytes(bytes, partSize);
-    const claims: LoonFS.UploadPartChecksumClaim[] = [];
-    for (const [index, chunk] of chunks.entries()) {
-        claims.push({
-            part_number: index + 1,
-            checksum: await checksum(algorithm, chunk),
-        });
-    }
-    const completedParts: LoonFS.CompletedUploadPart[] = [];
-    try {
-        const signed = await client.uploads.signParts({
-            namespace_id: namespaceId,
-            upload_id: begin.upload_id,
-            parts: claims,
-        });
-        const accessByPart = new Map(signed.parts.map((part) => [part.part_number, part.access]));
-        for (const [index, claim] of claims.entries()) {
-            const access = accessByPart.get(claim.part_number);
-            if (access === undefined) {
-                throw new Error(`server did not sign part ${claim.part_number}`);
-            }
-            requirePresignedMethod(access, "PUT", `part ${claim.part_number}`);
-            const response = await fetch(access.url, {
-                redirect: "error",
-                method: access.method,
-                headers: access.headers,
-                body: arrayBuffer(chunks[index]!),
-            });
-            requireSuccessfulResponse(response, `part ${claim.part_number}`);
-            const etag = response.headers.get("etag");
-            if (etag === null) {
-                throw new Error(`part ${claim.part_number} upload returned no etag`);
-            }
-            completedParts.push({
-                part_number: claim.part_number,
-                checksum: claim.checksum,
-                etag,
-            });
-        }
-    } catch (error) {
-        await abortQuietly(client, namespaceId, begin.upload_id);
-        throw error;
-    }
-
-    return stagedContent(
-        await client.uploads.complete({
-            namespace_id: namespaceId,
-            upload_id: begin.upload_id,
-            body: {
-                mode: "direct_multipart",
-                content: {
-                    size_bytes: bytes.byteLength,
-                    checksum: await checksum(algorithm, bytes),
+        if (begin.mode === "service_proxied") {
+            source.limit = limits[PROXY_UPLOAD_MAX_BYTES];
+            const response = await client.fetch(
+                `v0/namespaces/${encodeURIComponent(namespace)}/uploads/${encodeURIComponent(begin.upload_id)}/content`,
+                {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/octet-stream" },
+                    body: await uploadBody(source),
+                    duplex: "half",
+                } as RequestInit,
+                {
+                    timeoutInSeconds: options.timeoutInSeconds,
+                    maxRetries: 0,
+                    abortSignal: options.abortSignal,
+                    headers: await resolvedHeaders(options.headers),
                 },
-                parts: completedParts,
-            },
-        }),
+            );
+            requireSuccessfulResponse(response, "proxied upload");
+            await response.body?.cancel();
+            completion = { mode: "service_proxied" };
+        } else if (begin.mode === "direct_put") {
+            source.digest = new IncrementalChecksum(begin.checksum_algorithm);
+            await putStream(send, begin.access, await uploadBody(source), scope);
+            completion = {
+                mode: "direct_put",
+                content: { size_bytes: source.count, checksum: source.digest.finish() },
+            };
+        } else {
+            const partSize = begin.part_size_bytes;
+            if (!Number.isSafeInteger(partSize) || partSize <= 0)
+                throw new Error("invalid multipart part size");
+            source.digest = new IncrementalChecksum(begin.checksum_algorithm);
+            const parts: LoonFS.CompletedUploadPart[] = [];
+            while (true) {
+                const buffer = new Uint8Array(partSize);
+                let length = 0;
+                while (length < partSize) {
+                    const chunk = await source.read(partSize - length);
+                    if (!chunk) break;
+                    buffer.set(chunk, length);
+                    length += chunk.length;
+                }
+                if (!length) break;
+                if (parts.length === 10000) throw new Error("multipart upload exceeds 10000 parts");
+                const part = buffer.subarray(0, length),
+                    partNumber = parts.length + 1;
+                const digest = new IncrementalChecksum(begin.checksum_algorithm);
+                digest.update(part);
+                const checksum = digest.finish();
+                const signed = await client.uploads.signParts(
+                    {
+                        namespace_id: namespace,
+                        upload_id: begin.upload_id,
+                        parts: [{ part_number: partNumber, checksum }],
+                    },
+                    options,
+                );
+                if (signed.parts.length !== 1 || signed.parts[0]!.part_number !== partNumber)
+                    throw new Error(`server did not sign requested part ${partNumber}`);
+                const etag = await putStream(send, signed.parts[0]!.access, part, scope);
+                if (!etag) throw new Error(`part ${partNumber} returned no ETag`);
+                parts.push({ part_number: partNumber, checksum, etag });
+            }
+            completion = {
+                mode: "direct_multipart",
+                content: { size_bytes: source.count, checksum: source.digest.finish() },
+                parts,
+            };
+        }
+        source.finish();
+    } catch (error) {
+        try {
+            await client.uploads.abort(
+                { namespace_id: namespace, upload_id: begin.upload_id },
+                { timeoutInSeconds: 5, maxRetries: 0, abortSignal: AbortSignal.timeout(5000) },
+            );
+        } catch {
+            /* Preserve the transfer error. */
+        }
+        throw error;
+    }
+    // A lost completion response may still have completed the session.
+    const completed = await client.uploads.complete(
+        { namespace_id: namespace, upload_id: begin.upload_id, body: completion },
+        options,
     );
+    if (completed.status !== "completed") throw new Error(`upload is ${completed.status}, not completed`);
+    if (completed.content_ref.size_bytes !== source.count) throw new Error("completed upload size mismatch");
+    return { contentRef: completed.content_ref, contentToken: completed.content_token ?? undefined };
 }
 
-function splitBytes(bytes: Uint8Array, partSize: number): Uint8Array[] {
-    const parts: Uint8Array[] = [];
-    for (let offset = 0; offset < bytes.byteLength; offset += partSize) {
-        parts.push(bytes.subarray(offset, Math.min(offset + partSize, bytes.byteLength)));
-    }
-    return parts;
-}
-
-function stagedContent(response: LoonFS.UploadSession): PreparedFileContent {
-    if (response.status !== "completed") {
-        throw new Error(`upload ${response.upload_id} completed with status ${response.status}`);
-    }
-    return {
-        contentRef: response.content_ref,
-        contentToken: response.content_token,
-    };
-}
-
-async function abortQuietly(
-    client: GeneratedLoonFSClient,
-    namespaceId: LoonFS.NamespaceId,
-    uploadId: LoonFS.UploadId,
-): Promise<void> {
+async function putStream(
+    send: typeof fetch,
+    access: LoonFS.ObjectTransferAccess,
+    body: BodyInit,
+    scope: TransferScope,
+): Promise<string | null> {
+    requirePresignedMethod(access, "PUT", "upload");
+    scope.check();
+    const response = await send(access.url, {
+        redirect: "error",
+        method: "PUT",
+        headers: access.headers,
+        body,
+        signal: scope.signal,
+        duplex: "half",
+    } as RequestInit);
     try {
-        await client.uploads.abort({ namespace_id: namespaceId, upload_id: uploadId });
-    } catch {
-        // Preserve the transfer error.
+        requireSuccessfulResponse(response, "upload");
+        return response.headers.get("etag");
+    } finally {
+        await response.body?.cancel();
     }
 }
 
@@ -468,89 +474,21 @@ function requirePresignedMethod(
     expected: "GET" | "PUT",
     operation: string,
 ): void {
-    if (access.method !== expected) {
+    if (access.method !== expected)
         throw new Error(`${operation} received unsupported presigned method ${access.method}`);
-    }
 }
 
 function requireSuccessfulResponse(response: Response, operation: string): void {
-    if (!response.ok) {
-        throw new Error(`${operation} failed with HTTP ${response.status}`);
+    if (!response.ok) throw new Error(`${operation} failed with HTTP ${response.status}`);
+}
+
+async function resolvedHeaders(
+    headers: FilesClient.RequestOptions["headers"],
+): Promise<Record<string, string>> {
+    const result: Record<string, string> = {};
+    for (const [name, supplier] of Object.entries(headers ?? {})) {
+        const value = await core.Supplier.get(supplier);
+        if (value != null) result[name] = value;
     }
-}
-
-async function directPutBody(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): Promise<DirectPutBody> {
-    const body = arrayBuffer(bytes);
-    const sentBytes = new Uint8Array(body);
-    return {
-        body,
-        content: {
-            size_bytes: sentBytes.byteLength,
-            checksum: await checksum(algorithm, sentBytes),
-        },
-    };
-}
-
-async function checksum(algorithm: LoonFS.ChecksumAlgorithm, bytes: Uint8Array): Promise<LoonFS.Checksum> {
-    switch (algorithm) {
-        case "sha256": {
-            const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer(bytes));
-            return { algorithm, value: hex(new Uint8Array(digest)) };
-        }
-        case "crc32c":
-            return { algorithm, value: crc32c(bytes).toString(16).padStart(8, "0") };
-        case "crc64nvme":
-            return { algorithm, value: crc64Nvme(bytes).toString(16).padStart(16, "0") };
-    }
-}
-
-function hex(bytes: Uint8Array): string {
-    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
-}
-
-function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
-    const copy = new Uint8Array(bytes.byteLength);
-    copy.set(bytes);
-    return copy.buffer;
-}
-
-function makeCrc32cTable(): Uint32Array {
-    const table = new Uint32Array(256);
-    for (let index = 0; index < table.length; index += 1) {
-        let value = index;
-        for (let bit = 0; bit < 8; bit += 1) {
-            value = (value >>> 1) ^ ((value & 1) === 0 ? 0 : CRC32C_POLYNOMIAL);
-        }
-        table[index] = value >>> 0;
-    }
-    return table;
-}
-
-function crc32c(bytes: Uint8Array): number {
-    let value = 0xffffffff;
-    for (const byte of bytes) {
-        value = CRC32C_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
-    }
-    return (value ^ 0xffffffff) >>> 0;
-}
-
-function makeCrc64NvmeTable(): bigint[] {
-    const table: bigint[] = [];
-    for (let index = 0; index < 256; index += 1) {
-        let value = BigInt(index);
-        for (let bit = 0; bit < 8; bit += 1) {
-            value = (value >> 1n) ^ ((value & 1n) === 0n ? 0n : CRC64_NVME_POLYNOMIAL);
-        }
-        table.push(value & CRC64_MASK);
-    }
-    return table;
-}
-
-function crc64Nvme(bytes: Uint8Array): bigint {
-    let value = CRC64_MASK;
-    for (const byte of bytes) {
-        const index = Number((value ^ BigInt(byte)) & 0xffn);
-        value = CRC64_NVME_TABLE[index]! ^ (value >> 8n);
-    }
-    return (value ^ CRC64_MASK) & CRC64_MASK;
+    return result;
 }


### PR DESCRIPTION
SDK uploads currently require complete byte buffers even though downloads and recursive traversal are bounded. Add single-use streaming preparation and publication in Go, Python, and both TypeScript SDKs, with incremental checksums, bounded multipart parts, consistent transport controls, and no automatic payload replay; existing byte helpers use the same paths and retained prepared content supports publication retries. Shared conformance cases cover source and transport failures, size mismatches, timeout cleanup, and ambiguous completion, and all three SDK conformance suites plus Go race checks pass after regeneration. TypeScript preserves portable small fixed bodies and documents streaming-request support for large or unknown single-request uploads.
