### PR TITLE
perf(uploads): reuse confirmed staging session state for completion

### DIFF
--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -222,9 +222,34 @@ where
     F: Fn(UploadSessionState) -> Fut,
     Fut: Future<Output = crate::error::Result<UploadSessionUpdate<T>>>,
 {
+    update_upload_session_from_initial(store, namespace_id, upload_id, None, update).await
+}
+
+/// Reuses a confirmed state/ETag pair for only the first conditional attempt.
+/// Contention reloads authoritative state through the usual retry loop.
+pub(crate) async fn update_upload_session_from_initial<S, T, F, Fut>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &UploadId,
+    mut initial: Option<LoadedControl<UploadSessionState>>,
+    update: F,
+) -> crate::error::Result<T>
+where
+    S: ObjectStore + ?Sized,
+    F: Fn(UploadSessionState) -> Fut,
+    Fut: Future<Output = crate::error::Result<UploadSessionUpdate<T>>>,
+{
     let update = &update;
     retry_while_contended(
-        || async move { try_update_upload_session(store, namespace_id, upload_id, update).await },
+        || {
+            let initial = initial.take();
+            async move {
+                match initial {
+                    Some(loaded) => try_update_loaded_upload_session(store, loaded, update).await,
+                    None => try_update_upload_session(store, namespace_id, upload_id, update).await,
+                }
+            }
+        },
         |_, ()| async { Ok::<_, CoreError>(WriteEvidence::Unknown) },
     )
     .await?
@@ -243,6 +268,19 @@ where
     Fut: Future<Output = crate::error::Result<UploadSessionUpdate<T>>>,
 {
     let loaded = load_upload_session_object(store, namespace_id, upload_id).await?;
+    try_update_loaded_upload_session(store, loaded, update).await
+}
+
+async fn try_update_loaded_upload_session<S, T, F, Fut>(
+    store: &S,
+    loaded: LoadedControl<UploadSessionState>,
+    update: F,
+) -> crate::error::Result<CasAttempt<T, CoreError>>
+where
+    S: ObjectStore + ?Sized,
+    F: FnOnce(UploadSessionState) -> Fut,
+    Fut: Future<Output = crate::error::Result<UploadSessionUpdate<T>>>,
+{
     match update(loaded.state).await? {
         UploadSessionUpdate::Noop(outcome) => Ok(CasAttempt::Settled(outcome)),
         UploadSessionUpdate::Replace { next, outcome } => {

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -10,9 +10,10 @@
 //! durable owner and status.
 
 use crate::context::MutationContext;
+use crate::control_object::LoadedControl;
 use crate::control_update::{
     create_control_object_under_generated_id, load_upload_session_state, update_upload_session,
-    UploadSessionUpdate,
+    update_upload_session_from_initial, UploadSessionUpdate,
 };
 use crate::error::{CoreError, Result};
 use crate::limits::{
@@ -44,7 +45,8 @@ use loonfs_api::{
 };
 use loonfs_objectstore::keys::{content_blob, upload_session};
 use loonfs_objectstore::{
-    ByteStream, MultipartCompletion, MultipartPart, ObjectStore, PROVIDER_MULTIPART_PART_BYTES,
+    ByteStream, MultipartCompletion, MultipartPart, ObjectMetadata, ObjectStore,
+    PROVIDER_MULTIPART_PART_BYTES,
 };
 use std::num::NonZeroU64;
 
@@ -417,6 +419,17 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
     session: NewUploadSession,
     context: &MutationContext,
 ) -> Result<UploadId> {
+    let (state, _) =
+        create_upload_session_with_state(store, namespace_id, session, context).await?;
+    Ok(state.upload_id)
+}
+
+async fn create_upload_session_with_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    session: NewUploadSession,
+    context: &MutationContext,
+) -> Result<(UploadSessionState, ObjectMetadata)> {
     let upload_id = UploadId::generate();
     let state = UploadSessionState {
         namespace_id: namespace_id.clone(),
@@ -436,8 +449,9 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
                 message: error.to_string(),
             }
         })?;
-    create_control_object_under_generated_id(store, &object_key, Bytes::from(encoded)).await?;
-    Ok(upload_id)
+    let metadata =
+        create_control_object_under_generated_id(store, &object_key, Bytes::from(encoded)).await?;
+    Ok((state, metadata))
 }
 
 /// Verifies that the namespace exists and accepts writes.
@@ -847,7 +861,28 @@ async fn freeze_completed_session<S: ObjectStore + ?Sized>(
     verified: &ContentRef,
     now_ms: u64,
 ) -> Result<CompletedUpload> {
-    update_upload_session(store, namespace_id, upload_id, |mut state| {
+    freeze_completed_session_from_initial(
+        store,
+        namespace_id,
+        content_store_id,
+        upload_id,
+        verified,
+        now_ms,
+        None,
+    )
+    .await
+}
+
+async fn freeze_completed_session_from_initial<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
+    upload_id: &UploadId,
+    verified: &ContentRef,
+    now_ms: u64,
+    initial: Option<LoadedControl<UploadSessionState>>,
+) -> Result<CompletedUpload> {
+    update_upload_session_from_initial(store, namespace_id, upload_id, initial, |mut state| {
         let namespace_id = namespace_id.clone();
         let content_store_id = content_store_id.clone();
         let upload_id = upload_id.to_owned();
@@ -892,6 +927,7 @@ async fn freeze_completed_session<S: ObjectStore + ?Sized>(
 struct OwnedStagingSession {
     upload_id: UploadId,
     content_id: ContentId,
+    initial: Option<LoadedControl<UploadSessionState>>,
 }
 
 /// Stores in-process bytes through an upload session and returns prepared
@@ -920,6 +956,7 @@ pub(crate) async fn stage_owned_bytes<S: ObjectStore + ?Sized>(
         &session.upload_id,
         stored.into_content_ref(),
         context,
+        session.initial,
     )
     .await
 }
@@ -961,6 +998,7 @@ pub(crate) async fn stage_owned_stream<S: ObjectStore + ?Sized>(
         &session.upload_id,
         staged.content_ref,
         context,
+        session.initial,
     )
     .await
 }
@@ -979,11 +1017,24 @@ async fn open_owned_staging_session<S: ObjectStore + ?Sized>(
     // the namespace is deleted first, garbage collection removes the
     // unreferenced completed session and content.
     let session = NewUploadSession::service_proxied();
-    let content_id = session.content_id.clone();
-    let upload_id = create_upload_session(store, catalog.namespace_id(), session, context).await?;
+    let (state, metadata) =
+        create_upload_session_with_state(store, catalog.namespace_id(), session, context).await?;
+    let upload_id = state.upload_id.clone();
+    let content_id = state.content_id.clone();
+    // If a provider cannot return a usable compare token, retain the old load path.
+    // The creation helper also confirms ambiguous successes before returning it.
+    let initial = metadata
+        .etag
+        .filter(|etag| !etag.trim().is_empty())
+        .map(|etag| LoadedControl {
+            object_key: upload_session(catalog.namespace_id(), &upload_id),
+            etag,
+            state,
+        });
     Ok(OwnedStagingSession {
         upload_id,
         content_id,
+        initial,
     })
 }
 
@@ -999,14 +1050,16 @@ async fn complete_owned_staging<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     content_ref: ContentRef,
     context: &MutationContext,
+    initial: Option<LoadedControl<UploadSessionState>>,
 ) -> Result<PreparedContent> {
-    Ok(freeze_completed_session(
+    Ok(freeze_completed_session_from_initial(
         store,
         catalog.namespace_id(),
         catalog.content_store_id(),
         upload_id,
         &content_ref,
         context.now_ms,
+        initial,
     )
     .await?
     .prepared)

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -497,8 +497,8 @@ async fn read_after_write_is_served_from_seeded_caches() {
         .expect("steady-state put");
     // The publish must read the live head and root for freshness. Because no
     // root has been published yet, it also reads the floor to distinguish a
-    // young namespace from a lost recovery root. The upload session that owns
-    // the staged content has to be read to be completed on its own etag.
+    // young namespace from a lost recovery root. The owned upload session reuses
+    // its confirmed creation state and etag, so completion needs no session GET.
     let write_gets = recording.take_get_keys();
     let uploads_prefix = loonfs_objectstore::keys::upload_session_prefix(&namespace_id);
     let classify = |suffix: &str| {
@@ -515,12 +515,12 @@ async fn read_after_write_is_served_from_seeded_caches() {
             .iter()
             .filter(|key| key.starts_with(&uploads_prefix))
             .count(),
-        1,
-        "one staging session is opened and completed per put, got {write_gets:?}"
+        0,
+        "owned session completion reuses its creation etag, got {write_gets:?}"
     );
     assert_eq!(
         write_gets.len(),
-        4,
+        3,
         "a steady-state write reads nothing beyond those controls, got {write_gets:?}"
     );
 

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -422,8 +422,8 @@ async fn a_put_pays_two_control_writes_for_the_session_that_owns_its_content() {
     assert_eq!(counts.overwrite_puts, 0, "a session is never clobbered");
     assert_eq!(
         sessions.count(OperationClass::Read),
-        1,
-        "the swap reads the etag it swaps on, and nothing else reads a session"
+        0,
+        "the completion swap reuses the confirmed creation etag without rereading the session"
     );
     assert_eq!(
         counts.deletes, 0,


### PR DESCRIPTION
Owned uploads reread the session they just created before completing it. Reuse its confirmed state and ETag for the first completion CAS, retaining the existing reload/retry path on contention and falling back when no usable ETag is available. This removes one S3 GET without changing write ordering or durability checks. Repeated S3 benchmarks improved steady 1 KiB writes from 555 to 487 ms at 10k entries and 579 to 508 ms at 100k (~12%). Validation: release builds and all 13 S3 runs passed, including streamed read-back and identical-commit replay. Targeted race/failure tests and the normal correctness suite remain required before merge.