### PR TITLE
refactor(maintenance): delete the resume continuation nothing produces

### DIFF
--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -325,7 +325,7 @@ impl EmbeddedBackend {
             },
             || async {
                 let conclusion = job
-                    .run(namespace_id, None, &MaintenanceCancellation::new())
+                    .run(namespace_id, &MaintenanceCancellation::new())
                     .await
                     .scoped(namespace_id)?
                     .conclusion;
@@ -395,7 +395,7 @@ impl EmbeddedBackend {
     /// a budget to spend and per-key progress to report, and admission
     /// offers neither. It shuts the runner down first so a second scheduler
     /// cannot race these steps, then closes the writer and walks the
-    /// assignment. Each key's continuation passes from one run to the next.
+    /// assignment.
     pub(super) async fn drain_maintenance(
         &self,
         namespaces: &[NamespaceId],
@@ -417,21 +417,18 @@ impl EmbeddedBackend {
                     steps: 0,
                     conclusion: None,
                 };
-                let mut continuation = None;
                 while !budget.spent(steps, timer.monotonic_now_ms().saturating_sub(started_ms)) {
                     let result = self
                         .jobs
                         .execute(MaintenanceAssignment {
                             namespace_id: namespace_id.clone(),
                             job: *job,
-                            continuation,
                         })
                         .await
                         .scoped(namespace_id)?;
                     steps += 1;
                     key.steps += 1;
                     key.conclusion = Some(result.conclusion);
-                    continuation = result.continuation;
                     if key.settled() {
                         break;
                     }

--- a/crates/loonfs-core/src/checkpoint/release.rs
+++ b/crates/loonfs-core/src/checkpoint/release.rs
@@ -4,7 +4,6 @@
 //! through this operation.
 
 use super::record::{load_checkpoint_record, release_checkpoint_record};
-use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
 use loonfs_api::wire::control::CheckpointOwner;
 use loonfs_api::{CheckpointId, NamespaceId, ReleaseCheckpointResponse};
@@ -90,7 +89,6 @@ pub(crate) async fn release_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     checkpoint_id: &CheckpointId,
-    _context: &MutationContext,
 ) -> Result<ReleaseCheckpointResponse> {
     release_owned_checkpoint(
         store,

--- a/crates/loonfs-core/src/checkpoint/tests/inventory.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inventory.rs
@@ -94,7 +94,7 @@ async fn two_pins_under_one_label_list_as_two_records() {
 
     // Release is what takes a record out of the answer, and it takes out
     // exactly the one named.
-    super::super::release::release_checkpoint(&store, &namespace_id, &first, &context)
+    super::super::release::release_checkpoint(&store, &namespace_id, &first)
         .await
         .expect("release checkpoint");
     let after_release = list_all_checkpoints(&store, &namespace_id)
@@ -224,7 +224,7 @@ async fn released_pins_are_absent_from_later_pages() {
     }
     ids.sort();
     for checkpoint_id in &ids[1..6] {
-        super::super::release::release_checkpoint(&store, &namespace_id, checkpoint_id, &context)
+        super::super::release::release_checkpoint(&store, &namespace_id, checkpoint_id)
             .await
             .expect("release checkpoint in filtered run");
     }

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -523,12 +523,8 @@ async fn release_is_terminal_and_the_next_pin_is_a_different_record() {
             .is_empty()
     );
 
-    let release = crate::checkpoint::release_checkpoint(
-        &store,
-        &namespace_id,
-        &first.checkpoint_id,
-        &context,
-    );
+    let release =
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &first.checkpoint_id);
     let recreate = create_checkpoint(&store, &namespace_id, &context);
     let (release, second) = tokio::join!(release, recreate);
     assert_eq!(release.expect("release").checkpoint_id, first.checkpoint_id);
@@ -556,15 +552,10 @@ async fn release_is_terminal_and_the_next_pin_is_a_different_record() {
     );
 
     assert_eq!(
-        crate::checkpoint::release_checkpoint(
-            &store,
-            &namespace_id,
-            &first.checkpoint_id,
-            &context
-        )
-        .await
-        .expect_err("second release")
-        .code(),
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &first.checkpoint_id)
+            .await
+            .expect_err("second release")
+            .code(),
         ErrorCode::CheckpointNotFound
     );
 }
@@ -749,7 +740,7 @@ async fn a_pin_without_a_ttl_is_held_until_it_is_released() {
             .is_empty()
     );
 
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id, &distant)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id)
         .await
         .expect("release");
     let error = read_checkpoint_files(&store, &namespace_id, &pin.checkpoint_id)
@@ -2459,7 +2450,7 @@ async fn a_floor_past_a_pin_keeps_its_manifest_and_runs_readable_until_release()
         .await
         .expect("pinned manifest")
         .is_some());
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id, &aged)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id)
         .await
         .expect("release pin");
     crate::gc::gc_namespace(

--- a/crates/loonfs-core/src/control_object/error.rs
+++ b/crates/loonfs-core/src/control_object/error.rs
@@ -10,13 +10,6 @@ pub enum ControlObjectLoadError {
     #[error("missing control object `{object_key}`")]
     MissingObject { object_key: String },
     #[error(
-        "metadata root references seq `{root_manifest_head_seq}` beyond the reloaded head seq `{head_seq}`"
-    )]
-    RootAheadOfHead {
-        root_manifest_head_seq: loonfs_api::ChangeSeq,
-        head_seq: loonfs_api::ChangeSeq,
-    },
-    #[error(
         "control object namespace mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
     )]
     NamespaceMismatch {
@@ -70,7 +63,6 @@ impl ControlObjectLoadError {
 
         match self {
             Self::MissingObject { .. } => ErrorCode::NamespaceNotFound,
-            Self::RootAheadOfHead { .. } => ErrorCode::StaleHead,
             Self::NamespaceMismatch { .. }
             | Self::IdentityMismatch { .. }
             | Self::ForkBasisOwnerIsSelf { .. }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -887,13 +887,7 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
         &self,
         checkpoint_id: &CheckpointId,
     ) -> Result<ReleaseCheckpointResponse> {
-        crate::checkpoint::release_checkpoint(
-            &self.store,
-            &self.namespace_id,
-            checkpoint_id,
-            &self.mutation_context()?,
-        )
-        .await
+        crate::checkpoint::release_checkpoint(&self.store, &self.namespace_id, checkpoint_id).await
     }
 
     /// Extends a live snapshot without passing its lifetime ceiling.

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -284,18 +284,8 @@ impl MetadataViewError {
 pub enum MetadataProjectionLoadError {
     #[error(transparent)]
     LoadHead(#[from] ControlObjectLoadError),
-    #[error("missing head etag for `{object_key}`")]
-    MissingHeadEtag { object_key: String },
     #[error("namespace `{namespace_id}` is deleted")]
     NamespaceDeleted { namespace_id: NamespaceId },
-    #[error(
-        "namespace head changed during metadata projection load for `{object_key}`: loaded `{loaded_head_etag}`, current `{current_head_etag}`"
-    )]
-    HeadChangedDuringLoad {
-        object_key: String,
-        loaded_head_etag: String,
-        current_head_etag: String,
-    },
     #[error(transparent)]
     WalChainLoad(#[from] WalChainLoadError),
     #[error(transparent)]
@@ -322,8 +312,6 @@ impl MetadataProjectionLoadError {
                 crate::checkpoint::ManifestLoadFailureClass::Corrupt => ErrorCode::NamespaceCorrupt,
                 crate::checkpoint::ManifestLoadFailureClass::Store => ErrorCode::ServerError,
             },
-            Self::MissingHeadEtag { .. } => ErrorCode::ServerError,
-            Self::HeadChangedDuringLoad { .. } => ErrorCode::StaleHead,
         }
     }
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1510,7 +1510,7 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
         .await
         .expect("advance past the shared basis");
 
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &second.checkpoint_id, &setup)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &second.checkpoint_id)
         .await
         .expect("release one owner");
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
@@ -1560,7 +1560,7 @@ async fn fork_owned_checkpoints_reject_user_release() {
 
     let fork_record = read_fork_record(&store, &source).await;
 
-    let error = crate::checkpoint::release_checkpoint(&store, &source, &fork_record.pin_id, &setup)
+    let error = crate::checkpoint::release_checkpoint(&store, &source, &fork_record.pin_id)
         .await
         .expect_err("fork-owned release must fail");
     assert!(
@@ -1595,14 +1595,10 @@ async fn snapshot_owned_checkpoints_reject_user_release() {
     .await
     .expect("snapshot checkpoint");
 
-    let error = crate::checkpoint::release_checkpoint(
-        &store,
-        &namespace_id,
-        &snapshot.checkpoint_id,
-        &setup,
-    )
-    .await
-    .expect_err("snapshot-owned release must fail");
+    let error =
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &snapshot.checkpoint_id)
+            .await
+            .expect_err("snapshot-owned release must fail");
     assert!(
         matches!(
             &error,

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -38,9 +38,6 @@ pub const MAX_COMMIT_MESSAGE_BYTES: usize = 4096;
 /// Maximum attempts for a bounded compare-and-swap or allocation contention loop.
 pub const CONTENTION_RETRY_LIMIT: usize = 8;
 
-/// Maximum targeted rereads while reconciling one namespace control snapshot.
-pub const CONTROL_SNAPSHOT_REREAD_LIMIT: usize = 3;
-
 /// Longest visible WAL tail, in segments, a namespace may carry unflushed.
 /// Every publish surface rejects at this length with `maintenance_required`,
 /// so a landed publication never leaves more than this behind.

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -61,7 +61,6 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let build = match self.worker.build_step(namespace_id, self.policy).await {
@@ -152,7 +151,6 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepGcJo
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.worker

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -128,7 +128,7 @@ impl GrepHost {
                 return Ok(lifecycle);
             }
             match job
-                .run(namespace_id, None, &loonfs::MaintenanceCancellation::new())
+                .run(namespace_id, &loonfs::MaintenanceCancellation::new())
                 .await
                 .map_err(GrepError::Runtime)?
                 .conclusion

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -86,7 +86,7 @@ async fn a_tombstoned_namespace_concludes_not_enabled() {
 
     let job = job(&worker);
     assert_eq!(
-        job.run(&namespace_id, None, &MaintenanceCancellation::new())
+        job.run(&namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("step tombstone")
             .conclusion,
@@ -115,7 +115,7 @@ async fn a_disabled_root_concludes_not_enabled_on_the_next_step() {
 
     worker.disable(&namespace_id).await.expect("disable grep");
     assert_eq!(
-        job.run(&namespace_id, None, &MaintenanceCancellation::new())
+        job.run(&namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("step disabled root")
             .conclusion,
@@ -239,7 +239,7 @@ async fn catch_up<S: ObjectStore + Clone + Send + Sync + 'static>(
 ) {
     for _ in 0..64 {
         match job
-            .run(namespace_id, None, &MaintenanceCancellation::new())
+            .run(namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("grep step")
             .conclusion

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -117,7 +117,6 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "inode_kind",
     "maintain_only",
     "manifest_no",
-    "max_objects",
     "max_wal_tail_segments",
     "metadata_compaction",
     "metadata_segments",
@@ -1133,7 +1132,6 @@ impl MaintenanceJob for StepCountingJob {
     async fn run(
         &self,
         _namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> loonfs::Result<MaintenanceRunReport> {
         self.steps.fetch_add(1, Ordering::SeqCst);

--- a/crates/loonfs/src/maintenance/admission.rs
+++ b/crates/loonfs/src/maintenance/admission.rs
@@ -1,8 +1,8 @@
 //! Synchronous scheduling state for maintenance jobs.
 //!
 //! The runner's lock protects admission, coalescing, fairness, backoff,
-//! deadlines, continuations, and shutdown. The parent module handles async
-//! execution, permits, and timers.
+//! deadlines, and shutdown. The parent module handles async execution,
+//! permits, and timers.
 
 use super::runner::MaintenanceClock;
 use super::{MaintenanceConclusion, MaintenanceJobId, MaintenanceRunReport};
@@ -50,9 +50,6 @@ impl MaintenanceKey {
 pub(crate) struct MaintenanceDispatch {
     /// The key this permit is running.
     pub(crate) key: MaintenanceKey,
-    /// Where this key's job said its last step stopped, opaque here and
-    /// handed straight back to the step about to run.
-    pub(crate) continuation: Option<String>,
     /// How long the claimed run waited between taking its ticket and holding
     /// a permit. Read by the step's own trace.
     pub(crate) queue_wait_ms: u64,
@@ -61,12 +58,7 @@ pub(crate) struct MaintenanceDispatch {
 /// How one step ended, from admission's point of view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StepOutcome {
-    /// The executor answered. The result decides what happens to the key:
-    /// its conclusion when to run again, its continuation where to resume,
-    /// its not-before time when a deadline it saw comes due.
     Concluded(MaintenanceRunReport),
-    /// The executor failed. The key is retried after its backoff, from
-    /// wherever its last step left it.
     Failed,
 }
 
@@ -178,11 +170,6 @@ struct KeyState {
     obligations: Option<TimedObligations>,
     /// Consecutive failed steps since the last conclusion, for the backoff.
     consecutive_failures: u32,
-    /// Opaque continuation returned by the previous step.
-    ///
-    /// Admission stores it and passes it to the next step. Losing it only
-    /// restarts the scan because each step revalidates durable state.
-    continuation: Option<String>,
 }
 
 impl KeyState {
@@ -337,15 +324,6 @@ impl Admission {
             .get(key)
             .and_then(|state| state.obligations)
             .map(|owed| owed.earliest_at_ms)
-    }
-
-    /// Where the key's job stopped last time. A claim carries this to the
-    /// step it dispatches; nothing on the running path reads it back out.
-    #[cfg(test)]
-    pub(crate) fn continuation(&self, key: &MaintenanceKey) -> Option<String> {
-        self.keys
-            .get(key)
-            .and_then(|state| state.continuation.clone())
     }
 
     /// Keys holding a ticket: work admitted and waiting for a permit.
@@ -561,9 +539,6 @@ impl Admission {
         batch
     }
 
-    /// Ends the running step: what it concluded decides the key's
-    /// continuation and whether it is queued again, and the key stops
-    /// running either way.
     fn apply(&mut self, key: &MaintenanceKey, outcome: StepOutcome, now_ms: u64) {
         let result = match outcome {
             StepOutcome::Failed => {
@@ -573,9 +548,6 @@ impl Admission {
             StepOutcome::Concluded(result) => result,
         };
         if result.conclusion == MaintenanceConclusion::NotEnabled {
-            // The job has nothing to maintain here at all. Drop the key —
-            // its continuation and its obligations included — rather than
-            // reconcile it forever.
             self.keys.remove(key);
             return;
         }
@@ -583,29 +555,12 @@ impl Admission {
         if let Some(state) = self.keys.get_mut(key) {
             state.consecutive_failures = 0;
             let concluding_run = match result.conclusion {
-                // Work happened, or the step lost a race it should simply
-                // take again: eligible immediately, behind whatever else is
-                // waiting, resuming from wherever this step stopped.
                 MaintenanceConclusion::Progressed | MaintenanceConclusion::Superseded => {
-                    state.continuation = result.continuation;
                     Some(ReadyRun::queued(ticket, now_ms))
                 }
-                // Work is left and this step's policy could not move it.
-                // Parks like `Idle` — requeueing zero-progress work would
-                // only spin — but keeps where the step stopped, so a retry
-                // with room to work resumes instead of walking the same
-                // ground again.
-                MaintenanceConclusion::Blocked => {
-                    state.continuation = result.continuation;
-                    None
-                }
-                // Nothing to do. Whatever the last pass was carrying is
-                // spent, and the next step starts a fresh one.
-                MaintenanceConclusion::Idle => {
-                    state.continuation = None;
-                    None
-                }
-                MaintenanceConclusion::NotEnabled => None,
+                MaintenanceConclusion::Blocked
+                | MaintenanceConclusion::Idle
+                | MaintenanceConclusion::NotEnabled => None,
             };
             state.settle(concluding_run);
         }
@@ -617,7 +572,6 @@ impl Admission {
         }
     }
 
-    /// Applies retry backoff without changing the job's continuation.
     fn record_failure(&mut self, key: &MaintenanceKey, now_ms: u64) {
         let ticket = self.take_ticket();
         let Some(state) = self.keys.get_mut(key) else {
@@ -654,11 +608,7 @@ impl Admission {
         let key = self.pick_eligible(now_ms)?;
         let state = self.keys.get_mut(&key)?;
         let queue_wait_ms = state.claim(now_ms)?;
-        Some(MaintenanceDispatch {
-            key,
-            continuation: state.continuation.clone(),
-            queue_wait_ms,
-        })
+        Some(MaintenanceDispatch { key, queue_wait_ms })
     }
 }
 
@@ -746,16 +696,6 @@ mod tests {
 
     fn concluded(conclusion: MaintenanceConclusion) -> StepOutcome {
         StepOutcome::Concluded(MaintenanceRunReport::concluded(conclusion))
-    }
-
-    /// A conclusion that also tells the runner where the step stopped.
-    fn continuing(conclusion: MaintenanceConclusion, continuation: &str) -> StepOutcome {
-        StepOutcome::Concluded(MaintenanceRunReport {
-            conclusion,
-            continuation: Some(continuation.to_owned()),
-            not_before_ms: None,
-            follow_up: None,
-        })
     }
 
     fn idle() -> StepOutcome {
@@ -1113,122 +1053,25 @@ mod tests {
     }
 
     #[test]
-    fn the_runner_carries_a_continuation_between_steps() {
-        let mut admission = book(1);
-        let key = gc("paged");
-
-        admission.nudge(key.clone());
-        let first = admission
-            .try_dispatch(NOW)
-            .expect("the nudged key claims the permit");
-        assert_eq!(first.key, key);
-        assert_eq!(first.continuation, None, "a first step starts a fresh pass");
-
-        let resumed = admission
-            .finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW,
-            )
-            .expect("a progressing key is eligible again");
-        assert_eq!(resumed.key, key);
-        assert_eq!(
-            resumed.continuation,
-            Some("page-1".to_owned()),
-            "and the handoff carries where this step stopped to the next one"
-        );
-
-        assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Blocked, "page-2"),
-                NOW
-            )),
-            None,
-            "a blocked key parks"
-        );
-        assert_eq!(
-            admission.continuation(&key),
-            Some("page-2".to_owned()),
-            "keeping its position, so a retry with a bigger budget resumes"
-        );
-
-        admission.nudge(key.clone());
-        let retried = admission
-            .try_dispatch(NOW)
-            .expect("a later nudge claims the permit again");
-        assert_eq!(retried.key, key);
-        assert_eq!(
-            retried.continuation,
-            Some("page-2".to_owned()),
-            "the parked position is what the resumed step is handed"
-        );
-        assert_eq!(claimed(admission.finish(&key, idle(), NOW)), None);
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "an idle pass is a finished one: the next step starts over"
-        );
-    }
-
-    #[test]
-    fn an_evicted_key_drops_its_continuation() {
+    fn an_evicted_key_can_be_admitted_again() {
         let mut admission = book(1);
         let key = gc("gone");
 
         admission.nudge(key.clone());
         assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
         assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW
-            )),
+            claimed(admission.finish(&key, concluded(MaintenanceConclusion::Progressed), NOW)),
             Some(key.clone())
         );
         assert_eq!(
             claimed(admission.finish(&key, concluded(MaintenanceConclusion::NotEnabled), NOW)),
             None
         );
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "the key's whole state went with it"
-        );
+        assert!(!admission.is_pending(&key));
+        assert!(admission.reconcile_batch(1).is_empty());
 
         admission.nudge(key.clone());
         assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "and a re-admitted key starts a fresh pass"
-        );
-    }
-
-    #[test]
-    fn a_failed_step_keeps_where_its_last_one_stopped() {
-        let mut admission = book(1);
-        let key = gc("flaky");
-
-        admission.nudge(key.clone());
-        assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
-        assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW
-            )),
-            Some(key.clone())
-        );
-        assert_eq!(
-            claimed(admission.finish(&key, StepOutcome::Failed, NOW)),
-            None
-        );
-        assert_eq!(
-            admission.continuation(&key),
-            Some("page-1".to_owned()),
-            "a failure says nothing about where the last step stopped"
-        );
     }
 
     #[test]
@@ -1243,7 +1086,6 @@ mod tests {
                 &key,
                 StepOutcome::Concluded(MaintenanceRunReport {
                     conclusion: MaintenanceConclusion::Idle,
-                    continuation: None,
                     not_before_ms: Some(NOW + 60_000),
                     follow_up: None,
                 }),
@@ -1265,7 +1107,6 @@ mod tests {
                 &key,
                 StepOutcome::Concluded(MaintenanceRunReport {
                     conclusion: MaintenanceConclusion::Progressed,
-                    continuation: None,
                     not_before_ms: Some(NOW + 30_000),
                     follow_up: None,
                 }),

--- a/crates/loonfs/src/maintenance/gc.rs
+++ b/crates/loonfs/src/maintenance/gc.rs
@@ -48,7 +48,6 @@ impl MaintenanceJob for GarbageCollectionJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let response = match self
@@ -98,7 +97,6 @@ impl MaintenanceJob for GarbageCollectionJob {
 fn gc_run_result(gc: GcResponse) -> MaintenanceRunReport {
     MaintenanceRunReport {
         conclusion: gc_conclusion(&gc),
-        continuation: None,
         not_before_ms: gc.next_reclamation_at_ms,
         follow_up: None,
     }

--- a/crates/loonfs/src/maintenance/job.rs
+++ b/crates/loonfs/src/maintenance/job.rs
@@ -66,8 +66,6 @@ impl MaintenanceConclusion {
 pub struct MaintenanceRunReport {
     /// How the run settled.
     pub conclusion: MaintenanceConclusion,
-    /// Resume position for the next run.
-    pub continuation: Option<String>,
     /// Earliest Unix millisecond for another run.
     pub not_before_ms: Option<u64>,
     /// A job and namespace this run wants scheduled.
@@ -75,11 +73,10 @@ pub struct MaintenanceRunReport {
 }
 
 impl MaintenanceRunReport {
-    /// Builds a report without continuation, deadline, or follow-up.
+    /// Builds a report without a deadline or follow-up.
     pub fn concluded(conclusion: MaintenanceConclusion) -> Self {
         Self {
             conclusion,
-            continuation: None,
             not_before_ms: None,
             follow_up: None,
         }
@@ -148,7 +145,6 @@ pub trait MaintenanceJob: Send + Sync + 'static {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
         cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport>;
 

--- a/crates/loonfs/src/maintenance/metadata.rs
+++ b/crates/loonfs/src/maintenance/metadata.rs
@@ -41,7 +41,6 @@ impl MaintenanceJob for MetadataMaintenanceJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         match self

--- a/crates/loonfs/src/maintenance/metadata_compaction.rs
+++ b/crates/loonfs/src/maintenance/metadata_compaction.rs
@@ -44,13 +44,11 @@ impl MaintenanceJob for MetadataCompactionJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let Ok(_permit) = Arc::clone(&self.permits).try_acquire_owned() else {
             return Ok(MaintenanceRunReport {
                 conclusion: MaintenanceConclusion::Blocked,
-                continuation: None,
                 not_before_ms: Some(
                     loonfs_core::time::current_time_ms()?.saturating_add(RECONCILE_INTERVAL_MS),
                 ),
@@ -75,7 +73,6 @@ impl MaintenanceJob for MetadataCompactionJob {
         };
         Ok(MaintenanceRunReport {
             conclusion,
-            continuation: None,
             not_before_ms: None,
             follow_up,
         })

--- a/crates/loonfs/src/maintenance/registry.rs
+++ b/crates/loonfs/src/maintenance/registry.rs
@@ -20,8 +20,6 @@ pub struct MaintenanceAssignment {
     pub namespace_id: NamespaceId,
     /// Registered job to run.
     pub job: MaintenanceJobId,
-    /// Process-local resume position.
-    pub continuation: Option<String>,
 }
 
 impl MaintenanceRegistry {
@@ -67,21 +65,15 @@ impl MaintenanceRegistry {
         &self,
         id: MaintenanceJobId,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
     ) -> Result<MaintenanceRunReport> {
         self.require(id)?
-            .run(namespace_id, continuation, &MaintenanceCancellation::new())
+            .run(namespace_id, &MaintenanceCancellation::new())
             .await
     }
 
     /// Runs one assignment with a fresh cancellation token.
     pub async fn execute(&self, assignment: MaintenanceAssignment) -> Result<MaintenanceRunReport> {
-        self.run(
-            assignment.job,
-            &assignment.namespace_id,
-            assignment.continuation.as_deref(),
-        )
-        .await
+        self.run(assignment.job, &assignment.namespace_id).await
     }
 
     fn require(&self, id: MaintenanceJobId) -> Result<Arc<dyn MaintenanceJob>> {

--- a/crates/loonfs/src/maintenance/runner.rs
+++ b/crates/loonfs/src/maintenance/runner.rs
@@ -752,14 +752,10 @@ async fn run_step(inner: &Arc<RunnerInner>, dispatch: &MaintenanceDispatch) -> S
             MaintenanceConclusion::NotEnabled,
         ));
     };
-    let continuation = dispatch.continuation.as_deref();
     let queued_ms = dispatch.queue_wait_ms;
     let started = tokio::time::Instant::now();
     let invocation = InvocationCancellation::new(inner, key);
-    match job
-        .run(&key.namespace_id, continuation, &invocation.cancellation)
-        .await
-    {
+    match job.run(&key.namespace_id, &invocation.cancellation).await {
         Ok(result) => {
             let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
             inner
@@ -769,8 +765,6 @@ async fn run_step(inner: &Arc<RunnerInner>, dispatch: &MaintenanceDispatch) -> S
                 job = %key.job,
                 namespace_id = %key.namespace_id,
                 conclusion = result.conclusion.as_str(),
-                resumed = continuation.is_some(),
-                continues = result.continuation.is_some(),
                 not_before_ms = ?result.not_before_ms,
                 // The two halves of what a step cost: how long it waited
                 // for a permit, and how long it then took.

--- a/crates/loonfs/src/maintenance/tests.rs
+++ b/crates/loonfs/src/maintenance/tests.rs
@@ -54,8 +54,6 @@ impl MaintenanceClock for ManualClock {
 #[derive(Debug, Clone)]
 enum ScriptedStep {
     Conclude(MaintenanceConclusion),
-    /// Conclude, and tell the runner where this step stopped.
-    Continue(MaintenanceConclusion, Option<String>),
     /// Conclude, and tell the runner when what this step left behind
     /// becomes eligible — what a collection pass reports for what it
     /// retained.
@@ -111,8 +109,6 @@ struct TestJob {
     trailing_answer: ScriptedStep,
     probe_answer: StdMutex<MaintenanceProbe>,
     steps: StdMutex<Vec<NamespaceId>>,
-    /// The continuation each step was handed, in order.
-    resumed_from: StdMutex<Vec<Option<String>>>,
     probes: StdMutex<Vec<NamespaceId>>,
     gate: Option<Gate>,
 }
@@ -124,7 +120,6 @@ impl TestJob {
             trailing_answer,
             probe_answer: StdMutex::new(MaintenanceProbe::Idle),
             steps: StdMutex::new(Vec::new()),
-            resumed_from: StdMutex::new(Vec::new()),
             probes: StdMutex::new(Vec::new()),
             gate: None,
         })
@@ -149,7 +144,6 @@ impl TestJob {
             trailing_answer: trailing,
             probe_answer: StdMutex::new(MaintenanceProbe::Idle),
             steps: StdMutex::new(Vec::new()),
-            resumed_from: StdMutex::new(Vec::new()),
             probes: StdMutex::new(Vec::new()),
             gate: None,
         };
@@ -167,11 +161,6 @@ impl TestJob {
 
     fn stepped(&self) -> Vec<String> {
         names(&self.steps)
-    }
-
-    /// What the runner handed each step, in order.
-    fn resumed_from(&self) -> Vec<Option<String>> {
-        self.resumed_from.lock().expect("resumed from").clone()
     }
 
     fn probed(&self) -> Vec<String> {
@@ -196,17 +185,12 @@ impl MaintenanceJob for TestJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         if let Some(gate) = &self.gate {
             gate.enter().await;
         }
         self.steps.lock().expect("steps").push(namespace_id.clone());
-        self.resumed_from
-            .lock()
-            .expect("resumed from")
-            .push(continuation.map(str::to_owned));
         let answer = self
             .answers
             .lock()
@@ -215,15 +199,8 @@ impl MaintenanceJob for TestJob {
             .unwrap_or_else(|| self.trailing_answer.clone());
         match answer {
             ScriptedStep::Conclude(conclusion) => Ok(MaintenanceRunReport::concluded(conclusion)),
-            ScriptedStep::Continue(conclusion, continuation) => Ok(MaintenanceRunReport {
-                conclusion,
-                continuation,
-                not_before_ms: None,
-                follow_up: None,
-            }),
             ScriptedStep::Due(conclusion, not_before_ms) => Ok(MaintenanceRunReport {
                 conclusion,
-                continuation: None,
                 not_before_ms: Some(not_before_ms),
                 follow_up: None,
             }),
@@ -280,7 +257,6 @@ impl MaintenanceJob for SubscribingJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.steps.lock().expect("steps").push(namespace_id.clone());
@@ -373,66 +349,22 @@ async fn progressed_requeues_immediately_and_stays_fair_at_the_cap() {
 }
 
 #[tokio::test]
-async fn a_progressing_job_resumes_from_where_its_last_step_stopped() {
-    let job = TestJob::scripted(
-        [
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-1".to_owned())),
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-2".to_owned())),
-        ],
-        ScriptedStep::Conclude(MaintenanceConclusion::Idle),
-    );
-    let runner = enabled_runner(job.clone());
-    let namespace_id = namespace_id("paged");
-
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the pass settles");
-
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-1".to_owned()), Some("page-2".to_owned())],
-        "a fresh pass, then each step resuming from the one before it"
-    );
-
-    // The idle step that ended the pass spent the position, so the next
-    // nudge starts over rather than resuming a finished walk.
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the fresh pass settles");
-    assert_eq!(
-        job.resumed_from().last().expect("a fourth step ran"),
-        &None,
-        "an idle conclusion clears the continuation"
-    );
-}
-
-#[tokio::test]
-async fn a_blocked_job_resumes_from_where_it_parked() {
-    let job = TestJob::scripted(
-        [ScriptedStep::Continue(
-            MaintenanceConclusion::Blocked,
-            Some("page-7".to_owned()),
-        )],
-        ScriptedStep::Conclude(MaintenanceConclusion::Idle),
-    );
+async fn a_blocked_job_parks() {
+    let job = TestJob::answering(ScriptedStep::Conclude(MaintenanceConclusion::Blocked));
     let runner = enabled_runner(job.clone());
     let namespace_id = namespace_id("parked");
 
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("the blocked step settles");
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the retry settles");
 
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-7".to_owned())],
-        "a retry with room to work resumes where the blocked step stopped"
-    );
+    assert_eq!(job.stepped(), vec!["parked".to_owned()]);
 }
 
 #[tokio::test]
-async fn a_not_enabled_conclusion_drops_the_continuation() {
+async fn a_not_enabled_conclusion_evicts_the_key() {
     let job = TestJob::scripted(
         [
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-1".to_owned())),
+            ScriptedStep::Conclude(MaintenanceConclusion::Progressed),
             ScriptedStep::Conclude(MaintenanceConclusion::NotEnabled),
         ],
         ScriptedStep::Conclude(MaintenanceConclusion::Idle),
@@ -442,14 +374,13 @@ async fn a_not_enabled_conclusion_drops_the_continuation() {
 
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("both steps settle");
+    assert_eq!(job.stepped().len(), 2);
+    runner.reconcile_now().await;
+    assert!(job.probed().is_empty());
+
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("the re-admitted step settles");
-
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-1".to_owned()), None],
-        "a key re-admitted after eviction starts a fresh pass"
-    );
+    assert_eq!(job.stepped().len(), 3);
 }
 
 #[tokio::test]
@@ -829,7 +760,6 @@ impl MaintenanceJob for BlockingJob {
     async fn run(
         &self,
         _namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.runs.fetch_add(1, Ordering::SeqCst);
@@ -842,7 +772,6 @@ impl MaintenanceJob for BlockingJob {
             .forget();
         Ok(MaintenanceRunReport {
             conclusion: MaintenanceConclusion::Blocked,
-            continuation: None,
             not_before_ms: None,
             follow_up: self.follow_up.map(|job| (job, _namespace_id.clone())),
         })

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -701,7 +701,7 @@ async fn a_cold_metadata_job_probes_with_its_configured_options() {
     );
     for _ in 0..16 {
         immediate
-            .run(&namespace, None, &MaintenanceCancellation::new())
+            .run(&namespace, &MaintenanceCancellation::new())
             .await
             .expect("run configured maintenance");
         if immediate

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -209,7 +209,7 @@ fn a_collection_step_reports_what_the_pass_retained() {
             .register(Arc::new(GarbageCollectionJob::new(fs.maintenance.clone())))
             .expect("garbage collection job");
         registry
-            .run(MaintenanceJobId::GC, &namespace_id, None)
+            .run(MaintenanceJobId::GC, &namespace_id)
             .await
             .expect("run one collection pass");
         recorder.snapshot()

--- a/crates/loonfs/tests/it/namespace_advance_observer.rs
+++ b/crates/loonfs/tests/it/namespace_advance_observer.rs
@@ -92,7 +92,6 @@ impl MaintenanceJob for SubscribingJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.steps

--- a/crates/loonfs/tests/it/standalone_maintenance.rs
+++ b/crates/loonfs/tests/it/standalone_maintenance.rs
@@ -66,7 +66,6 @@ async fn a_registry_runs_every_core_job_without_a_writer() {
             .execute(MaintenanceAssignment {
                 namespace_id: namespace_id.clone(),
                 job,
-                continuation: None,
             })
             .await;
         assert!(result.is_ok(), "{job} failed: {:?}", result.err());


### PR DESCRIPTION
Garbage collection used to be resumable, and the maintenance runner carried an opaque continuation from one step to the next. Collection has been one complete pass per call since #914, and no job produces a continuation any more: every job ignored the parameter and returned none, the runner logged two fields that were always false, and the CLI's drain loop re-fed a value that was always empty. This PR deletes the whole path, from the `MaintenanceJob` trait through the registry, admission, the runner, every job, and the CLI, along with the tests that existed only to exercise resumption.

It also deletes three error variants nothing constructs, two for the hint-etag revalidation that no longer exists and one for a manifest ahead of a head that no longer exists, an unreferenced limit constant from the same era, an unused parameter on checkpoint release, and an entry in the server's wire-name allowlist that protected nothing.

Important callouts:

- `MaintenanceRunReport` and `MaintenanceJob::run` lose their continuation field and parameter. That is a Rust API change for embedders who implement a job; nothing on the wire changes.
- `ControlObjectLoadError::RootAheadOfHead` derived `Serialize`, so its removal also drops a dead wire shape that no path could produce.
- No behavior changes. Every remaining test on the maintenance runner still pins parking, eviction, and settlement.
