### PR TITLE
fix(core): read the plain read state in the retirement test

### DIFF
--- a/crates/loonfs-core/src/gc/tests/retirement.rs
+++ b/crates/loonfs-core/src/gc/tests/retirement.rs
@@ -63,7 +63,7 @@ async fn retirement_includes_listing_time_in_its_budget_and_retries_with_a_fresh
             let head = crate::namespace::control::load_head_object(&store, &namespace_id)
                 .await
                 .expect("head");
-            assert_eq!(head.state.status.reclaim_after_ms(), None);
+            assert_eq!(head.status.reclaim_after_ms(), None);
             let retry = context(clock.now_ms());
             let report = gc_namespace_with_timer(&store, &namespace_id, &config, &retry, &clock)
                 .await


### PR DESCRIPTION
`main` does not compile its core tests after #920 and #924 merged in sequence. The retirement test from #920 read the namespace status through the `state` field of a loaded control object, and #924 made the derived read state a plain value, so the field no longer exists. One line changes to read the status directly.

Important callouts:

- Test-only change; no runtime, wire, or durable behavior is involved.
- The same line is also fixed on the vocabulary-pass branch, so that PR rebases cleanly after this lands.
