### PR TITLE
fix(api): name the failing operation on every commit and detail generation mismatches

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -104,6 +104,14 @@ pub struct ErrorDetails {
     )]
     #[cfg_attr(feature = "openapi", schema(nullable = false))]
     pub actual_inode_id: Option<InodeId>,
+    /// Opaque binding token supplied by the request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub expected_binding_generation: Option<BindingGeneration>,
+    /// Current binding token; absent for the root, which has no binding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub actual_binding_generation: Option<BindingGeneration>,
     /// Revision the request expected to be current.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(nullable = false))]
@@ -286,7 +294,10 @@ pub struct ExpectedFileState {
 pub enum DestinationPreconditionError {
     /// A create-only operation supplied a replacement precondition.
     #[error("destination preconditions require replace behavior")]
-    PreconditionsRequireReplace,
+    PreconditionsRequireReplace {
+        /// First supplied expectation field, with inode before revision.
+        field: &'static str,
+    },
     /// A revision precondition did not name the inode whose revision it checks.
     #[error(
         "`{revision_field}` names the revision of one inode; pair it with `{inode_field}` so the precondition names which inode"
@@ -311,7 +322,14 @@ impl DestinationPrecondition {
                 (None, None)
             )
         {
-            return Err(DestinationPreconditionError::PreconditionsRequireReplace);
+            let (revision_field, inode_field) = fields.names();
+            return Err(DestinationPreconditionError::PreconditionsRequireReplace {
+                field: if self.expected_inode_id.is_some() {
+                    inode_field
+                } else {
+                    revision_field
+                },
+            });
         }
         let Some(inode_id) = self.expected_inode_id else {
             if self.expected_revision_no.is_some() {

--- a/crates/loonfs-api/tests/golden/commit_preconditions.v0.json
+++ b/crates/loonfs-api/tests/golden/commit_preconditions.v0.json
@@ -47,6 +47,8 @@
   },
   {
     "precondition_index": 0,
+    "expected_binding_generation": "aaaa",
+    "actual_binding_generation": "bbbb",
     "expected_head_seq": 42,
     "actual_head_seq": 43
   }

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -2539,6 +2539,12 @@ fn commit_precondition_wire_shapes_match_golden() {
         precondition_index: Some(0),
         expected_head_seq: Some(ChangeSeq(42)),
         actual_head_seq: Some(ChangeSeq(43)),
+        expected_binding_generation: Some(
+            loonfs_api::BindingGeneration::parse("aaaa").expect("generation"),
+        ),
+        actual_binding_generation: Some(
+            loonfs_api::BindingGeneration::parse("bbbb").expect("generation"),
+        ),
         ..ErrorDetails::default()
     };
     let bytes =

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -15,8 +15,8 @@ use crate::namespace::state::NamespaceReadState;
 use crate::storage::content::DurableContentValidationError;
 use crate::wal::{WalSegmentError, WalTailLoadError};
 use loonfs_api::{
-    ChangeSeq, CommitId, ErrorDetails, InodeId, InodeKind, NamespaceId, RevisionNo, UploadId,
-    WriterEpoch, WriterId,
+    BindingGeneration, ChangeSeq, CommitId, ErrorDetails, InodeId, InodeKind, NamespaceId,
+    RevisionNo, UploadId, WriterEpoch, WriterId,
 };
 use loonfs_objectstore::{ImmutableWriteError, ObjectStoreError};
 use thiserror::Error;
@@ -67,6 +67,12 @@ pub enum CoreError {
     InvalidPath(String),
     #[error("invalid commit request: {0}")]
     InvalidCommitRequest(String),
+    #[error("invalid commit request: {message}")]
+    InvalidCommitField {
+        field: &'static str,
+        message: String,
+        precondition_index: Option<u32>,
+    },
     #[error("path not found `{0}`")]
     PathNotFound(String),
     #[error("inode not found `{0}`")]
@@ -122,6 +128,8 @@ pub enum CoreError {
     #[error("inode `{inode_id}` is no longer bound at the generation the request named")]
     BindingGenerationMismatch {
         inode_id: InodeId,
+        expected_binding_generation: BindingGeneration,
+        actual_binding_generation: Option<BindingGeneration>,
         precondition_index: Option<u32>,
     },
     #[error("commit id conflict for `{commit_id}`")]
@@ -241,10 +249,7 @@ pub enum CoreError {
         actual: ChangeSeq,
         precondition_index: Option<u32>,
     },
-    /// Identifies the operation that caused a multi-operation request to fail.
-    /// The request remains atomic, and the error code is taken from the underlying
-    /// failure. Single-operation requests return the underlying error directly.
-    #[error("operation {operation_index}: {source}")]
+    #[error("{source}")]
     FailedOperation {
         operation_index: u32,
         source: Box<CoreError>,
@@ -408,6 +413,7 @@ impl CoreError {
             CoreError::InvalidPath(_)
             | CoreError::RootMutationForbidden
             | CoreError::InvalidCommitRequest(_)
+            | CoreError::InvalidCommitField { .. }
             | CoreError::InvalidCheckpointRequest(_)
             | CoreError::InvalidGcConfig(_)
             | CoreError::InvalidQuery(_)
@@ -460,8 +466,6 @@ impl CoreError {
         }
     }
 
-    /// Attributes this failure to the operation at `operation_index` of a
-    /// multi-operation request.
     pub(crate) fn at_operation(self, operation_index: usize) -> Self {
         let Ok(operation_index) = u32::try_from(operation_index) else {
             return self;
@@ -506,6 +510,7 @@ impl CoreError {
             | CoreError::WalBuild(_)
             | CoreError::InvalidPath(_)
             | CoreError::InvalidCommitRequest(_)
+            | CoreError::InvalidCommitField { .. }
             | CoreError::PathNotFound(_)
             | CoreError::InodeNotFound(_)
             | CoreError::RevisionNotFound { .. }
@@ -606,9 +611,20 @@ impl CoreError {
             }),
             CoreError::BindingGenerationMismatch {
                 inode_id,
-                precondition_index: Some(precondition_index),
+                expected_binding_generation,
+                actual_binding_generation,
+                precondition_index,
             } => Some(ErrorDetails {
                 inode_id: Some(*inode_id),
+                expected_binding_generation: Some(expected_binding_generation.clone()),
+                actual_binding_generation: actual_binding_generation.clone(),
+                precondition_index: *precondition_index,
+                ..ErrorDetails::default()
+            }),
+            CoreError::InvalidCommitField {
+                precondition_index: Some(precondition_index),
+                ..
+            } => Some(ErrorDetails {
                 precondition_index: Some(*precondition_index),
                 ..ErrorDetails::default()
             }),

--- a/crates/loonfs-core/src/path/write/mod.rs
+++ b/crates/loonfs-core/src/path/write/mod.rs
@@ -49,6 +49,20 @@ pub(super) fn ensure_expected_inode(
 
 impl From<loonfs_api::DestinationPreconditionError> for CoreError {
     fn from(error: loonfs_api::DestinationPreconditionError) -> Self {
-        Self::InvalidCommitRequest(error.to_string())
+        let field = match error {
+            loonfs_api::DestinationPreconditionError::PreconditionsRequireReplace { field } => {
+                field
+            }
+            loonfs_api::DestinationPreconditionError::RevisionRequiresInode {
+                revision_field,
+                ..
+            } => revision_field,
+            _ => return Self::InvalidCommitRequest(error.to_string()),
+        };
+        Self::InvalidCommitField {
+            field,
+            message: error.to_string(),
+            precondition_index: None,
+        }
     }
 }

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -50,8 +50,7 @@ pub(crate) fn commit_fingerprint(
 /// Each semantic operation is planned against the view and its compiled
 /// operations are immediately validated, with accepted effects applied to the
 /// shared view so later operations observe earlier ones. The first failure
-/// aborts the request; multi-operation requests attach the failing
-/// operation's index, while single-operation requests return the raw error.
+/// aborts the request and attaches the failing operation's index.
 ///
 /// The commit's identity moves into the returned [`ValidatedCommitPlan`]:
 /// the head is the validated source of the namespace and writer epoch
@@ -77,7 +76,6 @@ pub(crate) async fn prepare_commit_against_publish_view<S: ObjectStore + ?Sized>
     let mut resolved = PublishValidationView::new(base_view, accepted_rows, committed_seq);
     let mut numbering = CommitNumbering::default();
     let mut validated_ops: Vec<ValidatedOp> = Vec::new();
-    let operation_count = request.operations.len();
     for (index, operation) in request.operations.iter().enumerate() {
         let unit = {
             let resolution_view = resolved.view();
@@ -87,7 +85,7 @@ pub(crate) async fn prepare_commit_against_publish_view<S: ObjectStore + ?Sized>
             };
             plan_operation(operation, &view, allocation)
                 .await
-                .map_err(|error| attribute(error, index, operation_count))?
+                .map_err(|error| attribute(error, index))?
         };
         let unit_ops = unit.ops;
         let validated_unit = validate_ops(
@@ -99,7 +97,7 @@ pub(crate) async fn prepare_commit_against_publish_view<S: ObjectStore + ?Sized>
             committed_at_ms,
         )
         .await
-        .map_err(|error| attribute(error, index, operation_count))?;
+        .map_err(|error| attribute(error, index))?;
         validated_ops.extend(validated_unit);
     }
 
@@ -273,14 +271,7 @@ async fn plan_operation<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Names the operation a batch stopped at.
-///
-/// A one-operation request has one place to fail, so its error stays exactly
-/// what the operation produced; there is nothing to disambiguate.
-fn attribute(error: CoreError, index: usize, operation_count: usize) -> CoreError {
-    if operation_count < 2 {
-        return error;
-    }
+fn attribute(error: CoreError, index: usize) -> CoreError {
     error.at_operation(index)
 }
 

--- a/crates/loonfs-core/src/path/write/preconditions.rs
+++ b/crates/loonfs-core/src/path/write/preconditions.rs
@@ -133,14 +133,26 @@ async fn evaluate_binding<S: ObjectStore + ?Sized>(
     }
     if let (Some(binding), Some(expected)) = (actual, expected_binding_generation) {
         check_binding_generation(view, &binding, expected).map_err(|error| match error {
-            CoreError::BindingGenerationMismatch { inode_id, .. } => {
-                CoreError::BindingGenerationMismatch {
-                    inode_id,
-                    precondition_index,
-                }
-            }
+            CoreError::BindingGenerationMismatch {
+                inode_id,
+                expected_binding_generation,
+                actual_binding_generation,
+                ..
+            } => CoreError::BindingGenerationMismatch {
+                inode_id,
+                expected_binding_generation,
+                actual_binding_generation,
+                precondition_index,
+            },
             CoreError::RootMutationForbidden => CoreError::BindingGenerationMismatch {
                 inode_id: binding.inode_id,
+                expected_binding_generation: expected.clone(),
+                actual_binding_generation: None,
+                precondition_index,
+            },
+            CoreError::InvalidCommitField { field, message, .. } => CoreError::InvalidCommitField {
+                field,
+                message,
                 precondition_index,
             },
             error => error,

--- a/crates/loonfs-core/src/path/write/publish_path_planning.rs
+++ b/crates/loonfs-core/src/path/write/publish_path_planning.rs
@@ -103,8 +103,10 @@ pub(super) fn check_binding_generation<S: ObjectStore + ?Sized>(
     expected_binding_generation: &BindingGenerationToken,
 ) -> Result<()> {
     let expected = BindingGeneration::decode(expected_binding_generation, view.namespace_id)
-        .map_err(|error| {
-            CoreError::InvalidCommitRequest(format!("invalid expected binding generation: {error}"))
+        .map_err(|error| CoreError::InvalidCommitField {
+            field: "expected_binding_generation",
+            message: format!("invalid expected binding generation: {error}"),
+            precondition_index: None,
         })?;
     let Some(current) = resolved.binding_generation else {
         return Err(CoreError::RootMutationForbidden);
@@ -112,6 +114,15 @@ pub(super) fn check_binding_generation<S: ObjectStore + ?Sized>(
     if current != expected {
         return Err(CoreError::BindingGenerationMismatch {
             inode_id: resolved.inode_id,
+            expected_binding_generation: expected_binding_generation.clone(),
+            actual_binding_generation: Some(current.encode(view.namespace_id).map_err(
+                |error| {
+                    CoreError::Internal(format!(
+                        "failed to encode the binding generation of inode `{}`: {error}",
+                        resolved.inode_id
+                    ))
+                },
+            )?),
             precondition_index: None,
         });
     }

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -482,7 +482,10 @@ mod tests {
         results[0].as_ref().expect("first create succeeds");
         let error = results[1].as_ref().expect_err("duplicate create rejected");
         assert_eq!(error.code(), ErrorCode::PathConflict);
-        assert!(matches!(error, CoreError::DestinationExists { .. }));
+        assert!(
+            matches!(error, CoreError::FailedOperation { operation_index: 0, source }
+            if matches!(source.as_ref(), CoreError::DestinationExists { .. }))
+        );
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -38,7 +38,8 @@ fn path(value: &str) -> AbsolutePath {
 
 fn assert_invalid_commit_request(error: &CoreError, label: &str) {
     assert!(
-        matches!(error, CoreError::InvalidCommitRequest(_)),
+        matches!(error, CoreError::FailedOperation { operation_index: 0, source }
+            if matches!(source.as_ref(), CoreError::InvalidCommitRequest(_) | CoreError::InvalidCommitField { .. })),
         "for `{label}`: {error:?}"
     );
     assert_eq!(error.code(), ErrorCode::InvalidRequest, "for `{label}`");

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -1262,8 +1262,15 @@ async fn fresh_delete_path_expected_inode_precondition_still_matches_or_rejects(
     )
     .await
     .expect_err("mismatching precondition must fail planning");
+    let CoreError::FailedOperation {
+        operation_index: 0,
+        source,
+    } = error
+    else {
+        panic!("expected failed operation, got {error:?}");
+    };
     assert!(matches!(
-        error,
+        *source,
         CoreError::CommitValidation(CommitValidationError::BindingPreconditionMismatch {
             expected_inode_id: Some(InodeId(1)),
             actual_inode_id: Some(actual),

--- a/crates/loonfs-core/tests/it/inode_mutations.rs
+++ b/crates/loonfs-core/tests/it/inode_mutations.rs
@@ -270,7 +270,7 @@ async fn move_requires_the_current_binding_generation() {
         test_commit_id(Some("move-stale")),
         FilesystemOperation::MoveByInode {
             inode_id: report_inode_id,
-            expected_binding_generation: stale_generation,
+            expected_binding_generation: stale_generation.clone(),
             to_parent_inode_id: ROOT_INODE_ID,
             to_display_name: display_name("moved.txt"),
             precondition: loonfs_api::DestinationPrecondition {
@@ -284,6 +284,59 @@ async fn move_requires_the_current_binding_generation() {
     .await
     .expect_err("stale binding generation must fail");
     assert_eq!(error.code(), ErrorCode::BindingGenerationMismatch);
+    let details = error.details().expect("operation details");
+    assert_eq!(details.operation_index, Some(0));
+    assert_eq!(details.precondition_index, None);
+    assert_eq!(details.inode_id, Some(report_inode_id));
+    assert_eq!(
+        details.expected_binding_generation,
+        Some(stale_generation.clone())
+    );
+    assert_eq!(
+        details.actual_binding_generation,
+        Some(fresh_generation.clone())
+    );
+
+    for (path, inode_id, actual) in [
+        (
+            "/docs/renamed.txt",
+            report_inode_id,
+            Some(fresh_generation.clone()),
+        ),
+        ("/", ROOT_INODE_ID, None),
+    ] {
+        let error = submit_commit(
+            &store,
+            &namespace_id,
+            CommitRequest::single(
+                test_commit_id(Some("binding-precondition")),
+                loonfs_test_support::test_actor(),
+                None,
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/unwritten").expect("path"),
+                    parents: false,
+                },
+            )
+            .preconditions(vec![loonfs_api::CommitPrecondition::PathBinding {
+                path: AbsolutePath::parse(path).expect("path"),
+                expected_inode_id: inode_id,
+                expected_binding_generation: Some(stale_generation.clone()),
+            }]),
+            &context,
+        )
+        .await
+        .expect_err("binding precondition must fail");
+        assert_eq!(error.code(), ErrorCode::BindingGenerationMismatch);
+        let details = error.details().expect("precondition details");
+        assert_eq!(details.precondition_index, Some(0));
+        assert_eq!(details.operation_index, None);
+        assert_eq!(details.inode_id, Some(inode_id));
+        assert_eq!(
+            details.expected_binding_generation,
+            Some(stale_generation.clone())
+        );
+        assert_eq!(details.actual_binding_generation, actual);
+    }
 
     submit_operation(
         &store,

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -1567,7 +1567,14 @@ async fn put_precondition_matrix_covers_identity_aba_and_valid_combinations() {
     )
     .await
     .expect_err("the old identity must reject the recreated file");
-    match error {
+    let CoreError::FailedOperation {
+        operation_index: 0,
+        source,
+    } = error
+    else {
+        panic!("expected failed operation, got {error:?}");
+    };
+    match *source {
         CoreError::CommitValidation(CommitValidationError::BindingPreconditionMismatch {
             expected_inode_id: Some(expected_child_inode_id),
             actual_inode_id: Some(actual_child_inode_id),
@@ -1688,9 +1695,10 @@ async fn delete_path_non_recursive_rejects_non_empty_directory() {
     .expect_err("non-recursive delete should reject non-empty dir");
     assert!(matches!(
         &error,
-        CoreError::CommitValidation(CommitValidationError::DirectoryNotEmpty {
-            inode_id: InodeId(2)
-        })
+        CoreError::FailedOperation { operation_index: 0, source }
+            if matches!(source.as_ref(), CoreError::CommitValidation(
+                CommitValidationError::DirectoryNotEmpty { inode_id: InodeId(2) }
+            ))
     ));
     assert_eq!(error.code(), ErrorCode::DirectoryNotEmpty);
 }
@@ -1945,7 +1953,10 @@ async fn move_replace_atomically_replaces_a_file_destination() {
     )
     .await
     .expect_err("no-replace move onto an occupied name fails");
-    assert!(matches!(error, CoreError::DestinationExists { .. }));
+    assert!(
+        matches!(error, CoreError::FailedOperation { operation_index: 0, source }
+        if matches!(*source, CoreError::DestinationExists { .. }))
+    );
 
     // Replace compiles to one commit: the destination file's delete and the
     // source's rebind land atomically.
@@ -2019,7 +2030,10 @@ async fn move_replace_rejects_directory_destinations_and_self_moves() {
     )
     .await
     .expect_err("replace move onto a directory fails");
-    assert!(matches!(error, CoreError::ExpectedFile { .. }));
+    assert!(
+        matches!(error, CoreError::FailedOperation { operation_index: 0, source }
+        if matches!(*source, CoreError::ExpectedFile { .. }))
+    );
 
     // A path never replaces itself, force or not.
     let error = submit_operation(
@@ -2039,7 +2053,10 @@ async fn move_replace_rejects_directory_destinations_and_self_moves() {
     )
     .await
     .expect_err("replace move onto itself fails");
-    assert!(matches!(error, CoreError::DestinationExists { .. }));
+    assert!(
+        matches!(error, CoreError::FailedOperation { operation_index: 0, source }
+        if matches!(*source, CoreError::DestinationExists { .. }))
+    );
 }
 
 #[tokio::test]
@@ -2346,8 +2363,15 @@ async fn copy_path_precondition_matrix_covers_identity_aba_and_valid_combination
     )
     .await
     .expect_err("the old copy destination identity must reject the recreated file");
+    let CoreError::FailedOperation {
+        operation_index: 0,
+        source,
+    } = error
+    else {
+        panic!("expected failed operation, got {error:?}");
+    };
     assert!(matches!(
-        error,
+        *source,
         CoreError::CommitValidation(CommitValidationError::BindingPreconditionMismatch {
             expected_inode_id: Some(expected_child_inode_id),
             actual_inode_id: Some(actual_child_inode_id),

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -103,6 +103,9 @@ impl ApiResponseError {
         let message = error.public_message();
         let mut response = Self::new(code, &message);
         response.body.details = details.map(Box::new);
+        if let Some(param) = error.invalid_request_param() {
+            response = response.with_invalid_request_param(param);
+        }
         response
     }
 

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -359,6 +359,12 @@ fn error_detail_fields_match_the_api_spec_table() {
         inode_id: Some(InodeId(1)),
         expected_inode_id: Some(InodeId(2)),
         actual_inode_id: Some(InodeId(3)),
+        expected_binding_generation: Some(
+            loonfs_api::BindingGeneration::parse("aaaa").expect("generation"),
+        ),
+        actual_binding_generation: Some(
+            loonfs_api::BindingGeneration::parse("bbbb").expect("generation"),
+        ),
         expected_revision_no: Some(RevisionNo::from(1)),
         actual_revision_no: Some(RevisionNo::from(2)),
         expected_attributes_revision_no: Some(AttributeRevisionNo::from(1)),

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -567,6 +567,151 @@ async fn an_empty_operation_list_is_rejected() {
     harness.server.abort();
 }
 
+#[tokio::test]
+async fn a_put_revision_without_an_inode_identifies_the_revision_field() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "http-revision-field",
+        "http-revision-field",
+    ))
+    .await;
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let content = stage_uploaded_content(&harness.client, &namespace, FIRST_BYTES).await;
+    let error = harness
+        .client
+        .create_commit(
+            &namespace,
+            &CommitRequest {
+                preconditions: Vec::new(),
+                commit_id: commit_id("revision-without-inode"),
+                actor_id: loonfs_test_support::test_actor(),
+                message: None,
+                content_tokens: vec![content_token(&content)],
+                operations: vec![FilesystemOperation::PutFile {
+                    path: absolute(ROOT_FILE),
+                    content_ref: content.content_ref,
+                    behavior: DestinationBehavior::Replace,
+                    expected_inode_id: None,
+                    expected_revision_no: Some(RevisionNo(1)),
+                }],
+            },
+        )
+        .await
+        .expect_err("revision requires an inode");
+    match error {
+        ClientError::Api {
+            status,
+            code,
+            param,
+            details,
+            ..
+        } => {
+            assert_eq!(status, 400);
+            assert_eq!(code, ErrorCode::InvalidRequest.as_str());
+            assert_eq!(param.as_deref(), Some("/operations/0/expected_revision_no"));
+            let details = details.expect("operation details");
+            assert_eq!(details.operation_index, Some(0));
+            assert_eq!(details.precondition_index, None);
+        }
+        other => panic!("expected invalid_request, got {other:?}"),
+    }
+    harness.server.abort();
+}
+
+#[tokio::test]
+async fn a_foreign_binding_precondition_identifies_the_generation_field() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "http-generation-field",
+        "http-generation-field",
+    ))
+    .await;
+    let namespace = namespace_id("demo");
+    let foreign_namespace = namespace_id("foreign");
+    for namespace in [&namespace, &foreign_namespace] {
+        harness
+            .client
+            .create_namespace(namespace)
+            .await
+            .expect("create namespace");
+        harness
+            .client
+            .create_directory(
+                &NamespacePath::parse(namespace.as_str(), REPORTS_DIR).expect("path"),
+                &loonfs_client::CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("create directory");
+    }
+    let current = harness
+        .client
+        .get_path_entry(
+            &NamespacePath::parse(namespace.as_str(), REPORTS_DIR).expect("path"),
+            &Default::default(),
+        )
+        .await
+        .expect("stat current directory");
+    let foreign = harness
+        .client
+        .get_path_entry(
+            &NamespacePath::parse(foreign_namespace.as_str(), REPORTS_DIR).expect("path"),
+            &Default::default(),
+        )
+        .await
+        .expect("stat foreign directory");
+    let error = harness
+        .client
+        .create_commit(
+            &namespace,
+            &CommitRequest::single(
+                commit_id("foreign-generation"),
+                loonfs_test_support::test_actor(),
+                None,
+                FilesystemOperation::CreateDirectory {
+                    path: absolute("/unwritten"),
+                    parents: false,
+                },
+            )
+            .preconditions(vec![loonfs_api::CommitPrecondition::PathBinding {
+                path: absolute(REPORTS_DIR),
+                expected_inode_id: current.inode_id,
+                expected_binding_generation: Some(
+                    foreign.binding_generation.expect("named binding"),
+                ),
+            }]),
+        )
+        .await
+        .expect_err("generation belongs to another namespace");
+    match error {
+        ClientError::Api {
+            status,
+            code,
+            param,
+            details,
+            ..
+        } => {
+            assert_eq!(status, 400);
+            assert_eq!(code, ErrorCode::InvalidRequest.as_str());
+            assert_eq!(
+                param.as_deref(),
+                Some("/preconditions/0/expected_binding_generation")
+            );
+            let details = details.expect("precondition details");
+            assert_eq!(details.precondition_index, Some(0));
+            assert_eq!(details.operation_index, None);
+        }
+        other => panic!("expected invalid_request, got {other:?}"),
+    }
+    harness.server.abort();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn the_root_path_is_rejected_as_a_mutation_target() {
     let temp_dir = tempdir().expect("tempdir");
@@ -612,11 +757,7 @@ async fn the_root_path_is_rejected_as_a_mutation_target() {
             assert_eq!(status, 400);
             assert_eq!(code, ErrorCode::InvalidRequest.as_str());
             let details = details.expect("a failed commit carries details");
-            // One operation has one place to fail, so nothing disambiguates it.
-            assert_eq!(
-                details.operation_index, None,
-                "a one-operation request names no position"
-            );
+            assert_eq!(details.operation_index, Some(0));
             assert_eq!(
                 details.commit_id.as_ref().map(CommitId::as_str),
                 Some("root-alone")

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -250,6 +250,27 @@ impl RuntimeError {
         }
     }
 
+    /// Identifies a malformed commit field as a JSON Pointer for HTTP errors.
+    pub fn invalid_request_param(&self) -> Option<String> {
+        match self {
+            Self::Core(CoreError::FailedOperation {
+                operation_index,
+                source,
+            }) => match source.as_ref() {
+                CoreError::InvalidCommitField { field, .. } => {
+                    Some(format!("/operations/{operation_index}/{field}"))
+                }
+                _ => None,
+            },
+            Self::Core(CoreError::InvalidCommitField {
+                field,
+                precondition_index: Some(precondition_index),
+                ..
+            }) => Some(format!("/preconditions/{precondition_index}/{field}")),
+            _ => None,
+        }
+    }
+
     /// Returns an error message safe to show to users.
     pub fn public_message(&self) -> std::borrow::Cow<'static, str> {
         let store_message = match self {

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -214,6 +214,8 @@ depends on where the input came from:
 | Path parameter | Parameter name |
 | CLI-local input | Flag or argument spelling |
 
+Commit shape errors identify the offending expectation field as `/operations/{i}/{field}` or `/preconditions/{i}/{field}`, where `i` is its zero-based position.
+
 `code` is the stable machine contract; `message` is human-readable and may
 change between releases; `feature` is present only on `not_supported` errors
 and names the capability-document key the client should reconcile against.
@@ -244,13 +246,13 @@ The codes that populate it:
 | `path_conflict` | `expected_inode_id`, `actual_inode_id` (absent when unbound); `precondition_index` for a failed request precondition |
 | `stale_revision` | `inode_id`, `expected_revision_no`, `actual_revision_no` (absent when the inode has no current revision or is not visible); `precondition_index` for a failed request precondition |
 | `stale_attributes` | `inode_id`, `expected_attributes_revision_no` (absent when the caller stated no expectation), `actual_attributes_revision_no` (absent when the inode is not visible); `precondition_index` for a failed request precondition |
-| `binding_generation_mismatch` | `inode_id` and `precondition_index` for a failed request precondition |
+| `binding_generation_mismatch` | `inode_id`, `expected_binding_generation` (the request's token as supplied), `actual_binding_generation` (the current binding's token, absent for the root); `precondition_index` for a failed request precondition. Clients must not parse or order the tokens |
 | `commit_id_reuse_conflict` | `commit_id`, plus `committed_seq` and `committed_fingerprint` when the conflict was decided against a durable commit receipt — the sequence that `commit_id` already landed at, and the semantic identity of what landed there (section 5.1). Both come from the receipt, so both are present or neither is; both are absent when nothing has committed under the id yet and two live requests are claiming it at once |
 | `rebootstrap_required` | `after_seq`, `retention_floor_seq` |
 | `stale_head` | `expected_head_seq`, `actual_head_seq` for a caller-supplied head precondition; `precondition_index` identifies a failed request precondition. |
 | `not_deleted` | `inode_id`, plus `expected_deletion_seq` and `actual_deletion_seq` when a live deletion exists at a different generation |
 | any failed commit | `commit_id` — the idempotency key the request committed under, echoed so failed and uncertain outcomes carry the caller's reconciliation handle (section 5.2) |
-| any commit carrying more than one operation | `operation_index` — the position of the operation that stopped the request (section 5.1) |
+| any failed operation | `operation_index` — the zero-based position of the operation that stopped the request, 0 for a one-operation request (section 5.1) |
 
 One code exists specifically so capability handling is uniform from day one:
 
@@ -471,7 +473,7 @@ everything operations `0..k` do, so a request can create a directory and
 write into it, or delete a path and recreate it. Either every operation
 commits or none does: the first operation that fails aborts the whole
 request, nothing it or its predecessors would have written becomes visible,
-and — when the request carried more than one operation — the error names the
+and the error names the
 position that stopped it in `details.operation_index`. The error code stays
 the failing operation's own; no code is specific to batching.
 
@@ -1869,7 +1871,7 @@ position that stopped it. Had the put above raced another writer:
 ```json
 {
   "code": "path_conflict",
-  "message": "operation 1: destination `/reports/2026/january.pdf` already exists",
+  "message": "destination `/reports/2026/january.pdf` already exists",
   "request_id": "req_9c2f4a1b7d8e4f21a0b3c4d5e6f70819",
   "details": {
     "commit_id": "c_2a41d0c6b9f34e7d8a1b5c9e0f234567",

--- a/docs/specs/openapi-proxy.json
+++ b/docs/specs/openapi-proxy.json
@@ -971,6 +971,10 @@
             "$ref": "#/components/schemas/AttributeRevisionNo",
             "description": "Attribute revision that is actually current for the inode."
           },
+          "actual_binding_generation": {
+            "$ref": "#/components/schemas/BindingGeneration",
+            "description": "Current binding token; absent for the root, which has no binding."
+          },
           "actual_deletion_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Deletion generation actually active for the inode."
@@ -1006,6 +1010,10 @@
           "expected_attributes_revision_no": {
             "$ref": "#/components/schemas/AttributeRevisionNo",
             "description": "Attribute revision the request expected to be current."
+          },
+          "expected_binding_generation": {
+            "$ref": "#/components/schemas/BindingGeneration",
+            "description": "Opaque binding token supplied by the request."
           },
           "expected_deletion_seq": {
             "$ref": "#/components/schemas/ChangeSeq",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1289,6 +1289,10 @@
             "$ref": "#/components/schemas/AttributeRevisionNo",
             "description": "Attribute revision that is actually current for the inode."
           },
+          "actual_binding_generation": {
+            "$ref": "#/components/schemas/BindingGeneration",
+            "description": "Current binding token; absent for the root, which has no binding."
+          },
           "actual_deletion_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Deletion generation actually active for the inode."
@@ -1324,6 +1328,10 @@
           "expected_attributes_revision_no": {
             "$ref": "#/components/schemas/AttributeRevisionNo",
             "description": "Attribute revision the request expected to be current."
+          },
+          "expected_binding_generation": {
+            "$ref": "#/components/schemas/BindingGeneration",
+            "description": "Opaque binding token supplied by the request."
           },
           "expected_deletion_seq": {
             "$ref": "#/components/schemas/ChangeSeq",


### PR DESCRIPTION
Every failed operation now reports `details.operation_index`, including 0 for a one-operation commit, so client code no longer branches on operation count. `binding_generation_mismatch` errors carry `expected_binding_generation` and `actual_binding_generation` as opaque tokens. The commit shape rules (a revision expectation without its inode, expectations on a no-replace write, and a malformed or foreign binding generation) now set `param` to the JSON Pointer of the offending field, such as `/operations/0/expected_revision_no` or `/preconditions/0/expected_binding_generation`.

Important callouts:
- The position of a failed operation now lives only in `details.operation_index` and `param`. The message no longer carries an "operation N:" prefix on any commit, so a single-operation failure reads the same as before and the CLI prints it unchanged. Error codes and statuses are unchanged.
- Precondition failures keep `precondition_index` and never carry an operation index.
- Stacked on the vocabulary PR; merge that one first.
