### PR TITLE
fix(core): answer a known commit id at the WAL write-stop ceiling

### DIFF
--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1156,7 +1156,7 @@ async fn checkpoint_checksum_disagreement_is_terminal_corruption_and_releases_re
     );
 }
 
-async fn wal_segment_count(store: &LocalFsStore, namespace_id: &NamespaceId) -> usize {
+async fn wal_segment_count<S: ObjectStore>(store: &S, namespace_id: &NamespaceId) -> usize {
     store
         .list_prefix(&wal_segment_prefix(namespace_id))
         .await
@@ -1191,33 +1191,125 @@ async fn publish_backpressure_rejects_at_the_longest_tail_the_head_describes() {
     }
     assert_eq!(wal_segment_count(&store, &namespace_id).await, boundary - 1);
 
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/at-the-boundary.txt",
-        b"body\n",
-        &context,
+    let head_key = wal_head(&namespace_id);
+    let segment_prefix = wal_segment_prefix(&namespace_id);
+    let store = RecordingStore::new(
+        store,
+        KeyPredicate::new(move |key| key == head_key || key.starts_with(&segment_prefix)),
+    );
+    let request = CommitRequest::single(
+        CommitId::parse("at-the-boundary").expect("commit id"),
+        loonfs_test_support::test_actor(),
         None,
-    )
-    .await
-    .expect("the publish that lands exactly at the bound is still admitted");
+        FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse("/at-the-boundary").expect("path"),
+            parents: false,
+        },
+    );
+    let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
+    let tail_options = PublishTailOptions::default();
+    let original = engine
+        .publish_batch(
+            &store,
+            vec![CommitCandidate::new(request.clone())],
+            &context,
+            &tail_options,
+        )
+        .await
+        .results
+        .pop()
+        .expect("one result")
+        .expect("the publish that lands exactly at the bound is still admitted");
     assert_eq!(wal_segment_count(&store, &namespace_id).await, boundary);
+    store.reset();
 
-    let error = write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/one-too-many.txt",
-        b"body\n",
-        &context,
-        None,
-    )
-    .await
-    .expect_err("a publish against a tail at the bound must be rejected");
-    assert_eq!(error.code(), ErrorCode::MaintenanceRequired);
+    let replay = engine
+        .publish_batch(
+            &store,
+            vec![CommitCandidate::new(request.clone())],
+            &context,
+            &tail_options,
+        )
+        .await;
+    assert_eq!(replay.results.len(), 1);
     assert_eq!(
-        wal_segment_count(&store, &namespace_id).await,
-        boundary,
-        "the rejection lands before the segment PUT, so nothing new is written"
+        replay.results[0].as_ref().expect("replay at the bound"),
+        &original
+    );
+    assert_eq!(
+        replay.wal_tail_segments,
+        crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS
+    );
+    assert_eq!(store.counts().puts, 0);
+    assert_eq!(store.counts().compare_and_swaps, 0);
+
+    let mut conflict = request.clone();
+    conflict.operations = vec![FilesystemOperation::CreateDirectory {
+        path: AbsolutePath::parse("/different").expect("path"),
+        parents: false,
+    }];
+    let mut new_request = conflict.clone();
+    new_request.commit_id = CommitId::parse("one-too-many").expect("commit id");
+    for (candidate, expected_code) in [
+        (conflict, ErrorCode::CommitIdReuseConflict),
+        (new_request.clone(), ErrorCode::MaintenanceRequired),
+    ] {
+        let result = engine
+            .publish_batch(
+                &store,
+                vec![CommitCandidate::new(candidate)],
+                &context,
+                &tail_options,
+            )
+            .await;
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(
+            result.results[0]
+                .as_ref()
+                .expect_err("refused request")
+                .code(),
+            expected_code
+        );
+    }
+    let mixed = engine
+        .publish_batch(
+            &store,
+            vec![
+                CommitCandidate::new(request),
+                CommitCandidate::new(new_request.clone()),
+                CommitCandidate::new(new_request),
+            ],
+            &context,
+            &tail_options,
+        )
+        .await;
+    assert_eq!(mixed.results.len(), 3);
+    assert_eq!(
+        mixed.results[0].as_ref().expect("mixed batch replay"),
+        &original
+    );
+    for result in &mixed.results[1..] {
+        assert_eq!(
+            result
+                .as_ref()
+                .expect_err("new primary and alias refused")
+                .code(),
+            ErrorCode::MaintenanceRequired
+        );
+    }
+    assert_eq!(
+        mixed.wal_tail_segments,
+        crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS
+    );
+    assert_eq!(
+        store.counts().puts,
+        0,
+        "no WAL put or head write at the bound"
+    );
+    assert_eq!(
+        store.counts().compare_and_swaps,
+        0,
+        "no head swap at the bound"
     );
 
     // The whole legal tail is named by the tip plus its predecessor hints,

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -5,7 +5,7 @@
 use crate::checkpoint::MetadataSegmentCache;
 use crate::commit::CommitFingerprint;
 use crate::context::MutationContext;
-use crate::error::{CoreError, MetadataViewError, Result, WriterFence};
+use crate::error::{CoreError, Result, WriterFence};
 use crate::metadata::MetadataState;
 use crate::namespace::basis::MetadataBasis;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
@@ -495,25 +495,6 @@ impl NamespaceCommitEngine {
                 };
             }
         };
-
-        let reject_writes_at_segments = crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS;
-        // `wal_tail_segments` is the tail this publish would extend, so
-        // rejecting at the bound is what keeps the landed tail inside it.
-        if projection.wal_tail_segments >= reject_writes_at_segments {
-            let wal_tail_segments = projection.wal_tail_segments;
-            self.publish_tail_projection = Some(projection);
-            let error = MetadataViewError::MaintenanceRequired {
-                namespace_id: self.namespace_id.clone(),
-                reason: format!(
-                    "WAL tail has {wal_tail_segments} segments; publishes resume once maintenance brings it back under {reject_writes_at_segments}"
-                ),
-            };
-            return NamespaceCommitEnginePublishResult {
-                results: repeated_error(candidate_count, CoreError::from(error)),
-                wal_tail_segments,
-                resulting_read_state: None,
-            };
-        }
 
         let published = crate::protocol::publish_namespace_commits_batch_against_publish_view(
             store,

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -6,7 +6,8 @@ use super::batch::BatchOutcomeSlot;
 use super::publish_view::PublishMetadataView;
 use crate::commit::{CandidateAllocation, CommitFingerprint, ValidatedCommitPlan};
 use crate::commit_engine::{CommitCandidate, ContentPreparation, ContentPreparationError};
-use crate::error::{CoreError, Result};
+use crate::error::{CoreError, MetadataViewError, Result};
+use crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS;
 use crate::metadata::CommitReceiptRecord;
 use crate::path::write::{CommitRequest, FilesystemOperation, PublishPlanningSession};
 use crate::storage::content_admission::ContentAdmission;
@@ -114,6 +115,15 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         Ok(Some(admission)) => return admission,
         Ok(None) => {}
         Err(error) => return CandidateAdmission::independent(Err(error)),
+    }
+    if let Some(wal_tail_segments) = view.write_stop() {
+        return CandidateAdmission::independent(Err(MetadataViewError::MaintenanceRequired {
+            namespace_id: namespace_id.clone(),
+            reason: format!(
+                "WAL tail has {wal_tail_segments} segments; publishes resume once maintenance brings it back under {MAX_UNFLUSHED_WAL_SEGMENTS}"
+            ),
+        }
+        .into()));
     }
     if let Err(error) = candidate.validate_request_limits() {
         return CandidateAdmission::independent(Err(error));

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -7,6 +7,7 @@ use crate::checkpoint::{load_basis_metadata_segments, LoadedMetadataBasis, Metad
 use crate::control_object::ControlObjectLoadError;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result, StoreFailureClass};
+use crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS;
 use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
 use crate::namespace::basis::{MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
@@ -30,6 +31,11 @@ pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     pub(super) acquired_writer: AcquiredWriter,
     manifest_segments: VerifiedMetadataSegments<'a, S>,
     tail_state: Arc<MetadataState>,
+    /// The WAL tail length when it has reached the write-stop bound, so the
+    /// tail this publish would extend stays inside it. New commits are refused
+    /// with that count; a commit id the namespace already knows is still
+    /// answered from its receipt.
+    write_stop: Option<u64>,
 }
 
 impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
@@ -39,6 +45,10 @@ impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
 
     pub(crate) fn content_store_id(&self) -> &ContentStoreId {
         &self.content_store_id
+    }
+
+    pub(super) fn write_stop(&self) -> Option<u64> {
+        self.write_stop
     }
 
     pub(super) async fn find_commit_receipt(
@@ -209,6 +219,8 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
             acquired_writer,
             manifest_segments,
             tail_state,
+            write_stop: (projection.wal_tail_segments >= MAX_UNFLUSHED_WAL_SEGMENTS)
+                .then_some(projection.wal_tail_segments),
         },
         projection,
     ))

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1347,8 +1347,7 @@ impl NamespacePublisher {
             candidates,
         )
         .await;
-        let write_stopped =
-            !publish.results.is_empty() && publish.results.iter().all(is_maintenance_required);
+        let write_stopped = publish.results.iter().any(is_maintenance_required);
         if write_stopped {
             self.read_core.instruments().publisher_write_stop_refusal();
         }

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -8,11 +8,11 @@
 
 use crate::common::collect_path_entries;
 use loonfs::{
-    maintenance_hint_relay, CommitId, CreateCheckpointOptions, CreateNamespaceOptions, ErrorCode,
-    FsMaintenance, FsReader, FsWriter, GarbageCollectionJob, MaintenanceRegistry,
-    MaintenanceRunner, ManifestNo, MetadataCompactionJob, MetadataMaintenanceJob,
-    MetadataMaintenanceOptions, NamespaceId, PutFileOptions, RuntimeCacheConfig, RuntimeError,
-    SharedObjectStore, StoreConfig,
+    maintenance_hint_relay, CommitId, CreateCheckpointOptions, CreateDirectoryOptions,
+    CreateNamespaceOptions, ErrorCode, FsMaintenance, FsReader, FsWriter, GarbageCollectionJob,
+    MaintenanceRegistry, MaintenanceRunner, ManifestNo, MetadataCompactionJob,
+    MetadataMaintenanceJob, MetadataMaintenanceOptions, NamespaceId, PutFileOptions,
+    RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig,
 };
 use loonfs_core::test_support::append_wal_segments;
 use loonfs_core::MutationContext;
@@ -98,11 +98,12 @@ async fn writer_with_runner(
 async fn fill_wal_tail_to_write_stop<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    seed_segments: u64,
 ) {
     append_wal_segments(
         store,
         namespace_id,
-        loonfs_core::limits::MAX_UNFLUSHED_WAL_SEGMENTS,
+        loonfs_core::limits::MAX_UNFLUSHED_WAL_SEGMENTS - seed_segments,
         &MutationContext {
             writer_id: loonfs_api::WriterId::parse("wal-tail-test-writer").expect("writer id"),
             now_ms: 1_000,
@@ -606,14 +607,31 @@ fn a_runtime_publish_folds_a_preexisting_write_stopped_tail_and_lands() {
             .create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("create namespace");
+        let mut replay_options = CreateDirectoryOptions::new(loonfs_test_support::test_actor());
+        replay_options.commit.commit_id =
+            Some(CommitId::parse("before-write-stop").expect("commit id"));
+        let original = stalled
+            .create_directory(&namespace_id, "/before-write-stop", replay_options.clone())
+            .await
+            .expect("land the commit before the ceiling");
         let tail_store = LocalFsStore::new(temp_dir.path()).expect("open tail store");
-        fill_wal_tail_to_write_stop(&tail_store, &namespace_id).await;
+        fill_wal_tail_to_write_stop(&tail_store, &namespace_id, 1).await;
         stalled
             .shutdown()
             .await
             .expect("shut down the first writer");
 
-        let writer = writer(temp_dir.path()).await;
+        let blocking = Arc::new(BlockingStore::new(
+            tail_store,
+            KeyPredicate::family(DurableObjectFamily::MetadataManifest),
+            OperationClass::Put,
+        ));
+        let writer = FsWriter::builder_with_store(blocking.clone())
+            .writer_id("handle-test-writer")
+            .build()
+            .await
+            .expect("build writer");
+        blocking.block_next();
         let refused = writer
             .put_file_bytes(
                 &namespace_id,
@@ -624,6 +642,13 @@ fn a_runtime_publish_folds_a_preexisting_write_stopped_tail_and_lands() {
             .await
             .expect_err("the write-stopped tail refuses the first publish");
         assert_eq!(refused.code(), ErrorCode::MaintenanceRequired);
+        blocking.wait_until_blocked().await;
+        let replay = writer
+            .create_directory(&namespace_id, "/before-write-stop", replay_options)
+            .await
+            .expect("replay succeeds while the tail remains at the bound");
+        assert_eq!(replay, original);
+        blocking.release();
         writer
             .wait_for_fold(&namespace_id)
             .await

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -300,7 +300,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `shutting_down` | 503 | The serving process closed admission for shutdown; work admitted earlier still settles. Retry against a live instance. |
 | `deadline_exceeded` | 503 | The server cancelled a bounded request at its configured `request_deadline_ms`. A commit may still land after this response; reconcile it by commit id before retrying. |
 | `checkpoint_unavailable` | 503 | Required checkpoint state is unavailable: not yet published, released during the operation, or referenced material is missing. Retry after maintenance. |
-| `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
+| `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. The WAL write-stop threshold refuses new commits. A commit id the namespace already knows is still answered from its receipt. |
 | `index_lagging` | 503 | The grep index trails the head past the exhaustive-scan budget; let the grep worker catch up (or set `allow_stale`) and retry. |
 | `storage_permission_denied` | 503 | The backing object store rejected the deployment's storage credentials for this operation. Fix the storage credentials or bucket policy; an unchanged retry will not succeed. |
 | `index_corrupt` | 500 | The grep index's derived state failed validation. Disable and re-enable grep on the namespace to rebuild it; core filesystem state remains available. |
@@ -652,6 +652,12 @@ Identical resubmission is the reconciliation mechanism. There is no separate
 commit-status lookup: after `commit_outcome_unknown`, a transport failure, or
 a process restart, resubmit the same request with the same `commit_id` and
 read the definitive answer from the response.
+
+The WAL write-stop threshold refuses new commits with `maintenance_required`.
+A commit id the namespace already knows is still answered from its receipt, so
+reconciliation after `commit_outcome_unknown` or `deadline_exceeded` remains
+available under this backpressure. Writer-session, availability, and corruption
+checks still apply.
 
 The blocking Rust client retries operations labeled `idempotent` or `replayable`. It makes one attempt for operations labeled `not_idempotent`: namespace create, fork, and delete; upload-session begin; checkpoint create; maintenance; grep index collection; and store probe. Presigned direct PUT also receives one attempt.
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2313,9 +2313,10 @@ deployment's read costs bounded regardless of scheduling: the reference
 implementation's writer folds the WAL tail into a manifest after a publish
 observes the tail at or past the WAL-tail policy's checkpoint threshold
 (32 segments at defaults), without delaying that publish, and every publish
-surface rejects with `maintenance_required` once the tail reaches the same policy's
-write-rejection threshold (128 at defaults). Reads never gate on tail
-length. Bounded reads are the
+surface refuses new commits with `maintenance_required` once the tail reaches
+the same policy's write-rejection threshold (128 at defaults). A commit id the
+namespace already knows is still answered from its receipt. Reads never gate on
+tail length. Bounded reads are the
 automatic half only: the retention floor never advances on its own, so
 history retention — and the row reclamation that follows it — remains an
 explicit operator decision. An embedded engine where an operator


### PR DESCRIPTION
The WAL write-stop ceiling used to answer every candidate in a batch with `maintenance_required` before any of them reached receipt resolution. A client that lost the acknowledgement of a commit that landed at the ceiling and retried the same commit id before a fold completed was told to run maintenance, although its commit was already durable and answering it would write nothing. That withheld the one answer a client needs to resolve an uncertain outcome, and a client that gave up and retried under a fresh id duplicated the write.

The ceiling keeps its meaning and moves to where it belongs. The publish view records the tail length when it has reached the bound, and candidate admission refuses a candidate only after commit-id reuse resolution says it is a genuinely new primary. An identical retained commit returns its original result from its receipt, a retained id with different semantics still returns `commit_id_reuse_conflict`, a same-batch alias follows its primary, and a batch of replays and refused primaries writes no WAL segment and does not touch the head. The runtime publisher now counts a write-stop refusal when any result in a batch was refused, not only when all were, so the refusal metric and the fold trigger keep firing on mixed batches.
