### PR TITLE
feat(format): write a content-store descriptor when a content domain is created

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 use std::num::NonZeroU64;
 
-/// Selects one independently versioned mutable control-object family.
+/// Selects one independently versioned control-object family.
 ///
 /// See [mutable control-object rules](../../../docs/specs/format.md#17-mutable-control-object-rules).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -37,11 +37,13 @@ pub enum ControlObjectKind {
     CompactionOutputProtection,
     /// Coordinates bounded, resumable marking and sweeping.
     GcRun,
+    /// Identifies the content domain held by a backend.
+    ContentStore,
 }
 
 impl ControlObjectKind {
     /// Lists every registered control-object family in stable registry order.
-    pub const ALL: [Self; 8] = [
+    pub const ALL: [Self; 9] = [
         Self::WalHead,
         Self::WalFloor,
         Self::MetadataRoot,
@@ -50,6 +52,7 @@ impl ControlObjectKind {
         Self::CompactionLease,
         Self::CompactionOutputProtection,
         Self::GcRun,
+        Self::ContentStore,
     ];
 
     /// Durable format version for this control object kind.
@@ -68,6 +71,7 @@ impl ControlObjectKind {
             Self::CompactionLease => 3,
             Self::CompactionOutputProtection => 1,
             Self::GcRun => 1,
+            Self::ContentStore => 1,
         }
     }
 
@@ -82,6 +86,7 @@ impl ControlObjectKind {
             Self::CompactionLease => "compaction_lease",
             Self::CompactionOutputProtection => "compaction_output_protection",
             Self::GcRun => "gc_run",
+            Self::ContentStore => "content_store",
         }
     }
 
@@ -89,6 +94,16 @@ impl ControlObjectKind {
     pub fn parse(value: &str) -> Option<Self> {
         Self::ALL.into_iter().find(|kind| kind.as_str() == value)
     }
+}
+
+/// Identifies a content domain in its physical backend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContentStoreState {
+    /// Domain whose objects share this descriptor's prefix.
+    pub content_store_id: ContentStoreId,
+    /// Unix-millisecond stamp from the domain's creation context.
+    pub created_at_ms: u64,
 }
 
 /// Earliest sequence for which incremental WAL history is retained.

--- a/crates/loonfs-api/tests/golden/control_content_store.v1.json
+++ b/crates/loonfs-api/tests/golden/control_content_store.v1.json
@@ -1,0 +1,1 @@
+{"kind":"content_store","format_version":1,"payload_checksum":"sha256:6846651ecb633942e76ac5d0b68fee0bf7449d4d9607d58c69832d09ebabfd16","payload":{"content_store_id":"cs_0123456789abcdef0123456789abcdef","created_at_ms":1000}}

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -20,10 +20,10 @@
 
 use loonfs_api::wire::control::{
     decode_control_object, CheckpointOwner, CheckpointRecordState, CheckpointStatus,
-    CompactionLeaseStatus, ControlObjectEnvelope, ControlObjectKind, ForkBasis, HeadState,
-    ManifestRef, MetadataCompactionLeaseState, MetadataRootState, NamespaceStatus, ProxiedStaging,
-    UploadSessionMode, UploadSessionRecordStatus, UploadSessionState, WalFloorState,
-    WalSegmentPointer, WriterBlock,
+    CompactionLeaseStatus, ContentStoreState, ControlObjectEnvelope, ControlObjectKind, ForkBasis,
+    HeadState, ManifestRef, MetadataCompactionLeaseState, MetadataRootState, NamespaceStatus,
+    ProxiedStaging, UploadSessionMode, UploadSessionRecordStatus, UploadSessionState,
+    WalFloorState, WalSegmentPointer, WriterBlock,
 };
 use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::wire::manifest::{
@@ -622,6 +622,14 @@ fn head_status_rejects_unknown_fields_as_corruption() {
 #[test]
 fn control_objects_match_golden_bytes() {
     check_control_golden(
+        "control_content_store.v1.json",
+        ControlObjectKind::ContentStore,
+        ContentStoreState {
+            content_store_id: content_store_id(),
+            created_at_ms: 1_000,
+        },
+    );
+    check_control_golden(
         "control_wal_head.v2.json",
         ControlObjectKind::WalHead,
         sample_head_state(),
@@ -918,13 +926,18 @@ fn every_durable_status_is_a_kind_tagged_object() {
 }
 
 #[test]
-fn every_mutable_control_payload_rejects_unknown_fields_as_corruption() {
+fn every_control_payload_rejects_unknown_fields_as_corruption() {
     let add_unknown = |payload: &mut serde_json::Value| {
         payload["field_from_the_future"] = serde_json::Value::from(true);
     };
     assert_control_payload_edit_is_corrupt::<HeadState>(
         "control_wal_head.v2.json",
         ControlObjectKind::WalHead,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<ContentStoreState>(
+        "control_content_store.v1.json",
+        ControlObjectKind::ContentStore,
         add_unknown,
     );
     assert_control_payload_edit_is_corrupt::<WalFloorState>(
@@ -1354,6 +1367,14 @@ fn mutable_control_envelope_rejects_unknown_fields_as_corruption() {
 #[test]
 fn control_object_decoders_reject_wrong_format_version_without_fallback() {
     let cases = [
+        (
+            ControlObjectKind::ContentStore,
+            serde_json::to_value(ContentStoreState {
+                content_store_id: content_store_id(),
+                created_at_ms: 1_000,
+            })
+            .expect("content store state"),
+        ),
         (
             ControlObjectKind::CheckpointRecord,
             serde_json::to_value(CheckpointRecordState {

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -83,6 +83,29 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     allow_existing: bool,
 ) -> Result<Namespace, BootstrapNamespaceError> {
+    // Avoid creating an unreferenced descriptor for an already-taken id.
+    // Absence here is only a hint: the conditional head write still decides
+    // which concurrent creator wins.
+    match load_head_object(store, namespace_id).await {
+        Ok(existing) => {
+            if existing.state.status.is_deleted() {
+                return Err(BootstrapNamespaceError::NamespaceDeleted {
+                    namespace_id: namespace_id.clone(),
+                });
+            }
+            if !allow_existing {
+                return Err(BootstrapNamespaceError::NamespaceAlreadyExists {
+                    namespace_id: namespace_id.clone(),
+                });
+            }
+            return crate::namespace::status::load_namespace(store, namespace_id)
+                .await
+                .map_err(BootstrapNamespaceError::Core);
+        }
+        Err(ControlObjectLoadError::MissingObject { .. }) => {}
+        Err(error) => return Err(BootstrapNamespaceError::Head(error)),
+    }
+
     let mut head = HeadState::initial(
         namespace_id.clone(),
         ContentStoreId::generate(),

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -1,9 +1,4 @@
-//! Namespace creation: one conditional write of a complete head.
-//!
-//! The head is the namespace. Nothing is written before it and nothing
-//! after it, so a create either lands entirely or leaves the namespace
-//! absent — there is no partial state to classify, complete, or repair
-//! (format spec, "Creating a namespace").
+//! Namespace creation: a content-domain descriptor followed by a conditional head write.
 
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
@@ -12,11 +7,13 @@ use crate::error::{CoreError, StoreFailureClass};
 use crate::metadata::{InodeRecord, MetadataState};
 use crate::namespace::control::load_head_object;
 use bytes::Bytes;
-use loonfs_api::wire::control::{encode_control_state, ControlObjectKind, HeadState, WriterBlock};
+use loonfs_api::wire::control::{
+    encode_control_state, ContentStoreState, ControlObjectKind, HeadState, WriterBlock,
+};
 use loonfs_api::{
     ChangeSeq, ContentStoreId, ErrorCode, InodeKind, Namespace, NamespaceId, ROOT_INODE_ID,
 };
-use loonfs_objectstore::keys::wal_head;
+use loonfs_objectstore::keys::{content_store, wal_head};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
@@ -86,9 +83,6 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     allow_existing: bool,
 ) -> Result<Namespace, BootstrapNamespaceError> {
-    // A fresh content-store id per namespace. Nothing claims it durably:
-    // uniqueness rests on the generated id's randomness, exactly as it does
-    // for every other generated id in the format.
     let mut head = HeadState::initial(
         namespace_id.clone(),
         ContentStoreId::generate(),
@@ -98,6 +92,28 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         writer_id: context.writer_id.clone(),
         acquired_at_ms: context.now_ms,
     });
+
+    let object_key = content_store(&head.content_store_id);
+    let descriptor = ContentStoreState {
+        content_store_id: head.content_store_id.clone(),
+        created_at_ms: context.now_ms,
+    };
+    let bytes =
+        encode_control_state(ControlObjectKind::ContentStore, &descriptor).map_err(|error| {
+            CoreError::Codec {
+                object_key: object_key.clone(),
+                message: error.to_string(),
+            }
+        })?;
+    store
+        .put_if_absent(&object_key, Bytes::from(bytes))
+        .await
+        .map_err(|error| match error {
+            ObjectStoreError::PreconditionFailed { .. } => CoreError::Internal(format!(
+                "content store descriptor `{object_key}` already exists under a freshly minted identity"
+            )),
+            error => CoreError::store(&object_key, &error),
+        })?;
 
     match install_namespace_head(store, namespace_id, &head).await? {
         NamespaceHeadInstall::Landed => {}

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -1444,29 +1444,23 @@ async fn bootstrap_writes_a_descriptor_before_the_head_and_fork_writes_none() {
         fork_head.state.content_store_id,
         descriptor.content_store_id
     );
-    store.reset();
-    let error = bootstrap_namespace(&store, &source, &context, false)
-        .await
-        .expect_err("source exists");
-    assert_eq!(error.code(), ErrorCode::NamespaceExists);
-    let puts: Vec<_> = store
-        .take()
-        .into_iter()
-        .filter_map(|operation| match operation {
-            RecordedOperation::Put { key, mode, .. } => Some((key, mode)),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(puts.len(), 2);
-    assert_ne!(puts[0].0, descriptor_key);
-    assert!(puts[0].0.starts_with("content-stores/") && puts[0].0.ends_with("/store.json"));
-    assert_eq!(puts[0].1, PutMode::CreateIfAbsent);
-    assert_eq!(puts[1], (wal_head(&source), PutMode::CreateIfAbsent));
-    assert!(store
-        .head(&puts[0].0)
-        .await
-        .expect("orphan descriptor")
-        .is_some());
+    for allow_existing in [false, true] {
+        store.reset();
+        let result = bootstrap_namespace(&store, &source, &context, allow_existing).await;
+        if allow_existing {
+            assert_eq!(result.expect("adopt source").namespace_id, source);
+        } else {
+            assert_eq!(
+                result.expect_err("source exists").code(),
+                ErrorCode::NamespaceExists
+            );
+        }
+        let counts = store.counts();
+        assert_eq!(
+            (counts.puts, counts.compare_and_swaps, counts.deletes),
+            (0, 0, 0)
+        );
+    }
 }
 
 #[tokio::test]
@@ -1488,9 +1482,143 @@ async fn an_occupied_descriptor_key_fails_before_the_head_write() {
         if message.contains("already exists under a freshly minted identity"))
     );
     let operations = store.take();
-    assert_eq!(operations.len(), 1);
+    assert_eq!(operations.len(), 2);
     assert!(
-        matches!(&operations[0], RecordedOperation::Put { mode: PutMode::CreateIfAbsent, key, .. }
+        matches!(&operations[0], RecordedOperation::GetWithMetadata { key, .. }
+        if key == &wal_head(&namespace_id("demo")))
+    );
+    assert!(
+        matches!(&operations[1], RecordedOperation::Put { mode: PutMode::CreateIfAbsent, key, .. }
         if key.starts_with("content-stores/") && key.ends_with("/store.json"))
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_of_a_deleted_namespace_writes_nothing() {
+    let directory = tempdir().expect("tempdir");
+    let store = RecordingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::any(),
+    );
+    let namespace_id = namespace_id("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    namespace_engine(&store, &namespace_id, &context)
+        .delete_namespace(loonfs_core::DeleteNamespaceOptions::default())
+        .await
+        .expect("delete");
+    for allow_existing in [false, true] {
+        store.reset();
+        let error = bootstrap_namespace(&store, &namespace_id, &context, allow_existing)
+            .await
+            .expect_err("retired id");
+        assert_eq!(error.code(), ErrorCode::NamespaceDeleted);
+        let counts = store.counts();
+        assert_eq!(
+            (counts.puts, counts.compare_and_swaps, counts.deletes),
+            (0, 0, 0)
+        );
+    }
+}
+
+#[tokio::test]
+async fn bootstrap_head_read_failures_never_create_a_descriptor() {
+    for injected in [
+        InjectedError::Transport("head read failed".to_owned()),
+        InjectedError::PermissionDenied("head read denied".to_owned()),
+    ] {
+        let directory = tempdir().expect("tempdir");
+        let namespace_id = namespace_id("demo");
+        let failing = FailStore::new(
+            LocalFsStore::new(directory.path()).expect("store"),
+            KeyPredicate::exact(wal_head(&namespace_id)),
+            OperationClass::Read,
+            injected,
+        );
+        failing.fail_all();
+        let store = RecordingStore::new(failing, KeyPredicate::any());
+        for allow_existing in [false, true] {
+            let error =
+                bootstrap_namespace(&store, &namespace_id, &mutation_context(), allow_existing)
+                    .await
+                    .expect_err("head read failed");
+            assert!(matches!(
+                error,
+                loonfs_core::BootstrapNamespaceError::Head(_)
+            ));
+        }
+        let counts = store.counts();
+        assert_eq!(
+            (counts.puts, counts.compare_and_swaps, counts.deletes),
+            (0, 0, 0)
+        );
+    }
+}
+
+#[tokio::test]
+async fn bootstrap_of_a_corrupt_head_writes_nothing() {
+    let directory = tempdir().expect("tempdir");
+    let store = RecordingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::any(),
+    );
+    let namespace_id = namespace_id("demo");
+    store
+        .put_if_absent(
+            &wal_head(&namespace_id),
+            Bytes::from_static(b"invalid head"),
+        )
+        .await
+        .expect("corrupt head");
+    store.reset();
+    for allow_existing in [false, true] {
+        let error = bootstrap_namespace(&store, &namespace_id, &mutation_context(), allow_existing)
+            .await
+            .expect_err("corrupt head");
+        assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+    }
+    let counts = store.counts();
+    assert_eq!(
+        (counts.puts, counts.compare_and_swaps, counts.deletes),
+        (0, 0, 0)
+    );
+}
+
+#[tokio::test]
+async fn a_creator_losing_after_the_head_read_leaves_only_an_orphan_descriptor() {
+    let directory = tempdir().expect("tempdir");
+    let store = loonfs_test_support::stores::BlockingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::prefix("content-stores/"),
+        OperationClass::PutCreateIfAbsent,
+    );
+    let namespace_id = namespace_id("demo");
+    let context = mutation_context();
+    store.block_next();
+    let delayed = bootstrap_namespace(&store, &namespace_id, &context, false);
+    let winner = async {
+        store.wait_until_blocked().await;
+        let result = bootstrap_namespace(&store, &namespace_id, &context, false).await;
+        store.release();
+        result.expect("concurrent creator wins")
+    };
+    let (delayed, winner) = tokio::join!(delayed, winner);
+    assert_eq!(
+        delayed.expect_err("lost conditional write").code(),
+        ErrorCode::NamespaceExists
+    );
+    assert_eq!(winner.namespace_id, namespace_id);
+    let head = head_state(&store, &namespace_id).await;
+    let descriptors = store
+        .list_prefix("content-stores/")
+        .await
+        .expect("descriptors");
+    assert_eq!(descriptors.len(), 2);
+    assert!(descriptors.contains(&content_store(&head.content_store_id)));
+    assert_eq!(
+        namespace_keys(&store, &namespace_id).await,
+        vec![wal_head(&namespace_id)]
     );
 }

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -1,8 +1,7 @@
 //! Namespace creation, fork installation, and terminal lifecycle guards.
 //!
-//! Create and fork are one conditional write of a complete head, so these
-//! tests are mostly about what that single write does under contention and
-//! what a namespace looks like before it has published anything of its own.
+//! Tests cover descriptor creation, conditional head installation, and
+//! namespace state before the first metadata publication.
 
 #![allow(clippy::panic)]
 // These integration tests use panic in unexpected match arms for precise diagnostics.
@@ -12,7 +11,8 @@ use crate::common::namespace_engine;
 use bytes::Bytes;
 use loonfs_api::{
     wire::control::{
-        decode_control_object, CheckpointOwner, CheckpointStatus, ControlObjectKind, HeadState,
+        decode_control_object, CheckpointOwner, CheckpointStatus, ContentStoreState,
+        ControlObjectKind, HeadState,
     },
     wire::manifest::{
         decode_namespace_manifest_json, encode_namespace_manifest_json, MetadataRowFamily,
@@ -23,12 +23,14 @@ use loonfs_core::content::store_bytes_as_content;
 use loonfs_core::control::load_namespace_head_control;
 use loonfs_core::publish::FilesystemOperation;
 use loonfs_core::{Error as CoreError, ErrorCode, MutationContext};
-use loonfs_objectstore::keys::{metadata_manifest_object, metadata_root, wal_floor, wal_head};
+use loonfs_objectstore::keys::{
+    content_store, metadata_manifest_object, metadata_root, wal_floor, wal_head,
+};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::ObjectStore;
+use loonfs_objectstore::{ObjectStore, PutMode};
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{
-    FailStore, InjectedError, KeyPredicate, OperationClass, RecordingStore,
+    FailStore, InjectedError, KeyPredicate, OperationClass, RecordedOperation, RecordingStore,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -298,7 +300,7 @@ fn metadata_segment_counting_store(root: impl AsRef<Path>) -> RecordingStore<Loc
 }
 
 #[tokio::test]
-async fn a_created_namespace_is_one_object_until_its_first_flush() {
+async fn a_created_namespace_has_a_descriptor_and_only_a_head_until_its_first_flush() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
@@ -313,15 +315,17 @@ async fn a_created_namespace_is_one_object_until_its_first_flush() {
     assert_eq!(
         namespace_keys(&store, &namespace_id).await,
         vec![wal_head(&namespace_id)],
-        "creation writes the head and nothing else"
+        "creation writes only the head under the namespace prefix"
     );
-    assert!(
+    let head = load_namespace_head_control(&store, &namespace_id)
+        .await
+        .expect("load head");
+    assert_eq!(
         store
             .list_prefix("content-stores/")
             .await
-            .expect("list content stores")
-            .is_empty(),
-        "the content store is an id in the head, not an object"
+            .expect("list content stores"),
+        vec![content_store(&head.state.content_store_id)],
     );
 
     // Reads work against the built-in genesis state.
@@ -1375,4 +1379,118 @@ impl ObjectStore for ReleasePinBeforeRenewalStore {
     {
         self.inner.list_prefix_from_stream(prefix, start_after)
     }
+}
+
+#[tokio::test]
+async fn bootstrap_writes_a_descriptor_before_the_head_and_fork_writes_none() {
+    let directory = tempdir().expect("tempdir");
+    let store = RecordingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::any(),
+    );
+    let context = mutation_context();
+    let source = namespace_id("source");
+    bootstrap_namespace(&store, &source, &context, false)
+        .await
+        .expect("bootstrap");
+    let head = load_namespace_head_control(&store, &source)
+        .await
+        .expect("head");
+    let descriptor_key = content_store(&head.state.content_store_id);
+    let puts: Vec<_> = store
+        .take()
+        .into_iter()
+        .filter_map(|operation| match operation {
+            RecordedOperation::Put { key, mode, .. } => Some((key, mode)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        puts,
+        vec![
+            (descriptor_key.clone(), PutMode::CreateIfAbsent),
+            (wal_head(&source), PutMode::CreateIfAbsent),
+        ]
+    );
+    let bytes = store
+        .get(&descriptor_key, None)
+        .await
+        .expect("get descriptor")
+        .expect("descriptor");
+    let descriptor =
+        decode_control_object::<ContentStoreState>(&bytes, ControlObjectKind::ContentStore)
+            .expect("decode descriptor")
+            .into_payload();
+    assert_eq!(
+        descriptor,
+        ContentStoreState {
+            content_store_id: head.state.content_store_id.clone(),
+            created_at_ms: head.state.created_at_ms,
+        }
+    );
+    store.reset();
+    let target = namespace_id("target");
+    fork_namespace(&store, &source, &target, &context)
+        .await
+        .expect("fork");
+    assert!(store
+        .take()
+        .iter()
+        .all(|operation| !operation.key().starts_with("content-stores/")));
+    let fork_head = load_namespace_head_control(&store, &target)
+        .await
+        .expect("fork head");
+    assert_eq!(
+        fork_head.state.content_store_id,
+        descriptor.content_store_id
+    );
+    store.reset();
+    let error = bootstrap_namespace(&store, &source, &context, false)
+        .await
+        .expect_err("source exists");
+    assert_eq!(error.code(), ErrorCode::NamespaceExists);
+    let puts: Vec<_> = store
+        .take()
+        .into_iter()
+        .filter_map(|operation| match operation {
+            RecordedOperation::Put { key, mode, .. } => Some((key, mode)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(puts.len(), 2);
+    assert_ne!(puts[0].0, descriptor_key);
+    assert!(puts[0].0.starts_with("content-stores/") && puts[0].0.ends_with("/store.json"));
+    assert_eq!(puts[0].1, PutMode::CreateIfAbsent);
+    assert_eq!(puts[1], (wal_head(&source), PutMode::CreateIfAbsent));
+    assert!(store
+        .head(&puts[0].0)
+        .await
+        .expect("orphan descriptor")
+        .is_some());
+}
+
+#[tokio::test]
+async fn an_occupied_descriptor_key_fails_before_the_head_write() {
+    let directory = tempdir().expect("tempdir");
+    let failing = FailStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::prefix("content-stores/"),
+        OperationClass::Put,
+        InjectedError::PreconditionFailed,
+    );
+    failing.fail_all();
+    let store = RecordingStore::new(failing, KeyPredicate::any());
+    let error = bootstrap_namespace(&store, &namespace_id("demo"), &mutation_context(), false)
+        .await
+        .expect_err("descriptor collision");
+    assert!(
+        matches!(error, loonfs_core::BootstrapNamespaceError::Core(CoreError::Internal(message))
+        if message.contains("already exists under a freshly minted identity"))
+    );
+    let operations = store.take();
+    assert_eq!(operations.len(), 1);
+    assert!(
+        matches!(&operations[0], RecordedOperation::Put { mode: PutMode::CreateIfAbsent, key, .. }
+        if key.starts_with("content-stores/") && key.ends_with("/store.json"))
+    );
 }

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -155,6 +155,11 @@ pub fn upload_session(namespace_id: &NamespaceId, upload_id: &UploadId) -> Strin
     format!("namespaces/{namespace_id}/uploads/{upload_id}.json")
 }
 
+/// Builds the descriptor key beside a content domain's objects.
+pub fn content_store(content_store_id: &ContentStoreId) -> String {
+    format!("content-stores/{content_store_id}/store.json")
+}
+
 /// Builds the immutable content-object key for one content identity.
 pub fn content_blob(content_store_id: &ContentStoreId, content_id: &ContentId) -> String {
     let [first_shard, second_shard] = content_id.shard_prefixes();
@@ -189,7 +194,7 @@ pub fn gc_mark_page(
 #[cfg(test)]
 mod tests {
     use super::{
-        checkpoint_record, content_blob, metadata_compaction_lease,
+        checkpoint_record, content_blob, content_store, metadata_compaction_lease,
         metadata_compaction_output_protection, metadata_compaction_prefix,
         metadata_compaction_segment, metadata_manifest_object, metadata_root, metadata_segment,
         metadata_segment_object_key, upload_session, wal_floor, wal_head, wal_segment,
@@ -298,6 +303,10 @@ mod tests {
         };
 
         let built = [
+            (
+                "Content store descriptors",
+                content_store(&content_store_id()),
+            ),
             ("WAL head", wal_head(&namespace_id())),
             (
                 "WAL segments",

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -35,6 +35,8 @@ pub enum DurableObjectFamily {
     UploadSession,
     /// Classifies immutable whole-file content bytes.
     ContentBlob,
+    /// Identifies the content domain stored under a content-store prefix.
+    ContentStore,
 }
 
 /// Reports the durable family and identifiers recoverable from a recognized key.
@@ -69,6 +71,11 @@ impl<'a> ParsedObjectKey<'a> {
 pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
     let segments: Vec<_> = key.split('/').collect();
     match segments.as_slice() {
+        ["content-stores", content_store_id, "store.json"] => Some(parsed(
+            DurableObjectFamily::ContentStore,
+            None,
+            Some(content_store_id),
+        )),
         ["content-stores", _, "objects", _, _, content_id] => Some(parsed(
             DurableObjectFamily::ContentBlob,
             None,
@@ -232,9 +239,10 @@ fn parsed<'a>(
 mod tests {
     use super::{parse_object_key, DurableObjectFamily};
     use crate::keys::{
-        checkpoint_record, content_blob, metadata_compaction_lease, metadata_compaction_segment,
-        metadata_manifest_object, metadata_root, metadata_segment, metadata_segment_prefix,
-        upload_session, wal_floor, wal_head, wal_segment, wal_segment_prefix,
+        checkpoint_record, content_blob, content_store, metadata_compaction_lease,
+        metadata_compaction_segment, metadata_manifest_object, metadata_root, metadata_segment,
+        metadata_segment_prefix, upload_session, wal_floor, wal_head, wal_segment,
+        wal_segment_prefix,
     };
     use loonfs_api::{
         CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
@@ -261,6 +269,11 @@ mod tests {
         let content_id =
             ContentId::parse("con_abcdef0123456789abcdef0123456789").expect("content id");
         let cases = [
+            (
+                content_store(&content_store_id),
+                DurableObjectFamily::ContentStore,
+                Some(content_store_id.as_str()),
+            ),
             (wal_head(&namespace_id), DurableObjectFamily::WalHead, None),
             (
                 wal_floor(&namespace_id),
@@ -319,7 +332,11 @@ mod tests {
             assert_eq!(parsed.family(), family);
             assert_eq!(
                 parsed.owner_namespace_id(),
-                (family != DurableObjectFamily::ContentBlob).then_some("ns-1")
+                (!matches!(
+                    family,
+                    DurableObjectFamily::ContentBlob | DurableObjectFamily::ContentStore
+                ))
+                .then_some("ns-1")
             );
             assert_eq!(parsed.identifier(), identifier);
         }
@@ -332,6 +349,9 @@ mod tests {
             .expect("compaction id");
         let segment_id =
             MetadataSegmentId::parse("seg_00000000000000000000000000000001").expect("segment id");
+        let content_store_id = ContentStoreId::generate();
+        assert!(!content_store(&content_store_id)
+            .starts_with(&format!("content-stores/{content_store_id}/objects/")));
         let staged = metadata_compaction_segment(&namespace_id, &job, &segment_id);
 
         assert!(!staged.starts_with(&metadata_segment_prefix(&namespace_id)));

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -756,7 +756,9 @@ fn classify_key(key: &str) -> KeyClass {
         | DurableObjectFamily::CompactionOutputProtection
         | DurableObjectFamily::GcRun
         | DurableObjectFamily::GcMarkPage => KeyClass::GcControl,
-        DurableObjectFamily::UploadSession => KeyClass::Metadata,
+        DurableObjectFamily::UploadSession | DurableObjectFamily::ContentStore => {
+            KeyClass::Metadata
+        }
     }
 }
 

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -279,7 +279,7 @@ async fn instrumented_store_forwards_start_after_listing() {
 }
 
 #[tokio::test]
-async fn classifies_wal_manifest_segment_and_checkpoint_key_families() {
+async fn classifies_durable_key_families() {
     let temp_dir = tempdir().expect("tempdir");
     let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
     let store = instrumented_object_store(temp_dir.path(), recorder.clone());
@@ -329,11 +329,20 @@ async fn classifies_wal_manifest_segment_and_checkpoint_key_families() {
         .await
         .expect("put checkpoint record");
 
+    store
+        .put_if_absent(
+            &loonfs_objectstore::keys::content_store(&loonfs_api::ContentStoreId::generate()),
+            bytes(b"descriptor"),
+        )
+        .await
+        .expect("put content store descriptor");
+
     let samples = recorder.samples();
     assert_eq!(samples[0].key_class, KeyClass::WalSegment);
     assert_eq!(samples[1].key_class, KeyClass::NamespaceManifest);
     assert_eq!(samples[2].key_class, KeyClass::MetadataSegment);
     assert_eq!(samples[3].key_class, KeyClass::GcControl);
+    assert_eq!(samples[4].key_class, KeyClass::Metadata);
 }
 
 #[tokio::test]

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -66,7 +66,8 @@ pub async fn summarize_namespace_objects<S: ObjectStore + ?Sized>(
                 | DurableObjectFamily::GcMarkPage
                 | DurableObjectFamily::MetadataCompactionLease
                 | DurableObjectFamily::UploadSession
-                | DurableObjectFamily::ContentBlob => {}
+                | DurableObjectFamily::ContentBlob
+                | DurableObjectFamily::ContentStore => {}
             }
             continue;
         }

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -721,8 +721,8 @@ an unsigned 64-bit Unix-millisecond creation timestamp. Namespace creation
 writes it with create-if-absent before installing the head that names the
 new domain. An occupied key under the freshly generated id is corruption.
 The descriptor is immutable and never collected. An abandoned create,
-including a head install refused because the namespace exists or was
-deleted, can leave an orphan descriptor that no head names. Error paths
+including a head install that loses to another creator after the initial
+absence check, can leave an orphan descriptor that no head names. Error paths
 write nothing further. Forks share the source domain and write no descriptor.
 No reader consults it today. A deployment resolving a content domain to a
 physical backend may read it to confirm that backend holds the domain.
@@ -1758,11 +1758,19 @@ and everything written after it is ordinary namespace history.
 #### 3.9.1 Creating a namespace
 
 The request supplies only the new namespace id; the server supplies the
-mutation context. Build the complete active genesis head: sequence 0, the
+mutation context. First read and validate the namespace head. An existing
+active head returns `namespace_exists`, or the existing namespace when
+`allow_existing` is set; a deleted head returns `namespace_deleted`. These
+paths write nothing. Read failures and corrupt heads are errors, never
+absence. Only a missing head permits creation to proceed.
+
+Build the complete active genesis head: sequence 0, the
 genesis commit id, writer epoch 0, the next inode id after the root inode,
 a freshly minted content store id, and no fork basis. Write the descriptor
 for that domain with create-if-absent (section 2.4.1), then install the head
-with create-if-absent.
+with create-if-absent. The initial read does not reserve the namespace id;
+the conditional head write still decides races and retains the recovery
+rules in section 3.9.3.
 
 No manifest, root, or floor is prepared before the head write, and none is
 written after it: the genesis basis is built in (section 2.9.1). The root

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -104,6 +104,7 @@ The required durable object families and standard key patterns are:
 | **GC run** | Mutable CAS | Coordinates marking and sweeping across calls and hosts; one active run per namespace. | `namespaces/{namespace_id}/gc/run.json` |
 | **GC mark pages** | Immutable | Sorted, checksummed reference tables and intermediate merge output. | `namespaces/{namespace_id}/gc/runs/{gc_run_id}/tables/{table_id}/{page_index:020}.json` |
 | **WAL floor** | Mutable | Cold lower bound of retained WAL/change history; monotonic CAS. | `namespaces/{namespace_id}/wal/floor.json` |
+| **Content store descriptors** | Immutable | Identify the content domain held by a backend. | `content-stores/{content_store_id}/store.json` |
 | **Content objects** | Immutable | Store one file revision's complete bytes. | `content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id[6..8]}/{content_id}` |
 
 `.sst.zst` identifies the block encoding: sorted rows with each block compressed using zstd. Metadata and grep segments use this encoding. `.wal.zst` identifies the WAL encoding.
@@ -137,13 +138,9 @@ its starting basis, later target manifests may go on referencing source-owned
 metadata segments, and the source holds a fork-owned checkpoint record
 protecting that basis for the target's lifetime.
 
-The content-store keyspace holds blobs and nothing else. A content store has
-no descriptor object and no durable record of its own: its id is minted by
-random generation when a namespace is created and recorded in that
-namespace's head. Uniqueness rests on the generated id's randomness, so no
-object has to be claimed, read, or verified before bytes may be written under
-it, and a content store is shared exactly by the namespaces whose heads name
-it.
+The content-store keyspace holds an immutable domain descriptor beside its
+`objects/` collection (section 2.4.1). A content store is shared exactly by
+the namespaces whose heads name it.
 
 WAL segment names sort by history position (section 1.3); recovery still
 follows `head.visible_wal_tip` and the predecessor links inside verified WAL
@@ -183,12 +180,12 @@ The namespace tree's lifecycle can be read off its grammar:
 - **`wal/head.json` is the namespace.** The head exists, or the namespace does
   not. It is the existence marker, and after deletion it is kept forever as
   the tombstone that retires the namespace id.
-- **Creation and forking are one conditional write.** Create and fork both
+- **Creation and forking install the head with one conditional write.** Both
   build a complete active head in memory and install it with create-if-absent.
   Nothing under the new namespace's prefix is written before that write, so
-  there is no partial namespace to classify, complete, or reap, and no
-  ordering rule to get wrong. A create or fork that loses the conditional
-  write answers `namespace_exists`, or `namespace_deleted` against a
+  there is no partial namespace to classify, complete, or reap. Creation
+  first writes the content domain descriptor outside that prefix. A create
+  or fork that loses the conditional write answers `namespace_exists`, or `namespace_deleted` against a
   tombstone, unless the head it finds is its own earlier attempt, which
   succeeds idempotently (section 3.9.3).
 
@@ -346,10 +343,10 @@ Small mutable objects such as the namespace head must use compare-and-swap
 semantics. These objects must remain small enough that guarded rewrite is
 practical.
 
-Eight control-object kinds are registered: `wal_head`, `wal_floor`,
+Nine control-object kinds are registered: `wal_head`, `wal_floor`,
 `metadata_root`, `checkpoint_record`, `upload_session`, `compaction_lease`,
-`compaction_output_protection`, and `gc_run`. A control-object envelope carrying
-any other kind string is rejected, not skipped.
+`compaction_output_protection`, `gc_run`, and `content_store`. A control-object
+envelope carrying any other kind string is rejected, not skipped.
 
 The WAL floor and the metadata root are the only control objects that carry
 `updated_at_ms`. That field records when the object's last rewrite succeeded,
@@ -716,6 +713,20 @@ make content durable  ->  then make metadata visible
 This separation is part of the core model.
 
 #### 2.4.1 Immutable content storage
+
+Each content domain has a `content_store` version 1 control envelope at
+`content-stores/{content_store_id}/store.json`. Its strict payload is
+`ContentStoreState { content_store_id, created_at_ms }`, with `created_at_ms`
+an unsigned 64-bit Unix-millisecond creation timestamp. Namespace creation
+writes it with create-if-absent before installing the head that names the
+new domain. An occupied key under the freshly generated id is corruption.
+The descriptor is immutable and never collected. An abandoned create,
+including a head install refused because the namespace exists or was
+deleted, can leave an orphan descriptor that no head names. Error paths
+write nothing further. Forks share the source domain and write no descriptor.
+No reader consults it today. A deployment resolving a content domain to a
+physical backend may read it to confirm that backend holds the domain.
+The key is beside `objects/`, so content listings under `objects/` exclude it.
 
 The stable immutable content families are:
 
@@ -1740,22 +1751,23 @@ Deleted
 ```
 
 There is no state between absent and active. The head object is the
-namespace, so publishing it complete in one conditional write is the entire
-installation protocol: nothing under the new namespace's prefix is written
-before it, and everything written after it is ordinary namespace history.
+namespace. Publishing it complete in one conditional write installs the
+namespace: nothing under the new namespace's prefix is written before it,
+and everything written after it is ordinary namespace history.
 
 #### 3.9.1 Creating a namespace
 
 The request supplies only the new namespace id; the server supplies the
-mutation context. The protocol is one step: build the complete active genesis
-head — sequence 0, the genesis commit id, writer epoch 0, the next inode id
-after the root inode, a freshly minted content store id, and no fork basis —
-and write it with create-if-absent.
+mutation context. Build the complete active genesis head: sequence 0, the
+genesis commit id, writer epoch 0, the next inode id after the root inode,
+a freshly minted content store id, and no fork basis. Write the descriptor
+for that domain with create-if-absent (section 2.4.1), then install the head
+with create-if-absent.
 
-That write is the whole protocol. No manifest, root, or floor is prepared
-before it, and none is written after it: the genesis basis is built in
-(section 2.9.1), and the root and floor objects appear when the namespace's
-first flush and first retention advance need them.
+No manifest, root, or floor is prepared before the head write, and none is
+written after it: the genesis basis is built in (section 2.9.1). The root
+and floor objects appear when the namespace's first flush and first
+retention advance need them.
 
 #### 3.9.2 Forking a namespace
 
@@ -1779,9 +1791,10 @@ namespace id; the server supplies the mutation context. The protocol is:
 5. Write the target head with create-if-absent.
 
 The target copies the source's `content_store_id` because a fork shares file
-bytes copy-on-write. It inherits the source's materialized name keys
-unchanged, which is sound because name-key folding is a fixed rule of the
-format (section 2.3.1) rather than a per-namespace choice.
+bytes copy-on-write. It writes no content store descriptor. It inherits the
+source's materialized name keys unchanged, which is sound because name-key
+folding is a fixed rule of the format (section 2.3.1) rather than a
+per-namespace choice.
 
 The renewal races with garbage collection on the same record. If GC releases the record first, the renewal fails. If the renewal succeeds first, its later expiry changes the record and causes a stale release to fail its compare-and-swap. Once the target exists, its `fork_basis` keeps the checkpoint reachable. An abandoned attempt leaves only a checkpoint that GC can release after its lease expires.
 
@@ -1941,6 +1954,7 @@ and absent, and no schema language states it, so no durable encoding writes one.
 | Compaction lease | `compaction_lease` | JSON, uncompressed | 3 |
 | Compaction output protection | `compaction_output_protection` | JSON, uncompressed | 1 |
 | GC run | `gc_run` | JSON, uncompressed | 1 |
+| Content store descriptor | `content_store` | JSON, uncompressed | 1 |
 | GC mark page | `gc_mark_page` | JSON, uncompressed | 1 |
 
 JSON families keep their payload inline as raw JSON so manifests and control


### PR DESCRIPTION
Each content domain now gets a small, permanent identity file at `content-stores/{content_store_id}/store.json`. This prepares us to put metadata and content in separate stores: a future reader can use the file to check that it reached the correct content store. Nothing reads it yet, but creating it now avoids having to add it to existing domains later.

Namespace creation first reads and validates the namespace head. If the namespace already exists, it returns the existing namespace when `allow_existing` is set, or the appropriate exists/deleted error, without writing anything. A missing head allows creation to continue; read failures and corrupt heads stop it. Creation writes the descriptor before conditionally installing the head, so every newly created domain referenced by a head already has its descriptor. The conditional head write still decides which concurrent creator wins, and its existing recovery behavior is unchanged. Forks share the source domain and create no descriptor.

A new namespace costs one extra head read and one extra descriptor write. An interrupted create, or one that loses a race after the initial read, can still leave an unused descriptor; these are never collected. A descriptor collision under a freshly generated id is treated as corruption. The descriptor uses the shared control envelope as the new `content_store` family at version 1, with the content store id and creation timestamp. Existing format families are unchanged.

Tests cover write order, duplicate and deleted namespaces performing no writes, read failures and corrupt heads performing no writes, concurrent creation, descriptor collisions, forks, format validation, and key parsing. The format specification documents the protocol and the remaining orphan cases.
