### PR TITLE
fix(core): check content proofs at the head swap and bound receipt minting

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -451,6 +451,7 @@ impl NamespaceCommitEngine {
         context: &MutationContext,
         tail_options: &PublishTailOptions,
     ) -> NamespaceCommitEnginePublishResult {
+        let attempt_started_ms = self.timer.monotonic_now_ms();
         if candidates.is_empty() {
             return NamespaceCommitEnginePublishResult {
                 results: Vec::new(),
@@ -521,6 +522,7 @@ impl NamespaceCommitEngine {
             context,
             &publish_view,
             self.timer.as_ref(),
+            attempt_started_ms,
         )
         .await;
         let resulting_head = match &published.effect {
@@ -636,6 +638,10 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
         .delete_namespace(store, options, context)
         .await
 }
+
+#[cfg(test)]
+#[path = "commit_engine_content_tests.rs"]
+mod content_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/loonfs-core/src/commit_engine_content_tests.rs
+++ b/crates/loonfs-core/src/commit_engine_content_tests.rs
@@ -1,0 +1,388 @@
+//! Publication deadlines for completed content.
+
+use super::*;
+use crate::gc::{gc_namespace, GcConfig};
+use crate::limits::{
+    COMPLETED_UPLOAD_ADMISSION_WINDOW_MS, CONTENT_RECLAMATION_GRACE_MS, GC_MIN_GRACE_WINDOW_MS,
+};
+use crate::namespace::bootstrap::bootstrap_namespace;
+use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::namespace::control::load_head_object;
+use crate::protocol::{
+    begin_upload, complete_upload, upload_content, CompletedUpload, ResolvedUploadCompletion,
+};
+use loonfs_api::{AbsolutePath, ContentStoreId, DestinationBehavior, WriterId};
+use loonfs_objectstore::keys::{content_blob, metadata_root, wal_segment_prefix};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tempfile::tempdir;
+
+#[derive(Debug, Default)]
+struct PublicationTimer(AtomicU64);
+
+impl MonotonicTimer for PublicationTimer {
+    fn monotonic_now_ms(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+fn context(now_ms: u64) -> MutationContext {
+    MutationContext {
+        writer_id: WriterId::parse("writer").expect("writer id"),
+        now_ms,
+    }
+}
+
+async fn completed_upload<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> (CompletedUpload, ContentStoreId) {
+    let upload = begin_upload(
+        store,
+        namespace_id,
+        loonfs_api::v0::BeginUploadRequest::ServiceProxied {},
+        context,
+    )
+    .await
+    .expect("begin upload");
+    upload_content(
+        store,
+        namespace_id,
+        upload.upload_id(),
+        b"completed content",
+    )
+    .await
+    .expect("stage upload");
+    let content_store_id = load_namespace_content_store_id(store, namespace_id)
+        .await
+        .expect("content store");
+    let completed = complete_upload(
+        store,
+        namespace_id,
+        &content_store_id,
+        upload.upload_id(),
+        ResolvedUploadCompletion::KnownContent,
+        context,
+    )
+    .await
+    .expect("complete upload");
+    (completed, content_store_id)
+}
+
+fn put_candidate(completed: &CompletedUpload) -> CommitCandidate {
+    CommitCandidate::prepared(
+        CommitRequest::single(
+            CommitId::parse("publish-content").expect("commit id"),
+            loonfs_test_support::test_actor(),
+            None,
+            FilesystemOperation::PutFile {
+                path: AbsolutePath::parse("/content").expect("path"),
+                content_ref: completed.prepared.content_ref().clone(),
+                behavior: DestinationBehavior::NoReplace,
+                expected_inode_id: None,
+                expected_revision_no: None,
+            },
+        ),
+        vec![completed.prepared.clone()],
+    )
+}
+
+fn directory_request(commit_id: &str, name: &str) -> CommitRequest {
+    CommitRequest::single(
+        CommitId::parse(commit_id).expect("commit id"),
+        loonfs_test_support::test_actor(),
+        None,
+        FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse(format!("/{name}")).expect("path"),
+            parents: false,
+        },
+    )
+}
+
+#[tokio::test]
+async fn content_reclaimed_during_view_load_cannot_be_published() {
+    let directory = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let store = BlockingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::exact(metadata_root(&namespace_id)),
+        OperationClass::Read,
+    );
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (completed, content_store_id) = completed_upload(&store, &namespace_id, &setup).await;
+    let content_key = content_blob(
+        &content_store_id,
+        &namespace_id,
+        &completed.prepared.content_ref().content_id,
+    );
+    let head_before = load_head_object(&store, &namespace_id)
+        .await
+        .expect("head")
+        .state;
+    let publication = context(setup.now_ms + COMPLETED_UPLOAD_ADMISSION_WINDOW_MS - 1);
+    let reclaimed = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+    let timer = Arc::new(PublicationTimer::default());
+    let mut engine =
+        NamespaceCommitEngine::new(namespace_id.clone()).monotonic_timer(timer.clone());
+    store.block_next();
+    let options = PublishTailOptions::default();
+    let publish = engine.publish_batch(
+        &store,
+        vec![put_candidate(&completed)],
+        &publication,
+        &options,
+    );
+    let collect = async {
+        store.wait_until_blocked().await;
+        timer
+            .0
+            .store(reclaimed.now_ms - publication.now_ms, Ordering::SeqCst);
+        let report = gc_namespace(
+            &store,
+            &namespace_id,
+            &GcConfig {
+                grace_window_ms: GC_MIN_GRACE_WINDOW_MS,
+                max_steps: None,
+                cursor: None,
+            },
+            &reclaimed,
+        )
+        .await
+        .expect("gc");
+        assert_eq!(report.deleted.content_objects, 1);
+        assert!(store
+            .head(&content_key)
+            .await
+            .expect("content head")
+            .is_none());
+        store.release();
+    };
+    let (result, ()) = futures::join!(publish, collect);
+    assert_eq!(
+        result.results[0]
+            .as_ref()
+            .expect_err("reclaimed content must not publish")
+            .code(),
+        loonfs_api::ErrorCode::ContentNotPrepared
+    );
+    let head_after = load_head_object(&store, &namespace_id)
+        .await
+        .expect("head")
+        .state;
+    assert_eq!(head_after.seq, head_before.seq);
+    assert_eq!(head_after.visible_wal_tip, head_before.visible_wal_tip);
+    assert_eq!(
+        store
+            .list_prefix(&wal_segment_prefix(&namespace_id))
+            .await
+            .expect("WAL segments")
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn content_expiring_during_wal_write_aborts_the_unpublished_batch() {
+    let directory = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let store = BlockingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
+        OperationClass::Put,
+    );
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (completed, _) = completed_upload(&store, &namespace_id, &setup).await;
+    let timer = Arc::new(PublicationTimer::default());
+    let mut engine =
+        NamespaceCommitEngine::new(namespace_id.clone()).monotonic_timer(timer.clone());
+    let options = PublishTailOptions::default();
+    let replay = CommitCandidate::new(directory_request("original", "original"));
+    let original = engine
+        .publish_batch(&store, vec![replay.clone()], &setup, &options)
+        .await
+        .results
+        .remove(0)
+        .expect("original commit");
+    let head_before = load_head_object(&store, &namespace_id)
+        .await
+        .expect("head")
+        .state;
+    let publication = context(setup.now_ms + COMPLETED_UPLOAD_ADMISSION_WINDOW_MS - 1);
+    let primary = put_candidate(&completed);
+    let alias = CommitCandidate::new(primary.request().clone());
+    let later = CommitCandidate::new(directory_request("later", "later"));
+    store.block_next();
+    let publish = engine.publish_batch(
+        &store,
+        vec![primary, alias, later, replay],
+        &publication,
+        &options,
+    );
+    let advance = async {
+        store.wait_until_blocked().await;
+        let elapsed_ms = 2;
+        assert!(elapsed_ms < crate::limits::WAL_PUBLISH_BUDGET_MS);
+        timer.0.store(elapsed_ms, Ordering::SeqCst);
+        store.release();
+    };
+    let (result, ()) = futures::join!(publish, advance);
+    for result in &result.results[..3] {
+        assert_eq!(
+            result
+                .as_ref()
+                .expect_err("unpublished batch must fail")
+                .code(),
+            loonfs_api::ErrorCode::ContentNotPrepared
+        );
+    }
+    assert_eq!(
+        result.results[3].as_ref().expect("independent replay"),
+        &original
+    );
+    let head_after = load_head_object(&store, &namespace_id)
+        .await
+        .expect("head")
+        .state;
+    assert_eq!(head_after, head_before);
+    assert_eq!(
+        store
+            .list_prefix(&wal_segment_prefix(&namespace_id))
+            .await
+            .expect("WAL segments")
+            .len(),
+        2
+    );
+    drop(engine);
+    let reopened = crate::path::read::load_current_metadata_view(&store, &namespace_id)
+        .await
+        .expect("reopen namespace");
+    for path in ["/content", "/later"] {
+        assert_eq!(
+            reopened
+                .resolve_path(path, loonfs_api::AttributeInclusion::Omit)
+                .await
+                .expect_err("orphan operation must be absent")
+                .code(),
+            loonfs_api::ErrorCode::PathNotFound
+        );
+    }
+    reopened
+        .resolve_path("/original", loonfs_api::AttributeInclusion::Omit)
+        .await
+        .expect("original remains");
+}
+
+#[tokio::test]
+async fn swap_accepts_any_valid_matching_proof_and_expired_receipt_replays_without_content_io() {
+    use crate::content::{mint_content_token, verify_content_token};
+    use crate::namespace::catalog::load_namespace_catalog_entry;
+    use loonfs_test_support::stores::RecordingStore;
+
+    let directory = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let store = RecordingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::prefix("content-stores/"),
+    );
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (completed, _) = completed_upload(&store, &namespace_id, &setup).await;
+    let (unused, _) = completed_upload(&store, &namespace_id, &setup).await;
+    let catalog = load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("catalog");
+    let mut proofs = vec![completed.prepared.clone()];
+    for upload in [&completed, &unused] {
+        let token = mint_content_token(
+            "secret",
+            upload.receipt.as_ref().expect("receipt"),
+            setup.now_ms,
+        )
+        .expect("mint");
+        proofs.push(
+            verify_content_token("secret", &catalog, &token, setup.now_ms).expect("prepare token"),
+        );
+    }
+    let candidate =
+        CommitCandidate::prepared(put_candidate(&completed).request().clone(), proofs.clone());
+    let metadata = CommitCandidate::prepared(
+        directory_request("metadata", "metadata"),
+        proofs[1..].to_vec(),
+    );
+    let publication = context(setup.now_ms + COMPLETED_UPLOAD_ADMISSION_WINDOW_MS);
+    let mut engine = NamespaceCommitEngine::new(namespace_id.clone())
+        .monotonic_timer(Arc::new(PublicationTimer::default()));
+    let options = PublishTailOptions::default();
+    store.reset();
+    let result = engine
+        .publish_batch(
+            &store,
+            vec![candidate.clone(), metadata],
+            &publication,
+            &options,
+        )
+        .await;
+    let original = result.results[0]
+        .as_ref()
+        .expect("proof is valid at its exact deadline");
+    result.results[1]
+        .as_ref()
+        .expect("unused proofs do not constrain metadata");
+    assert_eq!(original.committed_at_ms, publication.now_ms);
+    assert_eq!(store.count(OperationClass::Any), 0);
+    let expired = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+    let later = CommitCandidate::new(directory_request("later", "later"));
+    let replay = engine
+        .publish_batch(&store, vec![candidate, later], &expired, &options)
+        .await;
+    assert_eq!(
+        replay.results[0].as_ref().expect("durable replay"),
+        original
+    );
+    replay.results[1].as_ref().expect("new metadata commit");
+    assert_eq!(store.count(OperationClass::Any), 0);
+}
+
+#[tokio::test]
+async fn retained_receipt_minting_stops_at_the_upload_issuance_deadline() {
+    use crate::content::mint_content_token;
+    use crate::limits::{COMPLETED_UPLOAD_RECEIPT_WINDOW_MS, CONTENT_RECEIPT_TTL_MS};
+    use base64::Engine as _;
+
+    let directory = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let store = LocalFsStore::new(directory.path()).expect("store");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (completed, _) = completed_upload(&store, &namespace_id, &setup).await;
+    let receipt = completed.receipt.expect("eligible receipt");
+    let deadline_ms = setup.now_ms + COMPLETED_UPLOAD_RECEIPT_WINDOW_MS;
+    for now_ms in [setup.now_ms, deadline_ms - 1] {
+        let token = mint_content_token("secret", &receipt, now_ms).expect("eligible mint");
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(token.token.split_once('.').expect("signed token").0)
+            .expect("payload");
+        let payload: serde_json::Value = serde_json::from_slice(&payload).expect("token payload");
+        let expires_at_ms = payload["expires_at_ms"].as_u64().expect("expiry");
+        assert_eq!(expires_at_ms, now_ms + CONTENT_RECEIPT_TTL_MS);
+        assert!(expires_at_ms <= setup.now_ms + COMPLETED_UPLOAD_ADMISSION_WINDOW_MS);
+    }
+    for now_ms in [deadline_ms, setup.now_ms + CONTENT_RECLAMATION_GRACE_MS * 2] {
+        assert_eq!(
+            mint_content_token("secret", &receipt, now_ms),
+            Err(ContentTokenError::Expired)
+        );
+    }
+}

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -263,7 +263,10 @@ pub const COMPLETED_UPLOAD_ADMISSION_WINDOW_MS: u64 =
 
 /// Minimum age of unreferenced content from a completed upload before
 /// collection. The value covers the receipt window, receipt lifetime, and a
-/// final publication with the clock-error and scheduling allowance.
+/// final publication with the clock-error and scheduling allowance. Every mint
+/// checks the upload's receipt issuance window. Immediately before the head
+/// swap, content proofs are checked against the request clock plus the whole
+/// attempt's elapsed monotonic time.
 pub const CONTENT_RECLAMATION_GRACE_MS: u64 =
     COMPLETED_UPLOAD_ADMISSION_WINDOW_MS + GC_MIN_GRACE_WINDOW_MS;
 

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -2,7 +2,10 @@
 //! plus one head compare-and-swap, with outcomes fanned back to every
 //! candidate slot.
 
-use super::candidates::{prepare_candidate_request, BatchDedup, CandidateAdmission};
+use super::candidates::{
+    prepare_candidate_request, validate_candidate_content_references, BatchDedup,
+    CandidateAdmission,
+};
 use super::changes::committed_change_from_wal_record;
 use super::publish_view::PublishMetadataView;
 use crate::commit::{
@@ -93,6 +96,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     context: &MutationContext,
     view: &PublishMetadataView<'_, S>,
     timer: &dyn MonotonicTimer,
+    attempt_started_ms: u64,
 ) -> PublishBatchAgainstViewResult {
     if candidates.is_empty() {
         return PublishBatchAgainstViewResult::unchanged(Vec::new());
@@ -225,6 +229,25 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             budget_ms: WAL_PUBLISH_BUDGET_MS,
         });
         return abort_batch(slots, &error);
+    }
+    let elapsed_ms = timer.monotonic_now_ms().saturating_sub(attempt_started_ms);
+    let Some(publication_now_ms) = context.now_ms.checked_add(elapsed_ms) else {
+        return abort_batch(
+            slots,
+            &CoreError::Internal("publication time overflow".to_owned()),
+        );
+    };
+    for (candidate, slot) in candidates.iter().zip(&slots) {
+        if matches!(slot, BatchOutcomeSlot::Accepted) {
+            if let Err(error) = validate_candidate_content_references(
+                candidate,
+                namespace_id,
+                view.content_store_id(),
+                publication_now_ms,
+            ) {
+                return abort_batch(slots, &error);
+            }
+        }
     }
     let head_etag = match cas_batch_head(
         store,
@@ -493,6 +516,7 @@ mod tests {
             &context,
             &view,
             &StdMonotonicTimer::default(),
+            0,
         )
         .await;
 

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -115,13 +115,11 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         Ok(None) => {}
         Err(error) => return CandidateAdmission::independent(Err(error)),
     }
-    let admissions = match validate_new_primary(candidate) {
-        Ok(admissions) => admissions,
-        Err(error) => return CandidateAdmission::independent(Err(error)),
-    };
-    if let Err(error) = validate_commit_content_references(
-        mutation,
-        admissions,
+    if let Err(error) = candidate.validate_request_limits() {
+        return CandidateAdmission::independent(Err(error));
+    }
+    if let Err(error) = validate_candidate_content_references(
+        candidate,
         namespace_id,
         view.content_store_id(),
         committed_at_ms,
@@ -150,11 +148,20 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     }
 }
 
-fn validate_new_primary(candidate: &CommitCandidate) -> Result<&[ContentAdmission]> {
-    // Check request limits before content preparation errors.
-    candidate.validate_request_limits()?;
+pub(super) fn validate_candidate_content_references(
+    candidate: &CommitCandidate,
+    namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
+    now_ms: u64,
+) -> Result<()> {
     match candidate.content_preparation() {
-        ContentPreparation::Ready(admissions) => Ok(admissions),
+        ContentPreparation::Ready(admissions) => validate_commit_content_references(
+            candidate.request(),
+            admissions,
+            namespace_id,
+            content_store_id,
+            now_ms,
+        ),
         ContentPreparation::Rejected(error) => Err(error.clone().into()),
     }
 }

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -1333,6 +1333,7 @@ fn receipt_within_window(
             namespace_id.clone(),
             content_store_id.clone(),
             content_ref.clone(),
+            completed_at_ms,
         )
     })
 }

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -6,7 +6,7 @@
 //! [`PreparedContent`] and checked again when a publish batch admits the
 //! proof.
 
-use crate::limits::CONTENT_RECEIPT_TTL_MS;
+use crate::limits::{COMPLETED_UPLOAD_RECEIPT_WINDOW_MS, CONTENT_RECEIPT_TTL_MS};
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use base64::Engine as _;
 use loonfs_api::v0::ContentToken;
@@ -26,6 +26,7 @@ pub struct CompletedUploadReceipt {
     namespace_id: NamespaceId,
     content_store_id: ContentStoreId,
     content_ref: ContentRef,
+    completed_at_ms: u64,
 }
 
 impl CompletedUploadReceipt {
@@ -33,11 +34,13 @@ impl CompletedUploadReceipt {
         namespace_id: NamespaceId,
         content_store_id: ContentStoreId,
         content_ref: ContentRef,
+        completed_at_ms: u64,
     ) -> Self {
         Self {
             namespace_id,
             content_store_id,
             content_ref,
+            completed_at_ms,
         }
     }
 
@@ -168,6 +171,13 @@ pub fn mint_content_token(
     receipt: &CompletedUploadReceipt,
     now_ms: u64,
 ) -> Result<ContentToken, ContentTokenError> {
+    let issuance_deadline_ms = receipt
+        .completed_at_ms
+        .checked_add(COMPLETED_UPLOAD_RECEIPT_WINDOW_MS)
+        .ok_or(ContentTokenError::TimeOverflow)?;
+    if now_ms >= issuance_deadline_ms {
+        return Err(ContentTokenError::Expired);
+    }
     let expires_at_ms = now_ms
         .checked_add(CONTENT_RECEIPT_TTL_MS)
         .ok_or(ContentTokenError::TimeOverflow)?;
@@ -288,6 +298,7 @@ mod tests {
             namespace_id.clone(),
             ContentStoreId::parse(content_store).expect("content store id"),
             content_ref.clone(),
+            1_000,
         )
     }
 

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -78,13 +78,16 @@ impl<'a> ContentTokenVerifier<'a> {
     fn mint_receipt(
         self,
         receipt: Option<&CompletedUploadReceipt>,
+        now_ms: u64,
     ) -> Result<Option<ContentToken>, ApiResponseError> {
         let Some(receipt) = receipt else {
             return Ok(None);
         };
-        let token = mint_content_token(self.secret, receipt, current_unix_ms()?)
-            .map_err(content_token_error)?;
-        Ok(Some(token))
+        match mint_content_token(self.secret, receipt, now_ms) {
+            Ok(token) => Ok(Some(token)),
+            Err(ContentTokenError::Expired) => Ok(None),
+            Err(error) => Err(content_token_error(error)),
+        }
     }
 }
 
@@ -455,9 +458,10 @@ fn with_content_token(
     mut response: UploadSession,
     verifier: ContentTokenVerifier<'_>,
     receipt: Option<&CompletedUploadReceipt>,
+    now_ms: u64,
 ) -> Result<UploadSession, ApiResponseError> {
     if let UploadSessionStatus::Completed { content_token, .. } = &mut response.status {
-        *content_token = verifier.mint_receipt(receipt)?;
+        *content_token = verifier.mint_receipt(receipt, now_ms)?;
     }
     Ok(response)
 }
@@ -593,6 +597,7 @@ pub(super) async fn complete_upload(
         completed.response,
         ContentTokenVerifier::new(state.config.content_token_secret()),
         completed.receipt.as_ref(),
+        current_unix_ms()?,
     )?))
 }
 
@@ -661,6 +666,7 @@ pub(super) async fn get_upload(
         response,
         ContentTokenVerifier::new(state.config.content_token_secret()),
         receipt.as_ref(),
+        current_unix_ms()?,
     )?))
 }
 
@@ -714,6 +720,53 @@ mod completion_body_tests {
 
     const CONTENT: &str =
         r#"{"size_bytes":5,"checksum":{"algorithm":"crc64nvme","value":"0123456789abcdef"}}"#;
+
+    #[tokio::test]
+    async fn completed_status_omits_the_token_when_the_receipt_expires_before_minting() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let store =
+            loonfs_objectstore::local_fs_store::LocalFsStore::new(directory.path()).expect("store");
+        let writer = FsWriter::builder_with_store(std::sync::Arc::new(store))
+            .writer_id("writer")
+            .build()
+            .await
+            .expect("writer");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        writer
+            .create_namespace(&namespace_id, Default::default())
+            .await
+            .expect("namespace");
+        let upload = writer.create_upload(&namespace_id).await.expect("upload");
+        writer
+            .put_upload_content(&namespace_id, upload.upload_id(), b"content")
+            .await
+            .expect("content");
+        let completed = writer
+            .complete_upload(
+                &namespace_id,
+                upload.upload_id(),
+                ResolvedUploadCompletion::KnownContent,
+            )
+            .await
+            .expect("complete");
+        let (status, receipt) = writer
+            .get_upload(&namespace_id, upload.upload_id())
+            .await
+            .expect("eligible status");
+        let receipt = receipt.expect("receipt eligible at status read");
+        let response = with_content_token(
+            status,
+            ContentTokenVerifier::new("secret"),
+            Some(&receipt),
+            u64::MAX,
+        )
+        .ok()
+        .expect("completed status must survive mint expiry");
+        assert_eq!(response, completed.response);
+        let json = serde_json::to_value(response).expect("HTTP response");
+        assert_eq!(json["status"], "completed");
+        assert!(json.get("content_token").is_none());
+    }
 
     #[test]
     fn stored_mode_selects_a_precise_completion_schema_error() {

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -434,9 +434,11 @@ Staging is staging wherever it happens, so `prepare_file_bytes` opens an
 upload session for the object it writes, exactly as a remote upload does: the
 session record lands before the bytes and completes after them. The opaque
 prepared value carries an admission deadline no later than the expiry of the
-last token the completed session could issue, and publication checks it when the
-batch is admitted. This is the same horizon that bounds remote upload tokens
-(section 6.3; format spec, "Garbage collection", rule 11), so content cannot
+last token the completed session could issue. Publication checks it at batch
+admission and immediately before the head swap, using the request clock plus
+the elapsed time of the whole publication attempt. This is the same horizon
+that bounds remote upload tokens (section 6.3; format spec, "Garbage
+collection", rule 11), so content cannot
 be reclaimed and then admitted through an older in-process proof.
 
 Prepared evidence is bound to both the namespace and its content store. Two

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2710,7 +2710,11 @@ publishing CAS) — under these rules:
 
    *The grace is derived, not tuned.* A reference can enter metadata only
    through a receipt, a receipt is minted only from a durable `completed`
-   session, and minting stops a fixed window after completion. So:
+   session, and minting stops a fixed window after completion. The signer checks
+   the completion time carried by the receipt on every mint. A retained receipt
+   cannot extend the issuance window: minting refuses `now_ms` at or after
+   `completed_at_ms + COMPLETED_UPLOAD_RECEIPT_WINDOW_MS`. A token expires at
+   `now_ms + CONTENT_RECEIPT_TTL_MS`. So:
 
    ```
    CONTENT_RECLAMATION_GRACE
@@ -2728,9 +2732,13 @@ publishing CAS) — under these rules:
    holds its admission directly instead of carrying a receipt, but that proof
    carries a deadline no later than the expiry of the last token the session
    could issue.
-   Batch admission checks the deadline again, so the same inequality covers
-   both local proofs and remote tokens. The reasoning above assumes a content
-   object is referenced only by the namespace whose session created it and by
+   Immediately before the head swap, publication checks every newly accepted
+   primary's content references for a matching, unexpired proof. This check uses
+   the request clock plus the attempt's elapsed monotonic time, including the
+   writer check, view load, planning, and WAL preparation. Durable receipt replays
+   need no fresh proof. The same inequality covers local proofs and remote
+   tokens. The reasoning above assumes a content object is referenced only by
+   the namespace whose session created it and by
    fork descendants reading through a pinned basis. Prepared evidence is
    therefore namespace-bound even when catalogs share a content store, and an
    embedded raw-ref import (section 2.8) writes the verified bytes under a


### PR DESCRIPTION
Garbage collection deletes an unpublished completed upload's object once the completion time plus the admission window and the minimum grace has passed. That rests on an assumption the publication path never enforced: a publication admitted before a proof's deadline finishes its head swap within the grace. Content admission ran once against the clock stamped when the batch left the publisher queue, then the writer check, view load, planning, and WAL write followed with no further look at the proofs; the only timing guard covered the WAL write to the swap. A stall longer than the grace between admission and the WAL write let the swap publish a reference to an object GC had already deleted.

Two changes close this. The engine reads its monotonic timer once at the start of a publication attempt, before the writer check and outside any re-plan after a lost swap, and the batch path re-runs the existing content admission for every newly accepted primary immediately before the head swap, against the request clock plus the attempt's elapsed time. A failure aborts the unpublished physical batch through the existing path; independently settled results, including durable receipt replays, survive, and the orphan WAL segment is left for GC as before. Separately, a completed-upload receipt now carries its completion time, and every mint refuses a clock at or past the issuance window, so a receipt an embedder keeps in memory cannot manufacture tokens past the horizon GC uses. The HTTP status and completion handlers answer a mint that expires between the eligibility read and the mint with the completed response and no token.
