### PR TITLE
fix(gc): bound the time between the call clock and retirement publication

### DIFF
--- a/crates/loonfs-core/src/commit_engine_content_tests.rs
+++ b/crates/loonfs-core/src/commit_engine_content_tests.rs
@@ -102,6 +102,64 @@ fn directory_request(commit_id: &str, name: &str) -> CommitRequest {
 }
 
 #[tokio::test]
+async fn a_completed_upload_token_cannot_publish_after_namespace_deletion() {
+    use crate::content::{mint_content_token, verify_content_token};
+    use crate::namespace::catalog::load_namespace_catalog_entry;
+    use loonfs_test_support::clock::ManualClock;
+    use loonfs_test_support::stores::RecordingStore;
+
+    let directory = tempdir().expect("directory");
+    let namespace_id = NamespaceId::parse("deleted-token").expect("namespace");
+    let store = RecordingStore::new(
+        LocalFsStore::new(directory.path()).expect("store"),
+        KeyPredicate::any(),
+    );
+    let clock = Arc::new(ManualClock::new(1_000));
+    let setup = context(clock.now_ms());
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (completed, _) = completed_upload(&store, &namespace_id, &setup).await;
+    let catalog = load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("catalog");
+    let token = mint_content_token(
+        "secret",
+        completed.receipt.as_ref().expect("completed receipt"),
+        clock.now_ms(),
+    )
+    .expect("mint token");
+    clock.advance_ms(1);
+    delete_namespace(
+        &store,
+        &namespace_id,
+        Default::default(),
+        &context(clock.now_ms()),
+    )
+    .await
+    .expect("delete");
+    let prepared = verify_content_token("secret", &catalog, &token, clock.now_ms())
+        .expect("token remains valid");
+    let candidate =
+        CommitCandidate::prepared(put_candidate(&completed).request().clone(), vec![prepared]);
+    let mut engine = NamespaceCommitEngine::new(namespace_id).monotonic_timer(clock.clone());
+    store.reset();
+    let result = engine
+        .publish_batch(
+            &store,
+            vec![candidate],
+            &context(clock.now_ms()),
+            &PublishTailOptions::default(),
+        )
+        .await;
+    assert!(matches!(
+        &result.results[..],
+        [Err(CoreError::NamespaceDeleted { .. })]
+    ));
+    assert_eq!(store.counts().puts, 0);
+}
+
+#[tokio::test]
 async fn content_reclaimed_during_view_load_cannot_be_published() {
     let directory = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");

--- a/crates/loonfs-core/src/gc/collect.rs
+++ b/crates/loonfs-core/src/gc/collect.rs
@@ -11,6 +11,7 @@ use crate::control_object::ControlObjectLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::control::load_head_object;
 use crate::namespace::control_snapshot::load_control_snapshot;
+use crate::time::{MonotonicTimer, StdMonotonicTimer};
 use futures::StreamExt;
 use loonfs_api::{GcResponse, NamespaceId};
 use loonfs_objectstore::ObjectStore;
@@ -21,6 +22,18 @@ pub async fn gc_namespace<S: ObjectStore + ?Sized>(
     config: &GcConfig,
     context: &MutationContext,
 ) -> Result<GcResponse> {
+    let timer = StdMonotonicTimer::default();
+    gc_namespace_with_timer(store, namespace_id, config, context, &timer).await
+}
+
+pub(super) async fn gc_namespace_with_timer<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    config: &GcConfig,
+    context: &MutationContext,
+    timer: &dyn MonotonicTimer,
+) -> Result<GcResponse> {
+    let started_ms = timer.monotonic_now_ms();
     config.validate()?;
     let mut report = GcResponse::empty(namespace_id.clone());
     let snapshot = match load_control_snapshot(store, namespace_id).await {
@@ -89,6 +102,8 @@ pub async fn gc_namespace<S: ObjectStore + ?Sized>(
                 namespace_id,
                 config.grace_window_ms,
                 context.now_ms,
+                timer,
+                started_ms,
             )
             .await?;
         }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -48,6 +48,7 @@ use loonfs_test_support::stores::{
 use tempfile::tempdir;
 
 mod many_pins;
+mod retirement;
 
 const GRACE_MS: u64 = 60 * 60 * 1000;
 

--- a/crates/loonfs-core/src/gc/tests/retirement.rs
+++ b/crates/loonfs-core/src/gc/tests/retirement.rs
@@ -1,0 +1,178 @@
+//! Retirement publication timing and outstanding multipart uploads.
+
+use super::*;
+use crate::gc::collect::gc_namespace_with_timer;
+use crate::limits::{
+    DIRECT_TRANSFER_URL_TTL_MS, NAMESPACE_RETIREMENT_GRACE_MS, RETIREMENT_PUBLICATION_BUDGET_MS,
+};
+use loonfs_test_support::clock::ManualClock;
+use loonfs_test_support::stores::FakeMultipartStore;
+
+#[tokio::test]
+async fn retirement_includes_listing_time_in_its_budget_and_retries_with_a_fresh_clock() {
+    for elapsed_ms in [
+        RETIREMENT_PUBLICATION_BUDGET_MS,
+        RETIREMENT_PUBLICATION_BUDGET_MS + 1,
+    ] {
+        let directory = tempdir().expect("directory");
+        let namespace_id = NamespaceId::parse("retirement-budget").expect("namespace");
+        let store = RecordingStore::new(
+            BlockingStore::new(
+                LocalFsStore::new(directory.path()).expect("store"),
+                KeyPredicate::exact(checkpoint_prefix(&namespace_id)),
+                OperationClass::List,
+            ),
+            KeyPredicate::any(),
+        );
+        let clock = ManualClock::new(1_000);
+        let call = context(clock.now_ms());
+        bootstrap_namespace(&store, &namespace_id, &call, false)
+            .await
+            .expect("bootstrap");
+        delete_namespace(&store, &namespace_id, Default::default(), &call)
+            .await
+            .expect("delete");
+        let config = GcConfig {
+            grace_window_ms: GC_MIN_GRACE_WINDOW_MS,
+        };
+        store.reset();
+        store.inner().block_next();
+        let (result, ()) = tokio::join!(
+            gc_namespace_with_timer(&store, &namespace_id, &config, &call, &clock),
+            async {
+                store.inner().wait_until_blocked().await;
+                clock.advance_ms(elapsed_ms);
+                store.inner().release();
+            }
+        );
+        if elapsed_ms == RETIREMENT_PUBLICATION_BUDGET_MS {
+            assert_eq!(
+                result.expect("within budget").reclaim_after_ms,
+                Some(call.now_ms + NAMESPACE_RETIREMENT_GRACE_MS)
+            );
+        } else {
+            assert!(matches!(
+                result,
+                Err(CoreError::MetadataPublicationBudgetExceeded {
+                    elapsed_ms: actual_elapsed_ms,
+                    budget_ms: RETIREMENT_PUBLICATION_BUDGET_MS,
+                }) if actual_elapsed_ms == elapsed_ms
+            ));
+            assert_eq!(store.counts().puts, 0);
+            assert_eq!(store.counts().deletes, 0);
+            let head = crate::namespace::control::load_head_object(&store, &namespace_id)
+                .await
+                .expect("head");
+            assert_eq!(head.state.status.reclaim_after_ms(), None);
+            let retry = context(clock.now_ms());
+            let report = gc_namespace_with_timer(&store, &namespace_id, &config, &retry, &clock)
+                .await
+                .expect("fresh call");
+            assert_eq!(
+                report.reclaim_after_ms,
+                Some(retry.now_ms + NAMESPACE_RETIREMENT_GRACE_MS)
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn open_direct_upload_outlives_retirement_and_still_gets_provider_cleanup() {
+    let directory = tempdir().expect("directory");
+    let namespace_id = NamespaceId::parse("retired-multipart").expect("namespace");
+    let inner = FakeMultipartStore::new(LocalFsStore::new(directory.path()).expect("store"));
+    let clock = ManualClock::new(1_000);
+    let setup = context(clock.now_ms());
+    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let upload = crate::protocol::begin_direct_multipart_upload_target(
+        &inner,
+        &namespace_id,
+        Default::default(),
+        &setup,
+    )
+    .await
+    .expect("open multipart upload");
+    let targets = crate::protocol::direct_multipart_part_targets(
+        &inner,
+        &namespace_id,
+        &upload.upload_id,
+        &[loonfs_api::v0::UploadPartChecksumClaim {
+            part_number: 1,
+            checksum: loonfs_api::Checksum::crc64nvme(b"part"),
+        }],
+    )
+    .await
+    .expect("prepare capability");
+    let expires_at_ms = clock.now_ms() + DIRECT_TRANSFER_URL_TTL_MS;
+    let content_store_id =
+        crate::namespace::catalog::load_namespace_content_store_id(&inner, &namespace_id)
+            .await
+            .expect("content store");
+    let owner_prefix =
+        loonfs_objectstore::keys::content_owner_prefix(&content_store_id, &namespace_id);
+    let store = RecordingStore::new(inner, KeyPredicate::prefix(owner_prefix));
+    clock.advance_ms(1);
+    delete_namespace(
+        &store,
+        &namespace_id,
+        Default::default(),
+        &context(clock.now_ms()),
+    )
+    .await
+    .expect("delete");
+    store
+        .inner()
+        .upload_part(&targets.provider_upload_id, 1, b"part")
+        .expect("issued capability still writes after deletion");
+    let config = GcConfig {
+        grace_window_ms: GC_MIN_GRACE_WINDOW_MS,
+    };
+    let report = gc_namespace(&store, &namespace_id, &config, &context(clock.now_ms()))
+        .await
+        .expect("retire");
+    let deadline = report.reclaim_after_ms.expect("deadline");
+    assert_eq!(deadline, clock.now_ms() + NAMESPACE_RETIREMENT_GRACE_MS);
+    assert!(deadline >= expires_at_ms);
+    clock.advance_ms(deadline - clock.now_ms() - 1);
+    let before = gc_namespace(&store, &namespace_id, &config, &context(clock.now_ms()))
+        .await
+        .expect("before deadline");
+    assert_eq!(before.next_reclamation_at_ms, Some(deadline));
+    assert_eq!(store.counts().lists, 0);
+    assert_eq!(store.counts().deletes, 0);
+    clock.advance_ms(1);
+    gc_namespace(&store, &namespace_id, &config, &context(clock.now_ms()))
+        .await
+        .expect("owner sweep");
+    assert_eq!(store.counts().lists, 1);
+    assert_eq!(store.inner().open_uploads(), 1);
+    assert_eq!(store.inner().aborts(), 0);
+    assert!(matches!(
+        read_upload_session(&store, &namespace_id, &upload.upload_id)
+            .await
+            .expect("open session")
+            .status,
+        UploadSessionRecordStatus::Open { .. }
+    ));
+    clock.advance_ms(
+        setup.now_ms + UPLOAD_SESSION_LEASE_MS + config.grace_window_ms - clock.now_ms(),
+    );
+    gc_namespace(&store, &namespace_id, &config, &context(clock.now_ms()))
+        .await
+        .expect("provider cleanup after retirement");
+    assert_eq!(store.inner().aborts(), 1);
+    assert_eq!(store.inner().open_uploads(), 0);
+    clock.advance_ms(config.grace_window_ms);
+    let reaped = gc_namespace(&store, &namespace_id, &config, &context(clock.now_ms()))
+        .await
+        .expect("reap session");
+    assert_eq!(reaped.deleted.upload_sessions, 1);
+    assert_eq!(store.inner().aborts(), 2);
+    assert!(
+        read_upload_session(&store, &namespace_id, &upload.upload_id)
+            .await
+            .is_none()
+    );
+}

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -90,6 +90,9 @@ pub const CHECKPOINT_VERIFY_BUDGET_MS: u64 = 60_000;
 /// garbage-collection candidates.
 pub const METADATA_PUBLICATION_BUDGET_MS: u64 = 15 * 60 * 1000;
 
+/// Bounds elapsed time from the collection call clock to retirement publication.
+pub const RETIREMENT_PUBLICATION_BUDGET_MS: u64 = METADATA_PUBLICATION_BUDGET_MS;
+
 /// Combined allowance for age overstatement from host-to-provider or
 /// host-to-host clock error and scheduling delay around publication checks.
 /// Direct expiry comparisons do not add this margin to stored deadlines.
@@ -113,6 +116,14 @@ pub const GC_MIN_GRACE_WINDOW_MS: u64 = max_u64(
     + PROVIDER_ATTEMPT_TIMEOUT_MS
     + GC_SAFETY_MARGIN_MS;
 
+const _: () = assert!(
+    RETIREMENT_PUBLICATION_BUDGET_MS
+        <= max_u64(
+            max_u64(WAL_PUBLISH_BUDGET_MS, CHECKPOINT_VERIFY_BUDGET_MS),
+            METADATA_PUBLICATION_BUDGET_MS,
+        )
+);
+
 /// Minimum provider age of a metadata segment no root manifest lists before
 /// garbage collection may delete it. A streaming compaction writes its
 /// output under `segments/` as it goes and publishes at the end, so its
@@ -133,18 +144,24 @@ pub const METADATA_COMPACTION_BUDGET_MS: u64 =
 pub const DIRECT_TRANSFER_URL_TTL_MS: u64 = 15 * 60 * 1000;
 
 /// Covers outstanding reads and direct capabilities after retirement.
-pub const NAMESPACE_RETIREMENT_GRACE_MS: u64 = max_u64(
-    GC_MIN_GRACE_WINDOW_MS,
-    DIRECT_TRANSFER_URL_TTL_MS
-        + PROVIDER_OPERATION_DEADLINE_MS
-        + PROVIDER_ATTEMPT_TIMEOUT_MS
-        + GC_SAFETY_MARGIN_MS,
-);
+///
+/// The deadline is measured from the collection call's clock, and the call
+/// may spend up to the retirement publication budget before it publishes,
+/// so the budget is added in front of the longest thing the grace covers.
+pub const NAMESPACE_RETIREMENT_GRACE_MS: u64 = RETIREMENT_PUBLICATION_BUDGET_MS
+    + max_u64(
+        GC_MIN_GRACE_WINDOW_MS,
+        DIRECT_TRANSFER_URL_TTL_MS
+            + PROVIDER_OPERATION_DEADLINE_MS
+            + PROVIDER_ATTEMPT_TIMEOUT_MS
+            + GC_SAFETY_MARGIN_MS,
+    );
 
 const fn covers_namespace_retirement(grace_ms: u64) -> bool {
-    grace_ms >= GC_MIN_GRACE_WINDOW_MS
+    grace_ms >= RETIREMENT_PUBLICATION_BUDGET_MS + GC_MIN_GRACE_WINDOW_MS
         && grace_ms
-            >= DIRECT_TRANSFER_URL_TTL_MS
+            >= RETIREMENT_PUBLICATION_BUDGET_MS
+                + DIRECT_TRANSFER_URL_TTL_MS
                 + PROVIDER_OPERATION_DEADLINE_MS
                 + PROVIDER_ATTEMPT_TIMEOUT_MS
                 + GC_SAFETY_MARGIN_MS

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -2,6 +2,7 @@
 
 use crate::checkpoint::publish::{encode_manifest, publish_manifest, ManifestPublicationOutcome};
 use crate::error::{CoreError, Result};
+use crate::limits::RETIREMENT_PUBLICATION_BUDGET_MS;
 use crate::namespace::control::load_current_manifest;
 use crate::namespace::control_snapshot::load_control_snapshot;
 use crate::namespace::writer_epoch::ensure_writer_not_fenced;
@@ -69,13 +70,13 @@ pub(crate) async fn retire_namespace<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     grace_window_ms: u64,
-    fresh_now_ms: u64,
+    call_now_ms: u64,
+    timer: &dyn MonotonicTimer,
+    started_ms: u64,
 ) -> Result<u64> {
-    let deadline = fresh_now_ms
+    let deadline = call_now_ms
         .checked_add(grace_window_ms.max(crate::limits::NAMESPACE_RETIREMENT_GRACE_MS))
         .ok_or_else(|| CoreError::Internal("namespace retirement deadline overflow".to_owned()))?;
-    let timer = StdMonotonicTimer::default();
-    let started_ms = timer.monotonic_now_ms();
     loop {
         let current = load_current_manifest(store, namespace_id).await?;
         let mut payload = current.envelope.payload().clone();
@@ -95,13 +96,20 @@ pub(crate) async fn retire_namespace<S: ObjectStore + ?Sized>(
             reclaim_after_ms: Some(deadline),
         };
         let manifest = encode_manifest(payload)?;
+        let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
+        if elapsed_ms > RETIREMENT_PUBLICATION_BUDGET_MS {
+            return Err(CoreError::MetadataPublicationBudgetExceeded {
+                elapsed_ms,
+                budget_ms: RETIREMENT_PUBLICATION_BUDGET_MS,
+            });
+        }
         if matches!(
             publish_manifest(
                 store,
                 namespace_id,
                 &manifest,
                 Some(current.state.manifest.manifest_no),
-                &timer,
+                timer,
                 started_ms
             )
             .await?,

--- a/crates/loonfs-core/tests/it/content_retirement_model.rs
+++ b/crates/loonfs-core/tests/it/content_retirement_model.rs
@@ -1,8 +1,12 @@
-//! Independent exploration of namespace retirement and fork record release.
+//! Independent exploration of namespace retirement and fork record deletion.
+//! The deadline is measured from the call clock. The budget bounds how far
+//! behind that clock can be at the moment of publication.
 
 use std::collections::HashSet;
 
-const GRACE: u64 = 2;
+const BUDGET: u64 = 1;
+const CAPABILITY_LIFETIME: u64 = 2;
+const GRACE: u64 = BUDGET + CAPABILITY_LIFETIME;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum Status {
@@ -12,21 +16,8 @@ enum Status {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-enum RecordStatus {
-    Active,
-    Released { at: u64 },
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct Record {
     source: usize,
-    status: RecordStatus,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-struct Run {
-    started: u64,
-    deleted: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -35,8 +26,8 @@ struct Model {
     records: [Option<Record>; 3],
     collectable: [bool; 3],
     inherited_owners: [u8; 3],
-    retired_at: [Option<u64>; 3],
-    runs: [Option<Run>; 3],
+    capabilities_until: [u64; 3],
+    calls: [Option<u64>; 3],
     clock: u64,
 }
 
@@ -50,10 +41,10 @@ enum Rule {
 #[derive(Clone, Copy)]
 enum Action {
     Fork(usize, usize),
+    Issue(usize),
     Delete(usize),
-    Gc(usize),
     Start(usize),
-    Resume(usize),
+    Gc(usize),
     Advance,
 }
 
@@ -64,8 +55,8 @@ impl Model {
             records: [None; 3],
             collectable: [false; 3],
             inherited_owners: [1, 2, 4],
-            retired_at: [None; 3],
-            runs: [None; 3],
+            capabilities_until: [0; 3],
+            calls: [None; 3],
             clock: 0,
         }
     }
@@ -80,10 +71,13 @@ impl Model {
                 }
                 self.namespaces[target] = Some(Status::Active);
                 self.inherited_owners[target] |= self.inherited_owners[source];
-                self.records[target] = Some(Record {
-                    source,
-                    status: RecordStatus::Active,
-                });
+                self.records[target] = Some(Record { source });
+            }
+            Action::Issue(namespace) => {
+                if self.namespaces[namespace] != Some(Status::Active) {
+                    return false;
+                }
+                self.capabilities_until[namespace] = self.clock + CAPABILITY_LIFETIME;
             }
             Action::Delete(namespace) => {
                 if self.namespaces[namespace] != Some(Status::Active) {
@@ -92,87 +86,66 @@ impl Model {
                 self.namespaces[namespace] = Some(Status::Deleted);
             }
             Action::Start(namespace) => {
-                if self.namespaces[namespace].is_none() || self.runs[namespace].is_some() {
+                if self.namespaces[namespace].is_none() || self.calls[namespace].is_some() {
                     return false;
                 }
-                self.runs[namespace] = Some(Run {
-                    started: self.clock,
-                    deleted: self.namespaces[namespace] == Some(Status::Deleted),
-                });
-            }
-            Action::Resume(namespace) => {
-                let Some(run) = self.runs[namespace].take() else {
-                    return false;
-                };
-                self.gc(namespace, run, rule);
+                self.calls[namespace] = Some(self.clock);
             }
             Action::Gc(namespace) => {
-                if !self.apply(Action::Start(namespace), rule) {
+                let Some(started) = self.calls[namespace].take() else {
                     return false;
-                }
-                self.apply(Action::Resume(namespace), rule);
+                };
+                self.gc(namespace, started, rule);
             }
-            Action::Advance => self.clock += GRACE + 1,
+            Action::Advance => self.clock += 1,
         }
         true
     }
 
-    fn gc(&mut self, namespace: usize, run: Run, rule: Rule) {
-        for (target, slot) in self.records.iter_mut().enumerate() {
-            let Some(record) = slot else { continue };
-            if record.source != namespace {
-                continue;
-            }
-            match record.status {
-                RecordStatus::Released { at } if run.started >= at + GRACE => *slot = None,
-                RecordStatus::Released { .. } => {}
-                RecordStatus::Active => {
-                    let release = match self.namespaces[target] {
-                        Some(Status::Active) | None => false,
-                        Some(Status::Deleted) => matches!(rule, Rule::ReleaseUnretired),
-                        Some(Status::Retired { deadline }) => deadline <= run.started,
-                    };
-                    if release {
-                        record.status = RecordStatus::Released { at: run.started };
-                    }
-                }
-            }
+    fn gc(&mut self, namespace: usize, started: u64, rule: Rule) {
+        let retired = matches!(
+            self.namespaces[namespace],
+            Some(Status::Retired { deadline }) if started >= deadline
+        );
+        if retired
+            || (matches!(rule, Rule::ReleaseUnretired)
+                && matches!(
+                    self.namespaces[namespace],
+                    Some(Status::Deleted | Status::Retired { .. })
+                ))
+        {
+            self.records[namespace] = None;
         }
         let retained = self
             .records
             .iter()
             .flatten()
             .any(|record| record.source == namespace);
-        if run.deleted && self.namespaces[namespace] == Some(Status::Deleted) && !retained {
-            let now = if matches!(rule, Rule::Backdate) {
-                run.started
-            } else {
-                self.clock
-            };
+        if self.namespaces[namespace] == Some(Status::Deleted)
+            && !retained
+            && (matches!(rule, Rule::Backdate) || self.clock - started <= BUDGET)
+        {
             self.namespaces[namespace] = Some(Status::Retired {
-                deadline: now + GRACE,
+                deadline: started + GRACE,
             });
-            self.retired_at[namespace] = Some(self.clock);
         }
-        if let Some(Status::Retired { deadline }) = self.namespaces[namespace] {
-            self.collectable[namespace] |= run.started >= deadline;
-        }
+        self.collectable[namespace] |= retired;
     }
 
     fn safe(&self) -> bool {
+        if self
+            .records
+            .iter()
+            .flatten()
+            .any(|record| self.collectable[record.source])
+        {
+            return false;
+        }
         for namespace in 0..3 {
-            let protected = match self.namespaces[namespace] {
-                None => false,
-                Some(Status::Active | Status::Deleted) => true,
-                Some(Status::Retired { deadline }) => {
-                    let retired_at =
-                        self.retired_at[namespace].expect("retired namespace has an instant");
-                    if deadline < retired_at + GRACE {
-                        return false;
-                    }
-                    self.clock < deadline
-                }
-            };
+            let protected = matches!(
+                self.namespaces[namespace],
+                Some(Status::Active | Status::Deleted)
+            ) || self.clock < self.capabilities_until[namespace];
             if !protected {
                 continue;
             }
@@ -187,11 +160,12 @@ impl Model {
 
     fn converges(mut self) -> bool {
         for namespace in 0..3 {
-            self.apply(Action::Resume(namespace), Rule::Correct);
+            self.apply(Action::Gc(namespace), Rule::Correct);
         }
         for _ in 0..16 {
             self.apply(Action::Advance, Rule::Correct);
             for namespace in 0..3 {
+                self.apply(Action::Start(namespace), Rule::Correct);
                 self.apply(Action::Gc(namespace), Rule::Correct);
                 if !self.safe() {
                     return false;
@@ -236,24 +210,36 @@ fn explore(
     true
 }
 
-use Action::{Advance, Delete, Fork, Gc, Resume, Start};
+use Action::{Advance, Delete, Fork, Gc, Issue, Start};
 
 #[test]
 fn every_bounded_interleaving_preserves_owners_and_deleted_families_converge() {
     let family = [
         Fork(0, 1),
         Fork(1, 2),
+        Issue(2),
         Delete(0),
         Delete(1),
         Delete(2),
+        Start(0),
         Gc(0),
+        Start(1),
         Gc(1),
         Start(2),
-        Resume(2),
+        Gc(2),
         Advance,
         Advance,
     ];
-    let leaf = [Fork(0, 1), Delete(1), Gc(0), Start(1), Resume(1), Advance];
+    let leaf = [
+        Fork(0, 1),
+        Issue(1),
+        Delete(1),
+        Start(0),
+        Gc(0),
+        Start(1),
+        Gc(1),
+        Advance,
+    ];
     for actions in [&family[..], &leaf[..]] {
         let mut completed = 0;
         assert!(explore(
@@ -269,32 +255,49 @@ fn every_bounded_interleaving_preserves_owners_and_deleted_families_converge() {
 
 #[test]
 fn removing_unretired_target_retention_breaks_safety() {
-    let mut model = Model::new();
     let actions = [
         Fork(0, 1),
         Fork(1, 2),
         Delete(0),
         Delete(1),
+        Start(1),
+        Gc(1),
+        Start(0),
         Gc(0),
         Advance,
-        Gc(0),
         Advance,
+        Advance,
+        Start(0),
         Gc(0),
     ];
-    for action in actions {
-        assert!(model.apply(action, Rule::ReleaseUnretired));
+    for rule in [Rule::Correct, Rule::ReleaseUnretired] {
+        let mut model = Model::new();
+        for action in actions {
+            assert!(model.apply(action, rule));
+        }
+        assert_eq!(model.safe(), matches!(rule, Rule::Correct));
     }
-    assert!(!model.safe());
 }
 
 #[test]
-fn using_the_run_start_for_retirement_breaks_the_grace_contract() {
-    let actions = [Delete(0), Start(0), Advance, Resume(0), Gc(0)];
+fn retirement_after_the_call_budget_can_collect_a_live_capability() {
+    let actions = [
+        Start(0),
+        Advance,
+        Advance,
+        Advance,
+        Issue(0),
+        Delete(0),
+        Gc(0),
+        Start(0),
+        Gc(0),
+    ];
     for rule in [Rule::Correct, Rule::Backdate] {
         let mut model = Model::new();
         for action in actions {
             assert!(model.apply(action, rule));
         }
+        assert!(model.clock < model.capabilities_until[0]);
         assert_eq!(model.safe(), matches!(rule, Rule::Correct));
         assert_eq!(model.collectable[0], matches!(rule, Rule::Backdate));
     }

--- a/crates/loonfs-test-support/src/clock.rs
+++ b/crates/loonfs-test-support/src/clock.rs
@@ -1,0 +1,27 @@
+//! Time advanced explicitly by tests.
+
+use loonfs_api::MonotonicTimer;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug)]
+pub struct ManualClock(AtomicU64);
+
+impl ManualClock {
+    pub fn new(now_ms: u64) -> Self {
+        Self(AtomicU64::new(now_ms))
+    }
+
+    pub fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    pub fn advance_ms(&self, elapsed_ms: u64) {
+        self.0.fetch_add(elapsed_ms, Ordering::SeqCst);
+    }
+}
+
+impl MonotonicTimer for ManualClock {
+    fn monotonic_now_ms(&self) -> u64 {
+        self.now_ms()
+    }
+}

--- a/crates/loonfs-test-support/src/lib.rs
+++ b/crates/loonfs-test-support/src/lib.rs
@@ -7,6 +7,7 @@
 //! stay in the crate that owns those types.
 
 pub mod block_on;
+pub mod clock;
 mod env_guard;
 pub mod http;
 pub mod ids;

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -678,7 +678,7 @@ reclaim_after_ms = call.now_ms
                   + max(configured_grace, NAMESPACE_RETIREMENT_GRACE_MS)
 ```
 
-The deadline uses the call's fixed clock. A concurrent collector's established deadline wins; it must never be cleared or moved. An uncertain publication requires readback. Every successor remains deleted.
+The deadline uses the call's fixed clock. A collector establishes retirement only while its elapsed monotonic time since capturing that clock is within `RETIREMENT_PUBLICATION_BUDGET_MS`. This bounds how far the call clock can lag publication, as the retirement grace calculation requires. A concurrent collector's established deadline wins; it must never be cleared or moved. An uncertain publication requires readback. Every successor remains deleted.
 
 Retirement itself deletes no content. After the deadline, collection can sweep the namespace's owner prefix and release its source pin. The shared descriptor and other owners' content remain outside that sweep.
 
@@ -1344,7 +1344,7 @@ A content reference is represented by exactly these fields, in this order:
 {"kind":"blob_v1","content_id":"con_0123456789abcdef0123456789abcdef","size_bytes":15}
 ```
 
-The owner namespace and checksum are excluded by the current v3 scheme. The scheme treats the randomly allocated content ID as the identity across owners; the checksum is verification evidence rather than a second identity. The mandatory owner and checksum are still present and validated on the actual reference. Their exclusion from the fingerprint does not make them optional on a commit.
+The owner namespace and checksum are excluded by the current v3 scheme. Every reference a commit can admit is owned by the committing namespace: an upload records its session's namespace as the owner, and admission requires the reference to match the prepared content exactly, so the owner repeats the `namespace_id` the preimage already names. The checksum is verification evidence rather than a second identity. Both fields are still present and validated on the actual reference; their exclusion from the fingerprint does not make them optional on a commit.
 
 Two uploads of identical bytes have different IDs and different fingerprints. A retry reuses the original reference rather than repeating the upload and substituting a new one.
 
@@ -1394,6 +1394,7 @@ Publication and collection use the timing relationships below. Configurable sizi
 | `WAL_PUBLISH_BUDGET_MS` | 60,000 | Observing the planning tip through initiation of its next numbered put. |
 | `CHECKPOINT_VERIFY_BUDGET_MS` | 60,000 | Pin write through completion of post-write verification. |
 | `METADATA_PUBLICATION_BUDGET_MS` | 900,000 | First output through initiation of a bounded manifest publication. |
+| `RETIREMENT_PUBLICATION_BUDGET_MS` | 900,000 | Capturing the collection call clock through initiation of retirement publication. |
 | `PROVIDER_OPERATION_DEADLINE_MS` | 120,000 | Shared client-operation retry budget. |
 | `PROVIDER_ATTEMPT_TIMEOUT_MS` | 30,000 | One control-operation attempt. |
 | `GC_SAFETY_MARGIN_MS` | 180,000 | Combined relative-clock, timestamp-precision, and scheduling allowance. |
@@ -1403,7 +1404,7 @@ Publication and collection use the timing relationships below. Configurable sizi
 | `METADATA_COMPACTION_BUDGET_MS` | 85,170,000 | Maximum elapsed time before initiating streaming publication. |
 | `FORK_INSTALL_BUDGET_MS` | 900,000 | Fork installation before initiating target manifest publication. |
 | `DIRECT_TRANSFER_URL_TTL_MS` | 900,000 | Lifetime of a direct transfer capability. |
-| `NAMESPACE_RETIREMENT_GRACE_MS` | 1,230,000 | Minimum grace after establishing retirement. |
+| `NAMESPACE_RETIREMENT_GRACE_MS` | 2,130,000 | Minimum grace after establishing retirement. |
 
 A provider attempt can begin before its operation deadline and finish within its separate timeout. The grace therefore includes both terms. This client-side calculation does not prove that a timed-out remote mutation had no effect.
 
@@ -1418,14 +1419,20 @@ GC_MIN_GRACE_WINDOW_MS
 METADATA_COMPACTION_BUDGET_MS
     = UNREFERENCED_SEGMENT_MIN_AGE_MS - GC_MIN_GRACE_WINDOW_MS
 
+RETIREMENT_PUBLICATION_BUDGET_MS
+    = METADATA_PUBLICATION_BUDGET_MS
+    <= max(WAL_PUBLISH_BUDGET_MS, CHECKPOINT_VERIFY_BUDGET_MS,
+           METADATA_PUBLICATION_BUDGET_MS)
+
 FORK_INSTALL_BUDGET_MS
     = GC_MIN_GRACE_WINDOW_MS - PROVIDER_OPERATION_DEADLINE_MS
       - PROVIDER_ATTEMPT_TIMEOUT_MS - GC_SAFETY_MARGIN_MS
 
 NAMESPACE_RETIREMENT_GRACE_MS
-    = max(GC_MIN_GRACE_WINDOW_MS,
-          DIRECT_TRANSFER_URL_TTL_MS + PROVIDER_OPERATION_DEADLINE_MS
-          + PROVIDER_ATTEMPT_TIMEOUT_MS + GC_SAFETY_MARGIN_MS)
+    = RETIREMENT_PUBLICATION_BUDGET_MS
+      + max(GC_MIN_GRACE_WINDOW_MS,
+            DIRECT_TRANSFER_URL_TTL_MS + PROVIDER_OPERATION_DEADLINE_MS
+            + PROVIDER_ATTEMPT_TIMEOUT_MS + GC_SAFETY_MARGIN_MS)
 ```
 
 Configured grace `T` cannot be below the minimum. Retirement uses the greater of `T` and the retirement minimum. Segment age and completed-content grace use their fixed constants. Changing a publication bound or its safety relationship changes the protocol, not just a scheduling preference.


### PR DESCRIPTION
Retirement measures its grace from the collection call's fixed clock, and the format says so. That rule is safe only if the call publishes retirement within a bounded time of capturing that clock, and nothing checked it: a call that spent a long time listing pins before it decided could establish a deadline that gave a capability issued just before the tombstone less than the full grace. Every other write with a grace relationship checks a monotonic budget before it publishes. Retirement now does the same. A collector establishes retirement only while its elapsed monotonic time since the call began is within `RETIREMENT_PUBLICATION_BUDGET_MS`, which equals the metadata publication budget, and otherwise fails with the existing budget error so a later call retries with a fresh clock. The retirement grace minimum now adds that budget in front of the longest thing it covers, so the inequality the model relies on holds for the production minimum, not only for the default configured grace.

The retirement model test describes the implementation again: pins are deleted directly by the target's collector, a call captures its clock and may run before it decides, and the correct rule is the budget check. The negative case that used to model a resumable run now models a call that decides after its budget and collects a live capability. Two implementation-level tests cover the capability cases the model abstracts: a token minted from a completed upload before the namespace is deleted cannot publish afterwards and writes nothing, and an open direct upload that outlives retirement still gets its provider cleanup.

Important callouts:

- `NAMESPACE_RETIREMENT_GRACE_MS` rises from 1,230,000 to 2,130,000 milliseconds. The default configured grace of one hour already exceeded both values. Appendix C.1 records the new term and the derivation.
- A retirement decision past the budget returns `MetadataPublicationBudgetExceeded`, which maps to the existing `checkpoint_unavailable` code and reports the elapsed time and the budget. No retirement manifest is published in that case.
- The parameter of `retire_namespace` that received the call clock was named as if it were fresh; it is now `call_now_ms`, and the collector passes its timer and start into it instead of starting a second timer.
- Appendix B now states why the content owner is excluded from the commit fingerprint: every reference a commit can admit is owned by the committing namespace, which the preimage already names.
- Test support gains a manually advanced monotonic clock; no durable shape, wire shape, or golden changes.
