### PR TITLE
feat(api): fold file names with ICU4X data at one Unicode version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1547,6 +1547,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_casemap"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ca9983e8bf51223c2f89014fa4eaa9e9b336c47f3af0d000538f86f841fba1"
+dependencies = [
+ "icu_casemap_data",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties",
+ "icu_provider",
+ "potential_utf",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_casemap_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d4663d0f99b301033a19e0acf94e9d2fa4b107638580165e5a6ccc49ad1450"
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1576,7 @@ checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1567,6 +1590,7 @@ checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -1583,6 +1607,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -1620,6 +1647,8 @@ checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1818,13 +1847,13 @@ dependencies = [
  "crc32c",
  "crc64fast-nvme",
  "getrandom 0.3.4",
+ "icu_casemap",
+ "icu_normalizer",
  "serde",
  "serde_bytes",
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
- "unicode-casefold",
- "unicode-normalization",
  "utoipa",
  "xxhash-rust",
  "zstd",
@@ -2192,7 +2221,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2398,6 +2427,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -2698,7 +2729,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3051,7 +3082,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3141,6 +3172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -3393,25 +3425,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "unicode-casefold"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f66b1c8f8caa2ab31dc6d3f35386f16efdab89668f93411e565ac368908e8f"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-width"
@@ -3466,6 +3483,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3739,7 +3762,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3996,6 +4019,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,6 +4156,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ crc32c = "0.6"
 crc64fast-nvme = "1.2"
 http = "1"
 http-body = "1"
+icu_casemap = "=2.1.1"
+icu_normalizer = "=2.1.1"
 indexmap = { version = "2", features = ["serde"] }
 # The `serde` feature makes foyer encode keys and values through their serde
 # impls, which is how the server's cache key reaches foyer's storage traits.
@@ -101,8 +103,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 ureq = { version = "2.10", features = ["json"] }
 utoipa = { version = "5.5", features = ["macros"] }
 urlencoding = "2"
-unicode-casefold = "0.2"
-unicode-normalization = "0.1"
 walkdir = "2"
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 zstd = "0.13"

--- a/crates/loonfs-api/Cargo.toml
+++ b/crates/loonfs-api/Cargo.toml
@@ -19,13 +19,13 @@ crc64fast-nvme.workspace = true
 # Content ids are 128 fully random bits, drawn straight from the system
 # generator so their shard prefixes stay uniform (see `ids::ContentId`).
 getrandom.workspace = true
+icu_casemap.workspace = true
+icu_normalizer.workspace = true
 serde.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-unicode-casefold.workspace = true
-unicode-normalization.workspace = true
 utoipa = { workspace = true, optional = true }
 xxhash-rust.workspace = true
 zstd.workspace = true

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -1036,6 +1036,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Checksum, ContentRefKind};
 
     #[test]
     fn completed_proxied_session_rejects_conflicting_staged_size() {

--- a/crates/loonfs-api/src/name_policy.rs
+++ b/crates/loonfs-api/src/name_policy.rs
@@ -3,17 +3,15 @@
 //! The fixed data versions and evolution rule are in `docs/specs/format.md`,
 //! section 2.3.1. Admission and lookup share this implementation.
 
-use unicode_casefold::UnicodeCaseFold;
-use unicode_normalization::UnicodeNormalization;
+use icu_casemap::CaseMapper;
+use icu_normalizer::ComposingNormalizer;
 
 /// Derives the canonical lookup key for a display name.
 pub fn name_key_for_display_name(display_name: &str) -> String {
-    display_name
-        .nfc()
-        .collect::<String>()
-        .case_fold()
-        .nfc()
-        .collect()
+    let normalizer = ComposingNormalizer::new_nfc();
+    let normalized = normalizer.normalize(display_name);
+    let folded = CaseMapper::new().fold_string(&normalized);
+    normalizer.normalize(&folded).into_owned()
 }
 
 #[cfg(test)]

--- a/crates/loonfs-api/tests/golden/name_folding.v1.json
+++ b/crates/loonfs-api/tests/golden/name_folding.v1.json
@@ -125,11 +125,35 @@
   },
   {
     "display_name": "Ა",
-    "name_key": "Ა"
+    "name_key": "ა"
   },
   {
     "display_name": "ა",
     "name_key": "ა"
+  },
+  {
+    "display_name": "Ꞹ",
+    "name_key": "ꞹ"
+  },
+  {
+    "display_name": "ꞹ",
+    "name_key": "ꞹ"
+  },
+  {
+    "display_name": "Ɤ",
+    "name_key": "ɤ"
+  },
+  {
+    "display_name": "ɤ",
+    "name_key": "ɤ"
+  },
+  {
+    "display_name": "Ꭰ",
+    "name_key": "Ꭰ"
+  },
+  {
+    "display_name": "ꭰ",
+    "name_key": "Ꭰ"
   },
   {
     "display_name": "readme-123.txt",

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -3008,8 +3008,6 @@ fn commit_assertion_wire_shapes_match_golden() {
 
 #[test]
 fn name_folding_matches_the_fixed_unicode_corpus() {
-    assert_eq!(unicode_normalization::UNICODE_VERSION, (17, 0, 0));
-    assert_eq!(unicode_casefold::UNICODE_VERSION, (9, 0, 0));
     let display_names = [
         "Cafe\u{301}.TXT",
         "CAFÉ.txt",
@@ -3044,6 +3042,12 @@ fn name_folding_matches_the_fixed_unicode_corpus() {
         "𐐀",
         "Ა",
         "ა",
+        "Ꞹ",
+        "ꞹ",
+        "Ɤ",
+        "ɤ",
+        "Ꭰ",
+        "ꭰ",
         "readme-123.txt",
         "123_+-",
     ];

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -679,19 +679,20 @@ archive, or through a sync client.
 #### 2.3.1 Name-key folding
 
 Sibling-name comparison is a fixed rule of the v0 format, not a per-namespace
-choice. Every name key is derived from its display name by normalizing to NFC
-with Unicode 17.0.0 data, applying full Unicode default (non-Turkic) case folding
-with Unicode 9.0.0 data, then normalizing to NFC with Unicode 17.0.0 data again.
-These are the fixed data versions used by `unicode-normalization` 0.1.25 and
-`unicode-casefold` 0.2.0 in `Cargo.lock`. Their source tables declare those
-versions separately; the normalization and folding versions differ.
+choice. Every name key is derived from its display name by normalizing to NFC,
+applying full Unicode default (non-Turkic) case folding, then normalizing to NFC
+again. Both steps use Unicode 17.0.0 data: `icu_normalizer` 2.1.1 and
+`icu_casemap` 2.1.1 use compiled data from `icu_normalizer_data` 2.1.1 and
+`icu_casemap_data` 2.1.1. Both data crates identify ICU `release-78.1rc` as
+their source. ICU 78 uses Unicode 17.0.0.
 
 Both admission and lookup use this rule. The display-name and name-key corpus
 in `crates/loonfs-api/tests/golden/name_folding.v1.json` pins its mappings and
 directory collisions. A dependency update that changes a mapping is a
 format-semantic change under section 4.3, even if no field or encoding changes.
 There is one rule, no per-namespace selector or head field, and no rewriting of
-stored keys.
+stored keys. A namespace written before a rule change keeps its stored keys;
+this is acceptable before the format is released.
 
 ### 2.4 Files and revisions
 


### PR DESCRIPTION
#895 pinned the name-key folding rule to the data the implementation used, and that exposed an eight-release gap: normalization used Unicode 17.0.0 data while case folding used Unicode 9.0.0 data from `unicode-casefold`. This change moves both steps of the rule, NFC then full default case folding then NFC, onto ICU4X: `icu_normalizer` and `icu_casemap`, both at 2.1.1 with compiled data from ICU release 78, which is Unicode 17.0.0. The workspace drops `unicode-casefold` and `unicode-normalization`, which nothing else used, and gains `icu_casemap` and its data crate; `icu_normalizer` was already in the lockfile transitively, so one copy of each ICU4X crate is built.

The shared helper keeps its signature and both admission and lookup still go through it. The corpus golden is regenerated deliberately and its diff is the whole behavior change: among existing entries only one mapping moves, the Georgian Mtavruli capital now folds to its Mkhedruli lowercase, so those two spellings collide as one name where they were distinct before. Six entries are added to exercise the newer data: a Latin U with stroke pair added in Unicode 11 and a capital Rams horn pair added in Unicode 16, which now fold together, and a Cherokee pair, which folds to uppercase as it did before. No existing collision becomes distinct. The format rule names the crates, the data crates, and the Unicode version they carry; the ICU4X crates expose no version constant to assert, so the corpus golden is the guard against a mapping change.

Behavior a reviewer should know about: this is a format-semantic change under the evolution rule #895 added, made before release on purpose. No stored name keys are rewritten; a namespace written with the old rule keeps its keys, and a stored key whose mapping changed is no longer reached by its former display spelling, which the spec now states as the pre-release treatment. No wire or durable encoding shape changes. The Codex run that wrote this had no network, so I resolved the dependencies, regenerated the corpus, and ran the gates here.

Builds on #894 and #895, both now merged into main.

