### PR TITLE
docs: correct the statements the format migration made false

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ Visit [loonfs.com/docs](https://loonfs.com/docs) to learn more.
 
 LoonFS is designed with a core set of foundational ideas.
 
-- **Object storage is the only required durable substrate.** LoonFS stores durable truth in object storage: file content, immutable metadata history, materialized manifests/checkpoints, and a small number of mutable control objects. Caches, queues, workers, and local state are safely rebuildable from the object store.
+- **Object storage is the only required durable substrate.** LoonFS stores immutable file content, manifests, numbered WAL objects, and metadata segments in object storage. Pins retain immutable manifests until released; snapshot expiry can be extended. Caches, queues, workers, and local state are rebuildable from the object store.
 
 - **A namespace is an independently addressable filesystem with its own history.** Forks share content and metadata under durable pins, so a namespace's storage is not confined to its own prefix.
 
 - **Inodes are identity, paths are views.** The identity of a filesystem item is `(namespace_id, inode_id)`. Paths are "views" that point to inodes, and may change over time without changing the item’s identity.
 
-- **Commits are the unit of transactional change.** File bytes are written to object storage before metadata can reference them. Metadata changes are recorded as logical commits, and a commit becomes visible only when the namespace head durably records it.
+- **Commits are the unit of transactional change.** File bytes are written to object storage before metadata can reference them. Metadata changes are recorded as logical commits, and a commit becomes visible when put-if-absent creates its numbered WAL object.
 
-- **The head decides visibility; retained metadata, the WAL, and checkpoint records are recovery state, not caches.** Local caches and rebuildable indexes are separate, and nothing creates a second commit history.
+- **Numbered manifests and WAL objects are authoritative.** The current manifest records namespace identity, status, and writer authority. Later WAL objects record committed changes. `hint.json` is advisory and starts discovery of those numbered objects.
 
 ## Design philosophy
 
@@ -78,6 +78,6 @@ LoonFS is built around a correctness-first protocol where the object store is th
 
 - **Correctness is the primary feature.** LoonFS favors designs with fewer valid states, explicit invariants, named failure modes, and deterministic tests. 
 
-- **Durability and visibility are separate.** LoonFS may durably store file content and metadata before a change appears in the filesystem. Changes are acknowledged only once the namespace head advances to include its commit.
+- **Durability and visibility are separate.** LoonFS may durably store file content and metadata before a change appears in the filesystem. Changes are acknowledged after their numbered WAL object is created.
 
 - **Serialize commits, scale everything else.** Every change is executed through a transactional core with an ordered WAL. LoonFS keeps expensive work (uploading and downloading, compaction, garbage collection, indexing) off the write path so it can scale independently.

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -681,11 +681,7 @@ string_id! {
 }
 
 string_id! {
-    /// Durable id for one streaming metadata compaction job.
-    ///
-    /// The job's staged output and its lease live under one prefix named by
-    /// this id, so a collector can tell one job's output from another's
-    /// without reading anything.
+    /// Identifies one streaming metadata compaction job for log correlation only.
     MetadataCompactionId,
     prefix = "cmp"
 }

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -190,7 +190,7 @@ pub struct NamespaceDiagnostics {
     pub head_seq: ChangeSeq,
     /// Oldest sequence still promised for incremental replay.
     pub retention_floor_seq: ChangeSeq,
-    /// Current manifest pointer recorded by the head.
+    /// The namespace's current manifest number.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(nullable = false))]
     pub current_manifest_no: Option<ManifestNo>,
@@ -882,15 +882,15 @@ pub struct ReleaseSnapshotResponse {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum FlushWalOutcome {
-    /// The root already covered the head; nothing was published.
+    /// The current manifest already covered the WAL tail; nothing was published.
     AlreadyCurrent,
-    /// This call published a new manifest and advanced the root to it.
+    /// This call published the next current manifest.
     Published,
-    /// Another publisher updated the root before this call could reference its manifest.
+    /// Another publisher changed the current manifest before this call could publish.
     RootAdvanced,
 }
 
-/// The metadata root state after one WAL flush.
+/// The current manifest state after one WAL flush.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FlushWalResponse {
@@ -1202,16 +1202,16 @@ pub struct MetadataCompactionRequest {}
 pub enum WalFlushStepOutcome {
     /// The tail was below the threshold, so there was nothing to flush.
     NotNeeded,
-    /// The step flushed the WAL tail and advanced the metadata root.
+    /// The step flushed the WAL tail and published the next current manifest.
     Flushed {
         /// Sequence covered by the published manifest.
         manifest_head_seq: ChangeSeq,
     },
-    /// The step did not update a root that already referenced another manifest.
+    /// The current manifest already covered the captured WAL tail; this step published no manifest.
     AlreadyPublished {
         /// Sequence this step attempted to flush through.
         attempted_seq: ChangeSeq,
-        /// Manifest the root currently references.
+        /// The namespace's current manifest number.
         current_manifest_no: ManifestNo,
     },
     /// Concurrent updates prevented every publication attempt.
@@ -1232,7 +1232,7 @@ pub enum ReorganizeStepOutcome {
     UnitPublished,
     /// A family group needs a streaming compaction. Run the `metadata_compaction` job.
     CompactionRequired,
-    /// Another publisher updated the metadata root before this step could reference its manifest.
+    /// Another publisher changed the current manifest before this step could publish.
     RootAdvanced,
 }
 

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -178,7 +178,7 @@ Snapshot management
     Keep a snapshot available for longer
 
   loonfs snapshot release <namespace> <snapshot-id>
-    Release a snapshot. Repeating the command succeeds.
+    Release a snapshot. Repeating the command returns snapshot_not_found.
 
 Pagination
   ls, grep, revisions, trash, changes, snapshot list, and maintenance checkpoint
@@ -341,8 +341,9 @@ Maintenance
     below the flushed manifest head but does not remove file revisions.
 
   loonfs maintenance gc [--grace-window-ms <ms>]
-    Run one complete pass and print its report. Each call reads current roots,
-    lists every family from the beginning, and sweeps it to the end.
+    Run one complete pass and print its report. Each call reads the current
+    manifest and hint, lists every family from the beginning, and sweeps it
+    to the end.
     --grace-window-ms protects objects younger than the window.
     --json includes every retention reason.
     Repeated GC runs reclaim a deleted namespace's own content once it retires,
@@ -379,8 +380,8 @@ Maintenance
 
   loonfs maintenance index gc
     Complete one collection pass over the namespace's gram-index objects.
-    Read durable roots before deletion. Reap aged index objects for an absent
-    or deleted namespace.
+    Read the current manifest and hint before deletion. Reap aged index
+    objects for an absent or deleted namespace.
 
 Profile create options
   Used by:

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -793,7 +793,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Releases a user-owned checkpoint pin by id. Idempotent.
+    /// Deletes a user-owned checkpoint pin. A missing id returns `checkpoint_not_found`.
     pub(crate) async fn release_checkpoint(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -325,7 +325,7 @@ impl EmbeddedBackend {
             },
             || async {
                 let conclusion = job
-                    .run(namespace_id, None, &MaintenanceCancellation::new())
+                    .run(namespace_id, &MaintenanceCancellation::new())
                     .await
                     .scoped(namespace_id)?
                     .conclusion;
@@ -395,7 +395,7 @@ impl EmbeddedBackend {
     /// a budget to spend and per-key progress to report, and admission
     /// offers neither. It shuts the runner down first so a second scheduler
     /// cannot race these steps, then closes the writer and walks the
-    /// assignment. Each key's continuation passes from one run to the next.
+    /// assignment.
     pub(super) async fn drain_maintenance(
         &self,
         namespaces: &[NamespaceId],
@@ -417,21 +417,18 @@ impl EmbeddedBackend {
                     steps: 0,
                     conclusion: None,
                 };
-                let mut continuation = None;
                 while !budget.spent(steps, timer.monotonic_now_ms().saturating_sub(started_ms)) {
                     let result = self
                         .jobs
                         .execute(MaintenanceAssignment {
                             namespace_id: namespace_id.clone(),
                             job: *job,
-                            continuation,
                         })
                         .await
                         .scoped(namespace_id)?;
                     steps += 1;
                     key.steps += 1;
                     key.conclusion = Some(result.conclusion);
-                    continuation = result.continuation;
                     if key.settled() {
                         break;
                     }

--- a/crates/loonfs-client/src/maintenance.rs
+++ b/crates/loonfs-client/src/maintenance.rs
@@ -153,10 +153,8 @@ impl Client {
             .await
     }
 
-    /// Runs one explicit grep index garbage-collection pass for a namespace.
+    /// Runs one complete grep index garbage-collection pass for a namespace.
     ///
-    /// `max_objects` bounds the reads the pass spends; when keys remain the
-    /// response carries a `next_cursor` to resume from.
     /// Retrying this request starts a distinct attempt.
     pub async fn gc_grep_index(
         &self,

--- a/crates/loonfs-conformance/README.md
+++ b/crates/loonfs-conformance/README.md
@@ -4,7 +4,7 @@ This private crate contains shared JSON test cases and a Rust test harness.
 
 ## Cases
 
-The ten cases cover:
+The thirteen cases cover:
 
 - standard API errors
 - repeated commit requests
@@ -13,6 +13,9 @@ The ten cases cover:
 - repeated upload aborts
 - direct downloads
 - cursor pagination and resumption
+- directory children by inode (`children_by_inode`)
+- mutations by inode (`inode_mutations`)
+- snapshot creation, reads, extension, and release (`snapshots`)
 - change feed identity fields
 - an end-to-end filesystem workflow
 - namespace-alias-scoped requests through a proxy

--- a/crates/loonfs-core/src/checkpoint/release.rs
+++ b/crates/loonfs-core/src/checkpoint/release.rs
@@ -4,7 +4,6 @@
 //! through this operation.
 
 use super::record::{load_checkpoint_record, release_checkpoint_record};
-use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
 use loonfs_api::wire::control::CheckpointOwner;
 use loonfs_api::{CheckpointId, NamespaceId, ReleaseCheckpointResponse};
@@ -90,7 +89,6 @@ pub(crate) async fn release_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     checkpoint_id: &CheckpointId,
-    _context: &MutationContext,
 ) -> Result<ReleaseCheckpointResponse> {
     release_owned_checkpoint(
         store,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -545,7 +545,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
             }
             ManifestPublicationOutcome::CoveredByCurrent(_) => "covered_by_current",
             ManifestPublicationOutcome::PredecessorChanged(_) => "predecessor_changed",
-            ManifestPublicationOutcome::Installable => "root_cas_race",
+            ManifestPublicationOutcome::Installable => "manifest_number_taken",
         };
         tracing::debug!(
             namespace_id = namespace_id.as_str(),

--- a/crates/loonfs-core/src/checkpoint/tests/inventory.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inventory.rs
@@ -94,7 +94,7 @@ async fn two_pins_under_one_label_list_as_two_records() {
 
     // Release is what takes a record out of the answer, and it takes out
     // exactly the one named.
-    super::super::release::release_checkpoint(&store, &namespace_id, &first, &context)
+    super::super::release::release_checkpoint(&store, &namespace_id, &first)
         .await
         .expect("release checkpoint");
     let after_release = list_all_checkpoints(&store, &namespace_id)
@@ -224,7 +224,7 @@ async fn released_pins_are_absent_from_later_pages() {
     }
     ids.sort();
     for checkpoint_id in &ids[1..6] {
-        super::super::release::release_checkpoint(&store, &namespace_id, checkpoint_id, &context)
+        super::super::release::release_checkpoint(&store, &namespace_id, checkpoint_id)
             .await
             .expect("release checkpoint in filtered run");
     }

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -523,12 +523,8 @@ async fn release_is_terminal_and_the_next_pin_is_a_different_record() {
             .is_empty()
     );
 
-    let release = crate::checkpoint::release_checkpoint(
-        &store,
-        &namespace_id,
-        &first.checkpoint_id,
-        &context,
-    );
+    let release =
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &first.checkpoint_id);
     let recreate = create_checkpoint(&store, &namespace_id, &context);
     let (release, second) = tokio::join!(release, recreate);
     assert_eq!(release.expect("release").checkpoint_id, first.checkpoint_id);
@@ -556,15 +552,10 @@ async fn release_is_terminal_and_the_next_pin_is_a_different_record() {
     );
 
     assert_eq!(
-        crate::checkpoint::release_checkpoint(
-            &store,
-            &namespace_id,
-            &first.checkpoint_id,
-            &context
-        )
-        .await
-        .expect_err("second release")
-        .code(),
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &first.checkpoint_id)
+            .await
+            .expect_err("second release")
+            .code(),
         ErrorCode::CheckpointNotFound
     );
 }
@@ -749,7 +740,7 @@ async fn a_pin_without_a_ttl_is_held_until_it_is_released() {
             .is_empty()
     );
 
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id, &distant)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id)
         .await
         .expect("release");
     let error = read_checkpoint_files(&store, &namespace_id, &pin.checkpoint_id)
@@ -2459,7 +2450,7 @@ async fn a_floor_past_a_pin_keeps_its_manifest_and_runs_readable_until_release()
         .await
         .expect("pinned manifest")
         .is_some());
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id, &aged)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id)
         .await
         .expect("release pin");
     crate::gc::gc_namespace(

--- a/crates/loonfs-core/src/control_object/error.rs
+++ b/crates/loonfs-core/src/control_object/error.rs
@@ -10,13 +10,6 @@ pub enum ControlObjectLoadError {
     #[error("missing control object `{object_key}`")]
     MissingObject { object_key: String },
     #[error(
-        "metadata root references seq `{root_manifest_head_seq}` beyond the reloaded head seq `{head_seq}`"
-    )]
-    RootAheadOfHead {
-        root_manifest_head_seq: loonfs_api::ChangeSeq,
-        head_seq: loonfs_api::ChangeSeq,
-    },
-    #[error(
         "control object namespace mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
     )]
     NamespaceMismatch {
@@ -70,7 +63,6 @@ impl ControlObjectLoadError {
 
         match self {
             Self::MissingObject { .. } => ErrorCode::NamespaceNotFound,
-            Self::RootAheadOfHead { .. } => ErrorCode::StaleHead,
             Self::NamespaceMismatch { .. }
             | Self::IdentityMismatch { .. }
             | Self::ForkBasisOwnerIsSelf { .. }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -887,13 +887,7 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
         &self,
         checkpoint_id: &CheckpointId,
     ) -> Result<ReleaseCheckpointResponse> {
-        crate::checkpoint::release_checkpoint(
-            &self.store,
-            &self.namespace_id,
-            checkpoint_id,
-            &self.mutation_context()?,
-        )
-        .await
+        crate::checkpoint::release_checkpoint(&self.store, &self.namespace_id, checkpoint_id).await
     }
 
     /// Extends a live snapshot without passing its lifetime ceiling.

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -162,7 +162,7 @@ pub enum CoreError {
     },
     #[error(
         "namespace `{namespace_id}` already has its limit of {max_live} live snapshots; \
-         release one or wait for a lease to expire"
+         release one or wait for a snapshot to expire"
     )]
     SnapshotQuotaExceeded {
         namespace_id: loonfs_api::NamespaceId,
@@ -170,7 +170,7 @@ pub enum CoreError {
     },
     #[error(
         "metadata publication budget exceeded after {elapsed_ms}ms (budget {budget_ms}ms); \
-         the root was not published"
+         the manifest was not published"
     )]
     MetadataPublicationBudgetExceeded { elapsed_ms: u64, budget_ms: u64 },
     #[error("invalid gc configuration: {0}")]

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -284,18 +284,8 @@ impl MetadataViewError {
 pub enum MetadataProjectionLoadError {
     #[error(transparent)]
     LoadHead(#[from] ControlObjectLoadError),
-    #[error("missing head etag for `{object_key}`")]
-    MissingHeadEtag { object_key: String },
     #[error("namespace `{namespace_id}` is deleted")]
     NamespaceDeleted { namespace_id: NamespaceId },
-    #[error(
-        "namespace head changed during metadata projection load for `{object_key}`: loaded `{loaded_head_etag}`, current `{current_head_etag}`"
-    )]
-    HeadChangedDuringLoad {
-        object_key: String,
-        loaded_head_etag: String,
-        current_head_etag: String,
-    },
     #[error(transparent)]
     WalChainLoad(#[from] WalChainLoadError),
     #[error(transparent)]
@@ -322,8 +312,6 @@ impl MetadataProjectionLoadError {
                 crate::checkpoint::ManifestLoadFailureClass::Corrupt => ErrorCode::NamespaceCorrupt,
                 crate::checkpoint::ManifestLoadFailureClass::Store => ErrorCode::ServerError,
             },
-            Self::MissingHeadEtag { .. } => ErrorCode::ServerError,
-            Self::HeadChangedDuringLoad { .. } => ErrorCode::StaleHead,
         }
     }
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1510,7 +1510,7 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
         .await
         .expect("advance past the shared basis");
 
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &second.checkpoint_id, &setup)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &second.checkpoint_id)
         .await
         .expect("release one owner");
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
@@ -1560,7 +1560,7 @@ async fn fork_owned_checkpoints_reject_user_release() {
 
     let fork_record = read_fork_record(&store, &source).await;
 
-    let error = crate::checkpoint::release_checkpoint(&store, &source, &fork_record.pin_id, &setup)
+    let error = crate::checkpoint::release_checkpoint(&store, &source, &fork_record.pin_id)
         .await
         .expect_err("fork-owned release must fail");
     assert!(
@@ -1595,14 +1595,10 @@ async fn snapshot_owned_checkpoints_reject_user_release() {
     .await
     .expect("snapshot checkpoint");
 
-    let error = crate::checkpoint::release_checkpoint(
-        &store,
-        &namespace_id,
-        &snapshot.checkpoint_id,
-        &setup,
-    )
-    .await
-    .expect_err("snapshot-owned release must fail");
+    let error =
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &snapshot.checkpoint_id)
+            .await
+            .expect_err("snapshot-owned release must fail");
     assert!(
         matches!(
             &error,

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -38,9 +38,6 @@ pub const MAX_COMMIT_MESSAGE_BYTES: usize = 4096;
 /// Maximum attempts for a bounded compare-and-swap or allocation contention loop.
 pub const CONTENTION_RETRY_LIMIT: usize = 8;
 
-/// Maximum targeted rereads while reconciling one namespace control snapshot.
-pub const CONTROL_SNAPSHOT_REREAD_LIMIT: usize = 3;
-
 /// Longest visible WAL tail, in segments, a namespace may carry unflushed.
 /// Every publish surface rejects at this length with `maintenance_required`,
 /// so a landed publication never leaves more than this behind.

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -1,7 +1,6 @@
-//! Structural acceptance tests for the namespace layout redesign (format
-//! spec, "Final design summary"): live visibility comes only from the WAL
-//! head, nothing correct depends on listing, and maintenance never touches
-//! the head.
+//! Namespace layout acceptance tests: numbered WAL objects make commits visible,
+//! readers discover state without listing, and maintenance publishes manifests
+//! without advancing the head sequence.
 
 use crate::common::{mutation_context, namespace_engine, read_context};
 use bytes::Bytes;

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -24,8 +24,8 @@ and core garbage collection.
 The `grep_gc` job completes one collection pass per call.
 `loonfs maintenance index gc` runs a pass directly for one namespace,
 including an absent or deleted namespace whose old index data remains.
-Every pass reads durable roots before deletion. Manifests use contiguous
-numbers and put-if-absent publication. `hint.json` starts forward discovery
+Every pass reads the current manifest and hint before deletion. Manifests use
+contiguous numbers and put-if-absent publication. `hint.json` starts forward discovery
 and may lag. Queries validate a cached manifest with one HEAD of its
 successor. The durable layout and collection rules are in
 [grep format](../../docs/specs/format.md#appendix-d-grep-extension-format).
@@ -38,12 +38,8 @@ these values from its `[grep]` table:
 mode = "serve_and_maintain"
 max_files_per_step = 256
 max_content_bytes_per_step = 67108864
-max_rows_per_segment = 65536
-max_delta_runs = 8
-max_mid_runs = 8
-max_decoded_input_rows_per_step = 131072
 ```
 
-Every step budget must be greater than zero. These values do not control
+Both input limits must be greater than zero. These values do not control
 concurrency. The runtime's shared `max_concurrent_maintenance` limit applies
 across all maintenance jobs, including grep.

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -41,9 +41,9 @@ pub enum GrepError {
         message: String,
     },
     /// A grep manifest publication lost to another publisher.
-    #[error("grep root publication conflict for `{object_key}`; retry")]
+    #[error("grep manifest publication conflict for `{object_key}`; retry")]
     PublicationConflict {
-        /// Manifest number whose publication raced.
+        /// Object key whose manifest publication raced.
         object_key: String,
     },
     /// A genuine runtime failure encountered while grep read or wrote

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -61,7 +61,6 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let build = match self.worker.build_step(namespace_id, self.policy).await {
@@ -152,7 +151,6 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepGcJo
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.worker

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -128,7 +128,7 @@ impl GrepHost {
                 return Ok(lifecycle);
             }
             match job
-                .run(namespace_id, None, &loonfs::MaintenanceCancellation::new())
+                .run(namespace_id, &loonfs::MaintenanceCancellation::new())
                 .await
                 .map_err(GrepError::Runtime)?
                 .conclusion

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -86,7 +86,7 @@ async fn a_tombstoned_namespace_concludes_not_enabled() {
 
     let job = job(&worker);
     assert_eq!(
-        job.run(&namespace_id, None, &MaintenanceCancellation::new())
+        job.run(&namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("step tombstone")
             .conclusion,
@@ -115,7 +115,7 @@ async fn a_disabled_root_concludes_not_enabled_on_the_next_step() {
 
     worker.disable(&namespace_id).await.expect("disable grep");
     assert_eq!(
-        job.run(&namespace_id, None, &MaintenanceCancellation::new())
+        job.run(&namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("step disabled root")
             .conclusion,
@@ -239,7 +239,7 @@ async fn catch_up<S: ObjectStore + Clone + Send + Sync + 'static>(
 ) {
     for _ in 0..64 {
         match job
-            .run(namespace_id, None, &MaintenanceCancellation::new())
+            .run(namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("grep step")
             .conclusion

--- a/crates/loonfs-server/docs/actor-attribution.md
+++ b/crates/loonfs-server/docs/actor-attribution.md
@@ -5,8 +5,7 @@ Every mutation includes an `actor_id`, such as `"usr_8f3c"`.
 Your backend authenticates and authorizes the request. LoonFS records the
 `actor_id` exactly as sent; it does not verify or manage identities. Use
 a stable internal ID, not an email address or display name.
-LoonFS does not parse the id. An application that used to rely on the kind
-to tell two identities apart must give them different ids.
+LoonFS does not parse the id.
 
 Use `committed_by` to identify the actor for each commit. Do not infer the actor
 from a commit message or error message.

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -305,9 +305,8 @@ indexing step; their defaults are 256 files and 64 MiB, and both must be positiv
 Indexing shares `max_concurrent_maintenance` with other maintenance work.
 
 Segment sizes, merge thresholds, and reorganization step sizes use engine
-defaults, like metadata compaction. The former `max_rows_per_segment`,
-`max_delta_runs`, `max_mid_runs`, and `max_decoded_input_rows_per_step` settings
-are rejected; remove them from existing pre-release configurations.
+defaults, like metadata compaction. The accepted input limits are
+`max_files_per_step` and `max_content_bytes_per_step`.
 
 ## Resource sizing
 

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -774,7 +774,7 @@ fn decode_checkpoint_cursor(
         path = "/v0/maintenance/namespaces/{namespace_id}/runs",
         tag = "maintenance",
         summary = "Run one maintenance job",
-        description = "Runs one maintenance job for the namespace. The body names the job with `kind`: `metadata`, `metadata_compaction`, `gc`, or `retention`. The response carries the same `kind` and that job's result. A deleted namespace accepts only `gc`. A `gc` call reads current roots, then sweeps every family to the end. Each listing starts at the beginning. The call keeps no continuation.",
+        description = "Runs one maintenance job for the namespace. The body names the job with `kind`: `metadata`, `metadata_compaction`, `gc`, or `retention`. The response carries the same `kind` and that job's result. A deleted namespace accepts only `gc`. A `gc` call reads the current manifest and lists pins, then sweeps every family to the end. Each listing starts at the beginning. The call keeps no continuation.",
         params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body(content = RunMaintenanceRequest, description = "The maintenance job to run"),
         responses(

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -302,7 +302,7 @@ pub(super) async fn disable_grep_index(
         request_body(content = ref("#/components/schemas/GrepGcRequest")),
         responses(
             (status = 200, description = "Namespace grep garbage collection completed", body = GrepGcResponse),
-            (status = 400, description = "Invalid budget or cursor", body = ApiError),
+            (status = 400, description = "Invalid namespace id or options", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -151,7 +151,6 @@ pub fn openapi_document() -> utoipa::openapi::OpenApi {
         loonfs_api::AttributeValue,
         loonfs_api::Attributes,
         loonfs_api::AttributeRevisionNo,
-        loonfs_api::InodeKind,
         loonfs_api::PathEntry,
         loonfs_api::PathEntryKind,
         loonfs_api::AttributesProjection,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -447,7 +447,7 @@ use tempfile::tempdir;
 
 const POISON_PROVIDER_DETAIL: &str = "<Error>AccessDenied</Error> \
     arn:aws:iam::123456789012:role/private-role private-bucket \
-    namespaces/customer-a/head.json x-amz-request-id=provider-request \
+    namespaces/customer-a/hint.json x-amz-request-id=provider-request \
     x-amz-id-2=provider-host-id AKIAEXAMPLE";
 
 fn assert_provider_markers_absent(rendered: &str) {
@@ -455,7 +455,7 @@ fn assert_provider_markers_absent(rendered: &str) {
         "<Error>AccessDenied</Error>",
         "arn:aws:iam::123456789012:role/private-role",
         "private-bucket",
-        "namespaces/customer-a/head.json",
+        "namespaces/customer-a/hint.json",
         "x-amz-request-id=provider-request",
         "x-amz-id-2=provider-host-id",
         "AKIAEXAMPLE",
@@ -538,7 +538,7 @@ async fn provider_failure_is_projected_in_the_presign_api_envelope() {
     let response = super::REQUEST_ID
         .scope("req_presign_hygiene".to_owned(), async {
             super::handlers_uploads::presign_issuer_error(PoisonProviderStore::denied(
-                "namespaces/customer-a/head.json",
+                "namespaces/customer-a/hint.json",
             ))
             .into_response()
         })

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -117,7 +117,6 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "inode_kind",
     "maintain_only",
     "manifest_no",
-    "max_objects",
     "max_wal_tail_segments",
     "metadata_compaction",
     "metadata_segments",
@@ -1133,7 +1132,6 @@ impl MaintenanceJob for StepCountingJob {
     async fn run(
         &self,
         _namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> loonfs::Result<MaintenanceRunReport> {
         self.steps.fetch_add(1, Ordering::SeqCst);

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -1362,6 +1362,13 @@ fn openapi_documents_string_id_contracts_without_dead_schemas() {
         .and_then(|components| components.get("schemas"))
         .and_then(Value::as_object)
         .expect("openapi schemas object");
+    let referenced = referenced_components(&spec);
+    for name in schemas.keys() {
+        assert!(
+            referenced.contains(&("schemas".to_owned(), name.clone())),
+            "OpenAPI schema `{name}` is not referenced by a path"
+        );
+    }
     let content_id = schemas.get("ContentId").expect("ContentId schema");
 
     assert_eq!(

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -86,7 +86,8 @@ pub async fn summarize_namespace_objects<S: ObjectStore + ?Sized>(
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use loonfs_api::IndexSegmentId;
+    use loonfs_api::wire::control::{encode_control_state, ControlObjectKind, HintState};
+    use loonfs_api::{IndexSegmentId, ManifestNo, WalNo};
     use loonfs_grep::keyspace::{hint_key, manifest_key, segment_key};
     use loonfs_objectstore::keys::{hint, wal_segment};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -98,9 +99,22 @@ mod tests {
         let namespace_id = NamespaceId::parse("sim").expect("valid namespace id");
 
         store
-            .put_overwrite(&hint(&namespace_id), Bytes::from_static(b"head"))
+            .put_overwrite(
+                &hint(&namespace_id),
+                Bytes::from(
+                    encode_control_state(
+                        ControlObjectKind::Hint,
+                        &HintState {
+                            namespace_id: namespace_id.clone(),
+                            manifest_no: ManifestNo(1),
+                            wal_no: WalNo(1),
+                        },
+                    )
+                    .expect("encode hint"),
+                ),
+            )
             .await
-            .expect("head");
+            .expect("hint");
         store
             .put_overwrite(
                 &wal_segment(&namespace_id, &loonfs_api::WalNo(1)),

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -465,7 +465,7 @@ impl FsMaintenance {
             }
             loonfs_core::MetadataReorganizeOutcome::Superseded => {
                 tracing::info!(
-                    "metadata root changed before reorganization published; a later step retries"
+                    "current manifest changed before reorganization published; a later step retries"
                 );
                 ReorganizeStepOutcome::RootAdvanced
             }

--- a/crates/loonfs/src/maintenance/admission.rs
+++ b/crates/loonfs/src/maintenance/admission.rs
@@ -1,8 +1,8 @@
 //! Synchronous scheduling state for maintenance jobs.
 //!
 //! The runner's lock protects admission, coalescing, fairness, backoff,
-//! deadlines, continuations, and shutdown. The parent module handles async
-//! execution, permits, and timers.
+//! deadlines, and shutdown. The parent module handles async execution,
+//! permits, and timers.
 
 use super::runner::MaintenanceClock;
 use super::{MaintenanceConclusion, MaintenanceJobId, MaintenanceRunReport};
@@ -50,9 +50,6 @@ impl MaintenanceKey {
 pub(crate) struct MaintenanceDispatch {
     /// The key this permit is running.
     pub(crate) key: MaintenanceKey,
-    /// Where this key's job said its last step stopped, opaque here and
-    /// handed straight back to the step about to run.
-    pub(crate) continuation: Option<String>,
     /// How long the claimed run waited between taking its ticket and holding
     /// a permit. Read by the step's own trace.
     pub(crate) queue_wait_ms: u64,
@@ -61,12 +58,7 @@ pub(crate) struct MaintenanceDispatch {
 /// How one step ended, from admission's point of view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StepOutcome {
-    /// The executor answered. The result decides what happens to the key:
-    /// its conclusion when to run again, its continuation where to resume,
-    /// its not-before time when a deadline it saw comes due.
     Concluded(MaintenanceRunReport),
-    /// The executor failed. The key is retried after its backoff, from
-    /// wherever its last step left it.
     Failed,
 }
 
@@ -178,11 +170,6 @@ struct KeyState {
     obligations: Option<TimedObligations>,
     /// Consecutive failed steps since the last conclusion, for the backoff.
     consecutive_failures: u32,
-    /// Opaque continuation returned by the previous step.
-    ///
-    /// Admission stores it and passes it to the next step. Losing it only
-    /// restarts the scan because each step revalidates durable state.
-    continuation: Option<String>,
 }
 
 impl KeyState {
@@ -337,15 +324,6 @@ impl Admission {
             .get(key)
             .and_then(|state| state.obligations)
             .map(|owed| owed.earliest_at_ms)
-    }
-
-    /// Where the key's job stopped last time. A claim carries this to the
-    /// step it dispatches; nothing on the running path reads it back out.
-    #[cfg(test)]
-    pub(crate) fn continuation(&self, key: &MaintenanceKey) -> Option<String> {
-        self.keys
-            .get(key)
-            .and_then(|state| state.continuation.clone())
     }
 
     /// Keys holding a ticket: work admitted and waiting for a permit.
@@ -561,9 +539,6 @@ impl Admission {
         batch
     }
 
-    /// Ends the running step: what it concluded decides the key's
-    /// continuation and whether it is queued again, and the key stops
-    /// running either way.
     fn apply(&mut self, key: &MaintenanceKey, outcome: StepOutcome, now_ms: u64) {
         let result = match outcome {
             StepOutcome::Failed => {
@@ -573,9 +548,6 @@ impl Admission {
             StepOutcome::Concluded(result) => result,
         };
         if result.conclusion == MaintenanceConclusion::NotEnabled {
-            // The job has nothing to maintain here at all. Drop the key —
-            // its continuation and its obligations included — rather than
-            // reconcile it forever.
             self.keys.remove(key);
             return;
         }
@@ -583,29 +555,12 @@ impl Admission {
         if let Some(state) = self.keys.get_mut(key) {
             state.consecutive_failures = 0;
             let concluding_run = match result.conclusion {
-                // Work happened, or the step lost a race it should simply
-                // take again: eligible immediately, behind whatever else is
-                // waiting, resuming from wherever this step stopped.
                 MaintenanceConclusion::Progressed | MaintenanceConclusion::Superseded => {
-                    state.continuation = result.continuation;
                     Some(ReadyRun::queued(ticket, now_ms))
                 }
-                // Work is left and this step's policy could not move it.
-                // Parks like `Idle` — requeueing zero-progress work would
-                // only spin — but keeps where the step stopped, so a retry
-                // with room to work resumes instead of walking the same
-                // ground again.
-                MaintenanceConclusion::Blocked => {
-                    state.continuation = result.continuation;
-                    None
-                }
-                // Nothing to do. Whatever the last pass was carrying is
-                // spent, and the next step starts a fresh one.
-                MaintenanceConclusion::Idle => {
-                    state.continuation = None;
-                    None
-                }
-                MaintenanceConclusion::NotEnabled => None,
+                MaintenanceConclusion::Blocked
+                | MaintenanceConclusion::Idle
+                | MaintenanceConclusion::NotEnabled => None,
             };
             state.settle(concluding_run);
         }
@@ -617,7 +572,6 @@ impl Admission {
         }
     }
 
-    /// Applies retry backoff without changing the job's continuation.
     fn record_failure(&mut self, key: &MaintenanceKey, now_ms: u64) {
         let ticket = self.take_ticket();
         let Some(state) = self.keys.get_mut(key) else {
@@ -654,11 +608,7 @@ impl Admission {
         let key = self.pick_eligible(now_ms)?;
         let state = self.keys.get_mut(&key)?;
         let queue_wait_ms = state.claim(now_ms)?;
-        Some(MaintenanceDispatch {
-            key,
-            continuation: state.continuation.clone(),
-            queue_wait_ms,
-        })
+        Some(MaintenanceDispatch { key, queue_wait_ms })
     }
 }
 
@@ -746,16 +696,6 @@ mod tests {
 
     fn concluded(conclusion: MaintenanceConclusion) -> StepOutcome {
         StepOutcome::Concluded(MaintenanceRunReport::concluded(conclusion))
-    }
-
-    /// A conclusion that also tells the runner where the step stopped.
-    fn continuing(conclusion: MaintenanceConclusion, continuation: &str) -> StepOutcome {
-        StepOutcome::Concluded(MaintenanceRunReport {
-            conclusion,
-            continuation: Some(continuation.to_owned()),
-            not_before_ms: None,
-            follow_up: None,
-        })
     }
 
     fn idle() -> StepOutcome {
@@ -1113,122 +1053,25 @@ mod tests {
     }
 
     #[test]
-    fn the_runner_carries_a_continuation_between_steps() {
-        let mut admission = book(1);
-        let key = gc("paged");
-
-        admission.nudge(key.clone());
-        let first = admission
-            .try_dispatch(NOW)
-            .expect("the nudged key claims the permit");
-        assert_eq!(first.key, key);
-        assert_eq!(first.continuation, None, "a first step starts a fresh pass");
-
-        let resumed = admission
-            .finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW,
-            )
-            .expect("a progressing key is eligible again");
-        assert_eq!(resumed.key, key);
-        assert_eq!(
-            resumed.continuation,
-            Some("page-1".to_owned()),
-            "and the handoff carries where this step stopped to the next one"
-        );
-
-        assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Blocked, "page-2"),
-                NOW
-            )),
-            None,
-            "a blocked key parks"
-        );
-        assert_eq!(
-            admission.continuation(&key),
-            Some("page-2".to_owned()),
-            "keeping its position, so a retry with a bigger budget resumes"
-        );
-
-        admission.nudge(key.clone());
-        let retried = admission
-            .try_dispatch(NOW)
-            .expect("a later nudge claims the permit again");
-        assert_eq!(retried.key, key);
-        assert_eq!(
-            retried.continuation,
-            Some("page-2".to_owned()),
-            "the parked position is what the resumed step is handed"
-        );
-        assert_eq!(claimed(admission.finish(&key, idle(), NOW)), None);
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "an idle pass is a finished one: the next step starts over"
-        );
-    }
-
-    #[test]
-    fn an_evicted_key_drops_its_continuation() {
+    fn an_evicted_key_can_be_admitted_again() {
         let mut admission = book(1);
         let key = gc("gone");
 
         admission.nudge(key.clone());
         assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
         assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW
-            )),
+            claimed(admission.finish(&key, concluded(MaintenanceConclusion::Progressed), NOW)),
             Some(key.clone())
         );
         assert_eq!(
             claimed(admission.finish(&key, concluded(MaintenanceConclusion::NotEnabled), NOW)),
             None
         );
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "the key's whole state went with it"
-        );
+        assert!(!admission.is_pending(&key));
+        assert!(admission.reconcile_batch(1).is_empty());
 
         admission.nudge(key.clone());
         assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "and a re-admitted key starts a fresh pass"
-        );
-    }
-
-    #[test]
-    fn a_failed_step_keeps_where_its_last_one_stopped() {
-        let mut admission = book(1);
-        let key = gc("flaky");
-
-        admission.nudge(key.clone());
-        assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
-        assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW
-            )),
-            Some(key.clone())
-        );
-        assert_eq!(
-            claimed(admission.finish(&key, StepOutcome::Failed, NOW)),
-            None
-        );
-        assert_eq!(
-            admission.continuation(&key),
-            Some("page-1".to_owned()),
-            "a failure says nothing about where the last step stopped"
-        );
     }
 
     #[test]
@@ -1243,7 +1086,6 @@ mod tests {
                 &key,
                 StepOutcome::Concluded(MaintenanceRunReport {
                     conclusion: MaintenanceConclusion::Idle,
-                    continuation: None,
                     not_before_ms: Some(NOW + 60_000),
                     follow_up: None,
                 }),
@@ -1265,7 +1107,6 @@ mod tests {
                 &key,
                 StepOutcome::Concluded(MaintenanceRunReport {
                     conclusion: MaintenanceConclusion::Progressed,
-                    continuation: None,
                     not_before_ms: Some(NOW + 30_000),
                     follow_up: None,
                 }),

--- a/crates/loonfs/src/maintenance/gc.rs
+++ b/crates/loonfs/src/maintenance/gc.rs
@@ -48,7 +48,6 @@ impl MaintenanceJob for GarbageCollectionJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let response = match self
@@ -98,7 +97,6 @@ impl MaintenanceJob for GarbageCollectionJob {
 fn gc_run_result(gc: GcResponse) -> MaintenanceRunReport {
     MaintenanceRunReport {
         conclusion: gc_conclusion(&gc),
-        continuation: None,
         not_before_ms: gc.next_reclamation_at_ms,
         follow_up: None,
     }

--- a/crates/loonfs/src/maintenance/job.rs
+++ b/crates/loonfs/src/maintenance/job.rs
@@ -66,8 +66,6 @@ impl MaintenanceConclusion {
 pub struct MaintenanceRunReport {
     /// How the run settled.
     pub conclusion: MaintenanceConclusion,
-    /// Resume position for the next run.
-    pub continuation: Option<String>,
     /// Earliest Unix millisecond for another run.
     pub not_before_ms: Option<u64>,
     /// A job and namespace this run wants scheduled.
@@ -75,11 +73,10 @@ pub struct MaintenanceRunReport {
 }
 
 impl MaintenanceRunReport {
-    /// Builds a report without continuation, deadline, or follow-up.
+    /// Builds a report without a deadline or follow-up.
     pub fn concluded(conclusion: MaintenanceConclusion) -> Self {
         Self {
             conclusion,
-            continuation: None,
             not_before_ms: None,
             follow_up: None,
         }
@@ -148,7 +145,6 @@ pub trait MaintenanceJob: Send + Sync + 'static {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
         cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport>;
 

--- a/crates/loonfs/src/maintenance/metadata.rs
+++ b/crates/loonfs/src/maintenance/metadata.rs
@@ -41,7 +41,6 @@ impl MaintenanceJob for MetadataMaintenanceJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         match self

--- a/crates/loonfs/src/maintenance/metadata_compaction.rs
+++ b/crates/loonfs/src/maintenance/metadata_compaction.rs
@@ -44,13 +44,11 @@ impl MaintenanceJob for MetadataCompactionJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let Ok(_permit) = Arc::clone(&self.permits).try_acquire_owned() else {
             return Ok(MaintenanceRunReport {
                 conclusion: MaintenanceConclusion::Blocked,
-                continuation: None,
                 not_before_ms: Some(
                     loonfs_core::time::current_time_ms()?.saturating_add(RECONCILE_INTERVAL_MS),
                 ),
@@ -75,7 +73,6 @@ impl MaintenanceJob for MetadataCompactionJob {
         };
         Ok(MaintenanceRunReport {
             conclusion,
-            continuation: None,
             not_before_ms: None,
             follow_up,
         })

--- a/crates/loonfs/src/maintenance/registry.rs
+++ b/crates/loonfs/src/maintenance/registry.rs
@@ -20,8 +20,6 @@ pub struct MaintenanceAssignment {
     pub namespace_id: NamespaceId,
     /// Registered job to run.
     pub job: MaintenanceJobId,
-    /// Process-local resume position.
-    pub continuation: Option<String>,
 }
 
 impl MaintenanceRegistry {
@@ -67,21 +65,15 @@ impl MaintenanceRegistry {
         &self,
         id: MaintenanceJobId,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
     ) -> Result<MaintenanceRunReport> {
         self.require(id)?
-            .run(namespace_id, continuation, &MaintenanceCancellation::new())
+            .run(namespace_id, &MaintenanceCancellation::new())
             .await
     }
 
     /// Runs one assignment with a fresh cancellation token.
     pub async fn execute(&self, assignment: MaintenanceAssignment) -> Result<MaintenanceRunReport> {
-        self.run(
-            assignment.job,
-            &assignment.namespace_id,
-            assignment.continuation.as_deref(),
-        )
-        .await
+        self.run(assignment.job, &assignment.namespace_id).await
     }
 
     fn require(&self, id: MaintenanceJobId) -> Result<Arc<dyn MaintenanceJob>> {

--- a/crates/loonfs/src/maintenance/runner.rs
+++ b/crates/loonfs/src/maintenance/runner.rs
@@ -752,14 +752,10 @@ async fn run_step(inner: &Arc<RunnerInner>, dispatch: &MaintenanceDispatch) -> S
             MaintenanceConclusion::NotEnabled,
         ));
     };
-    let continuation = dispatch.continuation.as_deref();
     let queued_ms = dispatch.queue_wait_ms;
     let started = tokio::time::Instant::now();
     let invocation = InvocationCancellation::new(inner, key);
-    match job
-        .run(&key.namespace_id, continuation, &invocation.cancellation)
-        .await
-    {
+    match job.run(&key.namespace_id, &invocation.cancellation).await {
         Ok(result) => {
             let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
             inner
@@ -769,8 +765,6 @@ async fn run_step(inner: &Arc<RunnerInner>, dispatch: &MaintenanceDispatch) -> S
                 job = %key.job,
                 namespace_id = %key.namespace_id,
                 conclusion = result.conclusion.as_str(),
-                resumed = continuation.is_some(),
-                continues = result.continuation.is_some(),
                 not_before_ms = ?result.not_before_ms,
                 // The two halves of what a step cost: how long it waited
                 // for a permit, and how long it then took.

--- a/crates/loonfs/src/maintenance/tests.rs
+++ b/crates/loonfs/src/maintenance/tests.rs
@@ -54,8 +54,6 @@ impl MaintenanceClock for ManualClock {
 #[derive(Debug, Clone)]
 enum ScriptedStep {
     Conclude(MaintenanceConclusion),
-    /// Conclude, and tell the runner where this step stopped.
-    Continue(MaintenanceConclusion, Option<String>),
     /// Conclude, and tell the runner when what this step left behind
     /// becomes eligible — what a collection pass reports for what it
     /// retained.
@@ -111,8 +109,6 @@ struct TestJob {
     trailing_answer: ScriptedStep,
     probe_answer: StdMutex<MaintenanceProbe>,
     steps: StdMutex<Vec<NamespaceId>>,
-    /// The continuation each step was handed, in order.
-    resumed_from: StdMutex<Vec<Option<String>>>,
     probes: StdMutex<Vec<NamespaceId>>,
     gate: Option<Gate>,
 }
@@ -124,7 +120,6 @@ impl TestJob {
             trailing_answer,
             probe_answer: StdMutex::new(MaintenanceProbe::Idle),
             steps: StdMutex::new(Vec::new()),
-            resumed_from: StdMutex::new(Vec::new()),
             probes: StdMutex::new(Vec::new()),
             gate: None,
         })
@@ -149,7 +144,6 @@ impl TestJob {
             trailing_answer: trailing,
             probe_answer: StdMutex::new(MaintenanceProbe::Idle),
             steps: StdMutex::new(Vec::new()),
-            resumed_from: StdMutex::new(Vec::new()),
             probes: StdMutex::new(Vec::new()),
             gate: None,
         };
@@ -167,11 +161,6 @@ impl TestJob {
 
     fn stepped(&self) -> Vec<String> {
         names(&self.steps)
-    }
-
-    /// What the runner handed each step, in order.
-    fn resumed_from(&self) -> Vec<Option<String>> {
-        self.resumed_from.lock().expect("resumed from").clone()
     }
 
     fn probed(&self) -> Vec<String> {
@@ -196,17 +185,12 @@ impl MaintenanceJob for TestJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         if let Some(gate) = &self.gate {
             gate.enter().await;
         }
         self.steps.lock().expect("steps").push(namespace_id.clone());
-        self.resumed_from
-            .lock()
-            .expect("resumed from")
-            .push(continuation.map(str::to_owned));
         let answer = self
             .answers
             .lock()
@@ -215,15 +199,8 @@ impl MaintenanceJob for TestJob {
             .unwrap_or_else(|| self.trailing_answer.clone());
         match answer {
             ScriptedStep::Conclude(conclusion) => Ok(MaintenanceRunReport::concluded(conclusion)),
-            ScriptedStep::Continue(conclusion, continuation) => Ok(MaintenanceRunReport {
-                conclusion,
-                continuation,
-                not_before_ms: None,
-                follow_up: None,
-            }),
             ScriptedStep::Due(conclusion, not_before_ms) => Ok(MaintenanceRunReport {
                 conclusion,
-                continuation: None,
                 not_before_ms: Some(not_before_ms),
                 follow_up: None,
             }),
@@ -280,7 +257,6 @@ impl MaintenanceJob for SubscribingJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.steps.lock().expect("steps").push(namespace_id.clone());
@@ -373,66 +349,22 @@ async fn progressed_requeues_immediately_and_stays_fair_at_the_cap() {
 }
 
 #[tokio::test]
-async fn a_progressing_job_resumes_from_where_its_last_step_stopped() {
-    let job = TestJob::scripted(
-        [
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-1".to_owned())),
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-2".to_owned())),
-        ],
-        ScriptedStep::Conclude(MaintenanceConclusion::Idle),
-    );
-    let runner = enabled_runner(job.clone());
-    let namespace_id = namespace_id("paged");
-
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the pass settles");
-
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-1".to_owned()), Some("page-2".to_owned())],
-        "a fresh pass, then each step resuming from the one before it"
-    );
-
-    // The idle step that ended the pass spent the position, so the next
-    // nudge starts over rather than resuming a finished walk.
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the fresh pass settles");
-    assert_eq!(
-        job.resumed_from().last().expect("a fourth step ran"),
-        &None,
-        "an idle conclusion clears the continuation"
-    );
-}
-
-#[tokio::test]
-async fn a_blocked_job_resumes_from_where_it_parked() {
-    let job = TestJob::scripted(
-        [ScriptedStep::Continue(
-            MaintenanceConclusion::Blocked,
-            Some("page-7".to_owned()),
-        )],
-        ScriptedStep::Conclude(MaintenanceConclusion::Idle),
-    );
+async fn a_blocked_job_parks() {
+    let job = TestJob::answering(ScriptedStep::Conclude(MaintenanceConclusion::Blocked));
     let runner = enabled_runner(job.clone());
     let namespace_id = namespace_id("parked");
 
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("the blocked step settles");
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the retry settles");
 
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-7".to_owned())],
-        "a retry with room to work resumes where the blocked step stopped"
-    );
+    assert_eq!(job.stepped(), vec!["parked".to_owned()]);
 }
 
 #[tokio::test]
-async fn a_not_enabled_conclusion_drops_the_continuation() {
+async fn a_not_enabled_conclusion_evicts_the_key() {
     let job = TestJob::scripted(
         [
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-1".to_owned())),
+            ScriptedStep::Conclude(MaintenanceConclusion::Progressed),
             ScriptedStep::Conclude(MaintenanceConclusion::NotEnabled),
         ],
         ScriptedStep::Conclude(MaintenanceConclusion::Idle),
@@ -442,14 +374,13 @@ async fn a_not_enabled_conclusion_drops_the_continuation() {
 
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("both steps settle");
+    assert_eq!(job.stepped().len(), 2);
+    runner.reconcile_now().await;
+    assert!(job.probed().is_empty());
+
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("the re-admitted step settles");
-
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-1".to_owned()), None],
-        "a key re-admitted after eviction starts a fresh pass"
-    );
+    assert_eq!(job.stepped().len(), 3);
 }
 
 #[tokio::test]
@@ -829,7 +760,6 @@ impl MaintenanceJob for BlockingJob {
     async fn run(
         &self,
         _namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.runs.fetch_add(1, Ordering::SeqCst);
@@ -842,7 +772,6 @@ impl MaintenanceJob for BlockingJob {
             .forget();
         Ok(MaintenanceRunReport {
             conclusion: MaintenanceConclusion::Blocked,
-            continuation: None,
             not_before_ms: None,
             follow_up: self.follow_up.map(|job| (job, _namespace_id.clone())),
         })

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -69,7 +69,7 @@ impl<E: MetricLabel> LabeledCounters<E> {
 pub(crate) enum CompactionOutcome {
     Completed,
     Failed,
-    Superseded,
+    Abandoned,
     Cancelled,
     Fenced,
 }
@@ -78,7 +78,7 @@ impl MetricLabel for CompactionOutcome {
     const VALUES: &'static [Self] = &[
         Self::Completed,
         Self::Failed,
-        Self::Superseded,
+        Self::Abandoned,
         Self::Cancelled,
         Self::Fenced,
     ];
@@ -87,7 +87,7 @@ impl MetricLabel for CompactionOutcome {
         match self {
             Self::Completed => "completed",
             Self::Failed => "failed",
-            Self::Superseded => "superseded",
+            Self::Abandoned => "abandoned",
             Self::Cancelled => "cancelled",
             Self::Fenced => "fenced",
         }
@@ -367,7 +367,7 @@ impl RuntimeInstruments {
                 CompactionOutcome::Completed,
                 Some((*rows_read, *rows_written, *input_bytes, *output_bytes)),
             ),
-            Ok(MetadataCompactionJobOutcome::Abandoned) => (CompactionOutcome::Superseded, None),
+            Ok(MetadataCompactionJobOutcome::Abandoned) => (CompactionOutcome::Abandoned, None),
             Ok(MetadataCompactionJobOutcome::Cancelled) => (CompactionOutcome::Cancelled, None),
             Ok(MetadataCompactionJobOutcome::Fenced) => (CompactionOutcome::Fenced, None),
             Err(_) => (CompactionOutcome::Failed, None),
@@ -1541,6 +1541,7 @@ mod tests {
             }),
             25,
         );
+        instruments.compaction_finished(&Ok(MetadataCompactionJobOutcome::Abandoned), 10);
 
         let snapshot = recorder.snapshot();
         assert_eq!(
@@ -1573,6 +1574,26 @@ mod tests {
             ),
             1
         );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.maintenance.compactions",
+                &[("outcome", "abandoned")],
+            ),
+            1
+        );
+        let duration = snapshot
+            .by_name("loonfs.maintenance.compaction_seconds")
+            .find(|entry| entry.labels == [("outcome", "abandoned")])
+            .expect("abandoned compaction duration");
+        assert!(matches!(
+            duration.value,
+            MetricValue::Histogram { count: 1, .. }
+        ));
+        assert!(snapshot
+            .all()
+            .iter()
+            .all(|entry| !entry.labels.contains(&("outcome", "superseded"))));
         assert_eq!(
             counter(
                 &snapshot,

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -701,7 +701,7 @@ async fn a_cold_metadata_job_probes_with_its_configured_options() {
     );
     for _ in 0..16 {
         immediate
-            .run(&namespace, None, &MaintenanceCancellation::new())
+            .run(&namespace, &MaintenanceCancellation::new())
             .await
             .expect("run configured maintenance");
         if immediate

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -209,7 +209,7 @@ fn a_collection_step_reports_what_the_pass_retained() {
             .register(Arc::new(GarbageCollectionJob::new(fs.maintenance.clone())))
             .expect("garbage collection job");
         registry
-            .run(MaintenanceJobId::GC, &namespace_id, None)
+            .run(MaintenanceJobId::GC, &namespace_id)
             .await
             .expect("run one collection pass");
         recorder.snapshot()

--- a/crates/loonfs/tests/it/namespace_advance_observer.rs
+++ b/crates/loonfs/tests/it/namespace_advance_observer.rs
@@ -92,7 +92,6 @@ impl MaintenanceJob for SubscribingJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.steps

--- a/crates/loonfs/tests/it/standalone_maintenance.rs
+++ b/crates/loonfs/tests/it/standalone_maintenance.rs
@@ -66,7 +66,6 @@ async fn a_registry_runs_every_core_job_without_a_writer() {
             .execute(MaintenanceAssignment {
                 namespace_id: namespace_id.clone(),
                 job,
-                continuation: None,
             })
             .await;
         assert!(result.is_ok(), "{job} failed: {:?}", result.err());

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -105,7 +105,7 @@ The new manifest replaces only the selected inputs and preserves newer or unrela
 
 Unreferenced segments are collectable only when their provider age is strictly greater than 24 hours. A streaming job must initiate publication within 23 hours, 39 minutes, and 30 seconds, reserving the minimum GC grace inside that day. The remaining interval covers provider operations, clock error, and scheduling allowance. Bounded merges use the ordinary 15-minute metadata publication budget.
 
-A changed epoch returns `fenced`. Changed inputs or an exceeded streaming bound return `abandoned`. None of these outcomes publishes a partial replacement. Unreferenced output follows the same age rule whether the job failed, was cancelled, or was superseded by another publication.
+A changed epoch returns `fenced`. Changed inputs or an exceeded streaming bound return `abandoned`. None of these outcomes publishes a partial replacement. Unreferenced output follows the same age rule whether the job failed, was cancelled, or was abandoned.
 
 ## Scheduling and restart
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -237,7 +237,7 @@ The codes that populate it:
 
 | Code | Detail fields |
 | --- | --- |
-| `writer_fenced` | `fenced_writer_epoch`, `active_writer_epoch`, plus `active_writer` and `active_acquired_at_ms` when the head recorded a writer block. Writer ids are process labels, so two runs on one machine can share one; the acquisition stamp is what tells them apart |
+| `writer_fenced` | `fenced_writer_epoch`, `active_writer_epoch`, plus `active_writer` and `active_acquired_at_ms` when the current manifest records a writer block. Writer ids are process labels, so two runs on one machine can share one; the acquisition stamp is what tells them apart |
 | `writer_capacity_exceeded` | `max_writer_sessions` |
 | `path_conflict` | `expected_inode_id`, `actual_inode_id` (absent when unbound); `assertion_index` for a failed request assertion |
 | `stale_revision` | `inode_id`, `expected_revision_no`, `actual_revision_no` (absent when the inode has no current revision or is not visible); `assertion_index` for a failed request assertion |
@@ -275,7 +275,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `revision_not_found` | 404 | The file has no such revision. |
 | `upload_not_found` | 404 | No upload session with this id, or one that was aborted: an aborted session will never select content, so it reports the absence that its deletion will. |
 | `namespace_exists` | 409 | The create or fork target already exists: another namespace holds the id. |
-| `snapshot_quota_exceeded` | 409 | Creating the snapshot would pass the namespace's live-snapshot limit. Release a snapshot or wait for a lease to expire. |
+| `snapshot_quota_exceeded` | 409 | Creating the snapshot would pass the namespace's live-snapshot limit. Release a snapshot or wait for a snapshot to expire. |
 | `content_not_prepared` | 409 | A path put or explicit create/replace operation references external content without a matching admission, or carries a rejected relevant token. Prepare the content and retry with its proof. |
 | `path_conflict` | 409 | The destination path is already bound. |
 | `directory_not_empty` | 409 | The directory has children and the operation is not recursive. |
@@ -855,14 +855,14 @@ its reclaimable state is collected; naming anything else is refused with
 `namespace_deleted`, because a tombstone has nothing to flush, reorganize,
 or retain.
 
-`wal_flush.outcome` has four values. `not_needed` means the WAL tail was below the threshold. `flushed` means this step published a manifest and updated the root. `already_published` means the root already referenced a different manifest, so this step did not update it. `retries_exhausted` means concurrent updates prevented every attempt from publishing; nothing was flushed, and a later step can try again.
+`wal_flush.outcome` has four values. `not_needed` means the WAL tail was below the threshold. `flushed` means this step published the next current manifest. `already_published` means the current manifest already covered the captured WAL tail, so this step published no manifest. `retries_exhausted` means concurrent updates prevented every attempt from publishing; nothing was flushed, and a later step can try again.
 
 `reorganize.outcome` has four values. `not_needed` means no bounded merge is
 due. `unit_published` means this run published one bounded merge.
 `compaction_required` means a family group needs streaming compaction; run the
-`metadata_compaction` job. `root_advanced` means another publisher updated the
-metadata root first. A manifest this run wrote remains unreferenced, and a
-later GC pass can delete it.
+`metadata_compaction` job. `root_advanced` means another publisher changed the
+current manifest first. Segments this run wrote remain unreferenced, and a
+later GC pass can delete them.
 
 `compaction.outcome` has six values. `not_needed` means no family group has
 eligible input. `bounded_merge_published` means the planner selected and
@@ -1011,13 +1011,13 @@ is irrevocable and the deadline never changes. A call whose clock is before
 the deadline reports it through `next_reclamation_at_ms`. Retirement itself
 deletes no content.
 
-Every call reads current durable roots and uses one fixed clock. It keeps
+Every call reads the current manifest and uses one fixed clock. It keeps
 its live set in memory and writes no collection progress. Every family lists
-from the beginning and sweeps to the end. Root discovery reads a separate
-complete pin listing. A retained pin, an unrecognized pin key, or an uncertain
-pin load prevents namespace retirement. A candidate the live set retains
+from the beginning and sweeps to the end. The collector uses a separate
+complete pin listing to find retained manifests. A retained pin, an unrecognized
+pin key, or an uncertain pin load prevents namespace retirement. A candidate the live set retains
 needs no further store request. Other candidates require an age check, a
-record read, or a deletion. Root read failures fail the call before sweeping.
+record read, or a deletion. Manifest read failures fail the call before sweeping.
 
 A GC response groups related counts. `deleted` contains `wal_segments`,
 `metadata_segments`, `manifests`, `checkpoint_records`, `upload_sessions`,
@@ -2657,15 +2657,15 @@ A conforming server must:
 
 1. treat object storage as the authoritative durable foundation;
 2. publish visible metadata only through logical commits stored in visible
-   WAL segments plus a successful head update;
+   numbered WAL objects;
 3. validate that referenced content is already durable before publish;
 4. preserve `(namespace_id, inode_id)` as canonical identity;
 5. resolve namespace content through the immutable `content_store_id` in the
-   namespace head;
+   current manifest;
 6. implement tombstone-first delete;
 7. serve replay from the highest numbered verified manifest found through
-   `hint.json`, plus the visible WAL segment chain, replayed as
-   logical commits; checkpoints pin manifest versions for retention, stable
+   `hint.json`, plus the numbered WAL objects after the folded boundary, replayed
+   as logical commits; checkpoints pin manifest versions for retention, stable
    reads, restore, and forks;
 8. fold sibling names into name keys by the v0 rule ([format: names and paths](format.md#14-names-and-paths));
 9. keep control-plane sessions and any implementation-specific coordinators

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2447,14 +2447,6 @@
         "pattern": "^ino_[1-9][0-9]*$",
         "type": "string"
       },
-      "InodeKind": {
-        "description": "Filesystem item kind.",
-        "enum": [
-          "file",
-          "dir"
-        ],
-        "type": "string"
-      },
       "ListChangesResponse": {
         "description": "Change-feed response after a cursor.",
         "properties": {
@@ -2879,7 +2871,7 @@
         "properties": {
           "current_manifest_no": {
             "$ref": "#/components/schemas/ManifestNo",
-            "description": "Current manifest pointer recorded by the head."
+            "description": "The namespace's current manifest number."
           },
           "head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
@@ -4135,7 +4127,7 @@
         ]
       },
       "WalFlushStepOutcomeAlreadyPublished": {
-        "description": "The step did not update a root that already referenced another manifest.",
+        "description": "The current manifest already covered the captured WAL tail; this step published no manifest.",
         "properties": {
           "attempted_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
@@ -4143,7 +4135,7 @@
           },
           "current_manifest_no": {
             "$ref": "#/components/schemas/ManifestNo",
-            "description": "Manifest the root currently references."
+            "description": "The namespace's current manifest number."
           },
           "outcome": {
             "enum": [
@@ -4160,7 +4152,7 @@
         "type": "object"
       },
       "WalFlushStepOutcomeFlushed": {
-        "description": "The step flushed the WAL tail and advanced the metadata root.",
+        "description": "The step flushed the WAL tail and published the next current manifest.",
         "properties": {
           "manifest_head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
@@ -5083,7 +5075,7 @@
                 }
               }
             },
-            "description": "Invalid budget or cursor"
+            "description": "Invalid namespace id or options"
           },
           "401": {
             "content": {
@@ -5136,7 +5128,7 @@
     },
     "/v0/maintenance/namespaces/{namespace_id}/runs": {
       "post": {
-        "description": "Runs one maintenance job for the namespace. The body names the job with `kind`: `metadata`, `metadata_compaction`, `gc`, or `retention`. The response carries the same `kind` and that job's result. A deleted namespace accepts only `gc`. A `gc` call reads current roots, then sweeps every family to the end. Each listing starts at the beginning. The call keeps no continuation.",
+        "description": "Runs one maintenance job for the namespace. The body names the job with `kind`: `metadata`, `metadata_compaction`, `gc`, or `retention`. The response carries the same `kind` and that job's result. A deleted namespace accepts only `gc`. A `gc` call reads the current manifest and lists pins, then sweeps every family to the end. Each listing starts at the beginning. The call keeps no continuation.",
         "operationId": "run_maintenance",
         "parameters": [
           {


### PR DESCRIPTION
The format migration left a set of statements that describe the old design as current: a head object that decides visibility, a root that gets published, a lease a snapshot waits on, a budget and cursor on grep collection, and a compaction outcome named `superseded`. This PR corrects them where they are wrong, in the root README, the API specification, generated field docs, crate READMEs, user-visible error and log strings, one metric label, and a few fixtures. Two of them were actively harmful: the grep README's configuration example lists four keys the server rejects, so copying it produces a server that will not start, and the client's grep collection doc promises a budget and a resume cursor that do not exist.

Important callouts:

- The compaction metric label `superseded` becomes `abandoned`, matching the outcome name the wire already reports for the same case. This is the one behavior-visible change.
- Error strings change wording only; codes and parameters are unchanged. The snapshot quota message no longer mentions a lease, the budget error names the manifest, and the grep publication conflict names the manifest.
- OpenAPI is regenerated for the reworded field docs and the corrected 400 description on grep collection. The `InodeKind` schema, which no field referenced, leaves the document, and a test now requires every schema to be referenced. No schema shape changes.
- Snapshot release is documented as returning `snapshot_not_found` on a second call; the CLI README and one backend doc still said it was idempotent.
- Test and simulator fixtures that named a `head.json` key or wrote `head` as a hint body now use keys and bodies that exist in the layout.
