### PR TITLE
fix(wal): bound every segment at the writer and refuse larger ones at the reader

### DIFF
--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -49,6 +49,12 @@ pub enum EnvelopeCodecError {
     /// Reports stored bytes that the configured transport codec could not decompress.
     #[error("failed to decompress envelope: {0}")]
     Decompress(String),
+    /// Reports a WAL document that exceeds the decompressed format limit.
+    #[error("decompressed WAL document exceeds the {max_bytes}-byte limit")]
+    WalSegmentTooLarge {
+        /// Largest accepted decompressed document.
+        max_bytes: usize,
+    },
     /// Reports an unrecognized durable-family discriminator found during the envelope probe.
     #[error("unknown envelope kind `{found}`")]
     UnknownKind {
@@ -173,9 +179,15 @@ impl<T> VerifiedEnvelope<T> {
 pub struct EncodedEnvelope<T> {
     pub(crate) envelope: VerifiedEnvelope<T>,
     pub(crate) bytes: Vec<u8>,
+    pub(crate) document_len: usize,
 }
 
 impl<T> EncodedEnvelope<T> {
+    /// Returns the document length before any compression.
+    pub fn document_len(&self) -> usize {
+        self.document_len
+    }
+
     /// Envelope derived while encoding, without decoding or serializing again.
     pub fn envelope(&self) -> &VerifiedEnvelope<T> {
         &self.envelope
@@ -221,6 +233,7 @@ pub fn encode_json_envelope<T: Serialize>(
             payload_checksum,
             payload,
         },
+        document_len: bytes.len(),
         bytes,
     })
 }

--- a/crates/loonfs-api/src/wal.rs
+++ b/crates/loonfs-api/src/wal.rs
@@ -10,12 +10,48 @@ use crate::{
 };
 use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
+use std::io::Read;
 
 /// Version 1: a zstd-compressed CBOR envelope document carrying the payload
 /// as an opaque CBOR byte string. `payload_checksum` covers exactly those
 /// bytes, and delta/precondition tags use the snake_case names the format
 /// spec fixes ("Standard mutation operations" and "Preconditions").
 pub const WAL_FORMAT_VERSION: u32 = 1;
+
+/// Largest decompressed WAL document allowed by [Appendix A.5](../../../docs/specs/format.md#a5-wal-records).
+pub const MAX_WAL_SEGMENT_BYTES: usize = 512 * 1024 * 1024;
+
+/// Upper bound for the document and payload fields outside commit records.
+pub const WAL_SEGMENT_OVERHEAD_BYTES: usize = cbor_map_bytes(&[
+    ("kind", cbor_string_bytes("namespace_wal_segment".len())),
+    ("format_version", 5),
+    ("payload_checksum", cbor_string_bytes(64)),
+    ("payload", 9),
+]) + cbor_map_bytes(&[
+    ("namespace_id", cbor_string_bytes(crate::ids::MAX_ID_BYTES)),
+    ("wal_no", 9),
+    ("next_inode_id", 9),
+    ("writer_epoch", 9),
+    ("base_head_seq", 9),
+    ("start_seq", 9),
+    ("end_seq", 9),
+    ("records", 9),
+]);
+
+// CBOR strings, collections, and u64 values need at most nine header bytes.
+const fn cbor_string_bytes(length: usize) -> usize {
+    9 + length
+}
+
+const fn cbor_map_bytes(fields: &[(&str, usize)]) -> usize {
+    let mut bytes = 9;
+    let mut index = 0;
+    while index < fields.len() {
+        bytes += cbor_string_bytes(fields[index].0.len()) + fields[index].1;
+        index += 1;
+    }
+    bytes
+}
 
 /// Identifies the durable payload family carried by a WAL envelope.
 ///
@@ -246,6 +282,7 @@ pub fn encode_wal_segment_envelope_zstd(
             payload,
         },
         bytes,
+        document_len: encoded.len(),
     })
 }
 
@@ -257,8 +294,23 @@ pub fn encode_wal_segment_envelope_zstd(
 pub fn decode_wal_segment_envelope_zstd(
     bytes: &[u8],
 ) -> Result<WalSegmentEnvelope, EnvelopeCodecError> {
-    let decompressed = zstd::stream::decode_all(bytes)
+    decode_wal_segment_envelope_zstd_with_limit(bytes, MAX_WAL_SEGMENT_BYTES)
+}
+
+fn decode_wal_segment_envelope_zstd_with_limit(
+    bytes: &[u8],
+    limit: usize,
+) -> Result<WalSegmentEnvelope, EnvelopeCodecError> {
+    let decoder = zstd::stream::read::Decoder::new(bytes)
         .map_err(|err| EnvelopeCodecError::Decompress(err.to_string()))?;
+    let mut decompressed = Vec::new();
+    decoder
+        .take(limit as u64 + 1)
+        .read_to_end(&mut decompressed)
+        .map_err(|err| EnvelopeCodecError::Decompress(err.to_string()))?;
+    if decompressed.len() > limit {
+        return Err(EnvelopeCodecError::WalSegmentTooLarge { max_bytes: limit });
+    }
     let probe: EnvelopeProbe = from_reader(decompressed.as_slice())
         .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
     let expected_kind = WalEnvelopeKind::NamespaceWalSegment;
@@ -275,4 +327,45 @@ pub fn decode_wal_segment_envelope_zstd(
         payload_checksum: document.payload_checksum,
         payload,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decoder_accepts_the_limit_and_rejects_the_next_byte_before_decoding() {
+        let encoded = encode_wal_segment_envelope_zstd(WalSegmentPayload {
+            namespace_id: NamespaceId::parse("bounded").expect("namespace"),
+            wal_no: WalNo(1),
+            next_inode_id: InodeId(2),
+            writer_epoch: WriterEpoch(1),
+            base_head_seq: ChangeSeq(0),
+            start_seq: ChangeSeq(0),
+            end_seq: ChangeSeq(0),
+            records: Vec::new(),
+        })
+        .expect("encode");
+        let document = zstd::stream::decode_all(encoded.as_bytes()).expect("decompress");
+        assert_eq!(document.len(), encoded.document_len());
+        assert!(document.len() <= WAL_SEGMENT_OVERHEAD_BYTES);
+        assert_eq!(
+            &decode_wal_segment_envelope_zstd_with_limit(encoded.as_bytes(), document.len())
+                .expect("at limit"),
+            encoded.envelope(),
+        );
+        assert!(matches!(
+            decode_wal_segment_envelope_zstd_with_limit(encoded.as_bytes(), document.len() - 1),
+            Err(EnvelopeCodecError::WalSegmentTooLarge { max_bytes }) if max_bytes == document.len() - 1
+        ));
+        let invalid = zstd::stream::encode_all(&[0xff; 64][..], 0).expect("compress");
+        assert!(matches!(
+            decode_wal_segment_envelope_zstd_with_limit(&invalid, 8),
+            Err(EnvelopeCodecError::WalSegmentTooLarge { max_bytes: 8 })
+        ));
+        assert!(matches!(
+            decode_wal_segment_envelope_zstd_with_limit(&invalid, 64),
+            Err(EnvelopeCodecError::EnvelopeDecode(_))
+        ));
+    }
 }

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -9,6 +9,13 @@ pub(crate) async fn publish_wal<S: ObjectStore + ?Sized>(
     store: &S,
     wal: &PreparedWalSegment,
 ) -> crate::error::Result<()> {
+    if wal.document_len() > loonfs_api::wire::wal::MAX_WAL_SEGMENT_BYTES {
+        return Err(crate::error::CoreError::Internal(format!(
+            "WAL document is {} bytes, over `MAX_WAL_SEGMENT_BYTES` ({})",
+            wal.document_len(),
+            loonfs_api::wire::wal::MAX_WAL_SEGMENT_BYTES,
+        )));
+    }
     let payload = wal.envelope().payload();
     let object_key = loonfs_objectstore::keys::wal_segment(&payload.namespace_id, &payload.wal_no);
     store.put_if_absent(&object_key, Bytes::copy_from_slice(wal.as_bytes())).await

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -158,6 +158,12 @@ impl CommitCandidate {
         Ok(bytes.0)
     }
 
+    /// Bounds the bytes this request adds to an encoded WAL document, excluding
+    /// the document envelope.
+    pub fn wal_record_bytes_upper_bound(&self) -> usize {
+        crate::commit_wal_size::estimated_wal_record_bytes(&self.request)
+    }
+
     pub(crate) fn validate_request_limits(&self) -> Result<()> {
         // Apply limits to the complete request because the serialized publisher
         // processes every operation before releasing the write path.

--- a/crates/loonfs-core/src/commit_wal_size.rs
+++ b/crates/loonfs-core/src/commit_wal_size.rs
@@ -1,0 +1,200 @@
+//! Bounds the WAL records produced by a request before metadata planning.
+
+use crate::path::write::CommitRequest;
+use loonfs_api::{
+    AbsolutePath, FilesystemOperation, MAX_ATTRIBUTES_TOTAL_BYTES, MAX_ATTRIBUTE_ENTRIES,
+    MAX_DISPLAY_NAME_BYTES, MAX_ID_BYTES, MAX_NAME_KEY_BYTES,
+};
+
+const INTEGER_BYTES: usize = 9;
+const INDEX_BYTES: usize = 5;
+const NAMES_BYTES: usize = string_bytes(MAX_NAME_KEY_BYTES) + string_bytes(MAX_DISPLAY_NAME_BYTES);
+const CREATE_INODE_BYTES: usize = delta_bytes(
+    "create_inode",
+    &[
+        ("inode_id", INTEGER_BYTES),
+        ("inode_kind", string_bytes("file".len())),
+    ],
+);
+const BIND_BYTES: usize = delta_bytes(
+    "bind_direntry",
+    &[
+        ("parent_inode_id", INTEGER_BYTES),
+        ("name_key", 0),
+        ("display_name", 0),
+        ("child_inode_id", INTEGER_BYTES),
+    ],
+);
+const UNBIND_BYTES: usize = delta_bytes(
+    "unbind_direntry",
+    &[
+        ("parent_inode_id", INTEGER_BYTES),
+        ("name_key", 0),
+        ("display_name", 0),
+        ("child_inode_id", INTEGER_BYTES),
+        ("bind_seq", INTEGER_BYTES),
+        ("bind_delta_index", INDEX_BYTES),
+    ],
+) + NAMES_BYTES;
+const TOMBSTONE_BYTES: usize = delta_bytes(
+    "tombstone_subtree",
+    &[
+        ("root_inode_id", INTEGER_BYTES),
+        (
+            "deleted_direntry",
+            map_bytes(&[
+                ("parent_inode_id", INTEGER_BYTES),
+                ("name_key", 0),
+                ("display_name", 0),
+            ]) + NAMES_BYTES,
+        ),
+    ],
+);
+const DELETE_BYTES: usize = UNBIND_BYTES + TOMBSTONE_BYTES;
+const CONTENT_REF_BYTES: usize = map_bytes(&[
+    ("kind", string_bytes("blob_v1".len())),
+    ("owner_namespace_id", string_bytes(MAX_ID_BYTES)),
+    ("content_id", string_bytes(MAX_ID_BYTES)),
+    ("size_bytes", INTEGER_BYTES),
+    (
+        "checksum",
+        map_bytes(&[
+            ("algorithm", string_bytes("crc64nvme".len())),
+            ("value", string_bytes(64)),
+        ]),
+    ),
+]);
+const REVISION_BYTES: usize = delta_bytes(
+    "append_file_revision",
+    &[
+        ("inode_id", INTEGER_BYTES),
+        ("revision_no", INTEGER_BYTES),
+        ("content_ref", CONTENT_REF_BYTES),
+    ],
+);
+const ATTRIBUTES_BYTES: usize = delta_bytes(
+    "append_attributes_revision",
+    &[
+        ("inode_id", INTEGER_BYTES),
+        ("attributes_revision_no", INTEGER_BYTES),
+        (
+            "attributes",
+            9 + MAX_ATTRIBUTES_TOTAL_BYTES + MAX_ATTRIBUTE_ENTRIES * (2 + 3),
+        ),
+    ],
+);
+const REVOKE_BYTES: usize = delta_bytes(
+    "revoke_subtree_tombstone",
+    &[
+        ("root_inode_id", INTEGER_BYTES),
+        (
+            "target",
+            map_bytes(&[("seq", INTEGER_BYTES), ("delta_index", INDEX_BYTES)]),
+        ),
+    ],
+);
+
+// CBOR lengths and u64 values use at most nine bytes; u32 values use five.
+const fn string_bytes(length: usize) -> usize {
+    9 + length
+}
+
+const fn map_bytes(fields: &[(&str, usize)]) -> usize {
+    let mut bytes = 9;
+    let mut index = 0;
+    while index < fields.len() {
+        bytes += string_bytes(fields[index].0.len()) + fields[index].1;
+        index += 1;
+    }
+    bytes
+}
+
+const fn delta_bytes(kind: &str, fields: &[(&str, usize)]) -> usize {
+    map_bytes(&[
+        ("semantic_op_index", INDEX_BYTES),
+        (
+            "delta",
+            map_bytes(&[
+                ("kind", string_bytes(kind.len())),
+                ("delta_index", INDEX_BYTES),
+            ]),
+        ),
+    ]) + map_bytes(fields)
+        - 9
+}
+
+pub(crate) fn estimated_wal_record_bytes(request: &CommitRequest) -> usize {
+    let fixed_bytes = map_bytes(&[
+        ("seq", INTEGER_BYTES),
+        ("commit_id", string_bytes(request.commit_id.as_str().len())),
+        (
+            "committed_by",
+            string_bytes(request.actor_id.as_str().len()),
+        ),
+        (
+            "semantic_commit_fingerprint",
+            string_bytes("v3:sha256:".len() + 64),
+        ),
+        ("committed_at_ms", INTEGER_BYTES),
+        (
+            "message",
+            string_bytes(request.message.as_ref().map_or(0, String::len)),
+        ),
+        ("deltas", 9),
+    ]);
+    request
+        .operations
+        .iter()
+        .fold(fixed_bytes, |bytes, operation| {
+            bytes.saturating_add(operation_bytes(operation))
+        })
+}
+
+fn operation_bytes(operation: &FilesystemOperation) -> usize {
+    match operation {
+        FilesystemOperation::CreateDirectory { path, parents } => {
+            if *parents {
+                create_path_bytes(path)
+            } else {
+                CREATE_INODE_BYTES + BIND_BYTES + NAMES_BYTES
+            }
+        }
+        FilesystemOperation::CreateDirectoryByInode { .. } => {
+            CREATE_INODE_BYTES + BIND_BYTES + NAMES_BYTES
+        }
+        FilesystemOperation::PutFile { path, .. } => create_path_bytes(path) + REVISION_BYTES,
+        FilesystemOperation::PutFileByInode { .. } => {
+            CREATE_INODE_BYTES + BIND_BYTES + NAMES_BYTES + REVISION_BYTES
+        }
+        FilesystemOperation::PutFileRevisionByInode { .. }
+        | FilesystemOperation::RestoreRevision { .. } => REVISION_BYTES,
+        FilesystemOperation::DeletePath { .. } | FilesystemOperation::DeleteByInode { .. } => {
+            DELETE_BYTES
+        }
+        FilesystemOperation::MovePath { .. } | FilesystemOperation::MoveByInode { .. } => {
+            DELETE_BYTES + UNBIND_BYTES + BIND_BYTES + NAMES_BYTES
+        }
+        FilesystemOperation::CopyPath { .. } => {
+            CREATE_INODE_BYTES + BIND_BYTES + NAMES_BYTES + REVISION_BYTES + ATTRIBUTES_BYTES
+        }
+        FilesystemOperation::Undelete { .. } => REVOKE_BYTES + BIND_BYTES + NAMES_BYTES,
+        FilesystemOperation::UpdateAttributes { .. } => ATTRIBUTES_BYTES,
+    }
+}
+
+fn create_path_bytes(path: &AbsolutePath) -> usize {
+    path.components().iter().fold(0_usize, |bytes, component| {
+        let display_name = component.as_str();
+        let name_key = loonfs_api::name_key_for_display_name(display_name);
+        bytes.saturating_add(
+            CREATE_INODE_BYTES
+                + BIND_BYTES
+                + string_bytes(display_name.len())
+                + string_bytes(name_key.len()),
+        )
+    })
+}
+
+#[cfg(test)]
+#[path = "commit_wal_size_tests.rs"]
+mod tests;

--- a/crates/loonfs-core/src/commit_wal_size_tests.rs
+++ b/crates/loonfs-core/src/commit_wal_size_tests.rs
@@ -1,0 +1,177 @@
+//! WAL size estimates checked against planned requests at the API limits.
+
+use super::*;
+use crate::commit::{materialize_commit, wal_payload_from_materialized_commit};
+use crate::commit_engine::CommitCandidate;
+use crate::limits::{MAX_COMMIT_MESSAGE_BYTES, MAX_COMMIT_OPERATIONS};
+use crate::metadata::{InMemoryMetadataView, MetadataState};
+use crate::namespace::state::NamespaceReadState;
+use crate::path::write::PublishPlanningSession;
+use loonfs_api::wire::wal::{
+    encode_wal_segment_envelope_zstd, WalDelta, WalSegmentPayload, MAX_WAL_SEGMENT_BYTES,
+    WAL_SEGMENT_OVERHEAD_BYTES,
+};
+use loonfs_api::{
+    ActorId, AttributeKey, AttributeRevisionNo, Attributes, ChangeSeq, Checksum, CommitId,
+    ContentId, ContentRef, ContentRefKind, ContentStoreId, DestinationBehavior, DestinationGuard,
+    DisplayName, InodeId, InodeKind, NameKey, NamespaceId, RevisionNo, WalNo, WriterEpoch,
+    MAX_ATTRIBUTE_KEY_BYTES, MAX_ATTRIBUTE_VALUE_BYTES, MAX_PUBLIC_INTEGER,
+};
+use loonfs_test_support::ids::{attribute_key, attribute_text};
+use std::collections::BTreeMap;
+
+fn full_attributes() -> Attributes {
+    let mut entries = BTreeMap::from([(attribute_key("x"), attribute_text("a"))]);
+    let mut remaining =
+        MAX_ATTRIBUTES_TOTAL_BYTES - 2 - (MAX_ATTRIBUTE_ENTRIES - 1) * MAX_ATTRIBUTE_KEY_BYTES;
+    for index in 1..MAX_ATTRIBUTE_ENTRIES {
+        let length = remaining.min(MAX_ATTRIBUTE_VALUE_BYTES);
+        remaining -= length;
+        entries.insert(
+            AttributeKey::parse(format!("{index:0128}")).expect("key"),
+            attribute_text(&"v".repeat(length)),
+        );
+    }
+    let attributes = Attributes::new(entries).expect("full attributes");
+    assert_eq!(attributes.logical_bytes(), MAX_ATTRIBUTES_TOTAL_BYTES);
+    assert_eq!(attributes.len(), MAX_ATTRIBUTE_ENTRIES);
+    attributes
+}
+
+#[tokio::test]
+async fn maximum_requests_encode_within_the_admitted_estimate() {
+    let namespace_id = NamespaceId::parse("n".repeat(MAX_ID_BYTES)).expect("namespace");
+    let actor = ActorId::parse("a".repeat(256)).expect("actor");
+    let mut head = NamespaceReadState::initial(namespace_id.clone(), ContentStoreId::generate(), 0);
+    head.seq = ChangeSeq(MAX_PUBLIC_INTEGER - 1);
+    head.next_inode_id = InodeId(MAX_PUBLIC_INTEGER - 1_000_000);
+    head.writer_epoch = WriterEpoch(MAX_PUBLIC_INTEGER);
+    let content_ref = ContentRef {
+        kind: ContentRefKind::BlobV1,
+        owner_namespace_id: namespace_id.clone(),
+        content_id: ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
+        size_bytes: u64::MAX,
+        checksum: Checksum::sha256(b"content"),
+    };
+    let mut state = MetadataState::default();
+    state.apply_committed_wal_deltas_mut(
+        head.seq,
+        &CommitId::parse("seed").expect("commit"),
+        &actor,
+        0,
+        &[
+            WalDelta::CreateInode {
+                delta_index: 0,
+                inode_id: InodeId(1),
+                inode_kind: InodeKind::Directory,
+            },
+            WalDelta::CreateInode {
+                delta_index: 1,
+                inode_id: InodeId(2),
+                inode_kind: InodeKind::File,
+            },
+            WalDelta::BindDirentry {
+                delta_index: 2,
+                parent_inode_id: InodeId(1),
+                name_key: NameKey::parse("source").expect("key"),
+                display_name: DisplayName::parse("source").expect("name"),
+                child_inode_id: InodeId(2),
+            },
+            WalDelta::AppendFileRevision {
+                delta_index: 3,
+                inode_id: InodeId(2),
+                revision_no: RevisionNo(MAX_PUBLIC_INTEGER - 1),
+                content_ref: content_ref.clone(),
+            },
+            WalDelta::AppendAttributesRevision {
+                delta_index: 4,
+                inode_id: InodeId(2),
+                attributes_revision_no: AttributeRevisionNo(
+                    MAX_PUBLIC_INTEGER - MAX_COMMIT_OPERATIONS as u64,
+                ),
+                attributes: full_attributes(),
+            },
+        ],
+    );
+    for kind in ["attributes", "copy", "put"] {
+        let operation_count = if kind == "put" {
+            1
+        } else {
+            MAX_COMMIT_OPERATIONS
+        };
+        let request = CommitRequest {
+            commit_id: CommitId::parse("c".repeat(MAX_ID_BYTES)).expect("commit"),
+            actor_id: actor.clone(),
+            message: Some("m".repeat(MAX_COMMIT_MESSAGE_BYTES)),
+            assertions: Vec::new(),
+            operations: (0..operation_count)
+                .map(|index| match kind {
+                    "attributes" => FilesystemOperation::UpdateAttributes {
+                        path: AbsolutePath::parse("/source").expect("path"),
+                        set: BTreeMap::from([(
+                            attribute_key("x"),
+                            attribute_text(if index % 2 == 0 { "b" } else { "a" }),
+                        )]),
+                        remove: Vec::new(),
+                        expected_inode_id: None,
+                        expected_attributes_revision_no: None,
+                    },
+                    "copy" => FilesystemOperation::CopyPath {
+                        from_path: AbsolutePath::parse("/source").expect("path"),
+                        to_path: AbsolutePath::parse(format!("/{index:0255}")).expect("path"),
+                        guard: DestinationGuard::default(),
+                    },
+                    _ => FilesystemOperation::PutFile {
+                        path: AbsolutePath::parse(format!(
+                            "/{}{index:0255}",
+                            "d/".repeat(loonfs_api::MAX_PATH_DEPTH - 1)
+                        ))
+                        .expect("path"),
+                        content_ref: content_ref.clone(),
+                        behavior: DestinationBehavior::NoReplace,
+                        expected_inode_id: None,
+                        expected_revision_no: None,
+                    },
+                })
+                .collect(),
+        };
+        let candidate = CommitCandidate::new(request);
+        candidate.validate_request_limits().expect("request limits");
+        let estimate = candidate.wal_record_bytes_upper_bound() + WAL_SEGMENT_OVERHEAD_BYTES;
+        assert!(estimate <= MAX_WAL_SEGMENT_BYTES, "{kind}");
+        let mut session = PublishPlanningSession::new(&head);
+        let mut allocation = session.begin_candidate();
+        let plan = session
+            .prepare_commit(
+                candidate.request(),
+                candidate
+                    .semantic_identity(&namespace_id)
+                    .expect("fingerprint"),
+                InMemoryMetadataView::in_memory(&state, None, head.seq),
+                u64::MAX,
+                &mut allocation,
+            )
+            .await
+            .expect("plan");
+        let next_inode_id = session.commit_candidate(allocation).expect("allocation");
+        let materialized = materialize_commit(plan.finish(next_inode_id), u64::MAX);
+        let record = wal_payload_from_materialized_commit(&materialized);
+        drop(materialized);
+        let encoded = encode_wal_segment_envelope_zstd(WalSegmentPayload {
+            namespace_id: namespace_id.clone(),
+            wal_no: WalNo(MAX_PUBLIC_INTEGER),
+            next_inode_id,
+            writer_epoch: head.writer_epoch,
+            base_head_seq: head.seq,
+            start_seq: record.seq,
+            end_seq: record.seq,
+            records: vec![record],
+        })
+        .expect("encode");
+        assert!(
+            encoded.document_len() <= estimate,
+            "{kind}: {} > {estimate}",
+            encoded.document_len()
+        );
+    }
+}

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -82,6 +82,11 @@ pub enum CoreError {
          this deployment buffers for one read"
     )]
     ContentTooLarge { size_bytes: u64, max_bytes: u64 },
+    #[error("commit is too large for one WAL segment: estimated {estimated_bytes} bytes exceeds `MAX_WAL_SEGMENT_BYTES` ({max_bytes} bytes)")]
+    CommitTooLarge {
+        estimated_bytes: usize,
+        max_bytes: usize,
+    },
     /// The request contains more items than one batch may read. No items were
     /// read; split the request into smaller batches.
     #[error("asked for {requested} items, over the {max} one batch answers")]
@@ -419,7 +424,9 @@ impl CoreError {
             CoreError::PathNotFound(_) => ErrorCode::PathNotFound,
             CoreError::InodeNotFound(_) => ErrorCode::InodeNotFound,
             CoreError::RevisionNotFound { .. } => ErrorCode::RevisionNotFound,
-            CoreError::ContentTooLarge { .. } => ErrorCode::ContentTooLarge,
+            CoreError::ContentTooLarge { .. } | CoreError::CommitTooLarge { .. } => {
+                ErrorCode::ContentTooLarge
+            }
             CoreError::NamespaceExists { .. } => ErrorCode::NamespaceExists,
             CoreError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
             CoreError::StaleHeadPrecondition { .. } => ErrorCode::StaleHead,
@@ -504,6 +511,7 @@ impl CoreError {
             | CoreError::InodeNotFound(_)
             | CoreError::RevisionNotFound { .. }
             | CoreError::ContentTooLarge { .. }
+            | CoreError::CommitTooLarge { .. }
             | CoreError::BatchTooLarge { .. }
             | CoreError::ResumeOffsetOutOfRange { .. }
             | CoreError::ResumePrefixIncomplete { .. }

--- a/crates/loonfs-core/src/gc/tests/retirement.rs
+++ b/crates/loonfs-core/src/gc/tests/retirement.rs
@@ -63,7 +63,7 @@ async fn retirement_includes_listing_time_in_its_budget_and_retries_with_a_fresh
             let head = crate::namespace::control::load_head_object(&store, &namespace_id)
                 .await
                 .expect("head");
-            assert_eq!(head.state.status.reclaim_after_ms(), None);
+            assert_eq!(head.status.reclaim_after_ms(), None);
             let retry = context(clock.now_ms());
             let report = gc_namespace_with_timer(&store, &namespace_id, &config, &retry, &clock)
                 .await

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -55,6 +55,7 @@ mod binding_generation;
 mod block_cache;
 mod checkpoint;
 mod commit_engine;
+mod commit_wal_size;
 mod context;
 mod control_object;
 mod control_update;

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -21,6 +21,7 @@ use crate::{
 use admission::{AdmittedWaiter, PublicationAdmission};
 use futures::FutureExt;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
+use loonfs_api::wire::wal::{MAX_WAL_SEGMENT_BYTES, WAL_SEGMENT_OVERHEAD_BYTES};
 use loonfs_api::{ChangeSeq, CommitId, NamespaceId};
 use loonfs_core::cache::Recency;
 use loonfs_core::commit::{CommitFingerprint, CommitHeadPublishError};
@@ -384,14 +385,14 @@ impl PublisherRegistry {
         namespace_id: NamespaceId,
         candidate: CommitCandidate,
     ) -> CommitResult {
-        let estimated_bytes = candidate.estimated_retained_bytes()?;
+        let candidate = PreparedCandidate::new(candidate)?;
         let permit = {
             let mut state = self.shared.lock_state();
             let publisher = self.publisher_for(&mut state, &namespace_id, false)?;
             publisher.check_admission(&publisher.lock_state())?;
             self.shared
                 .admission
-                .acquire(&namespace_id, estimated_bytes)?
+                .acquire_candidate(&namespace_id, &candidate)?
         };
         submit_with_admission(
             &namespace_id,
@@ -876,6 +877,23 @@ enum WorkItem {
 
 struct OpenBatch {
     candidates: Vec<BatchCandidate>,
+    wal_record_bytes_upper_bound: usize,
+}
+
+struct PreparedCandidate {
+    candidate: CommitCandidate,
+    estimated_retained_bytes: usize,
+    wal_record_bytes_upper_bound: usize,
+}
+
+impl PreparedCandidate {
+    fn new(candidate: CommitCandidate) -> Result<Self, CoreError> {
+        Ok(Self {
+            estimated_retained_bytes: candidate.estimated_retained_bytes()?,
+            wal_record_bytes_upper_bound: candidate.wal_record_bytes_upper_bound(),
+            candidate,
+        })
+    }
 }
 
 #[derive(Clone)]
@@ -899,7 +917,7 @@ enum SubmissionAdmission {
     /// conflict; if it fails, this submission gets another turn at admission.
     Contended {
         primary_identity: CommitFingerprint,
-        candidate: Box<CommitCandidate>,
+        candidate: Box<PreparedCandidate>,
         semantic_identity: CommitFingerprint,
     },
 }
@@ -1028,10 +1046,11 @@ impl NamespacePublisher {
     /// still owns and publishes the request.
     #[cfg(test)]
     async fn submit(&self, candidate: CommitCandidate) -> CommitResult {
+        let candidate = PreparedCandidate::new(candidate)?;
         self.check_admission(&self.lock_state())?;
         let permit = self
             .admission
-            .acquire(&self.namespace_id, candidate.estimated_retained_bytes()?)?;
+            .acquire_candidate(&self.namespace_id, &candidate)?;
         submit_with_admission(
             &self.namespace_id,
             candidate,
@@ -1052,7 +1071,7 @@ impl NamespacePublisher {
     fn admit(
         &self,
         commit_id: CommitId,
-        candidate: CommitCandidate,
+        candidate: PreparedCandidate,
         semantic_identity: CommitFingerprint,
         waiter: AdmittedWaiter<CommitResult>,
         enqueued_at: u64,
@@ -1076,18 +1095,30 @@ impl NamespacePublisher {
         }
 
         let queued = queued_candidates(&state);
+        let wal_record_bytes_upper_bound = candidate.wal_record_bytes_upper_bound;
         let candidate = BatchCandidate {
             commit_id: commit_id.clone(),
-            candidate,
+            candidate: candidate.candidate,
             enqueued_at,
         };
         match state.queue.back_mut() {
-            // Coalesce with the tail batch, unless a delete sits at the tail:
-            // work admitted after a delete opens a batch behind it and
-            // publishes only if that delete fails.
-            Some(WorkItem::Batch(batch)) => batch.candidates.push(candidate),
+            // Coalesce with the tail batch while its bound stays under the
+            // segment limit. A delete at the tail, or a full batch, opens a
+            // batch behind it; work behind a delete publishes only if that
+            // delete fails.
+            Some(WorkItem::Batch(batch))
+                if batch
+                    .wal_record_bytes_upper_bound
+                    .saturating_add(wal_record_bytes_upper_bound)
+                    .saturating_add(WAL_SEGMENT_OVERHEAD_BYTES)
+                    <= MAX_WAL_SEGMENT_BYTES =>
+            {
+                batch.wal_record_bytes_upper_bound += wal_record_bytes_upper_bound;
+                batch.candidates.push(candidate);
+            }
             _ => state.queue.push_back(WorkItem::Batch(OpenBatch {
                 candidates: vec![candidate],
+                wal_record_bytes_upper_bound,
             })),
         }
         self.trace_enqueue(queued + 1, "new");
@@ -1748,23 +1779,23 @@ impl NamespacePublisher {
 
 async fn submit_with_admission<F>(
     namespace_id: &NamespaceId,
-    candidate: CommitCandidate,
+    candidate: PreparedCandidate,
     timer: &dyn MonotonicTimer,
     mut admit: F,
 ) -> CommitResult
 where
     F: FnMut(
         CommitId,
-        CommitCandidate,
+        PreparedCandidate,
         CommitFingerprint,
         oneshot::Sender<CommitResult>,
         u64,
     ) -> Result<SubmissionAdmission, CoreError>,
 {
-    let commit_id = candidate.commit_id().clone();
+    let commit_id = candidate.candidate.commit_id().clone();
     let enqueued_at = timer.monotonic_now_ms();
     let mut candidate = candidate;
-    let mut semantic_identity = candidate.semantic_identity(namespace_id)?;
+    let mut semantic_identity = candidate.candidate.semantic_identity(namespace_id)?;
     for _ in 0..CONTENTION_RETRY_LIMIT {
         let (sender, receiver) = oneshot::channel();
         let admission = admit(

--- a/crates/loonfs/src/publisher/admission.rs
+++ b/crates/loonfs/src/publisher/admission.rs
@@ -1,7 +1,8 @@
 //! One budget for every caller whose publication has been admitted.
 
-use super::{CoreError, NamespaceId};
+use super::{CoreError, NamespaceId, PreparedCandidate};
 use crate::PublicationLimits;
+use loonfs_api::wire::wal::{MAX_WAL_SEGMENT_BYTES, WAL_SEGMENT_OVERHEAD_BYTES};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{oneshot, Semaphore};
@@ -42,6 +43,23 @@ impl PublicationAdmission {
     #[cfg(test)]
     pub(super) fn used_requests(&self) -> usize {
         self.lock_usage().total.requests
+    }
+
+    pub(super) fn acquire_candidate(
+        self: &Arc<Self>,
+        namespace_id: &NamespaceId,
+        candidate: &PreparedCandidate,
+    ) -> Result<Arc<AdmissionPermit>, CoreError> {
+        let document_bytes = candidate
+            .wal_record_bytes_upper_bound
+            .saturating_add(WAL_SEGMENT_OVERHEAD_BYTES);
+        if document_bytes > MAX_WAL_SEGMENT_BYTES {
+            return Err(CoreError::CommitTooLarge {
+                estimated_bytes: document_bytes,
+                max_bytes: MAX_WAL_SEGMENT_BYTES,
+            });
+        }
+        self.acquire(namespace_id, candidate.estimated_retained_bytes)
     }
 
     pub(super) fn acquire(
@@ -138,6 +156,31 @@ mod tests {
 
     fn limit(value: usize) -> NonZeroUsize {
         NonZeroUsize::new(value).expect("nonzero test limit")
+    }
+
+    #[test]
+    fn an_oversized_commit_is_rejected_before_queue_capacity() {
+        let budget = Arc::new(PublicationAdmission::new(PublicationLimits {
+            max_requests: limit(1),
+            ..PublicationLimits::default()
+        }));
+        let namespace_id = NamespaceId::parse("large").expect("namespace");
+        let permit = budget.acquire(&namespace_id, 0).expect("fill queue");
+        let mut candidate = PreparedCandidate::new(CommitCandidate::new(
+            super::super::tests::create_directory_request("large", "large"),
+        ))
+        .expect("prepare");
+        candidate.wal_record_bytes_upper_bound =
+            MAX_WAL_SEGMENT_BYTES - WAL_SEGMENT_OVERHEAD_BYTES + 1;
+        let error = budget
+            .acquire_candidate(&namespace_id, &candidate)
+            .err()
+            .expect("oversized commit");
+        assert_eq!(error.code(), loonfs_api::ErrorCode::ContentTooLarge);
+        assert!(error.to_string().contains("too large for one WAL segment"));
+        assert!(error.to_string().contains("MAX_WAL_SEGMENT_BYTES"));
+        drop(permit);
+        assert_eq!(budget.used_requests(), 0);
     }
 
     #[test]

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -530,12 +530,20 @@ fn try_admit_candidate(
     namespace_id: &NamespaceId,
     candidate: CommitCandidate,
 ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
-    let commit_id = candidate.commit_id().clone();
+    try_admit_prepared_candidate(publisher, namespace_id, PreparedCandidate::new(candidate)?)
+}
+
+fn try_admit_prepared_candidate(
+    publisher: &NamespacePublisher,
+    namespace_id: &NamespaceId,
+    candidate: PreparedCandidate,
+) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
+    let commit_id = candidate.candidate.commit_id().clone();
     publisher.check_admission(&publisher.lock_state())?;
     let permit = publisher
         .admission
-        .acquire(namespace_id, candidate.estimated_retained_bytes()?)?;
-    let semantic_identity = candidate.semantic_identity(namespace_id)?;
+        .acquire_candidate(namespace_id, &candidate)?;
+    let semantic_identity = candidate.candidate.semantic_identity(namespace_id)?;
     let (sender, receiver) = oneshot::channel();
     let admission = publisher.admit(
         commit_id,
@@ -553,6 +561,73 @@ async fn recv_commit(receiver: oneshot::Receiver<CommitResult>, label: &str) -> 
         .await
         .unwrap_or_else(|err| panic!("{label} receiver dropped: {err}"))
         .unwrap_or_else(|err| panic!("{label} failed: {err}"))
+}
+
+#[tokio::test]
+async fn publisher_splits_batches_at_the_wal_bound_in_admission_order() {
+    for extra_bytes in [0, 1] {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::parse("bounded").expect("namespace");
+        let store = Arc::new(RecordingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("store"),
+            KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
+        ));
+        let runtime = test_runtime(store.clone());
+        create_namespace(&runtime, &namespace_id).await;
+        let mut publisher = standalone_publisher(&namespace_id, &runtime);
+        publisher.min_publish_interval = Duration::ZERO;
+        recv_commit(
+            admit_commit(
+                &publisher,
+                &namespace_id,
+                create_directory_request("warmup", "warmup"),
+            ),
+            "warmup",
+        )
+        .await;
+        store.reset();
+
+        let available_bytes = MAX_WAL_SEGMENT_BYTES - WAL_SEGMENT_OVERHEAD_BYTES;
+        let first_bound = available_bytes / 2;
+        let mut responses = Vec::new();
+        for (name, bound) in [
+            ("first", first_bound),
+            ("second", available_bytes - first_bound + extra_bytes),
+        ] {
+            let mut candidate =
+                PreparedCandidate::new(CommitCandidate::new(create_directory_request(name, name)))
+                    .expect("prepare");
+            candidate.wal_record_bytes_upper_bound = bound;
+            responses.push(
+                try_admit_prepared_candidate(&publisher, &namespace_id, candidate).expect("admit"),
+            );
+        }
+        let expected_batches = if extra_bytes == 0 {
+            vec![2]
+        } else {
+            vec![1, 1]
+        };
+        let batches = publisher_state(&publisher)
+            .queue
+            .iter()
+            .map(|item| match item {
+                WorkItem::Batch(batch) => batch.candidates.len(),
+                WorkItem::Delete(_) => panic!("expected commit batch"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(batches, expected_batches);
+        for (response, expected_seq) in responses.into_iter().zip([ChangeSeq(2), ChangeSeq(3)]) {
+            assert_eq!(
+                recv_commit(response, "bounded").await.committed_seq,
+                expected_seq
+            );
+        }
+        assert_eq!(
+            store.count(OperationClass::PutCreateIfAbsent),
+            expected_batches.len()
+        );
+        publisher.wait_for_worker().await;
+    }
 }
 
 #[test]

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -23,6 +23,94 @@ fn owner_update() -> UpdateAttributesOptions {
 }
 
 #[test]
+fn maximum_small_attribute_updates_reopen_after_one_wal_publication() {
+    use loonfs_api::{Attributes, MAX_ATTRIBUTES_TOTAL_BYTES};
+    use loonfs_test_support::stores::{KeyPredicate, OperationClass, RecordingStore};
+    use std::sync::Arc;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("large-attributes");
+    let counted = Arc::new(RecordingStore::new(
+        store(temp_dir.path()),
+        KeyPredicate::prefix(loonfs_objectstore::keys::wal_segment_prefix(&namespace_id)),
+    ));
+    let fs = open_runtime(counted.clone(), "large-attributes-writer");
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("namespace");
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/file",
+        b"content",
+        PutFileOptions::new(loonfs_test_support::test_actor()),
+    )
+    .expect("file");
+    let mut set = BTreeMap::from([(attribute_key("x"), attribute_text("a"))]);
+    let mut remaining = MAX_ATTRIBUTES_TOTAL_BYTES - 2 - 16 * 3;
+    for index in 0..16 {
+        let length = remaining.min(loonfs_api::MAX_ATTRIBUTE_VALUE_BYTES);
+        remaining -= length;
+        set.insert(
+            attribute_key(&format!("k{index:02}")),
+            attribute_text(&"v".repeat(length)),
+        );
+    }
+    let initial = Attributes::new(set.clone()).expect("full map");
+    assert_eq!(initial.logical_bytes(), MAX_ATTRIBUTES_TOTAL_BYTES);
+    let mut options = UpdateAttributesOptions::new(loonfs_test_support::test_actor());
+    options.set = set;
+    block_on(fs.writer.update_attributes(&namespace_id, "/file", options))
+        .expect("fill attributes");
+    counted.reset();
+    let response = fs
+        .mutate_blocking(
+            &namespace_id,
+            CommitRequest {
+                commit_id: CommitId::parse("maximum-attribute-updates").expect("commit"),
+                actor_id: loonfs_test_support::test_actor(),
+                message: None,
+                assertions: Vec::new(),
+                operations: (0..loonfs::publish::MAX_COMMIT_OPERATIONS)
+                    .map(|index| FilesystemOperation::UpdateAttributes {
+                        path: parse_mutation_path("/file").expect("path"),
+                        set: BTreeMap::from([(
+                            attribute_key("x"),
+                            attribute_text(if index % 2 == 0 { "b" } else { "c" }),
+                        )]),
+                        remove: Vec::new(),
+                        expected_inode_id: None,
+                        expected_attributes_revision_no: None,
+                    })
+                    .collect(),
+            },
+        )
+        .expect("maximum updates fit one segment");
+    assert_eq!(counted.count(OperationClass::PutCreateIfAbsent), 1);
+    block_on(fs.writer.shutdown()).expect("shutdown");
+    drop(fs);
+    counted.reset();
+    let reopened = open_runtime(counted.clone(), "fresh-reader-runtime");
+    let entry = reopened
+        .stat_path_blocking(&namespace_id, "/file")
+        .expect("reopen committed state");
+    let projection = entry.attributes.expect("attributes");
+    assert_eq!(
+        projection.attributes_revision_no,
+        AttributeRevisionNo(1 + loonfs::publish::MAX_COMMIT_OPERATIONS as u64)
+    );
+    assert_eq!(
+        projection.attributes.get(&attribute_key("x")),
+        Some(&attribute_text("c"))
+    );
+    assert_eq!(
+        projection.attributes.logical_bytes(),
+        MAX_ATTRIBUTES_TOTAL_BYTES
+    );
+    assert!(response.committed_seq.0 > 0);
+    assert!(counted.count(OperationClass::Read) > 0);
+    assert_eq!(counted.count(OperationClass::Put), 0);
+}
+
+#[test]
 fn the_write_convenience_matches_a_hand_built_one_operation_commit() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "attributes-parity");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -458,6 +458,7 @@ one operation is the same shape as a request with many, so a convenience
 call and a one-element list are the same commit and fingerprint alike.
 A `message` is at most 4096 bytes; a longer one is rejected with
 `invalid_request` before planning, on every transport.
+A commit whose estimated encoded log would exceed one WAL segment is rejected with `content_too_large` before publication; the message names the [WAL document limit](format.md#a5-wal-records).
 The semantic fingerprint includes assertions in request order. Changing an
 assertion or its position changes identity. The fingerprint input always
 includes the assertion list, including an empty list.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1107,6 +1107,8 @@ The owner and segment ID determine the object key. The descriptor stores no sepa
 
 ### A.5 WAL records
 
+`MAX_WAL_SEGMENT_BYTES` is 512 MiB (536,870,912 bytes) for the complete decompressed WAL document, including its envelope. Writers keep every segment within this limit through request and batch admission; readers refuse larger documents. A writer composes each batch so the sum of its requests' bounds plus the document overhead stays within the limit. This is a format constraint because every successful publication must remain readable with bounded decompression.
+
 A WAL segment's payload contains `namespace_id`, `wal_no`, `next_inode_id`, `writer_epoch`, `base_head_seq`, `start_seq`, `end_seq`, and `records`.
 
 For a data segment, `records` covers the sequence interval contiguously; the first commit follows `base_head_seq`. The WAL number must match the key, and the allocation high-water mark must agree with replay. A fence has an empty record list, equal base/start/end sequences, and an unchanged allocator. Fences participate in WAL numbering and epoch validation but produce no logical changes.
@@ -1486,6 +1488,8 @@ These are reference producer and runtime defaults. A target size can be exceeded
 | Maximum commit-message size | 4,096 bytes |
 
 A decoder cannot use target block or segment sizes as hard allocation bounds. The reference block reader initially reserves at most the smaller of `decoded_len` and 64 KiB. Further allocation follows bytes actually decompressed. Output stops at the declared length plus one byte as specified in Appendix A.7; vector capacity can exceed that output length. This does not impose a smaller maximum block size. Request admission limits are specified in the [API specification][api-spec].
+
+The hard WAL document limit is specified in [Appendix A.5](#a5-wal-records).
 
 ## Appendix D. Grep extension format
 


### PR DESCRIPTION
A WAL segment had no size bound on either side. A commit's encoded log is not bounded by its request size, because an attribute update records the complete resulting map: a request of about 1 MB carrying 4,096 small updates on a full map encodes to more than 256 MiB, and group commit packs several requests into one segment. The reader then decompressed whatever it found. A limit only the reader enforced would turn a successful commit into an unreadable namespace, so this bounds segments by construction at the writer first and lets the reader refuse anything larger second, through one constant.

`MAX_WAL_SEGMENT_BYTES` is 512 MiB, which admits every request the API accepts today including the maximal attribute case. Each prepared request now carries two numbers with two jobs. The retained-bytes estimate keeps its old meaning and drives queue backpressure exactly as before. A separate upper bound on the bytes the request adds to an encoded WAL document, which counts a complete attribute map for every update, drives two checks: a request whose bound alone exceeds the constant is rejected before it enters a batch, and a request joins the batch at the tail of the queue only if the batch's running bound stays within the constant, otherwise it starts the next batch behind it. Batches still publish in admission order, so nothing is deferred or reordered. The encoded document is checked once more immediately before the numbered put, and the reader stops decompression one byte past the constant with its own error.

Important callouts:

- A commit whose bound exceeds one segment is rejected with the existing `content_too_large` code and a message naming the limit; nothing durable is written for it. Every request the API accepted before is still accepted.
- Backpressure budgets do not change meaning or defaults. The bound is not charged against them, so a commit of a few hundred small attribute updates is admitted as before.
- The bound is proven, not assumed: a test encodes requests built to the API's maximums and checks the document against the estimate. A commit of 4,096 small attribute updates on a full map is a test under default budgets, and the namespace reopens on a fresh runtime afterwards. A publisher test pins that two candidates whose bounds together exceed the constant form two batches and two WAL puts, in order.
- Appendix A.5 documents the constant as a format constraint and the batch composition rule; the API's request admission section names the error. Durable versions stay at 1; no encoding changes.
- Carries the one-line fix to the retirement test that reads the plain read state, so this branch compiles on the current `main`; the same line is in its own PR.
