### PR TITLE
docs: state the rollback format condition and the recovery state a namespace depends on

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ LoonFS is designed with a core set of foundational ideas.
 
 - **Object storage is the only required durable substrate.** LoonFS stores durable truth in object storage: file content, immutable metadata history, materialized manifests/checkpoints, and a small number of mutable control objects. Caches, queues, workers, and local state are safely rebuildable from the object store.
 
-- **A namespace is a self-contained filesystem.** Each namespace has it's own contents and history, and is managed independently of every other namespace.
+- **A namespace is an independently addressable filesystem with its own history.** Forks share content and metadata under durable pins, so a namespace's storage is not confined to its own prefix.
 
 - **Inodes are identity, paths are views.** The identity of a filesystem item is `(namespace_id, inode_id)`. Paths are "views" that point to inodes, and may change over time without changing the item’s identity.
 
 - **Commits are the unit of transactional change.** File bytes are written to object storage before metadata can reference them. Metadata changes are recorded as logical commits, and a commit becomes visible only when the namespace head durably records it.
 
-- **Materialization and background work are derived, not authoritative.** Manifests, checkpoints, indexes, compaction, retention advancement, and garbage collection make the system faster, cheaper, or easier to recover, but they should not create a second source of truth.
+- **The head decides visibility; retained metadata, the WAL, and checkpoint records are recovery state, not caches.** Local caches and rebuildable indexes are separate, and nothing creates a second commit history.
 
 ## Design philosophy
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,7 +34,9 @@ only after the normal PR checks pass.
 ## 2. Publish the GitHub release
 
 Write the release notes before publishing. Start with a short summary of the
-important changes, followed by the generated PR list:
+important changes and whether the previous release reads this release's
+durable format (rollback is supported only where the notes say so), followed
+by the generated PR list:
 
 ```sh
 gh api repos/loonfs/loonfs/releases/generate-notes -f tag_name=vX.Y.Z --jq .body

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -269,6 +269,7 @@ The script creates a temporary namespace and deletes it before exiting.
 - Set memory and open-file limits before enabling the local cache.
 - Monitor health, readiness, metrics, and repeated error logs.
 - Run the smoke test after installation and every upgrade.
+- Check the release notes for format compatibility before an upgrade; a namespace prefix copy or a fork is not a complete backup.
 
 ## Probes and metrics
 
@@ -403,7 +404,8 @@ helm upgrade loonfs-server oci://ghcr.io/loonfs/charts/loonfs-server \
 The chart stops the old pod before starting the new one. The API is
 unavailable during this period. Run the smoke test after the rollout.
 
-To roll back the Helm release:
+Roll back only to a release whose notes say it reads this release's durable
+format. A flush is not a format downgrade. To roll back the Helm release:
 
 ```bash
 helm rollback loonfs-server --namespace loonfs


### PR DESCRIPTION
The self-hosting guide gave a bare `helm rollback` with no condition, while the durable format makes an older binary refuse newer meaning. The guide now says to roll back only to a release whose notes say it reads this release's format, that a flush is not a format downgrade, and that a prefix copy or a fork is not a complete backup. The release checklist requires the notes to state that compatibility. The two README bullets that read as "manifests and checkpoints are disposable" and "a namespace lives in its own prefix" now say what the head decides, what recovery depends on, and what forks share.
