### PR TITLE
test(sdk): add an owner in the conformance harnesses to canned content references 

### DIFF
--- a/sdk/conformance/go/streaming_test.go
+++ b/sdk/conformance/go/streaming_test.go
@@ -44,7 +44,7 @@ func streamingCases(t *testing.T) []streamCase {
 func streamTestServer(t *testing.T, fixture streamCase, direct bool, content func(http.ResponseWriter, *http.Request)) *httptest.Server {
 	t.Helper()
 	var host *httptest.Server
-	claim := map[string]any{"kind": "blob", "content_id": "cnt_00000000000000000000000000000001", "size_bytes": fixture.SizeBytes, "checksum": map[string]any{"algorithm": fixture.Algorithm, "value": fixture.Checksum}}
+	claim := map[string]any{"kind": "blob", "owner_namespace_id": "demo", "content_id": "cnt_00000000000000000000000000000001", "size_bytes": fixture.SizeBytes, "checksum": map[string]any{"algorithm": fixture.Algorithm, "value": fixture.Checksum}}
 	host = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/object" {
 			if r.Header.Get("Authorization") != "" || r.Header.Get("X-Private") != "" {

--- a/sdk/conformance/go/streaming_uploads_test.go
+++ b/sdk/conformance/go/streaming_uploads_test.go
@@ -62,7 +62,7 @@ func TestStreamingUploads(t *testing.T) {
 			source := &uploadSource{reader: strings.NewReader(fixture.Content), fault: fixture.Fault == "source_error"}
 			var payload, abort, complete atomic.Int64
 			var bodies bytes.Buffer // server handlers complete before their response is consumed
-			claim := map[string]any{"kind": "blob", "content_id": "cnt_00000000000000000000000000000001", "size_bytes": fixture.SizeBytes, "checksum": map[string]any{"algorithm": fixture.Algorithm, "value": fixture.Checksum}}
+			claim := map[string]any{"kind": "blob", "owner_namespace_id": "demo", "content_id": "cnt_00000000000000000000000000000001", "size_bytes": fixture.SizeBytes, "checksum": map[string]any{"algorithm": fixture.Algorithm, "value": fixture.Checksum}}
 			var host *httptest.Server
 			host = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				path := r.URL.Path

--- a/sdk/conformance/python/test_streaming.py
+++ b/sdk/conformance/python/test_streaming.py
@@ -32,6 +32,7 @@ class Chunks(httpx.SyncByteStream):
 def stream_client(fixture, direct, body):
     claim = {
         "kind": "blob",
+        "owner_namespace_id": "demo",
         "content_id": "cnt_00000000000000000000000000000001",
         "size_bytes": fixture["size_bytes"],
         "checksum": {"algorithm": fixture["algorithm"], "value": fixture["checksum"]},

--- a/sdk/conformance/python/test_streaming_uploads.py
+++ b/sdk/conformance/python/test_streaming_uploads.py
@@ -36,6 +36,7 @@ def test_streaming_uploads(fixture):
     bodies = []
     claim = {
         "kind": "blob",
+        "owner_namespace_id": "demo",
         "content_id": "cnt_00000000000000000000000000000001",
         "size_bytes": fixture["size_bytes"],
         "checksum": {"algorithm": fixture["algorithm"], "value": fixture["checksum"]},

--- a/sdk/conformance/typescript/src/streaming-uploads.test.ts
+++ b/sdk/conformance/typescript/src/streaming-uploads.test.ts
@@ -47,6 +47,7 @@ for (const browser of [false, true])
             const bodies: Uint8Array[] = [];
             const claim = {
                 kind: "blob",
+                owner_namespace_id: "demo",
                 content_id: "cnt_00000000000000000000000000000001",
                 size_bytes: fixture.size_bytes,
                 checksum: { algorithm: fixture.algorithm, value: fixture.checksum },

--- a/sdk/conformance/typescript/src/streaming.test.ts
+++ b/sdk/conformance/typescript/src/streaming.test.ts
@@ -27,6 +27,7 @@ const fixtures: Fixture[] = JSON.parse(
 function fakeFetch(fixture: Fixture, direct: boolean, body: ReadableStream<Uint8Array>): typeof fetch {
     const claim = {
         kind: "blob",
+        owner_namespace_id: "demo",
         content_id: "cnt_00000000000000000000000000000001",
         size_bytes: fixture.size_bytes,
         checksum: { algorithm: fixture.algorithm, value: fixture.checksum },


### PR DESCRIPTION
The Python SDK conformance job has failed on main since #899. The streaming harnesses in all three languages serve canned content references from a fake object host, and those references predate the required `owner_namespace_id`. The freshly generated Python model rejects them; the Go and TypeScript harnesses do not validate responses, so only Python failed. This adds the owner to every canned reference in the six harness files.
