### PR TITLE
test(gc): model shared-content ownership and collection

### DIFF
--- a/crates/loonfs-core/tests/content_lifecycle_model.rs
+++ b/crates/loonfs-core/tests/content_lifecycle_model.rs
@@ -1,0 +1,752 @@
+//! Executable design model, not a production collector.
+//!
+//! See docs/design/content-lifecycle.md for the protocol and proof premises.
+//! A capture here is one complete, protected namespace cut. Object-store reads,
+//! metadata traversal, clocks, and upload admission bounds need integration tests.
+
+use std::collections::HashSet;
+
+const NAMESPACES: usize = 3;
+const OLD: u8 = 1;
+const FRESH: u8 = 2;
+type Roots = u8;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+enum Head {
+    #[default]
+    Absent,
+    Active {
+        version: u8,
+        roots: Roots,
+    },
+    Deleted,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct Pin {
+    source: usize,
+    roots: Roots,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct Commit {
+    namespace: usize,
+    version: u8,
+    roots: Roots,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum Phase {
+    Capturing,
+    Sealed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct Run {
+    id: u8,
+    members: u8,
+    captured: u8,
+    roots: Roots,
+    candidates: Roots,
+    phase: Phase,
+}
+
+// Deliberately independent of current run ownership: a provider request already
+// issued by an old worker can finish after a newer run starts.
+#[derive(Clone, Copy, Debug)]
+struct DeleteRequest(Roots);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Rules {
+    Safe,
+    NoRegistrationBarrier,
+    EarlyPinRelease,
+    NoCreationFence,
+    NoHeadCas,
+    UnsealedDelete,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Model {
+    objects: Roots,
+    heads: [Head; NAMESPACES],
+    intents: [Option<Roots>; NAMESPACES],
+    pins: [Option<Pin>; NAMESPACES],
+    members: u8,
+    control_version: u8,
+    next_run: u8,
+    run: Option<Run>,
+    commit: Option<Commit>,
+    admitted_view: Option<Pin>,
+    // Abstracts expiry of every preparation right AND admitted publication.
+    // Fresh identities are never candidates until this becomes false.
+    fresh_admission_open: bool,
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        Self {
+            objects: OLD | FRESH,
+            heads: [
+                Head::Active {
+                    version: 0,
+                    roots: OLD,
+                },
+                Head::Absent,
+                Head::Absent,
+            ],
+            intents: [Some(OLD), None, None],
+            pins: [None; NAMESPACES],
+            members: 1,
+            control_version: 0,
+            next_run: 0,
+            run: None,
+            commit: None,
+            admitted_view: None,
+            fresh_admission_open: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Action {
+    PrepareFork(usize, usize),
+    Register(usize),
+    ReleasePin(usize),
+    Install(usize),
+    Cancel(usize),
+    Delete(usize),
+    Retire(usize),
+    AdmitView(usize),
+    ReleaseView,
+    PrepareCopy(usize),
+    Expire(usize),
+    PublishCopy,
+    PublishFresh(usize),
+    Begin,
+    Capture(usize),
+    Seal,
+    Sweep,
+    Finish,
+}
+
+impl Model {
+    fn capturing(&self) -> bool {
+        self.run.is_some_and(|run| run.phase == Phase::Capturing)
+    }
+
+    fn register(&mut self, target: usize, expected_version: u8, rules: Rules) -> bool {
+        if expected_version != self.control_version
+            || (self.capturing() && rules != Rules::NoRegistrationBarrier)
+            || self.intents[target].is_none()
+        {
+            return false;
+        }
+        self.members |= 1 << target;
+        self.control_version += 1;
+        true
+    }
+
+    fn capture(&mut self, namespace: usize, available: bool) -> bool {
+        let Some(run) = self.run else { return false };
+        if run.phase != Phase::Capturing {
+            return false;
+        }
+        let bit = 1 << namespace;
+        if run.members & bit == 0 {
+            return true;
+        }
+        if !available {
+            return false;
+        }
+        // All still-promised views are represented by roots, not just the
+        // current file revision. Pins remain relevant on a terminal source.
+        let mut roots = match self.heads[namespace] {
+            Head::Active { roots, .. } => roots,
+            Head::Absent => self.intents[namespace].expect("registered creation intent"),
+            Head::Deleted => 0,
+        };
+        for pin in self.pins.iter().flatten() {
+            if pin.source == namespace {
+                roots |= pin.roots;
+            }
+        }
+        if let Some(view) = self.admitted_view {
+            if view.source == namespace {
+                roots |= view.roots;
+            }
+        }
+        self.run = Some(Run {
+            captured: run.captured | bit,
+            roots: run.roots | roots,
+            ..run
+        });
+        true
+    }
+
+    fn seal(&mut self, expected_run: u8, expected_version: u8) -> bool {
+        let Some(run) = self.run else { return false };
+        if run.id != expected_run
+            || self.control_version != expected_version
+            || run.phase != Phase::Capturing
+            || run.captured != run.members
+        {
+            return false;
+        }
+        // The model collapses protected-root sealing and content-mark traversal:
+        // roots are already object sets. Production must durably seal both.
+        self.run = Some(Run {
+            phase: Phase::Sealed,
+            ..run
+        });
+        self.control_version += 1;
+        true
+    }
+
+    fn delete_request(&self, rules: Rules) -> Option<DeleteRequest> {
+        let run = self.run?;
+        if run.phase != Phase::Sealed && rules != Rules::UnsealedDelete {
+            return None;
+        }
+        Some(DeleteRequest(run.candidates & !run.roots))
+    }
+
+    fn deliver_delete(&mut self, request: DeleteRequest) {
+        self.objects &= !request.0;
+    }
+
+    fn abort(&mut self, expected_run: u8) -> bool {
+        if !self
+            .run
+            .is_some_and(|run| run.id == expected_run && run.phase == Phase::Capturing)
+        {
+            return false;
+        }
+        self.run = None;
+        self.control_version += 1;
+        true
+    }
+
+    // False means the actor must wait/retry. A lost create/head CAS is a
+    // completed rejected operation, so it advances the actor without writing.
+    fn step(&mut self, action: Action, rules: Rules) -> bool {
+        match action {
+            Action::PrepareFork(source, target) => {
+                let Head::Active { roots, .. } = self.heads[source] else {
+                    return false;
+                };
+                self.intents[target] = Some(roots);
+                self.pins[target] = Some(Pin { source, roots });
+            }
+            Action::Register(target) => return self.register(target, self.control_version, rules),
+            Action::ReleasePin(target) => {
+                if self.members & (1 << target) == 0
+                    && self.heads[target] != Head::Deleted
+                    && rules != Rules::EarlyPinRelease
+                {
+                    return false;
+                }
+                self.pins[target] = None;
+            }
+            Action::Install(target) => {
+                if self.members & (1 << target) == 0 {
+                    return false;
+                }
+                if self.heads[target] == Head::Absent {
+                    self.heads[target] = Head::Active {
+                        version: 0,
+                        roots: self.intents[target].expect("registered intent"),
+                    };
+                }
+            }
+            Action::Cancel(target) => {
+                if self.heads[target] == Head::Absent {
+                    if rules != Rules::NoCreationFence {
+                        self.heads[target] = Head::Deleted;
+                    }
+                    // Drop protection only after winning the terminal-head CAS.
+                    self.pins[target] = None;
+                }
+            }
+            Action::Delete(namespace) => self.heads[namespace] = Head::Deleted,
+            Action::Retire(namespace) => {
+                if self.capturing()
+                    || self.heads[namespace] != Head::Deleted
+                    || self
+                        .admitted_view
+                        .is_some_and(|view| view.source == namespace)
+                    || self
+                        .pins
+                        .iter()
+                        .flatten()
+                        .any(|pin| pin.source == namespace)
+                {
+                    return false;
+                }
+                self.members &= !(1 << namespace);
+                self.control_version += 1;
+            }
+            Action::AdmitView(namespace) => {
+                let Head::Active { roots, .. } = self.heads[namespace] else {
+                    return false;
+                };
+                self.admitted_view = Some(Pin {
+                    source: namespace,
+                    roots,
+                });
+            }
+            Action::ReleaseView => self.admitted_view = None,
+            Action::PrepareCopy(namespace) => {
+                let Head::Active { version, roots } = self.heads[namespace] else {
+                    return false;
+                };
+                self.commit = Some(Commit {
+                    namespace,
+                    version,
+                    roots,
+                });
+            }
+            Action::Expire(namespace) => {
+                let Head::Active { version, .. } = self.heads[namespace] else {
+                    return false;
+                };
+                // Abstract explicit release of the final local promise, after
+                // the namespace has released it. Independent admitted views
+                // retain their own protection.
+                self.heads[namespace] = Head::Active {
+                    version: version + 1,
+                    roots: 0,
+                };
+            }
+            Action::PublishCopy => {
+                let commit = self.commit.take().expect("prepared copy");
+                if let Head::Active { version, .. } = self.heads[commit.namespace] {
+                    if version == commit.version || rules == Rules::NoHeadCas {
+                        self.heads[commit.namespace] = Head::Active {
+                            version: version + 1,
+                            roots: commit.roots,
+                        };
+                    }
+                }
+            }
+            Action::PublishFresh(namespace) => {
+                let Head::Active { version, roots } = self.heads[namespace] else {
+                    return false;
+                };
+                if self.fresh_admission_open {
+                    self.heads[namespace] = Head::Active {
+                        version: version + 1,
+                        roots: roots | FRESH,
+                    };
+                }
+            }
+            Action::Begin => {
+                if self.run.is_some() {
+                    return false;
+                }
+                self.next_run += 1;
+                self.control_version += 1;
+                self.run = Some(Run {
+                    id: self.next_run,
+                    members: self.members,
+                    captured: 0,
+                    roots: 0,
+                    candidates: if self.fresh_admission_open {
+                        OLD
+                    } else {
+                        OLD | FRESH
+                    },
+                    phase: Phase::Capturing,
+                });
+            }
+            Action::Capture(namespace) => return self.capture(namespace, true),
+            Action::Seal => {
+                let run = self.run.expect("started run");
+                return self.seal(run.id, self.control_version);
+            }
+            Action::Sweep => {
+                let Some(request) = self.delete_request(rules) else {
+                    return false;
+                };
+                self.deliver_delete(request);
+            }
+            Action::Finish => {
+                if !self.run.is_some_and(|run| run.phase == Phase::Sealed) {
+                    return false;
+                }
+                self.run = None;
+                self.control_version += 1;
+            }
+        }
+        true
+    }
+
+    fn safe(&self) -> bool {
+        let mut promised = 0;
+        for (namespace, head) in self.heads.iter().enumerate() {
+            match head {
+                Head::Active { roots, .. } => {
+                    if self.members & (1 << namespace) == 0 {
+                        return false;
+                    }
+                    promised |= roots;
+                }
+                Head::Absent if self.members & (1 << namespace) != 0 => {
+                    promised |= self.intents[namespace].expect("registered intent");
+                }
+                _ => {}
+            }
+        }
+        for pin in self.pins.iter().flatten() {
+            promised |= pin.roots;
+        }
+        if let Some(view) = self.admitted_view {
+            promised |= view.roots;
+        }
+        promised & !self.objects == 0
+    }
+}
+
+const COLLECT: &[Action] = &[
+    Action::Begin,
+    Action::Capture(0),
+    Action::Capture(1),
+    Action::Capture(2),
+    Action::Seal,
+    Action::Sweep,
+    Action::Finish,
+];
+
+#[derive(Default)]
+struct Exploration {
+    states: usize,
+    completed: usize,
+    counterexample: Option<Vec<Action>>,
+}
+
+fn explore(initial: Model, actors: &[&[Action]], rules: Rules) -> Exploration {
+    let mut result = Exploration::default();
+    let mut seen = HashSet::new();
+    let mut pending = vec![(initial, vec![0; actors.len()], Vec::new())];
+    while let Some((model, positions, trace)) = pending.pop() {
+        if !seen.insert((model.clone(), positions.clone())) {
+            continue;
+        }
+        result.states += 1;
+        if !model.safe() {
+            result.counterexample = Some(trace);
+            return result;
+        }
+        if positions
+            .iter()
+            .zip(actors)
+            .all(|(position, actor)| *position == actor.len())
+        {
+            result.completed += 1;
+        }
+        for (index, actor) in actors.iter().enumerate() {
+            let Some(&action) = actor.get(positions[index]) else {
+                continue;
+            };
+            let mut next = model.clone();
+            if next.step(action, rules) {
+                let mut next_positions = positions.clone();
+                next_positions[index] += 1;
+                let mut next_trace = trace.clone();
+                next_trace.push(action);
+                pending.push((next, next_positions, next_trace));
+            }
+        }
+    }
+    result
+}
+
+fn assert_safe_schedules(initial: Model, actors: &[&[Action]]) {
+    let result = explore(initial, actors, Rules::Safe);
+    assert!(
+        result.counterexample.is_none(),
+        "unsafe trace: {:?}",
+        result.counterexample
+    );
+    assert!(
+        result.completed > 0,
+        "no complete schedule in {} states",
+        result.states
+    );
+    assert!(result.states > 10, "scenario explored too little state");
+}
+
+fn apply(model: &mut Model, actions: &[Action]) {
+    for &action in actions {
+        assert!(model.step(action, Rules::Safe), "blocked step: {action:?}");
+        assert!(model.safe(), "unsafe after {action:?}");
+    }
+}
+
+#[test]
+fn fork_registration_and_source_deletion_all_schedules() {
+    let fork = &[
+        Action::PrepareFork(0, 1),
+        Action::Register(1),
+        Action::ReleasePin(1),
+        Action::Install(1),
+    ];
+    assert_safe_schedules(Model::default(), &[fork, &[Action::Delete(0)], COLLECT]);
+    let broken = explore(
+        Model::default(),
+        &[fork, &[Action::Delete(0)], COLLECT],
+        Rules::NoRegistrationBarrier,
+    );
+    assert!(
+        broken.counterexample.is_some(),
+        "barrier removal must expose a lost fork"
+    );
+}
+
+#[test]
+fn source_protection_cannot_end_before_registration() {
+    let fork = &[
+        Action::PrepareFork(0, 1),
+        Action::ReleasePin(1),
+        Action::Register(1),
+        Action::Install(1),
+    ];
+    // This actor order must block under the protocol. Removing the ordering
+    // requirement lets collection miss both source and target.
+    let result = explore(
+        Model::default(),
+        &[fork, &[Action::Delete(0)], COLLECT],
+        Rules::Safe,
+    );
+    assert!(result.counterexample.is_none());
+    assert_eq!(result.completed, 0);
+    let broken = explore(
+        Model::default(),
+        &[fork, &[Action::Delete(0)], COLLECT],
+        Rules::EarlyPinRelease,
+    );
+    assert!(broken.counterexample.is_some());
+}
+
+#[test]
+fn cancelled_creator_cannot_resume_into_collected_content() {
+    let mut initial = Model::default();
+    apply(&mut initial, &[Action::PrepareFork(0, 1)]);
+    let creator = &[Action::Register(1), Action::Install(1)];
+    let cleanup = &[Action::Cancel(1), Action::Delete(0)];
+    assert_safe_schedules(initial.clone(), &[creator, cleanup, COLLECT]);
+    let broken = explore(
+        initial,
+        &[creator, cleanup, COLLECT],
+        Rules::NoCreationFence,
+    );
+    assert!(
+        broken.counterexample.is_some(),
+        "timeout-only cleanup must expose a late creator"
+    );
+}
+
+#[test]
+fn registered_creation_is_a_root_before_head_installation() {
+    let mut model = Model::default();
+    apply(
+        &mut model,
+        &[
+            Action::PrepareFork(0, 1),
+            Action::Register(1),
+            Action::ReleasePin(1),
+            Action::Delete(0),
+        ],
+    );
+    apply(&mut model, COLLECT);
+    assert_ne!(model.objects & OLD, 0);
+    apply(&mut model, &[Action::Install(1)]);
+}
+
+#[test]
+fn nested_fork_survives_deleted_ancestors_and_eventually_reclaims() {
+    let mut initial = Model::default();
+    apply(
+        &mut initial,
+        &[
+            Action::PrepareFork(0, 1),
+            Action::Register(1),
+            Action::ReleasePin(1),
+            Action::Install(1),
+        ],
+    );
+    let grandchild = &[
+        Action::PrepareFork(1, 2),
+        Action::Register(2),
+        Action::ReleasePin(2),
+        Action::Install(2),
+    ];
+    assert_safe_schedules(
+        initial.clone(),
+        &[grandchild, &[Action::Delete(0), Action::Delete(1)], COLLECT],
+    );
+    apply(&mut initial, grandchild);
+    apply(
+        &mut initial,
+        &[
+            Action::Delete(0),
+            Action::Delete(1),
+            Action::Retire(0),
+            Action::Retire(1),
+        ],
+    );
+    apply(&mut initial, COLLECT);
+    assert_ne!(initial.objects & OLD, 0);
+    apply(&mut initial, &[Action::Delete(2), Action::Retire(2)]);
+    apply(&mut initial, COLLECT);
+    assert_eq!(initial.objects & OLD, 0);
+    assert_eq!(initial.members, 0);
+}
+
+#[test]
+fn prepared_local_copy_cannot_restore_a_released_promise() {
+    let actors: &[&[Action]] = &[
+        &[Action::PrepareCopy(0), Action::PublishCopy],
+        &[Action::Expire(0)],
+        COLLECT,
+    ];
+    assert_safe_schedules(Model::default(), actors);
+    let broken = explore(Model::default(), actors, Rules::NoHeadCas);
+    assert!(broken.counterexample.is_some());
+}
+
+#[test]
+fn fresh_publication_is_excluded_until_all_admission_has_ended() {
+    assert_safe_schedules(Model::default(), &[&[Action::PublishFresh(0)], COLLECT]);
+    let mut model = Model {
+        fresh_admission_open: false,
+        ..Model::default()
+    };
+    apply(&mut model, COLLECT);
+    assert_eq!(model.objects & FRESH, 0);
+    apply(&mut model, &[Action::PublishFresh(0)]);
+    assert!(
+        model.safe(),
+        "an expired proof must not resurrect the reclaimed identity"
+    );
+}
+
+#[test]
+fn unavailable_member_and_unsealed_marks_never_authorize_delete() {
+    let mut model = Model::default();
+    apply(&mut model, &[Action::Begin]);
+    assert!(!model.capture(0, false));
+    assert!(!model.step(Action::Seal, Rules::Safe));
+    assert!(model.delete_request(Rules::Safe).is_none());
+    let request = model
+        .delete_request(Rules::UnsealedDelete)
+        .expect("negative control");
+    let mut broken = model.clone();
+    broken.deliver_delete(request);
+    assert!(
+        !broken.safe(),
+        "partial marks must expose the missing live root"
+    );
+    // A different worker can resume the same durable model state after failure.
+    let mut resumed = model.clone();
+    apply(&mut resumed, &COLLECT[1..]);
+    assert!(resumed.safe());
+}
+
+#[test]
+fn stale_registration_and_aborted_capture_cannot_bypass_control_cas() {
+    let mut model = Model::default();
+    apply(&mut model, &[Action::PrepareFork(0, 1)]);
+    let observed_version = model.control_version;
+    apply(&mut model, &[Action::Begin]);
+    assert!(!model.register(1, observed_version, Rules::Safe));
+    let old_run = model.run.expect("run").id;
+    let old_version = model.control_version;
+    assert!(model.abort(old_run));
+    apply(&mut model, &[Action::Register(1), Action::Begin]);
+    assert!(!model.seal(old_run, old_version));
+    assert!(!model.abort(old_run));
+    assert!(model.delete_request(Rules::Safe).is_none());
+    apply(&mut model, &COLLECT[1..]);
+}
+
+#[test]
+fn delayed_delete_from_an_old_run_remains_safe_in_a_new_run() {
+    let mut model = Model::default();
+    apply(&mut model, &[Action::Expire(0)]);
+    apply(&mut model, &COLLECT[..5]);
+    let delayed = model.delete_request(Rules::Safe).expect("sealed request");
+    apply(&mut model, &[Action::Finish, Action::PublishFresh(0)]);
+    apply(
+        &mut model,
+        &[
+            Action::PrepareFork(0, 1),
+            Action::Register(1),
+            Action::ReleasePin(1),
+            Action::Install(1),
+            Action::Begin,
+        ],
+    );
+    model.deliver_delete(delayed);
+    assert!(model.safe());
+    assert_eq!(model.objects, FRESH);
+    apply(&mut model, &COLLECT[1..]);
+}
+
+#[test]
+fn retirement_waits_for_capture_and_outgoing_transfer() {
+    let mut model = Model::default();
+    apply(&mut model, &[Action::PrepareFork(0, 1), Action::Delete(0)]);
+    assert!(!model.step(Action::Retire(0), Rules::Safe));
+    apply(
+        &mut model,
+        &[Action::Register(1), Action::ReleasePin(1), Action::Begin],
+    );
+    assert!(!model.step(Action::Retire(0), Rules::Safe));
+    apply(&mut model, &COLLECT[1..]);
+    apply(&mut model, &[Action::Retire(0), Action::Install(1)]);
+}
+
+#[test]
+fn admitted_view_outlives_release_of_its_namespace_promise() {
+    let actors: &[&[Action]] = &[
+        &[Action::AdmitView(0), Action::ReleaseView],
+        &[Action::Expire(0), Action::Delete(0)],
+        COLLECT,
+    ];
+    assert_safe_schedules(Model::default(), actors);
+    let mut model = Model::default();
+    apply(&mut model, &[Action::AdmitView(0), Action::Delete(0)]);
+    assert!(!model.step(Action::Retire(0), Rules::Safe));
+    apply(&mut model, COLLECT);
+    assert_ne!(model.objects & OLD, 0);
+    apply(&mut model, &[Action::ReleaseView, Action::Retire(0)]);
+    apply(&mut model, COLLECT);
+    assert_eq!(model.objects & OLD, 0);
+}
+
+#[test]
+fn cancelling_an_absent_target_and_retiring_it_eventually_reclaims() {
+    let mut model = Model::default();
+    apply(
+        &mut model,
+        &[
+            Action::PrepareFork(0, 1),
+            Action::Register(1),
+            Action::Cancel(1),
+            Action::Delete(0),
+            Action::Retire(0),
+            Action::Retire(1),
+        ],
+    );
+    apply(&mut model, COLLECT);
+    assert_eq!(model.objects & OLD, 0);
+    assert_eq!(model.members, 0);
+    // A registration CAS delayed until after cleanup may leave an extra row;
+    // its delayed head installation still loses to the terminal head.
+    apply(
+        &mut model,
+        &[Action::Register(1), Action::Install(1), Action::Retire(1)],
+    );
+    assert_eq!(model.heads[1], Head::Deleted);
+}

--- a/docs/design/content-lifecycle.md
+++ b/docs/design/content-lifecycle.md
@@ -1,0 +1,217 @@
+# Shared-content ownership and collection
+
+Status: proposed protocol, with an executable bounded model in
+`crates/loonfs-core/tests/content_lifecycle_model.rs`. This is step 1 of the
+content-lifecycle work. It does not change the storage format, enable published
+content deletion, or change the launch policy of permanent retention.
+
+Baseline: `4bea72dae4de1478f9ff2c1c4ba39b8607162011`.
+
+## Decision
+
+Keep file commits local to their namespace. Serialize membership changes with
+one content-store control CAS. While a collector captures the registered roots,
+that CAS temporarily closes registration and membership removal. Reopen them
+once the complete root set has been durably protected. Marking and sweeping can
+then continue without holding the registration barrier.
+
+A fork transfers protection, never just a content identifier. Until its target
+is registered, its source checkpoint protects the inherited view. Registration
+makes the target's creation basis discoverable even before its head exists.
+Only then may the source-side transfer protection be released. Other metadata
+protection required by a live fork remains in place.
+
+This chooses a bounded-memory capture with potentially unbounded elapsed time
+over a second protocol for registering concurrent additions during capture.
+Creating namespaces and registering forks may wait for capture or its explicit
+abort. File writes, uploads, local copies, and namespace head tombstones do not
+wait for it. This is a real availability tradeoff, especially for large fork
+families or an unavailable member. Measure capture latency before enabling the
+collector; do not quietly add timeouts that bypass the barrier.
+
+## Authorities and linearization points
+
+These are logical records, not a new wire schema or a commitment to object-key
+spellings. All records belong to the existing `content_store_id` boundary.
+
+| Record | Authority and transition |
+| --- | --- |
+| Content-store control | One CAS selects a membership root and the current collection run. `open -> capturing -> open` gates membership edits. A sealed run may still be marking or sweeping while membership is open. Only one run is current. |
+| Membership | A bounded, immutable, paged index selected by the control record. Entries name namespaces and their immutable creation intents, including a fork's complete initial basis. Register/remove by publishing replacement index pages and CASing the control pointer while open. Never put all members in one mutable array. |
+| Namespace head | The existing create-if-absent write makes a namespace live. The existing terminal tombstone ends its public promises and prevents ID reuse. Ordinary commits still CAS this head. |
+| Source checkpoint | Holds a fork's source view before registration. Cleanup must establish that the target was registered, or permanently prevent that attempt from publishing, before releasing transfer protection. An expired clock alone is insufficient. |
+| Collection run and root pages | The control CAS starts a run against a fixed membership root. Capture records the full protected roots of each member. Sealing requires complete, verified, durable root pages and protection of the metadata they name. Only a sealed run may authorize content deletion. |
+
+A registry entry is lifecycle authority, not a copy of current file state. Its
+creation intent protects a registered target whose head is absent. Once a head
+exists, that head determines whether the namespace is active or terminal.
+Never treat a failed head read as an absent head.
+
+Candidate index pages written before a lost control CAS are unpublished orphans.
+A delayed registration must retry its CAS and observe `capturing`; a prior read
+of `open` is not an admission token. Index page reclamation and root-page
+protection must obey the existing immutable-metadata publication rules.
+
+## Creation, fork, cancellation, and retirement
+
+1. Prepare a complete creation intent. An independent namespace has a fresh
+   content store and no old content. A fork first obtains a source checkpoint
+   through the namespace's validated checkpoint publication path.
+2. Register the intent with the content-store control CAS. While capture is in
+   progress, wait or return a retryable result. Continue protecting the source
+   view while waiting; cancellation must fence publication before dropping it.
+3. Install the complete target head with create-if-absent. Registration already
+   protects the creation basis if the creator pauses before this write.
+4. Reconcile uncertain outcomes by reading authoritative records. Do not create
+   a second target or silently switch to a new source basis under the same
+   registered intent.
+
+An abandoned attempt consumes its namespace ID. Cleanup races the creator's
+head installation by conditionally installing a **terminal head** at the absent
+head key. If cleanup wins, every delayed create-if-absent fails. If the creator
+wins, cleanup must recognize the installed namespace and cannot tombstone it as
+an orphan. A head belonging to a different attempt also fences this attempt;
+its metadata must not be adopted as this intent's outcome. This deliberately
+uses the existing active/deleted head states rather than a new `creating` state.
+Only the admitted creator may install the intent; public writes cannot operate
+on registration alone.
+
+Cancellation before registration also needs this head fence. A delayed registry
+CAS might still add a now-terminal intent, but it cannot make the namespace live;
+a later pass removes that entry. The creation basis is not a public read promise
+for a terminal target. Initial content-store publication needs its own
+create-if-absent control record before installing its first head.
+
+Namespace deletion still tombstones the head first. Remove membership only when
+the head is terminal and all outgoing, not-yet-transferred fork protections have
+ended, including already admitted operations that still require a view.
+Membership removal uses the same open-state CAS as registration. A
+terminal member may still protect an outgoing fork; capture must inspect those
+protections even though public namespace reads are rejected. Deletion closes
+admission; it cannot revoke an already promised operation midway through its
+read. A snapshot is still not a way to reopen a deleted namespace.
+
+Registered descendants protect the full closure of their own metadata bases,
+including source-owned metadata. Parent and grandparent deletion does not remove
+those dependencies. Do not replace the current conservative ancestry rule until
+both metadata GC and content GC can follow this closure. In particular, a live
+fork's source checkpoint cannot simply be released because registration exists:
+registration transfers *content capture* responsibility, not permission for the
+old namespace metadata collector to delete that checkpoint's inputs.
+
+## Collection and the protection argument
+
+At run start, select only objects whose preparation/publication rights have
+already ended. Freeze this candidate cutoff for the entire run. Object creation
+age alone is insufficient: an upload can complete much later than its first
+object write. Reuse the completed-upload admission window and full publication
+budget from `limits.rs`; do not replace them with a guessed grace period. New
+objects and objects with remaining publication rights are not candidates.
+
+The control CAS then fixes the membership root and closes membership edits.
+Capture each member's full promise: current metadata and visible WAL, retained
+history, recoverable deletions, promised replay views, snapshots/checkpoints,
+and outgoing fork protections. Capture a registered but absent target from its
+creation intent. Capture a terminal member's surviving outgoing protections.
+Persist protected root pages incrementally; do not gather the family in memory.
+
+Each namespace capture must be a validated cut of its head and independently
+published protections. It is **not** one head GET followed by an unchecked
+checkpoint listing. The implementation must validate publication/retirement
+races, preserve the captured immutable metadata until traversal finishes, and
+cooperate with namespace metadata GC. A source checkpoint created after its
+source was captured is safe only because it derives from that captured promise
+or from content outside the candidate cutoff. The existing bounded checkpoint
+publication rules remain necessary while acquiring that protection.
+
+Seal the protected root set before reopening membership. Traverse those roots
+with the existing bounded mark/merge machinery; seal complete content marks
+before issuing any DELETE. Missing coverage blocks sealing. Corruption fails
+visibly. A capture may be explicitly aborted by CAS, reopening membership, but
+an aborted or replaced run can never subsequently seal or authorize deletion.
+
+The safety argument for an old candidate is:
+
+- A local commit may keep, remove, or copy an already promised reference. It may
+  introduce uploaded content only while its namespace-bound preparation proof
+  admits publication. Candidate selection excludes that entire window. A
+  stale local candidate must lose the head CAS and be revalidated; history
+  expiration cannot be bypassed by replaying a prepared copy or restore.
+- A fork registered before capture is in the fixed membership, including when
+  its head installation is paused. If registration comes later, its source
+  protection survives through capture. If that protection was created after
+  source capture, its old content was already protected by the source's cut.
+- Deleting a source cannot erase an outgoing transfer protection. Retiring a
+  member cannot race membership capture. Once protection is transferred, the
+  registered target or a subsequent protected descendant carries it.
+
+Therefore an unmarked candidate has no route back into a promised view. This
+last property matters beyond the current run: an already issued provider DELETE
+may arrive after collector handoff or a later run. A run-ID check cannot retract
+that request. Its safety comes from immutable, never-reused content identities
+and the prohibition on resurrecting an unprotected identity. Fresh-identity
+imports preserve this property. An identity-preserving import would require a
+new proof and is outside this design.
+
+Run/progress CASes still fence stale workers. A replacement worker resumes the
+same durable run; starting a later run cannot adopt incomplete marks from an
+aborted one. Aborting capture abandons its pages under normal protected-object
+cleanup; it does not authorize sweeping. Sealed runs retain their metadata roots
+until traversal and any required protection handoff have completed.
+
+## Routes audited in the current code
+
+| Route | Obligation for this protocol |
+| --- | --- |
+| Upload completion and prepared writes (`content/`, `publish/`) | Namespace-bound proof; exclude candidates until the last admitted publication can finish. An uncompleted session owns its object and transfer cleanup. |
+| Raw-reference import (`fs/writes.rs`) | Preserve verified copying to a fresh destination identity, even inside one content store. |
+| Copy and restore (`commit/validate/`, `commit/materialize.rs`) | Resolve a promised source in the namespace view and revalidate after a lost head CAS. |
+| Fork (`namespace/fork.rs`) | Acquire source protection, register the exact creation intent, then install the target. Preserve metadata ancestry independently of public source readability. |
+| Bootstrap (`namespace/bootstrap.rs`) | Publish lifecycle membership before the active head; replace the current single-write creation contract deliberately. |
+| Namespace deletion (`namespace/delete.rs`, `fs/namespaces.rs`) | Preserve writer fencing and the runtime barrier; tombstone before membership removal. |
+| Checkpoint creation/release and fork cleanup (`checkpoint/`, `gc/fork_checkpoints.rs`) | Account for promised views and admitted publications; never drop the last pre-registration transfer protection based only on time or a missing head. |
+| Replay, flush, compaction (`metadata/`, `wal/`) | Preserve every still-promised view and captured root. Physical row removal is not itself authorization to reclaim bytes. |
+| Future expiration/discard | Publish through the semantic commit path, retaining current revisions and independent promises. No policy change in this step. |
+| Upload GC (`gc/`) | Define one ownership handoff before adding prefix sweep: a removed completed session must not hide eligibility evidence or allow a second collector to use incompatible roots. |
+
+## Executable model and limits
+
+Run `cargo test -p loonfs-core --test content_lifecycle_model`.
+
+The dependency-free model explores all schedules of short, ordered actors. It
+models membership CAS, namespace head CAS/create-if-absent, source protection,
+registration, capture, seal, cancellation, and delayed physical deletion as
+separate steps. It asserts after every step that every promised object exists
+and every active namespace is registered. Negative controls intentionally remove
+individual safeguards and must produce a counterexample.
+
+A namespace root capture abstracts a **complete, validated, protected cut**;
+the model does not implement that multi-object read protocol. Likewise it treats
+candidate admission as already closed under the real upload timing bound and
+models one old object and one fresh object, not provider clocks or multipart
+uploads. An admitted view represents a still-promised operation independently
+of the namespace head; it does not prescribe a durable write for every read.
+The eventual read-admission protocol must establish that protection, or specify
+and enforce a complete bounded lifetime before reclaiming its bytes. These are
+explicit proof premises, not conclusions of the model.
+Deterministic storage fault tests must establish those premises in the real code
+before this proposal becomes a format requirement or enables deletion.
+
+The model checks finite safety schedules and concrete quiescent cleanup through
+multiple generations. It is not an unbounded model checker or a proof of
+production liveness. Eventual reclamation additionally requires fair retries,
+complete pagination, bounded resume progress, eventual end of protections, and
+available storage. Failed creations must be fenced and retired, including
+creation intents that were never installed. An active fork keeps inherited
+content as long as its view promises it; an entirely deleted family must not
+retain content merely because its ancestors once materialized metadata.
+
+## Next implementation gate
+
+Step 2 starts by implementing and fault-testing the validated namespace root cut
+and the source-checkpoint-to-registration handoff against the real object-store
+seams, before wiring membership into public namespace creation.
+Select the concrete bounded membership index after those tests establish its
+needed operations. Then specify the wire records and version gate together;
+old writers and collectors must reject the new format, with no mixed-format
+fallback. Do not enable deletion from this model alone.


### PR DESCRIPTION
Shared-content collection needs an ownership protocol that handles forks, deleted ancestors, and delayed publishers without adding coordination to ordinary file commits. Propose a content-store registration barrier during root capture, transfer protection through registered creation intents, and fence abandoned creators with the existing terminal namespace head.

Add a standalone executable model with 13 tests exploring operation schedules, cancellation, admitted views, stale publication, delayed deletes, and final-owner cleanup. Negative controls must find data-loss counterexamples when key safeguards are removed. Document the real object-store capture, metadata protection, and upload timing obligations that the model abstracts. Production behavior, the durable format, and permanent retention remain unchanged.

Validation: the model tests, targeted Clippy with warnings denied, formatting, and diff checks pass. Registration may wait during capture, and cancelled creation consumes its namespace ID.
