### PR TITLE
refactor(storage): group compaction leases and jobs under one prefix

### DIFF
--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -84,7 +84,7 @@ pub fn metadata_compaction_segment(
     metadata_segment_id: &MetadataSegmentId,
 ) -> String {
     format!(
-        "namespaces/{namespace_id}/metadata/compactions/{metadata_compaction_id}/segments/{metadata_segment_id}.sst.zst"
+        "namespaces/{namespace_id}/metadata/compactions/jobs/{metadata_compaction_id}/segments/{metadata_segment_id}.sst.zst"
     )
 }
 
@@ -106,7 +106,7 @@ pub fn metadata_segment_object_key(descriptor: &MetadataSegmentRef) -> String {
 /// Builds the mutable lease key for one metadata family group.
 pub fn metadata_compaction_lease(namespace_id: &NamespaceId, group: MetadataFamilyGroup) -> String {
     let group = group.as_str();
-    format!("namespaces/{namespace_id}/metadata/compaction_leases/{group}.json")
+    format!("namespaces/{namespace_id}/metadata/compactions/groups/{group}.json")
 }
 
 /// Builds the publication-protection key beside one job's sealed output.
@@ -114,7 +114,7 @@ pub fn metadata_compaction_output_protection(
     namespace_id: &NamespaceId,
     job_id: &MetadataCompactionId,
 ) -> String {
-    format!("namespaces/{namespace_id}/metadata/compactions/{job_id}/protection.json")
+    format!("namespaces/{namespace_id}/metadata/compactions/jobs/{job_id}/protection.json")
 }
 
 /// Extracts the family group from a current-format compaction lease key.
@@ -125,7 +125,7 @@ pub fn metadata_compaction_lease_group_from_key(key: &str) -> Option<MetadataFam
 /// Builds the listing prefix containing every streaming compaction job's
 /// objects for one namespace.
 pub fn metadata_compaction_prefix(namespace_id: &NamespaceId) -> String {
-    format!("namespaces/{namespace_id}/metadata/compactions/")
+    format!("namespaces/{namespace_id}/metadata/compactions/jobs/")
 }
 
 /// Extracts the job id from a key under one namespace's compaction prefix.
@@ -425,7 +425,7 @@ mod tests {
         );
         assert_eq!(
             metadata_compaction_prefix(&namespace_id()),
-            "namespaces/ns-1/metadata/compactions/"
+            "namespaces/ns-1/metadata/compactions/jobs/"
         );
     }
 

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -131,7 +131,7 @@ pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
                 )
             })
         }
-        ["namespaces", namespace, "metadata", "compactions", job_id, "segments", segment]
+        ["namespaces", namespace, "metadata", "compactions", "jobs", job_id, "segments", segment]
             if segment.ends_with(".sst.zst") =>
         {
             Some(parsed(
@@ -140,14 +140,14 @@ pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
                 Some(job_id),
             ))
         }
-        ["namespaces", namespace, "metadata", "compactions", job_id, "protection.json"] => {
+        ["namespaces", namespace, "metadata", "compactions", "jobs", job_id, "protection.json"] => {
             Some(parsed(
                 DurableObjectFamily::CompactionOutputProtection,
                 Some(namespace),
                 Some(job_id),
             ))
         }
-        ["namespaces", namespace, "metadata", "compaction_leases", lease] => {
+        ["namespaces", namespace, "metadata", "compactions", "groups", lease] => {
             lease.strip_suffix(".json").and_then(|group| {
                 parse_metadata_family_group(group).map(|_| {
                     parsed(
@@ -240,7 +240,8 @@ mod tests {
     use super::{parse_object_key, DurableObjectFamily};
     use crate::keys::{
         checkpoint_record, content_blob, content_owner_prefix, content_store,
-        metadata_compaction_lease, metadata_compaction_segment, metadata_manifest_object,
+        metadata_compaction_lease, metadata_compaction_output_protection,
+        metadata_compaction_prefix, metadata_compaction_segment, metadata_manifest_object,
         metadata_root, metadata_segment, metadata_segment_prefix, upload_session, wal_floor,
         wal_head, wal_segment, wal_segment_prefix,
     };
@@ -311,6 +312,11 @@ mod tests {
                 Some("bindings"),
             ),
             (
+                metadata_compaction_output_protection(&namespace_id, &compaction_id),
+                DurableObjectFamily::CompactionOutputProtection,
+                Some(compaction_id.as_str()),
+            ),
+            (
                 checkpoint_record(&namespace_id, &checkpoint_id),
                 DurableObjectFamily::CheckpointRecord,
                 Some(checkpoint_id.as_str()),
@@ -377,6 +383,12 @@ mod tests {
             .starts_with(&format!("content-stores/{content_store_id}/objects/")));
         let staged = metadata_compaction_segment(&namespace_id, &job, &segment_id);
 
+        let jobs = metadata_compaction_prefix(&namespace_id);
+        assert!(staged.starts_with(&jobs));
+        assert!(metadata_compaction_output_protection(&namespace_id, &job).starts_with(&jobs));
+        for group in MetadataFamilyGroup::ALL {
+            assert!(!metadata_compaction_lease(&namespace_id, group).starts_with(&jobs));
+        }
         assert!(!staged.starts_with(&metadata_segment_prefix(&namespace_id)));
         let wal_segments = wal_segment_prefix(&namespace_id);
         assert!(!wal_head(&namespace_id).starts_with(&wal_segments));
@@ -390,9 +402,13 @@ mod tests {
             "namespaces/ns-1/control/head.json",
             "namespaces/ns-1/wal/wal_00000000000000000001-0123456789abcdef.wal.zst",
             "namespaces/ns-1/wal/segments/random.tmp",
-            "namespaces/ns-1/metadata/compactions/cmp_1/segments/seg_1.tmp",
-            "namespaces/ns-1/metadata/compactions/cmp_1/lease.json",
-            "namespaces/ns-1/metadata/compaction_leases/unknown.json",
+            "namespaces/ns-1/metadata/compactions/jobs/cmp_1/segments/seg_1.tmp",
+            "namespaces/ns-1/metadata/compactions/jobs/cmp_1/lease.json",
+            "namespaces/ns-1/metadata/compactions/groups/unknown.json",
+            "namespaces/ns-1/metadata/compactions/groups/bindings/lease.json",
+            "namespaces/ns-1/metadata/compaction_leases/bindings.json",
+            "namespaces/ns-1/metadata/compactions/cmp_1/protection.json",
+            "namespaces/ns-1/metadata/compactions/cmp_1/segments/seg_1.sst.zst",
             "content-stores/cs-1/objects/ab/deadbeef",
         ] {
             assert!(

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -64,7 +64,7 @@ The complete operation has five stages:
 
 1. Capture an immutable compaction specification containing a generated job ID, the family group, selected input runs, output identity, and retention floor.
 2. Acquire the family-group lease, open sorted iterators over the selected runs, and merge their rows in key order.
-3. Apply the retention rules and write completed output segments under `metadata/compactions/{job_id}/segments/`.
+3. Apply the retention rules and write completed output segments under `metadata/compactions/jobs/{job_id}/segments/`.
 4. Reload the current manifest and confirm that every selected input is still present and unchanged.
 5. Publish one manifest update that removes the selected inputs and adds the completed output.
 
@@ -159,7 +159,7 @@ Step budgets therefore price the selected logical input, and a step-contained me
 
 ## Job leases and garbage collection
 
-Each family group has one lease at `metadata/compaction_leases/{group}.json`, and its payload names the job whose output under `metadata/compactions/{job_id}/segments/` it protects. An `active` unexpired group lease excludes every other job for that group.
+Each family group has one lease at `metadata/compactions/groups/{group}.json`, and its payload names the job whose output under `metadata/compactions/jobs/{job_id}/segments/` it protects. An `active` unexpired group lease excludes every other job for that group.
 
 The lease records the job ID, namespace ID, writer ID, status, start time, and absolute expiry. It does not contain a cursor, output descriptors, offsets, or progress, so it cannot be used to resume a failed job.
 
@@ -169,7 +169,7 @@ Garbage collection reads the seven group lease keys once per namespace per pass 
 
 A missing lease or a lease naming another job provides no ownership claim. An invalid lease fails the pass. Unreferenced objects in that prefix become eligible after a staging grace period derived from the lease expiry and the normal publication grace. Unrecognized keys under the compaction prefix are retained because ownership cannot be established safely.
 
-Before each publication attempt, the job confirms its refreshed lease deadline in `metadata/compactions/{job_id}/protection.json`. This is a separate control record containing namespace, job ID, and expiry; it is created only after output writing ends and updated by CAS. Confirming it before root publication covers a crash immediately after publication. After the final attempt, the job changes its group slot to `completed`, allowing the next job immediately. GC checks the protection deadline before group ownership, and removes that record only after its deadline and after the output prefix is empty. Group slots remain in place and are only replaced by CAS, so a paused collector cannot delete a newer job's claim. A failed completion write may leave the group held until expiry.
+Before each publication attempt, the job confirms its refreshed lease deadline in `metadata/compactions/jobs/{job_id}/protection.json`. This is a separate control record containing namespace, job ID, and expiry; it is created only after output writing ends and updated by CAS. Confirming it before root publication covers a crash immediately after publication. After the final attempt, the job changes its group slot to `completed`, allowing the next job immediately. GC checks the protection deadline before group ownership, and removes that record only after its deadline and after the output prefix is empty. Group slots remain in place and are only replaced by CAS, so a paused collector cannot delete a newer job's claim. A failed completion write may leave the group held until expiry.
 
 ## Finalization
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -96,9 +96,9 @@ The required durable object families and standard key patterns are:
 | **Namespace manifests** | Immutable | Record one namespace file-set version: its metadata segment references and a head summary. Segment references carry their own owner, so a fork target's manifest names source-owned segments without recording anything about the fork. | `namespaces/{namespace_id}/metadata/manifests/{manifest_object_id}.manifest.json` |
 | **Checkpoint records** | Mutable lifecycle | Durable stable-view pins to a metadata manifest, each carrying a required owner (user, fork target, or snapshot). The record's `status` is monotonic: a record is created `active` under a generated id, released once by compare-and-swap, and deleted a grace window after that release. | `namespaces/{namespace_id}/checkpoints/{checkpoint_id}.json` |
 | **Metadata segments** | Immutable | Store metadata rows referenced by manifests. Segments may be owned by the namespace itself or by a fork source namespace. | `namespaces/{owner_namespace_id}/metadata/segments/{segment_id}.sst.zst` |
-| **Compaction staging** | Immutable | Holds segments written by a streaming compaction before publication. The descriptor stores the job id used to derive this key. | `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/segments/{segment_id}.sst.zst` |
-| **Compaction leases** | Mutable group slot | An `active` lease owns a running job's output. `completed` and `reaping` jobs release the group. Slots are replaced by CAS and never deleted. | `namespaces/{owner_namespace_id}/metadata/compaction_leases/{group}.json` |
-| **Compaction output protection** | Mutable deadline | Before each publication attempt, a job records its lease deadline beside the sealed output. This record remains until the output prefix is empty. | `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/protection.json` |
+| **Compaction staging** | Immutable | Holds segments written by a streaming compaction before publication. The descriptor stores the job id used to derive this key. | `namespaces/{owner_namespace_id}/metadata/compactions/jobs/{job_id}/segments/{segment_id}.sst.zst` |
+| **Compaction leases** | Mutable group slot | An `active` lease owns a running job's output. `completed` and `reaping` jobs release the group. Slots are replaced by CAS and never deleted. | `namespaces/{owner_namespace_id}/metadata/compactions/groups/{group}.json` |
+| **Compaction output protection** | Mutable deadline | Before each publication attempt, a job records its lease deadline beside the sealed output. This record remains until the output prefix is empty. | `namespaces/{owner_namespace_id}/metadata/compactions/jobs/{job_id}/protection.json` |
 | **Upload sessions** | Mutable lifecycle | Track one staged-content upload. The record's `status` is monotonic: a session is created `open` under a lease, and moves once to `completed` or `aborted`, both terminal. | `namespaces/{namespace_id}/uploads/{upload_id}.json` |
 | **Metadata root** | Mutable | Cold pointer to the best known materialized metadata root; monotonic CAS. | `namespaces/{namespace_id}/metadata/root.json` |
 | **GC run** | Mutable CAS | Coordinates marking and sweeping across calls and hosts; one active run per namespace. | `namespaces/{namespace_id}/gc/run.json` |
@@ -124,6 +124,21 @@ For example, segment `wal_00000000000000000002-fedcba9876543210` in namespace
 `namespaces/demo/wal/segments/wal_00000000000000000002-fedcba9876543210.wal.zst`.
 Pointers never store this key; every store boundary derives it from the
 namespace and `segment_id`.
+
+Compaction keeps reusable family-group slots separate from per-job output
+under one subsystem prefix:
+
+```text
+namespaces/{namespace_id}/metadata/compactions/
+├── groups/{group}.json
+└── jobs/{job_id}/
+    ├── protection.json
+    └── segments/{segment_id}.sst.zst
+```
+
+The seven group slots are read directly and never swept. GC enumerates only
+`metadata/compactions/jobs/`; a job's protection record stays beside its
+output even after the group slot is reused.
 
 These key shapes are part of the interoperable storage contract.
 Implementations may keep additional private control-plane objects — queues,
@@ -2421,9 +2436,9 @@ an undelete give back the map the inode had. A rewrite refuses to compact
 when two rows for one inode share a revision number at or below the floor,
 because that makes "the newest at the floor" arbitrary and the drop unsafe.
 
-A rebuild that cannot fit within one bounded maintenance pass runs as a streaming compaction. The job merges every run in the group and writes output segments as they fill. These segments use `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/segments/{segment_id}.sst.zst` instead of `metadata/segments/`.
+A rebuild that cannot fit within one bounded maintenance pass runs as a streaming compaction. The job merges every run in the group and writes output segments as they fill. These segments use `namespaces/{owner_namespace_id}/metadata/compactions/jobs/{job_id}/segments/{segment_id}.sst.zst` instead of `metadata/segments/`.
 
-Each family group has one lease at `namespaces/{owner_namespace_id}/metadata/compaction_leases/{group}.json`. An unexpired `active` lease excludes another job for that group. An expired, `completed`, or `reaping` slot can be replaced with one compare-and-swap; the old job's refresh then fails. Before each publication attempt, the job confirms its current lease deadline at `metadata/compactions/{job_id}/protection.json`. No output is written after this record is created. After the final publication attempt, the group slot becomes `completed`. The protection record remains until the job's output prefix is empty. An older collector therefore retains its protection even after a newer job takes over the group. A published manifest references the segments in place. Each descriptor stores `compaction_job_id`, and readers use it to derive the key (section 4.2.1).
+Each family group has one lease at `namespaces/{owner_namespace_id}/metadata/compactions/groups/{group}.json`. An unexpired `active` lease excludes another job for that group. An expired, `completed`, or `reaping` slot can be replaced with one compare-and-swap; the old job's refresh then fails. Before each publication attempt, the job confirms its current lease deadline at `metadata/compactions/jobs/{job_id}/protection.json`. No output is written after this record is created. After the final publication attempt, the group slot becomes `completed`. The protection record remains until the job's output prefix is empty. An older collector therefore retains its protection even after a newer job takes over the group. A published manifest references the segments in place. Each descriptor stores `compaction_job_id`, and readers use it to derive the key (section 4.2.1).
 
 The rules a rebuild applies are the same however it runs them. A bounded
 merge holds every row of its window and decides them together. A streaming
@@ -2485,7 +2500,7 @@ There is no mixed-protocol collection or compatibility fallback.
 GC uses resumable listing mark-and-sweep. Its inputs are `wal/head.json`,
 `wal/floor.json`, `metadata/root.json`, the seven point-read compaction lease
 keys, and the `metadata/manifests/`, `metadata/segments/`,
-`metadata/compactions/`, `checkpoints/`, and `wal/segments/` collections. A live manifest roots every object key its
+`metadata/compactions/jobs/`, `checkpoints/`, and `wal/segments/` collections. A live manifest roots every object key its
 `runs` list names, wherever that key sits. The pass also
 sweeps `uploads/`, and that sweep owns content reclamation as well; the two
 halves are split at the completed line and described in rule 11.
@@ -2749,14 +2764,14 @@ publishing CAS) — under these rules:
    compaction ("Compaction") publishes nothing until it finishes and is paced
    by no budget, so its output is unreferenced for as long as the job runs.
    `T` only has to cover a publication in flight, so a sweep applying it to
-   `metadata/compactions/` would delete the output of a job still writing it,
+   `metadata/compactions/jobs/` would delete the output of a job still writing it,
    and no fixed window can replace it: any such window is a guess at how long
    a job may run, which is exactly what the design refuses to bound.
 
    The lease says so instead. Every job owns the prefix
-   `namespaces/{namespace_id}/metadata/compactions/{job_id}/` and writes its
+   `namespaces/{namespace_id}/metadata/compactions/jobs/{job_id}/` and writes its
    output under `segments/` inside it, while its family group has one lease at
-   `namespaces/{namespace_id}/metadata/compaction_leases/{group}.json`. The
+   `namespaces/{namespace_id}/metadata/compactions/groups/{group}.json`. The
    lease carries ownership only — job, namespace, group, `writer_id`, the tagged
    `status`, `started_at_ms`, `expires_at_ms` — and never a cursor, an output
    descriptor, an offset, or resumable progress. The job creates a missing
@@ -2785,7 +2800,7 @@ publishing CAS) — under these rules:
 
    Before each root publication attempt, after refreshing the group lease,
    the job confirms an output-protection record at
-   `metadata/compactions/{job_id}/protection.json`. It contains `namespace_id`,
+   `metadata/compactions/jobs/{job_id}/protection.json`. It contains `namespace_id`,
    `job_id`, and `expires_at_ms`, and its deadline only advances by CAS. No
    output writes follow the first protection record. Confirming protection
    before the root CAS also covers a crash immediately after publication.


### PR DESCRIPTION
Compaction coordination and output belong under one durable subsystem prefix. Move reusable leases to `metadata/compactions/groups/{group}.json` and job protection/output to `metadata/compactions/jobs/{job_id}/`, keeping GC listings confined to jobs and preserving the existing CAS and protection protocol. This is a breaking durable-key layout change with no migration or legacy-path fallback; payload shapes and envelope versions are unchanged. Validation: `cargo test --all --locked`, `cargo fmt --all --check`, and `cargo clippy --all-targets --all-features --locked -- -D warnings`.
