### PR TITLE
fix(checkpoints): acknowledge a pin only for a manifest current after the write

### DIFF
--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -66,7 +66,7 @@ pub use self::streaming_compaction::{
 };
 
 pub(crate) use self::compactor::claim_compactor;
-pub(crate) use self::create::{create_checkpoint, create_checkpoint_at_basis};
+pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::data_block_load::DecodedRowWeight;
 pub(crate) use self::files::list_checkpoint_files_page;
 pub(crate) use self::flush::flush_wal;

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -1,4 +1,4 @@
-//! Pin creation, point reads, deletion, and floor verification.
+//! Pin creation, point reads, deletion, and manifest verification.
 
 use crate::control_object::{
     expect_identity_field, expect_namespace, load_control_object, ControlObjectLoadError,
@@ -145,9 +145,12 @@ pub(crate) async fn verify_checkpoint_basis<S: ObjectStore + ?Sized>(
     record: &CheckpointRecordState,
 ) -> Result<CheckpointBasisVerification> {
     let manifest = load_current_manifest(store, &record.namespace_id).await?;
+    let pinned = record.manifest();
     Ok(
         if manifest.envelope.payload().status.is_deleted()
             || manifest.state.retention_floor_seq > record.manifest_head_seq
+            || manifest.state.manifest.manifest_no != pinned.manifest_no
+            || manifest.state.manifest.manifest_payload_checksum != pinned.manifest_payload_checksum
         {
             CheckpointBasisVerification::Invalid
         } else {

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -12,6 +12,7 @@ mod index_parity;
 pub(crate) mod inspection_materialization;
 mod inventory;
 mod manifest_round_trips;
+mod pin_verification;
 mod retention;
 mod streaming_compaction;
 

--- a/crates/loonfs-core/src/checkpoint/tests/pin_verification.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/pin_verification.rs
@@ -1,0 +1,257 @@
+//! Pin publication races and verification request counts.
+
+use super::*;
+use loonfs_api::wire::control::CheckpointOwner;
+use loonfs_objectstore::keys::checkpoint_prefix;
+use loonfs_test_support::stores::MetadataMapStore;
+
+#[tokio::test]
+async fn pin_creation_retries_after_compaction_and_collection() {
+    for advance_head in [false, true] {
+        let directory = tempdir().expect("directory");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace");
+        let store = BlockingStore::new(
+            MetadataMapStore::aged(
+                LocalFsStore::new(directory.path()).expect("store"),
+                KeyPredicate::metadata_segment(),
+            ),
+            KeyPredicate::prefix(checkpoint_prefix(&namespace_id)),
+            OperationClass::PutCreateIfAbsent,
+        );
+        let context = test_context();
+        bootstrap_namespace(&store, &namespace_id, &context, false)
+            .await
+            .expect("bootstrap");
+        for path in ["/one", "/two"] {
+            write_file_bytes(&store, &namespace_id, path, b"data", &context, None)
+                .await
+                .expect("write");
+            flush::flush_wal(&store, &namespace_id, &context)
+                .await
+                .expect("flush");
+        }
+        let selected = load_current_manifest(&store, &namespace_id)
+            .await
+            .expect("selected manifest");
+        store.block_next();
+        let (created, current) =
+            tokio::join!(create_checkpoint(&store, &namespace_id, &context), async {
+                store.wait_until_blocked().await;
+                if advance_head {
+                    write_file_bytes(&store, &namespace_id, "/three", b"data", &context, None)
+                        .await
+                        .expect("advance head");
+                    flush::flush_wal(&store, &namespace_id, &context)
+                        .await
+                        .expect("flush newer head");
+                }
+                let current =
+                    compact_and_collect_replaced_segments(&store, &namespace_id, &selected).await;
+                assert_eq!(
+                    selected.state.manifest.manifest_head_seq != current.manifest_head_seq,
+                    advance_head
+                );
+                store.release();
+                current
+            });
+        let checkpoint = created.expect("retry against the current manifest");
+        let page = crate::checkpoint::list_checkpoint_files_page(
+            &store,
+            None,
+            &namespace_id,
+            &checkpoint.checkpoint_id,
+            loonfs_api::PageRequest {
+                cursor: None,
+                limit: loonfs_test_support::ids::page_limit(10),
+            },
+        )
+        .await
+        .expect("acknowledged checkpoint remains readable");
+        assert_eq!(page.files.len(), if advance_head { 3 } else { 2 });
+        assert_eq!(checkpoint.manifest_no, current.manifest_no);
+        assert_eq!(checkpoint.checkpoint_seq, current.manifest_head_seq);
+        assert_eq!(
+            store
+                .list_prefix(&checkpoint_prefix(&namespace_id))
+                .await
+                .expect("pins"),
+            [loonfs_objectstore::keys::checkpoint_record(
+                &namespace_id,
+                &checkpoint.checkpoint_id
+            )]
+        );
+    }
+}
+
+async fn compact_and_collect_replaced_segments<S: ObjectStore>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    selected: &crate::namespace::control::LoadedManifest,
+) -> loonfs_api::wire::control::ManifestRef {
+    let report = reorganize_metadata_step(
+        store,
+        namespace_id,
+        selected.state.compactor_epoch,
+        MetadataLsmPolicy::default(),
+        MetadataCompactionPolicy::CompactImmediately,
+    )
+    .await
+    .expect("compact");
+    assert!(matches!(
+        report.outcome,
+        MetadataReorganizeOutcome::UnitPublished { .. }
+    ));
+    let current = load_current_manifest(store, namespace_id)
+        .await
+        .expect("current manifest");
+    assert_ne!(selected.state.manifest, current.state.manifest);
+    let current_segments: BTreeSet<_> = current
+        .envelope
+        .payload()
+        .runs
+        .iter()
+        .flat_map(|run| &run.segments)
+        .map(metadata_segment_object_key)
+        .collect();
+    let replaced: Vec<_> = selected
+        .envelope
+        .payload()
+        .runs
+        .iter()
+        .flat_map(|run| &run.segments)
+        .map(metadata_segment_object_key)
+        .filter(|key| !current_segments.contains(key))
+        .collect();
+    assert!(!replaced.is_empty());
+    assert!(store
+        .list_prefix(&checkpoint_prefix(namespace_id))
+        .await
+        .expect("pins")
+        .is_empty());
+    let collection = crate::gc::gc_namespace(
+        store,
+        namespace_id,
+        &crate::gc::GcConfig::default(),
+        &mutation_context(
+            "collector",
+            crate::limits::UNREFERENCED_SEGMENT_MIN_AGE_MS + 1,
+        ),
+    )
+    .await
+    .expect("collect before pin write");
+    assert!(collection.deleted.metadata_segments as usize >= replaced.len());
+    for key in replaced {
+        assert!(store.head(&key).await.expect("replaced segment").is_none());
+    }
+    current.state.manifest
+}
+
+#[tokio::test]
+async fn namespace_deletion_during_pin_verification_deletes_the_pin() {
+    let directory = tempdir().expect("directory");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace");
+    let store = BlockingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::exact(hint(&namespace_id)),
+        OperationClass::Read,
+    );
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    let writer = acquire_writer_epoch(&store, &namespace_id, &context)
+        .await
+        .expect("writer");
+    let current = load_current_manifest(&store, &namespace_id)
+        .await
+        .expect("current manifest");
+    store.block_next();
+    let (result, ()) = tokio::join!(
+        create::create_checkpoint_at_basis(
+            &store,
+            &namespace_id,
+            CheckpointOwner::User {
+                name: "racing".to_owned(),
+                expires_at_ms: None
+            },
+            current.state.manifest,
+            current.envelope.payload().head_commit_id.clone(),
+            &context,
+        ),
+        async {
+            store.wait_until_blocked().await;
+            assert_eq!(
+                store
+                    .inner()
+                    .list_prefix(&checkpoint_prefix(&namespace_id))
+                    .await
+                    .expect("durable pin")
+                    .len(),
+                1
+            );
+            crate::namespace::delete::delete_namespace(
+                store.inner(),
+                &namespace_id,
+                Default::default(),
+                writer,
+            )
+            .await
+            .expect("delete namespace during verification");
+            store.release();
+        }
+    );
+    assert!(matches!(result, Err(CoreError::CheckpointUnavailable(_))));
+    assert!(store
+        .list_prefix(&checkpoint_prefix(&namespace_id))
+        .await
+        .expect("pins")
+        .is_empty());
+}
+
+#[tokio::test]
+async fn pin_verification_checks_manifest_identity_with_only_the_current_manifest_load() {
+    let directory = tempdir().expect("directory");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace");
+    let store = RecordingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::any(),
+    );
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    let record = load_checkpoint_record(&store, &namespace_id, &checkpoint.checkpoint_id)
+        .await
+        .expect("load pin")
+        .expect("pin exists")
+        .state;
+    store.reset();
+    load_current_manifest(&store, &namespace_id)
+        .await
+        .expect("current manifest");
+    let expected = store.take();
+    let mut changed_number = record.clone();
+    changed_number.manifest_no = record.manifest_no.successor().expect("next number");
+    changed_number.pin_id = CheckpointId::generate(changed_number.manifest_no);
+    let mut changed_checksum = record.clone();
+    changed_checksum.manifest_payload_checksum = "sha256:different".to_owned();
+    for (record, expected_verification) in [
+        (record, record::CheckpointBasisVerification::Verified),
+        (changed_number, record::CheckpointBasisVerification::Invalid),
+        (
+            changed_checksum,
+            record::CheckpointBasisVerification::Invalid,
+        ),
+    ] {
+        assert_eq!(
+            record::verify_checkpoint_basis(&store, &record)
+                .await
+                .expect("verification"),
+            expected_verification
+        );
+        assert_eq!(store.take(), expected);
+    }
+}

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -1,17 +1,19 @@
 //! Fork installation copies pinned source runs into target manifest 1.
 
-use crate::checkpoint::record::release_checkpoint_record;
+use crate::checkpoint::record::{release_checkpoint_record, write_checkpoint_record};
 use crate::checkpoint::{
-    classify_live_snapshot, create_checkpoint, create_checkpoint_at_basis, load_checkpoint_record,
+    classify_live_snapshot, create_checkpoint, load_checkpoint_record,
     load_namespace_manifest_envelope,
 };
 use crate::context::MutationContext;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
-use crate::limits::FORK_INSTALL_BUDGET_MS;
+use crate::limits::{CHECKPOINT_VERIFY_BUDGET_MS, FORK_INSTALL_BUDGET_MS};
 use crate::namespace::bootstrap::{install_namespace_manifest, NamespaceInstall};
 use crate::time::{MonotonicTimer, StdMonotonicTimer};
-use loonfs_api::wire::control::{CheckpointOwner, ForkBasis, NamespaceStatus};
+use loonfs_api::wire::control::{
+    CheckpointOwner, CheckpointRecordState, ForkBasis, NamespaceStatus,
+};
 use loonfs_api::{CheckpointId, Namespace, NamespaceId, WriterEpoch};
 use loonfs_objectstore::ObjectStore;
 
@@ -27,13 +29,11 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     let owner = CheckpointOwner::Fork {
         target_namespace_id: new_namespace_id.clone(),
     };
-    let checkpoint = if let Some(snapshot_id) = snapshot_id {
+    let source_record = if let Some(snapshot_id) = snapshot_id {
         create_snapshot_fork_checkpoint(store, source_namespace_id, snapshot_id, owner, context)
             .await?
     } else {
-        create_checkpoint(store, source_namespace_id, owner, context).await?
-    };
-    let source_record =
+        let checkpoint = create_checkpoint(store, source_namespace_id, owner, context).await?;
         load_checkpoint_record(store, source_namespace_id, &checkpoint.checkpoint_id)
             .await?
             .ok_or_else(|| {
@@ -42,7 +42,8 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
                     checkpoint.checkpoint_id
                 ))
             })?
-            .state;
+            .state
+    };
     let source_manifest = load_namespace_manifest_envelope(
         store,
         source_namespace_id,
@@ -105,7 +106,7 @@ async fn create_snapshot_fork_checkpoint<S: ObjectStore + ?Sized>(
     snapshot_id: &CheckpointId,
     owner: CheckpointOwner,
     context: &MutationContext,
-) -> Result<loonfs_api::Checkpoint> {
+) -> Result<CheckpointRecordState> {
     let timer = StdMonotonicTimer::default();
     let started_ms = timer.monotonic_now_ms();
     let snapshot = classify_live_snapshot(
@@ -116,35 +117,53 @@ async fn create_snapshot_fork_checkpoint<S: ObjectStore + ?Sized>(
         context.now_ms,
     )?
     .state;
-    let checkpoint = create_checkpoint_at_basis(
+    let record = CheckpointRecordState {
+        pin_id: CheckpointId::generate(snapshot.manifest_no),
+        created_at_ms: context.now_ms,
+        owner,
+        ..snapshot
+    };
+    write_checkpoint_record(store, &record).await?;
+    let rechecked = verify_snapshot_fork_basis(
         store,
         source_namespace_id,
-        owner,
-        snapshot.manifest(),
-        snapshot.head_commit_id,
-        context,
+        snapshot_id,
+        context.now_ms,
+        &timer,
+        started_ms,
     )
-    .await?;
-    let rechecked = load_checkpoint_record(store, source_namespace_id, snapshot_id)
-        .await
-        .and_then(|record| {
-            classify_live_snapshot(
-                record,
-                snapshot_id,
-                context
-                    .now_ms
-                    .saturating_add(timer.monotonic_now_ms().saturating_sub(started_ms)),
-            )
-        });
+    .await;
     if let Err(error) = rechecked {
-        release_checkpoint_record(store, source_namespace_id, &checkpoint.checkpoint_id).await?;
-        return Err(match error {
-            CoreError::SnapshotNotFound { .. } => CoreError::SnapshotGone {
-                snapshot_id: snapshot_id.clone(),
-                reason: "released".to_owned(),
-            },
-            error => error,
-        });
+        release_checkpoint_record(store, source_namespace_id, &record.pin_id).await?;
+        return Err(error);
     }
-    Ok(checkpoint)
+    if timer.monotonic_now_ms().saturating_sub(started_ms) > CHECKPOINT_VERIFY_BUDGET_MS {
+        release_checkpoint_record(store, source_namespace_id, &record.pin_id).await?;
+        return Err(CoreError::CheckpointUnavailable(
+            "snapshot fork verification exceeded its budget".to_owned(),
+        ));
+    }
+    Ok(record)
+}
+
+async fn verify_snapshot_fork_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    source_namespace_id: &NamespaceId,
+    snapshot_id: &CheckpointId,
+    now_ms: u64,
+    timer: &dyn MonotonicTimer,
+    started_ms: u64,
+) -> Result<()> {
+    let snapshot = load_checkpoint_record(store, source_namespace_id, snapshot_id)
+        .await?
+        .ok_or_else(|| CoreError::SnapshotGone {
+            snapshot_id: snapshot_id.clone(),
+            reason: "released".to_owned(),
+        })?;
+    classify_live_snapshot(
+        Some(snapshot),
+        snapshot_id,
+        now_ms.saturating_add(timer.monotonic_now_ms().saturating_sub(started_ms)),
+    )?;
+    Ok(())
 }

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -27,7 +27,8 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectStore, PutMode};
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{
-    FailStore, InjectedError, KeyPredicate, OperationClass, RecordedOperation, RecordingStore,
+    BlockingStore, FailStore, InjectedError, KeyPredicate, MetadataMapStore, OperationClass,
+    RecordedOperation, RecordingStore,
 };
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -67,9 +68,12 @@ async fn listed_names<S: ObjectStore + ?Sized>(
 }
 
 #[tokio::test]
-async fn snapshot_fork_keeps_its_tree_after_snapshot_release_and_source_gc() {
+async fn snapshot_fork_keeps_its_view_after_source_compaction_collection_and_snapshot_release() {
     let directory = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(directory.path()).expect("store");
+    let store = MetadataMapStore::aged(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::metadata_segment(),
+    );
     let context = mutation_context();
     let source = namespace_id("source");
     let target = namespace_id("target");
@@ -97,6 +101,33 @@ async fn snapshot_fork_keeps_its_tree_after_snapshot_release_and_source_gc() {
     )
     .await
     .expect("advance source");
+    engine.flush_wal().await.expect("flush current source");
+    let floor = engine
+        .advance_retention_floor()
+        .await
+        .expect("advance floor");
+    assert!(floor.retention_floor_seq > snapshot.checkpoint_seq);
+    let mut compacted = false;
+    for _ in 0..16 {
+        let report = engine
+            .reorganize_metadata(loonfs_core::MetadataCompactionPolicy::CompactImmediately, 0)
+            .await
+            .expect("compact source");
+        match report.outcome {
+            loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+            loonfs_core::MetadataReorganizeOutcome::UnitPublished { .. } => compacted = true,
+            other => panic!("expected bounded compaction, got {other:?}"),
+        }
+    }
+    assert!(compacted);
+    let mut aged = context.clone();
+    aged.now_ms = u64::MAX / 4;
+    let collected =
+        loonfs_core::gc_namespace(&store, &source, &loonfs_core::GcConfig::default(), &aged)
+            .await
+            .expect("collect source before fork");
+    assert!(!collected.budget_exhausted);
+    assert!(collected.deleted.metadata_segments > 0);
     let fork = engine
         .fork_namespace(&target, Some(&snapshot.checkpoint_id))
         .await
@@ -128,11 +159,6 @@ async fn snapshot_fork_keeps_its_tree_after_snapshot_release_and_source_gc() {
         .release_snapshot(&snapshot.checkpoint_id)
         .await
         .expect("release snapshot");
-    engine
-        .create_checkpoint("current".to_owned(), None)
-        .await
-        .expect("flush current source");
-    let mut aged = context.clone();
     aged.now_ms = u64::MAX / 2;
     loonfs_core::gc_namespace(&store, &source, &loonfs_core::GcConfig::default(), &aged)
         .await
@@ -195,11 +221,7 @@ async fn snapshot_release_during_fork_releases_the_attempt_without_installing_a_
     let directory = tempdir().expect("tempdir");
     let source = namespace_id("source");
     let target = namespace_id("target");
-    let store = loonfs_test_support::stores::BlockingStore::new(
-        LocalFsStore::new(directory.path()).expect("store"),
-        KeyPredicate::prefix(format!("namespaces/{source}/pins/")),
-        OperationClass::PutCreateIfAbsent,
-    );
+    let store = LocalFsStore::new(directory.path()).expect("store");
     let context = mutation_context();
     seed_source_namespace_for_fork(&store, &source, &context).await;
     let engine = namespace_engine(&store, &source, &context);
@@ -207,15 +229,39 @@ async fn snapshot_release_during_fork_releases_the_attempt_without_installing_a_
         .create_snapshot("basis".to_owned(), u64::MAX / 2)
         .await
         .expect("snapshot");
+    let store = BlockingStore::new(
+        BlockingStore::new(
+            store,
+            KeyPredicate::exact(loonfs_objectstore::keys::checkpoint_record(
+                &source,
+                &snapshot.checkpoint_id,
+            )),
+            OperationClass::Read,
+        ),
+        KeyPredicate::prefix(loonfs_objectstore::keys::checkpoint_prefix(&source)),
+        OperationClass::PutCreateIfAbsent,
+    );
+    let engine = namespace_engine(&store, &source, &context);
     store.block_next();
     let forking = engine.fork_namespace(&target, Some(&snapshot.checkpoint_id));
     let releasing = async {
         store.wait_until_blocked().await;
-        engine
+        store.inner().block_next();
+        store.release();
+        store.inner().wait_until_blocked().await;
+        assert_eq!(
+            store
+                .list_prefix(&loonfs_objectstore::keys::checkpoint_prefix(&source))
+                .await
+                .expect("durable pins")
+                .len(),
+            2
+        );
+        namespace_engine(store.inner().inner(), &source, &context)
             .release_snapshot(&snapshot.checkpoint_id)
             .await
-            .expect("release snapshot during fork write");
-        store.release();
+            .expect("release snapshot after fork pin is durable");
+        store.inner().release();
     };
     let (result, ()) = tokio::join!(forking, releasing);
     assert_eq!(

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2018,9 +2018,10 @@ retention floor at least as high. A lost put-if-absent loads the winner.
 If it covers the candidate's head sequence and number, the attempt is
 superseded. Otherwise the publisher rebuilds against the new predecessor
 and retries at the next number. Flush, bounded reorganization, streaming
-compaction, and retention use this path. A successful publication refreshes
-the hint with a plain PUT within its publication budget. An expired attempt
-leaves the hint unchanged. GC preserves the numbered manifest chain from
+compaction, and retention use this path. A successful publication raises
+the hint by compare-and-swap of the greater numbers within its publication
+budget, as in section 1.7. An expired attempt leaves the hint unchanged.
+GC preserves the numbered manifest chain from
 the hint through the current number so discovery can cross a lagging hint.
 These intermediate manifests do not protect their runs. A later publication
 that advances the hint makes the older, unpinned numbers eligible for deletion.
@@ -2028,11 +2029,33 @@ that advances the hint makes the older, unpinned numbers eligible for deletion.
 A namespace manifest records one namespace file-set version (the section 1.2
 table lists its contents).
 
-A checkpoint is a durable pin to one numbered manifest. Creation writes the
-pin, then loads the current manifest and checks its retention floor within
-`CHECKPOINT_VERIFY_BUDGET_MS`. A passed floor deletes the pin and fails with
-`checkpoint_unavailable`. The verify step does not reload the pinned manifest. Readers must prefer the current verified manifest plus the
-visible WAL segment chain over unverified or partial manifest artifacts.
+A checkpoint is a durable pin to one numbered manifest. Creation from the
+current head writes the pin, then loads the current manifest within
+`CHECKPOINT_VERIFY_BUDGET_MS`. Its number and payload checksum must match the
+pinned reference. A different identity, a deleted namespace, or a retention
+floor past the pinned head sequence invalidates the attempt. The creator
+deletes the pin and retries from a fresh basis, bounded by
+`CONTENTION_RETRY_LIMIT`. Exhausted retries or an exceeded verification
+budget return `checkpoint_unavailable`. Verification or cleanup errors
+never acknowledge the pin. Verification uses the current manifest load
+without another request.
+
+A snapshot fork writes a fork pin for the snapshot's manifest, then reloads
+the snapshot pin and requires that it still exists and has not expired.
+If that pin is missing or expired, the creator deletes the fork pin and
+returns `snapshot_gone`. This path does not check the current manifest or its
+retention floor: the snapshot pin protects its historical manifest under
+section 6.4 rule 8. Verification remains bounded by
+`CHECKPOINT_VERIFY_BUDGET_MS`.
+
+For a pin acknowledged from the current head, a collector either captured
+the pinned manifest as current and protects its runs, or captured a successor
+after the pin was durable and includes it in its complete pin listing. For a snapshot
+fork, the collector's complete listing includes the protecting snapshot pin
+or the fork pin written before the snapshot recheck.
+
+Readers must prefer the current verified manifest plus the visible WAL
+segment chain over unverified or partial manifest artifacts.
 
 The namespace manifest may reference zero or more immutable metadata runs.
 Runs are produced from committed state. Once the WAL below the retention
@@ -2339,14 +2362,17 @@ concurrent publications under these rules:
     manifest is corruption. An absent target retains until creation plus grace; GC deletes the pin
     after that deadline and writes no target tombstone.
 
-    Checkpoint creation writes its record and then verifies it against the
-    manifest. `verify_checkpoint_basis` refuses a deleted namespace. A record that
-    protects anything was therefore durable before deletion, and a complete
+    Checkpoint creation from the current head writes its record and then
+    verifies it against the current manifest. `verify_checkpoint_basis`
+    refuses a deleted namespace. Such a verified record
+    was therefore durable before deletion, and a complete
     post-deletion listing encounters it. A record written after the sweep
     passed its key cannot verify, so its creator releases it. If the creator
     crashes first, the pin has an absent target and blocks retirement until its creation
     grace passes. Neither case
-    permits an early release of a verified dependency.
+    permits an early release of a verified dependency. A snapshot fork instead
+    rechecks its protecting snapshot pin after writing the fork pin, as in
+    section 6.1.
 
 11. **Uploads and content, split at `completed`.** One sweep of `uploads/`
    handles both halves. Retired namespaces also sweep their owner prefix


### PR DESCRIPTION
A pin could be acknowledged for a manifest that a concurrent collector was already entitled to sweep. A creator selects the current manifest M, whose runs name an old segment S; compaction publishes M+1 replacing S; a collector captures M+1 as its root and completes its pin listing before the pin exists; the creator writes the pin and verifies the floor, which has not moved, and succeeds; the collector deletes S, whose provider age is already past the minimum. The checkpoint is unreadable. Stage 1 of the format simplification removed the reference window that used to protect the segments of recently superseded manifests, and stage 5 reduced verification to the floor, so this is a regression of that program. The review in the durable-rewrite handoff found it.

Other related DBs have no such window because a checkpoint is an entry inside the manifest and creating one is a manifest compare-and-swap. The record equivalent is one comparison in the verification that already runs: the current manifest, loaded after the pin is durable, must be the pinned one by number and payload checksum. A collector then either captured that manifest as current, which protects its runs, or captured a successor only after the pin was in its complete listing. A creator that lost to a publication deletes its pin and retries from the new current through the contention loop that already exists. Snapshot forks pin a historical manifest, so they are protected by the snapshot pin instead: the fork pin is written, then the snapshot pin is reloaded and must still exist and be unexpired, else the fork pin is deleted and the fork fails with `snapshot_gone`.

Important callouts:

- No new request. Verification already loaded the current manifest; it now compares identity as well as deletion status and the floor. A pin from the current head can lose verification to any publication, including a compaction that leaves the head sequence unchanged, and retries bounded by `CONTENTION_RETRY_LIMIT`; exhausted retries or an exceeded verify budget return `checkpoint_unavailable`. User checkpoints, snapshots, and fork pins of a live source share this path.
- Snapshot forks no longer check the current manifest or its floor; an existing snapshot pin protects its manifest under rule 8. Their recheck is bounded by `CHECKPOINT_VERIFY_BUDGET_MS`, and a budget failure deletes the fork pin.
- The race is pinned by a deterministic test that blocks the pin write, compacts an aged segment, collects, and releases. Run against the old verification it returned a checkpoint whose segment was gone; it now retries onto the new manifest. Two variants cover an advanced head sequence and a namespace deleted during verification, and a request-accounting test shows verification makes no request beyond its manifest load.
- Section 6.1 of the format spec described the hint refresh as a plain PUT, which contradicted 1.7; it now says compare-and-swap of the greater numbers.
- No wire or durable shape changes.

