### PR TITLE
refactor(core): route upload content operations through the content module

### DIFF
--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -24,9 +24,10 @@ use crate::limits::{
 use crate::namespace::catalog::{load_namespace_content_store_id, VerifiedNamespaceCatalogEntry};
 use crate::namespace::control::load_namespace_head_control;
 use crate::storage::content::{
-    abort_unpublished_multipart_upload, delete_unpublished_content_object,
-    identify_streamed_payload, stage_bytes_under_content_id, stage_streamed_under_content_id,
-    verify_durable_content_checksum, DurableContentValidationError, StreamedPayloadKind,
+    abort_unpublished_multipart_upload, complete_content_multipart_upload, content_key_for_id,
+    create_content_multipart_upload, delete_unpublished_content_object, identify_streamed_payload,
+    stage_bytes_under_content_id, stage_streamed_under_content_id, verify_durable_content_checksum,
+    DurableContentValidationError, StreamedPayloadKind,
 };
 use crate::storage::content_admission::{CompletedUploadReceipt, PreparedContent};
 use bytes::Bytes;
@@ -43,7 +44,7 @@ use loonfs_api::{
     Checksum, ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind, ContentStoreId,
     NamespaceId, UploadId,
 };
-use loonfs_objectstore::keys::{content_blob, upload_session};
+use loonfs_objectstore::keys::upload_session;
 use loonfs_objectstore::{
     ByteStream, MultipartCompletion, MultipartPart, ObjectMetadata, ObjectStore,
     PROVIDER_MULTIPART_PART_BYTES,
@@ -146,7 +147,7 @@ pub(crate) async fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
     ensure_upload_namespace_available(store, namespace_id).await?;
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
     let content_id = ContentId::generate();
-    let object_key = content_blob(&content_store_id, &content_id);
+    let object_key = content_key_for_id(&content_store_id, &content_id);
     let upload_id = create_upload_session(
         store,
         namespace_id,
@@ -177,12 +178,10 @@ pub(crate) async fn begin_direct_multipart_upload_target<S: ObjectStore + ?Sized
     let part_size_bytes = multipart_part_size(options.part_size_bytes)?;
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
     let content_id = ContentId::generate();
-    let object_key = content_blob(&content_store_id, &content_id);
+    let object_key = content_key_for_id(&content_store_id, &content_id);
 
-    let provider_upload_id = store
-        .create_multipart_upload(&object_key)
-        .await
-        .map_err(|err| CoreError::store(&object_key, &err))?;
+    let provider_upload_id =
+        create_content_multipart_upload(store, &content_store_id, &content_id).await?;
     let session = NewUploadSession::direct_multipart(
         content_id.clone(),
         &provider_upload_id,
@@ -275,7 +274,7 @@ pub(crate) async fn direct_multipart_part_targets<S: ObjectStore + ?Sized>(
     }
 
     Ok(MultipartPartTargets {
-        object_key: content_blob(&content_store_id, &session.content_id),
+        object_key: content_key_for_id(&content_store_id, &session.content_id),
         provider_upload_id: provider_upload_id.to_owned(),
         parts,
     })
@@ -989,7 +988,7 @@ pub(crate) async fn stage_owned_stream<S: ObjectStore + ?Sized>(
         // replay, and it fails loudly.
         return Err(CoreError::Internal(format!(
             "content object `{}` already holds bytes under a freshly minted identity",
-            content_blob(catalog.content_store_id(), &staged.content_ref.content_id)
+            content_key_for_id(catalog.content_store_id(), &staged.content_ref.content_id)
         )));
     }
     complete_owned_staging(
@@ -1504,26 +1503,14 @@ async fn assemble_multipart_upload<S: ObjectStore + ?Sized>(
     expected: &ContentRef,
 ) -> Result<CompletionOutcome> {
     let parts = multipart_parts(parts, checksum_algorithm)?;
-    let object_key = content_blob(content_store_id, &expected.content_id);
-
-    let completion = match store
-        .complete_multipart_upload(&object_key, provider_upload_id, &parts, &expected.checksum)
-        .await
-    {
-        Ok(completion @ (MultipartCompletion::Assembled | MultipartCompletion::UnknownUpload)) => {
-            completion
-        }
-        Err(err) => {
-            // The object was not assembled on this call. The provider may
-            // have refused the parts, or the call may not have completed at
-            // all: a refusal arrives as the same transport failure as a lost
-            // response, so this cannot tell them apart and does not guess.
-            // Reporting the store failure leaves the session open and the
-            // object, if the provider did assemble one, in place — which is
-            // what a repeated completion reconciles from.
-            return Err(CoreError::store(&object_key, &err));
-        }
-    };
+    let completion = complete_content_multipart_upload(
+        store,
+        content_store_id,
+        expected,
+        provider_upload_id,
+        &parts,
+    )
+    .await?;
 
     match verify_durable_content_checksum(store, content_store_id, expected).await {
         Ok(()) => Ok(CompletionOutcome::Verified(expected.clone())),
@@ -1559,6 +1546,7 @@ mod tests {
     use super::*;
     use crate::namespace::bootstrap::bootstrap_namespace;
     use loonfs_api::wire::control::decode_control_object;
+    use loonfs_objectstore::keys::content_blob;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::PutMode;
     use loonfs_test_support::stores::{

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -17,7 +17,10 @@ use loonfs_api::{
     PathEntry, Sha256, StreamingChecksum,
 };
 use loonfs_objectstore::keys::content_blob;
-use loonfs_objectstore::{ByteRange, ByteStream, ObjectStore, ObjectStoreError, PutMode};
+use loonfs_objectstore::{
+    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectStore, ObjectStoreError,
+    PutMode,
+};
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
@@ -221,6 +224,36 @@ pub(crate) async fn verify_durable_content_checksum<S: ObjectStore + ?Sized>(
         });
     }
     Ok(())
+}
+
+pub(crate) async fn create_content_multipart_upload<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: &ContentStoreId,
+    content_id: &ContentId,
+) -> crate::error::Result<String> {
+    let object_key = content_key_for_id(content_store_id, content_id);
+    store
+        .create_multipart_upload(&object_key)
+        .await
+        .map_err(|err| CoreError::store(&object_key, &err))
+}
+
+/// A failed completion is reported as the store failure it was. The
+/// provider may have refused the parts or the response may have been lost,
+/// and the two arrive alike, so this does not guess; the session stays open
+/// and a repeated completion reconciles from whatever the provider holds.
+pub(crate) async fn complete_content_multipart_upload<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: &ContentStoreId,
+    expected: &ContentRef,
+    provider_upload_id: &str,
+    parts: &[MultipartPart],
+) -> crate::error::Result<MultipartCompletion> {
+    let object_key = content_key_for_id(content_store_id, &expected.content_id);
+    store
+        .complete_multipart_upload(&object_key, provider_upload_id, parts, &expected.checksum)
+        .await
+        .map_err(|err| CoreError::store(&object_key, &err))
 }
 
 /// Removes the content object an upload session owned but never published.
@@ -553,6 +586,13 @@ pub(crate) async fn get_durable_content_bytes<S: ObjectStore + ?Sized>(
     let bytes = load_required_object(store, &object_key).await?;
     validate_loaded_content_bytes(object_key, content_ref, &bytes)?;
     Ok(bytes)
+}
+
+pub(crate) fn content_key_for_id(
+    content_store_id: &ContentStoreId,
+    content_id: &ContentId,
+) -> String {
+    content_blob(content_store_id, content_id)
 }
 
 pub(crate) fn content_object_key_for_ref(


### PR DESCRIPTION
File bytes live under `content-stores/{content_store_id}/objects/...`, a keyspace the format keeps apart from namespace metadata so that content could one day sit in a different backend. Every read of file bytes, staging write, unpublished-content delete, and multipart abort already goes through the content module. The upload protocol was the one exception: it derived content object keys itself and called the store's multipart create and complete operations on them directly. This change moves those behind the content module, so file-byte I/O has one owner and a later split of content from metadata storage is a change to one module rather than an audit.

The content module gains a key helper for a content id beside the existing one for a content reference, and two functions that create and complete a provider multipart upload for a content id with the same error mapping the protocol used. The protocol calls those for the direct-put target key, the multipart part targets, multipart begin and completion, and the error message that names an occupied key. Completion outcome classification stays in the protocol because it depends on session state.

Behavior a reviewer should know about: none. Object keys, multipart arguments, checksums, return values, and error mapping are unchanged, and the existing upload and request-accounting suites pass unchanged. The only remaining production uses of a content key outside the content module are the read view's calls to the existing reference helper. No wire shape or durable encoding changes.
