### PR TITLE
feat(namespace): fork from a live snapshot

### DIFF
--- a/crates/loonfs-api/src/options.rs
+++ b/crates/loonfs-api/src/options.rs
@@ -270,3 +270,10 @@ pub struct DirectMultipartUploadOptions {
     /// default; providers allow at most 10,000 parts.
     pub part_size_bytes: Option<u64>,
 }
+
+/// Selects the source state for a namespace fork.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ForkNamespaceOptions {
+    /// Fork from this live snapshot instead of the current head.
+    pub snapshot_id: Option<crate::CheckpointId>,
+}

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -158,6 +158,10 @@ pub struct CreateNamespaceRequest {
 pub struct ForkNamespaceRequest {
     /// Durable namespace id for the fork target.
     pub new_namespace_id: NamespaceId,
+    /// Fork from this live snapshot instead of the current head.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub snapshot_id: Option<CheckpointId>,
 }
 
 /// Current state for one namespace.

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -787,6 +787,9 @@ pub(crate) struct NamespaceForkArgs {
     pub source: String,
     #[arg(value_hint = ValueHint::Other)]
     pub new_namespace_id: String,
+    /// Fork from a live snapshot instead of the current head.
+    #[arg(long = "snapshot", value_name = "id")]
+    pub snapshot_id: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -123,17 +123,18 @@ impl ResolvedTarget {
         &self,
         source_namespace_id: &NamespaceId,
         new_namespace_id: &NamespaceId,
+        options: loonfs::ForkNamespaceOptions,
     ) -> Result<Namespace, CliError> {
         match self {
             Self::Embedded(target) => {
                 target
                     .backend
-                    .fork_namespace(source_namespace_id, new_namespace_id)
+                    .fork_namespace(source_namespace_id, new_namespace_id, options)
                     .await
             }
             Self::Remote(target) => Ok(target
                 .client
-                .fork_namespace(source_namespace_id, new_namespace_id)
+                .fork_namespace(source_namespace_id, new_namespace_id, &options)
                 .await?),
         }
     }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -165,10 +165,11 @@ impl EmbeddedBackend {
         &self,
         source_namespace_id: &NamespaceId,
         new_namespace_id: &NamespaceId,
+        options: loonfs::ForkNamespaceOptions,
     ) -> Result<Namespace, CliError> {
         let result = self
             .writer
-            .fork_namespace(source_namespace_id, new_namespace_id)
+            .fork_namespace_with(source_namespace_id, new_namespace_id, options)
             .await
             .scoped(source_namespace_id);
         self.drain_runner_after(result).await

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -160,9 +160,19 @@ async fn run_namespace_fork(
     let new_namespace_id = parse_namespace_id(&args.new_namespace_id)
         .map_err(|error| error.with_param("new_namespace_id"))
         .map_err(|error| context.fail(kind, error))?;
+    let snapshot_id = args
+        .snapshot_id
+        .as_deref()
+        .map(super::snapshot::parse_snapshot_id)
+        .transpose()
+        .map_err(|error| context.fail(kind, error))?;
     let namespace = context
         .target
-        .fork_namespace(&source_namespace_id, &new_namespace_id)
+        .fork_namespace(
+            &source_namespace_id,
+            &new_namespace_id,
+            loonfs::ForkNamespaceOptions { snapshot_id },
+        )
         .await
         .map_err(|error| context.fail(kind, error))?;
 

--- a/crates/loonfs-cli/src/commands/snapshot.rs
+++ b/crates/loonfs-cli/src/commands/snapshot.rs
@@ -26,7 +26,7 @@ async fn resolve_snapshot_context(
     Ok(context)
 }
 
-fn parse_snapshot_id(value: &str) -> Result<CheckpointId, CliError> {
+pub(super) fn parse_snapshot_id(value: &str) -> Result<CheckpointId, CliError> {
     CheckpointId::parse(value).map_err(|error| {
         CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
             .with_param("snapshot_id")

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -1045,6 +1045,38 @@ fn embedded_profile_namespace_fork_reads_shared_content_and_diverges() {
 }
 
 #[test]
+fn embedded_namespace_fork_uses_the_selected_snapshot() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = harness.temp_dir.path().join("file.txt");
+    fs::write(&payload, b"captured").expect("payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("path"), "/first.txt"]));
+    let snapshot = harness.run(&[
+        "--json", "snapshot", "create", "demo", "--name", "basis", "--ttl-ms", "60000",
+    ]);
+    assert_success(&snapshot);
+    let snapshot = json_data(&snapshot);
+    assert_success(&harness.run(&["put", payload.to_str().expect("path"), "/second.txt"]));
+    let fork = harness.run(&[
+        "--json",
+        "namespace",
+        "fork",
+        "demo",
+        "clone",
+        "--snapshot",
+        snapshot["snapshot_id"].as_str().expect("snapshot id"),
+    ]);
+    assert_success(&fork);
+    assert_eq!(json_data(&fork)["head_seq"], snapshot["head_seq"]);
+    assert_success(&harness.run(&["stat", "--namespace", "clone", "/first.txt"]));
+    let missing = harness.run(&["--json", "stat", "--namespace", "clone", "/second.txt"]);
+    assert_failure(&missing);
+    assert_eq!(json_error(&missing)["code"], "path_not_found");
+}
+
+#[test]
 fn embedded_namespace_commands_reject_invalid_namespace_ids() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -68,9 +68,9 @@ pub use ClientError as Error;
 /// embedded `loonfs` runtime so the two surfaces cannot drift a field apart.
 pub use loonfs_api::options::{
     CommitOptions, CopyOptions, CreateDirectoryOptions, DeleteOptions,
-    DirectMultipartUploadOptions, ListInodeChildrenOptions, ListPathEntriesOptions, MoveOptions,
-    PutFileOptions, RestoreRevisionOptions, StatPathOptions, UndeleteOptions,
-    UpdateAttributesOptions,
+    DirectMultipartUploadOptions, ForkNamespaceOptions, ListInodeChildrenOptions,
+    ListPathEntriesOptions, MoveOptions, PutFileOptions, RestoreRevisionOptions, StatPathOptions,
+    UndeleteOptions, UpdateAttributesOptions,
 };
 
 /// Result type returned by the client.

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -608,7 +608,9 @@ mod tests {
 
         let (transport, client) = single_attempt_probe();
         assert_single_attempt(
-            client.fork_namespace(&namespace_id, &fork_id).await,
+            client
+                .fork_namespace(&namespace_id, &fork_id, &ForkNamespaceOptions::default())
+                .await,
             &transport,
         );
         drop(transport);

--- a/crates/loonfs-client/src/reads.rs
+++ b/crates/loonfs-client/src/reads.rs
@@ -169,12 +169,13 @@ impl Client {
             .await
     }
 
-    /// Creates a new namespace from the source namespace's current state and
+    /// Creates a new namespace from the selected current head or live snapshot and
     /// returns the target's state at the fork point.
     pub async fn fork_namespace(
         &self,
         source_namespace_id: &NamespaceId,
         new_namespace_id: &NamespaceId,
+        options: &ForkNamespaceOptions,
     ) -> Result<Namespace> {
         let url = format!(
             "{}/v0/namespaces/{source_namespace_id}/forks",
@@ -185,6 +186,7 @@ impl Client {
             self.post(&url),
             Some(&ForkNamespaceRequest {
                 new_namespace_id: new_namespace_id.clone(),
+                snapshot_id: options.snapshot_id.clone(),
             }),
             SendPolicy::Once,
         )

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -28,19 +28,6 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     owner: CheckpointOwner,
     context: &MutationContext,
 ) -> Result<Checkpoint> {
-    // Checkpoint creation pins a manifest version as a first-class record
-    // under `checkpoints/`, write-then-verify (format spec, "Checkpoints"):
-    //
-    // 1. Choose a basis manifest that the metadata root references,
-    //    flushing the WAL tail first when it lags the head (`flush.rs`).
-    // 2. Write `checkpoints/{id}.json` with state = active, under a freshly
-    //    generated id — one logical pin, one record, never a reuse of some
-    //    earlier record's key.
-    // 3. Verify, after the write is durable, that the floor has not passed
-    //    the basis and the basis manifest still loads, under the verify
-    //    budget.
-    // 4. On verification failure, release the record — terminally — and
-    //    retry against a newer basis under a new id.
     validate_checkpoint_owner(&owner)?;
     let timer = &StdMonotonicTimer::default();
     let owner = &owner;
@@ -55,60 +42,83 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
                 }
             };
 
-            let checkpoint_id = CheckpointId::generate();
-            let record = CheckpointRecordState {
-                checkpoint_id: checkpoint_id.clone(),
-                namespace_id: namespace_id.clone(),
-                manifest: basis.manifest.clone(),
-                head_commit_id: basis.head_commit_id.clone(),
-                created_at_ms: context.now_ms,
-                owner: owner.clone(),
-                status: CheckpointStatus::Active {},
-            };
-            let verify_started_ms = timer.monotonic_now_ms();
-            write_checkpoint_record(store, &record).await?;
-
-            let verification = match verify_checkpoint_basis(store, &record).await {
-                Ok(verification) => verification,
-                Err(error) => {
-                    // Cleanup is best effort on an error and must not replace its
-                    // original classification.
-                    if let Err(cleanup_error) = release_checkpoint_record(
-                        store,
-                        namespace_id,
-                        &checkpoint_id,
-                        context.now_ms,
-                    )
-                    .await
-                    {
-                        tracing::warn!(
-                            namespace_id = %namespace_id,
-                            checkpoint_id = %checkpoint_id,
-                            original_error = %error,
-                            cleanup_error = %cleanup_error,
-                            "failed to release a checkpoint record after basis verification failed"
-                        );
-                    }
-                    return Err(error);
+            match create_checkpoint_at_basis(
+                store,
+                namespace_id,
+                owner.clone(),
+                basis.manifest.clone(),
+                basis.head_commit_id.clone(),
+                context,
+            )
+            .await
+            {
+                Ok(checkpoint) => Ok(CasAttempt::Settled(checkpoint)),
+                Err(error @ CoreError::CheckpointUnavailable(_)) => {
+                    Ok(CasAttempt::Contended(error))
                 }
-            };
-            let within_budget = timer.monotonic_now_ms().saturating_sub(verify_started_ms)
-                <= CHECKPOINT_VERIFY_BUDGET_MS;
-            if verification == CheckpointBasisVerification::Verified && within_budget {
-                return Ok(CasAttempt::Settled(super::checkpoint_summary(record)));
+                Err(error) => Err(error),
             }
-
-            // Overrunning the budget counts as verification failure: the record
-            // may have raced the grace window, so it must not stand as a root.
-            release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms).await?;
-            Ok(CasAttempt::Contended(CoreError::CheckpointUnavailable(
-                "checkpoint publication retry exhausted".to_owned(),
-            )))
         },
         |_, ()| async { Ok(crate::control_update::WriteEvidence::Unknown) },
     )
     .await?;
     created
+}
+
+pub(crate) async fn create_checkpoint_at_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    owner: CheckpointOwner,
+    manifest: loonfs_api::wire::control::ManifestRef,
+    head_commit_id: loonfs_api::CommitId,
+    context: &MutationContext,
+) -> Result<Checkpoint> {
+    validate_checkpoint_owner(&owner)?;
+    let timer = StdMonotonicTimer::default();
+    let checkpoint_id = CheckpointId::generate();
+    let record = CheckpointRecordState {
+        checkpoint_id: checkpoint_id.clone(),
+        namespace_id: namespace_id.clone(),
+        manifest,
+        head_commit_id,
+        created_at_ms: context.now_ms,
+        owner,
+        status: CheckpointStatus::Active {},
+    };
+    let verify_started_ms = timer.monotonic_now_ms();
+    write_checkpoint_record(store, &record).await?;
+
+    let verification = match verify_checkpoint_basis(store, &record).await {
+        Ok(verification) => verification,
+        Err(error) => {
+            // Cleanup is best effort on an error and must not replace its
+            // original classification.
+            if let Err(cleanup_error) =
+                release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms).await
+            {
+                tracing::warn!(
+                    namespace_id = %namespace_id,
+                    checkpoint_id = %checkpoint_id,
+                    original_error = %error,
+                    cleanup_error = %cleanup_error,
+                    "failed to release a checkpoint record after basis verification failed"
+                );
+            }
+            return Err(error);
+        }
+    };
+    let within_budget =
+        timer.monotonic_now_ms().saturating_sub(verify_started_ms) <= CHECKPOINT_VERIFY_BUDGET_MS;
+    if verification == CheckpointBasisVerification::Verified && within_budget {
+        return Ok(super::checkpoint_summary(record));
+    }
+
+    // Overrunning the budget counts as verification failure: the record
+    // may have raced the grace window, so it must not stand as a root.
+    release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms).await?;
+    Err(CoreError::CheckpointUnavailable(
+        "checkpoint publication retry exhausted".to_owned(),
+    ))
 }
 
 fn validate_checkpoint_owner(owner: &CheckpointOwner) -> Result<()> {

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -69,7 +69,7 @@ pub(crate) use self::compaction_lease::{
     LoadedCompactionLease,
 };
 pub(crate) use self::compaction_merge::revision_content_block;
-pub(crate) use self::create::create_checkpoint;
+pub(crate) use self::create::{create_checkpoint, create_checkpoint_at_basis};
 pub(crate) use self::data_block_load::DecodedRowWeight;
 pub(crate) use self::files::list_checkpoint_files_page;
 pub(crate) use self::flush::flush_wal;
@@ -86,7 +86,7 @@ pub use self::reorganize::metadata_maintenance_due;
 pub(crate) use self::reorganize::reorganize_metadata_step;
 pub(crate) use self::retention::advance_retention_floor;
 pub(crate) use self::scan::{Readahead, VerifiedMetadataSegments};
-pub(crate) use self::snapshot::{extend_snapshot_expiry, release_snapshot};
+pub(crate) use self::snapshot::{classify_live_snapshot, extend_snapshot_expiry, release_snapshot};
 pub(crate) use self::streaming_compaction::run_metadata_compaction_job;
 
 fn checkpoint_summary(

--- a/crates/loonfs-core/src/checkpoint/snapshot.rs
+++ b/crates/loonfs-core/src/checkpoint/snapshot.rs
@@ -118,7 +118,7 @@ pub(crate) async fn release_snapshot<S: ObjectStore + ?Sized>(
     })
 }
 
-fn classify_live_snapshot(
+pub(crate) fn classify_live_snapshot(
     loaded: Option<LoadedCheckpointRecord>,
     checkpoint_id: &CheckpointId,
     now_ms: u64,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -230,15 +230,20 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
         .await
     }
 
-    /// Creates a new namespace at the current head of this namespace.
+    /// Creates a new namespace at this namespace's current head or a live snapshot.
     ///
     /// The fork shares immutable file bytes but gets its own metadata history.
     /// Returns the target's status at the fork point.
-    pub async fn fork_namespace(&self, target: &NamespaceId) -> Result<Namespace> {
+    pub async fn fork_namespace(
+        &self,
+        target: &NamespaceId,
+        snapshot_id: Option<&CheckpointId>,
+    ) -> Result<Namespace> {
         fork::fork_namespace(
             &self.store,
             &self.namespace_id,
             target,
+            snapshot_id,
             &self.mutation_context()?,
         )
         .await

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -699,7 +699,7 @@ async fn fork_protected_bases_survive_source_deletion_until_the_target_dies() {
         .await
         .expect("bootstrap");
     write_test_file(&store, &source, "/docs/shared.txt", "gc-shared", &setup).await;
-    fork_namespace(&store, &source, &clone, &setup)
+    fork_namespace(&store, &source, &clone, None, &setup)
         .await
         .expect("fork");
     delete_namespace(&store, &source, DeleteNamespaceOptions::default(), &setup)
@@ -3529,7 +3529,7 @@ async fn fork_owned_checkpoints_reject_user_release() {
         .await
         .expect("bootstrap");
     write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
-    fork_namespace(&store, &source, &clone, &setup)
+    fork_namespace(&store, &source, &clone, None, &setup)
         .await
         .expect("fork");
 
@@ -3732,7 +3732,7 @@ async fn gc_releases_fork_checkpoints_of_terminally_deleted_targets_across_passe
         .await
         .expect("bootstrap");
     write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
-    fork_namespace(&store, &source, &clone, &setup)
+    fork_namespace(&store, &source, &clone, None, &setup)
         .await
         .expect("fork");
     let fork_record = read_fork_record(&store, &source).await;
@@ -3811,7 +3811,7 @@ async fn a_corrupt_fork_target_head_fails_the_pass_and_an_unreadable_one_retains
         .await
         .expect("bootstrap");
     write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
-    fork_namespace(&store, &source, &clone, &setup)
+    fork_namespace(&store, &source, &clone, None, &setup)
         .await
         .expect("fork");
     let fork_record = read_fork_record(store.inner(), &source).await;
@@ -3885,7 +3885,7 @@ async fn gc_never_releases_a_fork_record_while_its_target_lives() {
         .await
         .expect("bootstrap");
     write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
-    fork_namespace(&store, &source, &clone, &setup)
+    fork_namespace(&store, &source, &clone, None, &setup)
         .await
         .expect("fork");
     let fork_record = read_fork_record(&store, &source).await;
@@ -3944,7 +3944,7 @@ async fn a_fork_pin_with_a_missing_basis_survives_the_missing_basis_pass() {
         .await
         .expect("bootstrap");
     write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
-    fork_namespace(&store, &source, &clone, &setup)
+    fork_namespace(&store, &source, &clone, None, &setup)
         .await
         .expect("fork");
     let fork_record = read_fork_record(&store, &source).await;
@@ -3981,7 +3981,7 @@ async fn gc_retains_a_released_fork_record_when_its_target_lives() {
         .await
         .expect("bootstrap");
     write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
-    fork_namespace(&store, &source, &clone, &setup)
+    fork_namespace(&store, &source, &clone, None, &setup)
         .await
         .expect("fork");
     let fork_record = read_fork_record(&store, &source).await;
@@ -4142,7 +4142,7 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
     .await
     .expect("leased fork record from the attempt that died");
 
-    fork_namespace(&store, &source, &clone, &setup)
+    fork_namespace(&store, &source, &clone, None, &setup)
         .await
         .expect("fork retry after abandonment");
     let retry = store

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -2,9 +2,10 @@
 //! fork-owned source checkpoint, sharing content bytes and reading the
 //! source's metadata until the target flushes its own.
 
-use crate::checkpoint::record::renew_fork_checkpoint_for_install;
+use crate::checkpoint::record::{release_checkpoint_record, renew_fork_checkpoint_for_install};
 use crate::checkpoint::{
-    create_checkpoint, load_checkpoint_record, load_namespace_manifest_envelope,
+    classify_live_snapshot, create_checkpoint, create_checkpoint_at_basis, load_checkpoint_record,
+    load_namespace_manifest_envelope,
 };
 use crate::context::MutationContext;
 use crate::error::MetadataProjectionLoadError;
@@ -15,30 +16,29 @@ use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::control::{
     CheckpointOwner, ForkBasis, HeadState, NamespaceStatus, WriterBlock,
 };
-use loonfs_api::{Namespace, NamespaceId, WriterEpoch};
+use loonfs_api::{CheckpointId, Namespace, NamespaceId, WriterEpoch};
 use loonfs_objectstore::ObjectStore;
 
 pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     store: &S,
     source_namespace_id: &NamespaceId,
     new_namespace_id: &NamespaceId,
+    snapshot_id: Option<&CheckpointId>,
     context: &MutationContext,
 ) -> Result<Namespace> {
     // Include time already spent on the fork when renewing its lease.
     let timer = StdMonotonicTimer::default();
     let started_ms = timer.monotonic_now_ms();
-    // Each attempt creates a checkpoint that keeps the target's source
-    // metadata alive. GC removes abandoned checkpoints after their lease.
-    let checkpoint = create_checkpoint(
-        store,
-        source_namespace_id,
-        CheckpointOwner::Fork {
-            target_namespace_id: new_namespace_id.clone(),
-            expires_at_ms: context.now_ms.saturating_add(FORK_CHECKPOINT_LEASE_MS),
-        },
-        context,
-    )
-    .await?;
+    let owner = CheckpointOwner::Fork {
+        target_namespace_id: new_namespace_id.clone(),
+        expires_at_ms: context.now_ms.saturating_add(FORK_CHECKPOINT_LEASE_MS),
+    };
+    let checkpoint = if let Some(snapshot_id) = snapshot_id {
+        create_snapshot_fork_checkpoint(store, source_namespace_id, snapshot_id, owner, context)
+            .await?
+    } else {
+        create_checkpoint(store, source_namespace_id, owner, context).await?
+    };
     let source_record =
         load_checkpoint_record(store, source_namespace_id, &checkpoint.checkpoint_id)
             .await?
@@ -120,4 +120,60 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     }
 
     crate::namespace::status::load_namespace(store, new_namespace_id).await
+}
+
+async fn create_snapshot_fork_checkpoint<S: ObjectStore + ?Sized>(
+    store: &S,
+    source_namespace_id: &NamespaceId,
+    snapshot_id: &CheckpointId,
+    owner: CheckpointOwner,
+    context: &MutationContext,
+) -> Result<loonfs_api::Checkpoint> {
+    let timer = StdMonotonicTimer::default();
+    let started_ms = timer.monotonic_now_ms();
+    let snapshot = classify_live_snapshot(
+        load_checkpoint_record(store, source_namespace_id, snapshot_id)
+            .await?
+            .filter(|record| matches!(record.state.owner, CheckpointOwner::Snapshot { .. })),
+        snapshot_id,
+        context.now_ms,
+    )?
+    .state;
+    let checkpoint = create_checkpoint_at_basis(
+        store,
+        source_namespace_id,
+        owner,
+        snapshot.manifest,
+        snapshot.head_commit_id,
+        context,
+    )
+    .await?;
+    let rechecked = load_checkpoint_record(store, source_namespace_id, snapshot_id)
+        .await
+        .and_then(|record| {
+            classify_live_snapshot(
+                record,
+                snapshot_id,
+                context
+                    .now_ms
+                    .saturating_add(timer.monotonic_now_ms().saturating_sub(started_ms)),
+            )
+        });
+    if let Err(error) = rechecked {
+        release_checkpoint_record(
+            store,
+            source_namespace_id,
+            &checkpoint.checkpoint_id,
+            context.now_ms,
+        )
+        .await?;
+        return Err(match error {
+            CoreError::SnapshotNotFound { .. } => CoreError::SnapshotGone {
+                snapshot_id: snapshot_id.clone(),
+                reason: "released".to_owned(),
+            },
+            error => error,
+        });
+    }
+    Ok(checkpoint)
 }

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -798,7 +798,7 @@ async fn a_fork_reads_the_sources_attributes_before_and_after_its_first_flush() 
 
     let target = namespace_id("fork");
     namespace_engine(&store, &source, &context)
-        .fork_namespace(&target)
+        .fork_namespace(&target, None)
         .await
         .expect("fork the namespace");
 

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -41,8 +41,213 @@ async fn fork_namespace<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<loonfs_api::Namespace, CoreError> {
     namespace_engine(store, source_namespace_id, context)
-        .fork_namespace(new_namespace_id)
+        .fork_namespace(new_namespace_id, None)
         .await
+}
+
+async fn listed_names<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Vec<String> {
+    let context = crate::common::read_context(store, namespace_id).await;
+    namespace_engine(store, namespace_id, &mutation_context())
+        .list_path_page(
+            "/docs",
+            loonfs_api::PageRequest {
+                limit: loonfs_test_support::ids::page_limit(10),
+                cursor: None,
+            },
+            Default::default(),
+            &context,
+        )
+        .await
+        .expect("list files")
+        .items
+        .into_iter()
+        .map(|entry| entry.display_name.expect("file name").to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn snapshot_fork_keeps_its_tree_after_snapshot_release_and_source_gc() {
+    let directory = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(directory.path()).expect("store");
+    let context = mutation_context();
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+    seed_source_namespace_for_fork(&store, &source, &context).await;
+    let engine = namespace_engine(&store, &source, &context);
+    let snapshot = engine
+        .create_snapshot("basis".to_owned(), u64::MAX / 2)
+        .await
+        .expect("snapshot");
+    let snapshot_record = loonfs_core::control::load_namespace_checkpoint_record_control(
+        &store,
+        &source,
+        &snapshot.checkpoint_id,
+    )
+    .await
+    .expect("load snapshot")
+    .expect("snapshot exists");
+    write_file_bytes(
+        &store,
+        &source,
+        "/docs/later.txt",
+        b"later",
+        &context,
+        Some("later"),
+    )
+    .await
+    .expect("advance source");
+    let fork = engine
+        .fork_namespace(&target, Some(&snapshot.checkpoint_id))
+        .await
+        .expect("fork snapshot");
+    assert_eq!(fork.head_seq, snapshot.checkpoint_seq);
+    let head = head_state(&store, &target).await;
+    assert_eq!(head.head_commit_id, snapshot_record.head_commit_id);
+    assert_eq!(
+        head.fork_basis.as_ref().expect("fork basis").manifest,
+        snapshot_record.manifest
+    );
+    assert_eq!(listed_names(&store, &target).await, ["shared.txt"]);
+    assert_eq!(
+        listed_names(&store, &source).await,
+        ["later.txt", "shared.txt"]
+    );
+    assert_eq!(
+        loonfs_core::control::load_namespace_checkpoint_record_control(
+            &store,
+            &source,
+            &snapshot.checkpoint_id,
+        )
+        .await
+        .expect("load snapshot")
+        .expect("snapshot exists"),
+        snapshot_record
+    );
+    engine
+        .release_snapshot(&snapshot.checkpoint_id)
+        .await
+        .expect("release snapshot");
+    engine
+        .create_checkpoint("current".to_owned(), None)
+        .await
+        .expect("flush current source");
+    let mut aged = context.clone();
+    aged.now_ms = u64::MAX / 2;
+    loonfs_core::gc_namespace(&store, &source, &loonfs_core::GcConfig::default(), &aged)
+        .await
+        .expect("collect source past grace window");
+    assert_eq!(listed_names(&store, &target).await, ["shared.txt"]);
+    assert_eq!(
+        read_file_bytes(&store, &target, "/docs/shared.txt")
+            .await
+            .expect("read fork")
+            .bytes,
+        b"base"
+    );
+}
+
+#[tokio::test]
+async fn invalid_snapshot_forks_write_nothing() {
+    let directory = tempdir().expect("tempdir");
+    let store = RecordingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::any(),
+    );
+    let context = mutation_context();
+    let source = namespace_id("source");
+    let other = namespace_id("other");
+    let target = namespace_id("target");
+    seed_source_namespace_for_fork(&store, &source, &context).await;
+    seed_source_namespace_for_fork(&store, &other, &context).await;
+    let engine = namespace_engine(&store, &source, &context);
+    let expired = engine
+        .create_snapshot("expired".to_owned(), 1)
+        .await
+        .expect("expired snapshot");
+    let foreign = namespace_engine(&store, &other, &context)
+        .create_snapshot("foreign".to_owned(), u64::MAX / 2)
+        .await
+        .expect("foreign snapshot");
+    let checkpoint = engine
+        .create_checkpoint("user".to_owned(), None)
+        .await
+        .expect("user checkpoint");
+    for (snapshot_id, expected_code) in [
+        (expired.checkpoint_id, ErrorCode::SnapshotGone),
+        (foreign.checkpoint_id, ErrorCode::SnapshotNotFound),
+        (checkpoint.checkpoint_id, ErrorCode::SnapshotNotFound),
+    ] {
+        store.take();
+        let error = engine
+            .fork_namespace(&target, Some(&snapshot_id))
+            .await
+            .expect_err("invalid snapshot");
+        assert_eq!(error.code(), expected_code);
+        assert_eq!(store.counts().puts, 0);
+        assert_eq!(store.counts().deletes, 0);
+        assert!(namespace_keys(&store, &target).await.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn snapshot_release_during_fork_releases_the_attempt_without_installing_a_target() {
+    let directory = tempdir().expect("tempdir");
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+    let store = loonfs_test_support::stores::BlockingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::prefix(format!("namespaces/{source}/checkpoints/")),
+        OperationClass::PutCreateIfAbsent,
+    );
+    let context = mutation_context();
+    seed_source_namespace_for_fork(&store, &source, &context).await;
+    let engine = namespace_engine(&store, &source, &context);
+    let snapshot = engine
+        .create_snapshot("basis".to_owned(), u64::MAX / 2)
+        .await
+        .expect("snapshot");
+    store.block_next();
+    let forking = engine.fork_namespace(&target, Some(&snapshot.checkpoint_id));
+    let releasing = async {
+        store.wait_until_blocked().await;
+        engine
+            .release_snapshot(&snapshot.checkpoint_id)
+            .await
+            .expect("release snapshot during fork write");
+        store.release();
+    };
+    let (result, ()) = tokio::join!(forking, releasing);
+    assert_eq!(
+        result.expect_err("snapshot gone").code(),
+        ErrorCode::SnapshotGone
+    );
+    assert!(namespace_keys(&store, &target).await.is_empty());
+    let records = store
+        .list_prefix(&format!("namespaces/{source}/checkpoints/"))
+        .await
+        .expect("list records");
+    let mut fork_records = 0;
+    for key in records {
+        let bytes = store
+            .get(&key, None)
+            .await
+            .expect("read record")
+            .expect("record exists");
+        let record = decode_control_object::<loonfs_api::wire::control::CheckpointRecordState>(
+            &bytes,
+            ControlObjectKind::CheckpointRecord,
+        )
+        .expect("decode record")
+        .into_payload();
+        if matches!(record.owner, CheckpointOwner::Fork { .. }) {
+            fork_records += 1;
+            assert!(matches!(record.status, CheckpointStatus::Released { .. }));
+        }
+    }
+    assert_eq!(fork_records, 1);
 }
 
 async fn seed_source_namespace_for_fork<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -350,16 +350,16 @@ fn parse_expected_head_seq(value: &str) -> Result<ChangeSeq, ApiResponseError> {
         path = "/v0/namespaces/{namespace_id}/forks",
         tag = "namespaces",
         summary = "Fork namespace",
-        description = "Creates a new namespace as a fork from the source namespace's current durable view.",
+        description = "Creates a new namespace from the source current head or a live snapshot.",
         params(("namespace_id" = String, Path, description = "Source namespace id")),
         request_body = ForkNamespaceRequest,
         responses(
             (status = 200, description = "Namespace forked", body = loonfs_api::Namespace),
             (status = 400, description = "Invalid namespace id", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 404, description = "Source namespace not found", body = ApiError),
+            (status = 404, description = "Source namespace or snapshot not found", body = ApiError),
             (status = 409, description = "Fork conflict", body = ApiError),
-            (status = 410, description = "Source namespace deleted", body = ApiError),
+            (status = 410, description = "Source namespace deleted or snapshot gone", body = ApiError),
             crate::http::openapi::UnavailableResponses
         )
     )
@@ -372,7 +372,13 @@ pub(super) async fn fork_namespace(
 ) -> Result<Json<loonfs_api::Namespace>, ApiResponseError> {
     let namespace = state
         .writer
-        .fork_namespace(&source_namespace_id, &request.new_namespace_id)
+        .fork_namespace_with(
+            &source_namespace_id,
+            &request.new_namespace_id,
+            loonfs::ForkNamespaceOptions {
+                snapshot_id: request.snapshot_id,
+            },
+        )
         .await
         .map_err(ApiResponseError::for_namespace(&source_namespace_id))?;
     Ok(Json(namespace))

--- a/crates/loonfs-server/tests/it/http_maintenance.rs
+++ b/crates/loonfs-server/tests/it/http_maintenance.rs
@@ -224,7 +224,11 @@ async fn http_maintenance_checkpoint_and_retention_are_idempotent_and_soft() {
     assert_eq!(repeated.expires_at_ms, first.expires_at_ms);
     assert!(repeated.created_at_ms >= first.created_at_ms);
     client
-        .fork_namespace(&namespace, &namespace_id("fork"))
+        .fork_namespace(
+            &namespace,
+            &namespace_id("fork"),
+            &loonfs_client::ForkNamespaceOptions::default(),
+        )
         .await
         .expect("fork namespace");
     let diagnostics = client

--- a/crates/loonfs-server/tests/it/http_smoke.rs
+++ b/crates/loonfs-server/tests/it/http_smoke.rs
@@ -366,7 +366,11 @@ async fn http_namespace_fork_shares_content_and_diverges() {
 
     let forked = harness
         .client
-        .fork_namespace(&namespace_id("demo"), &namespace_id("clone"))
+        .fork_namespace(
+            &namespace_id("demo"),
+            &namespace_id("clone"),
+            &loonfs_client::ForkNamespaceOptions::default(),
+        )
         .await
         .expect("fork namespace");
     assert_eq!(forked.namespace_id.as_str(), "clone");
@@ -450,5 +454,53 @@ async fn http_namespace_fork_shares_content_and_diverges() {
     assert_eq!(clone_changes.changes.len(), 1);
     assert_eq!(clone_changes.changes[0].committed_seq, ChangeSeq(2));
 
+    harness.server.abort();
+}
+
+// The client and HTTP server run concurrently on separate workers.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_namespace_fork_uses_the_snapshot_sequence() {
+    let directory = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        directory.path().join("store"),
+        "snapshot-fork",
+        "snapshot-fork",
+    ))
+    .await;
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+    harness
+        .client
+        .create_namespace(&source)
+        .await
+        .expect("namespace");
+    let path = NamespacePath::parse("source", "/file.txt").expect("path");
+    harness
+        .client
+        .put_file_bytes(&path, b"captured", &replace_file_options())
+        .await
+        .expect("first write");
+    let snapshot = harness
+        .client
+        .create_snapshot(&source, "basis", 60_000)
+        .await
+        .expect("snapshot");
+    harness
+        .client
+        .put_file_bytes(&path, b"current", &replace_file_options())
+        .await
+        .expect("advance source");
+    let fork = harness
+        .client
+        .fork_namespace(
+            &source,
+            &target,
+            &loonfs_client::ForkNamespaceOptions {
+                snapshot_id: Some(snapshot.snapshot_id),
+            },
+        )
+        .await
+        .expect("fork snapshot");
+    assert_eq!(fork.head_seq, snapshot.head_seq);
     harness.server.abort();
 }

--- a/crates/loonfs/src/fs/namespaces.rs
+++ b/crates/loonfs/src/fs/namespaces.rs
@@ -3,7 +3,8 @@
 use super::core::{should_invalidate_after_result, ReadCore, WriterIdentity};
 use crate::FsWriter;
 use crate::{
-    CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, Namespace, NamespaceId,
+    CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, ForkNamespaceOptions,
+    Namespace, NamespaceId,
 };
 use crate::{Result, RuntimeError};
 
@@ -41,9 +42,16 @@ impl FsWriter {
     }
 
     /// Forks `source` into `target` at the source's current head.
-    ///
-    /// The fork shares immutable file bytes but gets its own metadata history,
-    /// and the response reports the target at the fork point.
+    pub async fn fork_namespace(
+        &self,
+        source: &NamespaceId,
+        target: &NamespaceId,
+    ) -> Result<Namespace> {
+        self.fork_namespace_with(source, target, ForkNamespaceOptions::default())
+            .await
+    }
+
+    /// Forks `source` into `target` at the selected current head or live snapshot.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.fork_namespace",
@@ -56,15 +64,16 @@ impl FsWriter {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn fork_namespace(
+    pub async fn fork_namespace_with(
         &self,
         source: &NamespaceId,
         target: &NamespaceId,
+        options: ForkNamespaceOptions,
     ) -> Result<Namespace> {
         self.core.record_trace_context(&tracing::Span::current());
         let result = self
             .engine(source)
-            .fork_namespace(target)
+            .fork_namespace(target, options.snapshot_id.as_ref())
             .await
             .map_err(RuntimeError::from);
         if should_invalidate_after_result(&result) {

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -192,10 +192,10 @@ pub use maintenance::{
 pub use options::{
     gc_config_from_request, CommitOptions, CopyOptions, CreateCheckpointOptions,
     CreateDirectoryOptions, CreateNamespaceOptions, CreateSnapshotOptions, DeleteOptions,
-    DirectMultipartUploadOptions, ListChangesOptions, ListInodeChildrenOptions,
-    ListPathEntriesOptions, MetadataMaintenanceOptions, MoveOptions, PutFileOptions,
-    ReadFileStreamOptions, RestoreRevisionOptions, StatPathOptions, UndeleteOptions,
-    UpdateAttributesOptions,
+    DirectMultipartUploadOptions, ForkNamespaceOptions, ListChangesOptions,
+    ListInodeChildrenOptions, ListPathEntriesOptions, MetadataMaintenanceOptions, MoveOptions,
+    PutFileOptions, ReadFileStreamOptions, RestoreRevisionOptions, StatPathOptions,
+    UndeleteOptions, UpdateAttributesOptions,
 };
 pub use publisher::{CloseNamespaceReport, NamespaceSessionState, WriterSessionStats};
 pub use trace::{payload_class, TraceMode, TraceStoreKind};

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -13,9 +13,9 @@ use std::num::NonZeroU64;
 
 pub use loonfs_api::options::{
     CommitOptions, CopyOptions, CreateDirectoryOptions, DeleteOptions,
-    DirectMultipartUploadOptions, ListInodeChildrenOptions, ListPathEntriesOptions, MoveOptions,
-    PutFileOptions, RestoreRevisionOptions, StatPathOptions, UndeleteOptions,
-    UpdateAttributesOptions,
+    DirectMultipartUploadOptions, ForkNamespaceOptions, ListInodeChildrenOptions,
+    ListPathEntriesOptions, MoveOptions, PutFileOptions, RestoreRevisionOptions, StatPathOptions,
+    UndeleteOptions, UpdateAttributesOptions,
 };
 
 /// Overrides for the metadata-upkeep action.

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2419,17 +2419,23 @@ Representative response:
 }
 ```
 
-The server forks from the source namespace's current head. The new namespace
-shares the source namespace's content store and starts with independent future
-namespace metadata. The fork creates a fork-owned source checkpoint so the
+The optional `snapshot_id` request field selects a live user snapshot of the
+source namespace. Without it, the server captures the current head. The
+snapshot must remain live until the fork-owned checkpoint is written. Missing
+snapshots and ids owned by another namespace or checkpoint kind return
+`snapshot_not_found`; released or expired snapshots return `snapshot_gone`.
+Forking does not extend the snapshot, and later release does not affect the fork.
+
+The new namespace shares the source namespace's content store and starts with
+independent future namespace metadata. The fork creates a fork-owned source checkpoint so the
 source-owned immutable metadata segments stay available for as long as the
 target may still read them. It renews the checkpoint with compare-and-swap,
 then installs the target namespace's head in one conditional write. That head
 records the source checkpoint for the target's lifetime.
 
 The response contains the new namespace's initial state. Its head
-sequence and retention floor are set to the source namespace's sequence at
-the fork point.
+sequence and retention floor are set to the captured basis's sequence. For a
+fresh fork, `head_seq` reports the captured basis, including a current-head fork.
 
 If the target ID already exists or has been deleted, the server returns the
 same `namespace_exists` or `namespace_deleted` error as namespace creation.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1716,17 +1716,21 @@ first flush and first retention advance need them.
 
 #### 3.9.2 Forking a namespace
 
-A fork creates a new namespace from the source namespace's current head. The
-request supplies only the new namespace id; the server supplies the mutation
-context. The protocol is:
+A fork creates a new namespace from the source namespace's current head or a
+live user snapshot selected by `snapshot_id`. The request supplies the new
+namespace id; the server supplies the mutation context. The protocol is:
 
 1. Read and verify the source head and its WAL visibility chain.
-2. Create a verified fork-owned source checkpoint at that head under a freshly
-   generated id. Its owner carries the target namespace id and
+2. Create a verified fork-owned source checkpoint at that head, or at the selected
+   snapshot's manifest and `head_commit_id`, under a freshly generated id.
+   Its owner carries the target namespace id and
    `expires_at_ms = now + FORK_CHECKPOINT_LEASE_MS`. This record is the
    reachability root that keeps the source's basis manifest and segments alive
    for as long as the target or a nested descendant may need them. Each attempt
-   creates a new record.
+   creates a new record. When a snapshot is selected, verify it is live before
+   writing, then read it again after the fork record is durable. If it is no
+   longer live, release the fork record and return `snapshot_gone` without
+   installing a target head. The snapshot record is unchanged.
 3. Read the pinned manifest to get the target's next inode id. Build the active target head with the source's `content_store_id` and a `fork_basis` containing the record's `manifest` reference and checkpoint id. The reference's `manifest_head_seq` is the target's fork sequence.
 4. Renew the source checkpoint with compare-and-swap. The record must be active, fork-owned, and assigned to this target. The new expiry must be later than the stored expiry and at least `now + FORK_CHECKPOINT_LEASE_MS`. The remaining lease must cover the target-head write. If either check fails, the fork stops before creating the target.
 5. Write the target head with create-if-absent.

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2034,6 +2034,10 @@
           "new_namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Durable namespace id for the fork target."
+          },
+          "snapshot_id": {
+            "$ref": "#/components/schemas/CheckpointId",
+            "description": "Fork from this live snapshot instead of the current head."
           }
         },
         "required": [
@@ -6460,7 +6464,7 @@
     },
     "/v0/namespaces/{namespace_id}/forks": {
       "post": {
-        "description": "Creates a new namespace as a fork from the source namespace's current durable view.",
+        "description": "Creates a new namespace from the source current head or a live snapshot.",
         "operationId": "fork_namespace",
         "parameters": [
           {
@@ -6522,7 +6526,7 @@
                 }
               }
             },
-            "description": "Source namespace not found"
+            "description": "Source namespace or snapshot not found"
           },
           "409": {
             "content": {
@@ -6542,7 +6546,7 @@
                 }
               }
             },
-            "description": "Source namespace deleted"
+            "description": "Source namespace deleted or snapshot gone"
           },
           "503": {
             "$ref": "#/components/responses/UnavailableResponse"


### PR DESCRIPTION
A fork captures the source's current head. A caller who inspected a snapshot and wants to fork exactly what it inspected could not, because the source may have advanced between the read and the fork. This change lets the fork request name a live snapshot of the source as its basis. The fork starts at the snapshot's sequence with the snapshot's tree, and it stays readable after the snapshot is released, because the fork-owned checkpoint pins the same basis on its own.

`ForkNamespaceRequest` gains an optional `snapshot_id`. In core, the fork-owned checkpoint is created at the snapshot's manifest and head commit instead of the current head, through a variant of checkpoint creation that pins a caller-supplied basis and shares the existing write-then-verify path. The snapshot is checked before that record is written and again after it is durable; if it is no longer live at the second check, the fork record is released and the fork fails with `snapshot_gone` without installing a target head. The runtime keeps `fork_namespace` and adds `fork_namespace_with` taking `ForkNamespaceOptions`, which is defined once in `loonfs-api` and re-exported by the runtime and the client like the other option structs. The CLI's `namespace fork` takes `--snapshot`. The API and format specs describe the selector, its two failure codes, and the fact that a fresh fork's `head_seq` reports the basis it captured.

Behavior a reviewer should know about: a snapshot id that names another namespace's record, a released or expired snapshot, or a checkpoint that is not a snapshot fails before any write, and tests pin zero puts and deletes for those cases. The client's `fork_namespace` now takes an options argument, matching its other request methods. The current-head fork is unchanged; its checkpoint creation now goes through the extracted basis-pinning function with the same verification, budget, and retry behavior. Tests cover the exact basis capture, independence from the snapshot through a source GC pass past the grace window, the release race during the fork record write, the HTTP field, and the CLI flag. The OpenAPI document is regenerated. No durable format changes.
