### PR TITLE
perf(checkpoint): raise small-segment eager reads to 256 KiB

### DIFF
--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -191,7 +191,7 @@ pub(super) fn segment_codec_error(
 /// publishes every section to the memo and shared cache. Sized to catch
 /// delta-run segments (one or two data blocks) while leaving base segments
 /// on the per-section path.
-const WHOLE_SEGMENT_LOAD_MAX_BYTES: u64 = 128 * 1024;
+const WHOLE_SEGMENT_LOAD_MAX_BYTES: u64 = 256 * 1024;
 
 /// A segment object's total stored length: the index block is the last
 /// section, so it ends the object.

--- a/crates/loonfs-core/src/checkpoint/block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/block_load.rs
@@ -164,13 +164,13 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     let index = load_segment_index(store, segment_cache, memo, descriptor).await?;
     let needed = index_blocks_for_key_range(&index, lower_bound, upper_bound);
 
-    // A paged scan marches onward through the segment: read ahead so the
-    // following pages are served from the memo instead of their own GETs.
-    let extended_end = if readahead == Readahead::Enabled {
+    // Align the read-ahead end to a fixed window. Advancing within a cached
+    // window must not fetch one more speculative block on every lookup.
+    let extended_end = if readahead == Readahead::Enabled && !needed.is_empty() {
         needed
-            .start
-            .saturating_add(RANGE_SCAN_READAHEAD_BLOCKS)
-            .max(needed.end)
+            .end
+            .div_ceil(RANGE_SCAN_READAHEAD_BLOCKS)
+            .saturating_mul(RANGE_SCAN_READAHEAD_BLOCKS)
             .min(index.len())
     } else {
         needed.end


### PR DESCRIPTION
## Summary

**Stacked on #885. Review/merge the aligned read-ahead fix first, then retarget this PR to main.** This PR's diff is only the independent one-line threshold adjustment: eagerly fetch metadata segment objects up to 256 KiB instead of 128 KiB on first touch.

The existing decoder, memo, and shared cache are reused; no new setting, cache, or concurrency. Keep this separately reviewable/revertible because its extra speculative transfer is a tuning tradeoff, not the read-ahead amplification correction itself.

## S3 benchmark evidence

Independent release processes, same Mac, S3 us-east-2, unchanged 10k/100k scenarios. Two independent runs per scale for control, aligned-only, and combined. Times are first / next 1,000-entry page wall milliseconds, not percentiles.

| Dataset | Control | #885 alone | #885 + this PR |
|---|---:|---:|---:|
| 10k | 560–678 / 719–831 ms | 83–91 / 133–155 ms | 66–67 / 60–122 ms |
| 100k | 585–591 / 1,304–1,516 ms | 90–171 / 140–262 ms | 79–80 / 66 ms |

At 100k the combination eliminates remaining measured warm-page GETs (aligned-only: 0 / 1–2; combined: 0 / 0), retaining one freshness HEAD on each page. **Partially warm** means one untimed 100-entry page precedes first/next 100 and first/next 1,000 measurements. Cold-page timing is a separate case and follows an initial stat.

## Tradeoffs

- Initial 100k stat fetches 1.023–1.028 MB vs ~0.759 MB with #885 alone: **~35% more bytes**, but 13 vs 16 GETs. Stat improved from 717–761 to 582–588 ms; the following cold page improved from 603–695 to 543–554 ms. Neither is universally below 500 ms.
- Initial 10k stat transfer nearly doubles (~0.30 to ~0.57 MB). Keep this policy separate for future sparse/multi-namespace cache-residency evaluation.
- Post-cold process RSS was 862–866 MiB versus aligned-only 839–880 MiB. These are phase snapshots, not true peaks, per-namespace budgets, or proof of no memory cost.
- Raising the threshold alone was insufficient at 100k (223 / 1,015 ms in one run). A 2 MiB experiment bought no additional warm GET reduction beyond this combination and fetched ~1.96 MB during initial stat, with observed RSS929 MiB; it is not included.
- Recommendation is based on this S3 workload. The constant applies to shared code; performance on other providers has not been evaluated.

## Validation and remaining gates

- All four combined benchmark runs passed all four cases, recorded expected page counts/cursors, and cleaned their S3 prefixes. `git diff --check` passes.
- No local-store tests, unit tests, simulations, or other providers were run, per campaign constraints. Before merge: normal correctness suite and threshold-boundary, sparse/eviction, concurrent-reader, and snapshot/WAL coverage; benchmark success is not exhaustive content validation.
- Baseline `53b1faf0ff4987edf9cd75490894af41e33a1dcb`; measured combined commit `66648090505a746120b545709efe53750b546f69`; aligned-only `a40204a5014e3572aa96a1610ff59145fc6fc994`; lab source `704c812` (documentation checkpoint `fa57506`). Current main `040d49db` leaves both edited files unchanged, but the integrated newer tip has not been benchmarked. Rerun an S3 smoke before merge.

Combined run IDs in loonfs_lab: `20260907T044051Z-bench-s3-10k`, `20260907T061120Z-bench-s3-10k`, `20260907T050248Z-bench-s3-100k`, `20260907T061415Z-bench-s3-100k`. Aligned and control IDs are in #885. The full campaign report is preserved in local lab commit `0ae5579`, `analysis/s3-page-experiment-results-20260907.md`.
