### PR TITLE
perf(checkpoint): align metadata read-ahead windows

### DIFF
--- a/crates/loonfs-core/src/checkpoint/block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/block_load.rs
@@ -164,13 +164,13 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     let index = load_segment_index(store, segment_cache, memo, descriptor).await?;
     let needed = index_blocks_for_key_range(&index, lower_bound, upper_bound);
 
-    // A paged scan marches onward through the segment: read ahead so the
-    // following pages are served from the memo instead of their own GETs.
-    let extended_end = if readahead == Readahead::Enabled {
+    // Align the read-ahead end to a fixed window. Advancing within a cached
+    // window must not fetch one more speculative block on every lookup.
+    let extended_end = if readahead == Readahead::Enabled && !needed.is_empty() {
         needed
-            .start
-            .saturating_add(RANGE_SCAN_READAHEAD_BLOCKS)
-            .max(needed.end)
+            .end
+            .div_ceil(RANGE_SCAN_READAHEAD_BLOCKS)
+            .saturating_mul(RANGE_SCAN_READAHEAD_BLOCKS)
             .min(index.len())
     } else {
         needed.end


### PR DESCRIPTION
## Summary

Align the existing 32-block metadata read-ahead end to fixed windows instead of sliding it forward with every lookup. The sliding end can fetch another speculative trailing block even when the required blocks are already cached. This change removes that request amplification without adding a cache, concurrency, dependency, or runtime setting.

Required blocks, row validation, result assembly, and freshness checks remain unchanged. Empty selections do not trigger speculative reads. This is the primary improvement from the September 7 S3 experiment campaign; the separate 256 KiB tuning PR #886 builds on it.

## S3 benchmark evidence

Independent release processes, same Mac, S3 us-east-2, unchanged committed 10k/100k scenarios. Two runs per scale for both control and this candidate. Times are first / next 1,000-entry page wall milliseconds, **not percentiles**.

| Dataset | Control | This change |
|---|---:|---:|
| 10k | 560–678 / 719–831 ms | 83–91 / 133–155 ms |
| 100k | 585–591 / 1,304–1,516 ms | 90–171 / 140–262 ms |

At 100k, first/next-page GETs drop from 10 / 28–31 to 0 / 1–2. Every measured page retains one freshness HEAD. These pages are **partially warm**: an untimed 100-entry page precedes the measured page sequence.

Cold 100k page after stat improved from 1,139–1,188 to 603–695 ms. Initial stat was slower, 717–761 vs 660–661 ms, despite similar bytes and identical GET counts; causality is not established. Do not interpret the page win as universal sub-500-ms cold performance. Wider required ranges may warm a different bounded speculative tail.

## Validation and remaining gates

- All four candidate benchmark runs passed all four cases and cleaned their S3 prefixes. Recorded first/next pages have the expected 100/1,000 entries and continuation cursors.
- `git diff --check` passes. No local-store tests, unit tests, simulations, or other providers were run, per campaign constraints.
- Before merge: normal correctness suite plus empty/window-boundary/large ranges, sparse access, cache eviction, concurrent readers, and snapshot/WAL overlays. Benchmark success is not exhaustive content validation.
- Measurements pin baseline `53b1faf0ff4987edf9cd75490894af41e33a1dcb`, candidate `a40204a5014e3572aa96a1610ff59145fc6fc994`, and lab source `704c812` (documentation checkpoint `fa57506`). Current main `040d49db` leaves the edited file unchanged, but **the integrated newer tip has not been benchmarked**; rerun an S3 smoke before merge.

Candidate run IDs in loonfs_lab: `20260907T034101Z-bench-s3-10k`, `20260907T042213Z-bench-s3-10k`, `20260907T040254Z-bench-s3-100k`, `20260907T044346Z-bench-s3-100k`. Controls: `20260907T031157Z-bench-s3-10k`, `20260907T042533Z-bench-s3-10k`, `20260907T032056Z-bench-s3-100k`, `20260907T054052Z-bench-s3-100k`. Full campaign report is preserved in local lab commit `0ae5579`, `analysis/s3-page-experiment-results-20260907.md`.
