### PR TITLE
docs(format): keep one durable evolution rule and reject unknown content kinds

### DIFF
--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -7,25 +7,20 @@ use sha2::{Digest, Sha256 as Sha2Sha256};
 use std::fmt;
 use thiserror::Error;
 
-/// A content reference kind serialized as a string.
-///
-/// Unknown values use [`ContentRefKind::Unsupported`], and writers must not create them.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// A supported content reference kind serialized as a string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
 pub enum ContentRefKind {
     /// One immutable content object, addressed by its random content id.
     BlobV1,
-    /// A content kind unknown to this build, preserved verbatim.
-    Unsupported(String),
 }
 
 impl ContentRefKind {
-    const BLOB_V1: &'static str = "blob_v1";
-
-    /// Returns the frozen wire spelling, including an unknown spelling preserved by a reader.
+    /// Returns the frozen wire spelling.
     pub fn as_str(&self) -> &str {
         match self {
-            Self::BlobV1 => Self::BLOB_V1,
-            Self::Unsupported(other) => other,
+            Self::BlobV1 => "blob_v1",
         }
     }
 }
@@ -33,28 +28,6 @@ impl ContentRefKind {
 impl fmt::Display for ContentRefKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
-    }
-}
-
-impl Serialize for ContentRefKind {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for ContentRefKind {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        Ok(match value.as_str() {
-            Self::BLOB_V1 => Self::BlobV1,
-            _ => Self::Unsupported(value),
-        })
     }
 }
 
@@ -336,12 +309,6 @@ impl fmt::Debug for Sha256 {
 /// Describes why a content reference cannot be part of a durable commit.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum ContentRefValidationError {
-    /// The reference contains a content strategy this build cannot write.
-    #[error("unsupported content ref kind `{kind}`")]
-    UnsupportedKind {
-        /// Kind spelling carried by the rejected reference.
-        kind: String,
-    },
     /// The checksum is not in the algorithm's canonical form.
     #[error("invalid content ref checksum: {0}")]
     InvalidChecksum(ChecksumValidationError),
@@ -358,7 +325,6 @@ pub enum ContentRefValidationError {
 #[serde(deny_unknown_fields)]
 pub struct ContentRef {
     /// Content strategy used by the referenced object.
-    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub kind: ContentRefKind,
     /// Immutable identity of the referenced object.
     pub content_id: ContentId,
@@ -401,11 +367,6 @@ impl ContentRef {
     /// This is a shape check on the reference itself; proving that the
     /// object exists and matches is the storage layer's job.
     pub fn validate(&self) -> Result<(), ContentRefValidationError> {
-        if self.kind != ContentRefKind::BlobV1 {
-            return Err(ContentRefValidationError::UnsupportedKind {
-                kind: self.kind.as_str().to_owned(),
-            });
-        }
         self.checksum
             .validate()
             .map_err(ContentRefValidationError::InvalidChecksum)?;
@@ -434,15 +395,13 @@ mod tests {
     }
 
     #[test]
-    fn unknown_kind_is_preserved_verbatim_through_a_round_trip() {
-        let decoded: ContentRefKind =
-            serde_json::from_str("\"sparse_file_v9\"").expect("decode unknown kind");
+    fn unknown_kind_fails_to_decode() {
+        let error = serde_json::from_str::<ContentRefKind>("\"sparse_file_v9\"")
+            .expect_err("unknown content kind must be rejected");
         assert_eq!(
-            decoded,
-            ContentRefKind::Unsupported("sparse_file_v9".to_owned())
+            error.to_string(),
+            "unknown variant `sparse_file_v9`, expected `blob_v1` at line 1 column 16"
         );
-        let reencoded = serde_json::to_string(&decoded).expect("encode unknown kind");
-        assert_eq!(reencoded, "\"sparse_file_v9\"");
     }
 
     #[test]
@@ -496,14 +455,7 @@ mod tests {
     }
 
     #[test]
-    fn validation_rejects_an_unsupported_kind_and_a_malformed_checksum() {
-        let mut content_ref = ContentRef::blob_v1(content_id(), b"hello");
-        content_ref.kind = ContentRefKind::Unsupported("sparse_file_v9".to_owned());
-        assert!(matches!(
-            content_ref.validate(),
-            Err(ContentRefValidationError::UnsupportedKind { .. })
-        ));
-
+    fn validation_rejects_a_malformed_checksum() {
         let mut content_ref = ContentRef::blob_v1(content_id(), b"hello");
         content_ref.checksum = Checksum {
             algorithm: ChecksumAlgorithm::Crc64nvme,

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -4,9 +4,9 @@
 
 use crate::envelope::EnvelopeCodecError;
 use crate::{
-    wal_segment_id_start_seq, ChangeSeq, CheckpointId, Checksum, ChecksumAlgorithm, CommitId,
-    ContentId, ContentRef, ContentRefKind, ContentStoreId, InodeId, ManifestNo, ManifestObjectId,
-    MetadataCompactionId, MetadataFamilyGroup, NamespaceId, UploadId, WalSegmentId,
+    wal_segment_id_start_seq, ChangeSeq, CheckpointId, ChecksumAlgorithm, CommitId, ContentId,
+    ContentRef, ContentStoreId, InodeId, ManifestNo, ManifestObjectId, MetadataCompactionId,
+    MetadataFamilyGroup, NamespaceId, UploadId, WalSegmentId,
 };
 use crate::{WriterEpoch, WriterId};
 use serde::de::DeserializeOwned;
@@ -908,7 +908,7 @@ impl From<StrictUploadSessionMode> for UploadSessionMode {
 enum StrictProxiedStaging {
     Idle {},
     Claimed {},
-    Staged { content_ref: StrictContentRef },
+    Staged { content_ref: ContentRef },
 }
 
 impl From<StrictProxiedStaging> for ProxiedStaging {
@@ -916,14 +916,11 @@ impl From<StrictProxiedStaging> for ProxiedStaging {
         match staging {
             StrictProxiedStaging::Idle {} => Self::Idle,
             StrictProxiedStaging::Claimed {} => Self::Claimed,
-            StrictProxiedStaging::Staged { content_ref } => Self::Staged(content_ref.into()),
+            StrictProxiedStaging::Staged { content_ref } => Self::Staged(content_ref),
         }
     }
 }
 
-/// The status read back through the same strict content-ref decoder the
-/// rest of the record uses, so a completed session's reference is held to
-/// the durable schema rather than the wire one.
 #[derive(Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 enum StrictUploadSessionRecordStatus {
@@ -932,7 +929,7 @@ enum StrictUploadSessionRecordStatus {
     },
     Completed {
         completed_at_ms: u64,
-        content_ref: StrictContentRef,
+        content_ref: ContentRef,
     },
     Aborted {
         aborted_at_ms: u64,
@@ -948,40 +945,11 @@ impl From<StrictUploadSessionRecordStatus> for UploadSessionRecordStatus {
                 content_ref,
             } => Self::Completed {
                 completed_at_ms,
-                content_ref: content_ref.into(),
+                content_ref,
             },
             StrictUploadSessionRecordStatus::Aborted { aborted_at_ms } => {
                 Self::Aborted { aborted_at_ms }
             }
-        }
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct StrictContentRef {
-    kind: MutableContentRefKind,
-    content_id: ContentId,
-    size_bytes: u64,
-    checksum: Checksum,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum MutableContentRefKind {
-    BlobV1,
-}
-
-impl From<StrictContentRef> for ContentRef {
-    fn from(content_ref: StrictContentRef) -> Self {
-        let kind = match content_ref.kind {
-            MutableContentRefKind::BlobV1 => ContentRefKind::BlobV1,
-        };
-        Self {
-            kind,
-            content_id: content_ref.content_id,
-            size_bytes: content_ref.size_bytes,
-            checksum: content_ref.checksum,
         }
     }
 }

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -1028,21 +1028,17 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn validate_content_ref_rejects_unsupported_kind() {
-        let (_temp_dir, store, content_store_id) = test_store();
-        let content_ref = ContentRef {
-            kind: ContentRefKind::Unsupported("kind_from_the_future".to_owned()),
-            ..content_ref(b"bytes")
-        };
+    #[test]
+    fn content_ref_with_an_unknown_kind_fails_to_decode() {
+        let mut document = serde_json::to_value(content_ref(b"bytes")).expect("encode content ref");
+        document["kind"] = serde_json::json!("kind_from_the_future");
 
-        let err = validate_durable_content_reference(&store, &content_store_id, &content_ref)
-            .await
-            .expect_err("unsupported content ref kind");
-        assert!(matches!(
-            err,
-            DurableContentValidationError::InvalidContentRef(_)
-        ));
+        let error = serde_json::from_value::<ContentRef>(document)
+            .expect_err("unknown content kind must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "unknown variant `kind_from_the_future`, expected `blob_v1`"
+        );
     }
 
     #[tokio::test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -723,8 +723,9 @@ itself and so must tolerate fields it does not know (section 7.2).
 `ContentRef`, `Checksum`, and `ActorRef` are closed shapes on both sides: a
 response never adds a field to one of them, and new content strategies or
 checksum algorithms arrive as new `kind` and `algorithm` values, which is why
-those three schemas are `additionalProperties: false` in responses too. The
-encoding conventions in `format.md` state the same rules and extend them to
+those three schemas are `additionalProperties: false` in responses too.
+Unknown content kinds fail to decode, just like unknown checksum algorithms.
+The encoding conventions in `format.md` state the same rules and extend them to
 durable shapes.
 
 Query strings reject unknown parameters. For example, `DELETE /v0/namespaces/{ns}?expected_head_sq=418` returns 400 `invalid_request` rather than deleting the namespace without the intended guard. Routes that declare no query parameters reject all query parameters. `GET /health`, `GET /readiness`, and `GET /metrics` are exceptions because probes and scrapers may append their own parameters.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -339,10 +339,10 @@ Small mutable objects such as the namespace head must use compare-and-swap
 semantics. These objects must remain small enough that guarded rewrite is
 practical.
 
-Six control-object kinds are registered: `wal_head`, `wal_floor`,
-`metadata_root`, `checkpoint_record`, `upload_session`, and
-`compaction_lease`, `compaction_output_protection`, and `gc_run`. A control-object envelope carrying any other kind string
-is rejected, not skipped.
+Eight control-object kinds are registered: `wal_head`, `wal_floor`,
+`metadata_root`, `checkpoint_record`, `upload_session`, `compaction_lease`,
+`compaction_output_protection`, and `gc_run`. A control-object envelope carrying
+any other kind string is rejected, not skipped.
 
 The WAL floor and the metadata root are the only control objects that carry
 `updated_at_ms`. That field records when the object's last rewrite succeeded,
@@ -730,7 +730,8 @@ The core rules are:
   durability and validation rules before revisions may reference them.
 
 `ContentRef` rejects unknown fields in every context, including immutable
-durable records. Extend it with new `kind` values instead of adding fields:
+durable records. Unknown `kind` values fail to decode. A new content kind
+requires a version change on every durable family that carries references:
 
 ```json
 {
@@ -789,9 +790,9 @@ A `set` also carries the binding the delete removed, as one
 `display_name` together. Tombstone rows are immortal, so this is where a
 deleted name survives after unbind rows age out, and it is the binding
 undelete restores in place. Every deletion records the binding it removed.
-Only a `set` includes this field. A reader ignores it on a `revoke`, just like
-any other unknown field (encoding conventions above). A partial binding is
-not valid.
+Only the tagged `set` variant includes this field. The tagged `revoke`
+variant has no binding field, and a reader rejects a `revoke` carrying
+`deleted_direntry`. A partial binding is not valid.
 
 The `active_deletions` family tracks deletions that can still be restored. A
 `set` tombstone creates a `listed` row keyed by `(deletion_seq,
@@ -1028,12 +1029,12 @@ released { released_at_ms }
 Missing
 ```
 
-`released` is terminal. Nothing returns a record to `active`: there is no
-refresh, no renewal, and no revival, and a released record protects nothing
-and serves no read. A new pin is a new record under a new id — ids are
-generated, never derived and never supplied by a caller, so a pin can never
-land on a released record's key and a released id is never reused. Distinct
-pins over one basis are distinct records with independent lifecycles.
+`released` is terminal. A released record never returns to `active`, protects
+nothing, and serves no read. The only renewal is the expiry extension of an
+active fork-owned record during fork installation (section 3.9.2). A new pin
+is a new record under a new id. Ids are generated, never derived and never
+supplied by a caller, and a record id is never reused. Distinct pins over one
+basis are distinct records with independent lifecycles.
 
 No checkpoint status transition consults a provider object timestamp. Every
 instant the status depends on lives in the record: `created_at_ms` for the
@@ -1841,7 +1842,7 @@ Three rules apply:
 
 ## 4. Durable encodings and versioning
 
-A stable format needs explicit versioning in three places.
+Storage formats and protocol bindings are versioned separately.
 
 | Layer | What is versioned |
 | --- | --- |
@@ -1907,7 +1908,9 @@ and absent, and no schema language states it, so no durable encoding writes one.
 | Grep manifest | `grep_manifest` | JSON, uncompressed | 1 |
 | Grep segment | none (section 4.2.2) | block sections, per-block zstd + CRC32C | 1 (via the grep manifest) |
 | Namespace manifest | `namespace_manifest` | JSON, uncompressed | 4 |
-| Control objects (head, metadata root, WAL floor) | per-kind snake_case names | JSON, uncompressed | 1 (tracked per kind) |
+| WAL head | `wal_head` | JSON, uncompressed | 2 |
+| WAL floor | `wal_floor` | JSON, uncompressed | 1 |
+| Metadata root | `metadata_root` | JSON, uncompressed | 1 |
 | Checkpoint record | `checkpoint_record` | JSON, uncompressed | 1 |
 | Upload session | `upload_session` | JSON, uncompressed | 1 |
 | Compaction lease | `compaction_lease` | JSON, uncompressed | 3 |
@@ -1990,7 +1993,7 @@ A row key contains hyphen-separated components. The first component is the singu
 
 The row's `kind` and its family serve different purposes. A row kind may appear in multiple families, so their names do not need to match. For example, a `direntry_bind` row appears in both `direntry_binds` and `direntry_child_binds`.
 
-The ten families and their exact grammar:
+The nine families and their exact grammar:
 
 | Family | Row key | Filter key |
 | --- | --- | --- |
@@ -2016,7 +2019,7 @@ The family groups and their exact members:
 | `commit_receipts` | `commit_receipts` |
 | `attributes` | `attributes` |
 
-`direntry_binds` and `direntry_child_binds` store the same `direntry_bind` rows under different keys. The two revision families do the same for `file_revision` rows. A row key therefore depends on both the row and its family.
+`direntry_binds` and `direntry_child_binds` store the same `direntry_bind` rows under different keys. The single `revisions` family stores `file_revision` rows. A row key therefore depends on both the row and its family.
 
 The `inodes` and `active_deletions` families store the full row key in the filter. Inode lookups already know the full key, while active deletions are read only by range scans.
 
@@ -2153,14 +2156,16 @@ and grep maintenance does not collect core-owned objects.
   including nested objects, and no payload carries a `format_version` of its
   own. A kind name that ends in a version, such as the `blob_v1` content-ref
   kind, names one closed shape and is not a second version mechanism.
-- **Additive within a released version.** Readers ignore unknown payload and
-  envelope fields, at every level of nesting, except inside the closed shapes
-  named in the encoding conventions above. After the first stable release,
-  adding such fields is the only change permitted within an existing format
-  version.
-- **Other post-release changes require a new version.** After the first stable
-  release, renaming, removing, retyping, or re-tagging any field — or changing
-  the payload encoding — requires a new `format_version` for the owning family.
+  A version governs safe interpretation and operation, including collection
+  protocols, not only field layout.
+- **Every accepted field is understood.** A supported durable family version
+  understands every authoritative field it accepts. Readers reject unknown
+  envelope and payload fields at every level of nesting. New durable meaning
+  requires a supported version change for the owning family.
+- **Post-release changes require a new version.** After the first stable
+  release, adding, renaming, removing, retyping, or re-tagging any field, changing
+  the payload encoding, or changing an operation that the version governs
+  requires a new `format_version` for the owning family.
   Readers reject versions they do not support with a typed unsupported-version
   error; there is no silent fallback.
 - **A durable digest names its algorithm, and where the algorithm is chosen
@@ -2177,13 +2182,10 @@ and grep maintenance does not collect core-owned objects.
   additionally carry their canonicalization scheme (`v2:sha256:<hex>`, section
   3.3.1) because their preimage rules can evolve independently of the
   algorithm.
-- **Unknown content-ref kinds round-trip in immutable records.** A reader that
-  does not understand a `content_ref.kind` must preserve the original string
-  when it relays or rewrites an immutable record, so a later format version
-  can add a kind. A reader of a mutable control object rejects an unknown kind
-  instead, because a guarded rewrite must not carry a kind it cannot validate.
-  No reader may create new references with kinds it does not understand
-  (section 3.1.3).
+- **New content kinds require family version changes.** A new `content_ref.kind`
+  arrives with a version change on every durable family that carries references.
+  Readers reject unknown kinds during decoding, as they reject unknown checksum
+  algorithms. No reader preserves or creates a reference it cannot interpret.
 - **Every encoding is pinned by golden-byte fixtures**
   (`crates/loonfs-api/tests/golden_formats.rs`). An encoder change that alters
   durable bytes fails those tests. The grep families are pinned under the same
@@ -2237,9 +2239,13 @@ is useful only after both the checkpoint record and its referenced manifest
 are verified. Readers must prefer the current verified manifest plus the
 visible WAL segment chain over unverified or partial manifest artifacts.
 
-The namespace manifest may reference one or more immutable metadata runs. Runs
-are not a second source of truth; they are rebuildable metadata rows used to
-keep normal metadata view loading from replaying an unbounded WAL tail.
+The namespace manifest may reference one or more immutable metadata runs.
+Runs are produced from committed state. Once the WAL below the retention
+floor is reclaimed, these runs are required recovery material, not a cache.
+Recovery uses the verified materialized basis plus the required visible WAL,
+bounded by the head's visibility boundary. Verification must precede floor
+advancement (section 3.8). Missing or corrupt required recovery material is a
+hard error; readers do not substitute another basis or replay reclaimed history.
 
 File revisions are stored once in the `revisions` family, newest first within
 an inode, using the same descending revision, sequence, and delta ordering as

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -821,8 +821,8 @@
             "description": "Immutable identity of the referenced object."
           },
           "kind": {
-            "description": "Content strategy used by the referenced object.",
-            "type": "string"
+            "$ref": "#/components/schemas/ContentRefKind",
+            "description": "Content strategy used by the referenced object."
           },
           "size_bytes": {
             "description": "Complete byte length of the referenced content.",
@@ -838,6 +838,13 @@
           "checksum"
         ],
         "type": "object"
+      },
+      "ContentRefKind": {
+        "description": "A supported content reference kind serialized as a string.",
+        "enum": [
+          "blob_v1"
+        ],
+        "type": "string"
       },
       "ContentToken": {
         "additionalProperties": false,

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -987,8 +987,8 @@
             "description": "Immutable identity of the referenced object."
           },
           "kind": {
-            "description": "Content strategy used by the referenced object.",
-            "type": "string"
+            "$ref": "#/components/schemas/ContentRefKind",
+            "description": "Content strategy used by the referenced object."
           },
           "size_bytes": {
             "description": "Complete byte length of the referenced content.",
@@ -1004,6 +1004,13 @@
           "checksum"
         ],
         "type": "object"
+      },
+      "ContentRefKind": {
+        "description": "A supported content reference kind serialized as a string.",
+        "enum": [
+          "blob_v1"
+        ],
+        "type": "string"
       },
       "ContentToken": {
         "additionalProperties": false,


### PR DESCRIPTION
The format spec stated two evolution rules that contradict each other: section 1.7 says every durable decoder rejects unknown fields and new fields need a supported family version, while section 4.3 said readers ignore unknown fields and additive change is allowed within a version. The code follows the strict rule. This change makes the strict rule the only rule and fixes the prose that had drifted from the code: eight control-object kinds are registered, not six; the WAL head is version 2; there are nine row families with one revisions family; a revoke tombstone cannot carry a binding and a reader rejects one that does; released checkpoint records never revive and ids are never reused, with the fork-install renewal named as the one renewal that exists; and metadata runs are required recovery material once the WAL below the floor is reclaimed, not a cache.

The one code change follows from the rule: `ContentRefKind::Unsupported` is removed, so an unknown content kind fails to decode with a precise error, the same way an unknown checksum algorithm does. A new content kind arrives with a version change on every family that carries references. The duplicate strict content-reference decoder inside the upload session record goes away with it, since the shared type is now strict itself, and the validation error for an unsupported kind is removed because that state can no longer be constructed. The OpenAPI document now lists the one accepted kind.

Behavior a reviewer should know about: no stored bytes change and no golden fixture changes. A durable record carrying an unknown content kind, which no writer could have produced, is now rejected at decode instead of being preserved. HTTP response tolerance for unknown JSON fields is unchanged; that is a different contract and the API spec keeps it. The existing unknown-field rejection tests already cover envelopes, payloads, nested records, and tagged variants in core and grep, so none were duplicated, and no test parses the Markdown.
