### PR TITLE
fix(core): pair attribute revision expectations with an inode and accept unchanged maps

### DIFF
--- a/crates/loonfs-api/src/options.rs
+++ b/crates/loonfs-api/src/options.rs
@@ -98,7 +98,7 @@ pub struct UpdateAttributesOptions {
     pub commit: CommitOptions,
     /// The inode that the path must still resolve to before the update.
     pub expected_inode_id: Option<InodeId>,
-    /// The attribute revision that must still be current before the update.
+    /// With an inode guard, the attribute revision that must still be current.
     pub expected_attributes_revision_no: Option<AttributeRevisionNo>,
 }
 

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -18,8 +18,8 @@ pub use downloads::{
     BeginDownloadResponse,
 };
 pub use operations::{
-    AdvanceRetentionRequest, AdvanceRetentionResponse, ApiError, Checkpoint,
-    CheckpointOwnerSummary, CommitAssertion, CommitRequest, CreateCheckpointRequest,
+    validate_attributes_guard, AdvanceRetentionRequest, AdvanceRetentionResponse, ApiError,
+    Checkpoint, CheckpointOwnerSummary, CommitAssertion, CommitRequest, CreateCheckpointRequest,
     CreateNamespaceRequest, CreateSnapshotRequest, DeleteCheckpointResponse,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, DeleteSnapshotResponse,
     DeletedCheckpointsByOwner, DeletedObjectCounts, DestinationBehavior, DestinationGuard,

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -289,7 +289,7 @@ pub enum DestinationGuardError {
     GuardsRequireReplace,
     /// A revision guard did not name the inode whose revision it checks.
     #[error(
-        "{revision_field} asserts a revision of a specific file; pair it with {inode_field} so the assertion names which file"
+        "`{revision_field}` names the revision of one inode; pair it with `{inode_field}` so the request names which inode"
     )]
     RevisionRequiresInode {
         /// Revision field supplied by the request.
@@ -328,6 +328,20 @@ impl DestinationGuard {
             revision_no: self.expected_revision_no,
         }))
     }
+}
+
+/// Rejects an attribute revision guard without an inode guard.
+pub fn validate_attributes_guard(
+    expected_inode_id: Option<InodeId>,
+    expected_attributes_revision_no: Option<AttributeRevisionNo>,
+) -> Result<(), DestinationGuardError> {
+    if expected_attributes_revision_no.is_some() && expected_inode_id.is_none() {
+        return Err(DestinationGuardError::RevisionRequiresInode {
+            revision_field: "expected_attributes_revision_no",
+            inode_field: "expected_inode_id",
+        });
+    }
+    Ok(())
 }
 
 /// Directory delete behavior for path-oriented deletes.
@@ -543,7 +557,7 @@ pub enum FilesystemOperation {
         )]
         #[cfg_attr(feature = "openapi", schema(nullable = false))]
         expected_inode_id: Option<InodeId>,
-        /// The attribute revision that must still be current before the update.
+        /// With an inode guard, the attribute revision that must still be current.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[cfg_attr(feature = "openapi", schema(nullable = false))]
         expected_attributes_revision_no: Option<AttributeRevisionNo>,

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -878,7 +878,8 @@ pub(crate) struct FilesystemAnnotateArgs {
     #[arg(long, value_parser = parse_public_inode_id)]
     pub expected_inode_id: Option<InodeId>,
     /// Update only while the inode's attribute revision is still this one.
-    #[arg(long)]
+    /// Requires --expected-inode-id.
+    #[arg(long, requires = "expected_inode_id")]
     pub expected_attributes_revision: Option<u64>,
     #[command(flatten)]
     pub commit: CommitArgs,
@@ -1666,6 +1667,15 @@ mod tests {
     #[test]
     fn revision_guards_require_matching_inode_guards() {
         for arguments in [
+            vec![
+                "loonfs",
+                "annotate",
+                "/file.txt",
+                "--set",
+                "owner=ada",
+                "--expected-attributes-revision",
+                "1",
+            ],
             vec![
                 "loonfs",
                 "cp",

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -1801,7 +1801,6 @@ fn annotate_writes_and_removes_attributes_in_both_modes() {
         let entry = json_data(&removed);
         assert!(entry["attributes"]["owner"].is_null());
         assert_eq!(entry["attributes"]["note"], "has=equals");
-        // Three effective updates, three revisions.
         assert_eq!(entry["attributes_revision_no"], 3);
         assert!(entry.pointer("/attributes/attributes").is_none());
 

--- a/crates/loonfs-core/src/path/write/plan_attributes.rs
+++ b/crates/loonfs-core/src/path/write/plan_attributes.rs
@@ -21,6 +21,7 @@ pub(super) async fn plan_update_attributes<S: ObjectStore + ?Sized>(
 ) -> Result<CompiledFilesystemOperation> {
     ensure_mutation_path(absolute_path)?;
     validate_request_shape(set, remove)?;
+    loonfs_api::v0::validate_attributes_guard(expected_inode_id, expected_attributes_revision_no)?;
 
     // Attributes belong to the resource, so a directory is as valid a target
     // as a file; nothing here looks at the inode kind.
@@ -41,17 +42,6 @@ pub(super) async fn plan_update_attributes<S: ObjectStore + ?Sized>(
     }
     for key in remove {
         updated.remove(key);
-    }
-    // An update that leaves the map exactly as it was publishes nothing. This
-    // is new: an identical-content put deliberately appends a revision,
-    // because a file's revisions are its history. Attributes are current
-    // state with no history, so a revision that states the same map is a
-    // number with nothing behind it.
-    if updated == *current.as_map() {
-        return Err(CoreError::InvalidCommitRequest(format!(
-            "the update leaves the attributes of `{}` unchanged",
-            absolute_path.as_str()
-        )));
     }
     let attributes = Attributes::new(updated).map_err(|error| {
         CoreError::InvalidCommitRequest(format!("the resulting attribute map is invalid: {error}"))

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -1,11 +1,6 @@
 //! Inode attributes end to end: what the planner accepts, what the commit
 //! guards reject, and what survives a flush, a fork, and every operation that
 //! moves an inode around.
-//!
-//! There is no attribute read API yet, so these read attributes back through
-//! the change feed — which is also what pins the feed's own contract — and
-//! through the revision number a later update publishes, which is only right
-//! if the write path read the current state from where it was stored.
 
 #![allow(clippy::panic)]
 // These integration tests use panic in unexpected match arms for precise diagnostics.
@@ -18,11 +13,14 @@ use loonfs_api::{
     NamespaceId, RevisionNo, MAX_ATTRIBUTES_TOTAL_BYTES, MAX_ATTRIBUTE_VALUE_BYTES,
 };
 use loonfs_core::content::store_bytes_as_content;
-use loonfs_core::publish::{CommitRequest, FilesystemOperation};
+use loonfs_core::publish::{
+    CommitCandidate, CommitRequest, FilesystemOperation, NamespaceCommitEngine, PublishTailOptions,
+};
 use loonfs_core::{Error as CoreError, ErrorCode, MutationContext};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::ids::namespace_id;
+use loonfs_test_support::stores::{KeyPredicate, RecordingStore};
 use std::collections::BTreeMap;
 use tempfile::tempdir;
 
@@ -112,6 +110,24 @@ async fn update<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_operation(store, namespace_id, commit_id(id), operation, context).await
+}
+
+async fn publish_request<S: ObjectStore + ?Sized>(
+    engine: &mut NamespaceCommitEngine,
+    store: &S,
+    request: CommitRequest,
+    context: &MutationContext,
+) -> Result<loonfs_api::CommitResponse, CoreError> {
+    engine
+        .publish_batch(
+            store,
+            vec![CommitCandidate::new(request)],
+            context,
+            &PublishTailOptions::default(),
+        )
+        .await
+        .results
+        .remove(0)
 }
 
 /// Every attribute event the feed still holds, oldest first.
@@ -356,7 +372,7 @@ async fn an_update_rejects_a_request_that_does_not_describe_one_change() {
 }
 
 #[tokio::test]
-async fn an_update_that_changes_nothing_is_rejected() {
+async fn an_unchanged_update_replays_its_receipt_without_advancing_again() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
     put_file_bytes(
         &store,
@@ -379,30 +395,37 @@ async fn an_update_that_changes_nothing_is_rejected() {
     .await
     .expect("first write");
 
-    for (label, operation) in [
-        (
-            "same-value",
-            set_attributes("/docs/a.txt", &[("owner", "ada")]),
-        ),
-        (
-            "remove-absent",
-            remove_attributes("/docs/a.txt", &["never-written"]),
-        ),
-    ] {
-        let error = match update(&store, &namespace_id, label, operation, &context).await {
-            Ok(_) => panic!("`{label}` must be rejected"),
-            Err(error) => error,
-        };
-        assert_invalid_commit_request(&error, label);
-    }
-
-    // A first write on an inode that has no attributes is not a no-op even
-    // though it removes nothing: the map goes from empty to populated.
     let file_inode = inode_of(&store, &namespace_id, "/docs/a.txt").await;
+    let operation = FilesystemOperation::UpdateAttributes {
+        path: path("/docs/a.txt"),
+        set: BTreeMap::from([(key("owner"), text("ada"))]),
+        remove: Vec::new(),
+        expected_inode_id: Some(file_inode),
+        expected_attributes_revision_no: Some(AttributeRevisionNo(1)),
+    };
+    let request = CommitRequest::single(
+        commit_id("same-value"),
+        loonfs_test_support::test_actor(),
+        None,
+        operation,
+    );
+    let store = RecordingStore::new(store, KeyPredicate::any());
+    let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
+    let receipt = publish_request(&mut engine, &store, request.clone(), &context)
+        .await
+        .expect("an unchanged map advances the revision");
+
+    store.reset();
+    let replay = publish_request(&mut engine, &store, request, &context)
+        .await
+        .expect("the original receipt replays despite the stale guard");
+    assert_eq!(replay, receipt);
+    assert_eq!(store.counts().puts, 0);
+    assert_eq!(store.counts().deletes, 0);
     assert_eq!(
         attributes_of(&store, &namespace_id, file_inode).await,
-        Some((AttributeRevisionNo(1), map(&[("owner", "ada")]))),
-        "the rejected updates published nothing"
+        Some((AttributeRevisionNo(2), map(&[("owner", "ada")]))),
+        "receipt replay does not advance the revision"
     );
 }
 
@@ -469,7 +492,7 @@ async fn an_update_is_rejected_when_the_resulting_map_breaks_a_limit() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn a_caller_supplied_stale_expectation_reports_expected_and_actual() {
+async fn an_already_satisfied_patch_reports_a_stale_expectation() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
     put_file_bytes(
         &store,
@@ -492,15 +515,16 @@ async fn a_caller_supplied_stale_expectation_reports_expected_and_actual() {
     .await
     .expect("first write");
 
+    let file_inode = inode_of(&store, &namespace_id, "/docs/a.txt").await;
     let error = update(
         &store,
         &namespace_id,
         "stale-expectation",
         FilesystemOperation::UpdateAttributes {
             path: path("/docs/a.txt"),
-            set: BTreeMap::from([(key("owner"), text("grace"))]),
+            set: BTreeMap::from([(key("owner"), text("ada"))]),
             remove: Vec::new(),
-            expected_inode_id: None,
+            expected_inode_id: Some(file_inode),
             expected_attributes_revision_no: Some(AttributeRevisionNo(0)),
         },
         &context,
@@ -517,6 +541,174 @@ async fn a_caller_supplied_stale_expectation_reports_expected_and_actual() {
     assert_eq!(
         details.actual_attributes_revision_no,
         Some(AttributeRevisionNo(1))
+    );
+}
+
+#[tokio::test]
+async fn an_attribute_revision_guard_requires_an_inode_before_resolving_the_path() {
+    let (_temp_dir, store, namespace_id, context) = setup().await;
+    put_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        b"hello",
+        DestinationBehavior::NoReplace,
+        &context,
+        Some("seed"),
+    )
+    .await
+    .expect("seed file");
+
+    let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
+    publish_request(
+        &mut engine,
+        &store,
+        CommitRequest::single(
+            commit_id("set-owner"),
+            loonfs_test_support::test_actor(),
+            None,
+            set_attributes("/docs/a.txt", &[("owner", "ada")]),
+        ),
+        &context,
+    )
+    .await
+    .expect("write attributes in the retained writer session");
+
+    let file_before = resolve_path(&store, &namespace_id, "/docs/a.txt")
+        .await
+        .expect("read file");
+    let directory_before = resolve_path(&store, &namespace_id, "/docs")
+        .await
+        .expect("read directory");
+    let store = RecordingStore::new(store, KeyPredicate::any());
+    for (label, target) in [
+        ("file", "/docs/a.txt"),
+        ("directory", "/docs"),
+        ("missing", "/missing.txt"),
+    ] {
+        let request = CommitRequest::single(
+            commit_id(label),
+            loonfs_test_support::test_actor(),
+            None,
+            FilesystemOperation::UpdateAttributes {
+                path: path(target),
+                set: BTreeMap::from([(key("owner"), text("ada"))]),
+                remove: Vec::new(),
+                expected_inode_id: None,
+                expected_attributes_revision_no: Some(AttributeRevisionNo(0)),
+            },
+        );
+        let error = publish_request(&mut engine, &store, request, &context)
+            .await
+            .expect_err("the revision guard requires an inode guard");
+        assert_invalid_commit_request(&error, label);
+        let message = error.to_string();
+        assert!(
+            message.contains("expected_attributes_revision_no"),
+            "{message}"
+        );
+        assert!(message.contains("expected_inode_id"), "{message}");
+    }
+    assert_eq!(store.counts().puts, 0);
+    assert_eq!(store.counts().deletes, 0);
+    assert_eq!(
+        resolve_path(&store, &namespace_id, "/docs/a.txt")
+            .await
+            .expect("read file"),
+        file_before
+    );
+    assert_eq!(
+        resolve_path(&store, &namespace_id, "/docs")
+            .await
+            .expect("read directory"),
+        directory_before
+    );
+}
+
+#[tokio::test]
+async fn an_attribute_guard_rejects_a_recreated_path_before_checking_its_revision() {
+    let (_temp_dir, store, namespace_id, context) = setup().await;
+    put_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        b"hello",
+        DestinationBehavior::NoReplace,
+        &context,
+        Some("seed"),
+    )
+    .await
+    .expect("seed file");
+    update(
+        &store,
+        &namespace_id,
+        "set-owner",
+        set_attributes("/docs/a.txt", &[("owner", "ada")]),
+        &context,
+    )
+    .await
+    .expect("write attributes");
+    let original = resolve_path(&store, &namespace_id, "/docs/a.txt")
+        .await
+        .expect("read original inode");
+    update(
+        &store,
+        &namespace_id,
+        "delete",
+        FilesystemOperation::DeletePath {
+            path: path("/docs/a.txt"),
+            behavior: DeleteDirectoryBehavior::NonRecursive,
+            expected_inode_id: Some(original.inode_id),
+        },
+        &context,
+    )
+    .await
+    .expect("delete original inode");
+    put_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        b"replacement",
+        DestinationBehavior::NoReplace,
+        &context,
+        Some("recreate"),
+    )
+    .await
+    .expect("recreate file");
+    let replacement = resolve_path(&store, &namespace_id, "/docs/a.txt")
+        .await
+        .expect("read replacement inode");
+    assert_ne!(original.inode_id, replacement.inode_id);
+
+    let error = update(
+        &store,
+        &namespace_id,
+        "stale-inode",
+        FilesystemOperation::UpdateAttributes {
+            path: path("/docs/a.txt"),
+            set: BTreeMap::from([(key("owner"), text("grace"))]),
+            remove: Vec::new(),
+            expected_inode_id: Some(original.inode_id),
+            expected_attributes_revision_no: Some(
+                original
+                    .attributes
+                    .expect("original attributes")
+                    .attributes_revision_no,
+            ),
+        },
+        &context,
+    )
+    .await
+    .expect_err("the path names a new inode");
+    assert_eq!(error.code(), ErrorCode::PathConflict);
+    let details = error.details().expect("path conflict details");
+    assert_eq!(details.expected_inode_id, Some(original.inode_id));
+    assert_eq!(details.actual_inode_id, Some(replacement.inode_id));
+    assert_eq!(
+        resolve_path(&store, &namespace_id, "/docs/a.txt")
+            .await
+            .expect("read replacement after rejection"),
+        replacement
     );
 }
 
@@ -597,7 +789,7 @@ async fn a_put_and_an_update_of_the_new_path_commit_together() {
 }
 
 #[tokio::test]
-async fn two_updates_in_one_request_advance_the_revision_twice() {
+async fn an_unchanged_update_and_a_second_update_commit_together() {
     let (_temp_dir, store, namespace_id, context) = setup().await;
     put_file_bytes(
         &store,
@@ -620,7 +812,7 @@ async fn two_updates_in_one_request_advance_the_revision_twice() {
             actor_id: loonfs_test_support::test_actor(),
             message: None,
             operations: vec![
-                set_attributes("/docs/a.txt", &[("owner", "ada")]),
+                remove_attributes("/docs/a.txt", &["owner"]),
                 set_attributes("/docs/a.txt", &[("owner", "grace")]),
             ],
         },
@@ -639,7 +831,7 @@ async fn two_updates_in_one_request_advance_the_revision_twice() {
     assert_eq!(
         events,
         vec![
-            (AttributeRevisionNo(1), map(&[("owner", "ada")])),
+            (AttributeRevisionNo(1), Attributes::default()),
             (AttributeRevisionNo(2), map(&[("owner", "grace")])),
         ],
         "internal-op order survives into the feed"
@@ -737,9 +929,7 @@ async fn attributes_survive_a_flush_and_the_counter_keeps_going() {
         .await
         .expect("flush the WAL tail into metadata segments");
 
-    // A repeat of the current state is still a no-op, which it could only be
-    // if the flushed map is what the planner read.
-    let no_op = update(
+    update(
         &store,
         &namespace_id,
         "repeat-after-flush",
@@ -747,8 +937,21 @@ async fn attributes_survive_a_flush_and_the_counter_keeps_going() {
         &context,
     )
     .await
-    .expect_err("the flushed map is unchanged by this update");
-    assert_invalid_commit_request(&no_op, "repeat-after-flush");
+    .expect("an unchanged map advances the flushed revision");
+
+    let entry = resolve_path(&store, &namespace_id, "/docs/a.txt")
+        .await
+        .expect("read the updated attributes");
+    let attributes = entry.attributes.expect("attribute projection");
+    assert_eq!(attributes.attributes_revision_no, AttributeRevisionNo(3));
+    assert_eq!(
+        attributes.attributes,
+        map(&[("owner", "ada"), ("stage", "draft")])
+    );
+    assert_eq!(
+        attributes_of(&store, &namespace_id, entry.inode_id).await,
+        Some((AttributeRevisionNo(3), attributes.attributes))
+    );
 
     update(
         &store,
@@ -764,7 +967,7 @@ async fn attributes_survive_a_flush_and_the_counter_keeps_going() {
     assert_eq!(
         attributes_of(&store, &namespace_id, file_inode).await,
         Some((
-            AttributeRevisionNo(3),
+            AttributeRevisionNo(4),
             map(&[("owner", "grace"), ("stage", "draft")])
         )),
         "the counter continues from the flushed revision and the map is whole"
@@ -806,7 +1009,7 @@ async fn a_fork_reads_the_sources_attributes_before_and_after_its_first_flush() 
         .expect("fork the namespace");
 
     // Before the fork's first flush, its basis is the source's manifest.
-    let inherited = update(
+    update(
         &store,
         &target,
         "repeat-in-fork",
@@ -814,8 +1017,12 @@ async fn a_fork_reads_the_sources_attributes_before_and_after_its_first_flush() 
         &context,
     )
     .await
-    .expect_err("the fork already holds the source's map");
-    assert_invalid_commit_request(&inherited, "repeat-in-fork");
+    .expect("the unchanged inherited map advances the revision");
+    let file_inode = inode_of(&store, &target, "/docs/a.txt").await;
+    assert_eq!(
+        attributes_of(&store, &target, file_inode).await,
+        Some((AttributeRevisionNo(2), map(&[("owner", "ada")]))),
+    );
 
     update(
         &store,
@@ -841,11 +1048,10 @@ async fn a_fork_reads_the_sources_attributes_before_and_after_its_first_flush() 
     .await
     .expect("an update after the fork's flush commits");
 
-    let file_inode = inode_of(&store, &target, "/docs/a.txt").await;
     assert_eq!(
         attributes_of(&store, &target, file_inode).await,
         Some((
-            AttributeRevisionNo(3),
+            AttributeRevisionNo(4),
             map(&[("owner", "grace"), ("stage", "draft")])
         )),
         "the fork's own flush carries the inherited revision forward"
@@ -1009,8 +1215,7 @@ async fn a_delete_keeps_attributes_and_an_undelete_gives_them_back() {
         Some((AttributeRevisionNo(1), map(&[("owner", "ada")]))),
         "the recovered inode holds the map it had"
     );
-    // The map is the live one, so restating it is still a no-op.
-    let no_op = update(
+    update(
         &store,
         &namespace_id,
         "repeat-after-undelete",
@@ -1018,8 +1223,11 @@ async fn a_delete_keeps_attributes_and_an_undelete_gives_them_back() {
         &context,
     )
     .await
-    .expect_err("undelete revealed the same map");
-    assert_invalid_commit_request(&no_op, "repeat-after-undelete");
+    .expect("the unchanged map advances the recovered revision");
+    assert_eq!(
+        attributes_of(&store, &namespace_id, file_inode).await,
+        Some((AttributeRevisionNo(2), map(&[("owner", "ada")]))),
+    );
 }
 
 #[tokio::test]
@@ -1235,8 +1443,7 @@ async fn clearing_every_attribute_publishes_the_empty_map() {
         attributes_of(&store, &namespace_id, file_inode).await,
         Some((AttributeRevisionNo(2), Attributes::default()))
     );
-    // Clearing again changes nothing, so it is rejected like any other no-op.
-    let no_op = update(
+    update(
         &store,
         &namespace_id,
         "clear-again",
@@ -1244,8 +1451,11 @@ async fn clearing_every_attribute_publishes_the_empty_map() {
         &context,
     )
     .await
-    .expect_err("the map is already empty");
-    assert_invalid_commit_request(&no_op, "clear-again");
+    .expect("removing an absent key advances the revision");
+    assert_eq!(
+        attributes_of(&store, &namespace_id, file_inode).await,
+        Some((AttributeRevisionNo(3), Attributes::default()))
+    );
 
     // A cleared map is a real state that survives a flush.
     namespace_engine(&store, &namespace_id, &context)
@@ -1263,7 +1473,7 @@ async fn clearing_every_attribute_publishes_the_empty_map() {
     .expect("a write after the clear commits");
     assert_eq!(
         attributes_of(&store, &namespace_id, file_inode).await,
-        Some((AttributeRevisionNo(3), map(&[("owner", "hopper")]))),
+        Some((AttributeRevisionNo(4), map(&[("owner", "hopper")]))),
         "the cleared revision is what the write built on"
     );
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2026,6 +2026,7 @@ path resolves to:
         "tags": "draft,review"
       },
       "remove": ["stage"],
+      "expected_inode_id": "ino_7",
       "expected_attributes_revision_no": 3
     }
   ]
@@ -2054,11 +2055,14 @@ there is nothing to apply. So do a key that appears in both, a key repeated
 in `remove`, and any key under the reserved `loonfs.` prefix, which is
 system-owned and not a caller's to write.
 
-An update that leaves the map exactly as it was also answers
-`invalid_request`. Attributes are current state with no history, so a
-revision that restates the same map has nothing behind it — unlike a put of
-identical bytes, which appends a revision because a file's revisions *are* its
-history. The resulting map is checked against every limit in the format spec,
+An accepted update advances the attribute revision even when the resulting
+map is unchanged. The revision counts accepted updates, matching puts of
+identical content. The update writes the complete resulting map and produces
+an attributes event in the change feed. Replaying the same request with the
+same `commit_id` returns its original receipt without advancing the revision
+again; a new `commit_id` is a new update.
+
+The resulting map is checked against every limit in the format spec,
 so a small write that pushes an already-large map over a cap is rejected for
 the map it would produce.
 
@@ -2073,9 +2077,11 @@ file's content and nothing else.
 
 `expected_inode_id` and `expected_attributes_revision_no` are both optional
 guards, and both are part of the commit's semantic identity for commit-id
-reuse. A wrong `expected_inode_id` answers `path_conflict`, like the delete
-guard it mirrors, so a raced rebinding cannot land attributes on the wrong
-inode. A stale
+reuse. An attribute revision guard requires its matching inode guard because
+a revision identifies a version of one inode; a revision-only guard returns
+`invalid_request` before resolving the path. A wrong `expected_inode_id`
+answers `path_conflict`, like the delete guard it mirrors, so a raced
+rebinding cannot land attributes on the wrong inode. A stale
 `expected_attributes_revision_no` answers `stale_attributes`. Omitting the
 revision guard does not make the write a merge: every update carries the
 revision it read as its own guard, so a concurrent update still answers

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -142,7 +142,7 @@ Attribute keys are compared exactly, without normalization or case folding. A ke
 
 Values are UTF-8 strings of at most 4,096 bytes. Empty strings and control characters are valid values. Removing a key is an explicit operation; an empty value does not remove it. A map contains at most 100 entries and at most 65,536 logical UTF-8 bytes, counting all keys and values without serialization overhead. Invalid durable maps are rejected, not truncated.
 
-An inode begins with an empty map at attribute revision `0`; that initial state has no persisted attribute row. Each effective update increments `attributes_revision_no` by one and stores the complete resulting map. A request that does not change the map is rejected. Clearing the map is a real update and must remain distinguishable from an inode whose attributes were never changed.
+An inode begins with an empty map at attribute revision `0`; that initial state has no persisted attribute row. Each accepted update increments `attributes_revision_no` by one and stores the complete resulting map. An accepted update advances the revision even when the resulting map equals the previous one. Clearing the map is a real update and must remain distinguishable from an inode whose attributes were never changed.
 
 Attribute revision numbers support optimistic concurrency. The API does not expose a separate history-listing interface for old attribute maps. The storage layer nevertheless retains the rows needed to reconstruct supported sequence-based views, as specified in the compaction rules.
 

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -1853,7 +1853,7 @@
         "properties": {
           "expected_attributes_revision_no": {
             "$ref": "#/components/schemas/AttributeRevisionNo",
-            "description": "The attribute revision that must still be current before the update."
+            "description": "With an inode guard, the attribute revision that must still be current."
           },
           "expected_inode_id": {
             "$ref": "#/components/schemas/InodeId",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2171,7 +2171,7 @@
         "properties": {
           "expected_attributes_revision_no": {
             "$ref": "#/components/schemas/AttributeRevisionNo",
-            "description": "The attribute revision that must still be current before the update."
+            "description": "With an inode guard, the attribute revision that must still be current."
           },
           "expected_inode_id": {
             "$ref": "#/components/schemas/InodeId",


### PR DESCRIPTION
An `update_attributes` operation that names `expected_attributes_revision_no` must now also name `expected_inode_id`. An attribute revision belongs to one inode and a new inode starts at revision 0, so a revision alone could match a file that replaced the one the caller read. The put operation already has this rule, and the new check reuses it, including the CLI flag requirement.

An attribute update whose resulting map equals the current map now succeeds and advances the attribute revision, instead of answering `invalid_request`. The old rule ran before the revision guard, so a stale caller whose values happened to match got the wrong error, and a declarative client that set a value already present failed its whole commit. The revision now counts accepted updates, which is the rule a put of identical bytes already follows.

Important callouts:
- Behavior change: an unchanged-map update writes one attribute row and one WAL record and appears in the change feed with the same map. A client that used the revision as a did-it-change signal must compare maps.
- `expected_attributes_revision_no` without `expected_inode_id` is now `invalid_request` on every transport, and the CLI rejects the flag combination before sending.
- No wire shape change. Spec text in api.md and format.md is updated; no durable bytes change.
