### PR TITLE
perf(cache): key projections by manifest number and sequence, not an etag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ Visit [loonfs.com/docs](https://loonfs.com/docs) to learn more.
 
 LoonFS is designed with a core set of foundational ideas.
 
-- **Object storage is the only required durable substrate.** LoonFS stores durable truth in object storage: file content, immutable metadata history, materialized manifests/checkpoints, and a small number of mutable control objects. Caches, queues, workers, and local state are safely rebuildable from the object store.
+- **Object storage is the only required durable substrate.** LoonFS stores immutable file content, manifests, numbered WAL objects, and metadata segments in object storage. Pins retain immutable manifests until released; snapshot expiry can be extended. Caches, queues, workers, and local state are rebuildable from the object store.
 
 - **A namespace is an independently addressable filesystem with its own history.** Forks share content and metadata under durable pins, so a namespace's storage is not confined to its own prefix.
 
 - **Inodes are identity, paths are views.** The identity of a filesystem item is `(namespace_id, inode_id)`. Paths are "views" that point to inodes, and may change over time without changing the item’s identity.
 
-- **Commits are the unit of transactional change.** File bytes are written to object storage before metadata can reference them. Metadata changes are recorded as logical commits, and a commit becomes visible only when the namespace head durably records it.
+- **Commits are the unit of transactional change.** File bytes are written to object storage before metadata can reference them. Metadata changes are recorded as logical commits, and a commit becomes visible when put-if-absent creates its numbered WAL object.
 
-- **The head decides visibility; retained metadata, the WAL, and checkpoint records are recovery state, not caches.** Local caches and rebuildable indexes are separate, and nothing creates a second commit history.
+- **Numbered manifests and WAL objects are authoritative.** The current manifest records namespace identity, status, and writer authority. Later WAL objects record committed changes. `hint.json` is advisory and starts discovery of those numbered objects.
 
 ## Design philosophy
 
@@ -78,6 +78,6 @@ LoonFS is built around a correctness-first protocol where the object store is th
 
 - **Correctness is the primary feature.** LoonFS favors designs with fewer valid states, explicit invariants, named failure modes, and deterministic tests. 
 
-- **Durability and visibility are separate.** LoonFS may durably store file content and metadata before a change appears in the filesystem. Changes are acknowledged only once the namespace head advances to include its commit.
+- **Durability and visibility are separate.** LoonFS may durably store file content and metadata before a change appears in the filesystem. Changes are acknowledged after their numbered WAL object is created.
 
 - **Serialize commits, scale everything else.** Every change is executed through a transactional core with an ordered WAL. LoonFS keeps expensive work (uploading and downloading, compaction, garbage collection, indexing) off the write path so it can scale independently.

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -681,11 +681,7 @@ string_id! {
 }
 
 string_id! {
-    /// Durable id for one streaming metadata compaction job.
-    ///
-    /// The job's staged output and its lease live under one prefix named by
-    /// this id, so a collector can tell one job's output from another's
-    /// without reading anything.
+    /// Identifies one streaming metadata compaction job for log correlation only.
     MetadataCompactionId,
     prefix = "cmp"
 }

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -190,7 +190,7 @@ pub struct NamespaceDiagnostics {
     pub head_seq: ChangeSeq,
     /// Oldest sequence still promised for incremental replay.
     pub retention_floor_seq: ChangeSeq,
-    /// Current manifest pointer recorded by the head.
+    /// The namespace's current manifest number.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(nullable = false))]
     pub current_manifest_no: Option<ManifestNo>,
@@ -882,15 +882,15 @@ pub struct ReleaseSnapshotResponse {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum FlushWalOutcome {
-    /// The root already covered the head; nothing was published.
+    /// The current manifest already covered the WAL tail; nothing was published.
     AlreadyCurrent,
-    /// This call published a new manifest and advanced the root to it.
+    /// This call published the next current manifest.
     Published,
-    /// Another publisher updated the root before this call could reference its manifest.
+    /// Another publisher changed the current manifest before this call could publish.
     RootAdvanced,
 }
 
-/// The metadata root state after one WAL flush.
+/// The current manifest state after one WAL flush.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FlushWalResponse {
@@ -1202,16 +1202,16 @@ pub struct MetadataCompactionRequest {}
 pub enum WalFlushStepOutcome {
     /// The tail was below the threshold, so there was nothing to flush.
     NotNeeded,
-    /// The step flushed the WAL tail and advanced the metadata root.
+    /// The step flushed the WAL tail and published the next current manifest.
     Flushed {
         /// Sequence covered by the published manifest.
         manifest_head_seq: ChangeSeq,
     },
-    /// The step did not update a root that already referenced another manifest.
+    /// The current manifest already covered the captured WAL tail; this step published no manifest.
     AlreadyPublished {
         /// Sequence this step attempted to flush through.
         attempted_seq: ChangeSeq,
-        /// Manifest the root currently references.
+        /// The namespace's current manifest number.
         current_manifest_no: ManifestNo,
     },
     /// Concurrent updates prevented every publication attempt.
@@ -1232,7 +1232,7 @@ pub enum ReorganizeStepOutcome {
     UnitPublished,
     /// A family group needs a streaming compaction. Run the `metadata_compaction` job.
     CompactionRequired,
-    /// Another publisher updated the metadata root before this step could reference its manifest.
+    /// Another publisher changed the current manifest before this step could publish.
     RootAdvanced,
 }
 

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -178,7 +178,7 @@ Snapshot management
     Keep a snapshot available for longer
 
   loonfs snapshot release <namespace> <snapshot-id>
-    Release a snapshot. Repeating the command succeeds.
+    Release a snapshot. Repeating the command returns snapshot_not_found.
 
 Pagination
   ls, grep, revisions, trash, changes, snapshot list, and maintenance checkpoint
@@ -341,8 +341,9 @@ Maintenance
     below the flushed manifest head but does not remove file revisions.
 
   loonfs maintenance gc [--grace-window-ms <ms>]
-    Run one complete pass and print its report. Each call reads current roots,
-    lists every family from the beginning, and sweeps it to the end.
+    Run one complete pass and print its report. Each call reads the current
+    manifest and hint, lists every family from the beginning, and sweeps it
+    to the end.
     --grace-window-ms protects objects younger than the window.
     --json includes every retention reason.
     Repeated GC runs reclaim a deleted namespace's own content once it retires,
@@ -379,8 +380,8 @@ Maintenance
 
   loonfs maintenance index gc
     Complete one collection pass over the namespace's gram-index objects.
-    Read durable roots before deletion. Reap aged index objects for an absent
-    or deleted namespace.
+    Read the current manifest and hint before deletion. Reap aged index
+    objects for an absent or deleted namespace.
 
 Profile create options
   Used by:

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -793,7 +793,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Releases a user-owned checkpoint pin by id. Idempotent.
+    /// Deletes a user-owned checkpoint pin. A missing id returns `checkpoint_not_found`.
     pub(crate) async fn release_checkpoint(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -325,7 +325,7 @@ impl EmbeddedBackend {
             },
             || async {
                 let conclusion = job
-                    .run(namespace_id, None, &MaintenanceCancellation::new())
+                    .run(namespace_id, &MaintenanceCancellation::new())
                     .await
                     .scoped(namespace_id)?
                     .conclusion;
@@ -395,7 +395,7 @@ impl EmbeddedBackend {
     /// a budget to spend and per-key progress to report, and admission
     /// offers neither. It shuts the runner down first so a second scheduler
     /// cannot race these steps, then closes the writer and walks the
-    /// assignment. Each key's continuation passes from one run to the next.
+    /// assignment.
     pub(super) async fn drain_maintenance(
         &self,
         namespaces: &[NamespaceId],
@@ -417,21 +417,18 @@ impl EmbeddedBackend {
                     steps: 0,
                     conclusion: None,
                 };
-                let mut continuation = None;
                 while !budget.spent(steps, timer.monotonic_now_ms().saturating_sub(started_ms)) {
                     let result = self
                         .jobs
                         .execute(MaintenanceAssignment {
                             namespace_id: namespace_id.clone(),
                             job: *job,
-                            continuation,
                         })
                         .await
                         .scoped(namespace_id)?;
                     steps += 1;
                     key.steps += 1;
                     key.conclusion = Some(result.conclusion);
-                    continuation = result.continuation;
                     if key.settled() {
                         break;
                     }

--- a/crates/loonfs-client/src/maintenance.rs
+++ b/crates/loonfs-client/src/maintenance.rs
@@ -153,10 +153,8 @@ impl Client {
             .await
     }
 
-    /// Runs one explicit grep index garbage-collection pass for a namespace.
+    /// Runs one complete grep index garbage-collection pass for a namespace.
     ///
-    /// `max_objects` bounds the reads the pass spends; when keys remain the
-    /// response carries a `next_cursor` to resume from.
     /// Retrying this request starts a distinct attempt.
     pub async fn gc_grep_index(
         &self,

--- a/crates/loonfs-conformance/README.md
+++ b/crates/loonfs-conformance/README.md
@@ -4,7 +4,7 @@ This private crate contains shared JSON test cases and a Rust test harness.
 
 ## Cases
 
-The ten cases cover:
+The thirteen cases cover:
 
 - standard API errors
 - repeated commit requests
@@ -13,6 +13,9 @@ The ten cases cover:
 - repeated upload aborts
 - direct downloads
 - cursor pagination and resumption
+- directory children by inode (`children_by_inode`)
+- mutations by inode (`inode_mutations`)
+- snapshot creation, reads, extension, and release (`snapshots`)
 - change feed identity fields
 - an end-to-end filesystem workflow
 - namespace-alias-scoped requests through a proxy

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -194,13 +194,14 @@ pub struct WalTailProjectionCacheStats {
     pub cached_decoded_bytes: usize,
 }
 
+// Within a namespace, numbered immutable manifests and WAL fix the state between
+// manifest_head_seq and head_seq. Writer fences publish a new manifest number.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WalTailProjectionCacheKey {
     pub namespace_id: NamespaceId,
     pub manifest_no: ManifestNo,
     pub manifest_head_seq: ChangeSeq,
     pub head_seq: ChangeSeq,
-    pub head_etag: String,
 }
 
 impl DecodedBlock for Arc<MetadataState> {
@@ -358,7 +359,6 @@ mod tests {
             manifest_no: ManifestNo(7),
             manifest_head_seq: ChangeSeq(11),
             head_seq: ChangeSeq(12),
-            head_etag: "stable-head-etag".to_owned(),
         };
         let actors = [
             ActorId::parse("auth0|x").expect("actor id"),

--- a/crates/loonfs-core/src/checkpoint/compactor.rs
+++ b/crates/loonfs-core/src/checkpoint/compactor.rs
@@ -17,7 +17,7 @@ pub(crate) async fn claim_compactor<S: ObjectStore + ?Sized>(
     let head = crate::namespace::control::load_head_object(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    crate::namespace::control::ensure_namespace_live(&head.state)?;
+    crate::namespace::control::ensure_namespace_live(&head)?;
     let timer = StdMonotonicTimer::default();
     let started_ms = timer.monotonic_now_ms();
     loop {

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -268,7 +268,7 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
         .map_err(CoreError::ControlObjectLoad)?;
     let basis = snapshot.basis();
     let floor_seq = snapshot.retention_floor_seq;
-    let head = snapshot.head.state;
+    let head = snapshot.head;
     if head.status.is_deleted() {
         return Err(CoreError::MetadataProjection(
             MetadataProjectionLoadError::NamespaceDeleted {

--- a/crates/loonfs-core/src/checkpoint/read_basis.rs
+++ b/crates/loonfs-core/src/checkpoint/read_basis.rs
@@ -24,8 +24,6 @@ pub(crate) struct PinnedCheckpointBasis<'a, S: ObjectStore + ?Sized> {
 pub struct CheckpointReadBasis {
     /// The namespace head as of the captured sequence.
     pub head: NamespaceReadState,
-    /// The pinned manifest checksum, used as the read-cache key.
-    pub head_etag: String,
     /// The manifest the checkpoint pins.
     pub basis: MetadataBasis,
 }
@@ -88,7 +86,6 @@ pub(crate) async fn load_checkpoint_read_basis_from_record<S: ObjectStore + ?Siz
     let envelope = segments.manifest();
     Ok(CheckpointReadBasis {
         head: head_from_manifest(live_head, envelope),
-        head_etag: envelope.payload_checksum().to_owned(),
         basis: MetadataBasis(manifest),
     })
 }

--- a/crates/loonfs-core/src/checkpoint/release.rs
+++ b/crates/loonfs-core/src/checkpoint/release.rs
@@ -4,7 +4,6 @@
 //! through this operation.
 
 use super::record::{load_checkpoint_record, release_checkpoint_record};
-use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
 use loonfs_api::wire::control::CheckpointOwner;
 use loonfs_api::{CheckpointId, NamespaceId, ReleaseCheckpointResponse};
@@ -90,7 +89,6 @@ pub(crate) async fn release_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     checkpoint_id: &CheckpointId,
-    _context: &MutationContext,
 ) -> Result<ReleaseCheckpointResponse> {
     release_owned_checkpoint(
         store,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -287,8 +287,8 @@ pub async fn metadata_maintenance_due<S: ObjectStore + ?Sized>(
     let snapshot = load_control_snapshot(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    crate::namespace::control::ensure_namespace_live(&snapshot.head.state)?;
-    let head = &snapshot.head.state;
+    crate::namespace::control::ensure_namespace_live(&snapshot.head)?;
+    let head = &snapshot.head;
     let wal_tail_segments = head.wal_no.0 - head.last_folded_wal_no.0;
     if wal_tail_segments >= max_wal_tail_segments {
         return Ok(true);

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -545,7 +545,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
             }
             ManifestPublicationOutcome::CoveredByCurrent(_) => "covered_by_current",
             ManifestPublicationOutcome::PredecessorChanged(_) => "predecessor_changed",
-            ManifestPublicationOutcome::Installable => "root_cas_race",
+            ManifestPublicationOutcome::Installable => "manifest_number_taken",
         };
         tracing::debug!(
             namespace_id = namespace_id.as_str(),

--- a/crates/loonfs-core/src/checkpoint/tests/inventory.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inventory.rs
@@ -94,7 +94,7 @@ async fn two_pins_under_one_label_list_as_two_records() {
 
     // Release is what takes a record out of the answer, and it takes out
     // exactly the one named.
-    super::super::release::release_checkpoint(&store, &namespace_id, &first, &context)
+    super::super::release::release_checkpoint(&store, &namespace_id, &first)
         .await
         .expect("release checkpoint");
     let after_release = list_all_checkpoints(&store, &namespace_id)
@@ -224,7 +224,7 @@ async fn released_pins_are_absent_from_later_pages() {
     }
     ids.sort();
     for checkpoint_id in &ids[1..6] {
-        super::super::release::release_checkpoint(&store, &namespace_id, checkpoint_id, &context)
+        super::super::release::release_checkpoint(&store, &namespace_id, checkpoint_id)
             .await
             .expect("release checkpoint in filtered run");
     }

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -25,7 +25,7 @@ async fn a_publish_projection_fold_writes_the_replayed_tail_rows() {
         .expect("load head");
     let acquired_writer = loonfs_api::wire::control::AcquiredWriter {
         writer_id: context.writer_id.clone(),
-        writer_epoch: head.state.writer_epoch,
+        writer_epoch: head.writer_epoch,
     };
     let (_, projection) = crate::protocol::load_publish_metadata_view(
         &store,
@@ -224,10 +224,7 @@ async fn manifest_round_trip_supports_empty_namespace() {
     .await
     .expect("load genesis from manifest one");
     assert!(genesis.segments.manifest().payload().runs.is_empty());
-    let head = load_head_object(&store, &namespace_id)
-        .await
-        .expect("head")
-        .state;
+    let head = load_head_object(&store, &namespace_id).await.expect("head");
     assert_eq!(genesis.replay_head(&head), head);
     for family in CHECKPOINT_ROW_FAMILIES {
         assert!(genesis

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -227,8 +227,7 @@ async fn read_floor_seq<S: ObjectStore + ?Sized>(
 ) -> ChangeSeq {
     let head = load_head_object(store, namespace_id)
         .await
-        .expect("read head")
-        .state;
+        .expect("read head");
     crate::namespace::control_snapshot::resolve_retention_floor_seq(store, &head)
         .await
         .expect("resolve retention floor")

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -782,7 +782,7 @@ async fn checkpoint_creation_deletes_its_pin_when_the_floor_passed_its_manifest(
             expires_at_ms: None,
         },
         initial.basis().manifest().clone(),
-        initial.head.state.head_commit_id.clone(),
+        initial.head.head_commit_id.clone(),
         &context,
     )
     .await
@@ -871,7 +871,7 @@ async fn checkpoint_basis_verification_store_failure_deletes_the_record() {
             expires_at_ms: None,
         },
         initial.basis().manifest().clone(),
-        initial.head.state.head_commit_id.clone(),
+        initial.head.head_commit_id.clone(),
         &context,
     )
     .await
@@ -1671,8 +1671,7 @@ async fn a_namespace_retains_from_birth_before_retention_advances() {
 
     let head = crate::namespace::control::load_head_object(&store, &namespace_id)
         .await
-        .expect("head")
-        .state;
+        .expect("head");
     let floor = crate::namespace::control_snapshot::resolve_retention_floor_seq(&store, &head)
         .await
         .expect("missing floor defaults");

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -523,12 +523,8 @@ async fn release_is_terminal_and_the_next_pin_is_a_different_record() {
             .is_empty()
     );
 
-    let release = crate::checkpoint::release_checkpoint(
-        &store,
-        &namespace_id,
-        &first.checkpoint_id,
-        &context,
-    );
+    let release =
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &first.checkpoint_id);
     let recreate = create_checkpoint(&store, &namespace_id, &context);
     let (release, second) = tokio::join!(release, recreate);
     assert_eq!(release.expect("release").checkpoint_id, first.checkpoint_id);
@@ -556,15 +552,10 @@ async fn release_is_terminal_and_the_next_pin_is_a_different_record() {
     );
 
     assert_eq!(
-        crate::checkpoint::release_checkpoint(
-            &store,
-            &namespace_id,
-            &first.checkpoint_id,
-            &context
-        )
-        .await
-        .expect_err("second release")
-        .code(),
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &first.checkpoint_id)
+            .await
+            .expect_err("second release")
+            .code(),
         ErrorCode::CheckpointNotFound
     );
 }
@@ -749,7 +740,7 @@ async fn a_pin_without_a_ttl_is_held_until_it_is_released() {
             .is_empty()
     );
 
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id, &distant)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id)
         .await
         .expect("release");
     let error = read_checkpoint_files(&store, &namespace_id, &pin.checkpoint_id)
@@ -2459,7 +2450,7 @@ async fn a_floor_past_a_pin_keeps_its_manifest_and_runs_readable_until_release()
         .await
         .expect("pinned manifest")
         .is_some());
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id, &aged)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &pin.checkpoint_id)
         .await
         .expect("release pin");
     crate::gc::gc_namespace(

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -261,7 +261,6 @@ pub struct WalFoldSnapshot {
 #[derive(Debug, Clone)]
 pub struct ResultingReadState {
     pub head: NamespaceReadState,
-    pub head_etag: String,
     /// Metadata basis used for replay. The published head still references this
     /// basis, so a seeded read cache matches the next store-backed read.
     pub basis: MetadataBasis,
@@ -562,20 +561,15 @@ impl NamespaceCommitEngine {
                 self.invalidate_projection();
                 return (projection.wal_tail_segments, None);
             }
-            PublishViewEffect::Advanced {
-                records,
-                head,
-                head_etag,
-            } => {
+            PublishViewEffect::Advanced { records, head } => {
                 projection.wal_tail_segments += 1;
                 let tail_state = Arc::make_mut(&mut projection.tail_state);
                 for record in &records {
                     tail_state.apply_committed_wal_record_mut(record);
                 }
-                projection.reanchor(head.clone(), head_etag.clone());
+                projection.reanchor(head.clone());
                 Some(ResultingReadState {
                     head,
-                    head_etag,
                     basis: projection.basis().clone(),
                     manifest_head_seq: projection.manifest_head_seq(),
                     tail_rows: Arc::clone(&projection.tail_state),
@@ -900,7 +894,6 @@ mod tests {
         let epoch_after_takeover = load_head_object(&store, &namespace_id)
             .await
             .expect("read head")
-            .state
             .writer_epoch;
 
         // A is fenced terminally: both attempts fail with writer_fenced, the
@@ -920,8 +913,7 @@ mod tests {
         }
         let head = load_head_object(&store, &namespace_id)
             .await
-            .expect("read head")
-            .state;
+            .expect("read head");
         assert_eq!(head.writer_epoch, epoch_after_takeover);
         assert_eq!(
             head.writer.expect("writer block").writer_id.as_str(),
@@ -1055,7 +1047,6 @@ mod tests {
         let epoch_after_fencing = load_head_object(&store, &namespace_id)
             .await
             .expect("read head")
-            .state
             .writer_epoch;
 
         // A rebuilt engine — cache eviction, cache-disabled mode — shares
@@ -1078,8 +1069,7 @@ mod tests {
         assert_eq!(error.code(), ErrorCode::WriterFenced);
         let head = load_head_object(&store, &namespace_id)
             .await
-            .expect("read head")
-            .state;
+            .expect("read head");
         assert_eq!(head.writer_epoch, epoch_after_fencing);
         assert_eq!(
             head.writer.expect("writer block").writer_id.as_str(),
@@ -1114,10 +1104,7 @@ mod tests {
             .session_writer_epoch(&store, &writer)
             .await
             .expect("acquire");
-        let head_before = load_head_object(&store, &namespace_id)
-            .await
-            .expect("head")
-            .state;
+        let head_before = load_head_object(&store, &namespace_id).await.expect("head");
         let abandoned = over_budget
             .publish_batch(
                 &store,
@@ -1144,8 +1131,7 @@ mod tests {
 
         let head_after = load_head_object(&store, &namespace_id)
             .await
-            .expect("read head")
-            .state;
+            .expect("read head");
         assert_eq!(head_after.seq, head_before.seq);
         assert_eq!(head_after.wal_no, head_before.wal_no);
         assert_eq!(wal_segment_count(&store, &namespace_id).await, 1);
@@ -1164,8 +1150,7 @@ mod tests {
         assert_eq!(wal_segment_count(&store, &namespace_id).await, 3);
         let head_final = load_head_object(&store, &namespace_id)
             .await
-            .expect("read head")
-            .state;
+            .expect("read head");
         assert_eq!(head_final.seq, ChangeSeq(1));
         // Two engines are two sessions, and each acquires its own epoch: the
         // abandoned attempt took 1, the retry took 2.

--- a/crates/loonfs-core/src/commit_engine_content_tests.rs
+++ b/crates/loonfs-core/src/commit_engine_content_tests.rs
@@ -129,10 +129,7 @@ async fn content_reclaimed_during_view_load_cannot_be_published() {
         .session_writer_epoch(&store, &setup)
         .await
         .expect("acquire writer");
-    let head_before = load_head_object(&store, &namespace_id)
-        .await
-        .expect("head")
-        .state;
+    let head_before = load_head_object(&store, &namespace_id).await.expect("head");
     store.block_next();
     let options = PublishTailOptions::default();
     let publish = engine.publish_batch(
@@ -172,10 +169,7 @@ async fn content_reclaimed_during_view_load_cannot_be_published() {
             .code(),
         loonfs_api::ErrorCode::ContentNotPrepared
     );
-    let head_after = load_head_object(&store, &namespace_id)
-        .await
-        .expect("head")
-        .state;
+    let head_after = load_head_object(&store, &namespace_id).await.expect("head");
     assert_eq!(head_after.seq, head_before.seq);
     assert_eq!(head_after.wal_no, head_before.wal_no);
     assert_eq!(
@@ -213,10 +207,7 @@ async fn content_expiring_after_the_put_starts_does_not_undo_the_commit() {
         .results
         .remove(0)
         .expect("original commit");
-    let head_before = load_head_object(&store, &namespace_id)
-        .await
-        .expect("head")
-        .state;
+    let head_before = load_head_object(&store, &namespace_id).await.expect("head");
     let publication = context(setup.now_ms + COMPLETED_UPLOAD_ADMISSION_WINDOW_MS - 1);
     let primary = put_candidate(&completed);
     let alias = CommitCandidate::new(primary.request().clone());
@@ -252,10 +243,7 @@ async fn content_expiring_after_the_put_starts_does_not_undo_the_commit() {
         result.results[3].as_ref().expect("independent replay"),
         &original
     );
-    let head_after = load_head_object(&store, &namespace_id)
-        .await
-        .expect("head")
-        .state;
+    let head_after = load_head_object(&store, &namespace_id).await.expect("head");
     assert_eq!(head_after.seq, ChangeSeq(3));
     assert_eq!(
         head_after.wal_no,

--- a/crates/loonfs-core/src/control_object/error.rs
+++ b/crates/loonfs-core/src/control_object/error.rs
@@ -10,13 +10,6 @@ pub enum ControlObjectLoadError {
     #[error("missing control object `{object_key}`")]
     MissingObject { object_key: String },
     #[error(
-        "metadata root references seq `{root_manifest_head_seq}` beyond the reloaded head seq `{head_seq}`"
-    )]
-    RootAheadOfHead {
-        root_manifest_head_seq: loonfs_api::ChangeSeq,
-        head_seq: loonfs_api::ChangeSeq,
-    },
-    #[error(
         "control object namespace mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
     )]
     NamespaceMismatch {
@@ -70,7 +63,6 @@ impl ControlObjectLoadError {
 
         match self {
             Self::MissingObject { .. } => ErrorCode::NamespaceNotFound,
-            Self::RootAheadOfHead { .. } => ErrorCode::StaleHead,
             Self::NamespaceMismatch { .. }
             | Self::IdentityMismatch { .. }
             | Self::ForkBasisOwnerIsSelf { .. }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -51,7 +51,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct RuntimeReadContext {
     pub head: NamespaceReadState,
-    pub head_etag: String,
     /// Metadata basis referenced by the pinned head. This is the namespace's own
     /// root after one is published, or its genesis or fork basis before then.
     pub basis: MetadataBasis,
@@ -62,7 +61,6 @@ pub struct RuntimeReadContext {
 fn runtime_read_load_context(context: &RuntimeReadContext) -> ReadLoadContext<'_, '_> {
     ReadLoadContext::pinned_head(
         &context.head,
-        context.head_etag.as_str(),
         &context.basis,
         Some(&context.segment_cache),
         Some(&context.tail_cache),

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -887,13 +887,7 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
         &self,
         checkpoint_id: &CheckpointId,
     ) -> Result<ReleaseCheckpointResponse> {
-        crate::checkpoint::release_checkpoint(
-            &self.store,
-            &self.namespace_id,
-            checkpoint_id,
-            &self.mutation_context()?,
-        )
-        .await
+        crate::checkpoint::release_checkpoint(&self.store, &self.namespace_id, checkpoint_id).await
     }
 
     /// Extends a live snapshot without passing its lifetime ceiling.

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -162,7 +162,7 @@ pub enum CoreError {
     },
     #[error(
         "namespace `{namespace_id}` already has its limit of {max_live} live snapshots; \
-         release one or wait for a lease to expire"
+         release one or wait for a snapshot to expire"
     )]
     SnapshotQuotaExceeded {
         namespace_id: loonfs_api::NamespaceId,
@@ -170,7 +170,7 @@ pub enum CoreError {
     },
     #[error(
         "metadata publication budget exceeded after {elapsed_ms}ms (budget {budget_ms}ms); \
-         the root was not published"
+         the manifest was not published"
     )]
     MetadataPublicationBudgetExceeded { elapsed_ms: u64, budget_ms: u64 },
     #[error("invalid gc configuration: {0}")]

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -284,18 +284,8 @@ impl MetadataViewError {
 pub enum MetadataProjectionLoadError {
     #[error(transparent)]
     LoadHead(#[from] ControlObjectLoadError),
-    #[error("missing head etag for `{object_key}`")]
-    MissingHeadEtag { object_key: String },
     #[error("namespace `{namespace_id}` is deleted")]
     NamespaceDeleted { namespace_id: NamespaceId },
-    #[error(
-        "namespace head changed during metadata projection load for `{object_key}`: loaded `{loaded_head_etag}`, current `{current_head_etag}`"
-    )]
-    HeadChangedDuringLoad {
-        object_key: String,
-        loaded_head_etag: String,
-        current_head_etag: String,
-    },
     #[error(transparent)]
     WalChainLoad(#[from] WalChainLoadError),
     #[error(transparent)]
@@ -322,8 +312,6 @@ impl MetadataProjectionLoadError {
                 crate::checkpoint::ManifestLoadFailureClass::Corrupt => ErrorCode::NamespaceCorrupt,
                 crate::checkpoint::ManifestLoadFailureClass::Store => ErrorCode::ServerError,
             },
-            Self::MissingHeadEtag { .. } => ErrorCode::ServerError,
-            Self::HeadChangedDuringLoad { .. } => ErrorCode::StaleHead,
         }
     }
 }

--- a/crates/loonfs-core/src/gc/collect.rs
+++ b/crates/loonfs-core/src/gc/collect.rs
@@ -44,7 +44,7 @@ pub async fn gc_namespace<S: ObjectStore + ?Sized>(
                 continue;
             }
             verify_retired_owner(store, namespace_id, &live, context.now_ms).await?;
-            if let Some(basis) = &snapshot.head.state.fork_basis {
+            if let Some(basis) = &snapshot.head.fork_basis {
                 if release_source_checkpoint(store, basis).await? {
                     report.released_checkpoints.fork += 1;
                     report.deleted.checkpoint_records += 1;
@@ -105,10 +105,9 @@ async fn verify_retired_owner<S: ObjectStore + ?Sized>(
     let head = load_head_object(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    if !head.state.status.is_deleted()
-        || head.state.content_store_id != live.content_store_id
+    if !head.status.is_deleted()
+        || head.content_store_id != live.content_store_id
         || head
-            .state
             .status
             .reclaim_after_ms()
             .is_none_or(|deadline| now_ms < deadline)
@@ -129,7 +128,7 @@ async fn retirement_report<S: ObjectStore + ?Sized>(
     let head = load_head_object(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    report.reclaim_after_ms = head.state.status.reclaim_after_ms();
+    report.reclaim_after_ms = head.status.reclaim_after_ms();
     if let Some(deadline) = report
         .reclaim_after_ms
         .filter(|deadline| *deadline > now_ms)

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -27,7 +27,7 @@ impl LiveSet {
         namespace_id: &NamespaceId,
         snapshot: &NamespaceControlSnapshot,
     ) -> Result<Self> {
-        let head = &snapshot.head.state;
+        let head = &snapshot.head;
         let mut live = Self {
             content_store_id: head.content_store_id.clone(),
             namespace_deleted: head.status.is_deleted(),

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -2278,7 +2278,7 @@ async fn uncertain_retirement_reads_back_and_failed_retirement_writes_nothing_fu
             .await
             .expect("head");
         assert_eq!(
-            head.state.status.reclaim_after_ms(),
+            head.status.reclaim_after_ms(),
             landed.then_some(GRACE_MS * 2)
         );
         if !landed {

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1510,7 +1510,7 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
         .await
         .expect("advance past the shared basis");
 
-    crate::checkpoint::release_checkpoint(&store, &namespace_id, &second.checkpoint_id, &setup)
+    crate::checkpoint::release_checkpoint(&store, &namespace_id, &second.checkpoint_id)
         .await
         .expect("release one owner");
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
@@ -1560,7 +1560,7 @@ async fn fork_owned_checkpoints_reject_user_release() {
 
     let fork_record = read_fork_record(&store, &source).await;
 
-    let error = crate::checkpoint::release_checkpoint(&store, &source, &fork_record.pin_id, &setup)
+    let error = crate::checkpoint::release_checkpoint(&store, &source, &fork_record.pin_id)
         .await
         .expect_err("fork-owned release must fail");
     assert!(
@@ -1595,14 +1595,10 @@ async fn snapshot_owned_checkpoints_reject_user_release() {
     .await
     .expect("snapshot checkpoint");
 
-    let error = crate::checkpoint::release_checkpoint(
-        &store,
-        &namespace_id,
-        &snapshot.checkpoint_id,
-        &setup,
-    )
-    .await
-    .expect_err("snapshot-owned release must fail");
+    let error =
+        crate::checkpoint::release_checkpoint(&store, &namespace_id, &snapshot.checkpoint_id)
+            .await
+            .expect_err("snapshot-owned release must fail");
     assert!(
         matches!(
             &error,

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -53,13 +53,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> PublicationView<'a, 'store, S> {
                 load_metadata_view(
                     self.store,
                     self.namespace_id,
-                    ReadLoadContext::pinned_head(
-                        &snapshot.head.state,
-                        &snapshot.head.etag,
-                        self.basis,
-                        None,
-                        None,
-                    ),
+                    ReadLoadContext::pinned_head(&snapshot.head, self.basis, None, None),
                 )
             })
             .await

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -38,9 +38,6 @@ pub const MAX_COMMIT_MESSAGE_BYTES: usize = 4096;
 /// Maximum attempts for a bounded compare-and-swap or allocation contention loop.
 pub const CONTENTION_RETRY_LIMIT: usize = 8;
 
-/// Maximum targeted rereads while reconciling one namespace control snapshot.
-pub const CONTROL_SNAPSHOT_REREAD_LIMIT: usize = 3;
-
 /// Longest visible WAL tail, in segments, a namespace may carry unflushed.
 /// Every publish surface rejects at this length with `maintenance_required`,
 /// so a landed publication never leaves more than this behind.

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -12,7 +12,6 @@ use loonfs_api::NamespaceId;
 use loonfs_objectstore::keys::hint;
 use loonfs_objectstore::ObjectStore;
 
-pub(crate) type LoadedHeadObject = LoadedControl<NamespaceReadState>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CurrentManifest {
     pub manifest: ManifestRef,
@@ -26,7 +25,6 @@ pub struct LoadedManifest {
     pub object_key: String,
     pub discovery_start_manifest_no: loonfs_api::ManifestNo,
     pub state: CurrentManifest,
-    pub hint_etag: String,
     pub hinted_wal_no: loonfs_api::WalNo,
     pub envelope: loonfs_api::wire::manifest::NamespaceManifestEnvelope,
 }
@@ -187,7 +185,6 @@ pub(crate) async fn load_current_manifest_if_present<S: ObjectStore + ?Sized>(
     }
     if let Some(current) = &mut current {
         current.discovery_start_manifest_no = hint.state.manifest_no;
-        current.hint_etag = hint.etag;
         current.hinted_wal_no = hint.state.wal_no;
     }
     Ok(current)
@@ -220,7 +217,6 @@ pub(crate) async fn load_discovered_manifest<S: ObjectStore + ?Sized>(
     Ok(envelope.map(|envelope| LoadedManifest {
         object_key,
         discovery_start_manifest_no: manifest_no,
-        hint_etag: String::new(),
         hinted_wal_no: loonfs_api::WalNo(0),
         state: CurrentManifest {
             manifest: ManifestRef {
@@ -240,7 +236,7 @@ pub(crate) async fn load_discovered_manifest<S: ObjectStore + ?Sized>(
 pub(crate) async fn load_head_object<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<LoadedHeadObject, ControlObjectLoadError> {
+) -> Result<NamespaceReadState, ControlObjectLoadError> {
     Ok(
         crate::namespace::control_snapshot::load_control_snapshot(store, expected_namespace_id)
             .await?
@@ -271,7 +267,7 @@ pub async fn load_namespace_current_manifest<S: ObjectStore + ?Sized>(
 pub async fn load_namespace_read_anchor<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<(LoadedControl<NamespaceReadState>, MetadataBasis), ControlObjectLoadError> {
+) -> Result<(NamespaceReadState, MetadataBasis), ControlObjectLoadError> {
     let loaded = load_head_and_metadata_basis(store, expected_namespace_id).await?;
     Ok((loaded.head, loaded.basis))
 }
@@ -279,7 +275,7 @@ pub async fn load_namespace_read_anchor<S: ObjectStore + ?Sized>(
 pub async fn load_namespace_head_control<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<LoadedControl<NamespaceReadState>, ControlObjectLoadError> {
+) -> Result<NamespaceReadState, ControlObjectLoadError> {
     load_head_object(store, expected_namespace_id).await
 }
 

--- a/crates/loonfs-core/src/namespace/control_snapshot.rs
+++ b/crates/loonfs-core/src/namespace/control_snapshot.rs
@@ -1,15 +1,15 @@
 //! Loads a current manifest and discovers its numbered WAL tip.
 
-use crate::control_object::{ControlObjectLoadError, LoadedControl};
+use crate::control_object::ControlObjectLoadError;
 use crate::namespace::basis::MetadataBasis;
-use crate::namespace::control::{load_current_manifest, LoadedHeadObject, LoadedManifest};
+use crate::namespace::control::{load_current_manifest, LoadedManifest};
 use crate::namespace::state::NamespaceReadState;
 use crate::wal::load_wal_segment;
 use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 
 pub(crate) struct NamespaceControlSnapshot {
-    pub(crate) head: LoadedHeadObject,
+    pub(crate) head: NamespaceReadState,
     pub(crate) root: LoadedManifest,
     pub(crate) retention_floor_seq: ChangeSeq,
 }
@@ -21,7 +21,7 @@ impl NamespaceControlSnapshot {
 }
 
 pub(crate) struct LoadedNamespaceBasis {
-    pub(crate) head: LoadedHeadObject,
+    pub(crate) head: NamespaceReadState,
     pub(crate) basis: MetadataBasis,
     pub(crate) retention_floor_seq: Option<ChangeSeq>,
 }
@@ -29,7 +29,7 @@ pub(crate) struct LoadedNamespaceBasis {
 pub(crate) async fn load_head_and_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-) -> Result<(LoadedHeadObject, ChangeSeq), ControlObjectLoadError> {
+) -> Result<(NamespaceReadState, ChangeSeq), ControlObjectLoadError> {
     let snapshot = load_control_snapshot(store, namespace_id).await?;
     Ok((snapshot.head, snapshot.retention_floor_seq))
 }
@@ -73,11 +73,7 @@ pub(crate) async fn load_control_snapshot<S: ObjectStore + ?Sized>(
                 }
                 return Ok(NamespaceControlSnapshot {
                     retention_floor_seq: root.state.retention_floor_seq,
-                    head: LoadedControl {
-                        object_key: loonfs_objectstore::keys::hint(namespace_id),
-                        etag: root.hint_etag.clone(),
-                        state,
-                    },
+                    head: state,
                     root,
                 });
             }

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -21,7 +21,7 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
     let started_ms = timer.monotonic_now_ms();
     loop {
         let snapshot = load_control_snapshot(store, namespace_id).await?;
-        let head = &snapshot.head.state;
+        let head = &snapshot.head;
         super::control::ensure_namespace_live(head)?;
         ensure_writer_not_fenced(head, &acquired_writer)?;
         if let Some(expected) = options.expected_head_seq {

--- a/crates/loonfs-core/src/namespace/freshness.rs
+++ b/crates/loonfs-core/src/namespace/freshness.rs
@@ -22,7 +22,6 @@ pub async fn probe_namespace_wal<S: ObjectStore + ?Sized>(
         manifest_no: context.basis.manifest_no(),
         manifest_head_seq: context.basis.manifest().manifest_head_seq,
         head_seq: state.seq,
-        head_etag: context.head_etag.clone(),
     };
     let mut rows = None;
     let mut last_record = None;

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -41,7 +41,7 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
         .map_err(CoreError::ControlObjectLoad)?;
     let basis = snapshot.basis();
     let retention_floor_seq = snapshot.retention_floor_seq;
-    let head = snapshot.head.state;
+    let head = snapshot.head;
     super::control::ensure_namespace_live(&head)?;
     let current_manifest_no = Some(basis.manifest_no());
     Ok(LoadedHeadBasis {
@@ -59,7 +59,6 @@ pub async fn load_namespace<S: ObjectStore + ?Sized>(
     let (head, retention_floor_seq) = load_head_and_retention_floor(store, expected_namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    let head = head.state;
     super::control::ensure_namespace_live(&head)?;
     Ok(Namespace {
         namespace_id: head.namespace_id,
@@ -106,7 +105,6 @@ pub async fn load_deleted_namespace_diagnostics<S: ObjectStore + ?Sized>(
     let (head, retention_floor_seq) = load_head_and_retention_floor(store, expected_namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    let head = head.state;
     if !head.status.is_deleted() {
         return Err(CoreError::Internal(format!(
             "namespace `{expected_namespace_id}` is live; deleted diagnostics require a deleted namespace"

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -55,7 +55,7 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
         }
     };
     loop {
-        let head = load_head_object(store, namespace_id).await?.state;
+        let head = load_head_object(store, namespace_id).await?;
         ensure_writer_not_fenced(&head, &acquired)?;
         super::control::ensure_namespace_live(&head)?;
         let wal_no = head

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -38,7 +38,6 @@ use tracing::Instrument;
 #[derive(Clone, Copy)]
 pub(crate) struct ReadLoadContext<'anchor, 'cache> {
     head: &'anchor NamespaceReadState,
-    head_etag: &'anchor str,
     /// Basis pinned together with the head when the snapshot was taken. The
     /// live root may have moved past a pinned head; the pinned pair stays
     /// consistent (any manifest at or below the pinned seq serves it, with
@@ -51,14 +50,12 @@ pub(crate) struct ReadLoadContext<'anchor, 'cache> {
 impl<'anchor, 'cache> ReadLoadContext<'anchor, 'cache> {
     pub(crate) fn pinned_head(
         head: &'anchor NamespaceReadState,
-        head_etag: &'anchor str,
         basis: &'anchor MetadataBasis,
         segment_cache: Option<&'cache MetadataSegmentCache>,
         tail_cache: Option<&'cache WalTailProjectionCache>,
     ) -> Self {
         Self {
             head,
-            head_etag,
             basis,
             segment_cache,
             tail_cache,
@@ -101,13 +98,7 @@ pub(crate) async fn load_current_metadata_view<'a, S: ObjectStore + ?Sized>(
     let loaded = load_head_and_metadata_basis(store, namespace_id)
         .await
         .map_err(MetadataProjectionLoadError::LoadHead)?;
-    let context = ReadLoadContext::pinned_head(
-        &loaded.head.state,
-        &loaded.head.etag,
-        &loaded.basis,
-        None,
-        None,
-    );
+    let context = ReadLoadContext::pinned_head(&loaded.head, &loaded.basis, None, None);
     load_metadata_view(store, namespace_id, context).await
 }
 
@@ -197,7 +188,6 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             manifest_no,
             manifest_head_seq: manifest_head.seq,
             head_seq: head.seq,
-            head_etag: load_context.head_etag.to_owned(),
         };
         if let Some(cache) = load_context.tail_cache {
             if let Some(wal_tail_rows) = cache.get(&cache_key) {
@@ -1005,8 +995,7 @@ mod tests {
         let (_temp_dir, store, namespace_id) = namespace_with_annotated_children().await;
         let head = load_head_object(&store, &namespace_id)
             .await
-            .expect("state")
-            .state;
+            .expect("state");
         let key = loonfs_objectstore::keys::wal_segment(&namespace_id, &head.wal_no);
         let bytes = store.get(&key, None).await.expect("WAL").expect("exists");
         let mut payload = loonfs_api::wire::wal::decode_wal_segment_envelope_zstd(&bytes)

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -394,7 +394,7 @@ mod tests {
         let head = load_namespace_head_control(&store, &namespace_id)
             .await
             .expect("load head");
-        assert_eq!(head.state.next_inode_id, InodeId(5));
+        assert_eq!(head.next_inode_id, InodeId(5));
     }
 
     #[tokio::test]
@@ -421,7 +421,7 @@ mod tests {
         let head = load_namespace_head_control(&store, &namespace_id)
             .await
             .expect("load head");
-        assert_eq!(head.state.next_inode_id, InodeId(3));
+        assert_eq!(head.next_inode_id, InodeId(3));
     }
 
     #[tokio::test]
@@ -448,7 +448,7 @@ mod tests {
         let head = load_namespace_head_control(&store, &namespace_id)
             .await
             .expect("load head");
-        assert_eq!(head.state.next_inode_id, InodeId(3));
+        assert_eq!(head.next_inode_id, InodeId(3));
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -47,7 +47,6 @@ pub(crate) enum PublishViewEffect {
     Advanced {
         records: Vec<WalCommitPayload>,
         head: NamespaceReadState,
-        head_etag: String,
     },
 }
 
@@ -257,7 +256,6 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     if let Err(error) = publish_wal(store, &wal).await {
         return abort_batch(slots, &error);
     }
-    let head_etag = view.head_etag.clone();
 
     let wal_records = wal.envelope().payload().records.clone();
     assert_eq!(
@@ -287,7 +285,6 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         effect: PublishViewEffect::Advanced {
             records: wal_records,
             head: resulting_head,
-            head_etag,
         },
     }
 }

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -20,7 +20,6 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     let (head, retention_floor_seq) = load_head_and_retention_floor(store, namespace_id)
         .await
         .map_err(CoreError::ControlObjectLoad)?;
-    let head = head.state;
     crate::namespace::control::ensure_namespace_live(&head)?;
 
     if after_seq < retention_floor_seq {

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     content_store_id: ContentStoreId,
     pub(super) head: NamespaceReadState,
-    pub(super) head_etag: String,
     pub(super) acquired_writer: AcquiredWriter,
     manifest_segments: VerifiedMetadataSegments<'a, S>,
     tail_state: Arc<MetadataState>,
@@ -96,15 +95,9 @@ pub struct PublishTailWeight {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct HeadAnchor {
-    seq: ChangeSeq,
-    etag: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 struct PublishProjectionKey {
     namespace_id: NamespaceId,
-    head: HeadAnchor,
+    head_seq: ChangeSeq,
     basis: MetadataBasisIdentity,
 }
 
@@ -135,10 +128,6 @@ impl PublishTailProjection {
             && weight.decoded_bytes <= options.max_tail_decoded_bytes
     }
 
-    pub(crate) fn head_etag(&self) -> &str {
-        &self.key.head.etag
-    }
-
     pub(crate) fn basis(&self) -> &MetadataBasis {
         self.key.basis.basis()
     }
@@ -147,11 +136,8 @@ impl PublishTailProjection {
         self.key.basis.manifest_head_seq()
     }
 
-    pub(crate) fn reanchor(&mut self, head: NamespaceReadState, etag: String) {
-        self.key.head = HeadAnchor {
-            seq: head.seq,
-            etag,
-        };
+    pub(crate) fn reanchor(&mut self, head: NamespaceReadState) {
+        self.key.head_seq = head.seq;
         self.head = head;
     }
 }
@@ -166,11 +152,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
 ) -> Result<(PublishMetadataView<'a, S>, PublishTailProjection)> {
     let loaded = if let Some(cached) = cached_projection {
         crate::namespace::control_snapshot::LoadedNamespaceBasis {
-            head: crate::control_object::LoadedControl {
-                object_key: loonfs_objectstore::keys::hint(namespace_id),
-                etag: cached.head_etag().to_owned(),
-                state: cached.head.clone(),
-            },
+            head: cached.head.clone(),
             basis: cached.basis().clone(),
             retention_floor_seq: cached.retention_floor_seq,
         }
@@ -180,8 +162,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
             .map_err(CoreError::ControlObjectLoad)?
     };
     let retention_floor_seq = loaded.retention_floor_seq;
-    let head_etag = loaded.head.etag;
-    let head = loaded.head.state;
+    let head = loaded.head;
     if head.status.is_deleted() {
         return Err(CoreError::MetadataProjection(
             MetadataProjectionLoadError::NamespaceDeleted {
@@ -194,10 +175,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     let loaded_basis = load_basis_metadata_segments(store, segment_cache, &loaded.basis).await?;
     let key = PublishProjectionKey {
         namespace_id: namespace_id.clone(),
-        head: HeadAnchor {
-            seq: head.seq,
-            etag: head_etag.clone(),
-        },
+        head_seq: head.seq,
         basis: loaded_basis.identity.clone(),
     };
     let projection = if let Some(cached) =
@@ -215,7 +193,6 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
         PublishMetadataView {
             content_store_id: catalog_entry.content_store_id().clone(),
             head,
-            head_etag,
             acquired_writer,
             manifest_segments,
             tail_state,
@@ -290,16 +267,12 @@ mod tests {
     fn projection_key(
         namespace: &str,
         head_seq: u64,
-        head_etag: &str,
         basis: MetadataBasis,
         manifest_head_seq: u64,
     ) -> PublishProjectionKey {
         PublishProjectionKey {
             namespace_id: namespace_id(namespace),
-            head: HeadAnchor {
-                seq: ChangeSeq(head_seq),
-                etag: head_etag.to_owned(),
-            },
+            head_seq: ChangeSeq(head_seq),
             basis: MetadataBasisIdentity::from_verified_basis(basis, ChangeSeq(manifest_head_seq)),
         }
     }
@@ -311,7 +284,7 @@ mod tests {
                 .expect("valid content store id"),
             1_000,
         );
-        head.seq = key.head.seq;
+        head.seq = key.head_seq;
         PublishTailProjection {
             head,
             retention_floor_seq: Some(ChangeSeq(0)),
@@ -333,7 +306,6 @@ mod tests {
         let key = projection_key(
             "fork-target",
             9,
-            "head-etag-a",
             manifest_basis("fork-source", 4, "sha256:basis-a"),
             7,
         );
@@ -347,7 +319,6 @@ mod tests {
                 projection_key(
                     "other-target",
                     9,
-                    "head-etag-a",
                     manifest_basis("fork-source", 4, "sha256:basis-a"),
                     7,
                 ),
@@ -357,17 +328,6 @@ mod tests {
                 projection_key(
                     "fork-target",
                     10,
-                    "head-etag-a",
-                    manifest_basis("fork-source", 4, "sha256:basis-a"),
-                    7,
-                ),
-            ),
-            (
-                "head etag",
-                projection_key(
-                    "fork-target",
-                    9,
-                    "head-etag-b",
                     manifest_basis("fork-source", 4, "sha256:basis-a"),
                     7,
                 ),
@@ -377,7 +337,6 @@ mod tests {
                 projection_key(
                     "fork-target",
                     9,
-                    "head-etag-a",
                     manifest_basis("other-source", 4, "sha256:basis-a"),
                     7,
                 ),
@@ -387,7 +346,6 @@ mod tests {
                 projection_key(
                     "fork-target",
                     9,
-                    "head-etag-a",
                     manifest_basis("fork-source", 5, "sha256:basis-a"),
                     7,
                 ),
@@ -397,7 +355,6 @@ mod tests {
                 projection_key(
                     "fork-target",
                     9,
-                    "head-etag-a",
                     manifest_basis("fork-source", 4, "sha256:basis-b"),
                     7,
                 ),
@@ -407,7 +364,6 @@ mod tests {
                 projection_key(
                     "fork-target",
                     9,
-                    "head-etag-a",
                     manifest_basis("fork-source", 4, "sha256:basis-a"),
                     8,
                 ),
@@ -427,7 +383,6 @@ mod tests {
         let key = projection_key(
             "fork-target",
             9,
-            "head-etag-a",
             manifest_basis("fork-source", 4, "sha256:basis-a"),
             7,
         );
@@ -447,7 +402,6 @@ mod tests {
         let key = projection_key(
             "genesis-namespace",
             0,
-            "genesis-etag",
             manifest_basis("genesis-namespace", 1, "sha256:genesis"),
             0,
         );

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -373,7 +373,7 @@ async fn ack_lost_wal_put_reports_unknown_outcome_and_replays_idempotently() {
     let head = load_namespace_head_control(&store, &namespace_id)
         .await
         .expect("load head");
-    assert_eq!(head.state.seq, ChangeSeq(1));
+    assert_eq!(head.seq, ChangeSeq(1));
 }
 
 #[tokio::test]
@@ -480,7 +480,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
     let head = load_namespace_head_control(&store, &namespace_id)
         .await
         .expect("load head");
-    assert_eq!(head.state.seq, ChangeSeq(0));
+    assert_eq!(head.seq, ChangeSeq(0));
 
     let retried =
         publish_namespace_commits_batch(&store, &namespace_id, batch().await, &context).await;
@@ -1196,7 +1196,7 @@ async fn delete_path_commit_id_reuse_includes_expected_inode_id() {
     let head = load_namespace_head_control(&store, &namespace_id)
         .await
         .expect("load head");
-    assert_eq!(head.state.seq, ChangeSeq(8));
+    assert_eq!(head.seq, ChangeSeq(8));
 }
 
 #[tokio::test]
@@ -1419,7 +1419,7 @@ async fn head_assertions_use_admitted_pre_state_and_receipts_resolve_first() {
         let head = load_namespace_head_control(&store, &namespace_id)
             .await
             .expect("head");
-        assert_eq!(head.state.next_inode_id, InodeId(next_seq + 2));
+        assert_eq!(head.next_inode_id, InodeId(next_seq + 2));
         let replay = submit_commit(&store, &namespace_id, first.clone(), &context)
             .await
             .expect("receipt resolves despite stale assertion");
@@ -1548,7 +1548,7 @@ async fn file_revision_assertions_ignore_unrelated_commits_and_reject_rewrites_a
     let head = load_namespace_head_control(&store, &namespace_id)
         .await
         .expect("head");
-    assert_eq!(head.state.next_inode_id, InodeId(6));
+    assert_eq!(head.next_inode_id, InodeId(6));
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -303,8 +303,7 @@ async fn valid_content_admission_skips_durable_content_validation() {
     );
     let head_before = loonfs_core::control::load_namespace_head_control(&store, &namespace_id)
         .await
-        .expect("head")
-        .state;
+        .expect("head");
     store.reset();
     store.inner().reset();
     let rejected = publisher
@@ -335,8 +334,7 @@ async fn valid_content_admission_skips_durable_content_validation() {
     assert_eq!(
         loonfs_core::control::load_namespace_head_control(&store, &namespace_id)
             .await
-            .expect("head")
-            .state,
+            .expect("head"),
         head_before
     );
 }

--- a/crates/loonfs-core/tests/it/common/mod.rs
+++ b/crates/loonfs-core/tests/it/common/mod.rs
@@ -36,8 +36,7 @@ pub(crate) async fn read_context<S: ObjectStore + ?Sized>(
         .await
         .expect("load read anchor");
     RuntimeReadContext {
-        head: head.state,
-        head_etag: head.etag,
+        head,
         basis,
         segment_cache: Arc::new(MetadataSegmentCache::new(
             MetadataSegmentCacheConfig::default(),

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -302,7 +302,6 @@ async fn head_state<S: ObjectStore + ?Sized>(
     load_namespace_head_control(store, namespace_id)
         .await
         .expect("load head")
-        .state
 }
 
 async fn namespace_keys<S: ObjectStore + ?Sized>(
@@ -344,7 +343,7 @@ async fn a_created_namespace_reads_manifest_one_before_its_first_flush() {
             .list_prefix("content-stores/")
             .await
             .expect("list content stores"),
-        vec![content_store(&head.state.content_store_id)],
+        vec![content_store(&head.content_store_id)],
     );
 
     let root_entry = resolve_path(&store, &namespace_id, "/")
@@ -1382,7 +1381,7 @@ async fn creation_and_fork_install_descriptor_hint_and_manifest_in_order() {
     let head = load_namespace_head_control(&store, &source)
         .await
         .expect("head");
-    let descriptor_key = content_store(&head.state.content_store_id);
+    let descriptor_key = content_store(&head.content_store_id);
     let puts: Vec<_> = store
         .take()
         .into_iter()
@@ -1414,8 +1413,8 @@ async fn creation_and_fork_install_descriptor_hint_and_manifest_in_order() {
     assert_eq!(
         descriptor,
         ContentStoreState {
-            content_store_id: head.state.content_store_id.clone(),
-            created_at_ms: head.state.created_at_ms,
+            content_store_id: head.content_store_id.clone(),
+            created_at_ms: head.created_at_ms,
         }
     );
     store.reset();
@@ -1448,10 +1447,7 @@ async fn creation_and_fork_install_descriptor_hint_and_manifest_in_order() {
     let fork_head = load_namespace_head_control(&store, &target)
         .await
         .expect("fork head");
-    assert_eq!(
-        fork_head.state.content_store_id,
-        descriptor.content_store_id
-    );
+    assert_eq!(fork_head.content_store_id, descriptor.content_store_id);
     for allow_existing in [false, true] {
         store.reset();
         let result = bootstrap_namespace(&store, &source, &context, allow_existing).await;

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -175,8 +175,7 @@ async fn maintenance_preserves_namespace_identity_and_writer() {
 
     let before = loonfs_core::control::load_namespace_head_control(&store, &namespace_id)
         .await
-        .expect("namespace state")
-        .state;
+        .expect("namespace state");
 
     engine
         .create_checkpoint("test-pin".to_owned(), None)
@@ -208,8 +207,7 @@ async fn maintenance_preserves_namespace_identity_and_writer() {
 
     let after = loonfs_core::control::load_namespace_head_control(&store, &namespace_id)
         .await
-        .expect("namespace state")
-        .state;
+        .expect("namespace state");
     assert_eq!(after.namespace_id, before.namespace_id);
     assert_eq!(after.content_store_id, before.content_store_id);
     assert_eq!(after.created_at_ms, before.created_at_ms);

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -1,7 +1,6 @@
-//! Structural acceptance tests for the namespace layout redesign (format
-//! spec, "Final design summary"): live visibility comes only from the WAL
-//! head, nothing correct depends on listing, and maintenance never touches
-//! the head.
+//! Namespace layout acceptance tests: numbered WAL objects make commits visible,
+//! readers discover state without listing, and maintenance publishes manifests
+//! without advancing the head sequence.
 
 use crate::common::{mutation_context, namespace_engine, read_context};
 use bytes::Bytes;

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -24,8 +24,8 @@ and core garbage collection.
 The `grep_gc` job completes one collection pass per call.
 `loonfs maintenance index gc` runs a pass directly for one namespace,
 including an absent or deleted namespace whose old index data remains.
-Every pass reads durable roots before deletion. Manifests use contiguous
-numbers and put-if-absent publication. `hint.json` starts forward discovery
+Every pass reads the current manifest and hint before deletion. Manifests use
+contiguous numbers and put-if-absent publication. `hint.json` starts forward discovery
 and may lag. Queries validate a cached manifest with one HEAD of its
 successor. The durable layout and collection rules are in
 [grep format](../../docs/specs/format.md#appendix-d-grep-extension-format).
@@ -38,12 +38,8 @@ these values from its `[grep]` table:
 mode = "serve_and_maintain"
 max_files_per_step = 256
 max_content_bytes_per_step = 67108864
-max_rows_per_segment = 65536
-max_delta_runs = 8
-max_mid_runs = 8
-max_decoded_input_rows_per_step = 131072
 ```
 
-Every step budget must be greater than zero. These values do not control
+Both input limits must be greater than zero. These values do not control
 concurrency. The runtime's shared `max_concurrent_maintenance` limit applies
 across all maintenance jobs, including grep.

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -41,9 +41,9 @@ pub enum GrepError {
         message: String,
     },
     /// A grep manifest publication lost to another publisher.
-    #[error("grep root publication conflict for `{object_key}`; retry")]
+    #[error("grep manifest publication conflict for `{object_key}`; retry")]
     PublicationConflict {
-        /// Manifest number whose publication raced.
+        /// Object key whose manifest publication raced.
         object_key: String,
     },
     /// A genuine runtime failure encountered while grep read or wrote

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -61,7 +61,6 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let build = match self.worker.build_step(namespace_id, self.policy).await {
@@ -152,7 +151,6 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepGcJo
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.worker

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -207,7 +207,6 @@ pub(crate) mod control {
         loonfs::control::load_namespace_head_control(store, namespace_id)
             .await
             .expect("namespace state")
-            .state
     }
 
     pub(crate) async fn metadata_root(

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -128,7 +128,7 @@ impl GrepHost {
                 return Ok(lifecycle);
             }
             match job
-                .run(namespace_id, None, &loonfs::MaintenanceCancellation::new())
+                .run(namespace_id, &loonfs::MaintenanceCancellation::new())
                 .await
                 .map_err(GrepError::Runtime)?
                 .conclusion

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -86,7 +86,7 @@ async fn a_tombstoned_namespace_concludes_not_enabled() {
 
     let job = job(&worker);
     assert_eq!(
-        job.run(&namespace_id, None, &MaintenanceCancellation::new())
+        job.run(&namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("step tombstone")
             .conclusion,
@@ -115,7 +115,7 @@ async fn a_disabled_root_concludes_not_enabled_on_the_next_step() {
 
     worker.disable(&namespace_id).await.expect("disable grep");
     assert_eq!(
-        job.run(&namespace_id, None, &MaintenanceCancellation::new())
+        job.run(&namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("step disabled root")
             .conclusion,
@@ -239,7 +239,7 @@ async fn catch_up<S: ObjectStore + Clone + Send + Sync + 'static>(
 ) {
     for _ in 0..64 {
         match job
-            .run(namespace_id, None, &MaintenanceCancellation::new())
+            .run(namespace_id, &MaintenanceCancellation::new())
             .await
             .expect("grep step")
             .conclusion

--- a/crates/loonfs-server/docs/actor-attribution.md
+++ b/crates/loonfs-server/docs/actor-attribution.md
@@ -5,8 +5,7 @@ Every mutation includes an `actor_id`, such as `"usr_8f3c"`.
 Your backend authenticates and authorizes the request. LoonFS records the
 `actor_id` exactly as sent; it does not verify or manage identities. Use
 a stable internal ID, not an email address or display name.
-LoonFS does not parse the id. An application that used to rely on the kind
-to tell two identities apart must give them different ids.
+LoonFS does not parse the id.
 
 Use `committed_by` to identify the actor for each commit. Do not infer the actor
 from a commit message or error message.

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -305,9 +305,8 @@ indexing step; their defaults are 256 files and 64 MiB, and both must be positiv
 Indexing shares `max_concurrent_maintenance` with other maintenance work.
 
 Segment sizes, merge thresholds, and reorganization step sizes use engine
-defaults, like metadata compaction. The former `max_rows_per_segment`,
-`max_delta_runs`, `max_mid_runs`, and `max_decoded_input_rows_per_step` settings
-are rejected; remove them from existing pre-release configurations.
+defaults, like metadata compaction. The accepted input limits are
+`max_files_per_step` and `max_content_bytes_per_step`.
 
 ## Resource sizing
 

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -774,7 +774,7 @@ fn decode_checkpoint_cursor(
         path = "/v0/maintenance/namespaces/{namespace_id}/runs",
         tag = "maintenance",
         summary = "Run one maintenance job",
-        description = "Runs one maintenance job for the namespace. The body names the job with `kind`: `metadata`, `metadata_compaction`, `gc`, or `retention`. The response carries the same `kind` and that job's result. A deleted namespace accepts only `gc`. A `gc` call reads current roots, then sweeps every family to the end. Each listing starts at the beginning. The call keeps no continuation.",
+        description = "Runs one maintenance job for the namespace. The body names the job with `kind`: `metadata`, `metadata_compaction`, `gc`, or `retention`. The response carries the same `kind` and that job's result. A deleted namespace accepts only `gc`. A `gc` call reads the current manifest and lists pins, then sweeps every family to the end. Each listing starts at the beginning. The call keeps no continuation.",
         params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body(content = RunMaintenanceRequest, description = "The maintenance job to run"),
         responses(

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -302,7 +302,7 @@ pub(super) async fn disable_grep_index(
         request_body(content = ref("#/components/schemas/GrepGcRequest")),
         responses(
             (status = 200, description = "Namespace grep garbage collection completed", body = GrepGcResponse),
-            (status = 400, description = "Invalid budget or cursor", body = ApiError),
+            (status = 400, description = "Invalid namespace id or options", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -151,7 +151,6 @@ pub fn openapi_document() -> utoipa::openapi::OpenApi {
         loonfs_api::AttributeValue,
         loonfs_api::Attributes,
         loonfs_api::AttributeRevisionNo,
-        loonfs_api::InodeKind,
         loonfs_api::PathEntry,
         loonfs_api::PathEntryKind,
         loonfs_api::AttributesProjection,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -447,7 +447,7 @@ use tempfile::tempdir;
 
 const POISON_PROVIDER_DETAIL: &str = "<Error>AccessDenied</Error> \
     arn:aws:iam::123456789012:role/private-role private-bucket \
-    namespaces/customer-a/head.json x-amz-request-id=provider-request \
+    namespaces/customer-a/hint.json x-amz-request-id=provider-request \
     x-amz-id-2=provider-host-id AKIAEXAMPLE";
 
 fn assert_provider_markers_absent(rendered: &str) {
@@ -455,7 +455,7 @@ fn assert_provider_markers_absent(rendered: &str) {
         "<Error>AccessDenied</Error>",
         "arn:aws:iam::123456789012:role/private-role",
         "private-bucket",
-        "namespaces/customer-a/head.json",
+        "namespaces/customer-a/hint.json",
         "x-amz-request-id=provider-request",
         "x-amz-id-2=provider-host-id",
         "AKIAEXAMPLE",
@@ -538,7 +538,7 @@ async fn provider_failure_is_projected_in_the_presign_api_envelope() {
     let response = super::REQUEST_ID
         .scope("req_presign_hygiene".to_owned(), async {
             super::handlers_uploads::presign_issuer_error(PoisonProviderStore::denied(
-                "namespaces/customer-a/head.json",
+                "namespaces/customer-a/hint.json",
             ))
             .into_response()
         })

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -117,7 +117,6 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "inode_kind",
     "maintain_only",
     "manifest_no",
-    "max_objects",
     "max_wal_tail_segments",
     "metadata_compaction",
     "metadata_segments",
@@ -1133,7 +1132,6 @@ impl MaintenanceJob for StepCountingJob {
     async fn run(
         &self,
         _namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> loonfs::Result<MaintenanceRunReport> {
         self.steps.fetch_add(1, Ordering::SeqCst);

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2057,8 +2057,7 @@ async fn http_first_write_takes_over_a_namespace_owned_by_another_writer() {
         &namespace_id("demo"),
     )
     .await
-    .expect("read head")
-    .state;
+    .expect("read head");
     assert_eq!(
         head.writer.expect("writer block").writer_id,
         loonfs_api::WriterId::parse("server-writer").expect("writer id")

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -1362,6 +1362,13 @@ fn openapi_documents_string_id_contracts_without_dead_schemas() {
         .and_then(|components| components.get("schemas"))
         .and_then(Value::as_object)
         .expect("openapi schemas object");
+    let referenced = referenced_components(&spec);
+    for name in schemas.keys() {
+        assert!(
+            referenced.contains(&("schemas".to_owned(), name.clone())),
+            "OpenAPI schema `{name}` is not referenced by a path"
+        );
+    }
     let content_id = schemas.get("ContentId").expect("ContentId schema");
 
     assert_eq!(

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -86,7 +86,8 @@ pub async fn summarize_namespace_objects<S: ObjectStore + ?Sized>(
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use loonfs_api::IndexSegmentId;
+    use loonfs_api::wire::control::{encode_control_state, ControlObjectKind, HintState};
+    use loonfs_api::{IndexSegmentId, ManifestNo, WalNo};
     use loonfs_grep::keyspace::{hint_key, manifest_key, segment_key};
     use loonfs_objectstore::keys::{hint, wal_segment};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -98,9 +99,22 @@ mod tests {
         let namespace_id = NamespaceId::parse("sim").expect("valid namespace id");
 
         store
-            .put_overwrite(&hint(&namespace_id), Bytes::from_static(b"head"))
+            .put_overwrite(
+                &hint(&namespace_id),
+                Bytes::from(
+                    encode_control_state(
+                        ControlObjectKind::Hint,
+                        &HintState {
+                            namespace_id: namespace_id.clone(),
+                            manifest_no: ManifestNo(1),
+                            wal_no: WalNo(1),
+                        },
+                    )
+                    .expect("encode hint"),
+                ),
+            )
             .await
-            .expect("head");
+            .expect("hint");
         store
             .put_overwrite(
                 &wal_segment(&namespace_id, &loonfs_api::WalNo(1)),

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -10,8 +10,7 @@ use loonfs_core::cache::{MetadataSegmentCacheStats, WalTailProjectionCacheStats}
 use loonfs_core::control::NamespaceReadState;
 use loonfs_core::control::{
     load_checkpoint_read_basis, load_namespace_read_anchor, load_snapshot_read_basis,
-    CheckpointReadBasis, ControlObjectLoadError, LoadedControl, MetadataBasis,
-    VerifiedNamespaceCatalogEntry,
+    CheckpointReadBasis, ControlObjectLoadError, MetadataBasis, VerifiedNamespaceCatalogEntry,
 };
 use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext, StoreFailureClass};
 use loonfs_objectstore::keys::metadata_manifest_object;
@@ -25,19 +24,13 @@ pub(crate) struct RuntimeControlCache {
     namespace_order: Recency<NamespaceId>,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct CachedControl<T> {
-    pub(crate) etag: String,
-    pub(crate) state: T,
-}
-
 /// A head snapshot and the metadata basis it authorized at that point.
 /// Keeping them together ensures reads use a consistent pair. If compaction
 /// advances the live root, reads may replay additional WAL entries until the
 /// cache refreshes.
 #[derive(Debug, Clone)]
 pub(crate) struct CachedNamespaceAnchor {
-    pub(crate) head: CachedControl<NamespaceReadState>,
+    pub(crate) head: NamespaceReadState,
     pub(crate) basis: MetadataBasis,
     locally_published: bool,
     last_control_check_ms: u64,
@@ -276,7 +269,7 @@ impl ReadCore {
                 }
                 let mut context = self.runtime_read_context(&head);
                 if loonfs_core::control::probe_namespace_wal(self.store(), &mut context).await? {
-                    head.head.state = context.head;
+                    head.head = context.head;
                     return Ok(head);
                 }
             }
@@ -339,8 +332,7 @@ impl ReadCore {
         anchor: &CachedNamespaceAnchor,
     ) -> RuntimeReadContext {
         RuntimeReadContext {
-            head: anchor.head.state.clone(),
-            head_etag: anchor.head.etag.clone(),
+            head: anchor.head.clone(),
             basis: anchor.basis.clone(),
             segment_cache: Arc::clone(&self.inner.metadata_segment_cache),
             tail_cache: Arc::clone(&self.inner.wal_tail_projection_cache),
@@ -377,7 +369,7 @@ impl ReadCore {
         let pinned = load_checkpoint_read_basis(
             self.store(),
             Some(self.inner.metadata_segment_cache.as_ref()),
-            &live.head.state,
+            &live.head,
             checkpoint_id,
         )
         .await?;
@@ -398,7 +390,7 @@ impl ReadCore {
         let pinned = load_snapshot_read_basis(
             self.store(),
             Some(self.inner.metadata_segment_cache.as_ref()),
-            &live.head.state,
+            &live.head,
             snapshot_id,
             now_ms,
         )
@@ -415,10 +407,7 @@ impl ReadCore {
         RuntimeReadContext,
     ) {
         let read_context = self.runtime_read_context(&CachedNamespaceAnchor {
-            head: CachedControl {
-                etag: pinned.head_etag,
-                state: pinned.head,
-            },
+            head: pinned.head,
             basis: pinned.basis,
             locally_published: false,
             last_control_check_ms: 0,
@@ -447,7 +436,7 @@ impl ReadCore {
         namespace_id: &NamespaceId,
     ) -> Result<VerifiedNamespaceCatalogEntry> {
         let anchor = self.head_for_metadata_read(namespace_id).await?;
-        Ok(VerifiedNamespaceCatalogEntry::from_head(&anchor.head.state))
+        Ok(VerifiedNamespaceCatalogEntry::from_head(&anchor.head))
     }
 
     /// Namespace-terminal invalidation: the whole entry is removed, because
@@ -482,10 +471,7 @@ impl ReadCore {
         cache.insert_namespace_head(
             namespace_id,
             CachedNamespaceAnchor {
-                head: CachedControl {
-                    etag: state.head_etag.clone(),
-                    state: state.head,
-                },
+                head: state.head,
                 basis: state.basis,
                 locally_published: true,
                 last_control_check_ms,
@@ -500,7 +486,6 @@ impl ReadCore {
                 manifest_no,
                 manifest_head_seq: state.manifest_head_seq,
                 head_seq,
-                head_etag: state.head_etag,
             },
             state.tail_rows,
         );
@@ -536,14 +521,11 @@ impl ReadCore {
 }
 
 fn cached_anchor(
-    (head, basis): (LoadedControl<NamespaceReadState>, MetadataBasis),
+    (head, basis): (NamespaceReadState, MetadataBasis),
     last_control_check_ms: u64,
 ) -> CachedNamespaceAnchor {
     CachedNamespaceAnchor {
-        head: CachedControl {
-            etag: head.etag,
-            state: head.state,
-        },
+        head,
         basis,
         locally_published: false,
         last_control_check_ms,

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -88,8 +88,6 @@ impl FsMaintenance {
         engine
     }
 
-    /// Drops this runtime's read caches; publisher projections reload because
-    /// their keys include the head etag and basis identity.
     pub(crate) fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
         self.core.invalidate_namespace_read_cache(namespace_id);
     }

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -465,7 +465,7 @@ impl FsMaintenance {
             }
             loonfs_core::MetadataReorganizeOutcome::Superseded => {
                 tracing::info!(
-                    "metadata root changed before reorganization published; a later step retries"
+                    "current manifest changed before reorganization published; a later step retries"
                 );
                 ReorganizeStepOutcome::RootAdvanced
             }

--- a/crates/loonfs/src/maintenance/admission.rs
+++ b/crates/loonfs/src/maintenance/admission.rs
@@ -1,8 +1,8 @@
 //! Synchronous scheduling state for maintenance jobs.
 //!
 //! The runner's lock protects admission, coalescing, fairness, backoff,
-//! deadlines, continuations, and shutdown. The parent module handles async
-//! execution, permits, and timers.
+//! deadlines, and shutdown. The parent module handles async execution,
+//! permits, and timers.
 
 use super::runner::MaintenanceClock;
 use super::{MaintenanceConclusion, MaintenanceJobId, MaintenanceRunReport};
@@ -50,9 +50,6 @@ impl MaintenanceKey {
 pub(crate) struct MaintenanceDispatch {
     /// The key this permit is running.
     pub(crate) key: MaintenanceKey,
-    /// Where this key's job said its last step stopped, opaque here and
-    /// handed straight back to the step about to run.
-    pub(crate) continuation: Option<String>,
     /// How long the claimed run waited between taking its ticket and holding
     /// a permit. Read by the step's own trace.
     pub(crate) queue_wait_ms: u64,
@@ -61,12 +58,7 @@ pub(crate) struct MaintenanceDispatch {
 /// How one step ended, from admission's point of view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StepOutcome {
-    /// The executor answered. The result decides what happens to the key:
-    /// its conclusion when to run again, its continuation where to resume,
-    /// its not-before time when a deadline it saw comes due.
     Concluded(MaintenanceRunReport),
-    /// The executor failed. The key is retried after its backoff, from
-    /// wherever its last step left it.
     Failed,
 }
 
@@ -178,11 +170,6 @@ struct KeyState {
     obligations: Option<TimedObligations>,
     /// Consecutive failed steps since the last conclusion, for the backoff.
     consecutive_failures: u32,
-    /// Opaque continuation returned by the previous step.
-    ///
-    /// Admission stores it and passes it to the next step. Losing it only
-    /// restarts the scan because each step revalidates durable state.
-    continuation: Option<String>,
 }
 
 impl KeyState {
@@ -337,15 +324,6 @@ impl Admission {
             .get(key)
             .and_then(|state| state.obligations)
             .map(|owed| owed.earliest_at_ms)
-    }
-
-    /// Where the key's job stopped last time. A claim carries this to the
-    /// step it dispatches; nothing on the running path reads it back out.
-    #[cfg(test)]
-    pub(crate) fn continuation(&self, key: &MaintenanceKey) -> Option<String> {
-        self.keys
-            .get(key)
-            .and_then(|state| state.continuation.clone())
     }
 
     /// Keys holding a ticket: work admitted and waiting for a permit.
@@ -561,9 +539,6 @@ impl Admission {
         batch
     }
 
-    /// Ends the running step: what it concluded decides the key's
-    /// continuation and whether it is queued again, and the key stops
-    /// running either way.
     fn apply(&mut self, key: &MaintenanceKey, outcome: StepOutcome, now_ms: u64) {
         let result = match outcome {
             StepOutcome::Failed => {
@@ -573,9 +548,6 @@ impl Admission {
             StepOutcome::Concluded(result) => result,
         };
         if result.conclusion == MaintenanceConclusion::NotEnabled {
-            // The job has nothing to maintain here at all. Drop the key —
-            // its continuation and its obligations included — rather than
-            // reconcile it forever.
             self.keys.remove(key);
             return;
         }
@@ -583,29 +555,12 @@ impl Admission {
         if let Some(state) = self.keys.get_mut(key) {
             state.consecutive_failures = 0;
             let concluding_run = match result.conclusion {
-                // Work happened, or the step lost a race it should simply
-                // take again: eligible immediately, behind whatever else is
-                // waiting, resuming from wherever this step stopped.
                 MaintenanceConclusion::Progressed | MaintenanceConclusion::Superseded => {
-                    state.continuation = result.continuation;
                     Some(ReadyRun::queued(ticket, now_ms))
                 }
-                // Work is left and this step's policy could not move it.
-                // Parks like `Idle` — requeueing zero-progress work would
-                // only spin — but keeps where the step stopped, so a retry
-                // with room to work resumes instead of walking the same
-                // ground again.
-                MaintenanceConclusion::Blocked => {
-                    state.continuation = result.continuation;
-                    None
-                }
-                // Nothing to do. Whatever the last pass was carrying is
-                // spent, and the next step starts a fresh one.
-                MaintenanceConclusion::Idle => {
-                    state.continuation = None;
-                    None
-                }
-                MaintenanceConclusion::NotEnabled => None,
+                MaintenanceConclusion::Blocked
+                | MaintenanceConclusion::Idle
+                | MaintenanceConclusion::NotEnabled => None,
             };
             state.settle(concluding_run);
         }
@@ -617,7 +572,6 @@ impl Admission {
         }
     }
 
-    /// Applies retry backoff without changing the job's continuation.
     fn record_failure(&mut self, key: &MaintenanceKey, now_ms: u64) {
         let ticket = self.take_ticket();
         let Some(state) = self.keys.get_mut(key) else {
@@ -654,11 +608,7 @@ impl Admission {
         let key = self.pick_eligible(now_ms)?;
         let state = self.keys.get_mut(&key)?;
         let queue_wait_ms = state.claim(now_ms)?;
-        Some(MaintenanceDispatch {
-            key,
-            continuation: state.continuation.clone(),
-            queue_wait_ms,
-        })
+        Some(MaintenanceDispatch { key, queue_wait_ms })
     }
 }
 
@@ -746,16 +696,6 @@ mod tests {
 
     fn concluded(conclusion: MaintenanceConclusion) -> StepOutcome {
         StepOutcome::Concluded(MaintenanceRunReport::concluded(conclusion))
-    }
-
-    /// A conclusion that also tells the runner where the step stopped.
-    fn continuing(conclusion: MaintenanceConclusion, continuation: &str) -> StepOutcome {
-        StepOutcome::Concluded(MaintenanceRunReport {
-            conclusion,
-            continuation: Some(continuation.to_owned()),
-            not_before_ms: None,
-            follow_up: None,
-        })
     }
 
     fn idle() -> StepOutcome {
@@ -1113,122 +1053,25 @@ mod tests {
     }
 
     #[test]
-    fn the_runner_carries_a_continuation_between_steps() {
-        let mut admission = book(1);
-        let key = gc("paged");
-
-        admission.nudge(key.clone());
-        let first = admission
-            .try_dispatch(NOW)
-            .expect("the nudged key claims the permit");
-        assert_eq!(first.key, key);
-        assert_eq!(first.continuation, None, "a first step starts a fresh pass");
-
-        let resumed = admission
-            .finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW,
-            )
-            .expect("a progressing key is eligible again");
-        assert_eq!(resumed.key, key);
-        assert_eq!(
-            resumed.continuation,
-            Some("page-1".to_owned()),
-            "and the handoff carries where this step stopped to the next one"
-        );
-
-        assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Blocked, "page-2"),
-                NOW
-            )),
-            None,
-            "a blocked key parks"
-        );
-        assert_eq!(
-            admission.continuation(&key),
-            Some("page-2".to_owned()),
-            "keeping its position, so a retry with a bigger budget resumes"
-        );
-
-        admission.nudge(key.clone());
-        let retried = admission
-            .try_dispatch(NOW)
-            .expect("a later nudge claims the permit again");
-        assert_eq!(retried.key, key);
-        assert_eq!(
-            retried.continuation,
-            Some("page-2".to_owned()),
-            "the parked position is what the resumed step is handed"
-        );
-        assert_eq!(claimed(admission.finish(&key, idle(), NOW)), None);
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "an idle pass is a finished one: the next step starts over"
-        );
-    }
-
-    #[test]
-    fn an_evicted_key_drops_its_continuation() {
+    fn an_evicted_key_can_be_admitted_again() {
         let mut admission = book(1);
         let key = gc("gone");
 
         admission.nudge(key.clone());
         assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
         assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW
-            )),
+            claimed(admission.finish(&key, concluded(MaintenanceConclusion::Progressed), NOW)),
             Some(key.clone())
         );
         assert_eq!(
             claimed(admission.finish(&key, concluded(MaintenanceConclusion::NotEnabled), NOW)),
             None
         );
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "the key's whole state went with it"
-        );
+        assert!(!admission.is_pending(&key));
+        assert!(admission.reconcile_batch(1).is_empty());
 
         admission.nudge(key.clone());
         assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
-        assert_eq!(
-            admission.continuation(&key),
-            None,
-            "and a re-admitted key starts a fresh pass"
-        );
-    }
-
-    #[test]
-    fn a_failed_step_keeps_where_its_last_one_stopped() {
-        let mut admission = book(1);
-        let key = gc("flaky");
-
-        admission.nudge(key.clone());
-        assert_eq!(claimed(admission.try_dispatch(NOW)), Some(key.clone()));
-        assert_eq!(
-            claimed(admission.finish(
-                &key,
-                continuing(MaintenanceConclusion::Progressed, "page-1"),
-                NOW
-            )),
-            Some(key.clone())
-        );
-        assert_eq!(
-            claimed(admission.finish(&key, StepOutcome::Failed, NOW)),
-            None
-        );
-        assert_eq!(
-            admission.continuation(&key),
-            Some("page-1".to_owned()),
-            "a failure says nothing about where the last step stopped"
-        );
     }
 
     #[test]
@@ -1243,7 +1086,6 @@ mod tests {
                 &key,
                 StepOutcome::Concluded(MaintenanceRunReport {
                     conclusion: MaintenanceConclusion::Idle,
-                    continuation: None,
                     not_before_ms: Some(NOW + 60_000),
                     follow_up: None,
                 }),
@@ -1265,7 +1107,6 @@ mod tests {
                 &key,
                 StepOutcome::Concluded(MaintenanceRunReport {
                     conclusion: MaintenanceConclusion::Progressed,
-                    continuation: None,
                     not_before_ms: Some(NOW + 30_000),
                     follow_up: None,
                 }),

--- a/crates/loonfs/src/maintenance/gc.rs
+++ b/crates/loonfs/src/maintenance/gc.rs
@@ -78,7 +78,6 @@ impl MaintenanceJob for GarbageCollectionJob {
             )
             .await
             .map_err(loonfs_core::Error::ControlObjectLoad)?
-            .state
             .fork_basis
             .map(|basis| (MaintenanceJobId::GC, basis.manifest.owner_namespace_id))
         } else {

--- a/crates/loonfs/src/maintenance/gc.rs
+++ b/crates/loonfs/src/maintenance/gc.rs
@@ -48,7 +48,6 @@ impl MaintenanceJob for GarbageCollectionJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let response = match self
@@ -98,7 +97,6 @@ impl MaintenanceJob for GarbageCollectionJob {
 fn gc_run_result(gc: GcResponse) -> MaintenanceRunReport {
     MaintenanceRunReport {
         conclusion: gc_conclusion(&gc),
-        continuation: None,
         not_before_ms: gc.next_reclamation_at_ms,
         follow_up: None,
     }

--- a/crates/loonfs/src/maintenance/job.rs
+++ b/crates/loonfs/src/maintenance/job.rs
@@ -66,8 +66,6 @@ impl MaintenanceConclusion {
 pub struct MaintenanceRunReport {
     /// How the run settled.
     pub conclusion: MaintenanceConclusion,
-    /// Resume position for the next run.
-    pub continuation: Option<String>,
     /// Earliest Unix millisecond for another run.
     pub not_before_ms: Option<u64>,
     /// A job and namespace this run wants scheduled.
@@ -75,11 +73,10 @@ pub struct MaintenanceRunReport {
 }
 
 impl MaintenanceRunReport {
-    /// Builds a report without continuation, deadline, or follow-up.
+    /// Builds a report without a deadline or follow-up.
     pub fn concluded(conclusion: MaintenanceConclusion) -> Self {
         Self {
             conclusion,
-            continuation: None,
             not_before_ms: None,
             follow_up: None,
         }
@@ -148,7 +145,6 @@ pub trait MaintenanceJob: Send + Sync + 'static {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
         cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport>;
 

--- a/crates/loonfs/src/maintenance/metadata.rs
+++ b/crates/loonfs/src/maintenance/metadata.rs
@@ -41,7 +41,6 @@ impl MaintenanceJob for MetadataMaintenanceJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         match self

--- a/crates/loonfs/src/maintenance/metadata_compaction.rs
+++ b/crates/loonfs/src/maintenance/metadata_compaction.rs
@@ -44,13 +44,11 @@ impl MaintenanceJob for MetadataCompactionJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         let Ok(_permit) = Arc::clone(&self.permits).try_acquire_owned() else {
             return Ok(MaintenanceRunReport {
                 conclusion: MaintenanceConclusion::Blocked,
-                continuation: None,
                 not_before_ms: Some(
                     loonfs_core::time::current_time_ms()?.saturating_add(RECONCILE_INTERVAL_MS),
                 ),
@@ -75,7 +73,6 @@ impl MaintenanceJob for MetadataCompactionJob {
         };
         Ok(MaintenanceRunReport {
             conclusion,
-            continuation: None,
             not_before_ms: None,
             follow_up,
         })

--- a/crates/loonfs/src/maintenance/registry.rs
+++ b/crates/loonfs/src/maintenance/registry.rs
@@ -20,8 +20,6 @@ pub struct MaintenanceAssignment {
     pub namespace_id: NamespaceId,
     /// Registered job to run.
     pub job: MaintenanceJobId,
-    /// Process-local resume position.
-    pub continuation: Option<String>,
 }
 
 impl MaintenanceRegistry {
@@ -67,21 +65,15 @@ impl MaintenanceRegistry {
         &self,
         id: MaintenanceJobId,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
     ) -> Result<MaintenanceRunReport> {
         self.require(id)?
-            .run(namespace_id, continuation, &MaintenanceCancellation::new())
+            .run(namespace_id, &MaintenanceCancellation::new())
             .await
     }
 
     /// Runs one assignment with a fresh cancellation token.
     pub async fn execute(&self, assignment: MaintenanceAssignment) -> Result<MaintenanceRunReport> {
-        self.run(
-            assignment.job,
-            &assignment.namespace_id,
-            assignment.continuation.as_deref(),
-        )
-        .await
+        self.run(assignment.job, &assignment.namespace_id).await
     }
 
     fn require(&self, id: MaintenanceJobId) -> Result<Arc<dyn MaintenanceJob>> {

--- a/crates/loonfs/src/maintenance/runner.rs
+++ b/crates/loonfs/src/maintenance/runner.rs
@@ -752,14 +752,10 @@ async fn run_step(inner: &Arc<RunnerInner>, dispatch: &MaintenanceDispatch) -> S
             MaintenanceConclusion::NotEnabled,
         ));
     };
-    let continuation = dispatch.continuation.as_deref();
     let queued_ms = dispatch.queue_wait_ms;
     let started = tokio::time::Instant::now();
     let invocation = InvocationCancellation::new(inner, key);
-    match job
-        .run(&key.namespace_id, continuation, &invocation.cancellation)
-        .await
-    {
+    match job.run(&key.namespace_id, &invocation.cancellation).await {
         Ok(result) => {
             let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
             inner
@@ -769,8 +765,6 @@ async fn run_step(inner: &Arc<RunnerInner>, dispatch: &MaintenanceDispatch) -> S
                 job = %key.job,
                 namespace_id = %key.namespace_id,
                 conclusion = result.conclusion.as_str(),
-                resumed = continuation.is_some(),
-                continues = result.continuation.is_some(),
                 not_before_ms = ?result.not_before_ms,
                 // The two halves of what a step cost: how long it waited
                 // for a permit, and how long it then took.

--- a/crates/loonfs/src/maintenance/tests.rs
+++ b/crates/loonfs/src/maintenance/tests.rs
@@ -54,8 +54,6 @@ impl MaintenanceClock for ManualClock {
 #[derive(Debug, Clone)]
 enum ScriptedStep {
     Conclude(MaintenanceConclusion),
-    /// Conclude, and tell the runner where this step stopped.
-    Continue(MaintenanceConclusion, Option<String>),
     /// Conclude, and tell the runner when what this step left behind
     /// becomes eligible — what a collection pass reports for what it
     /// retained.
@@ -111,8 +109,6 @@ struct TestJob {
     trailing_answer: ScriptedStep,
     probe_answer: StdMutex<MaintenanceProbe>,
     steps: StdMutex<Vec<NamespaceId>>,
-    /// The continuation each step was handed, in order.
-    resumed_from: StdMutex<Vec<Option<String>>>,
     probes: StdMutex<Vec<NamespaceId>>,
     gate: Option<Gate>,
 }
@@ -124,7 +120,6 @@ impl TestJob {
             trailing_answer,
             probe_answer: StdMutex::new(MaintenanceProbe::Idle),
             steps: StdMutex::new(Vec::new()),
-            resumed_from: StdMutex::new(Vec::new()),
             probes: StdMutex::new(Vec::new()),
             gate: None,
         })
@@ -149,7 +144,6 @@ impl TestJob {
             trailing_answer: trailing,
             probe_answer: StdMutex::new(MaintenanceProbe::Idle),
             steps: StdMutex::new(Vec::new()),
-            resumed_from: StdMutex::new(Vec::new()),
             probes: StdMutex::new(Vec::new()),
             gate: None,
         };
@@ -167,11 +161,6 @@ impl TestJob {
 
     fn stepped(&self) -> Vec<String> {
         names(&self.steps)
-    }
-
-    /// What the runner handed each step, in order.
-    fn resumed_from(&self) -> Vec<Option<String>> {
-        self.resumed_from.lock().expect("resumed from").clone()
     }
 
     fn probed(&self) -> Vec<String> {
@@ -196,17 +185,12 @@ impl MaintenanceJob for TestJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         if let Some(gate) = &self.gate {
             gate.enter().await;
         }
         self.steps.lock().expect("steps").push(namespace_id.clone());
-        self.resumed_from
-            .lock()
-            .expect("resumed from")
-            .push(continuation.map(str::to_owned));
         let answer = self
             .answers
             .lock()
@@ -215,15 +199,8 @@ impl MaintenanceJob for TestJob {
             .unwrap_or_else(|| self.trailing_answer.clone());
         match answer {
             ScriptedStep::Conclude(conclusion) => Ok(MaintenanceRunReport::concluded(conclusion)),
-            ScriptedStep::Continue(conclusion, continuation) => Ok(MaintenanceRunReport {
-                conclusion,
-                continuation,
-                not_before_ms: None,
-                follow_up: None,
-            }),
             ScriptedStep::Due(conclusion, not_before_ms) => Ok(MaintenanceRunReport {
                 conclusion,
-                continuation: None,
                 not_before_ms: Some(not_before_ms),
                 follow_up: None,
             }),
@@ -280,7 +257,6 @@ impl MaintenanceJob for SubscribingJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.steps.lock().expect("steps").push(namespace_id.clone());
@@ -373,66 +349,22 @@ async fn progressed_requeues_immediately_and_stays_fair_at_the_cap() {
 }
 
 #[tokio::test]
-async fn a_progressing_job_resumes_from_where_its_last_step_stopped() {
-    let job = TestJob::scripted(
-        [
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-1".to_owned())),
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-2".to_owned())),
-        ],
-        ScriptedStep::Conclude(MaintenanceConclusion::Idle),
-    );
-    let runner = enabled_runner(job.clone());
-    let namespace_id = namespace_id("paged");
-
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the pass settles");
-
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-1".to_owned()), Some("page-2".to_owned())],
-        "a fresh pass, then each step resuming from the one before it"
-    );
-
-    // The idle step that ended the pass spent the position, so the next
-    // nudge starts over rather than resuming a finished walk.
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the fresh pass settles");
-    assert_eq!(
-        job.resumed_from().last().expect("a fourth step ran"),
-        &None,
-        "an idle conclusion clears the continuation"
-    );
-}
-
-#[tokio::test]
-async fn a_blocked_job_resumes_from_where_it_parked() {
-    let job = TestJob::scripted(
-        [ScriptedStep::Continue(
-            MaintenanceConclusion::Blocked,
-            Some("page-7".to_owned()),
-        )],
-        ScriptedStep::Conclude(MaintenanceConclusion::Idle),
-    );
+async fn a_blocked_job_parks() {
+    let job = TestJob::answering(ScriptedStep::Conclude(MaintenanceConclusion::Blocked));
     let runner = enabled_runner(job.clone());
     let namespace_id = namespace_id("parked");
 
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("the blocked step settles");
-    runner.handle().nudge(TEST_JOB, &namespace_id);
-    runner.drain().await.expect("the retry settles");
 
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-7".to_owned())],
-        "a retry with room to work resumes where the blocked step stopped"
-    );
+    assert_eq!(job.stepped(), vec!["parked".to_owned()]);
 }
 
 #[tokio::test]
-async fn a_not_enabled_conclusion_drops_the_continuation() {
+async fn a_not_enabled_conclusion_evicts_the_key() {
     let job = TestJob::scripted(
         [
-            ScriptedStep::Continue(MaintenanceConclusion::Progressed, Some("page-1".to_owned())),
+            ScriptedStep::Conclude(MaintenanceConclusion::Progressed),
             ScriptedStep::Conclude(MaintenanceConclusion::NotEnabled),
         ],
         ScriptedStep::Conclude(MaintenanceConclusion::Idle),
@@ -442,14 +374,13 @@ async fn a_not_enabled_conclusion_drops_the_continuation() {
 
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("both steps settle");
+    assert_eq!(job.stepped().len(), 2);
+    runner.reconcile_now().await;
+    assert!(job.probed().is_empty());
+
     runner.handle().nudge(TEST_JOB, &namespace_id);
     runner.drain().await.expect("the re-admitted step settles");
-
-    assert_eq!(
-        job.resumed_from(),
-        vec![None, Some("page-1".to_owned()), None],
-        "a key re-admitted after eviction starts a fresh pass"
-    );
+    assert_eq!(job.stepped().len(), 3);
 }
 
 #[tokio::test]
@@ -829,7 +760,6 @@ impl MaintenanceJob for BlockingJob {
     async fn run(
         &self,
         _namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.runs.fetch_add(1, Ordering::SeqCst);
@@ -842,7 +772,6 @@ impl MaintenanceJob for BlockingJob {
             .forget();
         Ok(MaintenanceRunReport {
             conclusion: MaintenanceConclusion::Blocked,
-            continuation: None,
             not_before_ms: None,
             follow_up: self.follow_up.map(|job| (job, _namespace_id.clone())),
         })

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -69,7 +69,7 @@ impl<E: MetricLabel> LabeledCounters<E> {
 pub(crate) enum CompactionOutcome {
     Completed,
     Failed,
-    Superseded,
+    Abandoned,
     Cancelled,
     Fenced,
 }
@@ -78,7 +78,7 @@ impl MetricLabel for CompactionOutcome {
     const VALUES: &'static [Self] = &[
         Self::Completed,
         Self::Failed,
-        Self::Superseded,
+        Self::Abandoned,
         Self::Cancelled,
         Self::Fenced,
     ];
@@ -87,7 +87,7 @@ impl MetricLabel for CompactionOutcome {
         match self {
             Self::Completed => "completed",
             Self::Failed => "failed",
-            Self::Superseded => "superseded",
+            Self::Abandoned => "abandoned",
             Self::Cancelled => "cancelled",
             Self::Fenced => "fenced",
         }
@@ -367,7 +367,7 @@ impl RuntimeInstruments {
                 CompactionOutcome::Completed,
                 Some((*rows_read, *rows_written, *input_bytes, *output_bytes)),
             ),
-            Ok(MetadataCompactionJobOutcome::Abandoned) => (CompactionOutcome::Superseded, None),
+            Ok(MetadataCompactionJobOutcome::Abandoned) => (CompactionOutcome::Abandoned, None),
             Ok(MetadataCompactionJobOutcome::Cancelled) => (CompactionOutcome::Cancelled, None),
             Ok(MetadataCompactionJobOutcome::Fenced) => (CompactionOutcome::Fenced, None),
             Err(_) => (CompactionOutcome::Failed, None),
@@ -1541,6 +1541,7 @@ mod tests {
             }),
             25,
         );
+        instruments.compaction_finished(&Ok(MetadataCompactionJobOutcome::Abandoned), 10);
 
         let snapshot = recorder.snapshot();
         assert_eq!(
@@ -1573,6 +1574,26 @@ mod tests {
             ),
             1
         );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.maintenance.compactions",
+                &[("outcome", "abandoned")],
+            ),
+            1
+        );
+        let duration = snapshot
+            .by_name("loonfs.maintenance.compaction_seconds")
+            .find(|entry| entry.labels == [("outcome", "abandoned")])
+            .expect("abandoned compaction duration");
+        assert!(matches!(
+            duration.value,
+            MetricValue::Histogram { count: 1, .. }
+        ));
+        assert!(snapshot
+            .all()
+            .iter()
+            .all(|entry| !entry.labels.contains(&("outcome", "superseded"))));
         assert_eq!(
             counter(
                 &snapshot,

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -76,6 +76,70 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
     );
 }
 
+#[tokio::test]
+async fn reader_reuses_published_projection_after_control_cache_eviction() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let other_namespace_id = NamespaceId::parse("other").expect("namespace id");
+    let object_store = store(temp_dir.path());
+    let fs = open_runtime_with_async(object_store.clone(), "shared-projection", |builder| {
+        builder.runtime_cache(RuntimeCacheConfig {
+            max_cached_namespaces: 1,
+            ..Default::default()
+        })
+    })
+    .await;
+    for namespace_id in [&namespace_id, &other_namespace_id] {
+        fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+    }
+    fs.writer
+        .create_directory(
+            &namespace_id,
+            "/docs",
+            CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("publish directory");
+    fs.writer.publisher().drain().await.expect("finish hints");
+    let head = loonfs_core::control::load_namespace_head_control(&object_store, &namespace_id)
+        .await
+        .expect("published head");
+    loonfs_core::control::raise_namespace_hint(&object_store, &namespace_id, head.wal_no, None)
+        .await
+        .expect("raise hint without changing visible state");
+
+    // Content preparation evicts the control entry without inserting a projection.
+    fs.writer
+        .prepare_file_bytes(&other_namespace_id, b"pending")
+        .await
+        .expect("evict published control entry");
+    let before_read = fs.runtime_cache_stats();
+    assert_eq!(before_read.wal_tail_projection_cache_inserts, 1);
+    assert_eq!(before_read.wal_tail_projection_cache_evictions, 0);
+
+    let entry = fs
+        .reader
+        .get_path_entry(&namespace_id, "/docs", Default::default())
+        .await
+        .expect("read published directory");
+    assert_eq!(entry.head_seq, ChangeSeq(1));
+    let after_read = fs.runtime_cache_stats();
+    assert_eq!(
+        after_read.wal_tail_projection_cache_hits,
+        before_read.wal_tail_projection_cache_hits + 1
+    );
+    assert_eq!(
+        after_read.wal_tail_projection_cache_misses,
+        before_read.wal_tail_projection_cache_misses
+    );
+    assert_eq!(
+        after_read.wal_tail_projection_cache_inserts,
+        before_read.wal_tail_projection_cache_inserts
+    );
+}
+
 #[test]
 fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -98,8 +98,7 @@ async fn fill_wal_tail_to_write_stop<S: ObjectStore + ?Sized>(
 ) {
     let current = loonfs_core::control::load_namespace_head_control(store, namespace_id)
         .await
-        .expect("tail state")
-        .state;
+        .expect("tail state");
     append_wal_segments(
         store,
         namespace_id,
@@ -221,8 +220,7 @@ fn standalone_reader_builds_without_writer_identity() {
         let store = LocalFsStore::new(temp_dir.path()).expect("open store for inspection");
         let head = loonfs_core::control::load_namespace_head_control(&store, &namespace_id)
             .await
-            .expect("load head")
-            .state;
+            .expect("load head");
         let writer_block = head.writer.expect("head records the writer that published");
         assert_eq!(writer_block.writer_id.as_str(), "handle-test-writer");
         assert_ne!(

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -84,7 +84,6 @@ async fn head_state(store: &SharedObjectStore, namespace_id: &NamespaceId) -> Na
     loonfs_core::control::load_namespace_head_control(store, namespace_id)
         .await
         .expect("load head")
-        .state
 }
 
 #[tokio::test]

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -701,7 +701,7 @@ async fn a_cold_metadata_job_probes_with_its_configured_options() {
     );
     for _ in 0..16 {
         immediate
-            .run(&namespace, None, &MaintenanceCancellation::new())
+            .run(&namespace, &MaintenanceCancellation::new())
             .await
             .expect("run configured maintenance");
         if immediate

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -209,7 +209,7 @@ fn a_collection_step_reports_what_the_pass_retained() {
             .register(Arc::new(GarbageCollectionJob::new(fs.maintenance.clone())))
             .expect("garbage collection job");
         registry
-            .run(MaintenanceJobId::GC, &namespace_id, None)
+            .run(MaintenanceJobId::GC, &namespace_id)
             .await
             .expect("run one collection pass");
         recorder.snapshot()

--- a/crates/loonfs/tests/it/namespace_advance_observer.rs
+++ b/crates/loonfs/tests/it/namespace_advance_observer.rs
@@ -92,7 +92,6 @@ impl MaintenanceJob for SubscribingJob {
     async fn run(
         &self,
         namespace_id: &NamespaceId,
-        _continuation: Option<&str>,
         _cancellation: &MaintenanceCancellation,
     ) -> Result<MaintenanceRunReport> {
         self.steps

--- a/crates/loonfs/tests/it/namespace_sessions.rs
+++ b/crates/loonfs/tests/it/namespace_sessions.rs
@@ -24,7 +24,6 @@ async fn writer_epoch(store: &SharedObjectStore, namespace_id: &NamespaceId) -> 
     loonfs::control::load_namespace_head_control(store, namespace_id)
         .await
         .expect("load namespace head")
-        .state
         .writer_epoch
         .0
 }

--- a/crates/loonfs/tests/it/standalone_maintenance.rs
+++ b/crates/loonfs/tests/it/standalone_maintenance.rs
@@ -66,7 +66,6 @@ async fn a_registry_runs_every_core_job_without_a_writer() {
             .execute(MaintenanceAssignment {
                 namespace_id: namespace_id.clone(),
                 job,
-                continuation: None,
             })
             .await;
         assert!(result.is_ok(), "{job} failed: {:?}", result.err());

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -105,7 +105,7 @@ The new manifest replaces only the selected inputs and preserves newer or unrela
 
 Unreferenced segments are collectable only when their provider age is strictly greater than 24 hours. A streaming job must initiate publication within 23 hours, 39 minutes, and 30 seconds, reserving the minimum GC grace inside that day. The remaining interval covers provider operations, clock error, and scheduling allowance. Bounded merges use the ordinary 15-minute metadata publication budget.
 
-A changed epoch returns `fenced`. Changed inputs or an exceeded streaming bound return `abandoned`. None of these outcomes publishes a partial replacement. Unreferenced output follows the same age rule whether the job failed, was cancelled, or was superseded by another publication.
+A changed epoch returns `fenced`. Changed inputs or an exceeded streaming bound return `abandoned`. None of these outcomes publishes a partial replacement. Unreferenced output follows the same age rule whether the job failed, was cancelled, or was abandoned.
 
 ## Scheduling and restart
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -237,7 +237,7 @@ The codes that populate it:
 
 | Code | Detail fields |
 | --- | --- |
-| `writer_fenced` | `fenced_writer_epoch`, `active_writer_epoch`, plus `active_writer` and `active_acquired_at_ms` when the head recorded a writer block. Writer ids are process labels, so two runs on one machine can share one; the acquisition stamp is what tells them apart |
+| `writer_fenced` | `fenced_writer_epoch`, `active_writer_epoch`, plus `active_writer` and `active_acquired_at_ms` when the current manifest records a writer block. Writer ids are process labels, so two runs on one machine can share one; the acquisition stamp is what tells them apart |
 | `writer_capacity_exceeded` | `max_writer_sessions` |
 | `path_conflict` | `expected_inode_id`, `actual_inode_id` (absent when unbound); `assertion_index` for a failed request assertion |
 | `stale_revision` | `inode_id`, `expected_revision_no`, `actual_revision_no` (absent when the inode has no current revision or is not visible); `assertion_index` for a failed request assertion |
@@ -275,7 +275,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `revision_not_found` | 404 | The file has no such revision. |
 | `upload_not_found` | 404 | No upload session with this id, or one that was aborted: an aborted session will never select content, so it reports the absence that its deletion will. |
 | `namespace_exists` | 409 | The create or fork target already exists: another namespace holds the id. |
-| `snapshot_quota_exceeded` | 409 | Creating the snapshot would pass the namespace's live-snapshot limit. Release a snapshot or wait for a lease to expire. |
+| `snapshot_quota_exceeded` | 409 | Creating the snapshot would pass the namespace's live-snapshot limit. Release a snapshot or wait for a snapshot to expire. |
 | `content_not_prepared` | 409 | A path put or explicit create/replace operation references external content without a matching admission, or carries a rejected relevant token. Prepare the content and retry with its proof. |
 | `path_conflict` | 409 | The destination path is already bound. |
 | `directory_not_empty` | 409 | The directory has children and the operation is not recursive. |
@@ -855,14 +855,14 @@ its reclaimable state is collected; naming anything else is refused with
 `namespace_deleted`, because a tombstone has nothing to flush, reorganize,
 or retain.
 
-`wal_flush.outcome` has four values. `not_needed` means the WAL tail was below the threshold. `flushed` means this step published a manifest and updated the root. `already_published` means the root already referenced a different manifest, so this step did not update it. `retries_exhausted` means concurrent updates prevented every attempt from publishing; nothing was flushed, and a later step can try again.
+`wal_flush.outcome` has four values. `not_needed` means the WAL tail was below the threshold. `flushed` means this step published the next current manifest. `already_published` means the current manifest already covered the captured WAL tail, so this step published no manifest. `retries_exhausted` means concurrent updates prevented every attempt from publishing; nothing was flushed, and a later step can try again.
 
 `reorganize.outcome` has four values. `not_needed` means no bounded merge is
 due. `unit_published` means this run published one bounded merge.
 `compaction_required` means a family group needs streaming compaction; run the
-`metadata_compaction` job. `root_advanced` means another publisher updated the
-metadata root first. A manifest this run wrote remains unreferenced, and a
-later GC pass can delete it.
+`metadata_compaction` job. `root_advanced` means another publisher changed the
+current manifest first. Segments this run wrote remain unreferenced, and a
+later GC pass can delete them.
 
 `compaction.outcome` has six values. `not_needed` means no family group has
 eligible input. `bounded_merge_published` means the planner selected and
@@ -1011,13 +1011,13 @@ is irrevocable and the deadline never changes. A call whose clock is before
 the deadline reports it through `next_reclamation_at_ms`. Retirement itself
 deletes no content.
 
-Every call reads current durable roots and uses one fixed clock. It keeps
+Every call reads the current manifest and uses one fixed clock. It keeps
 its live set in memory and writes no collection progress. Every family lists
-from the beginning and sweeps to the end. Root discovery reads a separate
-complete pin listing. A retained pin, an unrecognized pin key, or an uncertain
-pin load prevents namespace retirement. A candidate the live set retains
+from the beginning and sweeps to the end. The collector uses a separate
+complete pin listing to find retained manifests. A retained pin, an unrecognized
+pin key, or an uncertain pin load prevents namespace retirement. A candidate the live set retains
 needs no further store request. Other candidates require an age check, a
-record read, or a deletion. Root read failures fail the call before sweeping.
+record read, or a deletion. Manifest read failures fail the call before sweeping.
 
 A GC response groups related counts. `deleted` contains `wal_segments`,
 `metadata_segments`, `manifests`, `checkpoint_records`, `upload_sessions`,
@@ -2657,15 +2657,15 @@ A conforming server must:
 
 1. treat object storage as the authoritative durable foundation;
 2. publish visible metadata only through logical commits stored in visible
-   WAL segments plus a successful head update;
+   numbered WAL objects;
 3. validate that referenced content is already durable before publish;
 4. preserve `(namespace_id, inode_id)` as canonical identity;
 5. resolve namespace content through the immutable `content_store_id` in the
-   namespace head;
+   current manifest;
 6. implement tombstone-first delete;
 7. serve replay from the highest numbered verified manifest found through
-   `hint.json`, plus the visible WAL segment chain, replayed as
-   logical commits; checkpoints pin manifest versions for retention, stable
+   `hint.json`, plus the numbered WAL objects after the folded boundary, replayed
+   as logical commits; checkpoints pin manifest versions for retention, stable
    reads, restore, and forks;
 8. fold sibling names into name keys by the v0 rule ([format: names and paths](format.md#14-names-and-paths));
 9. keep control-plane sessions and any implementation-specific coordinators

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2447,14 +2447,6 @@
         "pattern": "^ino_[1-9][0-9]*$",
         "type": "string"
       },
-      "InodeKind": {
-        "description": "Filesystem item kind.",
-        "enum": [
-          "file",
-          "dir"
-        ],
-        "type": "string"
-      },
       "ListChangesResponse": {
         "description": "Change-feed response after a cursor.",
         "properties": {
@@ -2879,7 +2871,7 @@
         "properties": {
           "current_manifest_no": {
             "$ref": "#/components/schemas/ManifestNo",
-            "description": "Current manifest pointer recorded by the head."
+            "description": "The namespace's current manifest number."
           },
           "head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
@@ -4135,7 +4127,7 @@
         ]
       },
       "WalFlushStepOutcomeAlreadyPublished": {
-        "description": "The step did not update a root that already referenced another manifest.",
+        "description": "The current manifest already covered the captured WAL tail; this step published no manifest.",
         "properties": {
           "attempted_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
@@ -4143,7 +4135,7 @@
           },
           "current_manifest_no": {
             "$ref": "#/components/schemas/ManifestNo",
-            "description": "Manifest the root currently references."
+            "description": "The namespace's current manifest number."
           },
           "outcome": {
             "enum": [
@@ -4160,7 +4152,7 @@
         "type": "object"
       },
       "WalFlushStepOutcomeFlushed": {
-        "description": "The step flushed the WAL tail and advanced the metadata root.",
+        "description": "The step flushed the WAL tail and published the next current manifest.",
         "properties": {
           "manifest_head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
@@ -5083,7 +5075,7 @@
                 }
               }
             },
-            "description": "Invalid budget or cursor"
+            "description": "Invalid namespace id or options"
           },
           "401": {
             "content": {
@@ -5136,7 +5128,7 @@
     },
     "/v0/maintenance/namespaces/{namespace_id}/runs": {
       "post": {
-        "description": "Runs one maintenance job for the namespace. The body names the job with `kind`: `metadata`, `metadata_compaction`, `gc`, or `retention`. The response carries the same `kind` and that job's result. A deleted namespace accepts only `gc`. A `gc` call reads current roots, then sweeps every family to the end. Each listing starts at the beginning. The call keeps no continuation.",
+        "description": "Runs one maintenance job for the namespace. The body names the job with `kind`: `metadata`, `metadata_compaction`, `gc`, or `retention`. The response carries the same `kind` and that job's result. A deleted namespace accepts only `gc`. A `gc` call reads the current manifest and lists pins, then sweeps every family to the end. Each listing starts at the beginning. The call keeps no continuation.",
         "operationId": "run_maintenance",
         "parameters": [
           {


### PR DESCRIPTION
The namespace head used to be a mutable object with an etag, and that etag was part of every projection cache key so a swapped head invalidated cached state. The head object is gone, but the etag stayed in the keys, where one string now meant three things: the hint's compare-and-swap token on the live read path, the pinned manifest's checksum on the pin path, and on the publish path a value copied through unchanged after a landed commit. It discriminated nothing that the manifest number, the manifest head sequence, and the head sequence do not already fix, and it made the reader and the publisher miss each other's entries for the same state. A hint raise also changed it with no state change.

This PR removes the etag from the read context, the WAL-tail projection key, and the publish anchor, and keys projections by namespace, manifest number, manifest head sequence, and head sequence. Manifests and WAL objects are numbered and immutable, and a writer fence publishes a manifest, so that tuple identifies the visible state; the argument is written on the key type.

Important callouts:

- After a write through the publisher, a read on the same runtime now reuses the publisher's projection entry instead of building its own. One test pins that.
- The derived read state is no longer dressed as a loaded control object carrying the hint's key and etag. The hint's own loaded record, which the raise path uses for its compare-and-swap, is unchanged.
- No wire, durable, golden, or OpenAPI change. Existing invalidation and seeding tests pass unchanged apart from the removed field.
