### PR TITLE
refactor(runtime): probe the next wal number for freshness and raise the hint when due

### DIFF
--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -132,9 +132,10 @@ pub mod control {
     };
     pub use crate::namespace::control::{
         load_namespace_checkpoint_record_control, load_namespace_current_manifest,
-        load_namespace_head_control, load_namespace_read_anchor, raise_namespace_hint,
-        CurrentManifest, LoadedHint, LoadedManifest,
+        load_namespace_head_control, load_namespace_hint, load_namespace_read_anchor,
+        raise_namespace_hint, CurrentManifest, LoadedHint, LoadedManifest,
     };
+    pub use crate::namespace::freshness::probe_namespace_wal;
     pub use crate::namespace::state::NamespaceReadState;
     pub use crate::namespace::MetadataBasis;
 }

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -46,6 +46,9 @@ pub const CONTROL_SNAPSHOT_REREAD_LIMIT: usize = 3;
 /// so a landed publication never leaves more than this behind.
 pub const MAX_UNFLUSHED_WAL_SEGMENTS: u64 = 128;
 
+/// Bounds the WAL probes a cold open makes above the hinted number.
+pub const HINT_RAISE_SEGMENTS: u64 = 8;
+
 /// Visible WAL-tail length, in segments, at which maintenance publishes a
 /// checkpoint.
 pub const CHECKPOINT_AT_WAL_SEGMENTS: u64 = 32;

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -42,7 +42,7 @@ pub(crate) fn ensure_namespace_live(head: &NamespaceReadState) -> crate::error::
 
 pub type LoadedHint = LoadedControl<HintState>;
 
-async fn load_hint<S: ObjectStore + ?Sized>(
+pub async fn load_namespace_hint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> crate::error::Result<LoadedHint> {
@@ -70,7 +70,7 @@ pub(crate) async fn raise_hint<S: ObjectStore + ?Sized>(
     let object_key = hint(namespace_id);
     let mut current = match known {
         Some(known) => known,
-        None => load_hint(store, namespace_id).await?,
+        None => load_namespace_hint(store, namespace_id).await?,
     };
     loop {
         let raised = HintState {
@@ -100,7 +100,7 @@ pub(crate) async fn raise_hint<S: ObjectStore + ?Sized>(
                 })
             }
             Err(loonfs_objectstore::ObjectStoreError::PreconditionFailed { .. }) => {
-                current = load_hint(store, namespace_id).await?;
+                current = load_namespace_hint(store, namespace_id).await?;
             }
             Err(error) => return Err(CoreError::store(&object_key, &error)),
         }
@@ -283,8 +283,7 @@ pub async fn load_namespace_head_control<S: ObjectStore + ?Sized>(
     load_head_object(store, expected_namespace_id).await
 }
 
-/// Records a writer's acknowledged tip in the hint before the batch is
-/// acknowledged, so a reader polling the hint sees the commit at once.
+/// Raises the discovery start without changing the committed WAL tip.
 pub async fn raise_namespace_hint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/namespace/control_snapshot.rs
+++ b/crates/loonfs-core/src/namespace/control_snapshot.rs
@@ -153,7 +153,7 @@ async fn discover_head<S: ObjectStore + ?Sized>(
     Ok(state)
 }
 
-fn validate_segment(
+pub(super) fn validate_segment(
     namespace_id: &NamespaceId,
     base_seq: ChangeSeq,
     segment: &loonfs_api::wire::wal::WalSegmentEnvelope,
@@ -175,7 +175,7 @@ async fn load_required_segment<S: ObjectStore + ?Sized>(
         .ok_or_else(|| corrupt(&key, "hinted WAL object is missing"))
 }
 
-fn apply_segment(
+pub(super) fn apply_segment(
     state: &mut NamespaceReadState,
     segment: &loonfs_api::wire::wal::WalSegmentEnvelope,
     last_record: &mut Option<loonfs_api::CommitId>,
@@ -194,7 +194,10 @@ fn apply_segment(
     Ok(())
 }
 
-fn wal_error(object_key: &str, error: crate::wal::WalChainLoadError) -> ControlObjectLoadError {
+pub(super) fn wal_error(
+    object_key: &str,
+    error: crate::wal::WalChainLoadError,
+) -> ControlObjectLoadError {
     match error {
         crate::wal::WalChainLoadError::ReadWal {
             object_key,
@@ -209,7 +212,7 @@ fn wal_error(object_key: &str, error: crate::wal::WalChainLoadError) -> ControlO
     }
 }
 
-fn corrupt(object_key: &str, error: impl std::fmt::Display) -> ControlObjectLoadError {
+pub(super) fn corrupt(object_key: &str, error: impl std::fmt::Display) -> ControlObjectLoadError {
     ControlObjectLoadError::Codec {
         object_key: object_key.to_owned(),
         message: error.to_string(),

--- a/crates/loonfs-core/src/namespace/freshness.rs
+++ b/crates/loonfs-core/src/namespace/freshness.rs
@@ -1,0 +1,65 @@
+//! Advances a runtime read context through newly published WAL segments.
+
+use super::control_snapshot::{apply_segment, corrupt, validate_segment, wal_error};
+use crate::cache::WalTailProjectionCacheKey;
+use crate::control_object::ControlObjectLoadError;
+use crate::wal::{
+    load_wal_segment, project_validated_wal_tail, ValidatedWalChain, ValidatedWalSegment,
+};
+use crate::RuntimeReadContext;
+use loonfs_objectstore::{keys::wal_segment, ObjectStore};
+use std::sync::Arc;
+
+/// Probes the next WAL number and extends cached rows with the returned segments.
+/// Returns false when a different writer epoch requires full discovery.
+pub async fn probe_namespace_wal<S: ObjectStore + ?Sized>(
+    store: &S,
+    context: &mut RuntimeReadContext,
+) -> Result<bool, ControlObjectLoadError> {
+    let mut state = context.head.clone();
+    let mut cache_key = WalTailProjectionCacheKey {
+        namespace_id: state.namespace_id.clone(),
+        manifest_no: context.basis.manifest_no(),
+        manifest_head_seq: context.basis.manifest().manifest_head_seq,
+        head_seq: state.seq,
+        head_etag: context.head_etag.clone(),
+    };
+    let mut rows = None;
+    let mut last_record = None;
+    while let Ok(next) = state.wal_no.successor() {
+        let key = wal_segment(&state.namespace_id, &next);
+        let Some(segment) = load_wal_segment(store, &state.namespace_id, next)
+            .await
+            .map_err(|error| wal_error(&key, error))?
+        else {
+            break;
+        };
+        let epoch = segment.payload().writer_epoch;
+        if epoch != state.writer_epoch {
+            return Ok(false);
+        }
+        validate_segment(&state.namespace_id, state.seq, &segment, &key)?;
+        if state.wal_no == context.head.wal_no {
+            rows = context.tail_cache.get(&cache_key);
+        }
+        let before = state.clone();
+        apply_segment(&mut state, &segment, &mut last_record, &key)?;
+        if let Some(current) = rows {
+            let chain =
+                ValidatedWalChain::new(vec![ValidatedWalSegment::new(key.clone(), segment)]);
+            let replayed =
+                project_validated_wal_tail(&before, &current, Some(state.writer_epoch), &chain)
+                    .map_err(|error| corrupt(&key, error))?;
+            rows = Some(Arc::new(replayed.resulting_metadata_state));
+        }
+        if let Some(commit_id) = &last_record {
+            state.head_commit_id = commit_id.clone();
+        }
+    }
+    if let Some(rows) = rows {
+        cache_key.head_seq = state.seq;
+        context.tail_cache.insert(cache_key, rows);
+    }
+    context.head = state;
+    Ok(true)
+}

--- a/crates/loonfs-core/src/namespace/mod.rs
+++ b/crates/loonfs-core/src/namespace/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod control;
 pub(crate) mod control_snapshot;
 pub(crate) mod delete;
 pub(crate) mod fork;
+pub(crate) mod freshness;
 pub(crate) mod state;
 pub(crate) mod status;
 pub(crate) mod writer_epoch;

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -126,7 +126,6 @@ async fn snapshot_fork_keeps_its_view_after_source_compaction_collection_and_sna
         loonfs_core::gc_namespace(&store, &source, &loonfs_core::GcConfig::default(), &aged)
             .await
             .expect("collect source before fork");
-    assert!(!collected.budget_exhausted);
     assert!(collected.deleted.metadata_segments > 0);
     let fork = engine
         .fork_namespace(&target, Some(&snapshot.checkpoint_id))

--- a/crates/loonfs-server/tests/it/local_cache.rs
+++ b/crates/loonfs-server/tests/it/local_cache.rs
@@ -51,13 +51,16 @@ async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
     let namespace = namespace_id("warm");
     let listing = NamespacePath::parse("warm", "/docs").expect("parse path");
 
-    let first = start_graceful_server(test_config_with_local_cache(
+    // The writing server serves its own reads from the state its batches
+    // seeded, so a server that starts after the writes is what fills the
+    // local cache.
+    let writer = start_graceful_server(test_config_with_local_cache(
         &store_dir.path().join("store"),
         cache_dir.path(),
-        "local-cache-first",
+        "local-cache-writer",
     ))
     .await;
-    first
+    writer
         .client
         .create_namespace(&namespace)
         .await
@@ -65,13 +68,13 @@ async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
     for index in 0..4 {
         let path = format!("/docs/file-{index}.txt");
         let target = NamespacePath::parse("warm", &path).expect("parse path");
-        first
+        writer
             .client
             .put_file_bytes(&target, b"file", &replace_file_options())
             .await
             .expect("put file");
     }
-    first
+    writer
         .client
         .create_checkpoint(
             &namespace,
@@ -85,12 +88,19 @@ async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
     // One write after the checkpoint moves the head, so reads resolve
     // against the published manifest and touch its segments.
     let extra = NamespacePath::parse("warm", "/docs/after.txt").expect("parse path");
-    first
+    writer
         .client
         .put_file_bytes(&extra, b"after", &replace_file_options())
         .await
         .expect("put file after the checkpoint");
 
+    writer.shut_down().await;
+    let first = start_graceful_server(test_config_with_local_cache(
+        &store_dir.path().join("store"),
+        cache_dir.path(),
+        "local-cache-first",
+    ))
+    .await;
     let warmed = collect_path_entries(&first.client, &listing, &Default::default())
         .await
         .expect("warm the cache");

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -1,8 +1,5 @@
 //! Runtime caches for control-object reads and WAL-tail projections.
-//! This module also defines the cache-management methods on [`ReadCore`].
-//!
-//! Every cache revalidates against durable state before its contents are
-//! used; nothing here weakens read-after-write consistency.
+//! WAL probes observe commits; interval checks observe manifest changes.
 
 use crate::fs::{should_invalidate_after_result, ReadCore};
 use crate::metrics::RuntimeInstruments;
@@ -17,7 +14,7 @@ use loonfs_core::control::{
     VerifiedNamespaceCatalogEntry,
 };
 use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext, StoreFailureClass};
-use loonfs_objectstore::keys::hint;
+use loonfs_objectstore::keys::metadata_manifest_object;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -43,6 +40,8 @@ pub(crate) struct CachedNamespaceAnchor {
     pub(crate) head: CachedControl<NamespaceReadState>,
     pub(crate) basis: MetadataBasis,
     locally_published: bool,
+    last_control_check_ms: u64,
+    validation: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// Snapshot of runtime cache counters.
@@ -224,55 +223,67 @@ impl ReadCore {
         &self,
         namespace_id: &NamespaceId,
     ) -> std::result::Result<CachedNamespaceAnchor, ControlObjectLoadError> {
-        let cache_config = &self.inner.config.runtime_cache;
-        if !self.control_cache_enabled() {
-            return load_namespace_read_anchor(self.store(), namespace_id)
-                .await
-                .map(cached_anchor);
+        let validation = self
+            .inner
+            .control_cache()
+            .namespaces
+            .get(namespace_id)
+            .map(|(head, _)| Arc::clone(&head.validation))
+            .unwrap_or_default();
+        // Concurrent readers share the interval check and the resulting head.
+        let _validation = validation.lock().await;
+        let result = self
+            .refresh_namespace_head(namespace_id)
+            .await
+            .map(|mut head| {
+                head.validation = Arc::clone(&validation);
+                head
+            });
+        match &result {
+            Ok(head) => self.inner.control_cache().insert_namespace_head(
+                namespace_id,
+                head.clone(),
+                self.runtime_cache_config().max_cached_namespaces,
+            ),
+            Err(_) => self
+                .inner
+                .control_cache()
+                .invalidate_namespace(namespace_id),
         }
+        result
+    }
 
+    async fn refresh_namespace_head(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> std::result::Result<CachedNamespaceAnchor, ControlObjectLoadError> {
+        let now_ms = self.inner.timer.monotonic_now_ms();
         let cached = self
             .inner
             .control_cache()
             .cached_namespace_head(namespace_id);
-        if let Some(head) = cached {
+        if let Some(mut head) = cached {
             if head.locally_published {
+                head.locally_published = false;
                 return Ok(head);
             }
-            match self
-                .cached_control_identity_matches(&hint(namespace_id), &head.head.etag)
-                .await
-            {
-                Ok(true) => return Ok(head),
-                Ok(false) => self
-                    .inner
-                    .control_cache()
-                    .invalidate_namespace(namespace_id),
-                Err(error) => {
-                    self.inner
-                        .control_cache()
-                        .invalidate_namespace(namespace_id);
-                    return Err(error);
+            let check_due = now_ms.saturating_sub(head.last_control_check_ms)
+                >= self.runtime_cache_config().control_revalidation_interval_ms;
+            let matches = !check_due || self.manifest_is_current(namespace_id, &head.basis).await?;
+            if matches {
+                if check_due {
+                    head.last_control_check_ms = now_ms;
+                }
+                let mut context = self.runtime_read_context(&head);
+                if loonfs_core::control::probe_namespace_wal(self.store(), &mut context).await? {
+                    head.head.state = context.head;
+                    return Ok(head);
                 }
             }
         }
-
-        let loaded = match load_namespace_read_anchor(self.store(), namespace_id).await {
-            Ok(loaded) => loaded,
-            Err(error) => {
-                self.inner
-                    .control_cache()
-                    .invalidate_namespace(namespace_id);
-                return Err(error);
-            }
-        };
-        let head = cached_anchor(loaded);
-        self.inner.control_cache().insert_namespace_head(
-            namespace_id,
-            head.clone(),
-            cache_config.max_cached_namespaces,
-        );
-        Ok(head)
+        load_namespace_read_anchor(self.store(), namespace_id)
+            .await
+            .map(|loaded| cached_anchor(loaded, now_ms))
     }
 
     /// Loads the read anchor, mapping an absent head to the one answer it
@@ -290,31 +301,27 @@ impl ReadCore {
             })
     }
 
-    async fn cached_control_identity_matches(
+    /// The interval check. A deletion, a floor advance, a flush, or a
+    /// compaction each publish a successor to the cached manifest, so its
+    /// absence is what makes the cached anchor still current. Commits are
+    /// observed through the WAL probe instead; the hint is never consulted.
+    async fn manifest_is_current(
         &self,
-        object_key: &str,
-        expected_etag: &str,
+        namespace_id: &NamespaceId,
+        basis: &MetadataBasis,
     ) -> std::result::Result<bool, ControlObjectLoadError> {
-        let metadata = self
-            .store()
-            .head(object_key)
-            .await
-            .map_err(|error| ControlObjectLoadError::Store {
-                object_key: object_key.to_owned(),
+        let Ok(next) = basis.manifest_no().successor() else {
+            return Ok(true);
+        };
+        let object_key = metadata_manifest_object(namespace_id, &next);
+        let successor = self.store().head(&object_key).await.map_err(|error| {
+            ControlObjectLoadError::Store {
+                object_key: object_key.clone(),
                 message: error.public_message().into_owned(),
                 class: StoreFailureClass::of(&error),
-            })?
-            .ok_or_else(|| ControlObjectLoadError::MissingObject {
-                object_key: object_key.to_owned(),
-            })?;
-        let Some(etag) = metadata.etag else {
-            return Err(ControlObjectLoadError::Store {
-                object_key: object_key.to_owned(),
-                message: "missing control object etag".to_owned(),
-                class: StoreFailureClass::Other,
-            });
-        };
-        Ok(etag == expected_etag)
+            }
+        })?;
+        Ok(successor.is_none())
     }
 
     pub(crate) fn control_cache_enabled(&self) -> bool {
@@ -414,6 +421,8 @@ impl ReadCore {
             },
             basis: pinned.basis,
             locally_published: false,
+            last_control_check_ms: 0,
+            validation: Arc::default(),
         });
         (self.reader_engine(namespace_id), read_context)
     }
@@ -453,10 +462,6 @@ impl ReadCore {
             .invalidate_namespace(namespace_id);
     }
 
-    /// Seeds the read caches with the state one landed publish produced:
-    /// the head anchor and the projected WAL tail. Safe by construction —
-    /// the anchor is etag-revalidated against the store on every read, so a
-    /// wrong seed degrades to today's reload instead of a wrong read.
     pub(crate) fn seed_namespace_read_cache(
         &self,
         namespace_id: &NamespaceId,
@@ -468,7 +473,13 @@ impl ReadCore {
         let max_cached_namespaces = self.inner.config.runtime_cache.max_cached_namespaces;
         let head_seq = state.head.seq;
         let manifest_no = state.basis.manifest_no();
-        self.inner.control_cache().insert_namespace_head(
+        let mut cache = self.inner.control_cache();
+        let (last_control_check_ms, validation) = cache
+            .namespaces
+            .get(namespace_id)
+            .map(|(head, _)| (head.last_control_check_ms, Arc::clone(&head.validation)))
+            .unwrap_or_default();
+        cache.insert_namespace_head(
             namespace_id,
             CachedNamespaceAnchor {
                 head: CachedControl {
@@ -477,9 +488,12 @@ impl ReadCore {
                 },
                 basis: state.basis,
                 locally_published: true,
+                last_control_check_ms,
+                validation,
             },
             max_cached_namespaces,
         );
+        drop(cache);
         self.inner.wal_tail_projection_cache.insert(
             loonfs_core::cache::WalTailProjectionCacheKey {
                 namespace_id: namespace_id.clone(),
@@ -523,6 +537,7 @@ impl ReadCore {
 
 fn cached_anchor(
     (head, basis): (LoadedControl<NamespaceReadState>, MetadataBasis),
+    last_control_check_ms: u64,
 ) -> CachedNamespaceAnchor {
     CachedNamespaceAnchor {
         head: CachedControl {
@@ -531,5 +546,7 @@ fn cached_anchor(
         },
         basis,
         locally_published: false,
+        last_control_check_ms,
+        validation: Arc::default(),
     }
 }

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -88,6 +88,13 @@ pub(crate) struct ReadConfig {
 /// same way: a zero budget.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCacheConfig {
+    /// Minimum monotonic interval between checks for a successor to the
+    /// cached manifest, which is how a warm reader observes deletion, a
+    /// retention floor, or a new manifest. Defaults to 1000 milliseconds;
+    /// zero checks on every read. Commits are observed on every read by
+    /// probing the next WAL number, so a read after the interval costs two
+    /// requests and a read within it costs one.
+    pub control_revalidation_interval_ms: u64,
     /// Maximum namespaces retained by entry-counted runtime caches. Zero
     /// disables those caches. This does not affect maintenance scheduling.
     ///
@@ -112,6 +119,7 @@ impl RuntimeCacheConfig {
     /// Disables runtime caches by zeroing every budget.
     pub fn disabled() -> Self {
         Self {
+            control_revalidation_interval_ms: 1000,
             max_cached_namespaces: 0,
             max_cached_wal_tail_projection_rows: 0,
             max_cached_wal_tail_projection_decoded_bytes: 0,
@@ -125,6 +133,7 @@ impl RuntimeCacheConfig {
 impl Default for RuntimeCacheConfig {
     fn default() -> Self {
         Self {
+            control_revalidation_interval_ms: 1000,
             max_cached_namespaces: DEFAULT_MAX_CACHED_NAMESPACES,
             max_cached_wal_tail_projection_rows: DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS,
             max_cached_wal_tail_projection_decoded_bytes:

--- a/crates/loonfs/src/discovery_hints.rs
+++ b/crates/loonfs/src/discovery_hints.rs
@@ -1,128 +1,80 @@
-//! The writer's copy of each namespace hint, raised before every
-//! acknowledgement so readers polling the hint see the commit at once.
+//! The writer's periodic raise of each namespace hint's WAL number, which
+//! bounds the WAL probes a cold open makes above the hinted number.
 
+use crate::fs::ReadCore;
 use crate::NamespaceId;
 use loonfs_api::WalNo;
 use loonfs_core::control::LoadedHint;
-use loonfs_objectstore::ObjectStore;
+use loonfs_core::limits::HINT_RAISE_SEGMENTS;
 use std::collections::BTreeMap;
 use std::sync::Mutex;
 
 #[derive(Default)]
 pub(crate) struct DiscoveryHints {
-    known: Mutex<BTreeMap<NamespaceId, LoadedHint>>,
+    namespaces: Mutex<BTreeMap<NamespaceId, Raised>>,
+}
+
+struct Raised {
+    known: Option<LoadedHint>,
+    wal_no: WalNo,
+    at_ms: u64,
 }
 
 impl DiscoveryHints {
-    /// Raises the hint's WAL number from the token of the last raise, so the
-    /// steady state is one request, and returns the hint as written. A
-    /// failed raise never fails the commit: readers probe forward from
-    /// whatever the hint says.
-    pub(crate) async fn raise<S: ObjectStore + ?Sized>(
+    /// Raises the hint once the tip is `HINT_RAISE_SEGMENTS` past the last
+    /// raise or the revalidation interval has elapsed, whichever comes
+    /// first. Readers never depend on it: they observe commits through the
+    /// next WAL number. A failed raise is retried at the next trigger and
+    /// never fails a commit.
+    pub(crate) async fn raise_if_due(
         &self,
-        store: &S,
+        core: &ReadCore,
         namespace_id: &NamespaceId,
         wal_no: WalNo,
-    ) -> Option<LoadedHint> {
-        let known = self
-            .known
-            .lock()
-            .expect("hint token lock should be healthy")
-            .remove(namespace_id);
-        match loonfs_core::control::raise_namespace_hint(store, namespace_id, wal_no, known).await {
+    ) {
+        let now_ms = core.inner.timer.monotonic_now_ms();
+        let interval_ms = core.runtime_cache_config().control_revalidation_interval_ms;
+        let known = {
+            let mut namespaces = self
+                .namespaces
+                .lock()
+                .expect("hint state lock should be healthy");
+            let raised = namespaces
+                .entry(namespace_id.clone())
+                .or_insert_with(|| Raised {
+                    known: None,
+                    wal_no: WalNo(0),
+                    at_ms: now_ms,
+                });
+            let due = wal_no.0.saturating_sub(raised.wal_no.0) >= HINT_RAISE_SEGMENTS
+                || now_ms.saturating_sub(raised.at_ms) >= interval_ms;
+            if !due {
+                return;
+            }
+            raised.known.take()
+        };
+        match loonfs_core::control::raise_namespace_hint(core.store(), namespace_id, wal_no, known)
+            .await
+        {
             Ok(hint) => {
-                self.known
+                self.namespaces
                     .lock()
-                    .expect("hint token lock should be healthy")
-                    .insert(namespace_id.clone(), hint.clone());
-                Some(hint)
+                    .expect("hint state lock should be healthy")
+                    .insert(
+                        namespace_id.clone(),
+                        Raised {
+                            known: Some(hint),
+                            wal_no,
+                            at_ms: now_ms,
+                        },
+                    );
             }
             Err(error) => {
                 tracing::warn!(%namespace_id, %error, "namespace hint raise failed");
-                None
             }
         }
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use loonfs_api::wire::control::{decode_control_object, ControlObjectKind, HintState};
-    use loonfs_objectstore::{keys::hint, local_fs_store::LocalFsStore, ObjectStore};
-    use loonfs_test_support::stores::{KeyPredicate, OperationClass, RecordingStore};
-    use std::sync::Arc;
-
-    #[tokio::test]
-    async fn each_batch_raises_the_hint_from_its_last_token() {
-        let directory = tempfile::tempdir().expect("directory");
-        let namespace_id = NamespaceId::parse("hints").expect("namespace");
-        let store = Arc::new(RecordingStore::new(
-            LocalFsStore::new(directory.path()).expect("store"),
-            KeyPredicate::any(),
-        ));
-        let writer = crate::FsWriter::builder_with_store(store.clone())
-            .writer_id("writer")
-            .build()
-            .await
-            .expect("writer");
-        writer
-            .create_namespace(&namespace_id, crate::CreateNamespaceOptions::default())
-            .await
-            .expect("create");
-        let mut engine = loonfs_core::publish::NamespaceCommitEngine::new(namespace_id.clone());
-        let context = loonfs_core::MutationContext {
-            writer_id: loonfs_api::WriterId::parse("writer").expect("writer"),
-            now_ms: 1_000,
-        };
-        let mut states = Vec::new();
-        for index in 0..3 {
-            let request = loonfs_core::publish::CommitRequest::single(
-                loonfs_api::CommitId::parse(format!("commit-{index}")).expect("commit"),
-                loonfs_test_support::test_actor(),
-                None,
-                loonfs_core::publish::FilesystemOperation::CreateDirectory {
-                    path: loonfs_api::AbsolutePath::parse(format!("/directory-{index}"))
-                        .expect("path"),
-                    parents: false,
-                },
-            );
-            let result = engine
-                .publish_batch(
-                    store.as_ref(),
-                    vec![loonfs_core::publish::CommitCandidate::new(request)],
-                    &context,
-                    &Default::default(),
-                )
-                .await;
-            result.results[0].as_ref().expect("commit");
-            states.push(result.resulting_read_state.expect("read state").head);
-        }
-        let hints = DiscoveryHints::default();
-        store.reset();
-        for state in &states {
-            hints
-                .raise(store.as_ref(), &namespace_id, state.wal_no)
-                .await;
-        }
-        assert_eq!(store.counts().compare_and_swaps, states.len());
-        assert_eq!(
-            store.count(OperationClass::Read),
-            1,
-            "only the first raise reads the hint"
-        );
-        let bytes = store
-            .get(&hint(&namespace_id), None)
-            .await
-            .expect("read hint")
-            .expect("hint");
-        let current = decode_control_object::<HintState>(&bytes, ControlObjectKind::Hint)
-            .expect("decode hint");
-        assert_eq!(current.payload().wal_no, WalNo(4));
-        store.reset();
-        hints.raise(store.as_ref(), &namespace_id, WalNo(2)).await;
-        assert_eq!(store.counts().compare_and_swaps, 0);
-        assert_eq!(store.count(OperationClass::Put), 0);
-        writer.shutdown().await.expect("shutdown");
-    }
-}
+mod tests;

--- a/crates/loonfs/src/discovery_hints/tests.rs
+++ b/crates/loonfs/src/discovery_hints/tests.rs
@@ -1,0 +1,265 @@
+//! Store request contracts for WAL freshness and periodic hint raises.
+
+use crate::{CreateDirectoryOptions, CreateNamespaceOptions, FsReader, FsWriter, NamespaceId};
+use loonfs_api::wire::control::{decode_control_object, ControlObjectKind, HintState};
+use loonfs_api::{MonotonicTimer, WalNo};
+use loonfs_core::limits::HINT_RAISE_SEGMENTS;
+use loonfs_objectstore::{keys, local_fs_store::LocalFsStore, ObjectStore};
+use loonfs_test_support::stores::{KeyPredicate, OperationClass, RecordingStore};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+struct ManualTimer(AtomicU64);
+
+impl ManualTimer {
+    fn set(&self, now_ms: u64) {
+        self.0.store(now_ms, Ordering::SeqCst);
+    }
+}
+
+impl MonotonicTimer for ManualTimer {
+    fn monotonic_now_ms(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+async fn directory(writer: &FsWriter, namespace_id: &NamespaceId, index: u64) {
+    writer
+        .create_directory(
+            namespace_id,
+            &format!("/directory-{index}"),
+            CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("create directory");
+}
+
+async fn hint(store: &dyn ObjectStore, namespace_id: &NamespaceId) -> HintState {
+    let bytes = store
+        .get(&keys::hint(namespace_id), None)
+        .await
+        .expect("get hint")
+        .expect("hint");
+    decode_control_object::<HintState>(&bytes, ControlObjectKind::Hint)
+        .expect("decode hint")
+        .payload()
+        .clone()
+}
+
+#[tokio::test]
+async fn batches_write_only_the_wal_until_the_threshold_raise() {
+    let directory_path = tempfile::tempdir().expect("directory");
+    let namespace_id = NamespaceId::parse("threshold").expect("namespace");
+    let store = Arc::new(RecordingStore::new(
+        LocalFsStore::new(directory_path.path()).expect("store"),
+        KeyPredicate::any(),
+    ));
+    let timer = Arc::new(ManualTimer::default());
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("writer")
+        .min_publish_interval_ms(0)
+        .monotonic_timer(timer.clone())
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create");
+    // The first batch acquires the writer: a manifest with the new epoch,
+    // whose publication raises the hint's manifest number, and a fence at
+    // WAL number 1. Batch k then lands at number k + 1.
+    directory(&writer, &namespace_id, 0).await;
+    let initial = hint(store.as_ref(), &namespace_id).await;
+    store.reset();
+    for index in 1..HINT_RAISE_SEGMENTS - 2 {
+        directory(&writer, &namespace_id, index).await;
+    }
+    assert_eq!(store.counts().compare_and_swaps, 0);
+    assert_eq!(hint(store.as_ref(), &namespace_id).await, initial);
+    directory(&writer, &namespace_id, HINT_RAISE_SEGMENTS - 2).await;
+    assert_eq!(store.counts().compare_and_swaps, 1);
+    assert_eq!(
+        hint(store.as_ref(), &namespace_id).await.wal_no,
+        WalNo(HINT_RAISE_SEGMENTS)
+    );
+    writer.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn the_interval_raises_a_short_tail() {
+    let directory_path = tempfile::tempdir().expect("directory");
+    let namespace_id = NamespaceId::parse("interval").expect("namespace");
+    let store = Arc::new(RecordingStore::new(
+        LocalFsStore::new(directory_path.path()).expect("store"),
+        KeyPredicate::any(),
+    ));
+    let timer = Arc::new(ManualTimer::default());
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("writer")
+        .min_publish_interval_ms(0)
+        .monotonic_timer(timer.clone())
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create");
+    directory(&writer, &namespace_id, 0).await;
+    let initial = hint(store.as_ref(), &namespace_id).await;
+    timer.set(999);
+    directory(&writer, &namespace_id, 1).await;
+    assert_eq!(hint(store.as_ref(), &namespace_id).await, initial);
+    store.reset();
+    timer.set(1000);
+    directory(&writer, &namespace_id, 2).await;
+    assert_eq!(store.counts().compare_and_swaps, 1);
+    assert_eq!(hint(store.as_ref(), &namespace_id).await.wal_no, WalNo(4));
+    writer.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn a_failed_raise_keeps_the_batch_and_retries_at_the_next_trigger() {
+    use loonfs_test_support::stores::{FailStore, InjectedError};
+    let directory_path = tempfile::tempdir().expect("directory");
+    let namespace_id = NamespaceId::parse("retry").expect("namespace");
+    let store = Arc::new(RecordingStore::new(
+        FailStore::new(
+            LocalFsStore::new(directory_path.path()).expect("store"),
+            KeyPredicate::hint(&namespace_id),
+            OperationClass::CompareAndSwap,
+            InjectedError::Transport("hint raise failed".to_owned()),
+        ),
+        KeyPredicate::any(),
+    ));
+    let timer = Arc::new(ManualTimer::default());
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("writer")
+        .min_publish_interval_ms(0)
+        .monotonic_timer(timer.clone())
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create");
+    directory(&writer, &namespace_id, 0).await;
+    let initial = hint(store.as_ref(), &namespace_id).await;
+    store.inner().fail_next(1);
+    timer.set(1000);
+    directory(&writer, &namespace_id, 1).await;
+    assert_eq!(store.inner().attempts(), 1);
+    assert_eq!(hint(store.as_ref(), &namespace_id).await, initial);
+    store.reset();
+    timer.set(2000);
+    directory(&writer, &namespace_id, 2).await;
+    assert_eq!(store.counts().compare_and_swaps, 1);
+    assert_eq!(hint(store.as_ref(), &namespace_id).await.wal_no, WalNo(4));
+    writer.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn readers_probe_commits_immediately_and_check_deletion_on_the_interval() {
+    let directory_path = tempfile::tempdir().expect("directory");
+    let namespace_id = NamespaceId::parse("freshness").expect("namespace");
+    let store = Arc::new(RecordingStore::new(
+        LocalFsStore::new(directory_path.path()).expect("store"),
+        KeyPredicate::any(),
+    ));
+    let timer = Arc::new(ManualTimer::default());
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("writer")
+        .min_publish_interval_ms(0)
+        .monotonic_timer(Arc::new(ManualTimer::default()))
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create");
+    directory(&writer, &namespace_id, 0).await;
+    let reader = FsReader::builder_with_store(store.clone())
+        .monotonic_timer(timer.clone())
+        .build()
+        .await
+        .expect("reader");
+    reader
+        .get_path_entry(&namespace_id, "/directory-0", Default::default())
+        .await
+        .expect("warm read");
+    let initial = hint(store.as_ref(), &namespace_id).await;
+    directory(&writer, &namespace_id, 1).await;
+    assert_eq!(hint(store.as_ref(), &namespace_id).await, initial);
+    store.reset();
+    reader
+        .get_path_entry(&namespace_id, "/directory-1", Default::default())
+        .await
+        .expect("observe WAL commit");
+    assert_eq!(store.counts().gets, 2);
+    assert_eq!(store.counts().heads, 0);
+    timer.set(999);
+    store.reset();
+    reader
+        .get_path_entry(&namespace_id, "/directory-1", Default::default())
+        .await
+        .expect("warm read");
+    assert_eq!(store.take().len(), 1);
+    timer.set(1000);
+    reader
+        .get_path_entry(&namespace_id, "/directory-1", Default::default())
+        .await
+        .expect("check hint");
+    assert_eq!(store.counts().gets, 1);
+    assert_eq!(store.counts().heads, 1);
+    timer.set(2000);
+    store.reset();
+    let (first, second) = tokio::join!(
+        reader.get_path_entry(&namespace_id, "/directory-1", Default::default()),
+        reader.get_path_entry(&namespace_id, "/directory-1", Default::default()),
+    );
+    first.expect("first concurrent read");
+    second.expect("second concurrent read");
+    assert_eq!(store.counts().gets, 2);
+    assert_eq!(store.counts().heads, 1);
+    let always_check = FsReader::builder_with_store(store.clone())
+        .runtime_cache(crate::RuntimeCacheConfig {
+            control_revalidation_interval_ms: 0,
+            ..Default::default()
+        })
+        .build()
+        .await
+        .expect("reader without an interval");
+    always_check
+        .get_path_entry(&namespace_id, "/directory-1", Default::default())
+        .await
+        .expect("warm read");
+    store.reset();
+    for _ in 0..2 {
+        always_check
+            .get_path_entry(&namespace_id, "/directory-1", Default::default())
+            .await
+            .expect("check every read");
+    }
+    assert_eq!(store.counts().gets, 2);
+    assert_eq!(store.counts().heads, 2);
+    writer
+        .delete_namespace(&namespace_id, Default::default())
+        .await
+        .expect("delete");
+    timer.set(2999);
+    reader
+        .get_path_entry(&namespace_id, "/directory-1", Default::default())
+        .await
+        .expect("cached before interval");
+    timer.set(3000);
+    let error = reader
+        .get_path_entry(&namespace_id, "/directory-1", Default::default())
+        .await
+        .expect_err("observe deletion");
+    assert_eq!(error.code(), crate::ErrorCode::NamespaceDeleted);
+    writer.shutdown().await.expect("shutdown");
+}

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -38,6 +38,7 @@ pub(crate) struct ReadCore {
 pub(crate) struct ReadCoreInner {
     pub(crate) store: SharedObjectStore,
     pub(crate) config: ReadConfig,
+    pub(crate) timer: Arc<dyn loonfs_api::MonotonicTimer>,
     pub(crate) control_cache: Mutex<RuntimeControlCache>,
     pub(crate) metadata_segment_cache: Arc<MetadataSegmentCache>,
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
@@ -164,6 +165,7 @@ impl ReadCore {
         shared_metadata_segment_cache: Option<Arc<MetadataSegmentCache>>,
         stored_metadata_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
         instruments: Arc<RuntimeInstruments>,
+        timer: Arc<dyn loonfs_api::MonotonicTimer>,
     ) -> Self {
         let metadata_segment_cache = shared_metadata_segment_cache.unwrap_or_else(|| {
             Arc::new(MetadataSegmentCache::with_stored_block_cache_and_observer(
@@ -186,6 +188,7 @@ impl ReadCore {
             inner: Arc::new(ReadCoreInner {
                 store,
                 config,
+                timer,
                 control_cache: Mutex::new(RuntimeControlCache::default()),
                 metadata_segment_cache,
                 wal_tail_projection_cache,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -834,31 +834,18 @@ pub(crate) async fn publish_batch_with_engine(
     // crates) exceed rustc's type-recursion depth.
     let mut publish =
         Box::pin(engine.publish_batch(&store, candidates, &context, &tail_options)).await;
-    // A raise that finds a newer manifest in the hint has learned of a
-    // publication the engine never sees otherwise; both caches reload.
-    let mut manifest_moved = false;
-    if let Some(state) = &mut publish.resulting_read_state {
-        match writer
+    if let Some(state) = &publish.resulting_read_state {
+        writer
             .discovery_hints
-            .raise(store, namespace_id, state.head.wal_no)
-            .await
-        {
-            Some(hint) if hint.state.manifest_no > state.basis.manifest_no() => {
-                manifest_moved = true;
-            }
-            Some(hint) => state.head_etag = hint.etag,
-            None => {}
-        }
-    }
-    if manifest_moved {
-        engine.invalidate_projection();
+            .raise_if_due(core, namespace_id, state.head.wal_no)
+            .await;
     }
     {
         let _span = phase_span!(core, "batch_update_cache", namespace_id, batch_size).entered();
         match publish.resulting_read_state.take() {
             // A landed publish hands the caches exactly the state a
             // rebuild would recompute; use it instead of dropping.
-            Some(state) if !manifest_moved => {
+            Some(state) => {
                 core.seed_namespace_read_cache(namespace_id, state);
             }
             _ => {

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -29,6 +29,7 @@ pub(super) struct HandleBuilderCore {
     pub(super) source: StoreSource,
     pub(super) max_read_content_bytes: Option<u64>,
     pub(super) runtime_cache: RuntimeCacheConfig,
+    pub(super) timer: Arc<dyn loonfs_api::MonotonicTimer>,
     /// An existing decoded-block cache to share instead of sizing a fresh
     /// one from `runtime_cache`; see [`ReadCore::open`].
     pub(super) shared_metadata_segment_cache: Option<Arc<MetadataSegmentCache>>,
@@ -55,6 +56,7 @@ impl HandleBuilderCore {
             source,
             max_read_content_bytes: None,
             runtime_cache: RuntimeCacheConfig::default(),
+            timer: Arc::new(loonfs_api::StdMonotonicTimer::default()),
             shared_metadata_segment_cache: None,
             stored_metadata_block_cache: None,
             trace_mode: TraceMode::Embedded,
@@ -105,6 +107,7 @@ impl HandleBuilderCore {
             self.shared_metadata_segment_cache,
             self.stored_metadata_block_cache,
             instruments,
+            self.timer,
         ))
     }
 }

--- a/crates/loonfs/src/handle/maintenance.rs
+++ b/crates/loonfs/src/handle/maintenance.rs
@@ -100,6 +100,12 @@ impl FsMaintenanceBuilder {
         self
     }
 
+    /// Supplies monotonic time for runtime scheduling and deterministic tests.
+    pub fn monotonic_timer(mut self, timer: Arc<dyn loonfs_api::MonotonicTimer>) -> Self {
+        self.core.timer = timer;
+        self
+    }
+
     /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.core.runtime_cache = runtime_cache;

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -69,6 +69,12 @@ impl FsReaderBuilder {
         Self { core }
     }
 
+    /// Supplies monotonic time for runtime scheduling and deterministic tests.
+    pub fn monotonic_timer(mut self, timer: Arc<dyn loonfs_api::MonotonicTimer>) -> Self {
+        self.core.timer = timer;
+        self
+    }
+
     /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.core.runtime_cache = runtime_cache;

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -326,6 +326,12 @@ impl FsWriterBuilder {
         self
     }
 
+    /// Supplies monotonic time for runtime scheduling and deterministic tests.
+    pub fn monotonic_timer(mut self, timer: Arc<dyn loonfs_api::MonotonicTimer>) -> Self {
+        self.core.timer = timer;
+        self
+    }
+
     /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.core.runtime_cache = runtime_cache;

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -28,7 +28,7 @@ use loonfs_core::limits::{CHECKPOINT_AT_WAL_SEGMENTS, CONTENTION_RETRY_LIMIT};
 use loonfs_core::publish::{
     NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState, WriterSessionState,
 };
-use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
+use loonfs_objectstore::timing::MonotonicTimer;
 use std::collections::{HashMap, VecDeque};
 use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
@@ -353,10 +353,10 @@ impl PublisherRegistry {
                 }),
                 panicked_units: AtomicUsize::new(0),
             }),
+            timer: Arc::clone(&read_core.inner.timer),
             read_core,
             writer,
             runtime,
-            timer: Arc::new(StdMonotonicTimer::default()),
             min_publish_interval,
         }
     }

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -207,6 +207,7 @@ fn test_read_core(store: SharedStore) -> ReadCore {
         None,
         None,
         RuntimeInstruments::new(None),
+        Arc::new(loonfs_api::StdMonotonicTimer::default()),
     )
 }
 

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -24,7 +24,12 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
     let namespace_id = namespace_id("demo");
     let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
-    let fs = open_runtime(object_store, "tail-projection-cache-test");
+    let fs = open_runtime_with(object_store, "tail-projection-cache-test", |builder| {
+        builder.runtime_cache(RuntimeCacheConfig {
+            control_revalidation_interval_ms: u64::MAX,
+            ..Default::default()
+        })
+    });
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -48,7 +53,7 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
     raw_store.reset_wal_get_count();
     fs.get_file_bytes_blocking(&namespace_id, "/docs/file.txt")
         .expect("second read should reuse cached WAL-tail projection");
-    assert_eq!(raw_store.wal_get_count(), 0);
+    assert_eq!(raw_store.wal_get_count(), 1);
     let after_second = fs.runtime_cache_stats();
     assert!(
         after_second.wal_tail_projection_cache_hits > after_first.wal_tail_projection_cache_hits
@@ -233,7 +238,9 @@ fn runtime_cache_can_be_disabled() {
         .expect("first read should project WAL tail");
     fs.get_file_bytes_blocking(&namespace_id, "/docs/file.txt")
         .expect("second read should project WAL tail again");
-    assert_eq!(raw_store.wal_get_count(), 8);
+    // Each cold read discovers from the folded number, since the hint is
+    // raised only every eighth segment: three probes, then two tail reads.
+    assert_eq!(raw_store.wal_get_count(), 10);
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.wal_tail_projection_cache_hits, 0);
     assert_eq!(stats.wal_tail_projection_cache_misses, 0);
@@ -291,7 +298,9 @@ fn runtime_wal_tail_projection_cache_evicts_by_namespace_count() {
     fs.get_file_bytes_blocking(&first, "/file.txt")
         .expect("first tail projection reloads after eviction");
     let after_reload = fs.runtime_cache_stats();
-    assert_eq!(raw_store.wal_get_count(), 4);
+    // Discovery from the folded number probes three numbers, then the tail
+    // projection reads two.
+    assert_eq!(raw_store.wal_get_count(), 5);
     assert_eq!(after_reload.wal_tail_projection_cache_evictions, 2);
 }
 
@@ -303,6 +312,7 @@ fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
     let object_store = raw_store.store();
     let fs = open_runtime_with(object_store, "tail-oversized-test", |builder| {
         builder.runtime_cache(RuntimeCacheConfig {
+            control_revalidation_interval_ms: u64::MAX,
             max_cached_wal_tail_projection_rows: 0,
             ..RuntimeCacheConfig::default()
         })
@@ -324,7 +334,7 @@ fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
         .expect("first read projects oversized tail");
     fs.get_file_bytes_blocking(&namespace_id, "/file.txt")
         .expect("second read projects oversized tail again");
-    assert_eq!(raw_store.wal_get_count(), 4);
+    assert_eq!(raw_store.wal_get_count(), 5);
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.wal_tail_projection_cache_misses, 2);
     assert_eq!(stats.wal_tail_projection_cache_hits, 0);
@@ -580,12 +590,17 @@ fn control_cache_eviction_reloads_head_for_materialization_validation() {
 }
 
 #[test]
-fn runtime_control_cache_reloads_head_after_external_change() {
+fn runtime_control_cache_probes_wal_after_external_commit() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
-    let reader = open_runtime(object_store.clone(), "control-cache-reader");
+    let reader = open_runtime_with(object_store.clone(), "control-cache-reader", |builder| {
+        builder.runtime_cache(RuntimeCacheConfig {
+            control_revalidation_interval_ms: u64::MAX,
+            ..Default::default()
+        })
+    });
     let writer = open_runtime(object_store, "control-cache-writer");
 
     writer
@@ -620,8 +635,8 @@ fn runtime_control_cache_reloads_head_after_external_change() {
     raw_store.reset_control_get_counts();
     reader
         .stat_path_blocking(&namespace_id, "/docs/new")
-        .expect("reload changed head");
-    assert!(raw_store.head_get_count() > 0);
+        .expect("probe changed head");
+    assert_eq!(raw_store.head_get_count(), 0);
 }
 
 #[test]
@@ -703,17 +718,22 @@ fn an_installed_stored_block_cache_is_filled_and_then_serves_a_later_runtime() {
     )
     .expect("put second file");
 
-    let file = fs
+    // The writer's own reads are served from the state its batches seeded,
+    // so a runtime that reads cold is what fills the stored cache.
+    let filler = open_runtime_with(shared_store.clone(), "stored-block-filler", |builder| {
+        builder.stored_metadata_block_cache(stored_blocks.clone())
+    });
+    let file = filler
         .get_file_bytes_blocking(&namespace_id, "/docs/file.txt")
         .expect("read file");
     assert_eq!(file.bytes, b"file");
-    let entries = fs
+    let entries = filler
         .list_path_blocking(&namespace_id, "/docs")
         .expect("list docs");
     assert_eq!(entries.len(), 2);
 
     assert!(
-        fs.runtime_cache_stats().metadata_segment_cache_inserts > 0,
+        filler.runtime_cache_stats().metadata_segment_cache_inserts > 0,
         "the cycle must reach the decoded block cache for this to prove anything"
     );
     let offered: Vec<StoredMetadataBlockKind> = stored_blocks

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -781,8 +781,15 @@ fn metadata_upkeep_offers_nothing_to_the_local_block_cache() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     let stored_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    // Every read probes for a successor manifest, so the read after each
+    // fold reloads and reaches the cache whatever the wall clock did.
     let fs = open_runtime_with(store(temp_dir.path()), "maintenance-cold", |builder| {
-        builder.stored_metadata_block_cache(stored_blocks.clone())
+        builder
+            .stored_metadata_block_cache(stored_blocks.clone())
+            .runtime_cache(RuntimeCacheConfig {
+                control_revalidation_interval_ms: 0,
+                ..Default::default()
+            })
     });
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1447,10 +1447,20 @@ The `Namespace` object has exactly these fields:
 
 Namespace status derives the live sequence from the manifest and numbered
 WAL tip. A cold read follows a lagging hint by probing forward. A missing
-hint reads as an absent namespace. Runtime freshness polls HEAD
-`hint.json`, which every acknowledged batch has already raised; the
-acknowledging runtime supplies read-your-writes state without a store
-request.
+hint reads as an absent namespace. A cached runtime probes the next WAL
+number with GET, applies any new segments, and continues until 404. Commits
+are visible on the next read even when the hint has not been raised. The
+acknowledging runtime supplies read-your-writes state without a store request.
+
+`RuntimeCacheConfig::control_revalidation_interval_ms` sets the minimum
+monotonic interval between checks for a successor to the cached manifest.
+It defaults to 1000 milliseconds; `0` checks on every read. A read after the
+interval probes the successor manifest with HEAD as well as the next WAL
+number, so an unchanged warm head costs two requests; within the interval
+it costs one. A present successor reloads the namespace. Warm readers
+observe deletion, retention floor advances, and new manifests on this
+interval. Handle builders accept an injected monotonic timer for
+deterministic runtime timing.
 
 The maintenance endpoint `GET /v0/maintenance/namespaces/{ns}/diagnostics` returns the
 namespace state plus storage details used by maintenance:

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -294,14 +294,25 @@ cannot make a reclaimed WAL number look unused. Required missing or corrupt
 objects fail closed.
 
 A manifest publisher raises the hint within its publication budget. A
-writer raises the hint's WAL number after each WAL put and before the
-batch is acknowledged, so a reader polling the hint sees the commit at
-once. A raise compare-and-swaps the greater of each number from the token
-of the raiser's last write, reading the hint only when that token is stale,
-so no actor lowers what another wrote and a writer's steady state is one
-request. A raise never fails a commit. A writer whose raise finds a newer
-manifest number has learned of a publication and reloads its view. A
-freshness poll is HEAD on the hint.
+writer raises the hint's WAL number only when a raise is due: when the tip
+is at least `HINT_RAISE_SEGMENTS` (8) past the last raised number or the
+revalidation interval has elapsed since the last raise, whichever comes
+first. This bounds cold discovery above the hinted number while a writer is
+active; the WAL write stop still bounds the unfolded tail. A failed raise is
+logged and retried at the next trigger; it never fails a commit.
+
+A raise compare-and-swaps the greater of each number from the token of the
+raiser's last write, reading the hint only when that token is stale. No
+actor lowers what another wrote. A cached reader at WAL number `N` probes
+`wal/{N+1}` with GET. An absent object confirms the cached tip. A present
+object advances the read state, and the reader continues probing until
+404. A different writer epoch requires full discovery before replay.
+On a monotonic interval, defaulting to 1000 milliseconds, the runtime
+probes for a successor to its cached manifest with HEAD. A present
+successor reloads the namespace, which is how a warm reader observes
+deletion, a retention floor advance, and a new manifest. The hint is never
+a freshness input. A read after the interval probes the successor and the
+next WAL number; a locally published read state skips both once.
 
 Durable decoders reject unknown envelope and payload fields. A changed
 shape requires its golden fixture to change. These format families are
@@ -792,7 +803,10 @@ epoch with `status: {"kind":"deleted"}`. The manifest put is the deletion
 point. It records the final sequence, commit id, and next inode id, so these
 survive WAL reclamation. Its runs and folded WAL number remain the last
 materialized file set. Operations observing deletion return
-`namespace_deleted`. Previously acknowledged commits remain committed.
+`namespace_deleted`. A warm reader observes deletion when its next
+successor probe is due, within the revalidation interval. Reads before that
+probe may still use the cached active manifest. Previously acknowledged
+commits remain committed.
 
 GC keeps the current manifest permanently to prevent reuse of the id.
 A deleted namespace protects no WAL or current runs. Active checkpoint
@@ -1059,7 +1073,8 @@ when:
 4. Check the monotonic publication budget and content proofs immediately
    before putting that segment with put-if-absent.
 5. A successful put commits the batch. Update the in-process tip and read
-   state. Raise the hint's WAL number, then acknowledge.
+   state. Raise the hint's WAL number if its segment threshold or interval
+   is due, then acknowledge.
 
 A precondition failure writes nothing. Probe forward, detect fencing,
 re-plan, and retry. Other definite failures create no WAL object. An
@@ -1104,7 +1119,8 @@ The result is pinned to one sequence. Point reads and directory listings
 may query verified segments and the projected WAL tail directly. Missing or
 corrupt required objects are errors. A shared writer/read runtime can seed
 its read caches directly from an acknowledged batch without a store request.
-Subsequent freshness polls HEAD the hint.
+Subsequent reads probe the next WAL number with GET and probe for a
+successor manifest on the revalidation interval.
 
 #### 3.2.2 Visibility rules
 


### PR DESCRIPTION
Stacked on #914. A batch was two requests on the acknowledgement path: the WAL put, which is the commit, and a compare-and-swap raise of the hint's WAL number, which existed only so readers in other runtimes would see the commit at once. The WAL put is the only object that changes at commit time, so it is the only exact freshness signal. A cached reader at tip N now probes `wal/{N+1}` on every read: a 404 confirms the cached tip, and a 200 hands it the next segment, which it applies and continues. Commits are visible on the next read whether or not the hint moved. A batch is one request.

Manifest-only changes leave no WAL object, so readers observe those on an interval, one second by default as a runtime option: a HEAD for a successor to the cached manifest, and a reload when one exists. That is how a warm reader observes deletion, a retention floor advance, a flush, or a compaction. The hint is never a freshness input any more; an unchanged hint proved nothing once raises were best effort, which the durable-rewrite handoff's item B pointed out. Writers still raise the hint's WAL number, because the hinted number is what keeps a cold open short, but only when a raise is due: every eighth segment or once per interval, synchronously, and a failed raise never fails a commit.

Important callouts:

- Cross-runtime read-after-write for data stays immediate. Deletion, a floor advance, and a new manifest reach a warm reader within the interval. A reader that reads less than once per interval pays two requests per read; any higher rate pays about one.
- `RuntimeCacheConfig::control_revalidation_interval_ms` defaults to 1000; zero probes on every read. Handle builders accept an injected monotonic timer.
- A WAL probe that meets a segment with a different writer epoch, or any corruption, falls back to full discovery instead of applying it.
- The hint raise is `HINT_RAISE_SEGMENTS` (8) segments or one interval, whichever first, from the token of the last raise; the compare-and-swap of the greater numbers stays. Raising from a background task would need watch channels and a drain protocol, and it races tests that count a fenced session's writes; the raise is synchronous and runs only when due.
- The writer no longer learns of a foreign flush through a hint conflict; its own fold invalidates its projection, and a flush by another process reaches it at the fold threshold or the 60-second projection budget, as before this week.
- The tests that pinned the per-batch raise and the hint-ETag revalidation are replaced by ones that pin one write per batch, the threshold and interval raises, a failed raise retrying, immediate cross-runtime visibility through the WAL probe, and deletion observed on the interval. Two request-count tests move by the hint lag: a cold read discovers from the folded number, so it probes up to seven more numbers than before.
- Two on-disk block cache tests assumed a writer's read right after a foreign publication was cold, which on `main` was true only because a hint conflict invalidated the read cache. The seeded state is current and is served now, so those tests fill the cache through a runtime or server that starts after the writes. Tracing them showed something older worth a follow-up: the writer's engine fetches data blocks through a path that never consults or fills the on-disk tier, so a single-process server does not persist blocks its writer touched first.

